### PR TITLE
Implement variability to creature catching

### DIFF
--- a/tuxemon/core/states/combat.py
+++ b/tuxemon/core/states/combat.py
@@ -1058,18 +1058,18 @@ class Combat(tools._State):
             else:
                 prob_range = players['opponent']['monster'].level
                 if players['opponent']['monster'].current_hp < players['opponent']['monster'].hp: 
+                    print "--- Capture Probability ---"
                     print "Probability Range:", prob_range
                     print "Current HP:", players['opponent']['monster'].current_hp
                     print "Maximum HP:", players['opponent']['monster'].hp
                     hp_percent = (float(players['opponent']['monster'].current_hp) / players['opponent']['monster'].hp)*100
-                    print "HP Percent:", hp_percent
                     hp_percent = 100 - hp_percent
-                    print "HP Percent negative:", hp_percent
+                    print "Percent of missing HP:", hp_percent
                     prob_modifier = hp_percent * prob_range / 100
                     print "Probability Modifier:", prob_modifier
                     prob_range = int(prob_range - prob_modifier)
                     print "New Probability Range:", prob_range
-            if random.randint(1,prob_range) == 1:
+            if prob_range < 2 or random.randint(1,prob_range) == 1:
                 print "Capturing %s!!!" % players['opponent']['monster'].name
                 self.info_menu.text = "You captured %s!" % players['opponent']['monster'].name
                 self.info_menu.elapsed_time = 0.0

--- a/tuxemon/core/states/combat.py
+++ b/tuxemon/core/states/combat.py
@@ -1066,8 +1066,8 @@ class Combat(tools._State):
                 
                 # If opponent is damaged, subtract damage percentage from the prob_max (make it less likely to fail)
                 if players['opponent']['monster'].current_hp < players['opponent']['monster'].hp: 
-                    hp_percent = (float(players['opponent']['monster'].current_hp) / players['opponent']['monster'].hp)*100
-                    hp_percent = 100 - hp_percent
+                    total_damage = players['opponent']['monster'].hp - players['opponent']['monster'].current_hp
+                    hp_percent = (float(total_damage) / players['opponent']['monster'].hp)*100
                     prob_modifier = hp_percent * prob_max / 100
                     prob_max = int(prob_max - prob_modifier)
 

--- a/tuxemon/core/states/combat.py
+++ b/tuxemon/core/states/combat.py
@@ -36,6 +36,7 @@ import os
 import sys
 import pprint
 import time
+import random
 
 from core import prepare
 from core import tools
@@ -1057,19 +1058,27 @@ class Combat(tools._State):
             else:
                 prob_range = players['opponent']['monster'].level
                 if players['opponent']['monster'].current_hp < players['opponent']['monster'].hp: 
-                    # pprint(players)
-                    print prob_range
-                    hp_percent = (players['opponent']['monster'].current_hp / players['opponent']['monster'].hp)*100
-                    print hp_percent
+                    print "Probability Range:", prob_range
+                    print "Current HP:", players['opponent']['monster'].current_hp
+                    print "Maximum HP:", players['opponent']['monster'].hp
+                    hp_percent = (float(players['opponent']['monster'].current_hp) / players['opponent']['monster'].hp)*100
+                    print "HP Percent:", hp_percent
                     hp_percent = 100 - hp_percent
-                    print hp_percent
+                    print "HP Percent negative:", hp_percent
                     prob_modifier = hp_percent * prob_range / 100
-                    print prob_modifier
-                    prob_range = prob_range - prob_modifier
-                    print prob_range
-            self.info_menu.text = "You captured %s!" % players['opponent']['monster'].name
-            self.info_menu.elapsed_time = 0.0
-            self.state = "captured"
+                    print "Probability Modifier:", prob_modifier
+                    prob_range = int(prob_range - prob_modifier)
+                    print "New Probability Range:", prob_range
+            if random.randint(1,prob_range) == 1:
+                print "Capturing %s!!!" % players['opponent']['monster'].name
+                self.info_menu.text = "You captured %s!" % players['opponent']['monster'].name
+                self.info_menu.elapsed_time = 0.0
+                self.state = "captured"
+            else:
+                print "Could not capture %s!" % players['opponent']['monster'].name
+                self.info_menu.text = "%s broke free!" % players['opponent']['monster'].name
+                self.info_menu.elapsed_time = 0.0
+                self.state = "action phase"
 
         # Handle when all monsters in the player's party have fainted
         if (self.state == "lost" or self.state == "won" or self.state == "captured") and self.info_menu.elapsed_time > self.info_menu.delay:

--- a/tuxemon/core/states/combat.py
+++ b/tuxemon/core/states/combat.py
@@ -1051,7 +1051,22 @@ class Combat(tools._State):
 
         # Handle when a monster is being captured.
         if (self.state == "capturing") and self.info_menu.elapsed_time > self.info_menu.delay:
-            print "Capturing!!"
+            print "Attempting to capture"
+            if players['opponent']['monster'].level == 1:
+                prob_range = 1
+            else:
+                prob_range = players['opponent']['monster'].level
+                if players['opponent']['monster'].current_hp < players['opponent']['monster'].hp: 
+                    # pprint(players)
+                    print prob_range
+                    hp_percent = (players['opponent']['monster'].current_hp / players['opponent']['monster'].hp)*100
+                    print hp_percent
+                    hp_percent = 100 - hp_percent
+                    print hp_percent
+                    prob_modifier = hp_percent * prob_range / 100
+                    print prob_modifier
+                    prob_range = prob_range - prob_modifier
+                    print prob_range
             self.info_menu.text = "You captured %s!" % players['opponent']['monster'].name
             self.info_menu.elapsed_time = 0.0
             self.state = "captured"

--- a/tuxemon/tuxemon.cfg
+++ b/tuxemon/tuxemon.cfg
@@ -13,7 +13,7 @@ controller_transparency = 45
 starting_map = bedroom_test.tmx
 starting_position_x = 3
 starting_position_y = 3
-cli_enabled = 0 
+cli_enabled = 0
 
 [player]
 animation_speed = 0.15

--- a/tuxemon/tuxemon.cfg
+++ b/tuxemon/tuxemon.cfg
@@ -13,7 +13,7 @@ controller_transparency = 45
 starting_map = bedroom_test.tmx
 starting_position_x = 3
 starting_position_y = 3
-cli_enabled = 1 
+cli_enabled = 0 
 
 [player]
 animation_speed = 0.15

--- a/tuxemon/tuxemon.cfg
+++ b/tuxemon/tuxemon.cfg
@@ -13,7 +13,7 @@ controller_transparency = 45
 starting_map = bedroom_test.tmx
 starting_position_x = 3
 starting_position_y = 3
-cli_enabled = 0
+cli_enabled = 1 
 
 [player]
 animation_speed = 0.15


### PR DESCRIPTION
### Code Explanation:
* It starts by defining a range with `prob_min` and `prob_max`. These are used later as the range to generate a random number. If that random number is equal to `prob_min`, the capture is successful. Otherwise, it fails and battle continues.
* Before it generates the random number, the `prob_max` is decreased if the creature has taken damage or has any status effects
    * **Damage** - If the creature has taken damage, a percentage of (total damage received) / (max HP) is found. That percent is then removed from `prob_max` (narrowing the range).
    * **Status Effect** - If the creature's status is not normal, then the variable `status_modifier` is multiplied by `prob_max`. `status_modifier` is currently set to 0.25, therefore reducing `prob_max` by 25%.
* Then if `prob_max` is less than or equal to `prob_min`, it and the random number are set to `prob_min`. Otherwise the random number is generated with (`prob_min` to `prob_max`) as the range.
* If the random number then equals `prob_min`, the capture is successful. Otherwise, combat continues and the capture device is hidden.

### Notes:
I tried to do a good job of explaining things in the comments as well. This should resolve issue #29. One thing to note is that I was able to get the capture device sprite to hide on an unsuccessful capture, but I wasn't sure how to either delete it from the surface or move it back to its original starting position. Currently it hides and gets bumped by the opponent monster when its attack animation is done. If another capture device is used, the sprite shows up in the location it was bumped to (slightly to the left of the opponent monster) and moves back to the opponent monster.
