### PR TITLE
Move capture system to item.py and make it more versatile

### DIFF
--- a/tuxemon/core/components/item.py
+++ b/tuxemon/core/components/item.py
@@ -204,12 +204,51 @@ class Item(object):
         :type game: tuxemon.Game
 
         :rtype: None
-        :returns: None
+        :returns: True or False
 
         """
 
-        # TODO: Make this not work 100% of the time and check to see if this is a trainer battle.
-        game.player1.add_monster(target)
+        print "Attempting to capture"
+        prob_min = 1    # Set bottom of range for random number gen (alters likeliness of capture)
+        prob_max = prob_min   # Set top of range for random number gen
+      
+        if target.level > prob_min:
+            prob_max = target.level
+            print "Range top:", prob_max
+            prob_max -= self.power
+            print "Range top minus power:", prob_max
+            
+            # If opponent is damaged, subtract damage percentage from the prob_max (make it less likely to fail)
+            if target.current_hp < target.hp: 
+                total_damage = target.hp - target.current_hp
+                hp_percent = (float(total_damage) / target.hp)*100
+                prob_modifier = hp_percent * prob_max / 100
+                prob_max = int(prob_max - prob_modifier)
+
+            # If opponent has status effect, multiply the prob_max by status_modifier to determine new prob_max
+            if not target.status == "Normal":
+                # Decreases prob_max by 25% (again, making it less likely to fail)
+                status_modifier = 0.25 
+                prob_max = prob_max * status_modifier
+                prob_max = int(prob_max)
+
+        # If the prob_max is greater than prob_min, pick a random number between the two numbers
+        if prob_max > prob_min:
+            random_num = random.randint(prob_min,prob_max)
+        else:
+            prob_max = prob_min
+            random_num = prob_min
+
+        print "--- Capture Probability ---"
+        print "Probability range: %s-%s" % (prob_min, prob_max)
+        print "Random Number:", random_num
+
+        if random_num == prob_min:
+            game.player1.add_monster(target)
+            return True
+        else:
+            return False
+
 
 
 if __name__ == "__main__":

--- a/tuxemon/core/components/item.py
+++ b/tuxemon/core/components/item.py
@@ -209,46 +209,43 @@ class Item(object):
         """
 
         print "Attempting to capture"
-        prob_min = 1    # Set bottom of range for random number gen (alters likeliness of capture)
-        prob_max = prob_min   # Set top of range for random number gen
+
+        # Set up variables for capture equation
+        success_max = 0
         damage_modifier = 0
-        status_modifier = 1
-      
-        # Set top of range to the monster's level
-        if target.level > prob_min:
-            prob_max = target.level
-            
-            # If opponent is damaged, subtract damage percentage from the prob_max (make it less likely to fail)
-            if target.current_hp < target.hp: 
-                total_damage = target.hp - target.current_hp
-                hp_percent = (float(total_damage) / target.hp)*100
-                damage_modifier = int(hp_percent * prob_max / 100)
+        status_modifier = 0
+        item_power = self.power
+        
+        # Get percent of damage taken and multiply it by 10
+        if target.current_hp < target.hp: 
+            total_damage = target.hp - target.current_hp
+            damage_modifier = int((float(total_damage) / target.hp)*1000)
 
-            # If opponent has status effect, multiply the prob_max by status_modifier to determine new prob_max
-            if not target.status == "Normal":
-                # Decreases prob_max by 25% (again, making it less likely to fail)
-                status_modifier = 0.25 
+        # Check if target has any status effects
+        if not target.status == "Normal":
+            status_modifier = 150 
 
-            # Equation to determine top of range             
-            prob_max = ((prob_max - self.power) - damage_modifier) * status_modifier
+        # Calculate the top of success range (random_num must be in range to succeed)
+        success_max = (success_max - (target.level * 10)) + damage_modifier + status_modifier + item_power
 
-        # If the prob_max is greater than prob_min, pick a random number between the two numbers
-        if prob_max > prob_min:
-            random_num = random.randint(prob_min,prob_max)
-        else:
-            prob_max = prob_min
-            random_num = prob_min
+        #Generate random_num
+        random_num = random.randint(0,1000)
 
-        print "--- Capture Probability ---"
-        print "Probability range: %s-%s" % (prob_min, prob_max)
-        print "Random Number:", random_num
+        # Debugging Text
+        print "--- Capture Variables ---"
+        print "(success_max - (target.level * 10)) + damage_modifier + status_modifier + item_power"
+        print "(0 - (%s * 10)) + %s + %s + %s = %s" % (
+            target.level, damage_modifier, status_modifier, item_power, success_max)
+        print "Success if between: 0 -", success_max
+        print "Chance of capture: %s / 100" % (success_max / 10)
+        print "Random number:", random_num
 
-        if prob_min <= random_num <= 3:
+        # If random_num falls between 0 and success_max, capture target
+        if 0 <= random_num <= success_max:
             game.player1.add_monster(target)
             return True
         else:
             return False
-
 
 
 if __name__ == "__main__":

--- a/tuxemon/core/components/item.py
+++ b/tuxemon/core/components/item.py
@@ -211,26 +211,26 @@ class Item(object):
         print "Attempting to capture"
         prob_min = 1    # Set bottom of range for random number gen (alters likeliness of capture)
         prob_max = prob_min   # Set top of range for random number gen
+        damage_modifier = 0
+        status_modifier = 1
       
+        # Set top of range to the monster's level
         if target.level > prob_min:
             prob_max = target.level
-            print "Range top:", prob_max
-            prob_max -= self.power
-            print "Range top minus power:", prob_max
             
             # If opponent is damaged, subtract damage percentage from the prob_max (make it less likely to fail)
             if target.current_hp < target.hp: 
                 total_damage = target.hp - target.current_hp
                 hp_percent = (float(total_damage) / target.hp)*100
-                prob_modifier = hp_percent * prob_max / 100
-                prob_max = int(prob_max - prob_modifier)
+                damage_modifier = int(hp_percent * prob_max / 100)
 
             # If opponent has status effect, multiply the prob_max by status_modifier to determine new prob_max
             if not target.status == "Normal":
                 # Decreases prob_max by 25% (again, making it less likely to fail)
                 status_modifier = 0.25 
-                prob_max = prob_max * status_modifier
-                prob_max = int(prob_max)
+
+            # Equation to determine top of range             
+            prob_max = ((prob_max - self.power) - damage_modifier) * status_modifier
 
         # If the prob_max is greater than prob_min, pick a random number between the two numbers
         if prob_max > prob_min:
@@ -243,7 +243,7 @@ class Item(object):
         print "Probability range: %s-%s" % (prob_min, prob_max)
         print "Random Number:", random_num
 
-        if random_num == prob_min:
+        if prob_min <= random_num <= 3:
             game.player1.add_monster(target)
             return True
         else:

--- a/tuxemon/core/components/item.py
+++ b/tuxemon/core/components/item.py
@@ -215,6 +215,7 @@ class Item(object):
         damage_modifier = 0
         status_modifier = 0
         item_power = self.power
+        random_num = random.randint(0,1000)
         
         # Get percent of damage taken and multiply it by 10
         if target.current_hp < target.hp: 
@@ -227,9 +228,6 @@ class Item(object):
 
         # Calculate the top of success range (random_num must be in range to succeed)
         success_max = (success_max - (target.level * 10)) + damage_modifier + status_modifier + item_power
-
-        #Generate random_num
-        random_num = random.randint(0,1000)
 
         # Debugging Text
         print "--- Capture Variables ---"

--- a/tuxemon/core/states/combat.py
+++ b/tuxemon/core/states/combat.py
@@ -1055,46 +1055,16 @@ class Combat(tools._State):
             ########################################################
 
         # Success is determined by level, health, and status effects
-        if (self.state == "capturing") and self.info_menu.elapsed_time > self.info_menu.delay:
-
-            print "Attempting to capture"
-            prob_min = 2    # Set bottom of range for random number gen
-            prob_max = 2    # Set top of range for random number gen
-          
-            if players['opponent']['monster'].level > prob_min:
-                prob_max = players['opponent']['monster'].level
-                
-                # If opponent is damaged, subtract damage percentage from the prob_max (make it less likely to fail)
-                if players['opponent']['monster'].current_hp < players['opponent']['monster'].hp: 
-                    total_damage = players['opponent']['monster'].hp - players['opponent']['monster'].current_hp
-                    hp_percent = (float(total_damage) / players['opponent']['monster'].hp)*100
-                    prob_modifier = hp_percent * prob_max / 100
-                    prob_max = int(prob_max - prob_modifier)
-
-                # If opponent has status effect, multiply the prob_max by status_modifier to determine new prob_max
-                if not players['opponent']['monster'].status == "Normal":
-                    # Decreases prob_max by 25% (again, making it less likely to fail)
-                    status_modifier = 0.25 
-                    prob_max = prob_max * status_modifier
-                    prob_max = int(prob_max)
-
-            # If the prob_max is greater that prob_min, pick a random number between the two numbers
-            if prob_max > prob_min:
-                random_num = random.randint(prob_min,prob_max)
-            else:
-                prob_max = prob_min
-                random_num = prob_min
-
-            print "--- Capture Probability ---"
-            print "Probability range: %s-%s" % (prob_min, prob_max)
-            print "Random Number:", random_num
-
-            if random_num == prob_min:
+        if ("capturing" in self.state) and self.info_menu.elapsed_time > self.info_menu.delay:
+            
+            print self.state
+            
+            if self.state == "capturing success":
                 print "Capturing %s!!!" % players['opponent']['monster'].name
                 self.info_menu.text = "You captured %s!" % players['opponent']['monster'].name
                 self.info_menu.elapsed_time = 0.0
                 self.state = "captured"
-            else:
+            elif self.state == "capturing fail":
                 print "Could not capture %s!" % players['opponent']['monster'].name
                 self.info_menu.text = "%s broke free!" % players['opponent']['monster'].name
                 self.info_menu.elapsed_time = 0.0
@@ -1250,7 +1220,18 @@ class Combat(tools._State):
             item_name = player['action']['item']['name']
             item_target = player['action']['item']['target']
             item_to_use = player['player'].inventory[item_name]['item']
-            item_to_use.use(item_target, self.game)
+            
+            # Use item and change game state if captured or not
+            if "capture" in item_to_use.effect:
+                self.ui["capture"].visible = True
+                self.ui["capture"].move(self.ui["opponent_monster_sprite"].position, 1.)
+                if item_to_use.capture(item_target, self.game):
+                    self.state = "capturing success"
+                else:
+                    self.state = "capturing fail"   
+            else:
+                item_to_use.use(item_target, self.game)
+                
 
             # Display a dialog showing that we used an item
             self.info_menu.text = "%s used %s on %s!" % (player['player'].name,
@@ -1261,10 +1242,6 @@ class Combat(tools._State):
             self.info_menu.elapsed_time = 0.0
 
             logger.info("Using item!")
-            if "capture" in item_to_use.effect:
-                self.ui["capture"].visible = True
-                self.ui["capture"].move(self.ui["opponent_monster_sprite"].position, 1.)
-                self.state = "capturing"
 
         elif 'switch' in player['action']:
             for player_name, player_dict in self.current_players.items():

--- a/tuxemon/core/states/combat.py
+++ b/tuxemon/core/states/combat.py
@@ -36,7 +36,6 @@ import os
 import sys
 import pprint
 import time
-import random
 
 from core import prepare
 from core import tools
@@ -1054,10 +1053,7 @@ class Combat(tools._State):
             #                  Creature Capturing                  #
             ########################################################
 
-        # Success is determined by level, health, and status effects
         if ("capturing" in self.state) and self.info_menu.elapsed_time > self.info_menu.delay:
-            
-            print self.state
             
             if self.state == "capturing success":
                 print "Capturing %s!!!" % players['opponent']['monster'].name

--- a/tuxemon/resources/db/item/capture_device.json
+++ b/tuxemon/resources/db/item/capture_device.json
@@ -5,7 +5,7 @@
     ], 
     "id": 3, 
     "name": "Capture Device", 
-    "power": 1, 
+    "power": 100, 
     "sprite": "resources/gfx/items/capture_device.png", 
     "target": "opponent",
     "type": "Consumable",


### PR DESCRIPTION
So I did two things in this one. The first is that I moved the capture system over to item.py as we discussed. Second, I reworked the capture system (addressing issue #29). The way I had it set up before, there was no way to have a success rate between 50 and 100 percent. Now you can have any whole-number success rate percentage (1-100). Details are below:

## Code:
1. The top of the success range is set to 0 in `success_max`
2. Other variable defaults are set to zero
2. A random number named `random_num` is generated between 1 and 1000
    * I set it to 1000 so there is plenty of room for variability
    * Note: I changed the power of the capture device to 100 in order to better suit this system
3. If the target has taken damage, the percentage of total damage taken is found and multiplied by 10 to make the variable `damage_modifier`. Otherwise it remains 0.
4. If the target has a status condition other than normal `status_modifier` is set (to 150 at the moment)
5. Then the new `success_max` is calculated using the following equation:
    * success_max = (success_max - (target.level * 10)) + damage_modifier + status_modifier + item_power
6. Finally, if the random_num falls between 0 and `success_max` the capture is successful

## Example:
I am attacking a wild level 8 rockitten. I have dealt damage that equals 28% of its max health. Rockitten has no status effects. I then throw the capture device and the success range is calculated like this:
```python
(0 - (8 * 10)) + 280 + 0 + 100 = 300 
```
That makes the success range 0 to 300. So I have a 30% chance of the `random_num` falling within that range. The random number is then checked. It turns out to be 452, so the capture is unsuccessful and battle continues.