### PR TITLE
Add conditional collision zones

### DIFF
--- a/tuxemon/core/components/map.py
+++ b/tuxemon/core/components/map.py
@@ -397,20 +397,20 @@ class Map(object):
             # inside this region.
             for a in range(0, int(width)):
                 for b in range(0, int(height)):
-                  collision_tile = (a + x, b + y) 
-                  collision_map.add(collision_tile)
+                    collision_tile = (a + x, b + y) 
+                    collision_map.add(collision_tile)
 
-                  # Check if collision region has properties, and is therefore a conditional zone
-                  # then add the location and conditions to semi_collision_map
-                  if collision_region.properties:
+                    # Check if collision region has properties, and is therefore a conditional zone
+                    # then add the location and conditions to semi_collision_map
+                    if collision_region.properties:
 
-                      cond_collision_tile = {'location': collision_tile}
-                      for key in collision_region.properties.keys():
-                          if "enter" in key:
-                              cond_collision_tile['enter'] = collision_region.properties[key]
-                          if "exit" in key:
-                              cond_collision_tile['exit'] = collision_region.properties[key]
-                      cond_collision_map[collision_tile] = cond_collision_tile
+                        cond_collision_tile = {'location': collision_tile}
+                        for key in collision_region.properties.keys():
+                            if "enter" in key:
+                                cond_collision_tile['enter'] = collision_region.properties[key]
+                            if "exit" in key:
+                                cond_collision_tile['exit'] = collision_region.properties[key]
+                        cond_collision_map[collision_tile] = cond_collision_tile
 
         # Similar to collisions, except we need to identify the tiles
         # on either side of the poly-line and prevent moving between

--- a/tuxemon/core/components/map.py
+++ b/tuxemon/core/components/map.py
@@ -361,6 +361,7 @@ class Map(object):
         # Create a list of all tile positions that we cannot walk through
         collision_map = set()
 
+        # Create a dictionary of coordinates that have conditional collisions
         semi_collision_map = {}
 
         # Create a list of all pairs of adjacent tiles that are impassable (aka walls)
@@ -399,6 +400,8 @@ class Map(object):
                   collision_tile = (a + x, b + y) 
                   collision_map.add(collision_tile)
 
+                  # Check if collision region has properties, and is therefore a conditional zone
+                  # then add the location and conditions to semi_collision_map
                   if collision_region.properties:
 
                       semi_collision_tile = {'location': collision_tile}

--- a/tuxemon/core/components/map.py
+++ b/tuxemon/core/components/map.py
@@ -393,6 +393,19 @@ class Map(object):
             width = self.round_to_divisible(collision_region.width, self.tile_size[0]) / self.tile_size[0]
             height = self.round_to_divisible(collision_region.height, self.tile_size[1]) / self.tile_size[1]
             
+            # Loop through properties and create list of directions for each property
+            if collision_region.properties:
+                enters = []
+                exits = []
+
+                for key in collision_region.properties:
+                    if "enter" in key:
+                        for direction in collision_region.properties[key].split():
+                            enters.append(direction)
+                    elif "exit" in key:
+                        for direction in collision_region.properties[key].split():
+                            exits.append(direction)
+
             # Loop through the area of this region and create all the tile coordinates that are
             # inside this region.
             for a in range(0, int(width)):
@@ -407,9 +420,9 @@ class Map(object):
                         cond_collision_tile = {'location': collision_tile}
                         for key in collision_region.properties.keys():
                             if "enter" in key:
-                                cond_collision_tile['enter'] = collision_region.properties[key]
+                                cond_collision_tile['enter'] = enters
                             if "exit" in key:
-                                cond_collision_tile['exit'] = collision_region.properties[key]
+                                cond_collision_tile['exit'] = exits
                         cond_collision_map[collision_tile] = cond_collision_tile
 
         # Similar to collisions, except we need to identify the tiles

--- a/tuxemon/core/components/map.py
+++ b/tuxemon/core/components/map.py
@@ -400,13 +400,15 @@ class Map(object):
                   collision_map.add(collision_tile)
 
                   if collision_region.properties:
-                      semi_collision_map[collision_tile] = collision_tile
-                      for key in collision_region.properties.keys():
-                          if key == "enter":
-                              semi_collision_map[collision_tile]['enter'] = collision_region.properties[key]
-                          if key == "exit":
-                              semi_collision_map[collision_tile]['exit'] = collision_region.properties[key]
 
+                      semi_collision_tile = {'location': collision_tile}
+                      for key in collision_region.properties.keys():
+                          if "enter" in key:
+                              semi_collision_tile['enter'] = collision_region.properties[key]
+                          if "exit" in key:
+                              semi_collision_tile['exit'] = collision_region.properties[key]
+                      semi_collision_map[collision_tile] = semi_collision_tile
+                print(semi_collision_map)
 
 
         # Similar to collisions, except we need to identify the tiles

--- a/tuxemon/core/components/map.py
+++ b/tuxemon/core/components/map.py
@@ -362,7 +362,7 @@ class Map(object):
         collision_map = set()
 
         # Create a dictionary of coordinates that have conditional collisions
-        semi_collision_map = {}
+        cond_collision_map = {}
 
         # Create a list of all pairs of adjacent tiles that are impassable (aka walls)
         # example: ((5,4),(5,3), both)
@@ -404,15 +404,13 @@ class Map(object):
                   # then add the location and conditions to semi_collision_map
                   if collision_region.properties:
 
-                      semi_collision_tile = {'location': collision_tile}
+                      cond_collision_tile = {'location': collision_tile}
                       for key in collision_region.properties.keys():
                           if "enter" in key:
-                              semi_collision_tile['enter'] = collision_region.properties[key]
+                              cond_collision_tile['enter'] = collision_region.properties[key]
                           if "exit" in key:
-                              semi_collision_tile['exit'] = collision_region.properties[key]
-                      semi_collision_map[collision_tile] = semi_collision_tile
-                print(semi_collision_map)
-
+                              cond_collision_tile['exit'] = collision_region.properties[key]
+                      cond_collision_map[collision_tile] = cond_collision_tile
 
         # Similar to collisions, except we need to identify the tiles
         # on either side of the poly-line and prevent moving between
@@ -512,7 +510,7 @@ class Map(object):
                     collision_lines_map.add((top_side_tile, "down"))
                     collision_lines_map.add((bottom_side_tile, "up"))
 
-        return tiles, collision_map, collision_lines_map, semi_collision_map, mapsize
+        return tiles, collision_map, collision_lines_map, cond_collision_map, mapsize
 
     def round_to_divisible(self, x, base=16):
         """Rounds a number to a divisible base. This is used to round collision areas that aren't

--- a/tuxemon/core/components/player.py
+++ b/tuxemon/core/components/player.py
@@ -438,7 +438,7 @@ class Player(object):
         """
 
         collisions = []
-        
+
         current_pos = (player_tile_pos[0], player_tile_pos[1])
         down_tile = (player_tile_pos[0], player_tile_pos[1] + 1)
         up_tile = (player_tile_pos[0], player_tile_pos[1] - 1)
@@ -466,24 +466,24 @@ class Player(object):
 
         # Check to see if the tile above the player is a collision tile.
         if up_tile in collision_set:
-            if down_tile in cond_collision_map: # Used for conditional collision zones
-                if not "down" in cond_collision_map[down_tile]['enter']:
+            if up_tile in cond_collision_map: # Used for conditional collision zones
+                if not "down" in cond_collision_map[up_tile]['enter']:
                     collisions.append("up")
             else: 
                 collisions.append("up")
 
         # Check to see if the tile to the left of the player is a collision tile.
         if left_tile in collision_set:
-            if down_tile in cond_collision_map: # Used for conditional collision zones
-                if not "right" in cond_collision_map[down_tile]['enter']:
+            if left_tile in cond_collision_map: # Used for conditional collision zones
+                if not "right" in cond_collision_map[left_tile]['enter']:
                     collisions.append("left")
             else: 
                 collisions.append("left")
 
         # Check to see if the tile to the right of the player is a collision tile.
         if right_tile in collision_set:
-            if down_tile in cond_collision_map: # Used for conditional collision zones
-                if not "left" in cond_collision_map[down_tile]['enter']:
+            if right_tile in cond_collision_map: # Used for conditional collision zones
+                if not "left" in cond_collision_map[right_tile]['enter']:
                     collisions.append("right")
             else: 
                 collisions.append("right")

--- a/tuxemon/core/components/player.py
+++ b/tuxemon/core/components/player.py
@@ -445,6 +445,7 @@ class Player(object):
         left_tile = (player_tile_pos[0] - 1, player_tile_pos[1])
         right_tile = (player_tile_pos[0] + 1, player_tile_pos[1])
 
+        # Check if the players current position has any limitations.
         if current_pos in semi_collision_map:
             if not "down" in semi_collision_map[current_pos]["exit"]:
                 collisions.append("down")
@@ -457,7 +458,7 @@ class Player(object):
         
         # Check to see if the tile below the player is a collision tile.
         if down_tile in collision_set:
-            if down_tile in semi_collision_map:
+            if down_tile in semi_collision_map: # Used for conditional collision zones
                 if not "up" in semi_collision_map[down_tile]['enter']:
                     collisions.append("down")
             else: 
@@ -465,7 +466,7 @@ class Player(object):
 
         # Check to see if the tile above the player is a collision tile.
         if up_tile in collision_set:
-            if down_tile in semi_collision_map:
+            if down_tile in semi_collision_map: # Used for conditional collision zones
                 if not "down" in semi_collision_map[down_tile]['enter']:
                     collisions.append("up")
             else: 
@@ -473,7 +474,7 @@ class Player(object):
 
         # Check to see if the tile to the left of the player is a collision tile.
         if left_tile in collision_set:
-            if down_tile in semi_collision_map:
+            if down_tile in semi_collision_map: # Used for conditional collision zones
                 if not "right" in semi_collision_map[down_tile]['enter']:
                     collisions.append("left")
             else: 
@@ -481,7 +482,7 @@ class Player(object):
 
         # Check to see if the tile to the right of the player is a collision tile.
         if right_tile in collision_set:
-            if down_tile in semi_collision_map:
+            if down_tile in semi_collision_map: # Used for conditional collision zones
                 if not "left" in semi_collision_map[down_tile]['enter']:
                     collisions.append("right")
             else: 

--- a/tuxemon/core/components/player.py
+++ b/tuxemon/core/components/player.py
@@ -199,7 +199,7 @@ class Player(object):
                 if global_y >= self.move_destination[1] and self.direction["up"]:
 
                     # If the destination tile won't collide with anything, then proceed with moving.
-                    if not "up" in self.collision_check(player_pos, collision_set, game.collision_lines_map, game.semi_collision_map):
+                    if not "up" in self.collision_check(player_pos, collision_set, game.collision_lines_map, game.cond_collision_map):
                         self.moving = True
                         self.move_direction = "up"
 
@@ -224,7 +224,7 @@ class Player(object):
 
                 if global_y <= self.move_destination[1] and self.direction["down"]:
 
-                    if not "down" in self.collision_check(player_pos, collision_set, game.collision_lines_map, game.semi_collision_map):
+                    if not "down" in self.collision_check(player_pos, collision_set, game.collision_lines_map, game.cond_collision_map):
                         self.moving = True
                         self.move_direction = "down"
 
@@ -245,7 +245,7 @@ class Player(object):
 
                 if global_x >= self.move_destination[0] and self.direction["left"]:
 
-                    if not "left" in self.collision_check(player_pos, collision_set, game.collision_lines_map, game.semi_collision_map):
+                    if not "left" in self.collision_check(player_pos, collision_set, game.collision_lines_map, game.cond_collision_map):
                          self.moving = True
                          self.move_direction = "left"
 
@@ -266,7 +266,7 @@ class Player(object):
 
                 if global_x <= self.move_destination[0] and self.direction["right"]:
 
-                    if not "right" in self.collision_check(player_pos, collision_set, game.collision_lines_map, game.semi_collision_map):
+                    if not "right" in self.collision_check(player_pos, collision_set, game.collision_lines_map, game.cond_collision_map):
                         self.moving = True
                         self.move_direction = "right"
 
@@ -292,7 +292,7 @@ class Player(object):
                     self.move_destination = [int(global_x), int(global_y + tile_size[1])]
 
                     # If the destination tile won't collide with anything, then proceed with moving.
-                    if not "up" in self.collision_check(player_pos, collision_set, game.collision_lines_map, game.semi_collision_map):
+                    if not "up" in self.collision_check(player_pos, collision_set, game.collision_lines_map, game.cond_collision_map):
                         self.moving = True
                         self.move_direction = "up"
 
@@ -301,7 +301,7 @@ class Player(object):
                     # Set the destination position we'd wish to reach if we just started walking.
                     self.move_destination = [int(global_x), int(global_y - tile_size[1])]
 
-                    if not "down" in self.collision_check(player_pos, collision_set, game.collision_lines_map, game.semi_collision_map):
+                    if not "down" in self.collision_check(player_pos, collision_set, game.collision_lines_map, game.cond_collision_map):
                         self.moving = True
                         self.move_direction = "down"
 
@@ -310,7 +310,7 @@ class Player(object):
                     # Set the destination position we'd wish to reach if we just started walking.
                     self.move_destination = [int(global_x + tile_size[1]), int(global_y)]
 
-                    if not "left" in self.collision_check(player_pos, collision_set, game.collision_lines_map, game.semi_collision_map):
+                    if not "left" in self.collision_check(player_pos, collision_set, game.collision_lines_map, game.cond_collision_map):
                         self.moving = True
                         self.move_direction = "left"
 
@@ -319,7 +319,7 @@ class Player(object):
                     # Set the destination position we'd wish to reach if we just started walking.
                     self.move_destination = [int(global_x - tile_size[1]), int(global_y)]
 
-                    if not "right" in self.collision_check(player_pos, collision_set, game.collision_lines_map, game.semi_collision_map):
+                    if not "right" in self.collision_check(player_pos, collision_set, game.collision_lines_map, game.cond_collision_map):
                         self.moving = True
                         self.move_direction = "right"
 
@@ -421,7 +421,7 @@ class Player(object):
                                                               self.position[1] + offset))
 
 
-    def collision_check(self, player_tile_pos, collision_set, collision_lines_map, semi_collision_map):
+    def collision_check(self, player_tile_pos, collision_set, collision_lines_map, cond_collision_map):
         """Checks collision tiles around the player.
 
         :param player_pos: An (x, y) list of the player's current tile position. Must be an
@@ -446,44 +446,44 @@ class Player(object):
         right_tile = (player_tile_pos[0] + 1, player_tile_pos[1])
 
         # Check if the players current position has any limitations.
-        if current_pos in semi_collision_map:
-            if not "down" in semi_collision_map[current_pos]["exit"]:
+        if current_pos in cond_collision_map:
+            if not "down" in cond_collision_map[current_pos]["exit"]:
                 collisions.append("down")
-            if not "up" in semi_collision_map[current_pos]["exit"]:
+            if not "up" in cond_collision_map[current_pos]["exit"]:
                 collisions.append("up")
-            if not "left" in semi_collision_map[current_pos]["exit"]:
+            if not "left" in cond_collision_map[current_pos]["exit"]:
                 collisions.append("left")
-            if not "right" in semi_collision_map[current_pos]["exit"]:
+            if not "right" in cond_collision_map[current_pos]["exit"]:
                 collisions.append("right")
         
         # Check to see if the tile below the player is a collision tile.
         if down_tile in collision_set:
-            if down_tile in semi_collision_map: # Used for conditional collision zones
-                if not "up" in semi_collision_map[down_tile]['enter']:
+            if down_tile in cond_collision_map: # Used for conditional collision zones
+                if not "up" in cond_collision_map[down_tile]['enter']:
                     collisions.append("down")
             else: 
                 collisions.append("down")
 
         # Check to see if the tile above the player is a collision tile.
         if up_tile in collision_set:
-            if down_tile in semi_collision_map: # Used for conditional collision zones
-                if not "down" in semi_collision_map[down_tile]['enter']:
+            if down_tile in cond_collision_map: # Used for conditional collision zones
+                if not "down" in cond_collision_map[down_tile]['enter']:
                     collisions.append("up")
             else: 
                 collisions.append("up")
 
         # Check to see if the tile to the left of the player is a collision tile.
         if left_tile in collision_set:
-            if down_tile in semi_collision_map: # Used for conditional collision zones
-                if not "right" in semi_collision_map[down_tile]['enter']:
+            if down_tile in cond_collision_map: # Used for conditional collision zones
+                if not "right" in cond_collision_map[down_tile]['enter']:
                     collisions.append("left")
             else: 
                 collisions.append("left")
 
         # Check to see if the tile to the right of the player is a collision tile.
         if right_tile in collision_set:
-            if down_tile in semi_collision_map: # Used for conditional collision zones
-                if not "left" in semi_collision_map[down_tile]['enter']:
+            if down_tile in cond_collision_map: # Used for conditional collision zones
+                if not "left" in cond_collision_map[down_tile]['enter']:
                     collisions.append("right")
             else: 
                 collisions.append("right")

--- a/tuxemon/core/components/player.py
+++ b/tuxemon/core/components/player.py
@@ -199,7 +199,7 @@ class Player(object):
                 if global_y >= self.move_destination[1] and self.direction["up"]:
 
                     # If the destination tile won't collide with anything, then proceed with moving.
-                    if not "up" in self.collision_check(player_pos, collision_set, game.collision_lines_map):
+                    if not "up" in self.collision_check(player_pos, collision_set, game.collision_lines_map, game.semi_collision_map):
                         self.moving = True
                         self.move_direction = "up"
 
@@ -224,7 +224,7 @@ class Player(object):
 
                 if global_y <= self.move_destination[1] and self.direction["down"]:
 
-                    if not "down" in self.collision_check(player_pos, collision_set, game.collision_lines_map):
+                    if not "down" in self.collision_check(player_pos, collision_set, game.collision_lines_map, game.semi_collision_map):
                         self.moving = True
                         self.move_direction = "down"
 
@@ -245,7 +245,7 @@ class Player(object):
 
                 if global_x >= self.move_destination[0] and self.direction["left"]:
 
-                    if not "left" in self.collision_check(player_pos, collision_set, game.collision_lines_map):
+                    if not "left" in self.collision_check(player_pos, collision_set, game.collision_lines_map, game.semi_collision_map):
                          self.moving = True
                          self.move_direction = "left"
 
@@ -266,7 +266,7 @@ class Player(object):
 
                 if global_x <= self.move_destination[0] and self.direction["right"]:
 
-                    if not "right" in self.collision_check(player_pos, collision_set, game.collision_lines_map):
+                    if not "right" in self.collision_check(player_pos, collision_set, game.collision_lines_map, game.semi_collision_map):
                         self.moving = True
                         self.move_direction = "right"
 
@@ -292,7 +292,7 @@ class Player(object):
                     self.move_destination = [int(global_x), int(global_y + tile_size[1])]
 
                     # If the destination tile won't collide with anything, then proceed with moving.
-                    if not "up" in self.collision_check(player_pos, collision_set, game.collision_lines_map):
+                    if not "up" in self.collision_check(player_pos, collision_set, game.collision_lines_map, game.semi_collision_map):
                         self.moving = True
                         self.move_direction = "up"
 
@@ -301,7 +301,7 @@ class Player(object):
                     # Set the destination position we'd wish to reach if we just started walking.
                     self.move_destination = [int(global_x), int(global_y - tile_size[1])]
 
-                    if not "down" in self.collision_check(player_pos, collision_set, game.collision_lines_map):
+                    if not "down" in self.collision_check(player_pos, collision_set, game.collision_lines_map, game.semi_collision_map):
                         self.moving = True
                         self.move_direction = "down"
 
@@ -310,7 +310,7 @@ class Player(object):
                     # Set the destination position we'd wish to reach if we just started walking.
                     self.move_destination = [int(global_x + tile_size[1]), int(global_y)]
 
-                    if not "left" in self.collision_check(player_pos, collision_set, game.collision_lines_map):
+                    if not "left" in self.collision_check(player_pos, collision_set, game.collision_lines_map, game.semi_collision_map):
                         self.moving = True
                         self.move_direction = "left"
 
@@ -319,7 +319,7 @@ class Player(object):
                     # Set the destination position we'd wish to reach if we just started walking.
                     self.move_destination = [int(global_x - tile_size[1]), int(global_y)]
 
-                    if not "right" in self.collision_check(player_pos, collision_set, game.collision_lines_map):
+                    if not "right" in self.collision_check(player_pos, collision_set, game.collision_lines_map, game.semi_collision_map):
                         self.moving = True
                         self.move_direction = "right"
 
@@ -421,7 +421,7 @@ class Player(object):
                                                               self.position[1] + offset))
 
 
-    def collision_check(self, player_tile_pos, collision_set, collision_lines_map):
+    def collision_check(self, player_tile_pos, collision_set, collision_lines_map, semi_collision_map):
         """Checks collision tiles around the player.
 
         :param player_pos: An (x, y) list of the player's current tile position. Must be an
@@ -439,27 +439,53 @@ class Player(object):
 
         collisions = []
         
+        current_pos = (player_tile_pos[0], player_tile_pos[1])
         down_tile = (player_tile_pos[0], player_tile_pos[1] + 1)
         up_tile = (player_tile_pos[0], player_tile_pos[1] - 1)
         left_tile = (player_tile_pos[0] - 1, player_tile_pos[1])
         right_tile = (player_tile_pos[0] + 1, player_tile_pos[1])
 
+        if current_pos in semi_collision_map:
+            if not "down" in semi_collision_map[current_pos]["exit"]:
+                collisions.append("down")
+            if not "up" in semi_collision_map[current_pos]["exit"]:
+                collisions.append("up")
+            if not "left" in semi_collision_map[current_pos]["exit"]:
+                collisions.append("left")
+            if not "right" in semi_collision_map[current_pos]["exit"]:
+                collisions.append("right")
+        
         # Check to see if the tile below the player is a collision tile.
         if down_tile in collision_set:
-            # if not "down" in collision_set[down_tile][
-            collisions.append("down")
+            if down_tile in semi_collision_map:
+                if not "up" in semi_collision_map[down_tile]['enter']:
+                    collisions.append("down")
+            else: 
+                collisions.append("down")
 
         # Check to see if the tile above the player is a collision tile.
         if up_tile in collision_set:
-            collisions.append("up")
+            if down_tile in semi_collision_map:
+                if not "down" in semi_collision_map[down_tile]['enter']:
+                    collisions.append("up")
+            else: 
+                collisions.append("up")
 
         # Check to see if the tile to the left of the player is a collision tile.
         if left_tile in collision_set:
-            collisions.append("left")
+            if down_tile in semi_collision_map:
+                if not "right" in semi_collision_map[down_tile]['enter']:
+                    collisions.append("left")
+            else: 
+                collisions.append("left")
 
         # Check to see if the tile to the right of the player is a collision tile.
         if right_tile in collision_set:
-            collisions.append("right")
+            if down_tile in semi_collision_map:
+                if not "left" in semi_collision_map[down_tile]['enter']:
+                    collisions.append("right")
+            else: 
+                collisions.append("right")
 
         # From the players current tile, check to see if any nearby tile
         # is separated by a wall

--- a/tuxemon/core/components/player.py
+++ b/tuxemon/core/components/player.py
@@ -438,21 +438,27 @@ class Player(object):
         """
 
         collisions = []
+        
+        down_tile = (player_tile_pos[0], player_tile_pos[1] + 1)
+        up_tile = (player_tile_pos[0], player_tile_pos[1] - 1)
+        left_tile = (player_tile_pos[0] - 1, player_tile_pos[1])
+        right_tile = (player_tile_pos[0] + 1, player_tile_pos[1])
 
         # Check to see if the tile below the player is a collision tile.
-        if (player_tile_pos[0], player_tile_pos[1] + 1) in collision_set:
+        if down_tile in collision_set:
+            # if not "down" in collision_set[down_tile][
             collisions.append("down")
 
         # Check to see if the tile above the player is a collision tile.
-        if (player_tile_pos[0], player_tile_pos[1] - 1) in collision_set:
+        if up_tile in collision_set:
             collisions.append("up")
 
         # Check to see if the tile to the left of the player is a collision tile.
-        if (player_tile_pos[0] - 1, player_tile_pos[1]) in collision_set:
+        if left_tile in collision_set:
             collisions.append("left")
 
         # Check to see if the tile to the right of the player is a collision tile.
-        if (player_tile_pos[0] + 1, player_tile_pos[1]) in collision_set:
+        if right_tile in collision_set:
             collisions.append("right")
 
         # From the players current tile, check to see if any nearby tile

--- a/tuxemon/core/states/world.py
+++ b/tuxemon/core/states/world.py
@@ -97,7 +97,7 @@ class World(tools._State):
 
         # Create a new map instance
         self.current_map = map.Map(prepare.BASEDIR + "resources/maps/%s" % prepare.CONFIG.starting_map)
-        self.tiles, self.collision_map, self.collision_lines_map, self.map_size = \
+        self.tiles, self.collision_map, self.collision_lines_map, self.semi_collision_map, self.map_size = \
             self.current_map.loadfile(self.tile_size)
 
         # Create an empty collision_rectmap list which contains rectangle
@@ -1140,7 +1140,7 @@ class World(tools._State):
                     prepare.BASEDIR + "resources/maps/" + self.delayed_mapname)
                 self.event_engine.current_map = map.Map(
                     prepare.BASEDIR + "resources/maps/" + self.delayed_mapname)
-                self.tiles, self.collision_map, self.collision_lines_map, self.map_size = self.current_map.loadfile(
+                self.tiles, self.collision_map, self.collision_lines_map, self.semi_collision_map, self.map_size = self.current_map.loadfile(
                     self.tile_size)
                 self.game.events = self.current_map.events
 

--- a/tuxemon/core/states/world.py
+++ b/tuxemon/core/states/world.py
@@ -97,7 +97,7 @@ class World(tools._State):
 
         # Create a new map instance
         self.current_map = map.Map(prepare.BASEDIR + "resources/maps/%s" % prepare.CONFIG.starting_map)
-        self.tiles, self.collision_map, self.collision_lines_map, self.semi_collision_map, self.map_size = \
+        self.tiles, self.collision_map, self.collision_lines_map, self.cond_collision_map, self.map_size = \
             self.current_map.loadfile(self.tile_size)
 
         # Create an empty collision_rectmap list which contains rectangle
@@ -1140,7 +1140,7 @@ class World(tools._State):
                     prepare.BASEDIR + "resources/maps/" + self.delayed_mapname)
                 self.event_engine.current_map = map.Map(
                     prepare.BASEDIR + "resources/maps/" + self.delayed_mapname)
-                self.tiles, self.collision_map, self.collision_lines_map, self.semi_collision_map, self.map_size = self.current_map.loadfile(
+                self.tiles, self.collision_map, self.collision_lines_map, self.cond_collision_map, self.map_size = self.current_map.loadfile(
                     self.tile_size)
                 self.game.events = self.current_map.events
 

--- a/tuxemon/resources/maps/healing_center.tmx
+++ b/tuxemon/resources/maps/healing_center.tmx
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="15" height="15" tilewidth="16" tileheight="16" nextobjectid="21">
- <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88">
+<map version="1.0" orientation="orthogonal" renderorder="right-down" width="15" height="15" tilewidth="16" tileheight="16" nextobjectid="22">
+ <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>
  </tileset>
- <tileset firstgid="89" name="furniture" tilewidth="16" tileheight="16" tilecount="72">
+ <tileset firstgid="89" name="furniture" tilewidth="16" tileheight="16">
   <image source="../gfx/tilesets/furniture.png" width="192" height="96"/>
  </tileset>
- <tileset firstgid="161" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312">
+ <tileset firstgid="161" name="setPiecesTSR" tilewidth="16" tileheight="16">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>
  </tileset>
  <layer name="Tile Layer 1" width="15" height="15">
@@ -29,7 +29,7 @@
    eJxjYBgFAwU2sjAwbELCm1loY89q2hg7CqgEADW4BDo=
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collision" visible="0">
+ <objectgroup color="#ff0000" name="Collision">
   <object id="4" type="collision" x="16" y="208" width="208" height="32"/>
   <object id="5" type="collision" x="160" y="160" width="32" height="32"/>
   <object id="6" type="collision" x="176" y="80" width="32" height="16"/>
@@ -39,6 +39,12 @@
   <object id="11" type="collision" x="16" y="48" width="208" height="32"/>
   <object id="12" type="collision" x="-16" y="64" width="32" height="160"/>
   <object id="14" type="collision" x="224" y="64" width="32" height="160"/>
+  <object id="21" type="collision" x="16" y="144" width="16" height="16">
+   <properties>
+    <property name="enter_from" value="right"/>
+    <property name="exit_to" value="right"/>
+   </properties>
+  </object>
  </objectgroup>
  <objectgroup color="#ffff00" name="Events">
   <object id="16" name="Heal Tuxemon" type="event" x="112" y="128" width="16" height="16">

--- a/tuxemon/resources/maps/map1.tmx
+++ b/tuxemon/resources/maps/map1.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="64" height="60" tilewidth="16" tileheight="16" nextobjectid="111">
+<map version="1.0" orientation="orthogonal" renderorder="right-down" width="64" height="60" tilewidth="16" tileheight="16" nextobjectid="112">
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>
  </tileset>
@@ -22,7 +22,7 @@
  </layer>
  <layer name="Tile Layer 2" width="64" height="60">
   <data encoding="base64" compression="zlib">
-   eJztmtduE0EYhcfrHbjhDegE0QTJVYgfIIQ4BMQFTogokaiRECU0Ud4FHoD2MrQbeAhK7ihnZY+2ZHrZje050qdVdrz2f3z23/1th5C+FqgaHZ3D41bAm4SQt+AdeA8+JP39K5rrP1qE/AS/wG+w0Sqv87ijWSNPIs9dif8J7DvJYQp8hJ9P4DP4Ar4m5WNV6zvx9y6wG+wBeyvrPD0K4F+W/5Rk3x/U+xf8y+puE9Jqlx+nWp/F/lNgDpwG82BHKvfg4t9GMv+H4OcwOAKOgmMVf6r1u/B7D9wHD8A6mA7g/xXl83rwXCz7ac55PjN4DOuDycG+rBd7ilqWqD3Lgv6y8X8C7+kk6AneW+a/l+ZUxTsPrmDf1UCsUn7/2Phfgp9lMCs4lvk/nuZsBf+8/nHp/0WFf9P8VbpFcy4XvF2i5TXeY65L+sJUzJ/Kv2n+zwxqKZ4rq4LjdM4n0bEy6fo3zX9d8Hz70K/7wQEwAQ4mm/3zrm1N+a+KN+/MaPrP7t9deFkAZ8AiOMvxz7u23RT0RZHbNfjXFc9/dv9+mN2nwGPwBDzl+FfNBiLZXP9E/lPUStPNW12Jzn/edeuG4znM5NM/mwtstzz/oXqYyad/NhfYbp9zatHt4WvghQUvt1D+G3i+i7S/dZHp69rqwqBO1ueu+ftS3a/rmrtrDq712MpX7iY5zNEyvLW68veVu2kOopkyU4eGz9937qY5yPxnCp2/79x95m9Tn6l8526bf/VaUHf/68pnDt3C58o1wZzQ1H1HpFHrf1PV2f/zNVz/TRX7fzTnP12N+vyvUsw/5h/zj/mH2lbnwGHN39fnhnHL3/X1QqvO/NeGeP6L+cf+b2IuCC0f+XYkv4lU73/nRb8jxvyHNv+QdYSWKt9tbUK2t/PtuOX/LSHke5JvQ+TTkcwFoRX7P/Z/zL+Z/Itzw6jkz+Yb2UxkUkdoxf6P/R/zbzZ/2f+FhJZr/qbXOdM6Qiv09z+iz7u6dYRW3d//mNYRWnV//2daR2iNe/6jpv//lwfq
+   eJztmtlu00AYhSeOB254A3aK2ATtVWkeoFtKQVyQloqlEmslVKBlEcu7wAOwvQzbDTwES+9YjpWM7LizL3aTzJE+WfXEyX9y/Nt/khLS1QJVo6MLeNwKeJMQ8ha8A+/Bh6S7f0Vz/UeDkJ/gF/gNthr96zzuadbIk8hzW+J/DPvOcpgAH+HnE/gMvoCvSf+xqvW9+Hsf2A8OgIOldZ4eBfAvy39Csu8P6v0L/mV1NwlpNPsfp1qfxv4ZMAvmwDzYk8o9uPi3kcz/Mfg5Dk6Ak+BUyZ9qfR1+74MH4CHYAJMB/L+ifF73notlP8k5z6d6j2F9MN7bl/ViR1HLErVnWdBfNv7P4D0dBx3Be8v8d9KcsnjnwTXsux6IVcrvHxv/S/CzDKYFxzL/p9OcneCf1z8u/b+o8G+av0p3aM7VgrcrtH+N95ibkr4wFfOn8m+a/zODWornyqrgOJ3zSXSsTLr+TfPfEDzfIfTrYXAEjIGjyXb/vGtbXf7L4s07U5r+s/t3G14WwDmwCM5z/POubbcFfVHkbgX+dcXzn92/N7P7FHgMnoCnHP+q2UAkm+ufyH+KWmm6fasr0fnPu27dcjyHmXz6Z3OB7ZbnP1QPM/n0z+YC2+1zTi26PXwDvLDg5Q7KfwvPd5l2ty4yfV1bXerVyfrcNX9fqvp1XXN3zcG1Hlv5yt0kh1maM0f5a1Xl7yt30xxEM2WmFg2fv+/cTXOQ+c8UOn/fufvM36Y+U/nO3Tb/4rWgSF33HZF85tAufK5cE8wJdd13RBq2/jdVlf0/X8H131Sx/4dz/tPVsM//KsX8Y/4x/5h/qG15DhzU/H19bhi1/F1fL7SqzH9tgOe/mH/s/zrmgtDykW9L8ptI+f53UfQ7Ysx/YPMPWUdoqfLd1SRkdzPfjlr+3xJCvif5NkQ+LclcEFqx/2P/x/zryb84NwxL/my+kc1EJnWEVuz/2P8x/3rzl/1fSGi55m96nTOtI7RCf/8j+ryrW0doVf39j2kdoVX193+mdYTWqOc/bPoPKR4H6w==
   </data>
  </layer>
  <layer name="Tile Layer 3" width="64" height="60">
@@ -90,15 +90,60 @@
   <object id="51" type="collision" x="576" y="912" width="160" height="48"/>
   <object id="52" type="collision" x="672" y="880" width="64" height="32"/>
   <object id="53" type="collision" x="624" y="624" width="16" height="16"/>
-  <object id="54" type="collision" x="352" y="416" width="128" height="16"/>
-  <object id="55" type="collision" x="544" y="416" width="96" height="16"/>
-  <object id="56" type="collision" x="544" y="352" width="96" height="16"/>
-  <object id="57" type="collision" x="400" y="352" width="112" height="16"/>
-  <object id="58" type="collision" x="352" y="352" width="32" height="16"/>
-  <object id="59" type="collision" x="352" y="288" width="112" height="16"/>
-  <object id="60" type="collision" x="480" y="288" width="32" height="16"/>
-  <object id="61" type="collision" x="544" y="288" width="16" height="16"/>
-  <object id="62" type="collision" x="592" y="288" width="48" height="16"/>
+  <object id="54" type="collision" x="352" y="416" width="128" height="16">
+   <properties>
+    <property name="enter_from" value="up"/>
+    <property name="exit_to" value="down"/>
+   </properties>
+  </object>
+  <object id="55" type="collision" x="544" y="416" width="96" height="16">
+   <properties>
+    <property name="enter_from" value="up"/>
+    <property name="exit_to" value="down"/>
+   </properties>
+  </object>
+  <object id="56" type="collision" x="544" y="352" width="96" height="16">
+   <properties>
+    <property name="enter_from" value="up"/>
+    <property name="exit_to" value="down"/>
+   </properties>
+  </object>
+  <object id="57" type="collision" x="400" y="352" width="112" height="16">
+   <properties>
+    <property name="enter_from" value="up"/>
+    <property name="exit_to" value="down"/>
+   </properties>
+  </object>
+  <object id="58" type="collision" x="352" y="352" width="32" height="16">
+   <properties>
+    <property name="enter_from" value="up"/>
+    <property name="exit_to" value="down"/>
+   </properties>
+  </object>
+  <object id="59" type="collision" x="352" y="288" width="112" height="16">
+   <properties>
+    <property name="enter" value="up"/>
+    <property name="exit" value="down"/>
+   </properties>
+  </object>
+  <object id="60" type="collision" x="480" y="288" width="32" height="16">
+   <properties>
+    <property name="enter" value="up"/>
+    <property name="exit" value="down"/>
+   </properties>
+  </object>
+  <object id="61" type="collision" x="544" y="288" width="16" height="16">
+   <properties>
+    <property name="enter" value="up"/>
+    <property name="exit" value="down"/>
+   </properties>
+  </object>
+  <object id="62" type="collision" x="592" y="288" width="48" height="16">
+   <properties>
+    <property name="enter" value="up"/>
+    <property name="exit" value="down"/>
+   </properties>
+  </object>
   <object id="63" type="collision" x="576" y="0" width="32" height="48"/>
   <object id="64" type="collision" x="528" y="192" width="16" height="16"/>
   <object id="65" type="collision" x="288" y="64" width="16" height="16"/>


### PR DESCRIPTION
## Description
This PR closes issue #41. Conditional collision zones work and look just like normal collision zones. The only difference is that you add properties to them. Currently they only take 2 properties: `enter`, and `exit`. Each property can have a value of multiple directions separated by a space. The code only looks for the keyword "enter" or "exit" meaning you can name them enter_from and exit_to to make it easier to understand. 
## Changes Made
* Add logic for enter and exit properties on collision zones
* Implement the feature to make one-way ledges on map1 (note: does not include the jump animation)
* Implement the feature on the stairs in the healing center (can only enter and exit on the right)

## Example
If for some reason I want to have a zone that can only be entered from the tile above and only exited to the left or right, the properties in Tiled would look like this:

**Properties:**
* enter_from: 
 * up
* exit_to: 
 * left right

Note that this is per tile in the zone. So once you are in a conditional collision zone, these rules apply for each tile within it. 