### PR TITLE
Making keybindings configurable

### DIFF
--- a/tuxemon/core/components/config.py
+++ b/tuxemon/core/components/config.py
@@ -39,12 +39,12 @@ class Config(object):
         self.config = ConfigParser.ConfigParser()
         self.config.read(file)
 
-	self.key_up = self.config.get("keybindings", "up")
-	self.key_down = self.config.get("keybindings", "down")
-	self.key_left = self.config.get("keybindings", "left")
-	self.key_right = self.config.get("keybindings", "right")
-	self.key_action = self.config.get("keybindings", "action")
-	self.key_menu = self.config.get("keybindings", "menu")
+	self.key_up = eval('pygame.' + self.config.get("keybindings", "up"))
+	self.key_down = eval('pygame.' + self.config.get("keybindings", "down"))
+	self.key_left = eval('pygame.' + self.config.get("keybindings", "left"))
+	self.key_right = eval('pygame.' + self.config.get("keybindings", "right"))
+	self.key_action = eval('pygame.' + self.config.get("keybindings", "action"))
+	self.key_menu = eval('pygame.' + self.config.get("keybindings", "menu"))
         
         self.resolution_x = self.config.get("display", "resolution_x")
         self.resolution_y = self.config.get("display", "resolution_y")

--- a/tuxemon/core/components/config.py
+++ b/tuxemon/core/components/config.py
@@ -38,6 +38,13 @@ class Config(object):
     def __init__(self, file="tuxemon.cfg"):
         self.config = ConfigParser.ConfigParser()
         self.config.read(file)
+
+	self.key_up = self.config.get("keybindings", "up")
+	self.key_down = self.config.get("keybindings", "down")
+	self.key_left = self.config.get("keybindings", "left")
+	self.key_right = self.config.get("keybindings", "right")
+	self.key_action = self.config.get("keybindings", "action")
+	self.key_menu = self.config.get("keybindings", "menu")
         
         self.resolution_x = self.config.get("display", "resolution_x")
         self.resolution_y = self.config.get("display", "resolution_y")

--- a/tuxemon/core/components/event/actions/core.py
+++ b/tuxemon/core/components/event/actions/core.py
@@ -25,12 +25,15 @@
 #
 
 import logging
+from .... import prepare
 
 # Create a logger for optional handling of debug messages.
 logger = logging.getLogger(__name__)
 
 
 class Core(object):
+    
+    from .... import prepare
 
     def set_variable(self, game, action):
         """Sets the key in the player.game_variables dictionary.
@@ -165,6 +168,7 @@ class Core(object):
         ('wait_for_secs', '2.0')
 
         """
+	from .... import prepare
         secs = float(action[1])
         game.event_engine.state = "waiting"
         game.event_engine.wait = secs
@@ -193,6 +197,7 @@ class Core(object):
         ('wait_for_input', 'K_RETURN')
 
         """
+	from .... import prepare
         button = str(action[1])
         game.event_engine.state = "waiting for input"
         game.event_engine.wait = 2

--- a/tuxemon/core/components/menu/__init__.py
+++ b/tuxemon/core/components/menu/__init__.py
@@ -588,7 +588,7 @@ class Menu(UserInterface):
             return False
 
         # If the down key was pressed, move our selection down.
-        if event.type == pygame.KEYDOWN and event.key == pygame.K_DOWN:
+        if event.type == pygame.KEYDOWN and event.key == prepare.CONFIG.key_down:
 
             self.selected_menu_item += self.columns
             if self.selected_menu_item > len(self.menu_items) -1:
@@ -600,7 +600,7 @@ class Menu(UserInterface):
 
 
         # If the up key was pressed, move our selection up.
-        if event.type == pygame.KEYDOWN and event.key == pygame.K_UP:
+        if event.type == pygame.KEYDOWN and event.key == prepare.CONFIG.key_up:
 
             # Get the total number of rows based on the number of items divided by the number of columns
             total_rows = len(self.menu_items) / self.columns
@@ -620,7 +620,7 @@ class Menu(UserInterface):
 
 
         # If the right key was pressed, move our selection to the right.
-        if event.type == pygame.KEYDOWN and event.key == pygame.K_RIGHT:
+        if event.type == pygame.KEYDOWN and event.key == prepare.CONFIG.key_right:
 
             # If the next selected menu item is PERFECTLY divisble by the product of the number of
             # columns times the selected row, then we need to go BACK to the beginning of the row
@@ -635,7 +635,7 @@ class Menu(UserInterface):
 
 
         # If the left key was pressed, move our selection to the left.
-        if event.type == pygame.KEYDOWN and event.key == pygame.K_LEFT:
+        if event.type == pygame.KEYDOWN and event.key == prepare.CONFIG.key_left:
 
             # If the previos selected menu item is PERFECTLY divisble by the product of the number
             # of columns times the previous selected row, then we need to go BACK to the beginning
@@ -656,7 +656,7 @@ class Menu(UserInterface):
 
 
         # Handle the player pressing ENTER on one of the selected letters.
-        if input_allowed and event.type == pygame.KEYDOWN and event.key == pygame.K_RETURN:
+        if input_allowed and event.type == pygame.KEYDOWN and event.key == prepare.CONFIG.key_action:
 
             # If the "CLR" button was selected, delete the last character from our name
             if self.menu_items[self.selected_menu_item] == "CLR":

--- a/tuxemon/core/components/menu/dialog_menu.py
+++ b/tuxemon/core/components/menu/dialog_menu.py
@@ -1,6 +1,7 @@
 
 import pygame
 from core.components.menu import Menu
+from ... import prepare
 
 class DialogMenu(Menu):
 
@@ -13,7 +14,7 @@ class DialogMenu(Menu):
 
     def get_event(self, event):
 
-        if event.type == pygame.KEYDOWN and event.key == pygame.K_RETURN:
+        if event.type == pygame.KEYDOWN and event.key == prepare.CONFIG.key_action:
 
             # Hide the menu
             self.visible = False

--- a/tuxemon/core/components/menu/item_menu.py
+++ b/tuxemon/core/components/menu/item_menu.py
@@ -169,7 +169,7 @@ class ItemMenu(Menu):
 
     def get_event(self, event, game):
         # Handle when the player presses "ESC".
-        if event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+        if event.type == pygame.KEYDOWN and event.key == prepare.CONFIG.key_menu:
 
             # If the "ESC" key was pressed while the decision menu was up, close it.
             if self.decision_menu.visible:
@@ -190,7 +190,7 @@ class ItemMenu(Menu):
 
 
         # Handle when the player presses "ENTER"
-        elif event.type == pygame.KEYDOWN and event.key == pygame.K_RETURN: #and len(self.menu_items) > 0:
+        elif event.type == pygame.KEYDOWN and event.key == prepare.CONFIG.key_action: #and len(self.menu_items) > 0:
             # Decision Menu
             if self.decision_menu.interactable:
                 if self.decision_menu.menu_items[self.decision_menu.selected_menu_item] == "Cancel":
@@ -240,7 +240,7 @@ class ItemMenu(Menu):
                     self.item_list.interactable = False
 
         # Handle when the player presses "Up"
-        elif event.type == pygame.KEYDOWN and event.key == pygame.K_UP:
+        elif event.type == pygame.KEYDOWN and event.key == prepare.CONFIG.key_up:
 
             # Handle the decision submenu.
             if self.decision_menu.interactable:
@@ -262,7 +262,7 @@ class ItemMenu(Menu):
 
 
         # Handle when the player presses "Down"
-        elif event.type == pygame.KEYDOWN and event.key == pygame.K_DOWN:
+        elif event.type == pygame.KEYDOWN and event.key == prepare.CONFIG.key_down:
 
             # Handle the decision submenu.
             if self.decision_menu.interactable:

--- a/tuxemon/core/components/menu/main_menu.py
+++ b/tuxemon/core/components/menu/main_menu.py
@@ -43,14 +43,14 @@ class MainMenu(Menu):
         if len(self.menu_items) > 0:
             self.line_spacing = (self.size_y / len(self.menu_items)) - self.font_size
 
-        if event.type == pygame.KEYDOWN and event.key == pygame.K_DOWN:
+        if event.type == pygame.KEYDOWN and event.key == prepare.CONFIG.key_down:
             self.selected_menu_item += 1
             if self.selected_menu_item > len(self.menu_items) -1:
                 self.selected_menu_item = 0
 
             self.menu_select_sound.play()
 
-        if event.type == pygame.KEYDOWN and event.key == pygame.K_UP:
+        if event.type == pygame.KEYDOWN and event.key == prepare.CONFIG.key_up:
             self.selected_menu_item -= 1
             if self.selected_menu_item < 0:
                 self.selected_menu_item = len(self.menu_items) -1
@@ -59,7 +59,7 @@ class MainMenu(Menu):
 
 
         # If the player presses Enter while a menu item is selected
-        if event.type == pygame.KEYDOWN and event.key == pygame.K_RETURN:
+        if event.type == pygame.KEYDOWN and event.key == prepare.CONFIG.key_action:
             self.menu_select_sound.play()
 
             if self.menu_items[self.selected_menu_item] == "JOURNAL":

--- a/tuxemon/core/components/menu/monster_menu.py
+++ b/tuxemon/core/components/menu/monster_menu.py
@@ -182,7 +182,7 @@ class MonsterMenu(Menu):
     def get_event(self, event, game):
 
         # Handle when the player presses "ESC".
-        if event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+        if event.type == pygame.KEYDOWN and event.key == prepare.CONFIG.key_menu:
 
             # If the "ESC" key was pressed while the decision menu was up, close it.
             if self.decision_menu.visible:
@@ -202,7 +202,7 @@ class MonsterMenu(Menu):
                     game.state.action_menu.interactable = True
 
 
-        elif event.type == pygame.KEYDOWN and event.key == pygame.K_DOWN:
+        elif event.type == pygame.KEYDOWN and event.key == prepare.CONFIG.key_down:
 
             if self.decision_menu.interactable:
                 pass
@@ -211,7 +211,7 @@ class MonsterMenu(Menu):
                 if self.selected_menu_item >= len(self.game.player1.monsters):
                     self.selected_menu_item = 0
 
-        elif event.type == pygame.KEYDOWN and event.key == pygame.K_UP:
+        elif event.type == pygame.KEYDOWN and event.key == prepare.CONFIG.key_up:
 
             if self.decision_menu.interactable:
                 pass
@@ -223,7 +223,7 @@ class MonsterMenu(Menu):
                     else:
                         self.selected_menu_item = 0
 
-        elif event.type == pygame.KEYDOWN and event.key == pygame.K_RETURN:
+        elif event.type == pygame.KEYDOWN and event.key == prepare.CONFIG.key_action:
 
             if game.state_name == "COMBAT":
                 for player_name, player_dict in self.game.state_dict["COMBAT"].current_players.items():

--- a/tuxemon/core/components/menu/save_menu.py
+++ b/tuxemon/core/components/menu/save_menu.py
@@ -102,17 +102,17 @@ class SaveMenu(Menu):
         
     def get_event(self, event):
         # Handle key events when the menu is visible
-        if event.type == pygame.KEYDOWN and event.key == pygame.K_DOWN:
+        if event.type == pygame.KEYDOWN and event.key == prepare.CONFIG.key_down:
             self.selected_menu_item += 1
             if self.selected_menu_item > self.slots - 1:
                 self.selected_menu_item = 0
 
-        if event.type == pygame.KEYDOWN and event.key == pygame.K_UP:
+        if event.type == pygame.KEYDOWN and event.key == prepare.CONFIG.key_up:
             self.selected_menu_item -= 1
             if self.selected_menu_item < 0:
                 self.selected_menu_item = self.slots - 1
                 
-        if event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+        if event.type == pygame.KEYDOWN and event.key == prepare.CONFIG.key_menu:
             logger.info("Closing save menu!")
             self.visible = False
             self.interactable = False
@@ -120,7 +120,7 @@ class SaveMenu(Menu):
             self.game.main_menu.interactable = True
 
 
-        if event.type == pygame.KEYDOWN and event.key == pygame.K_RETURN and not self.first_run:
+        if event.type == pygame.KEYDOWN and event.key == prepare.CONFIG.key_action and not self.first_run:
             logger.info("Saving!")
             # Save the game!!
             try:

--- a/tuxemon/core/states/combat.py
+++ b/tuxemon/core/states/combat.py
@@ -747,7 +747,7 @@ class Combat(tools._State):
 
         # If the not implemented window is open, send pygame events to it.
         if self.not_implmeneted_menu.interactable:
-            if event.type == pygame.KEYDOWN and event.key == pygame.K_RETURN:
+            if event.type == pygame.KEYDOWN and event.key == prepare.CONFIG.key_action:
                 self.not_implmeneted_menu.visible = False
                 self.not_implmeneted_menu.interactable = False
 
@@ -768,7 +768,7 @@ class Combat(tools._State):
 
 
         # Handle key inputs.
-        if event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+        if event.type == pygame.KEYDOWN and event.key == prepare.CONFIG.key_menu:
             if self.fight_menu.visible:
                 self.fight_menu.visible = False
                 self.fight_menu.interactable = False
@@ -778,7 +778,7 @@ class Combat(tools._State):
 
 
         # If the player presses Enter while a menu item is selected
-        if event.type == pygame.KEYDOWN and event.key == pygame.K_RETURN:
+        if event.type == pygame.KEYDOWN and event.key == prepare.CONFIG.key_action:
 
             ### Action Menu Events ###
             if self.action_menu.interactable:
@@ -1470,7 +1470,7 @@ if __name__ == "__main__":
                         sys.exit()
 
                     # Exit the game if you press ESC
-                    if event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+                    if event.type == pygame.KEYDOWN and event.key == prepare.CONFIG.key_menu:
                         pygame.quit()
                         sys.exit()
 

--- a/tuxemon/core/states/world.py
+++ b/tuxemon/core/states/world.py
@@ -555,7 +555,7 @@ class World(tools._State):
 
         # If the not implemented window is open, send pygame events to it.
         if self.not_implmeneted_menu.interactable:
-            if event.type == pygame.KEYDOWN and event.key == pygame.K_RETURN:
+            if event.type == pygame.KEYDOWN and event.key == prepare.CONFIG.key_action:
                 self.not_implmeneted_menu.visible = False
                 self.not_implmeneted_menu.interactable = False
 
@@ -574,7 +574,7 @@ class World(tools._State):
         if self.dialog_window.visible:
             self.dialog_window.get_event(event)
             self.menu_blocking = True
-            if event.type == pygame.KEYDOWN and event.key == pygame.K_RETURN:
+            if event.type == pygame.KEYDOWN and event.key == prepare.CONFIG.key_action:
                 logger.info("Closing dialog window!")
                 self.dialog_window.state = "closing"
                 self.menu_blocking = False
@@ -592,7 +592,7 @@ class World(tools._State):
             self.exit = True
             self.game.exit = True
 
-        if event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+        if event.type == pygame.KEYDOWN and event.key == prepare.CONFIG.key_menu:
             if self.main_menu.visible and self.main_menu.interactable:
                 logger.info("Closing main menu!")
                 self.main_menu.state = "closing"
@@ -609,16 +609,16 @@ class World(tools._State):
             if event.type == pygame.KEYDOWN:
                 # If we receive an arrow key press, set the facing and
                 # moving direction to that direction
-                if event.key == pygame.K_UP:
+                if event.key == prepare.CONFIG.key_up:
                     self.player1.direction["up"] = True
                     self.player1.facing = "up"
-                if event.key == pygame.K_DOWN:
+                if event.key == prepare.CONFIG.key_down:
                     self.player1.direction["down"] = True
                     self.player1.facing = "down"
-                if event.key == pygame.K_LEFT:
+                if event.key == prepare.CONFIG.key_left:
                     self.player1.direction["left"] = True
                     self.player1.facing = "left"
-                if event.key == pygame.K_RIGHT:
+                if event.key == prepare.CONFIG.key_right:
                     self.player1.direction["right"] = True
                     self.player1.facing = "right"
 
@@ -626,16 +626,16 @@ class World(tools._State):
             if event.type == pygame.KEYUP:
                     # If the player lets go of the key, set the moving
                     # direction to false
-                    if event.key == pygame.K_UP:
+                    if event.key == prepare.CONFIG.key_up:
                         self.player1.direction["up"] = False
 
-                    if event.key == pygame.K_DOWN:
+                    if event.key == prepare.CONFIG.key_down:
                         self.player1.direction["down"] = False
 
-                    if event.key == pygame.K_LEFT:
+                    if event.key == prepare.CONFIG.key_left:
                         self.player1.direction["left"] = False
 
-                    if event.key == pygame.K_RIGHT:
+                    if event.key == prepare.CONFIG.key_right:
                         self.player1.direction["right"] = False
 
         # print self.events

--- a/tuxemon/tuxemon.cfg
+++ b/tuxemon/tuxemon.cfg
@@ -1,10 +1,10 @@
 [keybindings]
-up = K_w
-down = K_s
-left = K_a
-right = K_d
-action = K_j
-menu = K_h
+up = K_UP
+down = K_DOWN
+left = K_LEFT
+right = K_RIGHT
+action = K_RETURN
+menu = K_ESCAPE
 
 [display]
 resolution_x = 1280

--- a/tuxemon/tuxemon.cfg
+++ b/tuxemon/tuxemon.cfg
@@ -1,3 +1,11 @@
+[keybindings]
+up = K_w
+down = K_s
+left = K_a
+right = K_d
+action = K_j
+menu = K_h
+
 [display]
 resolution_x = 1280
 resolution_y = 720


### PR DESCRIPTION
An attempt at making keybindings configurable instead of hardcoded. It works for the most part, except for commands executed through maps (i.e. examining objects) which are still hardcoded to the enter key. As long as the user keeps their action key bound to enter, this shouldn't affect gameplay. Otherwise, the enter key will still be a dedicated examine objects button for now. 
