### PR TITLE
Monster stat increase upon creation

### DIFF
--- a/tuxemon/core/components/event/actions/combat.py
+++ b/tuxemon/core/components/event/actions/combat.py
@@ -102,6 +102,7 @@ class Combat(object):
 
             # Create a monster object for each monster the NPC has in their party.
             current_monster = monster.Monster()
+            current_monster.load_from_db(npc_monster_details['name'])
             current_monster.name = npc_monster_details['name']
             current_monster.monster_id = npc_monster_details['monster_id']
             current_monster.level = npc_monster_details['level']
@@ -117,6 +118,8 @@ class Combat(object):
 
             current_monster.type1 = results['types'][0]
 
+            current_monster.set_level(current_monster.level)
+           
             if len(results['types']) > 1:
                 current_monster.type2 = results['types'][1]
 
@@ -221,6 +224,7 @@ class Combat(object):
 
             # Set the monster's level
             current_monster.level = level
+            current_monster.set_level(current_monster.level)
 
             # Create an NPC object which will be this monster's "trainer"
             npc = player.Npc()

--- a/tuxemon/core/components/event/actions/combat.py
+++ b/tuxemon/core/components/event/actions/combat.py
@@ -102,7 +102,7 @@ class Combat(object):
 
             # Create a monster object for each monster the NPC has in their party.
             current_monster = monster.Monster()
-            current_monster.load_from_db(npc_monster_details['name'])
+            current_monster.load_from_db(npc_monster_details['monster_id'])
             current_monster.name = npc_monster_details['name']
             current_monster.monster_id = npc_monster_details['monster_id']
             current_monster.level = npc_monster_details['level']

--- a/tuxemon/core/components/monster.py
+++ b/tuxemon/core/components/monster.py
@@ -302,6 +302,19 @@ class Monster(object):
         self.level = level
         self.total_experience = self.experience_required_modifier * self.level ** 3
 
+        count = 0
+
+        while count < self.level:
+            hp_up = random.choice(self.hp_modifier)
+            self.hp += hp_up
+            self.current_hp += hp_up
+            self.attack += random.choice(self.attack_modifier)
+            self.defense += random.choice(self.defense_modifier)
+            self.speed += random.choice(self.speed_modifier)
+            self.special_attack += random.choice(self.special_attack_modifier)
+            self.special_defense += random.choice(self.special_defense_modifier)        
+            count += 1
+
     def load_sprites(self, scale):
         """Loads the monster's sprite images as Pygame surfaces.
 

--- a/tuxemon/core/components/monster.py
+++ b/tuxemon/core/components/monster.py
@@ -137,7 +137,7 @@ class Monster(object):
         self.menu_sprite = ""
 
 
-    def load_from_db(self, name):
+    def load_from_db(self, id):
         """Loads and sets this monster's attributes from the monster.db database.
         The monster is looked up in the database by name.
 
@@ -152,12 +152,12 @@ class Monster(object):
         **Examples:**
 
         >>> bulbatux = Monster()
-        >>> bulbatux.load_from_db("Bulbatux")
+        >>> bulbatux.load_from_db(2)
 
         """
 
         # Look up the monster by name and set the attributes in this instance
-        results = monsters.lookup(name)
+        results = monsters.lookup(id)
 
         self.name               = results["name"]
         self.monster_id         = results["id"]

--- a/tuxemon/core/components/monster.py
+++ b/tuxemon/core/components/monster.py
@@ -302,8 +302,9 @@ class Monster(object):
         self.level = level
         self.total_experience = self.experience_required_modifier * self.level ** 3
 
-        count = 0
+        count = 1 
 
+        # For each level between 1 and current, calculate stats 
         while count < self.level:
             hp_up = random.choice(self.hp_modifier)
             self.hp += hp_up


### PR DESCRIPTION
This is a very simple PR to enable stat increase upon monster creation. All I did was implement the level up code and have it cycle through that once for each level of the monster to be created. I also made sure that the `random_encounter` and `start_battle` events call the `set_level` method. I'm not tying to close issue #43 with this PR. I just thought it might be useful as a foundation or outline for a future implementation. 