### PR TITLE
Fix bug that broke normal teleports after adding cond_collision

### DIFF
--- a/tuxemon/core/components/event/actions/player.py
+++ b/tuxemon/core/components/event/actions/player.py
@@ -94,7 +94,7 @@ class Player(object):
                     prepare.BASEDIR + "resources/maps/" + mapname)
                 world.event_engine.current_map = Map(
                     prepare.BASEDIR + "resources/maps/" + mapname)
-                world.tiles, world.collision_map, world.collision_lines_map, world.map_size = world.current_map.loadfile(
+                world.tiles, world.collision_map, world.collision_lines_map, world.cond_collision_map, world.map_size = world.current_map.loadfile(
                     world.tile_size)
                 world.game.events = world.current_map.events
 


### PR DESCRIPTION
I realized after the conditional collision zones were added that non-transition teleports weren't working. Looks like I just forgot to add the cond_collision_map variable in one spot. This should fix it though.