### PR TITLE
Add new version of monster stats

### DIFF
--- a/tuxemon/core/components/monster.py
+++ b/tuxemon/core/components/monster.py
@@ -258,6 +258,47 @@ class Monster(object):
             #Level up worthy monsters
             self.level_up()
 
+    def set_stats(self):
+        """Sets the monsters initial stats, or imporves stats 
+        when called during a level up. If this is being called
+        when the game is creating a monster, it should be looped
+        through. Once for each level of the monster being created.
+
+        :rtype: None
+        :returns: None
+        
+        **Example:**
+
+
+        """
+        if self.level < 10:
+            level = 10
+        else:
+            level = self.level
+
+        hp_up = int(self.hp * 0.1 + random.choice(self.hp_modifier) * (level / 10))
+        self.current_hp += hp_up
+        self.hp += hp_up
+
+        self.attack += int(
+            self.attack * 0.1 + random.choice(self.attack_modifier) * (level / 10))
+        self.defense += int(
+            self.defense * 0.1 + random.choice(self.defense_modifier) * (level / 10))
+        self.speed += int(
+            self.speed * 0.1 + random.choice(self.speed_modifier) * (level / 10))
+        self.special_attack += int(
+            self.special_attack * 0.1 + random.choice(self.special_attack_modifier) * (level / 10))
+        self.special_defense += int(
+            self.special_defense * 0.1 + random.choice(self.special_defense_modifier) * (level / 10))
+
+        # print "---- Level: %s ----" % self.level
+        # print "HP:", self.hp
+        # print "Attack:", self.attack
+        # print "Defense:", self.defense
+        # print "Speed:", self.speed
+        # print "Spc Atk:", self.special_attack
+        # print "Spc Def:", self.special_defense
+
     def level_up(self):
         """Increases a Monster's level by one and increases stats
         accordingly
@@ -268,14 +309,7 @@ class Monster(object):
         logger.info("Leveling %s from %i to %i!" % (self.name, self.level, self.level + 1))
         #Increase Level and stats
         self.level += 1
-        hp_up = random.choice(self.hp_modifier)
-        self.hp += hp_up
-        self.current_hp += hp_up
-        self.attack += random.choice(self.attack_modifier)
-        self.defense += random.choice(self.defense_modifier)
-        self.speed += random.choice(self.speed_modifier)
-        self.special_attack += random.choice(self.special_attack_modifier)
-        self.special_defense += random.choice(self.special_defense_modifier)
+        self.set_stats()
 
         #Learn New Moves
         for move in self.moveset:
@@ -302,19 +336,12 @@ class Monster(object):
         self.level = level
         self.total_experience = self.experience_required_modifier * self.level ** 3
 
-        count = 1 
+        count = 0 
 
         # For each level between 1 and current, calculate stats 
         while count < self.level:
-            hp_up = random.choice(self.hp_modifier)
-            self.hp += hp_up
-            self.current_hp += hp_up
-            self.attack += random.choice(self.attack_modifier)
-            self.defense += random.choice(self.defense_modifier)
-            self.speed += random.choice(self.speed_modifier)
-            self.special_attack += random.choice(self.special_attack_modifier)
-            self.special_defense += random.choice(self.special_defense_modifier)        
             count += 1
+            self.set_stats()
 
     def load_sprites(self, scale):
         """Loads the monster's sprite images as Pygame surfaces.

--- a/tuxemon/core/components/monster.py
+++ b/tuxemon/core/components/monster.py
@@ -169,12 +169,36 @@ class Monster(object):
         self.special_attack     = results["special_attack_base"]
         self.special_defense    = results["special_defense_base"]
 
-        self.hp_modifier        = results["hp_mod"]
-        self.attack_modifier    = results["attack_mod"]
-        self.defense_modifier   = results["defense_mod"]
-        self.speed_modifier     = results["speed_mod"]
-        self.special_attack_modifier = results["special_attack_mod"]
-        self.special_defense_modifier = results["special_defense_mod"]
+        self.hp_modifier = (
+            results["hp_mod"] - 1,
+            results["hp_mod"],
+            results["hp_mod"] + 1 
+            )
+        self.attack_modifier = (
+            results["attack_mod"] - 1,
+            results["attack_mod"],
+            results["attack_mod"] + 1
+            )
+        self.defense_modifier = (
+            results["defense_mod"] - 1,
+            results["defense_mod"],
+            results["defense_mod"] + 1,
+            )
+        self.speed_modifier = (
+            results["speed_mod"] - 1,
+            results["speed_mod"],
+            results["speed_mod"] + 1,
+            )
+        self.special_attack_modifier = (
+            results["special_attack_mod"] - 1,
+            results["special_attack_mod"],
+            results["special_attack_mod"] + 1,
+            )
+        self.special_defense_modifier = (
+            results["special_defense_mod"] - 1,
+            results["special_defense_mod"],
+            results["special_defense_mod"] + 1,
+            )
         self.experience_give_modifier = results["exp_give_mod"]
         self.experience_required_modifier = results["exp_req_mod"]
 

--- a/tuxemon/core/components/monster.py
+++ b/tuxemon/core/components/monster.py
@@ -315,13 +315,15 @@ class Monster(object):
         self.special_defense += int(
             self.special_defense * 0.1 + random.choice(self.special_defense_modifier) * (level / 10))
 
-        print "---- Level: %s ----" % self.level
+        # Display stats each time they are calculated 
+        """print "---- Level: %s ----" % self.level
         print "HP:", self.hp
         print "Attack:", self.attack
         print "Defense:", self.defense
         print "Speed:", self.speed
         print "Spc Atk:", self.special_attack
         print "Spc Def:", self.special_defense
+        """
 
     def level_up(self):
         """Increases a Monster's level by one and increases stats

--- a/tuxemon/core/components/monster.py
+++ b/tuxemon/core/components/monster.py
@@ -291,13 +291,13 @@ class Monster(object):
         self.special_defense += int(
             self.special_defense * 0.1 + random.choice(self.special_defense_modifier) * (level / 10))
 
-        # print "---- Level: %s ----" % self.level
-        # print "HP:", self.hp
-        # print "Attack:", self.attack
-        # print "Defense:", self.defense
-        # print "Speed:", self.speed
-        # print "Spc Atk:", self.special_attack
-        # print "Spc Def:", self.special_defense
+        print "---- Level: %s ----" % self.level
+        print "HP:", self.hp
+        print "Attack:", self.attack
+        print "Defense:", self.defense
+        print "Speed:", self.speed
+        print "Spc Atk:", self.special_attack
+        print "Spc Def:", self.special_defense
 
     def level_up(self):
         """Increases a Monster's level by one and increases stats

--- a/tuxemon/resources/db/monster/bamboon.json
+++ b/tuxemon/resources/db/monster/bamboon.json
@@ -1,23 +1,23 @@
 {
-    "attack_base": 60, 
-    "attack_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
-    "defense_base": 7, 
-    "defense_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
-    "hp_base": 50, 
-    "hp_mod": [
-        0.9, 
-        1.0, 
-        1.1
-    ], 
     "id": 1, 
+
+    "attack_base":            60, 
+    "defense_base":           7, 
+    "hp_base":                50, 
+    "special_attack_base":    6, 
+    "special_defense_base":   10, 
+    "speed_base":             7,
+ 
+    "attack_mod":             1, 
+    "defense_mod":            1,
+    "hp_mod":                 1, 
+    "special_attack_mod":     1,
+    "special_defense_mod":    1,
+    "speed_mod":              1,
+
+    "exp_give_mod":           2,
+    "exp_req_mod":            25,
+
     "moveset": [
         {
             "level_learned": 2, 
@@ -29,24 +29,6 @@
         }
     ], 
     "name": "Bamboon", 
-    "special_attack_base": 6, 
-    "special_attack_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
-    "special_defense_base": 10, 
-    "special_defense_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
-    "speed_base": 7, 
-    "speed_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
     "sprites": {
         "battle1": "resources/gfx/sprites/battle/bamboon-front.png", 
         "battle2": "resources/gfx/sprites/battle/bamboon-back.png", 
@@ -56,7 +38,5 @@
     "types": [
         "wood"
     ], 
-    "weight": 30,
-    "exp_give_mod": 2,
-    "exp_req_mod": 25
+    "weight": 30
 }

--- a/tuxemon/resources/db/monster/bigfin.json
+++ b/tuxemon/resources/db/monster/bigfin.json
@@ -1,23 +1,23 @@
 {
-    "attack_base": 60, 
-    "attack_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
-    "defense_base": 7, 
-    "defense_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
-    "hp_base": 50, 
-    "hp_mod": [
-        0.9, 
-        1.0, 
-        1.1
-    ], 
     "id": 4, 
+
+    "attack_base":            60, 
+    "defense_base":           7, 
+    "hp_base":                50,   
+    "special_attack_base":    6, 
+    "special_defense_base":   10, 
+    "speed_base":             7, 
+
+    "attack_mod":             1, 
+    "defense_mod":            1,
+    "hp_mod":                 1,
+    "special_attack_mod":     1,
+    "special_defense_mod":    1,
+    "speed_mod":              1,
+
+    "exp_give_mod":           3,
+    "exp_req_mod":            27,
+
     "moveset": [
         {
             "level_learned": 2, 
@@ -29,24 +29,6 @@
         }
     ], 
     "name": "Bigfin", 
-    "special_attack_base": 6, 
-    "special_attack_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
-    "special_defense_base": 10, 
-    "special_defense_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
-    "speed_base": 7, 
-    "speed_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
     "sprites": {
         "battle1": "resources/gfx/sprites/battle/bigfin-front.png", 
         "battle2": "resources/gfx/sprites/battle/bigfin-back.png", 
@@ -57,7 +39,5 @@
         "water",
         "wood"
     ], 
-    "weight": 50,
-    "exp_give_mod": 3,
-    "exp_req_mod": 27
+    "weight": 50
 }

--- a/tuxemon/resources/db/monster/bolt.json
+++ b/tuxemon/resources/db/monster/bolt.json
@@ -1,23 +1,23 @@
 {
-    "attack_base": 60, 
-    "attack_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
-    "defense_base": 7, 
-    "defense_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
-    "hp_base": 50, 
-    "hp_mod": [
-        0.9, 
-        1.0, 
-        1.1
-    ], 
     "id": 7, 
+
+    "attack_base":            60, 
+    "defense_base":           7, 
+    "hp_base":                50, 
+    "special_attack_base":    6, 
+    "special_defense_base":   10, 
+    "speed_base":             7, 
+
+    "attack_mod":             1,
+    "defense_mod":            1,
+    "hp_mod":                 1, 
+    "special_attack_mod":     1,
+    "special_defense_mod":    1, 
+    "speed_mod":              1, 
+
+    "exp_give_mod":           3,
+    "exp_req_mod":            27,
+
     "moveset": [
         {
             "level_learned": 2, 
@@ -29,24 +29,6 @@
         }
     ], 
     "name": "Bolt", 
-    "special_attack_base": 6, 
-    "special_attack_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
-    "special_defense_base": 10, 
-    "special_defense_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
-    "speed_base": 7, 
-    "speed_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
     "sprites": {
         "battle1": "resources/gfx/sprites/battle/bolt-front.png", 
         "battle2": "resources/gfx/sprites/battle/bolt-back.png", 
@@ -56,7 +38,5 @@
     "types": [
         "metal"
     ], 
-    "weight": 25,
-    "exp_give_mod": 3,
-    "exp_req_mod": 27
+    "weight": 25
 }

--- a/tuxemon/resources/db/monster/djinnbo.json
+++ b/tuxemon/resources/db/monster/djinnbo.json
@@ -1,23 +1,23 @@
 {
-    "attack_base": 60, 
-    "attack_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
-    "defense_base": 7, 
-    "defense_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
-    "hp_base": 50, 
-    "hp_mod": [
-        0.9, 
-        1.0, 
-        1.1
-    ], 
     "id": 5, 
+
+    "attack_base":            60, 
+    "defense_base":           7, 
+    "hp_base":                50, 
+    "special_attack_base":    6, 
+    "special_defense_base":   10, 
+    "speed_base":             7, 
+
+    "attack_mod":             1, 
+    "defense_mod":            1,
+    "hp_mod":                 1,
+    "special_attack_mod":     1,
+    "special_defense_mod":    1,
+    "speed_mod":              1,
+
+    "exp_give_mod":           3,
+    "exp_req_mod":            27,
+
     "moveset": [
         {
             "level_learned": 2, 
@@ -29,24 +29,6 @@
         }
     ], 
     "name": "Djinnbo", 
-    "special_attack_base": 6, 
-    "special_attack_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
-    "special_defense_base": 10, 
-    "special_defense_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
-    "speed_base": 7, 
-    "speed_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
     "sprites": {
         "battle1": "resources/gfx/sprites/battle/djinnbo-front.png", 
         "battle2": "resources/gfx/sprites/battle/djinnbo-back.png", 
@@ -57,7 +39,5 @@
         "water",
         "wood"
     ], 
-    "weight": 50,
-    "exp_give_mod": 3,
-    "exp_req_mod": 27
+    "weight": 50
 }

--- a/tuxemon/resources/db/monster/eyenemy.json
+++ b/tuxemon/resources/db/monster/eyenemy.json
@@ -1,23 +1,23 @@
 {
-    "attack_base": 60, 
-    "attack_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
-    "defense_base": 7, 
-    "defense_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
-    "hp_base": 50, 
-    "hp_mod": [
-        0.9, 
-        1.0, 
-        1.1
-    ], 
     "id": 8, 
+
+    "attack_base":            60, 
+    "defense_base":           7, 
+    "hp_base":                50, 
+    "special_attack_base":    6, 
+    "special_defense_base":   10, 
+    "speed_base":             7, 
+
+    "attack_mod":             1,
+    "defense_mod":            1,
+    "hp_mod":                 1,
+    "special_attack_mod":     1,
+    "special_defense_mod":    1, 
+    "speed_mod":              1,
+
+    "exp_give_mod":           3,
+    "exp_req_mod":            27,
+
     "moveset": [
         {
             "level_learned": 2, 
@@ -29,24 +29,6 @@
         }
     ], 
     "name": "Eyenemy", 
-    "special_attack_base": 6, 
-    "special_attack_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
-    "special_defense_base": 10, 
-    "special_defense_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
-    "speed_base": 7, 
-    "speed_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
     "sprites": {
         "battle1": "resources/gfx/sprites/battle/eyenemy-front.png", 
         "battle2": "resources/gfx/sprites/battle/eyenemy-back.png", 
@@ -57,7 +39,5 @@
         "wood",
         "poison"
     ], 
-    "weight": 25,
-    "exp_give_mod": 3,
-    "exp_req_mod": 27
+    "weight": 25
 }

--- a/tuxemon/resources/db/monster/nut.json
+++ b/tuxemon/resources/db/monster/nut.json
@@ -1,23 +1,23 @@
 {
-    "attack_base": 60, 
-    "attack_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
-    "defense_base": 7, 
-    "defense_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
-    "hp_base": 50, 
-    "hp_mod": [
-        0.9, 
-        1.0, 
-        1.1
-    ], 
     "id": 6, 
+
+    "attack_base":            60, 
+    "defense_base":           7, 
+    "hp_base":                50, 
+    "special_attack_base":    6, 
+    "special_defense_base":   10, 
+    "speed_base":             7, 
+
+    "attack_mod":             1,
+    "defense_mod":            1,
+    "hp_mod":                 1,
+    "special_attack_mod":     1,
+    "special_defense_mod":    1, 
+    "speed_mod":              1,
+
+    "exp_give_mod":           3,
+    "exp_req_mod":            27,
+
     "moveset": [
         {
             "level_learned": 2, 
@@ -29,24 +29,6 @@
         }
     ], 
     "name": "Nut", 
-    "special_attack_base": 6, 
-    "special_attack_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
-    "special_defense_base": 10, 
-    "special_defense_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
-    "speed_base": 7, 
-    "speed_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
     "sprites": {
         "battle1": "resources/gfx/sprites/battle/nut-front.png", 
         "battle2": "resources/gfx/sprites/battle/nut-back.png", 
@@ -56,7 +38,5 @@
     "types": [
         "metal"
     ], 
-    "weight": 25,
-    "exp_give_mod": 3,
-    "exp_req_mod": 27
+    "weight": 25
 }

--- a/tuxemon/resources/db/monster/rockitten.json
+++ b/tuxemon/resources/db/monster/rockitten.json
@@ -1,23 +1,23 @@
 {
-    "attack_base": 60, 
-    "attack_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
-    "defense_base": 7, 
-    "defense_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
-    "hp_base": 50, 
-    "hp_mod": [
-        0.9, 
-        1.0, 
-        1.1
-    ], 
     "id": 2, 
+
+    "attack_base":            60, 
+    "defense_base":           7, 
+    "hp_base":                50, 
+    "special_attack_base":    6, 
+    "special_defense_base":   10, 
+    "speed_base":             7, 
+
+    "attack_mod":             1,
+    "defense_mod":            1,
+    "hp_mod":                 1,
+    "special_attack_mod":     1,
+    "special_defense_mod":    1,
+    "speed_mod":              1,
+
+    "exp_give_mod":           3,
+    "exp_req_mod":            27,
+
     "moveset": [
         {
             "level_learned": 2, 
@@ -29,24 +29,6 @@
         }
     ], 
     "name": "Rockitten", 
-    "special_attack_base": 6, 
-    "special_attack_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
-    "special_defense_base": 10, 
-    "special_defense_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
-    "speed_base": 7, 
-    "speed_mod": [
-        1.0, 
-        1.1, 
-        1.2
-    ], 
     "sprites": {
         "battle1": "resources/gfx/sprites/battle/rockitten-front.png", 
         "battle2": "resources/gfx/sprites/battle/rockitten-back.png", 
@@ -56,7 +38,5 @@
     "types": [
         "earth"
     ], 
-    "weight": 25,
-    "exp_give_mod": 3,
-    "exp_req_mod": 27
+    "weight": 25
 }

--- a/tuxemon/resources/db/monster/template.json
+++ b/tuxemon/resources/db/monster/template.json
@@ -1,5 +1,5 @@
 {
-    "id": 3, 
+    "id":   0,
 
     "attack_base":            60, 
     "defense_base":           7, 
@@ -11,12 +11,12 @@
     "attack_mod":             1,
     "defense_mod":            1,
     "hp_mod":                 1,
-    "special_attack_mod":     1, 
+    "special_attack_mod":     1,
     "special_defense_mod":    1,
     "speed_mod":              1,
 
-    "exp_give_mod": 3,
-    "exp_req_mod": 27,
+    "exp_give_mod":           3,
+    "exp_req_mod":            27,
 
     "moveset": [
         {
@@ -28,15 +28,15 @@
             "technique_id": 2
         }
     ], 
-    "name": "Fruitera", 
+    "name": "Template", 
     "sprites": {
-        "battle1": "resources/gfx/sprites/battle/fruitera-front.png", 
-        "battle2": "resources/gfx/sprites/battle/fruitera-back.png", 
-        "menu1": "resources/gfx/sprites/battle/fruitera-menu01.png", 
-        "menu2": "resources/gfx/sprites/battle/fruitera-menu02.png"
+        "battle1": "resources/gfx/sprites/battle/template-front.png", 
+        "battle2": "resources/gfx/sprites/battle/template-back.png", 
+        "menu1": "resources/gfx/sprites/battle/template-menu01.png", 
+        "menu2": "resources/gfx/sprites/battle/template-menu02.png"
     }, 
     "types": [
-        "wood"
+        "earth"
     ], 
     "weight": 25
 }


### PR DESCRIPTION
This PR addresses issue #43, and includes only the Nature Points discussed in [this thread](https://forum.tuxemon.org/viewtopic.php?id=64). I also updated each of the JSON files in the monster db to fit the new system and changed the way they are imported to make the JSON files cleaner and easier to create. Currently, their stat modifiers are all set to 1.