### PR TITLE
Fixes for #63

### DIFF
--- a/tuxemon/core/components/event/actions/combat.py
+++ b/tuxemon/core/components/event/actions/combat.py
@@ -23,11 +23,16 @@
 #
 # William Edwards <shadowapex@gmail.com>
 #
+from __future__ import absolute_import
 
 import logging
 import random
 
-# from core import prepare
+from core import prepare
+from core.components import ai
+from core.components import db
+from core.components import monster
+from core.components import player
 
 # Create a logger for optional handling of debug messages.
 logger = logging.getLogger(__name__)
@@ -63,20 +68,14 @@ class Combat(object):
         ... (u'start_battle', u'1', 1, 9)
 
         """
-        prepare = game.imports["prepare"]
-        ai = game.imports["ai"]
-        db = game.imports["db"]
-        monster = game.imports["monster"]
-        player = game.imports["player"]
-
         # Don't start a battle if we don't even have monsters in our party yet.
         if not self.check_battle_legal(game.player1):
             return False
-        
+
         # Stop movement and keypress on the server.
         if game.isclient or game.ishost:
                 game.client.update_player(game.player1.facing, event_type="CLIENT_START_BATTLE")
-                
+
         # Start combat
         npc_id = int(action[1])
 
@@ -188,7 +187,6 @@ class Combat(object):
         logger.info("Playing battle music!")
         filename = "147066_pokemon.ogg"
 
-        prepare = game.imports['prepare']
         mixer.music.load(prepare.BASEDIR + "resources/music/" + filename)
         mixer.music.play(-1)
 
@@ -212,13 +210,6 @@ class Combat(object):
         Valid Parameters: encounter_id
 
         """
-
-        prepare = game.imports["prepare"]
-        ai = game.imports["ai"]
-        db = game.imports["db"]
-        monster = game.imports["monster"]
-        player = game.imports["player"]
-
         player1 = game.player1
 
         # Don't start a battle if we don't even have monsters in our party yet.
@@ -250,11 +241,11 @@ class Combat(object):
         # battle.
         if encounter:
             logger.info("Start battle!")
-            
+
             # Stop movement and keypress on the server.
             if game.isclient or game.ishost:
                 game.client.update_player(game.player1.facing, event_type="CLIENT_START_BATTLE")
-            
+
             # Create a monster object
             current_monster = monster.Monster()
             current_monster.load_from_db(encounter['monster_id'])

--- a/tuxemon/core/components/event/actions/core.py
+++ b/tuxemon/core/components/event/actions/core.py
@@ -23,8 +23,11 @@
 #
 # William Edwards <shadowapex@gmail.com>
 #
+from __future__ import absolute_import
 
 import logging
+
+from core.components import networking
 
 # Create a logger for optional handling of debug messages.
 logger = logging.getLogger(__name__)
@@ -297,7 +300,7 @@ class Core(object):
         # Handle if networking is not supported and the PC is trying to be
         # accessed.
         if action[1] == "PC":
-            if not game.imports["networking"].networking:
+            if not networking.networking:
                 message = "Networking is not supported on your system"
                 self.dialog(game, (action[0], message))
                 return

--- a/tuxemon/core/components/event/actions/map.py
+++ b/tuxemon/core/components/event/actions/map.py
@@ -23,11 +23,16 @@
 #
 # William Edwards <shadowapex@gmail.com>
 #
+from __future__ import absolute_import
 
 import logging
 import os
-import pygame
 import re
+
+import pygame
+
+from core import prepare
+from core.components import pyganim
 
 # Create a logger for optional handling of debug messages.
 logger = logging.getLogger(__name__)
@@ -128,8 +133,6 @@ class Map(object):
 
         # ('play_animation', 'grass,1.5,noloop,player', '1', 6)
         # "position" can be either a (x, y) tile coordinate or "player"
-        prepare = game.imports["prepare"]
-
         parameters = action[1].split(",")
         animation_name = parameters[0]
         duration = float(parameters[1])
@@ -156,7 +159,7 @@ class Map(object):
             return True
 
         # Loop through our animation resources and find the animation files based on name.
-        scale = game.imports['prepare'].SCALE
+        scale = prepare.SCALE
         images_and_durations = []
         for animation_frame in os.listdir(directory):
             pattern = animation_name + "\.[0-9].*"
@@ -168,7 +171,6 @@ class Map(object):
         # Scale the animations based on our game's scale: world.scale
 
         # Create an animation object and conductor.
-        pyganim = game.imports["pyganim"]
         animation = pyganim.PygAnimation(images_and_durations, loop=loop)
         conductor = pyganim.PygConductor({'animation': animation})
         conductor.play()

--- a/tuxemon/core/components/event/actions/npc.py
+++ b/tuxemon/core/components/event/actions/npc.py
@@ -23,6 +23,11 @@
 #
 # William Edwards <shadowapex@gmail.com>
 #
+from __future__ import absolute_import
+
+from core.components import ai
+from core.components import player
+
 
 class Npc(object):
 
@@ -47,13 +52,9 @@ class Npc(object):
         ('create_npc', 'Oak,1,5,oak,wander', '1', 6)
 
         """
-
-        ai = game.imports["ai"]
-        player = game.imports["player"]
-
         # Get a copy of the world state.
         world = game.get_world_state()
-        if not world: 
+        if not world:
             return
 
         # Get the npc's parameters from the action

--- a/tuxemon/core/components/event/actions/player.py
+++ b/tuxemon/core/components/event/actions/player.py
@@ -28,8 +28,10 @@ from __future__ import absolute_import
 import logging
 
 from core import prepare
+from core import tools
 from core.components import item
 from core.components import monster
+from core.components.map import Map
 
 # Create a logger for optional handling of debug messages.
 logger = logging.getLogger(__name__)

--- a/tuxemon/core/components/event/actions/player.py
+++ b/tuxemon/core/components/event/actions/player.py
@@ -23,9 +23,13 @@
 #
 # William Edwards <shadowapex@gmail.com>
 #
+from __future__ import absolute_import
 
 import logging
-import pygame
+
+from core import prepare
+from core.components import item
+from core.components import monster
 
 # Create a logger for optional handling of debug messages.
 logger = logging.getLogger(__name__)
@@ -54,12 +58,6 @@ class Player(object):
         ('teleport', 'pallet_town-room.tmx,5,5', '1', 1)
 
         """
-        prepare = game.imports["prepare"]
-        item = game.imports["item"]
-        monster = game.imports["monster"]
-        tools = game.imports["tools"]
-        Map = game.imports["map"].Map
-
         # Get the player object from the game.
         player = game.player1
         world = game.current_state
@@ -222,9 +220,6 @@ class Player(object):
         ... [<core.components.monster.Monster instance at 0x2d0b3b0>]
 
         """
-
-        monster = game.imports["monster"]
-
         parameters = action[1].split(",")
         monster_name = parameters[0]
         monster_level = parameters[1]
@@ -257,9 +252,6 @@ class Player(object):
         >>>
 
         """
-
-        item = game.imports["item"]
-
         player = game.player1
         item_to_add = item.Item(action[1])
 

--- a/tuxemon/core/components/event/actions/sound.py
+++ b/tuxemon/core/components/event/actions/sound.py
@@ -23,8 +23,11 @@
 #
 # William Edwards <shadowapex@gmail.com>
 #
+from __future__ import absolute_import
 
 import logging
+
+from core import prepare
 
 # Create a logger for optional handling of debug messages.
 logger = logging.getLogger(__name__)
@@ -59,8 +62,6 @@ class Sound(object):
         ('play_sound', 'interface/NenadSimic_Click.ogg', '4', 1)
 
         """
-
-        prepare = game.imports["prepare"]
         filename = str(action[1])
         sound = mixer.Sound(prepare.BASEDIR + "resources/sounds/" + filename)
         sound.play()
@@ -87,8 +88,6 @@ class Sound(object):
         ('play_music', '147066_pokemon.ogg', '4', 1)
 
         """
-
-        prepare = game.imports["prepare"]
         filename = str(action[1])
         mixer.music.load(prepare.BASEDIR + "resources/music/" + filename)
         mixer.music.play(-1)

--- a/tuxemon/core/components/networking.py
+++ b/tuxemon/core/components/networking.py
@@ -30,14 +30,12 @@
 """This module contains the Tuxemon server and client.
 """
 from core.components.middleware import Multiplayer, Controller
-from core.components import player
-from core.components.event.actions.npc import Npc
 from core import prepare
 
 from datetime import datetime
 
 import pprint
-import pygame
+import pygame as pg
 
 # Create a logger for optional handling of debug messages.
 import logging
@@ -116,11 +114,11 @@ class TuxemonServer():
                     self.notify_client(cuuid, event_data)
                     del self.server.registry[cuuid]
                     return False
-            
+
             except KeyError:
                 self.server.registry[cuuid]["ping_timestamp"] = datetime.now()
-            
-            
+
+
 
 
     def server_event_handler(self, cuuid, event_data):
@@ -153,10 +151,10 @@ class TuxemonServer():
             self.server.registry[cuuid]["char_dict"] = event_data["char_dict"]
             self.server.registry[cuuid]["ping_timestamp"] = datetime.now()
             self.notify_populate_client(cuuid, event_data)
-        
+
         elif event_data["type"] == "PING":
             self.server.registry[cuuid]["ping_timestamp"] = datetime.now()
-            
+
         elif event_data["type"] == "CLIENT_INTERACTION" or event_data["type"] == "CLIENT_RESPONSE":
             self.notify_client_interaction(cuuid, event_data)
 
@@ -177,13 +175,13 @@ class TuxemonServer():
                 self.notify_client(cuuid, event_data)
             elif event_data["kb_key"] == "ALT":
                 self.notify_client(cuuid, event_data)
-        
+
         elif event_data["type"] == "CLIENT_START_BATTLE":
             self.server.registry[cuuid]["char_dict"]["running"] = False
             self.update_char_dict(cuuid, event_data["char_dict"])
             self.server.registry[cuuid]["map_name"] = event_data["map_name"]
             self.notify_client(cuuid, event_data)
-            
+
         else:
             self.update_char_dict(cuuid, event_data["char_dict"])
             if "map_name" in event_data:
@@ -487,13 +485,13 @@ class TuxemonClient():
             self.game.isclient = True
             self.game.current_state.multiplayer_join_success_menu.text = ["Success!"]
             self.populate_player()
-        
+
         if self.ping_time >= 2:
             self.ping_time = 0
             self.client_alive()
-        else: 
+        else:
             self.ping_time += time_delta
-            
+
         self.check_notify()
 
 
@@ -508,11 +506,11 @@ class TuxemonClient():
 
         """
         for euuid, event_data in self.client.event_notifies.items():
-            
+
             if event_data["type"] == "NOTIFY_CLIENT_DISCONNECTED":
                 del self.client.registry[event_data["cuuid"]]
                 del self.client.event_notifies[euuid]
-                
+
             if event_data["type"] == "NOTIFY_PUSH_SELF":
                 if not event_data["cuuid"] in self.client.registry:
                     self.client.registry[str(event_data["cuuid"])]={}
@@ -525,7 +523,7 @@ class TuxemonClient():
                 sprite = self.client.registry[event_data["cuuid"]]["sprite"]
                 sprite.facing = direction
                 for d in sprite.direction:
-                    if sprite.direction[d]: 
+                    if sprite.direction[d]:
                         sprite.direction[d] = False
                 sprite.direction[direction] = True
                 del self.client.event_notifies[euuid]
@@ -534,7 +532,7 @@ class TuxemonClient():
                 sprite = self.client.registry[event_data["cuuid"]]["sprite"]
                 sprite.final_move_dest = event_data["char_dict"]["tile_pos"]
                 for d in sprite.direction:
-                    if sprite.direction[d]: 
+                    if sprite.direction[d]:
                         sprite.direction[d] = False
                 del self.client.event_notifies[euuid]
 
@@ -574,13 +572,13 @@ class TuxemonClient():
                     return
                 world.handle_interaction(event_data, self.client.registry)
                 del self.client.event_notifies[euuid]
-            
+
             if event_data["type"] == "NOTIFY_CLIENT_START_BATTLE":
                 sprite = self.client.registry[event_data["cuuid"]]["sprite"]
                 sprite.running = False
                 sprite.final_move_dest = event_data["char_dict"]["tile_pos"]
                 for d in sprite.direction:
-                   if sprite.direction[d]: 
+                   if sprite.direction[d]:
                        sprite.direction[d] = False
                 del self.client.event_notifies[euuid]
 
@@ -614,7 +612,7 @@ class TuxemonClient():
         if self.wait_broadcast >= self.wait_delay:
             self.update_multiplayer_list()
             self.wait_broadcast = 0
-        else: 
+        else:
             self.wait_broadcast += time_delta
 
 
@@ -726,43 +724,43 @@ class TuxemonClient():
         """
         if self.game.current_state != self.game.get_world_state():
             return False
-        
+
         event_type = None
         kb_key = None
-        if event.type == pygame.KEYDOWN:
+        if event.type == pg.KEYDOWN:
             event_type = "CLIENT_KEYDOWN"
-            if event.key == pygame.K_LSHIFT or event.key == pygame.K_RSHIFT:
+            if event.key == pg.K_LSHIFT or event.key == pg.K_RSHIFT:
                 kb_key = "SHIFT"
-            elif  event.key == pygame.K_LCTRL or event.key == pygame.K_RCTRL:
+            elif  event.key == pg.K_LCTRL or event.key == pg.K_RCTRL:
                 kb_key = "CTRL"
-            elif event.key == pygame.K_LALT or event.key == pygame.K_RALT:
+            elif event.key == pg.K_LALT or event.key == pg.K_RALT:
                 kb_key = "ALT"
 
-            elif event.key == pygame.K_UP:
+            elif event.key == pg.K_UP:
                 kb_key = "up"
-            elif event.key == pygame.K_DOWN:
+            elif event.key == pg.K_DOWN:
                 kb_key = "down"
-            elif event.key == pygame.K_LEFT:
+            elif event.key == pg.K_LEFT:
                 kb_key = "left"
-            elif event.key == pygame.K_RIGHT:
+            elif event.key == pg.K_RIGHT:
                 kb_key = "right"
 
-        if event.type == pygame.KEYUP:
+        if event.type == pg.KEYUP:
             event_type = "CLIENT_KEYUP"
-            if event.key == pygame.K_LSHIFT or event.key == pygame.K_RSHIFT:
+            if event.key == pg.K_LSHIFT or event.key == pg.K_RSHIFT:
                 kb_key = "SHIFT"
-            elif  event.key == pygame.K_LCTRL or event.key == pygame.K_RCTRL:
+            elif  event.key == pg.K_LCTRL or event.key == pg.K_RCTRL:
                 kb_key = "CTRL"
-            elif event.key == pygame.K_LALT or event.key == pygame.K_RALT:
+            elif event.key == pg.K_LALT or event.key == pg.K_RALT:
                 kb_key = "ALT"
 
-            elif event.key == pygame.K_UP:
+            elif event.key == pg.K_UP:
                 kb_key = "up"
-            elif event.key == pygame.K_DOWN:
+            elif event.key == pg.K_DOWN:
                 kb_key = "down"
-            elif event.key == pygame.K_LEFT:
+            elif event.key == pg.K_LEFT:
                 kb_key = "left"
-            elif event.key == pygame.K_RIGHT:
+            elif event.key == pg.K_RIGHT:
                 kb_key = "right"
 
         if kb_key == "up" or kb_key == "down" or kb_key == "left" or kb_key == "right":
@@ -839,9 +837,9 @@ class TuxemonClient():
                       }
         self.event_list[event_type] +=1
         self.client.event(event_data)
-    
-    
-    def client_alive(self): 
+
+
+    def client_alive(self):
         """Sends server a ping to let it know that it is still alive.
 
         :param: None
@@ -854,10 +852,10 @@ class TuxemonClient():
             self.event_list[event_type] = 1
         else:
             self.event_list[event_type] +=1
-        
+
         event_data = {"type": event_type,
                       "event_number": self.event_list[event_type]}
-        
+
         self.client.event(event_data)
 
 
@@ -898,6 +896,9 @@ def populate_client(cuuid, event_data, game, registry):
     :returns: sprite
 
     """
+    # TODO: move NPC from actions make make a common core class
+    from core.components.event.actions.npc import Npc
+
     char_dict = event_data["char_dict"]
     sn = str(event_data["sprite_name"])
     nm = str(char_dict["name"])

--- a/tuxemon/core/components/plugin.py
+++ b/tuxemon/core/components/plugin.py
@@ -29,11 +29,10 @@
 #
 #
 
-from pprint import pformat, pprint
+import importlib
+import inspect
 import logging
 import os
-import inspect
-import importlib
 import sys
 
 # Create a logger for optional handling of debug messages.
@@ -42,6 +41,7 @@ log_hdlr = logging.StreamHandler(sys.stdout)
 log_hdlr.setLevel(logging.DEBUG)
 log_hdlr.setFormatter(logging.Formatter("%(asctime)s - %(name)s - "
                                         "%(levelname)s - %(message)s"))
+
 
 class Plugin(object):
     def __init__(self, name, module):
@@ -95,7 +95,6 @@ class PluginManager(object):
                     imported_modules.append(Plugin(module + "." + class_name, class_obj()))
 
         return imported_modules
-
 
     def _getClassesFromModule(self, module):
         members = inspect.getmembers(module, predicate=inspect.isclass)

--- a/tuxemon/core/control.py
+++ b/tuxemon/core/control.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import time
 
 import pygame as pg
@@ -58,20 +59,6 @@ class Control(StateManager):
         self.client = networking.TuxemonClient(self)
 
         # Set up our game's configuration from the prepare module.
-        from core import prepare
-        self.imports = {
-            "prepare": prepare,
-            "ai": ai,
-            "rumble": rumble,
-            "db": db,
-            "monster": monster,
-            "player": player,
-            "item": item,
-            "map": maps,
-            "networking": networking,
-            "pyganim": pyganim,
-            "tools": tools
-        }
         self.config = prepare.CONFIG
 
         # Set up our game's event engine which executes actions based on
@@ -700,18 +687,6 @@ class HeadlessControl(StateManager):
         self.server.server.listen()
 
         #Set up our game's configuration from the prepare module.
-        from core import prepare
-        self.imports = {
-            "prepare": prepare,
-            "ai": ai,
-            "rumble": rumble,
-            "db": db,
-            "monster": monster,
-            "player": player,
-            "item": item,
-            "map": maps,
-            "pyganim": pyganim
-        }
         self.config = prepare.HEADLESSCONFIG
 
         # Set up the command line. This provides a full python shell for

--- a/tuxemon/core/state.py
+++ b/tuxemon/core/state.py
@@ -187,14 +187,10 @@ class StateManager(object):
         Abstract Base Classes, those whose metaclass is abc.ABCMeta, will
         not be included in the state dictionary.
         """
-        import abc
         classes = inspect.getmembers(sys.modules[import_name], inspect.isclass)
 
-        for c in classes:
-            c = c[1]
-
+        for c in [i[1] for i in classes]:
             if issubclass(c, State):
-                print c
                 yield c
 
     def collect_states_from_path(self, folder):
@@ -267,7 +263,6 @@ class StateManager(object):
         instance.startup(params)
 
         self._current_state_requires_resume = True
-
         self.state_stack.insert(0, instance)
 
         return instance


### PR DESCRIPTION
This PR fixes the issues in #63.  The modules are slightly changed to remove need to pass around references to imported modules.  The bulk of the issue was resolved by adding the following at the head of each plugin.
```python
from __future__ import absolute_import
```


Also included is minor PEP8 and linting, as usual.