### PR TITLE
 Darkish screen and lost of the transition effect #116 

### DIFF
--- a/tuxemon/core/components/animation.py
+++ b/tuxemon/core/components/animation.py
@@ -109,7 +109,18 @@ class Task(pygame.sprite.Sprite):
         self._chain = list()
         self._state = ANIMATION_RUNNING
 
-    def chain(self, *others):
+    def chain(self, callback, interval=0, loops=1, args=None, kwargs=None):
+        """Schedule something to be called after.  Uses same sig. as Task
+
+        If you attempt to chain a task that will never end (loops=-1),
+        then ValueError will be raised.
+
+        :param others: Task instances
+        :returns: None
+        """
+        return self.chain_task(Task(callback, interval=0, loops=1, args=None, kwargs=None))
+
+    def chain_task(self, *tasks):
         """Schedule Task(s) to execute when this one is finished
 
         If you attempt to chain a task that will never end (loops=-1),
@@ -120,11 +131,11 @@ class Task(pygame.sprite.Sprite):
         """
         if self._loops <= -1:
             raise ValueError
-        for task in others:
+        for task in tasks:
             if not isinstance(task, Task):
                 raise TypeError
             self._chain.append(task)
-        return others
+        return tasks
 
     def update(self, dt):
         """Update the Task

--- a/tuxemon/core/components/event/actions/map.py
+++ b/tuxemon/core/components/event/actions/map.py
@@ -106,10 +106,9 @@ class Map(object):
 
         """
 
-        world = game.current_state
-        if not world.start_transition or not world.start_transition_back:
-            world.start_transition = True
-            world.transition_time = float(action.parameters[0])
+        world = game.get_state_name("WorldState")
+        if not world.in_transition:
+            world.fade_and_teleport(float(action.parameters[0]))
 
 
     def start_cinema_mode(self, game, action):

--- a/tuxemon/core/components/event/actions/player.py
+++ b/tuxemon/core/components/event/actions/player.py
@@ -79,12 +79,12 @@ class Player(object):
         # If we're doing a screen transition with this teleport, set the map name that we'll
         # load during the apex of the transition.
         # TODO: This only needs to happen once.
-        if world.start_transition:
+        if world.in_transition:
             world.delayed_mapname = mapname
 
         # Check to see if we're also performing a transition. If we are, wait to perform the
         # teleport at the apex of the transition
-        if world.start_transition:
+        if world.in_transition:
             world.delayed_teleport = True
             # Set the global_x/y variables based on the player's pixel position and the tile size.
             world.delayed_x = player.position[0] - (position_x * player.tile_size[0])
@@ -99,13 +99,41 @@ class Player(object):
             if map_path != world.current_map.filename:
                 world.change_map(map_path)
 
-        # Update the server/clients of our new map and populate any other players.
-        if game.isclient or game.ishost:
-            game.add_clients_to_map(game.client.client.registry)
-            game.client.update_player(player.facing)
-
         # Stop the player's movement so they don't continue their move after they teleported.
         player.moving = False
+
+
+    def delayed_teleport(self, game, action):
+        """ Set teleport information.  Teleport will be triggered during screen transition
+
+        Only use this if followed by a transition
+
+        :param game: core.control.Control
+        :param action: Tuple
+        :return: None
+        """
+        # Get the world object from the game.
+        world = game.current_state
+
+        # give up if there is a teleport in progress
+        if world.delayed_teleport:
+            return
+
+        # Get the teleport parameters for the position x,y and the map to load.
+        mapname = str(action.parameters[0])
+        position_x = int(action.parameters[1])
+        position_y = int(action.parameters[2])
+
+        world.delayed_mapname = mapname
+        world.delayed_teleport = True
+
+        # Get the player object from the game.
+        player = game.player1
+
+        # Set the global_x/y variables based on the player's pixel position and the tile size.
+        world.delayed_x = player.position[0] - (position_x * player.tile_size[0])
+        world.delayed_y = player.position[1] - (position_y * player.tile_size[1]) + player.tile_size[1]
+
 
     def transition_teleport(self, game, action):
         """Combines the "teleport" and "screen_transition" actions to perform a teleport with a
@@ -138,10 +166,7 @@ class Player(object):
         }
 
         """
-        # Get the teleport parameters for the position x,y and the map to load.
-        mapname = action.parameters[0]
-        position_x = action.parameters[1]
-        position_y = action.parameters[2]
+        # Get transition parameters
         transition_time = action.parameters[3]
 
         # Start the screen transition
@@ -150,11 +175,8 @@ class Player(object):
         transition_action = Action(action.type, [transition_time])
         screen_transition(game, transition_action)
 
-        # Start the teleport. The teleport action will notice a screen transition in progress,
-        # and wait until it is done before teleporting.
-        teleport_action = Action(action.type, action.parameters)
-
-        self.teleport(game, action)
+        # set the delayed teleport
+        self.delayed_teleport(game, action)
 
 
     def add_monster(self, game, action):
@@ -285,7 +307,7 @@ class Player(object):
 
         # If we're doing a transition, only change the player's facing when we've reached the apex
         # of the transition.
-        if game.current_state.start_transition:
+        if game.current_state.in_transition:
             game.current_state.delayed_facing = direction
         else:
             game.player1.facing = direction

--- a/tuxemon/core/components/menu/menu.py
+++ b/tuxemon/core/components/menu/menu.py
@@ -416,9 +416,6 @@ class Menu(state.State):
         for attribute, value in self._anchors.items():
             setattr(self.rect, attribute, value)
 
-    def update(self, time_delta):
-        self.animations.update(time_delta)
-
     # ============================================================================
     #   The following methods are designed to be monkey patched or overloaded
     # ============================================================================

--- a/tuxemon/core/components/sprite.py
+++ b/tuxemon/core/components/sprite.py
@@ -266,7 +266,7 @@ class RelativeGroup(SpriteGroup):
         """
         rect = super(RelativeGroup, self).calc_bounding_rect()
         for sprite in self.sprites():
-            print (sprite, sprite.rect)
+            print sprite, sprite.rect
         return rect
         return self.calc_absolute_rect(rect)
 

--- a/tuxemon/core/components/status/__init__.py
+++ b/tuxemon/core/components/status/__init__.py
@@ -1,9 +1,0 @@
-"""
-status modifier
-- needs phase to act in
-- needs condition to be active
-- needs number of iterations
-- needs stuff to modify
-- needs function to apply against stuff
-- needs modification value
-"""

--- a/tuxemon/core/state.py
+++ b/tuxemon/core/state.py
@@ -138,7 +138,7 @@ class State(object):
         :returns: None
         :rtype: None
         """
-        pass
+        self.animations.update(time_delta)
 
     def draw(self, surface):
         """ Render the state to the surface passed.  Must be overloaded in children

--- a/tuxemon/core/states/world/worldstate.py
+++ b/tuxemon/core/states/world/worldstate.py
@@ -33,6 +33,7 @@ from __future__ import division
 # Import various python libraries
 import logging
 import math
+from functools import partial
 
 import pygame
 
@@ -42,6 +43,7 @@ from core import state
 from core import tools
 from core.components import map
 from core.components import networking
+from core.components.animation import Task
 
 # Create a logger for optional handling of debug messages.
 logger = logging.getLogger(__name__)
@@ -118,11 +120,9 @@ class WorldState(state.State):
         ######################################################################
 
         # default variables for transition
-        self.SAVE_THIS_FUCKING_SCREEN = pygame.Surface(prepare.SCREEN_SIZE)
         self.transition_alpha = 0
-        self.start_transition = False
-        self.start_transition_back = False
-        self.black_screen = 0
+        self.transition_surface = None
+        self.in_transition = False
 
         # The delayed teleport variable is used to perform a teleport in the
         # middle of a transition. For example, fading to black, then
@@ -183,14 +183,98 @@ class WorldState(state.State):
         self.cinema_bottom['on_position'] = [
             0, self.resolution[1] - self.cinema_bottom['surface'].get_height()]
 
-    def trigger_fade_in(self):
+    def fade_and_teleport(self, duration=2):
+        """ Fade out, teleport, fade in
+
+        :return:
+        """
+        def cleanup():
+            self.in_transition = False
+
+        def fade_in():
+            self.trigger_fade_in(duration)
+            self.task(cleanup, duration)
+
+        # stop player movement
+        self.player1.moving = False
+
+        # cancel any fades that may be going one
+        self.remove_animations_of(self)
+        self.remove_animations_of(cleanup)
+
+        self.in_transition = True
+        self.trigger_fade_out(duration)
+
+        task = self.task(self.handle_delayed_teleport, duration)
+        task.chain(fade_in, duration + .5)
+
+    def trigger_fade_in(self, duration=2):
         """ World state has own fade code b/c moving maps doesn't change state
 
         :returns: None
         """
-        self.transition_time = 1
-        self.start_transition_back = True
-        self.transition_alpha = 255
+        self.set_transition_surface()
+        self.animate(self, transition_alpha=0, initial=255, duration=duration, round_values=True)
+
+    def trigger_fade_out(self, duration=2):
+        """ World state has own fade code b/c moving maps doesn't change state
+
+        * will cause player to teleport if set somewhere else
+
+        :returns: None
+        """
+        self.set_transition_surface()
+        self.animate(self, transition_alpha=255, initial=0, duration=duration, round_values=True)
+
+    def handle_delayed_teleport(self):
+        """ Call to teleport player if delayed_teleport is set
+
+        * load a map
+        * move player
+        * send data to network about teleport
+
+        :return: None
+        """
+        if self.delayed_teleport:
+            self.global_x = self.delayed_x
+            self.global_y = self.delayed_y
+
+            if self.delayed_facing:
+                self.player1.facing = self.delayed_facing
+                self.delayed_facing = None
+
+            # check if map has changed, and if so, change it
+            map_name = prepare.BASEDIR + "resources/maps/" + self.delayed_mapname
+            if map_name != self.current_map.filename:
+                self.change_map(map_name)
+
+            self.delayed_teleport = False
+
+    def set_transition_surface(self, color=(0, 0, 0)):
+        self.transition_surface = pygame.Surface(self.game.screen.get_size())
+        self.transition_surface.fill(color)
+
+    def broadcast_player_teleport_change(self):
+        """ Tell clients/host that player has moved or changed map after teleport
+
+        :return:
+        """
+        # Set the transition variable in event_data to false when we're done
+        self.game.event_data["transition"] = False
+
+        # Update the server/clients of our new map and populate any other players.
+        if self.game.isclient or self.game.ishost:
+            self.game.add_clients_to_map(self.game.client.client.registry)
+            self.game.client.update_player(self.player1.facing)
+
+        # Update the location of the npcs. Doesn't send network data.
+        for npc in self.npcs:
+            char_dict = {"tile_pos": npc.tile_pos}
+            networking.update_client(npc, char_dict, self.game)
+
+        for npc in self.npcs_off_map:
+            char_dict = {"tile_pos": npc.tile_pos}
+            networking.update_client(npc, char_dict, self.game)
 
     def update(self, time_delta):
         """The primary game loop that executes the world's game functions every frame.
@@ -203,6 +287,7 @@ class WorldState(state.State):
         :returns: None
 
         """
+        super(WorldState, self).update(time_delta)
         logger.debug("*** Game Loop Started ***")
         logger.debug("Player Variables:" + str(self.player1.game_variables))
 
@@ -621,83 +706,9 @@ class WorldState(state.State):
         :returns: None
 
         """
-
-        # artificially set the time passed to make up for case
-        # when map loads drop fps and causes the fade to be skipped
-        td = 0.016  # 60 fps
-
-        # FUCKIN' MATH! 0 = NO ALPHA NOT 255 DAMNIT BILLY!
-        # if the value of start_transition event is set to true
-        if self.start_transition:
-            if self.transition_alpha == 0:
-                self.SAVE_THIS_FUCKING_SCREEN = surface.copy()
-            self.transition_surface = self.SAVE_THIS_FUCKING_SCREEN.copy()
-            # fucking dumb ass math wont let me do less than 1 second so I had to speed that shit up so
-            # I multiplied time_passed_seconds testing around making the fade faster because Billys'
-            # teleport is TOO FUCKING FAST
-            self.transition_alpha += 255 * (td / self.transition_time)
-            if self.transition_alpha >= 255:
-                self.transition_alpha = 255
-                # created a black screen variable so it actually looks like he teleported, gotta figure out
-                # how to make the event start earlier, initial testing proves I need sleep. Also billys'
-                # teleport is STILL TOO FUCKING FAST!
-                if self.black_screen >= 50:
-                    self.black_screen = 50
-                    self.start_transition_back = True
-                    self.start_transition = False
-                self.black_screen += 50 * (td / self.transition_time)
+        if self.in_transition:
             self.transition_surface.set_alpha(self.transition_alpha)
-            self.transition_surface.fill((0, 0, 0))
             surface.blit(self.transition_surface, (0, 0))
-            # print(transition_alpha)
-
-        # Perform a delayed teleport if we're also doing a teleport and we've
-        # faded out completely
-        if self.delayed_teleport and self.start_transition_back:
-            self.global_x = self.delayed_x
-            self.global_y = self.delayed_y
-
-            if self.delayed_facing:
-                self.player1.facing = self.delayed_facing
-                self.delayed_facing = None
-
-            # check if map has changed, and if so, change it
-            map_name = prepare.BASEDIR + "resources/maps/" + self.delayed_mapname
-            if map_name != self.current_map.filename:
-                self.change_map(map_name)
-
-            self.delayed_teleport = False
-
-        # Replace this SAVE_THIS_FUCKING_SCREEN with the value of the blit of
-        # the new map
-        if self.start_transition_back:
-            self.transition_back_surface = self.SAVE_THIS_FUCKING_SCREEN.copy()
-            # same shit as above down here as well, except i slowed that shit
-            # down
-            self.transition_alpha -= 255 * (td / self.transition_time)
-            if self.transition_alpha <= 0:
-                self.transition_alpha = 0
-                self.start_transition_back = False
-                self.black_screen = 0
-            self.transition_back_surface.set_alpha(self.transition_alpha)
-            self.transition_back_surface.fill((0, 0, 0))
-            surface.blit(self.transition_back_surface, (0, 0))
-            self.game.event_data[
-                "transition"] = False    # Set the transition variable in event_data to false when we're done
-
-            # Update the server/clients of our new map and populate any other players.
-            if self.game.isclient or self.game.ishost:
-                self.game.add_clients_to_map(self.game.client.client.registry)
-                self.game.client.update_player(self.player1.facing)
-
-            # Update the location of the npcs. Doesn't send network data.
-            for npc in self.npcs:
-                char_dict = {"tile_pos": npc.tile_pos}
-                networking.update_client(npc, char_dict, self.game)
-
-            for npc in self.npcs_off_map:
-                char_dict = {"tile_pos": npc.tile_pos}
-                networking.update_client(npc, char_dict, self.game)
 
     ####################################################
     #             Map Change/Load Functions            #


### PR DESCRIPTION
Correct fix required decoupling screen transition effect from event handling code to teleport the player and from the graphic effect.  Some refactor/simplification of the graphic fades and timing was afforded by use the Tasks and Animations.  There are still some edge cases where movement is possible because player input is not disabled, but it is much more robust and seems less fragile.  In the future, it will be needed to lock player controls during the screen fading to prevent any movement during screen transitions.