### PR TITLE
Fix #160

### DIFF
--- a/tuxemon/core/components/item.py
+++ b/tuxemon/core/components/item.py
@@ -116,15 +116,10 @@ class Item(object):
         elif id:
             results = items.lookup_by_id(id, table="item")
 
-        # Try and get this item's translated name and description if it exists.
-        if translator.has_key(results["name_trans"]):
-            self.name = trans(results["name_trans"])
-        else:
-            self.name = results["name"]
-        if translator.has_key(results["description_trans"]):
-            self.description = trans(results["description_trans"])
-        else:
-            self.description = results["description"]
+        self.name = results["name"]
+        self.name_trans = trans(results["name_trans"])
+        self.description = results["description"]
+        self.description_trans = trans(results["description_trans"])
 
         self.id = results["id"]
         self.type = results["type"]
@@ -208,7 +203,7 @@ class Item(object):
             target.current_hp = target.hp
 
         return True
-        
+
     def advance_round(self):
         pass
 

--- a/tuxemon/core/components/sprite.py
+++ b/tuxemon/core/components/sprite.py
@@ -265,8 +265,6 @@ class RelativeGroup(SpriteGroup):
         """A rect object that contains all sprites of this group
         """
         rect = super(RelativeGroup, self).calc_bounding_rect()
-        for sprite in self.sprites():
-            print(sprite, sprite.rect)
         # return self.calc_absolute_rect(rect)
         return rect
 

--- a/tuxemon/core/components/technique.py
+++ b/tuxemon/core/components/technique.py
@@ -99,11 +99,8 @@ class Technique(object):
         elif id:
             results = techniques.database['technique'][id]
 
-        # Try and get this item's translated name if it exists.
-        if translator.has_key(results["name_trans"]):
-            self.name = trans(results["name_trans"])
-        else:
-            self.name = results["name"]
+        self.name = results["name"]
+        self.name_trans = trans(results["name_trans"])
         self.tech_id = results["id"]
         self.category = results["category"]
         self.icon = results["icon"]

--- a/tuxemon/core/states/combat/combat.py
+++ b/tuxemon/core/states/combat/combat.py
@@ -542,8 +542,7 @@ class CombatState(CombatAnimations):
         # is synchronized with the damage shake motion
         hit_delay = 0
         if user:
-            # message = "%s used %s!" % (user.name, technique.name)
-            message = trans('combat_used_x', {"user": user.name, "name": technique.name})
+            message = trans('combat_used_x', {"user": user.name, "name": technique.name_trans})
 
             # TODO: a real check or some params to test if should tackle, etc
             if technique in user.moves:
@@ -570,7 +569,7 @@ class CombatState(CombatAnimations):
         else:
             if result:
                 self.suppress_phase_change()
-                self.alert(trans('combat_status_damage', {"name": target.name, "status": technique.name}))
+                self.alert(trans('combat_status_damage', {"name": target.name, "status": technique.name_trans}))
 
         if result and target_sprite and hasattr(technique, "images"):
             tech_sprite = self.get_technique_animation(technique)

--- a/tuxemon/core/states/combat/combat_menus.py
+++ b/tuxemon/core/states/combat/combat_menus.py
@@ -88,8 +88,8 @@ class MainCombatMenuState(PopUpMenu):
 
             # add techniques to the menu
             for tech in self.monster.moves:
-                image = self.shadow_text(tech.name)
-                item = MenuItem(image, tech.name, None, tech)
+                image = self.shadow_text(tech.name_trans)
+                item = MenuItem(image, None, None, tech)
                 menu.add(item)
 
             # position the new menu

--- a/tuxemon/core/states/items/__init__.py
+++ b/tuxemon/core/states/items/__init__.py
@@ -32,11 +32,10 @@ class ItemMenuState(Menu):
 
         # this is the area where the item description is displayed
         rect = self.game.screen.get_rect()
-        center = rect.center
-        rect.width *= .95
-        rect.height *= .25
-        rect.center = center
-        rect.top = tools.scale(190)
+        rect.top = tools.scale(106)
+        rect.left = tools.scale(3)
+        rect.width = tools.scale(250)
+        rect.height = tools.scale(32)
         self.text_area = TextArea(self.font, self.font_color, (96, 96, 128))
         self.text_area.rect = rect
         self.sprites.add(self.text_area, layer=100)
@@ -142,8 +141,8 @@ class ItemMenuState(Menu):
         """
         for name, properties in self.game.player1.inventory.items():
             obj = properties['item']
-            image = self.shadow_text(obj.name, bg=(128, 128, 128))
-            yield MenuItem(image, obj.name, obj.description, obj)
+            image = self.shadow_text(obj.name_trans, bg=(128, 128, 128))
+            yield MenuItem(image, obj.name_trans, obj.description_trans, obj)
 
     def on_menu_selection_change(self):
         """ Called when menu selection changes

--- a/tuxemon/core/states/items/__init__.py
+++ b/tuxemon/core/states/items/__init__.py
@@ -37,7 +37,6 @@ class ItemMenuState(Menu):
         rect.width = tools.scale(250)
         rect.height = tools.scale(32)
         self.text_area = TextArea(self.font, self.font_color, (96, 96, 128))
-        print(rect)
         self.text_area.rect = rect
         self.sprites.add(self.text_area, layer=100)
 

--- a/tuxemon/core/states/items/__init__.py
+++ b/tuxemon/core/states/items/__init__.py
@@ -3,7 +3,7 @@ from __future__ import division
 from core import tools
 from core.components.locale import translator
 from core.components.menu.interface import MenuItem
-from core.components.menu.menu import Menu, PopUpMenu
+from core.components.menu.menu import Menu
 from core.components.sprite import Sprite
 from core.components.ui.text import TextArea
 
@@ -37,6 +37,7 @@ class ItemMenuState(Menu):
         rect.width = tools.scale(250)
         rect.height = tools.scale(32)
         self.text_area = TextArea(self.font, self.font_color, (96, 96, 128))
+        print(rect)
         self.text_area.rect = rect
         self.sprites.add(self.text_area, layer=100)
 
@@ -71,7 +72,7 @@ class ItemMenuState(Menu):
         if state in item.usable_in:
             self.open_confirm_use_menu(item)
         else:
-            msg = trans('item_cannot_use_here', {'name': item.name})
+            msg = trans('item_cannot_use_here', {'name': item.name_trans})
             tools.open_dialog(self.game, [msg])
 
     def open_confirm_use_menu(self, item):

--- a/tuxemon/core/states/world/world_menus.py
+++ b/tuxemon/core/states/world/world_menus.py
@@ -84,7 +84,6 @@ class WorldMenuState(Menu):
         right, height = prepare.SCREEN_SIZE
 
         # TODO: more robust API for sizing (kivy esque?)
-        # TODO: after menu "add" merge, this can be simplified
         # this is highly irregular:
         # shrink to get the final width
         # record the width

--- a/tuxemon/core/states/world/world_menus.py
+++ b/tuxemon/core/states/world/world_menus.py
@@ -91,12 +91,12 @@ class WorldMenuState(Menu):
         # turn off shrink, then adjust size
         self.shrink_to_items = True     # force shrink of menu
         self.menu_items.expand = False  # force shrink of items
-        self.initialize_items()         # re-add items, trigger layout
+        self.refresh_layout()           # rearrange items
         width = self.rect.width         # store the ideal width
 
         self.shrink_to_items = False    # force shrink of menu
         self.menu_items.expand = True   # force shrink of items
-        self.initialize_items()        # re-add items, trigger layout
+        self.refresh_layout()           # rearrange items
         self.rect = pygame.Rect(right, 0, width, height)  # set new rect
 
         # animate the menu sliding in


### PR DESCRIPTION
Basically, battles were not working properly because the game was refering to things using untranslated strings as item/technique names.  These changes will allow battles to function as expected.  In addition to fixing the battle locale, the follow locale issues were resolved:

- Monster techniques during batter are untranslated
- Item descriptions are untranslated

The changes in world_menus.py ensure that "refresh layout" becomes a common practice.  It is designated to be used when menu items are added or removed by simply rearranging the items in the menu.  Using initialize_items forces all menu items to be re-rendered, which is slower than just "reflowing" or updating the layout with "refresh layout".  While not a problem with simple text objects, more complex layouts in the future may incur a penalty on a slow platform (ie raspberry pi), so refresh layout is needed.