### PR TITLE
Remove overreaching copyright transfer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,10 +3,8 @@ Contributing
 
 By committing or contributing data/files to the Tuxemon project, or any sub-
 projects (the "Projects"), you agree to license your code under the GNU General
-Public License version 3 and any later version (the "License"), and you give
-the Tuxemon project coordinators the permission to re-license or dual-license
-it under a different license, with a minimum license being GPLv2. In
-particular, you guarantee that you have acquired all necessary legal rights
+Public License version 3 and any later version (the "License").
+In particular, you guarantee that you have acquired all necessary legal rights
 from possible other copyright holders to license the contributions.
 
 In any case, any contributions to the Projects must be able to be


### PR DESCRIPTION
When I wrote the original CONTRIBUTING.md, I didn't really understand copyright and licensing very well. Forcing people to give the maintainers the "rights to change what rights you get to keep" will make people more wary of contributing, and I shouldn't have added that clause in the first place.