### PR TITLE
Change the combat target selection menu for items to that of the the technique target selection menu + 1st fork

### DIFF
--- a/tuxemon/core/components/item.py
+++ b/tuxemon/core/components/item.py
@@ -33,6 +33,7 @@
 import logging
 import pprint
 import random
+from collections import namedtuple
 
 from core import tools
 from . import db
@@ -47,6 +48,7 @@ logger.debug("%s successfully imported" % __name__)
 items = db.JSONDatabase()
 items.load("item")
 
+item_use_value = namedtuple("use", "name success properties")
 
 class Item(object):
     """An item object is an item that can be used either in or out of combat.
@@ -165,7 +167,9 @@ class Item(object):
         """
 
         # Loop through all the effects of this technique and execute the effect's function.
+        effectString = "Empty"
         for effect in self.effect:
+            effectString = str(effect)
             result = getattr(self, str(effect))(user, target)
 
         # If this is a consumable item, remove it from the player's inventory.
@@ -176,7 +180,10 @@ class Item(object):
                 else:
                     user.inventory[self.name]['quantity'] -= 1
 
-        return result
+        if type(result) == bool:
+            result = (result, {"is_item": True})
+        
+        return item_use_value(effectString, *result)
 
     def heal(self, user, target):
         """This effect heals the target based on the item's power attribute.
@@ -238,6 +245,10 @@ class Item(object):
         if not target.status == "Normal":
             status_modifier = 150
 
+        # This is taken from http://bulbapedia.bulbagarden.net/wiki/Catch_rate#Capture_method_.28Generation_VI.29
+        catch_check = (3*target.hp - 2*target.current_hp) * target.catch_rate * item_power * float(status_modifier)/100 / (3*target.hp)
+        shake_check = 65536 / (255/catch_check)**0.1875
+
         # Calculate the top of success range (random_num must be in range to succeed)
         success_max = (success_max - (target.level * 10)) + damage_modifier + status_modifier + item_power
 
@@ -249,12 +260,10 @@ class Item(object):
         print("Success if between: 0 -", success_max)
         print("Chance of capture: %s / 100" % (success_max / 10))
         print("Random number:", random_num)
+        print("a, b:", catch_check, shake_check)
 
-        # If random_num falls between 0 and success_max, capture target
-        if 0 <= random_num <= success_max:
-            print("It worked!")
-            user.add_monster(target)
-            return True
-        else:
-            print("It failed!")
-            return False
+        for i in range(0, 4):
+            if random.randint(0, 65536) > shake_check:
+                return False, {"num_shakes": i+1, "is_item": True}
+
+        return True, {"num_shakes": 4, "is_item": True}

--- a/tuxemon/core/components/monster.py
+++ b/tuxemon/core/components/monster.py
@@ -122,6 +122,9 @@ class Monster(object):
 
         self.weight = 0
 
+		# the multiplier for checks when a monster ball is thrown.
+        self.catch_rate = 1;
+
         # The tuxemon's state is used for various animations, etc. For example
         # a tuxemon's state might be "attacking" or "fainting" so we know when
         # to play the animations for those states.

--- a/tuxemon/core/components/technique.py
+++ b/tuxemon/core/components/technique.py
@@ -30,6 +30,7 @@
 #
 import os
 import random
+from collections import namedtuple
 
 from core import prepare, tools
 from core.components import db
@@ -41,6 +42,7 @@ trans = translator.translate
 techniques = db.JSONDatabase()
 techniques.load("technique")
 
+tech_ret_value = namedtuple("use", "success properties")
 
 class Technique(object):
     """A technique object is a particular skill that tuxemon monsters can use
@@ -188,7 +190,8 @@ class Technique(object):
             if getattr(self, str(effect))(user, target):
                 successful = True
 
-        return successful
+        # the {} here should just be considered a placeholder
+        return tech_ret_value(successful, {})
 
     def calculate_damage(self, user, target):
         # Original Pokemon battle damage formula:

--- a/tuxemon/core/components/technique.py
+++ b/tuxemon/core/components/technique.py
@@ -42,7 +42,7 @@ trans = translator.translate
 techniques = db.JSONDatabase()
 techniques.load("technique")
 
-tech_ret_value = namedtuple("use", "success properties")
+tech_ret_value = namedtuple("use", "name success properties")
 
 class Technique(object):
     """A technique object is a particular skill that tuxemon monsters can use
@@ -185,13 +185,18 @@ class Technique(object):
         """
         # Loop through all the effects of this technique and execute the effect's function.
         # TODO: more robust API
-        successful = False
-        for effect in self.effect:
-            if getattr(self, str(effect))(user, target):
-                successful = True
 
-        # the {} here should just be considered a placeholder
-        return tech_ret_value(successful, {})
+        # 'result' can either be a tuple or a boolean.
+        result = None
+        last_effect_name = None
+        for effect in self.effect:
+            last_effect_name = str(effect)
+            result = getattr(self, last_effect_name)(user, target)
+
+        if type(result) is tuple:
+            return tech_ret_value(last_effect_name, *result)
+
+        return tech_ret_value(last_effect_name, result, {"should_tackle": True})
 
     def calculate_damage(self, user, target):
         # Original Pokemon battle damage formula:

--- a/tuxemon/core/states/combat/combat.py
+++ b/tuxemon/core/states/combat/combat.py
@@ -545,7 +545,7 @@ class CombatState(CombatAnimations):
             message = trans('combat_used_x', {"user": user.name, "name": technique.name})
 
             # TODO: a real check or some params to test if should tackle, etc
-            if technique in user.moves:
+            if result.properties["should_tackle"]:
                 hit_delay += .5
                 user_sprite = self._monster_sprite_map[user]
                 self.animate_sprite_tackle(user_sprite)

--- a/tuxemon/core/states/combat/combat.py
+++ b/tuxemon/core/states/combat/combat.py
@@ -558,8 +558,11 @@ class CombatState(CombatAnimations):
                 self._damage_map[target].add(user)
 
             else:  # assume this was an item used
-                if result:
-                    message += "\n" + trans('item_success')
+                if result.name == "capture":
+                    message += "\n" + trans('attempting_capture')
+                    self.task(partial(self.animate_capture_monster, result.success, result.properties["num_shakes"], target_sprite))
+                if result.success:
+                	message += "\n" + trans('item_success')
                 else:
                     message += "\n" + trans('item_failure')
 
@@ -567,11 +570,11 @@ class CombatState(CombatAnimations):
             self.suppress_phase_change()
 
         else:
-            if result:
+            if result.success:
                 self.suppress_phase_change()
                 self.alert(trans('combat_status_damage', {"name": target.name, "status": technique.name}))
 
-        if result and target_sprite and hasattr(technique, "images"):
+        if result.success and target_sprite and hasattr(technique, "images"):
             tech_sprite = self.get_technique_animation(technique)
             tech_sprite.rect.center = target_sprite.rect.center
             self.task(tech_sprite.image.play, hit_delay)

--- a/tuxemon/core/states/combat/combat_animations.py
+++ b/tuxemon/core/states/combat/combat_animations.py
@@ -390,5 +390,12 @@ class CombatAnimations(Menu):
         animate(trainer1.rect, front_island.rect, y=y_mod,
                 transition='out_back', relative=True)
 
-    def animate_capture_monster(self, is_captured, num_shakes, monster):
-        print("Capture animation goes here!")
+    def animate_capture_monster(self, is_captured, num_shakes, monster_sprite):
+        capdev = self.load_sprite('gfx/items/capture_device.png')
+        animate = partial(self.animate, capdev.rect, transition='in_quad', duration=1.0)
+        scale_sprite(capdev, .4)
+        capdev.rect.center = scale(0), scale(0)
+        animate(x=monster_sprite.rect.centerx)
+        animate(y=monster_sprite.rect.centery)
+
+

--- a/tuxemon/core/states/combat/combat_animations.py
+++ b/tuxemon/core/states/combat/combat_animations.py
@@ -389,3 +389,6 @@ class CombatAnimations(Menu):
         animate(trainer1.rect, front_island.rect, centerx=player_home.centerx)
         animate(trainer1.rect, front_island.rect, y=y_mod,
                 transition='out_back', relative=True)
+
+    def animate_capture_monster(self, is_captured, num_shakes, monster):
+        print("Capture animation goes here!")

--- a/tuxemon/core/states/items/__init__.py
+++ b/tuxemon/core/states/items/__init__.py
@@ -102,14 +102,21 @@ class ItemMenuState(Menu):
                 combat_state.enqueue_action(player, item, monster)
                 # TODO: in the future, it cannot be assumed that monster screen is up
                 self.game.pop_state()    # pop the monster screen
-                self.game.pop_state()    # pop this menu, returning to combat
+                # self.game.pop_state()    # pop this menu, returning to combat
                 self.game.pop_state()    # pop the combat menu, ending turn
 
         def confirm():
             self.game.pop_state()  # close the confirm dialog
+            combat_state = self.game.get_state_name("CombatState") # determine if in combat state
             # TODO: allow items to be used on player or "in general"
             # currently, items are only used on monsters
-            menu = self.game.push_state("MonsterMenuState")
+            menu = None
+            if combat_state is None:
+                menu = self.game.push_state("MonsterMenuState")
+            else:
+                self.game.pop_state() # pop the item selection menu
+                menu = self.game.push_state("CombatTargetMenuState")
+
             menu.on_menu_selection = use_item
 
         def cancel():

--- a/tuxemon/core/states/items/__init__.py
+++ b/tuxemon/core/states/items/__init__.py
@@ -92,7 +92,7 @@ class ItemMenuState(Menu):
                 result = item.use(player, monster)
                 # TODO: in the future, it cannot be assumed that monster screen is up
                 self.game.pop_state()    # pop the monster screen
-                if result:
+                if result.success:
                     tools.open_dialog(self.game, [trans('item_success')])
                 else:
                     tools.open_dialog(self.game, [trans('item_failure')])


### PR DESCRIPTION
This allows us to select hostile monsters.

ALSO: this implements a prototype capture animation.

NOTE: this is the 2nd earliest out of 3 forks. Please accept none or one.