### PR TITLE
#16 monsters can be sorted in the menu

### DIFF
--- a/tuxemon/core/states/monster/__init__.py
+++ b/tuxemon/core/states/monster/__init__.py
@@ -11,9 +11,10 @@ from core.components.ui.text import draw_text, TextArea
 
 
 class MonsterMenuState(Menu):
-    """ A class to create monster menu objects. The monster menu allows you to view monsters in
-    your party, teach them moves, and switch them both in and out of combat.
+    """ A class to create monster menu objects.
 
+    The monster menu allows you to view monsters in your party,
+    teach them moves, and switch them both in and out of combat.
     """
     background_filename = "gfx/ui/monster/monster_menu_bg.png"
     draw_borders = False
@@ -77,6 +78,7 @@ class MonsterMenuState(Menu):
         width, height = prepare.SCREEN_SIZE
         self.monster_portrait.rect = image.get_rect(centerx=width // 4, top=height // 12)
         self.sprites.add(self.monster_portrait)
+        self.animations.empty()
         self.animate_monster_down()
 
         width = prepare.SCREEN_SIZE[0] // 2
@@ -86,18 +88,10 @@ class MonsterMenuState(Menu):
         for i in range(self.game.player1.party_limit):
             rect = pygame.Rect(0, 0, width, height)
             surface = pygame.Surface(rect.size, pygame.SRCALPHA)
-
-            try:
-                monster = self.game.player1.monsters[i]
-            except IndexError:
-                monster = None
-
-            item = MenuItem(surface, None, None, monster)
-            if monster is None:
-                item.enabled = False
-
-            self.render_monster_slot(surface, rect, monster, item.in_focus)
+            item = MenuItem(surface, None, None, None)
             yield item
+
+        self.refresh_menu_items()
 
     def on_menu_selection(self, menu_item):
         pass
@@ -115,8 +109,17 @@ class MonsterMenuState(Menu):
 
         :return:
         """
-        for item in self.menu_items:
+        for index, item in enumerate(self.menu_items):
+            try:
+                monster = self.game.player1.monsters[index]
+            except IndexError:
+                monster = None
+            item.game_object = monster
+            item.enabled = monster is not None
             item.image.fill((0, 0, 0, 0))
+            # TODO: Cleanup this hack
+            if index == self.selected_index:
+                item.in_focus = True
             self.render_monster_slot(item.image, item.image.get_rect(), item.game_object, item.in_focus)
 
     def draw_monster_info(self, surface, monster, rect):

--- a/tuxemon/core/states/world/world_menus.py
+++ b/tuxemon/core/states/world/world_menus.py
@@ -26,6 +26,14 @@ def adapter(name, *args):
     return func
 
 
+def add_menu_items(state, items):
+    for key, callback in items:
+        label = translator.translate(key).upper()
+        image = state.shadow_text(label)
+        item = MenuItem(image, label, None, callback)
+        state.add(item)
+
+
 class WorldMenuState(Menu):
     """
     Menu for the world state
@@ -36,8 +44,6 @@ class WorldMenuState(Menu):
     def startup(self, *args, **kwargs):
         super(WorldMenuState, self).startup(*args, **kwargs)
 
-        trans = translator.translate
-
         def change_state(state, **kwargs):
             return partial(self.game.replace_state, state, **kwargs)
 
@@ -46,19 +52,13 @@ class WorldMenuState(Menu):
             self.game.done = True
             self.game.exit = True
 
-        def battle():
-            self.game.pop_state(self)
-            from core.components.event.actions.combat import Combat
-            start_battle = partial(adapter("start_battle"))
-            Combat().start_battle(self.game, start_battle(1))
-
         def not_implemented_dialog():
-            open_dialog(self.game, [trans('not_implemented')])
+            open_dialog(self.game, [translator.translate('not_implemented')])
 
         # Main Menu - Allows users to open the main menu in game.
         menu_items_map = (
             ('menu_journal', not_implemented_dialog),
-            ('menu_monster', change_state("MonsterMenuState")),
+            ('menu_monster', self.open_monster_menu),
             ('menu_bag', change_state("ItemMenuState")),
             ('menu_player', not_implemented_dialog),
             ('menu_save', change_state("SaveMenuState")),
@@ -66,12 +66,77 @@ class WorldMenuState(Menu):
             ('menu_options', not_implemented_dialog),
             ('exit', exit_game)
         )
+        add_menu_items(self, menu_items_map)
 
-        for key, callback in menu_items_map:
-            label = translator.translate(key).upper()
-            image = self.shadow_text(label)
-            item = MenuItem(image, label, None, callback)
-            self.add(item)
+    def open_monster_menu(self):
+        from core.states.monster import MonsterMenuState
+
+        def monster_menu_hook():
+            """ Used to rearrange monsters interactively
+
+            This is slow b/c forces each slot to be re-rendered.
+            Probably not an issue except for very slow systems.
+
+            :return: None
+            """
+            monster = context.get('monster')
+            if monster:
+                # TODO: maybe some API for re-arranging menu items
+                # at this point, the cursor will have changed
+                # so we need to re-arrange the list before it is rendered again
+                # TODO: API for getting the game player object
+                player = self.game.player1
+                monster_list = player.monsters
+
+                # get the newly selected item.  it will be set to previous position
+                original_monster = monster_menu.get_selected_item().game_object
+
+                # get the position in the list of the cursor
+                index = monster_list.index(original_monster)
+
+                # set the old spot to the old monster
+                monster_list[context['old_index']] = original_monster
+
+                # set the current cursor position to the monster we move
+                monster_list[index] = context['monster']
+
+                # store the old index
+                context['old_index'] = index
+
+            # call the super class to re-render the menu with new positions
+            # TODO: maybe add more hooks to eliminate this runtime patching
+            MonsterMenuState.on_menu_selection_change(monster_menu)
+
+        def select_first_monster():
+            # TODO: API for getting the game player obj
+            player = self.game.player1
+            monster = monster_menu.get_selected_item().game_object
+            context['monster'] = monster
+            context['old_index'] = player.monsters.index(monster)
+            self.game.pop_state()  # close the info/move menu
+
+        def open_monster_stats():
+            open_dialog(self.game, [translator.translate('not_implemented')])
+
+        def open_monster_submenu(menu_item):
+            menu_items_map = (
+                ('monster_menu_info', open_monster_stats),
+                ('monster_menu_move', select_first_monster),
+            )
+            menu = self.game.push_state("Menu")
+            menu.shrink_to_items = True
+            add_menu_items(menu, menu_items_map)
+
+        def handle_selection(menu_item):
+            if 'monster' in context:
+                del context['monster']
+            else:
+                open_monster_submenu(menu_item)
+
+        context = dict()    # dict passed around to hold info between menus/callbacks
+        monster_menu = self.game.replace_state("MonsterMenuState")
+        monster_menu.on_menu_selection = handle_selection
+        monster_menu.on_menu_selection_change = monster_menu_hook
 
     def animate_open(self):
         """ Animate the menu sliding in

--- a/tuxemon/resources/db/locale/en_US.json
+++ b/tuxemon/resources/db/locale/en_US.json
@@ -40,6 +40,8 @@
     "item_capture_device_name": "Capture Device",
     "item_capture_device_descr": "Captures a monster.",
     "item_cannot_use_here": "${{name}} cannot be used here!",
+    "monster_menu_info": "Info",
+    "monster_menu_move": "Move",
     "log_off": "Log Off",
     "menu_bag": "Bag",
     "menu_fight": "Fight",


### PR DESCRIPTION
Basic ability to arrange monsters in the party.  There is no animation at this point but it seems to work fine without it.  Only works when called from the World State.  Not sure if that is desired or not (can't sort during combat).  Also, some minor cleanup of docstrings and older code.

Addresses issue and milestone blocker #16 
