### PR TITLE
input state & menu touch awareness

### DIFF
--- a/tuxemon/core/components/menu/__init__.py
+++ b/tuxemon/core/components/menu/__init__.py
@@ -3,7 +3,7 @@
 #
 # Tuxemon
 # Copyright (C) 2014, William Edwards <shadowapex@gmail.com>,
-#                     Benjamin Bean <superman2k5@gmail.com>
+# Benjamin Bean <superman2k5@gmail.com>
 #
 # This file is part of Tuxemon.
 #
@@ -14,11 +14,11 @@
 #
 # Tuxemon is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Tuxemon.  If not, see <http://www.gnu.org/licenses/>.
+# along with Tuxemon. If not, see <http://www.gnu.org/licenses/>.
 #
 # Contributor(s):
 #
@@ -28,9 +28,11 @@
 # core.components.menu Menu handling module.
 #
 #
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
 # convenience imports, do not remove!
 from .menu import Menu
-from core.components.menu.menu import PopUpMenu
+from .menu import PopUpMenu
+from .input import InputMenu

--- a/tuxemon/core/components/menu/__init__.py
+++ b/tuxemon/core/components/menu/__init__.py
@@ -3,7 +3,7 @@
 #
 # Tuxemon
 # Copyright (C) 2014, William Edwards <shadowapex@gmail.com>,
-# Benjamin Bean <superman2k5@gmail.com>
+#                     Benjamin Bean <superman2k5@gmail.com>
 #
 # This file is part of Tuxemon.
 #
@@ -14,11 +14,11 @@
 #
 # Tuxemon is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Tuxemon. If not, see <http://www.gnu.org/licenses/>.
+# along with Tuxemon.  If not, see <http://www.gnu.org/licenses/>.
 #
 # Contributor(s):
 #

--- a/tuxemon/core/components/menu/input.py
+++ b/tuxemon/core/components/menu/input.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+
+from functools import partial
+
+from core import tools
+from core.components.menu import Menu
+from core.components.menu.interface import MenuItem
+from core.components.ui.text import TextArea
+
+import pygame
+
+
+class InputMenu(Menu):
+    background = None
+    draw_borders = False
+
+    chars = u"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890.-!"
+    alphabet_length = 26
+
+    def startup(self, *items, **kwargs):
+        """
+
+        Accepted Keyword Arguments:
+            prompt: String used to let user know what value is being inputted (ie "Name?", "IP Address?")
+
+        :param items:
+        :param kwargs:
+        :return:
+        """
+        super(InputMenu, self).startup(*items, **kwargs)
+        self.input_string = ""
+
+        # area where the input will be shown
+        self.text_area = TextArea(self.font, self.font_color, (96, 96, 96))
+        self.text_area.animated = False
+        self.text_area.rect = pygame.Rect(tools.scale_sequence([100, 20, 80, 100]))
+        self.sprites.add(self.text_area)
+
+        # prompt
+        self.prompt = TextArea(self.font, self.font_color, (96, 96, 96))
+        self.prompt.animated = False
+        self.prompt.rect = pygame.Rect(tools.scale_sequence([50, 20, 80, 100]))
+        self.sprites.add(self.prompt)
+
+        self.prompt.text = kwargs.get("prompt", "")
+
+    def calc_internal_rect(self):
+        w = self.rect.width - self.rect.width * .8
+        h = self.rect.height - self.rect.height * .5
+        rect = self.rect.inflate(-w, -h)
+        rect.top = self.rect.centery * .7
+        return rect
+
+    def initialize_items(self):
+        self.menu_items.columns = self.alphabet_length // 2
+
+        # add the keys
+        for char in self.chars:
+            yield MenuItem(self.shadow_text(char), None, None, partial(self.add_input_char, char))
+
+        yield MenuItem(self.shadow_text("<="), None, None, partial(self.backspace))
+        yield MenuItem(self.shadow_text("END"), None, None, partial(self.confirm))
+
+    def process_event(self, event):
+        super(InputMenu, self).process_event(event)
+
+        if event.type == pygame.KEYDOWN:
+            if event.key == pygame.K_BACKSPACE:
+                self.backspace()
+
+            char = event.unicode
+            if char in self.chars:
+                self.add_input_char(char)
+
+    def backspace(self):
+        self.input_string = self.input_string[:-1]
+        self.update_text_area()
+
+    def add_input_char(self, char):
+        self.input_string += char
+        self.update_text_area()
+
+    def update_text_area(self):
+        self.text_area.text = self.input_string
+
+    def confirm(self):
+        pass

--- a/tuxemon/core/components/menu/input.py
+++ b/tuxemon/core/components/menu/input.py
@@ -17,6 +17,7 @@ import pygame
 class InputMenu(Menu):
     background = None
     draw_borders = False
+    touch_aware = True
 
     chars = u"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890.-!"
     alphabet_length = 26
@@ -62,8 +63,11 @@ class InputMenu(Menu):
         for char in self.chars:
             yield MenuItem(self.shadow_text(char), None, None, partial(self.add_input_char, char))
 
-        yield MenuItem(self.shadow_text("<="), None, None, partial(self.backspace))
-        yield MenuItem(self.shadow_text("END"), None, None, partial(self.confirm))
+        # backspace key
+        yield MenuItem(self.shadow_text("<="), None, None, self.backspace)
+
+        # button to confirm the input and close the dialog
+        yield MenuItem(self.shadow_text("END"), None, None, self.confirm)
 
     def process_event(self, event):
         super(InputMenu, self).process_event(event)
@@ -88,4 +92,10 @@ class InputMenu(Menu):
         self.text_area.text = self.input_string
 
     def confirm(self):
-        pass
+        """ Confirm the input
+
+        This is called when user selects "End".  Override, maybe?
+
+        :return:
+        """
+        self.game.pop_state(self)

--- a/tuxemon/core/components/menu/menu.py
+++ b/tuxemon/core/components/menu/menu.py
@@ -53,6 +53,7 @@ class Menu(state.State):
     shrink_to_items = False    # fit the border to contents
     escape_key_exits = True    # escape key closes menu
     animate_contents = False   # show contents while window opens
+    touch_aware = False        # if true, then menu items can be selected with the mouse/touch
 
     def startup(self, *items, **kwargs):
         self.rect = self.rect.copy()  # do not remove!
@@ -401,6 +402,35 @@ class Menu(state.State):
                     index = self.menu_items.determine_cursor_movement(self.selected_index, event)
                     if not self.selected_index == index:
                         self.change_selection(index)
+
+        # TODO: handling of click/drag, miss-click, etc
+        # TODO: eventually, maybe move some handling into menuitems
+        # TODO: handle screen scaling?
+        # TODO: generalized widget system
+        elif self.touch_aware and event.type == pygame.MOUSEBUTTONDOWN:
+            # menu items is (sometimes) a relative group, so their rect will be relative to their parent
+            # we need to adjust the point to topleft of the containing rect
+            # eventually, a widget system could do this automatically
+
+            # make sure that the rect's position is current
+            # a sprite group may not be a relative group... so an attribute error will be raised
+            # obvi, a wart, but will be fixed sometime (tm)
+            try:
+                self.menu_items.update_rect_from_parent()
+            except AttributeError:
+                # not a relative group, no need to adjust cursor
+                mouse_pos = event.pos
+            else:
+                # move the mouse/touch origin to be relative to the menu_items
+                # TODO: a vector type would be niceeee
+                mouse_pos = [a - b for a, b in zip(event.pos, self.menu_items.rect.topleft)]
+
+            # loop through all the items here and see if they collide
+            # eventually, we should make this more generic...not part of the menu
+            for index, item in enumerate([i for i in self.menu_items if i.enabled]):
+                if item.rect.collidepoint(mouse_pos):
+                    self.change_selection(index)
+                    self.on_menu_selection(self.get_selected_item())
 
     def change_selection(self, index, animate=True):
         """ Force the menu to be evaluated and move cursor and trigger focus changes

--- a/tuxemon/core/components/sprite.py
+++ b/tuxemon/core/components/sprite.py
@@ -477,8 +477,7 @@ class VisualSpriteList(RelativeGroup):
 
             # in order to accommodate disabled menu items,
             # the mod incrementer will loop until a suitable
-            # mod is found...one that is not disabled.
-            # seeking_mod once false, will exit the loop
+            # index is found...one that is not disabled.
             items = len(self)
             mod = 0
 
@@ -528,6 +527,7 @@ class VisualSpriteList(RelativeGroup):
 
             original_index = index
             seeking_index = True
+            # seeking_index once false, will exit the loop
             while seeking_index and mod:
                 index += mod
 

--- a/tuxemon/core/components/sprite.py
+++ b/tuxemon/core/components/sprite.py
@@ -463,6 +463,9 @@ class VisualSpriteList(RelativeGroup):
            [1] [2] [3]
            [4] [5]
 
+        Works pretty well for most menus, but large grids may require
+        handling them differently.
+
         :param index: Index of the item in the list
         :param event: pygame.Event
         :returns: New menu item offset
@@ -473,32 +476,72 @@ class VisualSpriteList(RelativeGroup):
         if event.type == pygame.KEYDOWN:
 
             # in order to accommodate disabled menu items,
-            # the index incrementer will loop until a suitable
-            # index is found...one that is not disabled.
-            # seeking_index once false, will exit the loop
+            # the mod incrementer will loop until a suitable
+            # mod is found...one that is not disabled.
+            # seeking_mod once false, will exit the loop
+            items = len(self)
+            mod = 0
+
+            # horizontal movement: left and right will inc/dec mod by one
+            if self.columns > 1:
+                if event.key == pygame.K_LEFT:
+                    mod -= 1
+
+                elif event.key == pygame.K_RIGHT:
+                    mod += 1
+
+            # vertical movement: up/down will inc/dec the mod by adjusted
+            # value of number of items in a column
+            rows, remainder = divmod(items, self.columns)
+            row, col = divmod(index, self.columns)
+
+            # down key pressed
+            if event.key == pygame.K_DOWN:
+                if remainder:
+                    if row == rows:
+                        mod += remainder
+
+                    elif col < remainder:
+                        mod += self.columns
+                    else:
+                        if row == rows - 1:
+                            mod += self.columns + remainder
+                        else:
+                            mod += self.columns
+
+                else:
+                    mod = self.columns
+
+            # up key pressed
+            elif event.key == pygame.K_UP:
+                if remainder:
+                    if row == 0:
+                        if col < remainder:
+                            mod -= remainder
+                        else:
+                            mod += self.columns * (rows - 1)
+                    else:
+                        mod -= self.columns
+
+                else:
+                    mod -= self.columns
+
+            original_index = index
             seeking_index = True
-            while seeking_index:
-
-                # ignore left/right if there is only one column
-                if self.columns > 1:
-                    if event.key == pygame.K_LEFT:
-                        index -= 1
-
-                    elif event.key == pygame.K_RIGHT:
-                        index += 1
-
-                if event.key == pygame.K_DOWN:
-                    index += self.columns
-
-                elif event.key == pygame.K_UP:
-                    index -= self.columns
+            while seeking_index and mod:
+                index += mod
 
                 # wrap the cursor position
-                items = len(self)
                 if index < 0:
                     index = items - abs(index)
                 if index >= items:
                     index -= items
+
+                # while looking for a suitable index, we've looked over all choices
+                # just raise an error for now, instead of infinite looping
+                # TODO: some graceful way to handle situations where cannot find an index
+                if index == original_index:
+                    raise RuntimeError
 
                 seeking_index = not self._spritelist[index].enabled
 

--- a/tuxemon/core/components/ui/text.py
+++ b/tuxemon/core/components/ui/text.py
@@ -11,11 +11,12 @@ min_font_size = 7
 class TextArea(Sprite):
     """ Area of the screen that can draw text
     """
+    animated = True
 
     def __init__(self, font, font_color, bg=(192, 192, 192)):
         super(TextArea, self).__init__()
         self.rect = pygame.Rect(0, 0, 0, 0)
-        self.drawing_text = True
+        self.drawing_text = False
         self.font = font
         self.font_color = font_color
         self.font_bg = bg
@@ -38,16 +39,23 @@ class TextArea(Sprite):
     def text(self, value):
         if value != self._text:
             self._text = value
-        self._start_text_animation()
+
+        if self.animated:
+            self._start_text_animation()
+        else:
+            self.image = draw.shadow_text(self.font, self.font_color, self.font_bg, self._text)
 
     def __next__(self):
-        try:
-            dirty, dest, scrap = next(self._iter)
-            self._image.fill((0, 0, 0, 0), dirty)
-            self._image.blit(scrap, dest)
-        except StopIteration:
-            self.drawing_text = False
-            raise
+        if self.animated:
+            try:
+                dirty, dest, scrap = next(self._iter)
+                self._image.fill((0, 0, 0, 0), dirty)
+                self._image.blit(scrap, dest)
+            except StopIteration:
+                self.drawing_text = False
+                raise
+        else:
+            raise StopIteration
 
     next = __next__
 

--- a/tuxemon/core/control.py
+++ b/tuxemon/core/control.py
@@ -243,6 +243,10 @@ class Control(StateManager):
                 for game_event in self.get_controller_event(pg_event):
                     yield game_event
 
+            # Loop through normal mouse events
+            if pg_event.type == pg.MOUSEBUTTONDOWN:
+                yield pg_event
+
             # Loop through our joystick events
             for game_event in self.get_joystick_event(pg_event):
                 yield game_event

--- a/tuxemon/core/states/input/__init__.py
+++ b/tuxemon/core/states/input/__init__.py
@@ -1,0 +1,5 @@
+"""
+Just a placeholder for now.  Don't delete though.
+
+"""
+from core.components.menu.input import InputMenu


### PR DESCRIPTION
Add the code for the input state.  Addresses issue #156. 

So far, the state is not being used, but it could be used for naming players and monsters, IP addresses & hostnames, etc.  Its a little rough, but can be cleaned up by adding a background and eventually adding different alphabets for locale changes.

So far there is no mechanism to collect the input values, but we can work that out later.

The prompt can be changed when pushing the state:

```python

state = game.push_state("InputState", prompt="Name?")
```

One possible way to collect input would be to use the "input_string" attribute, which contains the test entered:
```python

input_state = game.push_state("InputState", prompt="Name?")

...some other work...

print(input_state.input_string)
```

Allowing the user to touch/tap/click the letters in the menu meant adding touch support to menus.... So now all menus have the ability to respond to touches or clicks.  Right now, it is only enabled for the input state, but it is trivial to enable it for others.... Just change the touch_aware attribute to True.

https://github.com/bitcraft/Tuxemon/blob/development/tuxemon/core/components/menu/menu.py#L56