### PR TITLE
targeting works as expected

### DIFF
--- a/tuxemon/core/components/db.py
+++ b/tuxemon/core/components/db.py
@@ -33,11 +33,25 @@ import json
 import logging
 import os
 
+from operator import itemgetter
+
 from core import prepare
 
 # Create a logger for optional handling of debug messages.
 logger = logging.getLogger(__name__)
 logger.debug("%s successfully imported" % __name__)
+
+
+def process_targets(json_targets):
+    """ Return values in order of preference for targeting things.
+
+    example: ["own monster", "enemy monster"]
+
+    :param json_targets:
+    :return:
+    """
+
+    return list(map(itemgetter(0), filter(itemgetter(1), sorted(json_targets.items(), key=itemgetter(1), reverse=True))))
 
 
 class JSONDatabase(object):

--- a/tuxemon/core/components/menu/menu.py
+++ b/tuxemon/core/components/menu/menu.py
@@ -458,6 +458,19 @@ class Menu(state.State):
         self.get_selected_item().in_focus = True   # set focus flag of new item
         self.on_menu_selection_change()            # let subclass know menu has changed
 
+    def search_items(self, game_object):
+        """ Non-optimised search through menu_items for a particular thing
+
+        TODO: address the confusing name "game object"
+
+        :param game_object:
+        :return:
+        """
+        for menu_item in self.menu_items:
+            if game_object == menu_item.game_object:
+                return menu_item
+        return None
+
     def trigger_cursor_update(self, animate=True):
         """ Force the menu cursor to move into the correct position
 

--- a/tuxemon/core/components/sprite.py
+++ b/tuxemon/core/components/sprite.py
@@ -470,7 +470,10 @@ class VisualSpriteList(RelativeGroup):
         :param event: pygame.Event
         :returns: New menu item offset
         """
-        if not len(self):
+        # sanity check:
+        # if there are 0 or 1 enabled items, then ignore movement
+        enabled = len([i for i in self if i.enabled])
+        if enabled < 2:
             return 0
 
         if event.type == pygame.KEYDOWN:

--- a/tuxemon/core/components/technique.py
+++ b/tuxemon/core/components/technique.py
@@ -110,11 +110,7 @@ class Technique(object):
 
         self.power = results["power"]
         self.effect = results["effects"]
-
-        #TODO: maybe break out into own function
-        from operator import itemgetter
-        self.target = map(itemgetter(0), filter(itemgetter(1),
-                          sorted(results["target"].items(), key=itemgetter(1), reverse=True)))
+        self.target = db.process_targets(results["target"])
 
         # Load the animation sprites that will be used for this technique
         self.animation = results["animation"]

--- a/tuxemon/core/states/combat/combat.py
+++ b/tuxemon/core/states/combat/combat.py
@@ -560,21 +560,23 @@ class CombatState(CombatAnimations):
                 self._damage_map[target].add(user)
 
             else:  # assume this was an item used
+                # handle the capture device
                 if result["name"] == "capture":
                     message += "\n" + trans('attempting_capture')
-                    self.task(partial(self.animate_capture_monster, result["success"], result["num_shakes"], target))
                     action_time = result["num_shakes"] + 1.8
+                    self.animate_capture_monster(result["success"], result["num_shakes"], target)
                     if result["success"]: # end combat right here
                         self.task(self.end_combat, action_time + 0.5) # Display 'Gotcha!' first.
                         self.task(partial(self.alert, trans('gotcha')), action_time)
-                        self.alert(message)
                         self._animation_in_progress = True
                         return
 
-                if result["success"]:
-                    message += "\n" + trans('item_success')
+                # generic handling of anything else
                 else:
-                    message += "\n" + trans('item_failure')
+                    if result["success"]:
+                        message += "\n" + trans('item_success')
+                    else:
+                        message += "\n" + trans('item_failure')
 
             self.alert(message)
             self.suppress_phase_change(action_time)

--- a/tuxemon/core/states/combat/combat_menus.py
+++ b/tuxemon/core/states/combat/combat_menus.py
@@ -207,6 +207,20 @@ class CombatTargetMenuState(Menu):
 
         for player, monsters in combat_state.monsters_in_play.items():
             for monster in monsters:
+
+                # TODO: more targeting classes
+                if player == self.player:
+                    targeting_class = "own monster"
+                else:
+                    targeting_class = "enemy monster"
+
+                self.targeting_map[targeting_class].append(monster)
+
+                # TODO: handle odd cases where a situation creates no valid targets
+                # if this target type is not handled by this action, then skip it
+                if targeting_class not in self.action.target:
+                    continue
+
                 # inspect the monster sprite and make a border image for it
                 sprite = combat_state._monster_sprite_map[monster]
                 item = MenuItem(None, None, None, monster)

--- a/tuxemon/core/states/combat/combat_menus.py
+++ b/tuxemon/core/states/combat/combat_menus.py
@@ -229,12 +229,6 @@ class CombatTargetMenuState(Menu):
                 item.rect.inflate_ip(tools.scale(16), tools.scale(16))
                 item.rect.center = center
 
-                # determine who owns the monster
-                if player == self.player:
-                    self.targeting_map["own monster"].append(monster)
-                else:
-                    self.targeting_map["enemy monster"].append(monster)
-
                 yield item
 
     def refresh_layout(self):

--- a/tuxemon/core/states/items/__init__.py
+++ b/tuxemon/core/states/items/__init__.py
@@ -83,40 +83,21 @@ class ItemMenuState(Menu):
             player = self.game.player1
             monster = menu_item.game_object
 
-            # determine if being called during combat state
-            combat_state = self.game.get_state_name("CombatState")
-            if combat_state is None:
-                # item screen was not opened during combat
-                # item must be used before state is popped.
-                # don't try to combine with "if result..." condition below
-                result = item.use(player, monster)
-                # TODO: in the future, it cannot be assumed that monster screen is up
-                self.game.pop_state()    # pop the monster screen
-                if result.success:
-                    tools.open_dialog(self.game, [trans('item_success')])
-                else:
-                    tools.open_dialog(self.game, [trans('item_failure')])
+            # item must be used before state is popped.
+            # don't try to combine with "if result..." condition below
+            result = item.use(player, monster)
+            self.game.pop_state()    # pop the monster screen
+            self.game.pop_state()    # pop the item screen
+            if result["success"]:
+                tools.open_dialog(self.game, [trans('item_success')])
             else:
-                # item screen was opened during combat
-                # add this item to the combat action queue
-                combat_state.enqueue_action(player, item, monster)
-                # TODO: in the future, it cannot be assumed that monster screen is up
-                self.game.pop_state()    # pop the monster screen
-                # self.game.pop_state()    # pop this menu, returning to combat
-                self.game.pop_state()    # pop the combat menu, ending turn
+                tools.open_dialog(self.game, [trans('item_failure')])
 
         def confirm():
             self.game.pop_state()  # close the confirm dialog
-            combat_state = self.game.get_state_name("CombatState") # determine if in combat state
             # TODO: allow items to be used on player or "in general"
-            # currently, items are only used on monsters
-            menu = None
-            if combat_state is None:
-                menu = self.game.push_state("MonsterMenuState")
-            else:
-                self.game.pop_state() # pop the item selection menu
-                menu = self.game.push_state("CombatTargetMenuState")
 
+            menu = self.game.push_state("MonsterMenuState")
             menu.on_menu_selection = use_item
 
         def cancel():

--- a/tuxemon/resources/db/item/capture_device.json
+++ b/tuxemon/resources/db/item/capture_device.json
@@ -11,7 +11,7 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "own monster": 1,
+    "own monster": 0,
     "own team": 0,
     "own trainer": 0,
     "item": 0

--- a/tuxemon/resources/db/item/potion.json
+++ b/tuxemon/resources/db/item/potion.json
@@ -11,7 +11,7 @@
     "enemy monster": 1,
     "enemy team": 0,
     "enemy trainer": 0,
-    "own monster": 0,
+    "own monster": 2,
     "own team": 0,
     "own trainer": 0,
     "item": 0


### PR DESCRIPTION
seems like a lot, but mostly reorganization.  targeting now works correctly.  attacks will default to the other party, and healing items will default to the players monster.

- moved the "read json file targets" code to a function in db.py
- modify items.py and techniques.py to use the new function to read targeting data
- finalize and fix the "return a dictionary of results from technique or item"
- fixed issue of items not working after combat (#235).  related to the line above
- fixed a crash when menus only contain one item (not reported)
- when using items during combat, the game will show the battle scene when choosing target of item
- simplified the item screen
- modified a few items where the targeting was incorrect
- linting and documentation
