### PR TITLE
Add init and interact objects to the maps.

### DIFF
--- a/tuxemon/core/components/event/__init__.py
+++ b/tuxemon/core/components/event/__init__.py
@@ -97,6 +97,27 @@ class EventEngine(object):
         """
 
         if self.state == "running":
+            for e in game.inits:
+                should_run = True
+
+                # If any conditions fail, the event should not be run
+                for cond in e['conds']:
+                    # Conditions have so-called "operators".  If a condition's operator == "is" then
+                    # the condition should be processed as usual.
+                    # However, if the condition != "is", the result should be inverted.
+                    # The following line implements this.
+                    # I am not satisfied with the clarity of this line, so if anyone can express this better,
+                    # please change it.
+                    if not self.state == "running":
+                        return
+                    check_condition = self.conditions[cond.type]['method']
+                    should_run = (check_condition(game, cond) == (cond.operator == 'is'))
+                    if not should_run:
+                        break
+
+                if should_run:
+                    self.execute_action(e['acts'], game)
+            game.inits = list()
             for e in game.events:
                 should_run = True
 

--- a/tuxemon/core/components/event/actions/core.py
+++ b/tuxemon/core/components/event/actions/core.py
@@ -479,8 +479,8 @@ class Core(object):
         events = game.events
 
         for e in events:
-            if e['id'] == int(action.parameters[0]):
-                event_engine.execute_action(e['acts'], game)
+            if e.id == int(action.parameters[0]):
+                event_engine.execute_action(e.acts, game)
 
     def dialog_choice(self, game, action, contexts):
         """Asks the player to make a choice.

--- a/tuxemon/core/components/map.py
+++ b/tuxemon/core/components/map.py
@@ -36,6 +36,7 @@ from collections import namedtuple
 from core.components.pyganim import PygAnimation
 from core.components.event import Action
 from core.components.event import Condition
+from core.components.event import EventObject
 
 # Handle older versions of PyTMX.
 try:
@@ -77,6 +78,7 @@ class Map(object):
 
         self.events = []
         self.inits = []
+        self.interacts = []
 
         # Initialize the map
         self.load(filename)
@@ -177,6 +179,9 @@ class Map(object):
             elif obj.type == 'init':
                 self.inits.append(self.loadevent(obj))
 
+            elif obj.type == 'interact':
+                self.interacts.append(self.loadevent(obj))
+
     def loadevent(self, obj):
         conds = []
         acts = []
@@ -228,7 +233,7 @@ class Map(object):
 
                 acts.append(action)
 
-        return {'conds': conds, 'acts': acts, 'id': obj.id}
+        return EventObject(obj.id, int(obj.x / self.tile_size[0]), int(obj.y / self.tile_size[1]), conds, acts)
 
     def loadfile(self, tile_size):
         """Loads the tile and collision data from the map file and returns a list of tiles with

--- a/tuxemon/core/components/map.py
+++ b/tuxemon/core/components/map.py
@@ -76,6 +76,7 @@ class Map(object):
         self.collision_lines = []
 
         self.events = []
+        self.inits = []
 
         # Initialize the map
         self.load(filename)
@@ -171,58 +172,63 @@ class Map(object):
                 self.collision_lines.append(obj)
 
             elif obj.type == 'event':
-                conds = []
-                acts = []
+                self.events.append(self.loadevent(obj))
 
-                # Conditions & actions are stored as Tiled properties.
-                # We need to sort them by name, so that "act1" comes before "act2" and so on..
-                keys = sorted(obj.properties.keys())
+            elif obj.type == 'init':
+                self.inits.append(self.loadevent(obj))
 
-                for k in keys:
-                    if k.startswith('cond'):
-                        words = obj.properties[k].split(' ', 2)
+    def loadevent(self, obj):
+        conds = []
+        acts = []
 
-                        # Conditions have the form 'operator type parameters'.
-                        operator, cond_type = words[0:2]
+        # Conditions & actions are stored as Tiled properties.
+        # We need to sort them by name, so that "act1" comes before "act2" and so on..
+        keys = sorted(obj.properties.keys())
 
-                        # If this condition has parameters, split them into a
-                        # list
-                        if len(words) > 2:
-                            args = self.split_escaped(words[2])
-                        else:
-                            args = list()
+        for k in keys:
+            if k.startswith('cond'):
+                words = obj.properties[k].split(' ', 2)
 
-                        # Create a condition object using named tuples
-                        condition = Condition(cond_type,
-                                              args,
-                                              int(obj.x / self.tile_size[0]),
-                                              int(obj.y / self.tile_size[1]),
-                                              int(obj.width / self.tile_size[0]),
-                                              int(obj.height / self.tile_size[1]),
-                                              operator)
+                # Conditions have the form 'operator type parameters'.
+                operator, cond_type = words[0:2]
 
-                        conds.append(condition)
+                # If this condition has parameters, split them into a
+                # list
+                if len(words) > 2:
+                    args = self.split_escaped(words[2])
+                else:
+                    args = list()
 
-                    elif k.startswith('act'):
-                        words = obj.properties[k].split(' ', 1)
+                # Create a condition object using named tuples
+                condition = Condition(cond_type,
+                                      args,
+                                      int(obj.x / self.tile_size[0]),
+                                      int(obj.y / self.tile_size[1]),
+                                      int(obj.width / self.tile_size[0]),
+                                      int(obj.height / self.tile_size[1]),
+                                      operator)
 
-                        # Actions have the form 'type parameters'.
-                        act_type = words[0]
+                conds.append(condition)
 
-                        # If this action has parameters, split them into a
-                        # list
-                        if len(words) > 1:
-                            args = self.split_escaped(words[1])
-                        else:
-                            args = list()
+            elif k.startswith('act'):
+                words = obj.properties[k].split(' ', 1)
 
-                        # Create an action object using named tuples
-                        action = Action(act_type, args)
+                # Actions have the form 'type parameters'.
+                act_type = words[0]
 
-                        acts.append(action)
+                # If this action has parameters, split them into a
+                # list
+                if len(words) > 1:
+                    args = self.split_escaped(words[1])
+                else:
+                    args = list()
 
-                self.events.append({'conds': conds, 'acts': acts, 'id': obj.id})
+                # Create an action object using named tuples
+                action = Action(act_type, args)
 
+                acts.append(action)
+
+        return {'conds': conds, 'acts': acts, 'id': obj.id}
 
     def loadfile(self, tile_size):
         """Loads the tile and collision data from the map file and returns a list of tiles with

--- a/tuxemon/core/control.py
+++ b/tuxemon/core/control.py
@@ -47,6 +47,7 @@ class Control(StateManager):
         # somehow this value is being patched somewhere
         self.events = list()
         self.inits = list()
+        self.interacts = list()
 
         # TODO: move out to state manager
         self.package = "core.states"

--- a/tuxemon/core/control.py
+++ b/tuxemon/core/control.py
@@ -46,6 +46,7 @@ class Control(StateManager):
 
         # somehow this value is being patched somewhere
         self.events = list()
+        self.inits = list()
 
         # TODO: move out to state manager
         self.package = "core.states"

--- a/tuxemon/core/states/world/worldstate.py
+++ b/tuxemon/core/states/world/worldstate.py
@@ -784,6 +784,7 @@ class WorldState(state.State):
         self.map_size = map_data["map_size"]
         self.game.events = map_data["events"]
         self.game.inits = map_data["inits"]
+        self.game.interacts = map_data["interacts"]
         self.game.event_engine.current_map = map_data
 
         # Clear out any existing NPCs
@@ -797,6 +798,7 @@ class WorldState(state.State):
         map_data["data"] = map.Map(map_name)
         map_data["events"] = map_data["data"].events
         map_data["inits"] = map_data["data"].inits
+        map_data["interacts"] = map_data["data"].interacts
         map_data["tiles"], map_data["collision_map"], map_data["collision_lines_map"], map_data["map_size"] = \
             map_data["data"].loadfile(self.tile_size)
 

--- a/tuxemon/core/states/world/worldstate.py
+++ b/tuxemon/core/states/world/worldstate.py
@@ -783,6 +783,7 @@ class WorldState(state.State):
         self.collision_lines_map = map_data["collision_lines_map"]
         self.map_size = map_data["map_size"]
         self.game.events = map_data["events"]
+        self.game.inits = map_data["inits"]
         self.game.event_engine.current_map = map_data
 
         # Clear out any existing NPCs
@@ -795,6 +796,7 @@ class WorldState(state.State):
         map_data = {}
         map_data["data"] = map.Map(map_name)
         map_data["events"] = map_data["data"].events
+        map_data["inits"] = map_data["data"].inits
         map_data["tiles"], map_data["collision_map"], map_data["collision_lines_map"], map_data["map_size"] = \
             map_data["data"].loadfile(self.tile_size)
 

--- a/tuxemon/resources/maps/bedroom_test.tmx
+++ b/tuxemon/resources/maps/bedroom_test.tmx
@@ -61,7 +61,7 @@
     <property name="cond3" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
-  <object id="11" name="Get Fruitera" type="event" x="144" y="112" width="16" height="16">
+  <object id="11" name="Get Fruitera" type="interact" x="144" y="112" width="16" height="16">
    <properties>
     <property name="act1" value="add_monster txmn_fruitera,10"/>
     <property name="act2" value="translated_dialog received_x,name=Fruitera"/>
@@ -69,19 +69,15 @@
     <property name="act4" value="add_item item_potion"/>
     <property name="act5" value="add_item item_capture_device"/>
     <property name="act6" value="set_variable got_fruitera:yes"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="not variable_set got_fruitera:yes"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="not variable_set got_fruitera:yes"/>
    </properties>
   </object>
-  <object id="16" name="Lord Lampy" type="event" x="32" y="32" width="16" height="16">
+  <object id="16" name="Lord Lampy" type="interact" x="32" y="32" width="16" height="16">
    <properties>
     <property name="act1" value="dialog_chain Hello stranger!"/>
     <property name="act2" value="dialog_chain My name is Lampy, lord of all lamps."/>
     <property name="act3" value="dialog_chain Go forth and inact my lampy will."/>
     <property name="act4" value="dialog_chain ${{end}}"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="17" name="Lord or Filth" type="event" x="48" y="32" width="16" height="16">

--- a/tuxemon/resources/maps/downstairs_test.tmx
+++ b/tuxemon/resources/maps/downstairs_test.tmx
@@ -46,7 +46,7 @@
   <object id="8" type="collision" x="16" y="128" width="144" height="16"/>
  </objectgroup>
  <objectgroup color="#ffff00" name="Events">
-  <object id="23" name="Play Music" type="event" x="144" y="16" width="16" height="16">
+  <object id="23" name="Play Music" type="init" x="144" y="16" width="16" height="16">
    <properties>
     <property name="act1" value="play_music 472452_8-Bit-Ambient.ogg"/>
     <property name="cond1" value="not music_playing 472452_8-Bit-Ambient.ogg"/>

--- a/tuxemon/resources/maps/map1.tmx
+++ b/tuxemon/resources/maps/map1.tmx
@@ -200,7 +200,7 @@
     <property name="cond1" value="is player_at 43,45"/>
    </properties>
   </object>
-  <object id="68" name="Play Music" type="event" x="0" y="0" width="16" height="16">
+  <object id="68" name="Play Music" type="init" x="0" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="play_music 479403_its-a-unix-system.ogg"/>
     <property name="cond1" value="not music_playing 479403_its-a-unix-system.ogg"/>


### PR DESCRIPTION
This implements issue #251 

The init object type is run when the map is loaded. This allows us to avoid constantly checking events that only run once.

The interact object runs when the player is facing the tile and pressing return. This makes adding interactive squares easier for map designers. It also decreases the number of events we need to check if return is not being pressed.

Right now the code cheats a little for the interact check. I created an EventObject (I'm open to better name for the object). It has x and y coordinates. That is passed into the check_condition function since we don't have a Condition object. Ideally I'd like to see check_condition take the EventObject and Condition object. That way x and y information is only stored once and is removed from the Condition object. Same could be done with width and height but that is not in the patch at the moment.

When should the wiki be updated? Should I add information about the init and interact objects now? Wait until it is committed to the Tuxemon/Tuxemon repository? Wait until it is merged into master?