### PR TITLE
Implement healing action

### DIFF
--- a/tuxemon/core/components/event/actions/player.py
+++ b/tuxemon/core/components/event/actions/player.py
@@ -283,6 +283,9 @@ class Player(object):
         monster_health = action.parameters[1]
 
         if monster_slot:
+            if len(game.player1.monsters) < int(monster_slot):
+                return
+
             monster = game.player1.monsters[int(monster_slot)]
             if monster_health:
                 monster.current_hp = int(monster.hp * min(1, max(0, float(monster_health))))
@@ -331,6 +334,9 @@ class Player(object):
         monster_status = action.parameters[1]
 
         if monster_slot:
+            if len(game.player1.monsters) < int(monster_slot):
+                return
+
             monster = game.player1.monsters[int(monster_slot)]
             if monster_status:
                 monster.status.append(monster_status)
@@ -379,6 +385,9 @@ class Player(object):
         monster_level = action.parameters[1]
 
         if monster_slot:
+            if len(game.player1.monsters) < int(monster_slot):
+                return
+
             monster = game.player1.monsters[int(monster_slot)]
             if monster_level:
                 monster.level = max(1, monster.level + int(monster_level))

--- a/tuxemon/core/components/event/actions/player.py
+++ b/tuxemon/core/components/event/actions/player.py
@@ -293,6 +293,96 @@ class Player(object):
                     monster.current_hp = monster.hp
 
 
+    def set_monster_status(self, game, action, contexts):
+        """Changes the status of a monster in the current player's party. The action parameters
+        may contain a monster slot and the new status to be appended. If no slot is specified,
+        all monsters are modified. If no status is specified, the status is cleared.
+
+        :param game: The main game object that contains all the game's variables.
+        :param action: The action (tuple) retrieved from the database that contains the action's
+            parameters
+
+        :type game: core.control.Control
+        :type action: Tuple
+
+        :rtype: None
+        :returns: None
+
+        Valid Parameters: slot,status
+
+        **Example:**
+
+        >>> action.__dict__
+        {
+            "type": "set_monster_status",
+            "parameters": [
+                "0",
+                "status_poison"
+            ]
+        }
+        """
+        monster_slot = action.parameters[0]
+        monster_status = action.parameters[1]
+
+        if monster_slot:
+            monster = game.player1.monsters[int(monster_slot)]
+            if monster_status:
+                monster.status.append(monster_status)
+            else:
+                monster.status = []
+        else:
+            for monster in game.player1.monsters:
+                if monster_status:
+                    monster.status.append(monster_status)
+                else:
+                    monster.status = []
+
+
+    def set_monster_level(self, game, action, contexts):
+        """Changes the level of a monster in the current player's party. The action parameters
+        may contain a monster slot and the amount by which to level. If no slot is specified,
+        all monsters are leveled. If no level is specified, the level is reverted to 1.
+
+        :param game: The main game object that contains all the game's variables.
+        :param action: The action (tuple) retrieved from the database that contains the action's
+            parameters
+
+        :type game: core.control.Control
+        :type action: Tuple
+
+        :rtype: None
+        :returns: None
+
+        Valid Parameters: slot,level
+
+        **Example:**
+
+        >>> action.__dict__
+        {
+            "type": "set_monster_level",
+            "parameters": [
+                "0",
+                "1"
+            ]
+        }
+        """
+        monster_slot = action.parameters[0]
+        monster_level = action.parameters[1]
+
+        if monster_slot:
+            monster = game.player1.monsters[int(monster_slot)]
+            if monster_level:
+                monster.level = max(1, monster.level + int(monster_level))
+            else:
+                monster.level = 1
+        else:
+            for monster in game.player1.monsters:
+                if monster_level:
+                    monster.level = max(1, monster.level + int(monster_level))
+                else:
+                    monster.level = 1
+
+
     def add_item(self, game, action, contexts):
         """Adds an item to the current player's inventory. The action parameter must contain an
         item name to look up in the item database.

--- a/tuxemon/core/components/event/actions/player.py
+++ b/tuxemon/core/components/event/actions/player.py
@@ -248,6 +248,51 @@ class Player(object):
         game.player1.add_monster(current_monster)
 
 
+    def set_monster_health(self, game, action, contexts):
+        """Changes the hp of a monster in the current player's party. The action parameters
+        may contain a monster slot and the amount of health. If no slot is specified,
+        all monsters are healed. If no health is specified, the hp is maxed out.
+
+        :param game: The main game object that contains all the game's variables.
+        :param action: The action (tuple) retrieved from the database that contains the action's
+            parameters
+
+        :type game: core.control.Control
+        :type action: Tuple
+
+        :rtype: None
+        :returns: None
+
+        Valid Parameters: slot,health
+
+        **Example:**
+
+        >>> action.__dict__
+        {
+            "type": "set_monster_health",
+            "parameters": [
+                "0",
+                "1"
+            ]
+        }
+        """
+        monster_slot = action.parameters[0]
+        monster_health = action.parameters[1]
+
+        if monster_slot:
+            monster = game.player1.monsters[int(monster_slot)]
+            if monster_health:
+                monster.current_hp = int(monster.hp * min(1, max(0, float(monster_health))))
+            else:
+                monster.current_hp = monster.hp
+        else:
+            for monster in game.player1.monsters:
+                if monster_health:
+                    monster.current_hp = int(monster.hp * min(1, max(0, float(monster_health))))
+                else:
+                    monster.current_hp = monster.hp
+
+
     def add_item(self, game, action, contexts):
         """Adds an item to the current player's inventory. The action parameter must contain an
         item name to look up in the item database.

--- a/tuxemon/core/components/event/actions/player.py
+++ b/tuxemon/core/components/event/actions/player.py
@@ -276,6 +276,9 @@ class Player(object):
             ]
         }
         """
+        if not game.player1.monsters > 0:
+            return
+
         monster_slot = action.parameters[0]
         monster_health = action.parameters[1]
 
@@ -321,6 +324,9 @@ class Player(object):
             ]
         }
         """
+        if not game.player1.monsters > 0:
+            return
+
         monster_slot = action.parameters[0]
         monster_status = action.parameters[1]
 
@@ -366,6 +372,9 @@ class Player(object):
             ]
         }
         """
+        if not game.player1.monsters > 0:
+            return
+
         monster_slot = action.parameters[0]
         monster_level = action.parameters[1]
 

--- a/tuxemon/resources/maps/healing_center.tmx
+++ b/tuxemon/resources/maps/healing_center.tmx
@@ -49,7 +49,8 @@
  <objectgroup color="#ffff00" name="Events">
   <object id="16" name="Heal Tuxemon" type="event" x="112" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog Your tuxemon are now at full health! (Not yet implemented)"/>
+    <property name="act1" value="set_monster_health ,"/>
+    <property name="act2" value="dialog Your tuxemon are now at full health!"/>
     <property name="cond1" value="is player_at"/>
     <property name="cond2" value="is player_facing up"/>
     <property name="cond3" value="is button_pressed K_RETURN"/>

--- a/tuxemon/resources/maps/healing_center.tmx
+++ b/tuxemon/resources/maps/healing_center.tmx
@@ -50,7 +50,8 @@
   <object id="16" name="Heal Tuxemon" type="event" x="112" y="128" width="16" height="16">
    <properties>
     <property name="act1" value="set_monster_health ,"/>
-    <property name="act2" value="dialog Your tuxemon are now at full health!"/>
+    <property name="act2" value="set_monster_status ,"/>
+    <property name="act3" value="dialog Your tuxemon are now at full health!"/>
     <property name="cond1" value="is player_at"/>
     <property name="cond2" value="is player_facing up"/>
     <property name="cond3" value="is button_pressed K_RETURN"/>


### PR DESCRIPTION
Today I decided it's time to attempt my first pull request for Tuxemon. I noticed that although a lot of features got done, the healing center is still unable to heal your Tuxemon! Since this is one of the basics that's still missing, and a fairly easy thing to fix, I decided to start off by giving it a shot.

This implements a set_monster_health action. It takes two optional parameters: The first is which monster slot to heal, if left empty then all are healed. The second is the amount of health to give them, if left empty the health is maxed out. The healing center map was also updated, and talking to the counter will actually heal your Tuxemon now.

Note: Although I try to code as cleanly and efficiently as possible, I'm not familiar with Tuxemon's code and Python in general. My changes might need to be checked and modified by a more experienced developer. I have tested them to be work properly, but extra testing wouldn't hurt.