### PR TITLE
Append quantity to item names

### DIFF
--- a/tuxemon/core/states/items/__init__.py
+++ b/tuxemon/core/states/items/__init__.py
@@ -129,8 +129,17 @@ class ItemMenuState(Menu):
         """
         for name, properties in self.game.player1.inventory.items():
             obj = properties['item']
+            quantity = properties['quantity']
+
+            # temporarily add the quantity to the name
+            old_name = obj.name
+            obj.name += " x " + str(quantity)
+
             image = self.shadow_text(obj.name, bg=(128, 128, 128))
             yield MenuItem(image, obj.name, obj.description, obj)
+
+            # restore the original name
+            obj.name = old_name
 
     def on_menu_selection_change(self):
         """ Called when menu selection changes


### PR DESCRIPTION
I noticed that, when viewing items in the bag, there's no way of knowing how many you have. This patch adds the quantity to the right of each item, in a classic "name x #" format.

![screenshot_20170117_013040](https://cloud.githubusercontent.com/assets/825418/22002870/f7d8359c-dc57-11e6-9398-c8e576097f0d.png)

An obvious and important mention: The way I'm doing this isn't really the nicest and cleanest, though after looking through the code I concluded it's the only one possible. Basically I need to change the item's real name before the menu entry is generated, then revert it back afterward. The developers know best whether a better method is possible, in which case this should be redone by someone more knowing in the menu code.