### PR TITLE
Monster properties in dialogs

### DIFF
--- a/tuxemon/core/components/event/actions/core.py
+++ b/tuxemon/core/components/event/actions/core.py
@@ -59,6 +59,15 @@ class Core(object):
         text = text.replace("${{name}}", game.player1.name)
         text = text.replace(r"\n", "\n")
 
+        for i in range(len(game.player1.monsters)):
+            monster = game.player1.monsters[i]
+            text = text.replace("${{monster_" + str(i) + "_name}}", monster.name)
+            text = text.replace("${{monster_" + str(i) + "_desc}}", monster.description)
+            text = text.replace("${{monster_" + str(i) + "_type}}", monster.slug)
+            text = text.replace("${{monster_" + str(i) + "_hp}}", str(monster.current_hp))
+            text = text.replace("${{monster_" + str(i) + "_hp_max}}", str(monster.hp))
+            text = text.replace("${{monster_" + str(i) + "_level}}", str(monster.level))
+
         return text
 
 

--- a/tuxemon/resources/maps/downstairs_test.tmx
+++ b/tuxemon/resources/maps/downstairs_test.tmx
@@ -52,6 +52,15 @@
     <property name="cond1" value="not music_playing 472452_8-Bit-Ambient.ogg"/>
    </properties>
   </object>
+  <object id="24" name="Watch TV" type="event" x="32" y="96" width="16" height="16">
+   <properties>
+    <property name="act1" value="dialog You watch some TV with your beloved Lv ${{monster_0_level}} ${{monster_0_name}}."/>
+    <property name="cond1" value="is party_size greater_than,0"/>
+    <property name="cond2" value="is player_at 2,6"/>
+    <property name="cond3" value="is player_facing up"/>
+    <property name="cond4" value="is button_pressed K_RETURN"/>
+   </properties>
+  </object>
   <object id="25" name="Read Sign" type="event" x="32" y="48" width="16" height="16">
    <properties>
     <property name="act1" value="dialog Home Sweet Home"/>


### PR DESCRIPTION
A little patch adding new text replacement variables for dialogs, capable of listing several monster properties. They operate based on party slot, so for instance ${{monster_0_name}} is the name of the first monster in your party. Properties include: Name, description, type, hp, maximum hp, level. The patch also includes a simple test case in the player's house.

The main reason for this addition is allowing NPC's to make various comments about the player's Tuxemon. For instance, someone you encounter in the world may say "Wow... you have your own Fruitera, and it's even a level 10!". As an idea for later, conditionals for these values could be implemented as well, though I don't know how to do that right now.

![screenshot_20170117_150923](https://cloud.githubusercontent.com/assets/825418/22023624/98699222-dccf-11e6-8c7e-821795eb17df.png)