### PR TITLE
Collision property to force continuous movement

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -495,4 +495,4 @@ Special Thanks
 
 ### Patreon Supporters
 * [Chris Sakkas](https://www.patreon.com/user?u=40864)
-
+* [Kelvin Shadewing](https://www.patreon.com/kelvin)

--- a/tuxemon/core/components/map.py
+++ b/tuxemon/core/components/map.py
@@ -476,6 +476,8 @@ class Map(object):
                                 tile_conditions['enter'] = enters
                             if "exit" in key:
                                 tile_conditions['exit'] = exits
+                            if "continue" in key:
+                                tile_conditions['continue'] = collision_region.properties[key]
                         collision_map[collision_tile] = tile_conditions
 
         # Similar to collisions, except we need to identify the tiles

--- a/tuxemon/core/components/player.py
+++ b/tuxemon/core/components/player.py
@@ -345,22 +345,26 @@ class Player(object):
                     if game.game.isclient or game.game.ishost:
                         game.game.client.update_player(self.facing, event_type="CLIENT_MOVE_COMPLETE")
 
-        # If this collision tile has a continue direction, force the player to walk toward it
+        # If this collision tile has a continue direction, force the player to keep walking
         if not self.moving:
             if player_pos in collision_dict:
-                if collision_dict[player_pos]["continue"] == "up":
+                direction_next = collision_dict[player_pos]["continue"]
+                if not (direction_next == "up" or direction_next == "down" or direction_next == "left" or direction_next == "right"):
+                    direction_next = self.move_direction
+
+                if direction_next == "up":
                     self.move_destination = [int(global_x), int(global_y + tile_size[1])]
                     self.move_direction = "up"
                     self.moving = True
-                elif collision_dict[player_pos]["continue"] == "down":
+                elif direction_next == "down":
                     self.move_destination = [int(global_x), int(global_y - tile_size[1])]
                     self.move_direction = "down"
                     self.moving = True
-                elif collision_dict[player_pos]["continue"] == "left":
+                elif direction_next == "left":
                     self.move_destination = [int(global_x + tile_size[1]), int(global_y)]
                     self.move_direction = "left"
                     self.moving = True
-                elif collision_dict[player_pos]["continue"] == "right":
+                elif direction_next == "right":
                     self.move_destination = [int(global_x - tile_size[1]), int(global_y)]
                     self.move_direction = "right"
                     self.moving = True

--- a/tuxemon/core/components/player.py
+++ b/tuxemon/core/components/player.py
@@ -345,6 +345,26 @@ class Player(object):
                     if game.game.isclient or game.game.ishost:
                         game.game.client.update_player(self.facing, event_type="CLIENT_MOVE_COMPLETE")
 
+        # If this collision tile has a continue direction, force the player to walk toward it
+        if not self.moving:
+            if player_pos in collision_dict:
+                if collision_dict[player_pos]["continue"] == "up":
+                    self.move_destination = [int(global_x), int(global_y + tile_size[1])]
+                    self.move_direction = "up"
+                    self.moving = True
+                elif collision_dict[player_pos]["continue"] == "down":
+                    self.move_destination = [int(global_x), int(global_y - tile_size[1])]
+                    self.move_direction = "down"
+                    self.moving = True
+                elif collision_dict[player_pos]["continue"] == "left":
+                    self.move_destination = [int(global_x + tile_size[1]), int(global_y)]
+                    self.move_direction = "left"
+                    self.moving = True
+                elif collision_dict[player_pos]["continue"] == "right":
+                    self.move_destination = [int(global_x - tile_size[1]), int(global_y)]
+                    self.move_direction = "right"
+                    self.moving = True
+
         return global_x, global_y
 
     def move_one_tile(self, direction):

--- a/tuxemon/resources/maps/map1.tmx
+++ b/tuxemon/resources/maps/map1.tmx
@@ -130,54 +130,63 @@
    <properties>
     <property name="enter_from" value="up"/>
     <property name="exit_to" value="down"/>
+    <property name="continue" value="down"/>
    </properties>
   </object>
   <object id="55" type="collision" x="544" y="416" width="96" height="16">
    <properties>
     <property name="enter_from" value="up"/>
     <property name="exit_to" value="down"/>
+    <property name="continue" value="down"/>
    </properties>
   </object>
   <object id="56" type="collision" x="544" y="352" width="96" height="16">
    <properties>
     <property name="enter_from" value="up"/>
     <property name="exit_to" value="down"/>
+    <property name="continue" value="down"/>
    </properties>
   </object>
   <object id="57" type="collision" x="400" y="352" width="112" height="16">
    <properties>
     <property name="enter_from" value="up"/>
     <property name="exit_to" value="down"/>
+    <property name="continue" value="down"/>
    </properties>
   </object>
   <object id="58" type="collision" x="352" y="352" width="32" height="16">
    <properties>
     <property name="enter_from" value="up"/>
     <property name="exit_to" value="down"/>
+    <property name="continue" value="down"/>
    </properties>
   </object>
   <object id="59" type="collision" x="352" y="288" width="112" height="16">
    <properties>
     <property name="enter" value="up"/>
     <property name="exit" value="down"/>
+    <property name="continue" value="down"/>
    </properties>
   </object>
   <object id="60" type="collision" x="480" y="288" width="32" height="16">
    <properties>
     <property name="enter" value="up"/>
     <property name="exit" value="down"/>
+    <property name="continue" value="down"/>
    </properties>
   </object>
   <object id="61" type="collision" x="544" y="288" width="16" height="16">
    <properties>
     <property name="enter" value="up"/>
     <property name="exit" value="down"/>
+    <property name="continue" value="down"/>
    </properties>
   </object>
   <object id="62" type="collision" x="592" y="288" width="48" height="16">
    <properties>
     <property name="enter" value="up"/>
     <property name="exit" value="down"/>
+    <property name="continue" value="down"/>
    </properties>
   </object>
   <object id="63" type="collision" x="576" y="0" width="32" height="48"/>


### PR DESCRIPTION
Pull request for #264

This implements a 'continue' parameter for collisions, which forces the player to keep walking in the specified direction after reaching the tile. For example: If a tile has "continue down" and the player steps on it from the left, the player will walk right then immediately down.

This implements support for features like ice and conveyor belts. Until jumping is implemented, I've also enabled it for the cliffs on the default map, so the player is forced to walk all the way over a ledge.

My implementation is simple and clean, so overall I'm happy with it. I tested the feature and it seems to be working, but someone else should definitely do extra testing before this is merged.