### PR TITLE
initial pyscroll rendering

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pytmx>=3.20.14
-pyscroll>=2.16.12
+pyscroll>=2.16.13
 pygame
 six
 neteria

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pytmx>=3.20.14
+pyscroll>=2.16.12
 pygame
 six
 neteria

--- a/tuxemon/core/components/player.py
+++ b/tuxemon/core/components/player.py
@@ -510,9 +510,10 @@ class Player(object):
             except AttributeError:
                 return frame
 
-        state = self.animation_mapping[self.moving][self.move_direction]
-        frame_dict = self.sprite if self.moving else self.standing
         surfaces = list()
+        direction = self.move_direction if self.moving else self.facing
+        frame_dict = self.sprite if self.moving else self.standing
+        state = self.animation_mapping[self.moving][direction]
 
         # If this is the bottom half, we need to draw it at a lower position.
         offset = self.standing["front"].get_height() / 2

--- a/tuxemon/core/components/player.py
+++ b/tuxemon/core/components/player.py
@@ -523,7 +523,7 @@ class Player(object):
 
         # top surfaces
         surface = get_frame(frame_dict, state + "-top")
-        surfaces.append((surface, self.position, 3))
+        urfaces.append((surface, self.position, 3))
 
         return surfaces
 

--- a/tuxemon/core/components/player.py
+++ b/tuxemon/core/components/player.py
@@ -523,7 +523,7 @@ class Player(object):
 
         # top surfaces
         surface = get_frame(frame_dict, state + "-top")
-        urfaces.append((surface, self.position, 3))
+        surfaces.append((surface, self.position, 3))
 
         return surfaces
 

--- a/tuxemon/core/components/ui/text.py
+++ b/tuxemon/core/components/ui/text.py
@@ -113,6 +113,10 @@ def draw_text(surface, text=None, rect=None, justify="left", align=None,
 
     # Calculate the number of pixels per letter based on the size
     # of the text and the number of characters in the text
+
+    if not text:
+        return
+
     pixels_per_letter = text_surface.get_width() / len(text)
 
     # Create a list of the lines of text as well as a list of the

--- a/tuxemon/core/control.py
+++ b/tuxemon/core/control.py
@@ -616,52 +616,6 @@ class Control(StateManager):
         if self.exit:
             self.done = True
 
-    # def scale_new_player(self, sprite):
-    #     """Scales a new player to the screen.
-    #
-    #     :param sprite: Player sprite from the server registry.
-    #
-    #     :type sprite: -- Player or Npc object from core.components.player
-    #
-    #     :rtype: None
-    #     :returns: None
-    #
-    #     """
-    #     SCALE = prepare.SCALE
-    #     TILE_SIZE = prepare.TILE_SIZE
-    #     SCREEN_SIZE = prepare.TILE_SIZE
-    #
-    #     for key, animation in sprite.sprite.items():
-    #         animation.scale(
-    #                 tuple(i * SCALE for i in animation.getMaxSize()))
-    #
-    #     for key, image in sprite.standing.items():
-    #         sprite.standing[key] = scale_surface(image, SCALE)
-    #
-    #     # Set the player's width and height based on the size of our scaled
-    #     # sprite.
-    #     sprite.playerWidth, sprite.playerHeight = \
-    #         sprite.standing["front"].get_size()
-    #     sprite.playerWidth = TILE_SIZE[0]
-    #     sprite.playerHeight = TILE_SIZE[1]
-    #     sprite.tile_size = TILE_SIZE
-    #
-    #     # Put the player right in the middle of our screen.
-    #     sprite.position = [
-    #         (SCREEN_SIZE[0] / 2) - (sprite.playerWidth / 2),
-    #         (SCREEN_SIZE[1] / 2) - (sprite.playerHeight / 2)]
-    #
-    #     # Set the player's collision rectangle
-    #     sprite.rect = pg.Rect(
-    #             sprite.position[0],
-    #             sprite.position[1],
-    #             TILE_SIZE[0],
-    #             TILE_SIZE[1])
-    #
-    #     # Set the walking and running pixels per second based on the scale
-    #     sprite.walkrate *= SCALE
-    #     sprite.runrate *= SCALE
-
     def add_clients_to_map(self, registry):
         """Checks to see if clients are supposed to be displayed on the current map. If
         they are on the same map as the host then it will add them to the npc's list.

--- a/tuxemon/core/states/world/worldstate.py
+++ b/tuxemon/core/states/world/worldstate.py
@@ -32,17 +32,13 @@ from __future__ import division
 
 import itertools
 import logging
-import math
-
 from os.path import join
 
 import pygame
 from six.moves import map as imap
 
-from core import prepare
-from core import state
-from core.components import map
-from core.components import networking
+from core import prepare, state
+from core.components import map, networking
 from core.components.game_event import GAME_EVENT, INPUT_EVENT
 
 # Create a logger for optional handling of debug messages.
@@ -54,25 +50,6 @@ class WorldState(state.State):
     """
 
     preloaded_maps = {}
-
-    # def __init__(self):
-    #     self.state = "WorldState"
-    #     self.map_size = []
-    #     self.screen = None
-    #     self.screen_rect = None
-    #     self.tile_size = None
-    #     self.icon_size = None
-    #     self.resolution = None
-    #     self.native_resolution = None
-    #     self.player1 = None
-    #     self.npcs = None
-    #     self.npcs_off_map = None
-    #     self.wants_duel = None
-    #     self.global_x = None
-    #     self.global_x_diff = None
-    #     self.global_y = None
-    #     self.global_y_diff = None
-    #     self.start_position = None
 
     def startup(self):
         # Provide access to the screen surface
@@ -557,28 +534,28 @@ class WorldState(state.State):
         return pygame.Rect(npc, self.tile_size)
 
     def debug_drawing(self, surface):
-            # We need to iterate over all collidable objects.  So, let's start
-            # with the walls/collision boxes.
-            box_iter = imap(self._collision_box_to_pgrect, self.collision_map)
+        # We need to iterate over all collidable objects.  So, let's start
+        # with the walls/collision boxes.
+        box_iter = imap(self._collision_box_to_pgrect, self.collision_map)
 
-            # Next, deal with solid NPCs.
-            npc_iter = imap(self._npc_to_pgrect, self.npcs.values())
+        # Next, deal with solid NPCs.
+        npc_iter = imap(self._npc_to_pgrect, self.npcs.values())
 
-            for item in itertools.chain(box_iter, npc_iter):
-                surface.blit(self.collision_tile, (item[0], item[1]))
+        for item in itertools.chain(box_iter, npc_iter):
+            surface.blit(self.collision_tile, (item[0], item[1]))
 
-            if self.player1.direction["up"]:
-                surface.blit(self.collision_tile, (
-                    self.player1.position[0], self.player1.position[1] - self.tile_size[1]))
-            elif self.player1.direction["down"]:
-                surface.blit(self.collision_tile, (
-                    self.player1.position[0], self.player1.position[1] + self.tile_size[1]))
-            elif self.player1.direction["left"]:
-                surface.blit(self.collision_tile, (
-                    self.player1.position[0] - self.tile_size[0], self.player1.position[1]))
-            elif self.player1.direction["right"]:
-                surface.blit(self.collision_tile, (
-                    self.player1.position[0] + self.tile_size[0], self.player1.position[1]))
+        if self.player1.direction["up"]:
+            surface.blit(self.collision_tile, (
+                self.player1.position[0], self.player1.position[1] - self.tile_size[1]))
+        elif self.player1.direction["down"]:
+            surface.blit(self.collision_tile, (
+                self.player1.position[0], self.player1.position[1] + self.tile_size[1]))
+        elif self.player1.direction["left"]:
+            surface.blit(self.collision_tile, (
+                self.player1.position[0] - self.tile_size[0], self.player1.position[1]))
+        elif self.player1.direction["right"]:
+            surface.blit(self.collision_tile, (
+                self.player1.position[0] + self.tile_size[0], self.player1.position[1]))
 
     def midscreen_animations(self, surface):
         """Handles midscreen animations that will be drawn UNDER menus and dialog.

--- a/tuxemon/core/tools.py
+++ b/tuxemon/core/tools.py
@@ -35,13 +35,9 @@ import os.path
 
 import pygame
 
-import core.components.sprite
-
-#import prepare
-#Changed to this because of a import error
 from core import prepare
-
 from core.platform import mixer
+import core.components.sprite
 
 # Create a logger for optional handling of debug messages.
 logger = logging.getLogger(__name__)
@@ -97,7 +93,7 @@ def transform_resource_filename(filename):
     :param filename: String
     :rtype: basestring
     """
-    return prepare.BASEDIR + "resources/" + filename
+    return os.path.join(prepare.BASEDIR, 'resources', filename)
 
 
 def load_and_scale(filename):
@@ -222,7 +218,7 @@ def scale_sprite(sprite, ratio):
     sprite.rect.width *= ratio
     sprite.rect.height *= ratio
     sprite.rect.center = center
-    sprite._original_image = pygame.transform.scale(sprite._original_image, (sprite.rect.width, sprite.rect.height))
+    sprite._original_image = pygame.transform.scale(sprite._original_image, sprite.rect.get_size())
     sprite._needs_update = True
 
 
@@ -292,6 +288,7 @@ def load_sound(filename):
     :type filename: basestring
     :rtype: core.platform.mixer.Sound
     """
+
     class DummySound(object):
         def play(self):
             pass
@@ -304,7 +301,7 @@ def load_sound(filename):
         raise ValueError
     try:
         return mixer.Sound(filename)
-    except MemoryError:   # raised on some systems if there is no mixer
+    except MemoryError:  # raised on some systems if there is no mixer
         return DummySound()
     except pygame.error:  # raised on some systems is there is no mixer
         return DummySound()
@@ -323,7 +320,7 @@ def calc_dialog_rect(screen_rect):
     return rect
 
 
-def open_dialog(game, text, menu = None):
+def open_dialog(game, text, menu=None):
     """ Open a dialog with the standard window size
 
     :param game:

--- a/tuxemon/core/tools.py
+++ b/tuxemon/core/tools.py
@@ -218,7 +218,7 @@ def scale_sprite(sprite, ratio):
     sprite.rect.width *= ratio
     sprite.rect.height *= ratio
     sprite.rect.center = center
-    sprite._original_image = pygame.transform.scale(sprite._original_image, sprite.rect.get_size())
+    sprite._original_image = pygame.transform.scale(sprite._original_image, sprite.rect.size)
     sprite._needs_update = True
 
 


### PR DESCRIPTION
Using pyscroll for map rendering.  Improvements include much faster map loading (still room for improvement...), and more synchronized map animations (water tiles).  There is one bug in the pyscroll library affecting Tuxemon that we may wait to be fixed, or just wait.  Map animations that cover sprites will not be animated.  For example, the moving "M" sign will not animate if the player is behind it.

Also, there is some linting done for pep8 and docstrings added.  Some sections of code have been commented out to hold them as a reference for a while until any/all visual bugs are worked out.