### PR TITLE
draw matches end properly 

### DIFF
--- a/tuxemon/core/components/map.py
+++ b/tuxemon/core/components/map.py
@@ -48,7 +48,7 @@ logger = logging.getLogger(__name__)
 logger.debug("%s successfully imported" % __name__)
 
 
-def tuxemon_image_loader(filename, colorkey, **kwargs):
+def scaled_image_loader(filename, colorkey, **kwargs):
     """ pytmx image loader for pygame
     
     Modified to load images at a scaled size
@@ -203,7 +203,7 @@ class Map(object):
         # Scale the loaded tiles if enabled
         if prepare.CONFIG.scaling == "1":
             self.data = pytmx.TiledMap(filename,
-                                       image_loader=tuxemon_image_loader,
+                                       image_loader=scaled_image_loader,
                                        pixelalpha=True)
             self.data.tilewidth, self.data.tileheight = prepare.TILE_SIZE
         else:

--- a/tuxemon/core/components/map.py
+++ b/tuxemon/core/components/map.py
@@ -37,17 +37,58 @@ from core.components.event import Action
 from core.components.event import Condition
 from core.components.event import EventObject
 
-# Handle older versions of PyTMX.
-try:
-    from pytmx import load_pygame
-except ImportError:
-    from pytmx.util_pygame import load_pygame
-
+import pytmx
+from pytmx.util_pygame import handle_transformation, smart_convert, load_pygame
 import pyscroll
+
+import pygame
 
 # Create a logger for optional handling of debug messages.
 logger = logging.getLogger(__name__)
 logger.debug("%s successfully imported" % __name__)
+
+
+def tuxemon_image_loader(filename, colorkey, **kwargs):
+    """ pytmx image loader for pygame
+    
+    Modified to load images at a scaled size
+    
+    :param filename:
+    :param colorkey:
+    :param kwargs:
+    :return:
+    """
+    if colorkey:
+        colorkey = pygame.Color('#{0}'.format(colorkey))
+
+    pixelalpha = kwargs.get('pixelalpha', True)
+
+    # load the tileset image
+    image = pygame.image.load(filename)
+
+    # scale the tileset image to match game scale
+    scaled_size = tools.scale_sequence(image.get_size())
+    image = pygame.transform.scale(image, scaled_size)
+
+    def load_image(rect=None, flags=None):
+        if rect:
+            # scale the rect to match the scaled image
+            rect = tools.scale_rect(rect)
+            try:
+                tile = image.subsurface(rect)
+            except ValueError:
+                logger.error('Tile bounds outside bounds of tileset image')
+                raise
+        else:
+            tile = image.copy()
+
+        if flags:
+            tile = handle_transformation(tile, flags)
+
+        tile = smart_convert(tile, colorkey, pixelalpha)
+        return tile
+
+    return load_image
 
 
 class Map(object):
@@ -158,14 +199,18 @@ class Map(object):
         """
         # Load the tmx map data using the pytmx library.
         self.filename = filename
-        self.data = load_pygame(filename, pixelalpha=True)
 
         # Scale the loaded tiles if enabled
         if prepare.CONFIG.scaling == "1":
-            self.scale_tiles(prepare.TILE_SIZE)
+            self.data = pytmx.TiledMap(filename,
+                                       image_loader=tuxemon_image_loader,
+                                       pixelalpha=True)
+            self.data.tilewidth, self.data.tileheight = prepare.TILE_SIZE
+        else:
+            self.data = load_pygame(filename, pixelalpha=True)
 
-        # make a scrolling rendererer
-        self.initialize_renderer()
+        # make a scrolling renderer
+        self.renderer = self.initialize_renderer()
 
         # Get the map dimensions
         self.size = self.data.width, self.data.height
@@ -191,31 +236,13 @@ class Map(object):
                 self.interacts.append(self.loadevent(obj))
 
     def initialize_renderer(self):
-        """ Tuxemon uses the pyscroll library to draw the game map
+        """ Initialize the renderer for the map and sprites
 
-        Here it is initialized.  This must be done again if tile size changes.
-
-        :return:
+        :rtype: pyscroll.BufferedRenderer
         """
         visual_data = pyscroll.data.TiledMapData(self.data)
-        self.renderer = pyscroll.BufferedRenderer(visual_data, prepare.SCREEN_SIZE, clamp_camera=False)
-        visual_data.convert_surfaces(self.renderer._buffer, True)
-
-    def scale_tiles(self, tile_size):
-        """ Scale the tiles of the map data.
-
-        If you call this, you will have to reinitialize the renderer
-
-        :param tile_size:
-        :return: None
-        """
-        def scale_tile(image):
-            if image:
-                return tools.scale_tile(image, tile_size)
-            return None
-
-        self.data.images = [scale_tile(i) for i in self.data.images]
-        self.data.tilewidth, self.data.tileheight = tile_size
+        # TODO: Tuxemon will not work with clamp_camera=True
+        return pyscroll.BufferedRenderer(visual_data, prepare.SCREEN_SIZE, clamp_camera=False)
 
     def loadevent(self, obj):
         conds = []

--- a/tuxemon/core/states/combat/combat_animations.py
+++ b/tuxemon/core/states/combat/combat_animations.py
@@ -15,8 +15,9 @@ from core.components.menu import Menu
 from core.components.menu.interface import HpBar
 from core.components.pyganim import PygAnimation
 from core.components.sprite import Sprite
-from core.tools import scale_sequence, scale_sprite, scale
+from core.tools import scale, scale_sequence, scale_sprite
 from core.components.locale import translator
+
 trans = translator.translate
 
 # Create a logger for optional handling of debug messages.
@@ -440,18 +441,18 @@ class CombatAnimations(Menu):
             animate = partial(self.animate, duration=0.1, transition='linear', delay=initial_delay)
             animate(capdev.rect, y=scale(3), relative=True)
 
-            animate = partial(self.animate, duration=0.2, transition='linear', delay=initial_delay+0.1)
-            animate(capdev.rect, y= -scale(6), relative=True)
+            animate = partial(self.animate, duration=0.2, transition='linear', delay=initial_delay + 0.1)
+            animate(capdev.rect, y=-scale(6), relative=True)
 
-            animate = partial(self.animate, duration=0.1, transition='linear', delay=initial_delay+0.3)
+            animate = partial(self.animate, duration=0.1, transition='linear', delay=initial_delay + 0.3)
             animate(capdev.rect, y=scale(3), relative=True)
 
         for i in range(0, num_shakes):
-            shake_ball(1.8 + i*1.0) # leave a 0.6s wait between each shake
+            shake_ball(1.8 + i * 1.0) # leave a 0.6s wait between each shake
 
         if is_captured:
             self.task(kill, 2 + num_shakes)
         else:
-            self.task(partial(toggle_visible, monster_sprite), 1.8 + num_shakes*1.0) # make the monster appear again!
-            self.task(tech.play, 1.8 + num_shakes*1.0)
-            self.task(capdev.kill, 1.8 + num_shakes*1.0)
+            self.task(partial(toggle_visible, monster_sprite), 1.8 + num_shakes * 1.0) # make the monster appear again!
+            self.task(tech.play, 1.8 + num_shakes * 1.0)
+            self.task(capdev.kill, 1.8 + num_shakes * 1.0)

--- a/tuxemon/core/states/combat/combat_menus.py
+++ b/tuxemon/core/states/combat/combat_menus.py
@@ -11,7 +11,7 @@ from core.components.locale import translator
 from core.components.menu import PopUpMenu
 from core.components.menu.interface import MenuItem
 from core.components.menu.menu import Menu
-from core.components.sprite import SpriteGroup, MenuSpriteGroup
+from core.components.sprite import MenuSpriteGroup, SpriteGroup
 from core.components.technique import Technique
 from core.components.ui.draw import GraphicBox
 
@@ -53,7 +53,7 @@ class MainCombatMenuState(PopUpMenu):
         # TODO: only works for player0
         self.game.pop_state(self)
         combat_state = self.game.get_state_name("CombatState")
-        combat_state.remove_player(combat_state.players[0])
+        combat_state.trigger_player_run(combat_state.players[0])
 
     def open_swap_menu(self):
         """ Open menus to swap monsters in party
@@ -148,7 +148,7 @@ class MainCombatMenuState(PopUpMenu):
             # open menu to choose target of technique
             technique = menu_item.game_object
             combat_state = self.game.get_state_name("CombatState")
-            state = self.game.push_state("CombatTargetMenuState",player=combat_state.players[0],
+            state = self.game.push_state("CombatTargetMenuState", player=combat_state.players[0],
                                          user=self.monster, action=technique)
             state.on_menu_selection = partial(enqueue_technique, technique)
 

--- a/tuxemon/core/states/splash/__init__.py
+++ b/tuxemon/core/states/splash/__init__.py
@@ -47,11 +47,15 @@ class SplashState(state.State):
     default_duration = 3
 
     def fade_out(self):
+        self.fading_out = True
         self.game.push_state("FadeOutTransition", caller=self)
 
     def startup(self, **kwargs):
         # this task will skip the splash screen after some time
         self.task(self.fade_out, self.default_duration)
+
+        # used to ignore keypresses after fadeout has started
+        self.fading_out = False
 
         width, height = prepare.SCREEN_SIZE
         splash_border = prepare.SCREEN_SIZE[0] / 20     # The space between the edge of the screen
@@ -79,7 +83,8 @@ class SplashState(state.State):
 
         """
         # Skip the splash screen if a key is pressed.
-        if event.type == pygame.KEYDOWN:
+        if event.type == pygame.KEYDOWN and not self.fading_out:
+            self.animations.empty()
             self.fade_out()
 
     def draw(self, surface):

--- a/tuxemon/resources/db/locale/en_US.json
+++ b/tuxemon/resources/db/locale/en_US.json
@@ -9,6 +9,7 @@
     "combat_status_damage": "${{name}} took ${{status}} damage!",
     "combat_victory": "You have won!",
     "combat_defeat": "You've been defeated!",
+    "combat_draw": "All parties have fainted!",
     "combat_capturing success": "You captured ${{name}}!",
     "combat_capturing_fail": "${{name}} broke free!",
     "combat_replacement": "Choose a replacement!",


### PR DESCRIPTION
Draw matches, where both parties are defeated in the same round are now properly handled.  There are details like, "where does experience go", etc, but this PR just addresses the bug where it will not end at all.

Also, linting, and a new locale string for draw matches.