### PR TITLE
map animations restored

### DIFF
--- a/tuxemon/core/control.py
+++ b/tuxemon/core/control.py
@@ -83,9 +83,6 @@ class Control(StateManager):
         # Set up a variable that will keep track of currently playing music.
         self.current_music = {"status": "stopped", "song": None, "previoussong": None}
 
-        # Keep track of animations that we will play.
-        self.animations = {}
-
         # Create these Pygame event objects to simulate KEYDOWN and KEYUP
         # events for all the directional keys
         self.keyboard_events = {}


### PR DESCRIPTION
- fix #300 
- linting, docstrings.
- moved some animation loading to core.tools

Map tile animations that are created with actions are working again.  

Note, when testing, there are some patches of tall grass that will not animate due to the conditions in it.  In the patches nearest the player home, you must have a monster in your party, due to cond3.  Consider it a map bug.

To test without monsters, find the tall grass in the upper left corner.


Map bug:
![capture](https://cloud.githubusercontent.com/assets/556711/26137166/0cdac9b4-3a86-11e7-9b8c-6041be5c788f.PNG)
