### PR TITLE
Increase audio buffer size

### DIFF
--- a/tuxemon/core/platform/__init__.py
+++ b/tuxemon/core/platform/__init__.py
@@ -31,7 +31,7 @@ def init():
     # reduce sound latency.  the pygame defaults were ok for 2001,
     # but these values are more acceptable for faster computers
     if _pygame:
-        mixer.pre_init(frequency=44100, size=-16, channels=2, buffer=512)
+        mixer.pre_init(frequency=44100, size=-16, channels=2, buffer=1024)
 
 def get_config_path():
     if android:


### PR DESCRIPTION
Hi,

Currently, with `512` there'll be a lot of warnings like: `ALSA lib pcm.c:8306:(snd_pcm_recover) underrun occurred` on a lot of linux machine.

While I agree `4096` is probably too much (the pygame default), `512` is not enough. I think `1024` is better - it's the default for ALSA.

So, I switched to `1024` as it won't have important impact on latency while fixing the issue with ALSA.

A better solution would be to let the user decide or set the value according to the platform, but I would involes more complicated changes. But until it's done (with #278), it seems better to fix it to the minimum value compatible with all platforms.

Fix #260.