### PR TITLE
Use xdg directory for config, data and cache

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pillow
 pygame
 six
 neteria
+xdg

--- a/tuxemon/core/components/locale.py
+++ b/tuxemon/core/components/locale.py
@@ -59,8 +59,8 @@ class Translator(object):
         directories = [prepare.BASEDIR + LOCALE_PATH]
         for item in os.listdir(prepare.USER_DATA_PATH):
             item = prepare.USER_DATA_PATH + "/" + item
-            if os.path.isdir(item):
-                locale_directory = item + LOCALE_PATH
+            locale_directory = item + "/" + LOCALE_PATH
+            if os.path.isdir(locale_directory):
                 directories.append(locale_directory)
 
         return directories

--- a/tuxemon/core/platform/__init__.py
+++ b/tuxemon/core/platform/__init__.py
@@ -7,6 +7,8 @@ from os.path import expanduser
 
 _pygame = False
 
+from xdg import (XDG_CACHE_HOME, XDG_CONFIG_HOME, XDG_DATA_HOME)
+
 # Import the android module and android specific components. If we can't import, set to None - this
 # lets us test it, and check to see if we want android-specific behavior.
 android = None
@@ -33,9 +35,20 @@ def init():
     if _pygame:
         mixer.pre_init(frequency=44100, size=-16, channels=2, buffer=1024)
 
-def get_config_path():
+def get_config_directory():
     if android:
-        return "/sdcard/org.tuxemon"
+        return "/sdcard/org.tuxemon/config/"
     else:
-        return expanduser("~")
+        return XDG_CONFIG_HOME + "/tuxemon/"
 
+def get_data_directory():
+    if android:
+        return "/sdcard/org.tuxemon/data/"
+    else:
+        return XDG_DATA_HOME + "/tuxemon/"
+
+def get_cache_directory():
+    if android:
+        return "/sdcard/org.tuxemon/cache/"
+    else:
+        return XDG_CACHE_HOME + "/tuxemon/"

--- a/tuxemon/core/prepare.py
+++ b/tuxemon/core/prepare.py
@@ -38,7 +38,7 @@ import shutil
 import pygame as pg
 
 from .components import config
-from .platform import get_config_path
+from .platform import get_config_directory, get_data_directory, get_cache_directory
 
 
 # Get the tuxemon base directory
@@ -47,11 +47,25 @@ if "library.zip" in BASEDIR:
     BASEDIR = os.path.abspath(os.path.join(BASEDIR, "..")) + os.sep
 
 # Set up our config directory
-CONFIG_PATH = get_config_path() + "/.tuxemon/"
+CONFIG_PATH = get_config_directory()
 try:
     os.makedirs(CONFIG_PATH)
 except OSError:
     if not os.path.isdir(CONFIG_PATH):
+        raise
+
+DATA_PATH = get_data_directory()
+try:
+    os.makedirs(DATA_PATH)
+except OSError:
+    if not os.path.isdir(DATA_PATH):
+        raise
+
+CACHE_PATH = get_cache_directory()
+try:
+    os.makedirs(CACHE_PATH)
+except OSError:
+    if not os.path.isdir(CACHE_PATH):
         raise
 
 # Create a copy of our default config if one does not exist in the home dir.
@@ -63,13 +77,7 @@ if not os.path.isfile(CONFIG_FILE_PATH):
         raise
 
 # Set up our custom campaign data directory.
-USER_DATA_PATH = CONFIG_PATH + "data/"
-if not os.path.isdir(USER_DATA_PATH):
-    try:
-        os.makedirs(USER_DATA_PATH)
-    except OSError:
-        if not os.path.isdir(USER_DATA_PATH):
-            raise
+USER_DATA_PATH = DATA_PATH
 
 # Read the "tuxemon.cfg" configuration file
 CONFIG = config.Config(CONFIG_FILE_PATH)
@@ -105,12 +113,12 @@ else:
 
 # Set up the saves directory
 try:
-    os.makedirs(CONFIG_PATH + "saves/")
+    os.makedirs(DATA_PATH + "saves/")
 except OSError:
-    if not os.path.isdir(CONFIG_PATH + "saves/"):
+    if not os.path.isdir(DATA_PATH + "saves/"):
         raise
-SAVE_PATH = CONFIG_PATH + "saves/slot"
 
+SAVE_PATH = DATA_PATH + "saves/slot"
 
 # Initialization of PyGame dependent systems.
 def init():


### PR DESCRIPTION
Hi,

Fix #314.

There are a few things left to do:

* `from xdg import (XDG_CACHE_HOME, XDG_CONFIG_HOME, XDG_DATA_HOME)`  I can't put this a few lines before with the other import for a reason I don't understand (I don't use Python).
* `xdg` provides default values when the env. var is not defined, I don't know if they're valid on Androïd as I don't use and can't test on Androïd, so I kept the `/sdcard/org.tuxemon/` as a base directory, let me know if you think it should be handled differently. 
* something was strange in the locale discovery, I had to fix it but I'm not sure of what I did.
* now we have `USER_DATA_PATH = DATA_PATH`, it looks weird, I can remove this and use `DATA_PATH` everywhere if you want.
* `SAVE_PATH = DATA_PATH + "saves/slot"` looks weird too as `slot` is actually part of future files name like `saves/slot1.png` and `saves/slot2.save`. But it has nothing to do with this PR. I just noticed it.
* I also added the cache directory. If you think it will never be useful, I can remove it.