### PR TITLE
Setting for clamp_camera

### DIFF
--- a/tuxemon/core/components/config.py
+++ b/tuxemon/core/components/config.py
@@ -67,6 +67,7 @@ class Config(object):
         self.controller_transparency = int(self.config.get("display", "controller_transparency"))
 
         self.starting_map = self.config.get("game", "starting_map")
+        self.clamp_camera = self.config.get("game", "clamp_camera")
         self.cli = int(self.config.get("game", "cli_enabled"))
         self.net_controller_enabled = self.config.get("game", "net_controller_enabled")
         try:

--- a/tuxemon/core/components/map.py
+++ b/tuxemon/core/components/map.py
@@ -322,7 +322,8 @@ class Map(object):
         :rtype: pyscroll.BufferedRenderer
         """
         visual_data = pyscroll.data.TiledMapData(self.data)
-        return pyscroll.BufferedRenderer(visual_data, prepare.SCREEN_SIZE, clamp_camera=False)
+        clamp = (prepare.CONFIG.clamp_camera == "1")
+        return pyscroll.BufferedRenderer(visual_data, prepare.SCREEN_SIZE, clamp_camera = clamp)
 
     def loadevent(self, obj):
         """

--- a/tuxemon/tuxemon.cfg
+++ b/tuxemon/tuxemon.cfg
@@ -17,6 +17,7 @@ music_volume=255
 [game]
 data = resources
 starting_map = bedroom_test.tmx
+clamp_camera = 0
 cli_enabled = 0
 net_controller_enabled = 1
 locale = en_US


### PR DESCRIPTION
Fix for #373 This lets players choose whether to enable camera clamping, limiting the view within the map boundaries. Some players dislike the black borders visible beyond the edge of a map, whereas others dislike the player not always being in the center of the screen... with this you can choose your favorite compromise among the two solutions for handling map edges.