### PR TITLE
Implement map properties, camera clamping

### DIFF
--- a/tuxemon/core/components/map.py
+++ b/tuxemon/core/components/map.py
@@ -187,6 +187,9 @@ class Map(object):
         self.size = None
         self.renderer = None
 
+        # Initiate the properties of the map at their default values
+        self.edges = ""
+
         # Get the tile size from a tileset in our map. This is used to calculate the number of tiles
         # in a collision region.
         self.tile_size = (0, 0)
@@ -290,6 +293,12 @@ class Map(object):
         else:
             self.data = load_pygame(filename, pixelalpha=True)
 
+        # Get the properties of the map
+        if type(self.data.properties) == dict:
+            # Get the edge type of the map
+            if "edges" in self.data.properties:
+                self.edges = self.data.properties["edges"]
+
         # make a scrolling renderer
         self.renderer = self.initialize_renderer()
 
@@ -321,8 +330,10 @@ class Map(object):
 
         :rtype: pyscroll.BufferedRenderer
         """
+        # TODO: Use self.edges == "stitched" here when implementing seamless maps
         visual_data = pyscroll.data.TiledMapData(self.data)
-        return pyscroll.BufferedRenderer(visual_data, prepare.SCREEN_SIZE, clamp_camera=False, tall_sprites=2)
+        clamp = (self.edges == "clamped")
+        return pyscroll.BufferedRenderer(visual_data, prepare.SCREEN_SIZE, clamp_camera = clamp, tall_sprites = 2)
 
     def loadevent(self, obj):
         """

--- a/tuxemon/resources/maps/BuddhaMountain.tmx
+++ b/tuxemon/resources/maps/BuddhaMountain.tmx
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" renderorder="right-down" width="100" height="100" tilewidth="16" tileheight="16" nextobjectid="227">
+ <properties>
+  <property name="edges" value="clamped"/>
+ </properties>
  <tileset firstgid="1" name="My_tuxemon_sheet" tilewidth="16" tileheight="16" tilecount="104" columns="8">
   <image source="../gfx/tilesets/My_tuxemon_sheet.png" width="128" height="208"/>
  </tileset>

--- a/tuxemon/resources/maps/candy_town.tmx
+++ b/tuxemon/resources/maps/candy_town.tmx
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" renderorder="right-down" width="40" height="40" tilewidth="16" tileheight="16" nextobjectid="211">
+ <properties>
+  <property name="edges" value="clamped"/>
+ </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>
   <tile id="839">

--- a/tuxemon/resources/maps/citypark.tmx
+++ b/tuxemon/resources/maps/citypark.tmx
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" renderorder="right-down" width="40" height="40" tilewidth="16" tileheight="16" nextobjectid="104">
+ <properties>
+  <property name="edges" value="clamped"/>
+ </properties>
  <tileset firstgid="1" name="My_tuxemon_sheet" tilewidth="16" tileheight="16" tilecount="104" columns="8">
   <image source="../gfx/tilesets/My_tuxemon_sheet.png" width="128" height="208"/>
  </tileset>

--- a/tuxemon/resources/maps/cotton_town.tmx
+++ b/tuxemon/resources/maps/cotton_town.tmx
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" tiledversion="1.0.3" orientation="orthogonal" renderorder="right-down" width="40" height="40" tilewidth="16" tileheight="16" nextobjectid="275">
+ <properties>
+  <property name="edges" value="clamped"/>
+ </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>
   <tile id="839">

--- a/tuxemon/resources/maps/dragonscave.tmx
+++ b/tuxemon/resources/maps/dragonscave.tmx
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" renderorder="right-down" width="20" height="40" tilewidth="16" tileheight="16" nextobjectid="61">
+ <properties>
+  <property name="edges" value="clamped"/>
+ </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>
  </tileset>

--- a/tuxemon/resources/maps/dryadsgrove.tmx
+++ b/tuxemon/resources/maps/dryadsgrove.tmx
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" renderorder="right-down" width="40" height="20" tilewidth="16" tileheight="16" nextobjectid="40">
+ <properties>
+  <property name="edges" value="clamped"/>
+ </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>
  </tileset>

--- a/tuxemon/resources/maps/flower_city.tmx
+++ b/tuxemon/resources/maps/flower_city.tmx
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" renderorder="right-down" width="40" height="40" tilewidth="16" tileheight="16" nextobjectid="206">
+ <properties>
+  <property name="edges" value="clamped"/>
+ </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>
   <tile id="839">

--- a/tuxemon/resources/maps/leather_town.tmx
+++ b/tuxemon/resources/maps/leather_town.tmx
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" renderorder="right-down" width="40" height="40" tilewidth="16" tileheight="16" nextobjectid="93">
+ <properties>
+  <property name="edges" value="clamped"/>
+ </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>
  </tileset>

--- a/tuxemon/resources/maps/map1.tmx
+++ b/tuxemon/resources/maps/map1.tmx
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" renderorder="right-down" width="64" height="60" tilewidth="16" tileheight="16" nextobjectid="123">
+ <properties>
+  <property name="edges" value="clamped"/>
+ </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>
   <tile id="839">

--- a/tuxemon/resources/maps/paper_town.tmx
+++ b/tuxemon/resources/maps/paper_town.tmx
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" renderorder="right-down" width="40" height="20" tilewidth="16" tileheight="16" nextobjectid="214">
+ <properties>
+  <property name="edges" value="clamped"/>
+ </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>
   <tile id="839">

--- a/tuxemon/resources/maps/route1.tmx
+++ b/tuxemon/resources/maps/route1.tmx
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" renderorder="right-down" width="60" height="46" tilewidth="16" tileheight="16" nextobjectid="85">
+ <properties>
+  <property name="edges" value="clamped"/>
+ </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>
  </tileset>

--- a/tuxemon/resources/maps/route1_sanglorian.tmx
+++ b/tuxemon/resources/maps/route1_sanglorian.tmx
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" renderorder="right-down" width="40" height="20" tilewidth="16" tileheight="16" nextobjectid="160">
+ <properties>
+  <property name="edges" value="clamped"/>
+ </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>
   <tile id="839">

--- a/tuxemon/resources/maps/route2.tmx
+++ b/tuxemon/resources/maps/route2.tmx
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" tiledversion="1.0.3" orientation="orthogonal" renderorder="right-down" width="40" height="20" tilewidth="16" tileheight="16" nextobjectid="87">
+ <properties>
+  <property name="edges" value="clamped"/>
+ </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>
  </tileset>

--- a/tuxemon/resources/maps/route3.tmx
+++ b/tuxemon/resources/maps/route3.tmx
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" renderorder="right-down" width="40" height="40" tilewidth="16" tileheight="16" nextobjectid="178">
+ <properties>
+  <property name="edges" value="clamped"/>
+ </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>
  </tileset>

--- a/tuxemon/resources/maps/route4.tmx
+++ b/tuxemon/resources/maps/route4.tmx
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" renderorder="right-down" width="20" height="40" tilewidth="16" tileheight="16" nextobjectid="37">
+ <properties>
+  <property name="edges" value="clamped"/>
+ </properties>
  <tileset firstgid="1" name="My_tuxemon_sheet" tilewidth="16" tileheight="16" tilecount="104" columns="8">
   <image source="../gfx/tilesets/My_tuxemon_sheet.png" width="128" height="208"/>
  </tileset>

--- a/tuxemon/resources/maps/route5.tmx
+++ b/tuxemon/resources/maps/route5.tmx
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" renderorder="right-down" width="40" height="20" tilewidth="16" tileheight="16" nextobjectid="20">
+ <properties>
+  <property name="edges" value="clamped"/>
+ </properties>
  <tileset firstgid="1" name="PastTheFuture_Grass_Sand_Snow" tilewidth="16" tileheight="16" tilecount="360" columns="24">
   <image source="../gfx/tilesets/PastTheFuture_Grass_Sand_Snow.png" width="384" height="240"/>
  </tileset>

--- a/tuxemon/resources/maps/route6.tmx
+++ b/tuxemon/resources/maps/route6.tmx
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" renderorder="right-down" width="40" height="20" tilewidth="16" tileheight="16" nextobjectid="71">
+ <properties>
+  <property name="edges" value="clamped"/>
+ </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>
  </tileset>

--- a/tuxemon/resources/maps/routea.tmx
+++ b/tuxemon/resources/maps/routea.tmx
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" renderorder="right-down" width="20" height="40" tilewidth="16" tileheight="16" nextobjectid="56">
+ <properties>
+  <property name="edges" value="clamped"/>
+ </properties>
  <tileset firstgid="1" name="PastTheFuture_Grass_Sand_Snow" tilewidth="16" tileheight="16" tilecount="360" columns="24">
   <image source="../gfx/tilesets/PastTheFuture_Grass_Sand_Snow.png" width="384" height="240"/>
  </tileset>

--- a/tuxemon/resources/maps/routec.tmx
+++ b/tuxemon/resources/maps/routec.tmx
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" renderorder="right-down" width="40" height="20" tilewidth="16" tileheight="16" nextobjectid="151">
+ <properties>
+  <property name="edges" value="clamped"/>
+ </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>
   <tile id="839">

--- a/tuxemon/resources/maps/sphalian_town.tmx
+++ b/tuxemon/resources/maps/sphalian_town.tmx
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" renderorder="right-down" width="23" height="25" tilewidth="16" tileheight="16" nextobjectid="38">
+ <properties>
+  <property name="edges" value="clamped"/>
+ </properties>
  <tileset firstgid="1" name="Sand_n_water" tilewidth="16" tileheight="16" tilecount="104" columns="8">
   <image source="../gfx/tilesets/Sand_n_water.png" width="128" height="208"/>
  </tileset>

--- a/tuxemon/resources/maps/test.tmx
+++ b/tuxemon/resources/maps/test.tmx
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" renderorder="right-down" width="25" height="25" tilewidth="16" tileheight="16" nextobjectid="41">
+ <properties>
+  <property name="edges" value="clamped"/>
+ </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>
  </tileset>

--- a/tuxemon/resources/maps/test_pathfinding.tmx
+++ b/tuxemon/resources/maps/test_pathfinding.tmx
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" tiledversion="1.0.3" orientation="orthogonal" renderorder="right-down" width="15" height="15" tilewidth="16" tileheight="16" nextobjectid="37">
+ <properties>
+  <property name="edges" value="clamped"/>
+ </properties>
  <tileset firstgid="1" name="Sand_n_water" tilewidth="16" tileheight="16" tilecount="104" columns="8">
   <image source="../gfx/tilesets/Sand_n_water.png" width="128" height="208"/>
  </tileset>

--- a/tuxemon/resources/maps/timber_town.tmx
+++ b/tuxemon/resources/maps/timber_town.tmx
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" renderorder="right-down" width="40" height="40" tilewidth="16" tileheight="16" nextobjectid="182">
+ <properties>
+  <property name="edges" value="clamped"/>
+ </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>
   <tile id="839">

--- a/tuxemon/resources/maps/tunnel.tmx
+++ b/tuxemon/resources/maps/tunnel.tmx
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" renderorder="right-down" width="20" height="40" tilewidth="16" tileheight="16" nextobjectid="103">
+ <properties>
+  <property name="edges" value="clamped"/>
+ </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>
  </tileset>

--- a/tuxemon/resources/maps/tunnel_below.tmx
+++ b/tuxemon/resources/maps/tunnel_below.tmx
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" renderorder="right-down" width="20" height="40" tilewidth="16" tileheight="16" nextobjectid="42">
+ <properties>
+  <property name="edges" value="clamped"/>
+ </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>
  </tileset>


### PR DESCRIPTION
Improved replacement for #374 in providing a solution to #373

This PR implements a skeleton for loading map properties from Tiled. The property "edges" with the value "clamped" will indicate the usage of clamp_camera in the PyScroll renderer. This allows maps to limit the view within the world boundaries, in case avoiding black borders at the cost of the player not always being in the center of the screen looks better on a given map.

The new property is designed to also allow an alternate value for map stitching, for later when that feature will be implemented. Setting "edges" to "stitched" should connect opposite corners and edges of the map together, allowing the player to loop indefinitely in any direction.

I took the liberty of enabling the clamped camera on all outdoor maps, without using it indoors where the classic camera looks better. Other players shared my opinion that the bounded camera doesn't make sense indoors but may look good outside, thus it seemed worth defaulting to. This was done in a separate commit, so if the map changes are rejected it can be easily reverted.

The changes were tested and seem to work fine without negative side effects. Checks are present to ensure that the properties exist, in order to avoid crashes on maps where they are absent.