### PR TITLE
Minor scripting improvements

### DIFF
--- a/tuxemon/core/components/event/actions/npc_face.py
+++ b/tuxemon/core/components/event/actions/npc_face.py
@@ -23,6 +23,7 @@ from __future__ import absolute_import
 
 from tuxemon.core.components.event import get_npc
 from tuxemon.core.components.event.eventaction import EventAction
+from tuxemon.core.components.map import get_direction, dirs2
 
 
 class NpcFaceAction(EventAction):
@@ -40,4 +41,12 @@ class NpcFaceAction(EventAction):
 
     def start(self):
         npc = get_npc(self.game, self.parameters.npc_slug)
-        npc.facing = self.parameters.direction
+        direction = self.parameters.direction
+        if direction not in dirs2:
+            if direction == "player":
+                target = self.game.player1
+            else:
+                target = get_npc(self.game, direction)
+            direction = get_direction(npc.tile_pos, target.tile_pos)
+
+        npc.facing = direction

--- a/tuxemon/core/components/event/actions/player_face.py
+++ b/tuxemon/core/components/event/actions/player_face.py
@@ -21,7 +21,9 @@
 #
 from __future__ import absolute_import
 
+from tuxemon.core.components.event import get_npc
 from tuxemon.core.components.event.eventaction import EventAction
+from tuxemon.core.components.map import dirs2, get_direction
 
 
 class PlayerFaceAction(EventAction):
@@ -39,6 +41,9 @@ class PlayerFaceAction(EventAction):
     def start(self):
         # Get the parameters to determine what direction the player will face.
         direction = self.parameters.direction
+        if direction not in dirs2:
+            target = get_npc(self.game, direction)
+            direction = get_direction(self.game.player1.tilepos, target.tilepos)
 
         # If we're doing a transition, only change the player's facing when we've reached the apex
         # of the transition.

--- a/tuxemon/core/components/event/conditions/npc_facing_tile.py
+++ b/tuxemon/core/components/event/conditions/npc_facing_tile.py
@@ -62,37 +62,42 @@ class NPCFacingTileCondition(EventCondition):
             ...
         }
         """
-        # Get the player object from the game.
-        player = get_npc(game, condition.parameters[0])
-        if not player:
+        # Get the npc object from the game.
+        npc = get_npc(game, condition.parameters[0])
+        if not npc:
             return False
 
-        coordinates = (condition.x, condition.y)
+        tiles = [
+            (condition.x + w, condition.y + h)
+            for w in range(0, condition.width)
+            for h in range(0, condition.height)
+        ]
         tile_location = None
 
-        # Next, we check the player position and see if we're one tile away from
-        # the tile.
-        if coordinates[1] == player.tile_pos[1]:
-            # Check to see if the tile is to the left of the player
-            if coordinates[0] == player.tile_pos[0] - 1:
-                logger.debug("Tile is to the left of the NPC")
-                tile_location = "left"
-            # Check to see if the tile is to the right of the player
-            elif coordinates[0] == player.tile_pos[0] + 1:
-                logger.debug("Tile is to the right of the player")
-                tile_location = "right"
+        for coordinates in tiles:
+            # Next, we check the npc position and see if we're one tile away from
+            # the tile.
+            if coordinates[1] == npc.tile_pos[1]:
+                # Check to see if the tile is to the left of the npc
+                if coordinates[0] == npc.tile_pos[0] - 1:
+                    logger.debug("Tile is to the left of the NPC")
+                    tile_location = "left"
+                # Check to see if the tile is to the right of the npc
+                elif coordinates[0] == npc.tile_pos[0] + 1:
+                    logger.debug("Tile is to the right of the NPC")
+                    tile_location = "right"
 
-        if coordinates[0] == player.tile_pos[0]:
-            # Check to see if the tile is above the player
-            if coordinates[1] == player.tile_pos[1] - 1:
-                logger.debug("Tile is above the player")
-                tile_location = "up"
-            elif coordinates[1] == player.tile_pos[1] + 1:
-                logger.debug("Tile is below the player")
-                tile_location = "down"
+            if coordinates[0] == npc.tile_pos[0]:
+                # Check to see if the tile is above the npc
+                if coordinates[1] == npc.tile_pos[1] - 1:
+                    logger.debug("Tile is above the NPC")
+                    tile_location = "up"
+                elif coordinates[1] == npc.tile_pos[1] + 1:
+                    logger.debug("Tile is below the NPC")
+                    tile_location = "down"
 
-        # Then we check to see if we're facing the Tile
-        if player.facing == tile_location:
-            return True
-        else:
-            return False
+            # Then we check to see the npc is facing the Tile
+            if npc.facing == tile_location:
+                return True
+
+        return False

--- a/tuxemon/core/components/event/conditions/player_facing_tile.py
+++ b/tuxemon/core/components/event/conditions/player_facing_tile.py
@@ -63,32 +63,37 @@ class PlayerFacingTileCondition(EventCondition):
 
         """
 
-        coordinates = (condition.x, condition.y)
+        tiles = [
+            (condition.x + w, condition.y + h)
+            for w in range(0, condition.width)
+            for h in range(0, condition.height)
+        ]
         tile_location = None
 
         # Next, we check the player position and see if we're one tile away from
         # the tile.
-        if coordinates[1] == game.player1.tile_pos[1]:
-            # Check to see if the tile is to the left of the player
-            if coordinates[0] == game.player1.tile_pos[0] - 1:
-                logger.debug("Tile is to the left of the player")
-                tile_location = "left"
-            # Check to see if the tile is to the right of the player
-            elif coordinates[0] == game.player1.tile_pos[0] + 1:
-                logger.debug("Tile is to the right of the player")
-                tile_location = "right"
+        for coordinates in tiles:
+            if coordinates[1] == game.player1.tile_pos[1]:
+                # Check to see if the tile is to the left of the player
+                if coordinates[0] == game.player1.tile_pos[0] - 1:
+                    logger.debug("Tile is to the left of the player")
+                    tile_location = "left"
+                # Check to see if the tile is to the right of the player
+                elif coordinates[0] == game.player1.tile_pos[0] + 1:
+                    logger.debug("Tile is to the right of the player")
+                    tile_location = "right"
 
-        if coordinates[0] == game.player1.tile_pos[0]:
-            # Check to see if the tile is above the player
-            if coordinates[1] == game.player1.tile_pos[1] - 1:
-                logger.debug("Tile is above the player")
-                tile_location = "up"
-            elif coordinates[1] == game.player1.tile_pos[1] + 1:
-                logger.debug("Tile is below the player")
-                tile_location = "down"
+            elif coordinates[0] == game.player1.tile_pos[0]:
+                # Check to see if the tile is above the player
+                if coordinates[1] == game.player1.tile_pos[1] - 1:
+                    logger.debug("Tile is above the player")
+                    tile_location = "up"
+                elif coordinates[1] == game.player1.tile_pos[1] + 1:
+                    logger.debug("Tile is below the player")
+                    tile_location = "down"
 
-        # Then we check to see if we're facing the Tile
-        if game.player1.facing == tile_location:
-            return True
-        else:
-            return False
+            # Then we check to see if we're facing the Tile
+            if game.player1.facing == tile_location:
+                return True
+
+        return False

--- a/tuxemon/core/components/event/conditions/to_talk.py
+++ b/tuxemon/core/components/event/conditions/to_talk.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+#
+# Tuxemon
+# Copyright (c) 2014-2017 William Edwards <shadowapex@gmail.com>,
+#                         Benjamin Bean <superman2k5@gmail.com>
+#
+# This file is part of Tuxemon
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import absolute_import
+
+from tuxemon.core.components.event.eventcondition import EventCondition
+from tuxemon.core.components.event.conditions.button_pressed import ButtonPressedCondition
+from tuxemon.core.components.event.conditions.player_facing_npc import PlayerFacingNPCCondition
+from tuxemon.core.components.map import MapCondition
+
+
+class ToTalkCondition(EventCondition):
+    """ Checks if we are attempting to talk to an npc
+    """
+    name = "to_talk"
+
+    def test(self, game, condition):
+        """ Checks to see the player is next to and facing a particular NPC and that the Return button is pressed.
+
+        :param game: The main game object that contains all the game's variables.
+        :param condition: The condition details.
+
+        :type game: core.control.Control
+        :type condition: NamedTuple
+
+        :rtype: Boolean
+        :returns: True or False
+
+        Valid Parameters: npc slug
+
+        **Examples:**
+
+        condition.__dict__ = {
+            "type": "to_talk",
+            "parameters": [
+                "npc_oak"
+            ],
+            "width": 1,
+            "height": 1,
+            "operator": "is",
+            "x": 0,
+            "y": 0,
+            ...
+        }
+        """
+        player_next_to_and_facing_target = PlayerFacingNPCCondition().test(game, condition)
+        button_pressed = ButtonPressedCondition().test(
+            game,
+            MapCondition(
+                type="button_pressed",
+                parameters=[
+                    "K_RETURN",
+                ],
+                operator="is",
+                width=0,
+                height=0,
+                x=0,
+                y=0,
+            )
+        )
+        return player_next_to_and_facing_target and button_pressed
+

--- a/tuxemon/core/components/event/conditions/to_use_tile.py
+++ b/tuxemon/core/components/event/conditions/to_use_tile.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+#
+# Tuxemon
+# Copyright (c) 2014-2017 William Edwards <shadowapex@gmail.com>,
+#                         Benjamin Bean <superman2k5@gmail.com>
+#
+# This file is part of Tuxemon
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import absolute_import
+
+from tuxemon.core.components.event.eventcondition import EventCondition
+from tuxemon.core.components.event.conditions.button_pressed import ButtonPressedCondition
+from tuxemon.core.components.event.conditions.player_facing_tile import PlayerFacingTileCondition
+from tuxemon.core.components.map import MapCondition
+
+
+class ToUseTileCondition(EventCondition):
+    """ Checks if we are attempting to talk to an npc
+    """
+    name = "to_use_tile"
+
+    def test(self, game, condition):
+        """ Checks to see the player is next to and facing a particular tile and that the Return button is pressed.
+
+        :param game: The main game object that contains all the game's variables.
+        :param condition: The condition details.
+
+        :type game: core.control.Control
+        :type condition: NamedTuple
+
+        :rtype: Boolean
+        :returns: True or False
+
+        Valid Parameters: None
+
+        **Examples:**
+
+        condition.__dict__ = {
+            "type": "to_use_tile",
+            "parameters": [],
+            "width": 1,
+            "height": 1,
+            "operator": "is",
+            "x": 0,
+            "y": 0,
+            ...
+        }
+        """
+        player_next_to_and_facing_tile = PlayerFacingTileCondition().test(game, condition)
+        button_pressed = ButtonPressedCondition().test(
+            game,
+            MapCondition(
+                type="button_pressed",
+                parameters=[
+                    "K_RETURN",
+                ],
+                operator="is",
+                width=0,
+                height=0,
+                x=0,
+                y=0,
+            )
+        )
+        return player_next_to_and_facing_tile and button_pressed
+

--- a/tuxemon/core/components/map.py
+++ b/tuxemon/core/components/map.py
@@ -94,21 +94,16 @@ def translate_short_path(path, position=(0, 0)):
         yield position
 
 
-def get_direction(start, end):
-    """ Get direction name from two points
+def get_direction(base, target):
+    y_offset = base[1] - target[1]
+    x_offset = base[0] - target[0]
+    # Is it further away vertically or horizontally?
+    look_on_y_axis = abs(y_offset) >= abs(x_offset)
 
-    :param start:
-    :param end:
-    :return:
-    """
-    if start[0] > end[0]:
-        return "left"
-    elif start[0] < end[0]:
-        return "right"
-    elif start[1] < end[1]:
-        return "down"
-    elif start[1] > end[1]:
-        return "up"
+    if look_on_y_axis:
+        return "up" if y_offset > 0 else "down"
+    else:
+        return "left" if x_offset > 0 else "right"
 
 
 def proj(point):

--- a/tuxemon/core/components/map.py
+++ b/tuxemon/core/components/map.py
@@ -384,6 +384,24 @@ class Map(object):
                 action = MapAction(act_type, args)
                 acts.append(action)
 
+        for k in keys:
+            if k.startswith('behav'):
+                words = obj.properties[k].split(' ', 1)
+
+                # Actions have the form 'type parameters'.
+                behav_type = words[0]
+
+                # If this action has parameters, split them into a
+                # list
+                if len(words) > 1:
+                    args = self.split_escaped(words[1])
+                else:
+                    args = list()
+
+                if behav_type == "talk":
+                    conds.insert(0, MapCondition("to_talk", args, x, y, w, h, "is"))
+                    acts.insert(0, MapAction("npc_face", [args[0], "player"]))
+
         # TODO: move this to some post-creation function, as more may be needed
         # add a player_facing_tile condition automatically
         if obj.type == "interact":

--- a/tuxemon/resources/db/locale/en_US.json
+++ b/tuxemon/resources/db/locale/en_US.json
@@ -381,8 +381,6 @@
     "mwah5": "... ... No! what do you mean no? Unless... ... You're Jess's new boyfriend aren't you! She played me this whole time!",
     "mwah6": "JESS!!!",
     "itslockedboi": "Allie locked the door behind her...",
-    "dontmakemeturn": "Come on, be a man and talk in front of me.",
-    "dontmakemeturn2": "The cameras can't see us, so move around front. I want to preserve this forever.",
     "hellothere": "???: Hello there!",
     "kmere": "Why don't you come over here and talk to me?",
     "theinfo": "I'm sorry about that scene, Allie is sometimes hard to deal with, unlike my daughter Jess.",

--- a/tuxemon/resources/maps/cotton_town.tmx
+++ b/tuxemon/resources/maps/cotton_town.tmx
@@ -445,44 +445,34 @@
     <property name="cond3" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
-  <object id="263" name="purple flowers1" type="event" x="128" y="304" width="16" height="16">
+  <object id="263" name="purple flowers1" type="event" x="128" y="320" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog purple_flowers"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is to_use_tile"/>
    </properties>
   </object>
-  <object id="264" name="purple flowers2" type="event" x="160" y="304" width="16" height="16">
+  <object id="264" name="purple flowers2" type="event" x="160" y="320" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog purple_flowers"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is to_use_tile"/>
    </properties>
   </object>
-  <object id="265" name="purple flowers3" type="event" x="256" y="304" width="16" height="16">
+  <object id="265" name="purple flowers3" type="event" x="256" y="320" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog purple_flowers"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is to_use_tile"/>
    </properties>
   </object>
-  <object id="266" name="purple flowers4" type="event" x="288" y="304" width="16" height="16">
+  <object id="266" name="purple flowers4" type="event" x="288" y="320" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog purple_flowers"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is to_use_tile"/>
    </properties>
   </object>
-  <object id="267" name="purple flowers5" type="event" x="384" y="304" width="16" height="16">
+  <object id="267" name="purple flowers5" type="event" x="384" y="320" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog purple_flowers"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is to_use_tile"/>
    </properties>
   </object>
   <object id="269" name="orange flowers" type="event" x="208" y="272" width="16" height="16">

--- a/tuxemon/resources/maps/cotton_town.tmx
+++ b/tuxemon/resources/maps/cotton_town.tmx
@@ -413,6 +413,7 @@
   </object>
   <object id="257" name="learn from me" type="event" x="240" y="160" width="16" height="16">
    <properties>
+    <property name="act0" value="npc_face npc_aeble,player"/>
     <property name="act1" value="translated_dialog theinfo"/>
     <property name="act2" value="translated_dialog theinfo2"/>
     <property name="act3" value="translated_dialog theinfo2.5"/>
@@ -436,9 +437,7 @@
     <property name="act95" value="pathfind npc_aeble, 22, 10"/>
     <property name="act96" value="remove_npc npc_aeble"/>
     <property name="act97" value="set_variable donewithyou:yes"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is to_talk npc_aeble"/>
     <property name="cond4" value="not variable_set donewithyou:yes"/>
    </properties>
   </object>

--- a/tuxemon/resources/maps/cotton_town.tmx
+++ b/tuxemon/resources/maps/cotton_town.tmx
@@ -378,7 +378,6 @@
   </object>
   <object id="253" name="Hiya" type="event" x="352" y="176" width="16" height="16">
    <properties>
-    <property name="act0" value="npc_face npc_allie,player"/>
     <property name="act1" value="translated_dialog mwah"/>
     <property name="act11" value="set_variable npcs_are_created:yes"/>
     <property name="act2" value="translated_dialog mwah2"/>
@@ -389,7 +388,7 @@
     <property name="act9" value="npc_face npc_allie,up"/>
     <property name="act91" value="translated_dialog mwah6"/>
     <property name="act92" value="remove_npc npc_allie"/>
-    <property name="cond1" value="is to_talk npc_allie"/>
+    <property name="behav0" value="talk npc_allie"/>
    </properties>
   </object>
   <object id="257" name="learn from me" type="event" x="240" y="160" width="16" height="16">

--- a/tuxemon/resources/maps/cotton_town.tmx
+++ b/tuxemon/resources/maps/cotton_town.tmx
@@ -508,12 +508,10 @@
     <property name="cond3" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
-  <object id="273" name="fountain" type="event" x="464" y="400" width="48" height="16">
+  <object id="273" name="fountain" type="event" x="464" y="368" width="48" height="32">
    <properties>
     <property name="act1" value="translated_dialog cotton_town_fountain"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is to_use_tile"/>
    </properties>
   </object>
   <object id="274" name="tree" type="event" x="144" y="144" width="16" height="16">

--- a/tuxemon/resources/maps/cotton_town.tmx
+++ b/tuxemon/resources/maps/cotton_town.tmx
@@ -378,6 +378,7 @@
   </object>
   <object id="253" name="Hiya" type="event" x="352" y="176" width="16" height="16">
    <properties>
+    <property name="act0" value="npc_face npc_allie,player"/>
     <property name="act1" value="translated_dialog mwah"/>
     <property name="act11" value="set_variable npcs_are_created:yes"/>
     <property name="act2" value="translated_dialog mwah2"/>
@@ -388,27 +389,7 @@
     <property name="act9" value="npc_face npc_allie,up"/>
     <property name="act91" value="translated_dialog mwah6"/>
     <property name="act92" value="remove_npc npc_allie"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
-   </properties>
-  </object>
-  <object id="254" name="come on over" type="event" x="336" y="160" width="16" height="16">
-   <properties>
-    <property name="act1" value="translated_dialog dontmakemeturn"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
-    <property name="cond4" value="is npc_exists npc_allie"/>
-   </properties>
-  </object>
-  <object id="255" name="come to me2" type="event" x="368" y="160" width="16" height="16">
-   <properties>
-    <property name="act1" value="translated_dialog dontmakemeturn2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
-    <property name="cond4" value="is npc_exists npc_allie"/>
+    <property name="cond1" value="is to_talk npc_allie"/>
    </properties>
   </object>
   <object id="257" name="learn from me" type="event" x="240" y="160" width="16" height="16">

--- a/tuxemon/resources/maps/cotton_town.tmx
+++ b/tuxemon/resources/maps/cotton_town.tmx
@@ -393,7 +393,6 @@
   </object>
   <object id="257" name="learn from me" type="event" x="240" y="160" width="16" height="16">
    <properties>
-    <property name="act0" value="npc_face npc_aeble,player"/>
     <property name="act1" value="translated_dialog theinfo"/>
     <property name="act2" value="translated_dialog theinfo2"/>
     <property name="act3" value="translated_dialog theinfo2.5"/>
@@ -417,8 +416,8 @@
     <property name="act95" value="pathfind npc_aeble, 22, 10"/>
     <property name="act96" value="remove_npc npc_aeble"/>
     <property name="act97" value="set_variable donewithyou:yes"/>
-    <property name="cond1" value="is to_talk npc_aeble"/>
     <property name="cond4" value="not variable_set donewithyou:yes"/>
+    <property name="behav1" value="talk npc_aeble"/>
    </properties>
   </object>
   <object id="259" name="Create liela" type="event" x="16" y="80" width="16" height="16">
@@ -486,9 +485,7 @@
    <properties>
     <property name="act1" value="translated_dialog liela_goes_to_battle"/>
     <property name="act2" value="start_battle npc_liela"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="behav1" value="talk npc_liela"/>
    </properties>
   </object>
   <object id="271" name="statue1" type="event" x="448" y="464" width="16" height="16">

--- a/tuxemon/resources/maps/maple_house.tmx
+++ b/tuxemon/resources/maps/maple_house.tmx
@@ -43,10 +43,9 @@
   </object>
   <object id="30" name="talkHouse" type="event" x="144" y="128" width="16" height="16">
    <properties>
+    <property name="act0" value="npc_face npc_wife,player"/>
     <property name="act1" value="dialog Professor's Wife: \n The Professor is out at the moment. You might want to check his lab or somewhere in town"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is to_talk npc_wife"/>
    </properties>
   </object>
   <object id="32" name="wife appears" type="event" x="112" y="176" width="16" height="16">

--- a/tuxemon/resources/maps/maple_house.tmx
+++ b/tuxemon/resources/maps/maple_house.tmx
@@ -43,9 +43,8 @@
   </object>
   <object id="30" name="talkHouse" type="event" x="144" y="128" width="16" height="16">
    <properties>
-    <property name="act0" value="npc_face npc_wife,player"/>
     <property name="act1" value="dialog Professor's Wife: \n The Professor is out at the moment. You might want to check his lab or somewhere in town"/>
-    <property name="cond1" value="is to_talk npc_wife"/>
+    <property name="behav1" value="talk npc_wife"/>
    </properties>
   </object>
   <object id="32" name="wife appears" type="event" x="112" y="176" width="16" height="16">

--- a/tuxemon/resources/maps/paper_scoop.tmx
+++ b/tuxemon/resources/maps/paper_scoop.tmx
@@ -72,7 +72,6 @@
   </object>
   <object id="37" name="Talk to the professor" type="event" x="112" y="128" width="16" height="16">
    <properties>
-    <property name="act0" value="npc_face npc_professor,player"/>
     <property name="act1" value="translated_dialog_chain professor_dialog1"/>
     <property name="act2" value="translated_dialog_chain professor_dialog2"/>
     <property name="act3" value="translated_dialog_chain professor_dialog3"/>
@@ -80,8 +79,8 @@
     <property name="act5" value="translated_dialog_chain professor_dialog5"/>
     <property name="act6" value="translated_dialog_chain ${{end}}"/>
     <property name="act7" value="dialog_choice Hydrone:Rockitten:Fruitera,tuxchoice"/>
-    <property name="cond1" value="is to_talk npc_professor"/>
     <property name="cond5" value="is variable_set tuxchoice:welcome"/>
+    <property name="behav1" value="talk npc_professor"/>
    </properties>
   </object>
   <object id="42" name="hello Professor" type="event" x="144" y="192" width="16" height="16">

--- a/tuxemon/resources/maps/paper_scoop.tmx
+++ b/tuxemon/resources/maps/paper_scoop.tmx
@@ -72,6 +72,7 @@
   </object>
   <object id="37" name="Talk to the professor" type="event" x="112" y="128" width="16" height="16">
    <properties>
+    <property name="act0" value="npc_face npc_professor,player"/>
     <property name="act1" value="translated_dialog_chain professor_dialog1"/>
     <property name="act2" value="translated_dialog_chain professor_dialog2"/>
     <property name="act3" value="translated_dialog_chain professor_dialog3"/>
@@ -79,10 +80,7 @@
     <property name="act5" value="translated_dialog_chain professor_dialog5"/>
     <property name="act6" value="translated_dialog_chain ${{end}}"/>
     <property name="act7" value="dialog_choice Hydrone:Rockitten:Fruitera,tuxchoice"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
-    <property name="cond4" value="is npc_exists npc_professor"/>
+    <property name="cond1" value="is to_talk npc_professor"/>
     <property name="cond5" value="is variable_set tuxchoice:welcome"/>
    </properties>
   </object>

--- a/tuxemon/resources/maps/tuxe_mart.tmx
+++ b/tuxemon/resources/maps/tuxe_mart.tmx
@@ -72,7 +72,6 @@
   </object>
   <object id="37" name="Talk to the professor" type="event" x="112" y="128" width="16" height="16">
    <properties>
-    <property name="act0" value="npc_face npc_professor,player"/>
     <property name="act1" value="translated_dialog_chain professor_dialog1"/>
     <property name="act2" value="translated_dialog_chain professor_dialog2"/>
     <property name="act3" value="translated_dialog_chain professor_dialog3"/>
@@ -80,8 +79,8 @@
     <property name="act5" value="translated_dialog_chain professor_dialog5"/>
     <property name="act6" value="translated_dialog_chain ${{end}}"/>
     <property name="act7" value="dialog_choice Hydrone:Rockitten:Fruitera,tuxchoice"/>
-    <property name="cond1" value="is to_talk npc_professor"/>
     <property name="cond5" value="is variable_set tuxchoice:welcome"/>
+    <property name="behav1" value="talk npc_professor"/>
    </properties>
   </object>
   <object id="42" name="hello Professor" type="event" x="144" y="192" width="16" height="16">

--- a/tuxemon/resources/maps/tuxe_mart.tmx
+++ b/tuxemon/resources/maps/tuxe_mart.tmx
@@ -72,6 +72,7 @@
   </object>
   <object id="37" name="Talk to the professor" type="event" x="112" y="128" width="16" height="16">
    <properties>
+    <property name="act0" value="npc_face npc_professor,player"/>
     <property name="act1" value="translated_dialog_chain professor_dialog1"/>
     <property name="act2" value="translated_dialog_chain professor_dialog2"/>
     <property name="act3" value="translated_dialog_chain professor_dialog3"/>
@@ -79,10 +80,7 @@
     <property name="act5" value="translated_dialog_chain professor_dialog5"/>
     <property name="act6" value="translated_dialog_chain ${{end}}"/>
     <property name="act7" value="dialog_choice Hydrone:Rockitten:Fruitera,tuxchoice"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
-    <property name="cond4" value="is npc_exists npc_professor"/>
+    <property name="cond1" value="is to_talk npc_professor"/>
     <property name="cond5" value="is variable_set tuxchoice:welcome"/>
    </properties>
   </object>


### PR DESCRIPTION
npc_face can now be used to look at another npc or the player.
Usage:

- npc_face npc_slug1,npcslug2
- npc_face npc_slug1,player
- npc_face npc_slug1,left

to_talk is a convenience condition which checks if the player is next to and looking at the npc, and that K_RETURN is down. I'm open to a different name.
Usage:
- to_talk npc_slug

"to_use_tile" is a similar condition which checks the same, but for the the tile the event is registered with.

npc_facing_tile, player_facing_tile and to_use_tile now respect height and width. This is demonstrated on the fountain in cotton_town.

I've added "talk" which is a "behaviour": all it does is insert "to_talk" in front of the the conditions, and npc_face in front of the actions. It's a common pattern, so I felt it deserved it's own idiom. 
```
    <property name="act1" value="translated_dialog liela_goes_to_battle"/>
    <property name="act2" value="start_battle npc_liela"/>
    <property name="behav1" value="talk npc_liela"/>

```
**Internal:**
I also changed "get_direction". This makes npc_face more natural; it looks weird if the npc looks left when the player is one tile left and 10 tiles above them. I'm happy for this to be a new function. 

