### PR TITLE
Fix npc sprite issues

### DIFF
--- a/tests/test_sprites.py
+++ b/tests/test_sprites.py
@@ -1,0 +1,79 @@
+from __future__ import print_function
+
+import glob
+import json
+from os.path import dirname, join, normpath
+import unittest
+
+
+RESOURCES_DIR = normpath(join(dirname(__file__), '../tuxemon/resources'))
+
+# assume run from tests folder
+MAP_ROOT = join(RESOURCES_DIR, 'maps')
+NPC_ROOT = join(RESOURCES_DIR, 'db/npc')
+SPRITE_ROOT = join(RESOURCES_DIR, 'sprites')
+
+# If a sprite is deliberately partially implemented
+SKIPPED_SPRITES = {
+    # 'maple_back',
+    # 'maple_back_walk',
+}
+
+SPRITES = {
+    name.replace(SPRITE_ROOT + "/", "").split(".")[0].split('0')[0]
+    for name in
+    glob.glob(join(SPRITE_ROOT, '*.png'))
+}
+assert SPRITES, "No sprites found. Is the path correct?"
+
+
+def load_keys(filename):
+    with open(filename) as _fp:
+        return set(json.load(_fp).keys())
+
+
+def get_expected_sprites(slug):
+    return {
+        slug + "_back",
+        slug + "_back_walk",
+        slug + "_front",
+        slug + "_front_walk",
+        slug + "_left",
+        slug + "_left_walk",
+        slug + "_right",
+        slug + "_right_walk",
+    }
+
+
+def get_missing_sprites():
+    undefined = []
+    partial = []
+    for record_file in glob.glob(join(NPC_ROOT, '*.json')):
+        with open(record_file) as r:
+            sprite = json.load(r).get('sprite_name')
+            if sprite is None:
+                record_file = record_file.replace(NPC_ROOT + "/", "").replace(".json", "")
+                undefined.append(record_file)
+            else:
+                expected = get_expected_sprites(sprite)
+                partials = expected.difference(SPRITES).difference(SKIPPED_SPRITES)
+                if partials:
+                    partial += partials
+
+    if undefined:
+        print("No sprite defined for:")
+        print("\t" + "\n\t".join(sorted(undefined)))
+    if partial:
+        print("Missing sprite for:")
+        print("\t" + "\n\t".join(sorted(partial)))
+
+    return not undefined and not partial
+
+
+class TestSprites(unittest.TestCase):
+    def test_missing(self):
+        self.assertTrue(get_missing_sprites(), "Sprites are missing or undefined")
+
+
+if __name__ == "__main__":
+    get_missing_sprites()

--- a/tuxemon/core/components/db.py
+++ b/tuxemon/core/components/db.py
@@ -58,14 +58,15 @@ class JSONDatabase(object):
 
     """
 
-    def __init__(self):
+    def __init__(self, dir=None):
         self.path = prepare.BASEDIR + prepare.DATADIR + "/db/"
         self.database = {"item": {},
                          "monster": {},
                          "npc": {},
                          "technique": {},
                          "encounter": {}}
-
+        if dir:
+            self.load(dir)
 
     def load(self, directory="all"):
         """Loads all data from JSON files located under our data path.

--- a/tuxemon/core/components/npc.py
+++ b/tuxemon/core/components/npc.py
@@ -35,7 +35,7 @@ import pygame
 
 from item import decode_inventory, encode_inventory
 from monster import decode_monsters, encode_monsters
-from tuxemon.core.components import db, pyganim
+from tuxemon.core.components import db, monster, pyganim, technique
 from tuxemon.core.components.entity import Entity
 from tuxemon.core.components.locale import translator
 from tuxemon.core.components.map import proj, facing, dirs3, dirs2, get_direction
@@ -548,3 +548,52 @@ class Npc(Entity):
         :returns: None
         """
         self.monsters[index_1], self.monsters[index_2] = self.monsters[index_2], self.monsters[index_1]
+
+    def load_party(self):
+        self.monsters = []
+
+        # Look up the NPC's details from our NPC database
+        npcs = db.JSONDatabase()
+        npcs.load("npc")
+        npc_details = npcs.database['npc'][self.slug]
+
+        # Look up the NPC's monster party
+        npc_party = npc_details['monsters']
+        # Look up the monster's details
+        monsters = db.JSONDatabase()
+        monsters.load("monster")
+        # Look up each monster in the NPC's party
+        for npc_monster_details in npc_party:
+            results = monsters.database['monster'][npc_monster_details['monster']]
+
+            # Create a monster object for each monster the NPC has in their party.
+            # TODO: unify save/load of monsters
+            current_monster = monster.Monster()
+            current_monster.load_from_db(npc_monster_details['monster'])
+            current_monster.name = npc_monster_details['name']
+            current_monster.level = npc_monster_details['level']
+            current_monster.hp = npc_monster_details['hp']
+            current_monster.current_hp = npc_monster_details['hp']
+            current_monster.attack = npc_monster_details['attack']
+            current_monster.defense = npc_monster_details['defense']
+            current_monster.speed = npc_monster_details['speed']
+            current_monster.special_attack = npc_monster_details['special_attack']
+            current_monster.special_defense = npc_monster_details['special_defense']
+            current_monster.experience_give_modifier = npc_monster_details['exp_give_mod']
+            current_monster.experience_required_modifier = npc_monster_details['exp_req_mod']
+
+            current_monster.type1 = results['types'][0]
+
+            current_monster.set_level(current_monster.level)
+
+            if len(results['types']) > 1:
+                current_monster.type2 = results['types'][1]
+
+            current_monster.load_sprite_from_db()
+
+            pound = technique.Technique('technique_pound')
+
+            current_monster.learn(pound)
+
+            # Add our monster to the NPC's party
+            self.monsters.append(current_monster)

--- a/tuxemon/core/components/npc.py
+++ b/tuxemon/core/components/npc.py
@@ -550,50 +550,24 @@ class Npc(Entity):
         self.monsters[index_1], self.monsters[index_2] = self.monsters[index_2], self.monsters[index_1]
 
     def load_party(self):
+        """ Loads the party of this npc from their npc.json entry.
+
+        :rtype: None
+        :returns: None
+        """
         self.monsters = []
 
         # Look up the NPC's details from our NPC database
         npcs = db.JSONDatabase()
         npcs.load("npc")
         npc_details = npcs.database['npc'][self.slug]
-
-        # Look up the NPC's monster party
-        npc_party = npc_details['monsters']
-        # Look up the monster's details
-        monsters = db.JSONDatabase()
-        monsters.load("monster")
-        # Look up each monster in the NPC's party
-        for npc_monster_details in npc_party:
-            results = monsters.database['monster'][npc_monster_details['monster']]
-
-            # Create a monster object for each monster the NPC has in their party.
-            # TODO: unify save/load of monsters
-            current_monster = monster.Monster()
-            current_monster.load_from_db(npc_monster_details['monster'])
-            current_monster.name = npc_monster_details['name']
-            current_monster.level = npc_monster_details['level']
-            current_monster.hp = npc_monster_details['hp']
-            current_monster.current_hp = npc_monster_details['hp']
-            current_monster.attack = npc_monster_details['attack']
-            current_monster.defense = npc_monster_details['defense']
-            current_monster.speed = npc_monster_details['speed']
-            current_monster.special_attack = npc_monster_details['special_attack']
-            current_monster.special_defense = npc_monster_details['special_defense']
+        for npc_monster_details in npc_details['monsters']:
+            current_monster = monster.Monster(save_data=npc_monster_details)
+            current_monster.current_hp = current_monster.hp
             current_monster.experience_give_modifier = npc_monster_details['exp_give_mod']
             current_monster.experience_required_modifier = npc_monster_details['exp_req_mod']
-
-            current_monster.type1 = results['types'][0]
-
             current_monster.set_level(current_monster.level)
-
-            if len(results['types']) > 1:
-                current_monster.type2 = results['types'][1]
-
             current_monster.load_sprite_from_db()
-
-            pound = technique.Technique('technique_pound')
-
-            current_monster.learn(pound)
 
             # Add our monster to the NPC's party
             self.monsters.append(current_monster)

--- a/tuxemon/resources/db/npc/aeble.json
+++ b/tuxemon/resources/db/npc/aeble.json
@@ -1,4 +1,5 @@
 {
     "slug": "npc_aeble",
-    "name_trans": "npc_aeble"
+    "name_trans": "npc_aeble",
+    "sprite_name": "omnichannelceo"
 }

--- a/tuxemon/resources/db/npc/allie.json
+++ b/tuxemon/resources/db/npc/allie.json
@@ -1,4 +1,5 @@
 {
     "slug": "npc_allie",
-    "name_trans": "npc_allie"
+    "name_trans": "npc_allie",
+    "sprite_name": "omnichannelfemale"
 }

--- a/tuxemon/resources/db/npc/cottonnurse.json
+++ b/tuxemon/resources/db/npc/cottonnurse.json
@@ -1,4 +1,5 @@
 {
     "slug": "npc_cottonnurse",
-    "name_trans": "npc_cottonnurse"
+    "name_trans": "npc_cottonnurse",
+    "sprite_name": "nurse"
 }

--- a/tuxemon/resources/db/npc/knight1.json
+++ b/tuxemon/resources/db/npc/knight1.json
@@ -1,4 +1,5 @@
 {
     "slug": "npc_knight1",
-    "name_trans": "npc_knight1"
+    "name_trans": "npc_knight1",
+    "sprite_name": "knight"
 }

--- a/tuxemon/resources/db/npc/knight2.json
+++ b/tuxemon/resources/db/npc/knight2.json
@@ -1,4 +1,5 @@
 {
     "slug": "npc_knight2",
-    "name_trans": "npc_knight2"
+    "name_trans": "npc_knight2",
+    "sprite_name": "knight"
 }

--- a/tuxemon/resources/db/npc/liela.json
+++ b/tuxemon/resources/db/npc/liela.json
@@ -9,7 +9,7 @@
             "name": "Capiti",
             "special_attack": 12,
             "level": 6,
-            "monster": "txmn_capiti",
+            "slug": "txmn_capiti",
             "hp": 55,
             "speed": 14,
             "special_defense": 20,
@@ -17,6 +17,5 @@
             "exp_req_mod": 27
         }
     ],
-    "id": 2,
     "name": "Liela"
 }

--- a/tuxemon/resources/db/npc/tabanurse.json
+++ b/tuxemon/resources/db/npc/tabanurse.json
@@ -1,4 +1,5 @@
 {
     "slug": "npc_tabanurse",
-    "name_trans": "npc_tabanurse"
+    "name_trans": "npc_tabanurse",
+    "sprite_name": "nurse"
 }

--- a/tuxemon/resources/db/npc/xerogrund1.json
+++ b/tuxemon/resources/db/npc/xerogrund1.json
@@ -1,4 +1,5 @@
 {
     "slug": "npc_xerogrund1",
-    "name_trans": "npc_xerogrund1"
+    "name_trans": "npc_xerogrund1",
+    "sprite_name": "teamxerogrunt1"
 }

--- a/tuxemon/resources/db/npc/xerogrund2.json
+++ b/tuxemon/resources/db/npc/xerogrund2.json
@@ -1,4 +1,5 @@
 {
     "slug": "npc_xerogrund2",
-    "name_trans": "npc_xerogrund2"
+    "name_trans": "npc_xerogrund2",
+    "sprite_name": "teamxerogrunt1"
 }

--- a/tuxemon/resources/db/npc/xerogrunt1.json
+++ b/tuxemon/resources/db/npc/xerogrunt1.json
@@ -1,4 +1,5 @@
 {
     "slug": "npc_xerogrunt1",
-    "name_trans": "npc_xerogrunt1"
+    "name_trans": "npc_xerogrunt1",
+    "sprite_name": "teamxerogrunt1"
 }

--- a/tuxemon/resources/db/npc/xerogrunt10.json
+++ b/tuxemon/resources/db/npc/xerogrunt10.json
@@ -1,4 +1,5 @@
 {
     "slug": "npc_xerogrunt10",
-    "name_trans": "npc_xerogrunt10"
+    "name_trans": "npc_xerogrunt10",
+    "sprite_name": "teamxerogrunt1"
 }

--- a/tuxemon/resources/db/npc/xerogrunt2.json
+++ b/tuxemon/resources/db/npc/xerogrunt2.json
@@ -1,4 +1,5 @@
 {
     "slug": "npc_xerogrunt2",
-    "name_trans": "npc_xerogrunt2"
+    "name_trans": "npc_xerogrunt2",
+    "sprite_name": "teamxerogrunt1"
 }

--- a/tuxemon/resources/db/npc/xerogrunt3.json
+++ b/tuxemon/resources/db/npc/xerogrunt3.json
@@ -1,4 +1,5 @@
 {
     "slug": "npc_xerogrunt3",
-    "name_trans": "npc_xerogrunt3"
+    "name_trans": "npc_xerogrunt3",
+    "sprite_name": "teamxerogrunt1"
 }

--- a/tuxemon/resources/db/npc/xerogrunt4.json
+++ b/tuxemon/resources/db/npc/xerogrunt4.json
@@ -1,4 +1,5 @@
 {
     "slug": "npc_xerogrunt4",
-    "name_trans": "npc_xerogrunt4"
+    "name_trans": "npc_xerogrunt4",
+    "sprite_name": "teamxerogrunt1"
 }

--- a/tuxemon/resources/db/npc/xerogrunt5.json
+++ b/tuxemon/resources/db/npc/xerogrunt5.json
@@ -1,4 +1,5 @@
 {
     "slug": "npc_xerogrunt5",
-    "name_trans": "npc_xerogrunt5"
+    "name_trans": "npc_xerogrunt5",
+    "sprite_name": "teamxerogrunt1"
 }

--- a/tuxemon/resources/db/npc/xerogrunt6.json
+++ b/tuxemon/resources/db/npc/xerogrunt6.json
@@ -1,4 +1,5 @@
 {
     "slug": "npc_xerogrunt6",
-    "name_trans": "npc_xerogrunt6"
+    "name_trans": "npc_xerogrunt6",
+    "sprite_name": "teamxerogrunt1"
 }

--- a/tuxemon/resources/db/npc/xerogrunt7.json
+++ b/tuxemon/resources/db/npc/xerogrunt7.json
@@ -1,4 +1,5 @@
 {
     "slug": "npc_xerogrunt7",
-    "name_trans": "npc_xerogrunt7"
+    "name_trans": "npc_xerogrunt7",
+    "sprite_name": "teamxerogrunt1"
 }

--- a/tuxemon/resources/db/npc/xerogrunt8.json
+++ b/tuxemon/resources/db/npc/xerogrunt8.json
@@ -1,4 +1,5 @@
 {
     "slug": "npc_xerogrunt8",
-    "name_trans": "npc_xerogrunt8"
+    "name_trans": "npc_xerogrunt8",
+    "sprite_name": "teamxerogrunt1"
 }

--- a/tuxemon/resources/db/npc/xerogrunt9.json
+++ b/tuxemon/resources/db/npc/xerogrunt9.json
@@ -1,4 +1,5 @@
 {
     "slug": "npc_xerogrunt9",
-    "name_trans": "npc_xerogrunt9"
+    "name_trans": "npc_xerogrunt9",
+    "sprite_name": "teamxerogrunt1"
 }

--- a/tuxemon/resources/maps/cotton_town.tmx
+++ b/tuxemon/resources/maps/cotton_town.tmx
@@ -217,7 +217,7 @@
    <properties>
     <property name="act1" value="translated_dialog itslockedboi"/>
     <property name="act2" value="translated_dialog hellothere"/>
-    <property name="act3" value="create_npc npc_aeble,14,10,omnichannelceo,stand"/>
+    <property name="act3" value="create_npc npc_aeble,14,10,,stand"/>
     <property name="act4" value="npc_face npc_aeble,right"/>
     <property name="act5" value="translated_dialog kmere"/>
     <property name="cond1" value="is player_at"/>
@@ -371,7 +371,7 @@
   </object>
   <object id="252" name="create allie" type="event" x="0" y="352" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc npc_allie,22,10,omnichannelfemale,stand"/>
+    <property name="act1" value="create_npc npc_allie,22,10,,stand"/>
     <property name="cond1" value="not npc_exists npc_allie"/>
     <property name="cond2" value="not variable_set npcs_are_created:yes"/>
    </properties>
@@ -400,7 +400,7 @@
   </object>
   <object id="259" name="Create liela" type="event" x="16" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc npc_liela,38,17,femaletrainer,stand"/>
+    <property name="act1" value="create_npc npc_liela,38,17,,stand"/>
     <property name="act2" value="npc_face npc_liela,up"/>
     <property name="cond1" value="not npc_exists npc_liela"/>
    </properties>


### PR DESCRIPTION
Script and unit test (verify_sprites.py) which checks/fails if any npc.json don't have a sprite defined, or if any of the sprites for the npc are missing. 

Create battle will grab the npc from the map, not create it's own version.

Create_npc can be called without specifying a sprite, and a warning will be logged if a sprite is specified.