### PR TITLE
Optimise pathfinding

### DIFF
--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -1,0 +1,47 @@
+from os.path import join
+from unittest import TestCase
+import mock
+import pygame as pg
+
+from tuxemon.core import prepare
+from tuxemon.core.states.world import WorldState
+
+pg.display.set_mode((1, 1), 0, 0)
+control = mock.MagicMock()
+state = WorldState(control)
+map_name = join(prepare.BASEDIR, prepare.DATADIR, 'maps', 'test_cotton_town.tmx')
+state.change_map(map_name)
+
+
+class Test(TestCase):
+    def test_long_path(self):
+        path = state.pathfind(
+            (1, 39),
+            (36, 4),
+        )
+        expected = [
+            (36, 4), (36, 5), (36, 6), (35, 6), (35, 7), (35, 8), (34, 8), (34, 9), (34, 10),
+            (33, 10), (32, 10), (31, 10), (30, 10), (29, 10), (28, 10), (27, 10), (26, 10),
+            (26, 11), (26, 12), (25, 12), (24, 12), (24, 13), (23, 13), (22, 13), (21, 13),
+            (20, 13), (19, 13), (19, 14), (19, 15), (19, 16), (19, 17), (19, 18), (19, 19),
+            (18, 19), (17, 19), (17, 20), (17, 21), (17, 22), (17, 23), (16, 23), (16, 24),
+            (15, 24), (14, 24), (14, 25), (14, 26), (14, 27), (14, 28), (14, 29), (14, 30),
+            (14, 31), (14, 32), (14, 33), (14, 34), (14, 35), (14, 36), (14, 37), (14, 38),
+            (14, 39), (13, 39), (12, 39), (11, 39), (10, 39), (9, 39), (8, 39), (7, 39),
+            (6, 39), (5, 39), (4, 39), (3, 39), (2, 39),
+        ]
+        self.assertEqual(expected, path)
+
+    def test_blocked_route(self):
+        path = state.pathfind(
+            (1, 39),
+            (1, 21),
+        )
+        self.assertEquals(path, None)
+
+    def test_out_of_bounds(self):
+        path = state.pathfind(
+            (1, 39),
+            (-1, 0),
+        )
+        self.assertEquals(path, None)

--- a/tuxemon/resources/maps/test_pathfinding_town.tmx
+++ b/tuxemon/resources/maps/test_pathfinding_town.tmx
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.0" tiledversion="1.0.3" orientation="orthogonal" renderorder="right-down" width="40" height="40" tilewidth="16" tileheight="16" nextobjectid="275">
+ <properties>
+  <property name="edges" value="clamped"/>
+ </properties>
+ <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
+  <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>
+  <tile id="839">
+   <animation>
+    <frame tileid="839" duration="200"/>
+    <frame tileid="842" duration="200"/>
+    <frame tileid="845" duration="200"/>
+    <frame tileid="848" duration="200"/>
+   </animation>
+  </tile>
+  <tile id="880">
+   <animation>
+    <frame tileid="880" duration="200"/>
+    <frame tileid="883" duration="200"/>
+    <frame tileid="886" duration="200"/>
+    <frame tileid="889" duration="200"/>
+   </animation>
+  </tile>
+ </tileset>
+ <tileset firstgid="1313" name="My_tuxemon_sheet_OLD" tilewidth="16" tileheight="16" tilecount="104" columns="8">
+  <image source="../gfx/tilesets/My_tuxemon_sheet.png" width="128" height="208"/>
+ </tileset>
+ <tileset firstgid="1417" name="Sand_n_water" tilewidth="16" tileheight="16" tilecount="104" columns="8">
+  <image source="../gfx/tilesets/Sand_n_water.png" width="128" height="208"/>
+ </tileset>
+ <tileset firstgid="1521" name="buddha-statues" tilewidth="16" tileheight="16" tilecount="10" columns="5">
+  <image source="../gfx/tilesets/buddha-statues.png" width="80" height="32"/>
+ </tileset>
+ <tileset firstgid="1531" name="PastTheFuture_Grass_Sand_Snow" tilewidth="16" tileheight="16" tilecount="360" columns="24">
+  <image source="../gfx/tilesets/PastTheFuture_Grass_Sand_Snow.png" width="384" height="240"/>
+  <tile id="255">
+   <animation>
+    <frame tileid="248" duration="150"/>
+    <frame tileid="249" duration="150"/>
+    <frame tileid="250" duration="150"/>
+    <frame tileid="251" duration="150"/>
+    <frame tileid="252" duration="150"/>
+    <frame tileid="253" duration="150"/>
+    <frame tileid="254" duration="150"/>
+    <frame tileid="255" duration="150"/>
+   </animation>
+  </tile>
+ </tileset>
+ <tileset firstgid="1891" name="city tiles" tilewidth="16" tileheight="16" tilecount="1440" columns="40">
+  <image source="../gfx/tilesets/Outdoor_Tiles_-_City_and_Country_-_by_ArMM1998.png" width="640" height="576"/>
+ </tileset>
+ <tileset firstgid="3331" name="Outdoor_Tiles_-_City_and_Country_-_by_ArMM1998" tilewidth="16" tileheight="16" tilecount="1440" columns="40">
+  <image source="../gfx/tilesets/Outdoor_Tiles_-_City_and_Country_-_by_ArMM1998.png" width="640" height="576"/>
+ </tileset>
+ <tileset firstgid="4771" name="Furniture_and_Fittings_by_George" tilewidth="16" tileheight="16" tilecount="110" columns="10">
+  <image source="../gfx/tilesets/Furniture_and_Fittings_by_George.png" width="160" height="176"/>
+ </tileset>
+ <tileset firstgid="4881" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
+  <image source="../gfx/tilesets/boxfont.png" width="208" height="192"/>
+ </tileset>
+ <tileset firstgid="5037" name="Furniture_and_Fittings_by_George" tilewidth="16" tileheight="16" tilecount="110" columns="10">
+  <image source="../gfx/tilesets/Furniture_and_Fittings_by_George.png" width="160" height="176"/>
+ </tileset>
+ <layer name="Tile Layer 1" width="40" height="40">
+  <data encoding="base64" compression="zlib">
+   eJztl0sOgjAQQNnA8coKWShh4Ycr6Eo9gXoIo95Cb+Y0wWQwbZnSKW2Uxcs0GWge/UyLSJMkB8QUp8gcJQUwQ5QoF9pPuq2AY5Yke+AALJFjSL+Pm3TCfrJdt8+E9KvSrhNuL9F8x+iH2zH6zSG3acHvnSB3ZuaS6T0XluvvBrk7Mw+DX2XwUz1P9cN9ufit0TxiGoLfFXgy8DL42UbsVzP0xx3xnvoFP0Hsdyhj+eUO6PzwGROC0uBHOXd8t/H82Z6JPtsqPxm3mb5ejoX0MPntsm7sywuL96n7NaQfpQ7o1h9nnaKOm6qe+PBz+a7Jbxw/Uy2Pwc9XzY3dr2bw6zs3vvuljM2Q8cP/6y77w8aP637wb37U/atbU00kfpT7s4oiAj/qOA2pbS7OgujnG9O/0OTH4/cGmHllbw==
+  </data>
+ </layer>
+ <layer name="Tile Layer 2" width="40" height="40">
+  <data encoding="base64" compression="zlib">
+   eJzNmGdPFEEcxvfKnpqYkOhLG01ABATUxNjiCwtdjNIlKk1jYqEKxApoNLF9Bztqom98oy/8BFZA3/g5rIC/DTdh7pi5LbegT/LLsDe7Mw/P/ndu9gzDMF5HDONNxHtrKQBBCEEYTLC6FsFiWAL5dBRALdSF9cey7jHI/UjybS5jrYc8ywcUwAYohCIoNmZ9CCU6Fl6TzU60BxnzENRY80Ad1EMDNEKToc5HJ+F1i5l8dpbOwwW4CJfgMlyBIRiGEUVeiST/L37U3wN4CI/gMTyBUXgKz+C5x/xUWXjRO3gPH+AjfILPMAbjMGF4y0+VhRd9hx/wE37Bb/gDkzAF04a3/CzpsusIOPeXyrlpkA4ZkAlrIQuyISfgLj9Zuuy+uRijlPnLoBwqoBKqYD9Uw4GAu/yE/Ki/jczZxfzd0AO90AfnoB8GYNBlfn7Xn98S/8tRM/ln16lEJiWm83MtLVR2dvc3TJ8Zjj3Xr/UvkeKfC3Gsa+VzFqL+RBYiH3Gsa8NhZ+ufW+2Kr6vQTGOXl661fFpjznf92eWla/MXqP68qvY/Xv/in6m3y/+dF5XEPc6TPBbyAlEExTAOm+DVspk+q93Kd9Q22A47YGcgtj/R9U50WHq+RH41kr8GxmuEJpiC5mBsXbbipw3aAzN7m+PR/U1LRH+90PUUw7iRkthfs+RPld8Q4w3DCGSzNlwLxtblTfzcgttwB+7G7b9U1wu9wNtLF/5U+clqMGdJ1K+T3fXFimdRl99YtF4m4At8DcZeZ9e/guOVsApWw5q4fqfS5TcZrZfp6At2IBR7nV3/bj7fA3thH5TAUg/7ZF1+WaGZesmBdZAbN79d/yn8nIYzcBY6YbMLf6ORuf7k/Gps9mO1pnfqHOz1hFT5xX/ut4549Cd/f8ynPzeyW/906jBnkdf4JjO2T3VOq4taaNPUX7/He6C7d37cDzm/Ts14qTyHaZAOGZAZnOtPtTb64U/OT+evlLnKoBwqoFLhT7U2tmvuuwrd3tlJfl3M2Q090At9Cn92a6NKVdExrLF0e2ehRPnZ1bCbtUOlZnPuPrSQz6qlcXX5OamhZP1ZkvM6IY1XH/3bym9AMY+TGrrKtS20gx44KXEsOr/8u4J4FxTrX73Co1u5fX9Uyfq9JUfyotv/eZHb90cn+guyKzOG
+  </data>
+ </layer>
+ <layer name="Tile Layer 3" width="40" height="40">
+  <data encoding="base64" compression="zlib">
+   eJztlklLw0AYhqdN46099BeI4IpKXQ7idhdBPKh1QXBfj55UBLXiye3kUn+BetWjuPQutsX/4FIvetCK21s6waS0mTQLmUpfeJhMJsm88yXz5SOEP3W77HagrkrO/eXjZ0w8xu9d/DtWi98u2AP74AAEZWM+JyE1oBbUgXqnJVZV43cBLsEV7YdAuzt53Ac//WAg4UsgZNAEf6+isv8ipr9O0j14AI+0HwNz8HfqJWQVfgJgDZTD37pF8eNtf8RpzD5oy+P+kIu3+KUqHz9j0hq/G+zPW0oYRECU7tlGByFNoBm0gFZH8rw8R95ZmCMTesOzu0Cc4gefdL5R+BkD42ACTFJ/Xxj/Bj80RzoE6/wV4tlLmKdISLKM42K0Z8iFG/CzCbbANtih/kowXgrKhGSOrLDQX15sRd12O7Bf0/hvLWhgllEbWKWnAvXxIN7hIXhmXGeVWP6u4S2UpT8Xcrho0n8m1d+KB7UaCHiU57PxVwVv1WAowzfRILLX4BPT+zuCr2NwYsBfD+b1g94M/hJzS2tgKdVfGL4iIGrAnxZJa2CJ9f1J4nV/SOLB37lXOSbv2+Vvnubf4Qzf8ggdX7QpP5uptn+whlxXrr+DDlHZmqmYifU6y598fErnWjo13Kf32XLNiEoy5So1SfWC3pY3SfWF1jrDiPTsWam+UKszfgGhJ1/o
+  </data>
+ </layer>
+ <objectgroup color="#ff0000" name="Collisions">
+  <object id="124" type="collision" x="256" y="512">
+   <polygon points="0,0 0,48 80,48 80,0"/>
+  </object>
+  <object id="126" type="collision-line" x="400" y="336">
+   <polyline points="0,0 0,32"/>
+  </object>
+  <object id="127" type="collision-line" x="576" y="336">
+   <polyline points="0,0 0,144"/>
+  </object>
+  <object id="128" type="collision" x="528" y="464" width="48" height="16"/>
+  <object id="130" type="collision" x="448" y="448">
+   <polyline points="0,0 0,16 16,16 16,0 0,0"/>
+  </object>
+  <object id="132" type="collision" x="464" y="368">
+   <polygon points="0,0 48,0 48,32 0,32 0,0"/>
+  </object>
+  <object id="135" type="collision" x="416" y="336">
+   <polygon points="0,0 0,32 32,32 32,16 32,0"/>
+  </object>
+  <object id="136" type="collision" x="528" y="336">
+   <polygon points="0,0 0,32 32,32 32,0"/>
+  </object>
+  <object id="137" type="collision" x="400" y="208" width="32" height="16"/>
+  <object id="138" type="collision" x="64" y="96" width="80" height="32"/>
+  <object id="151" type="collision" x="544" y="80" width="16" height="16"/>
+  <object id="153" type="collision" x="512" y="112" width="16" height="16"/>
+  <object id="154" type="collision" x="528" y="144" width="16" height="16"/>
+  <object id="155" type="collision" x="560" y="144" width="16" height="16"/>
+  <object id="156" type="collision" x="576" y="112" width="16" height="16"/>
+  <object id="168" type="collision" x="0" y="288" width="64" height="16"/>
+  <object id="169" type="collision" x="32" y="80" width="16" height="208"/>
+  <object id="170" type="collision" x="48" y="208" width="16" height="32"/>
+  <object id="171" type="collision" x="48" y="144" width="16" height="32"/>
+  <object id="172" type="collision" x="48" y="64" width="16" height="48"/>
+  <object id="173" type="collision" x="64" y="48" width="208" height="32"/>
+  <object id="174" type="collision" x="272" y="16" width="16" height="32"/>
+  <object id="175" type="collision" x="64" y="128" width="48" height="16"/>
+  <object id="176" type="collision" x="112" y="128" width="128" height="16"/>
+  <object id="177" type="collision" x="240" y="128" width="16" height="16"/>
+  <object id="178" type="collision" x="176" y="96" width="80" height="32"/>
+  <object id="179" type="collision" x="288" y="16" width="64" height="144"/>
+  <object id="180" type="collision" x="272" y="144" width="16" height="16"/>
+  <object id="181" type="collision" x="0" y="304" width="16" height="144"/>
+  <object id="182" type="collision" x="48" y="320" width="96" height="48"/>
+  <object id="183" type="collision" x="16" y="384" width="80" height="48"/>
+  <object id="184" type="collision" x="96" y="368" width="48" height="16"/>
+  <object id="185" type="collision" x="96" y="384" width="32" height="32"/>
+  <object id="187" type="collision" x="144" y="384" width="80" height="48"/>
+  <object id="188" type="collision" x="176" y="320" width="80" height="48"/>
+  <object id="189" type="collision" x="160" y="320" width="16" height="16"/>
+  <object id="190" type="collision" x="256" y="320" width="16" height="16"/>
+  <object id="191" type="collision" x="224" y="368" width="32" height="16"/>
+  <object id="192" type="collision" x="240" y="400" width="64" height="32"/>
+  <object id="193" type="collision" x="304" y="320" width="80" height="48"/>
+  <object id="194" type="collision" x="272" y="384" width="80" height="16"/>
+  <object id="195" type="collision" x="304" y="400" width="48" height="16"/>
+  <object id="196" type="collision" x="320" y="416" width="48" height="16"/>
+  <object id="197" type="collision" x="192" y="560" width="16" height="16"/>
+  <object id="198" type="collision" x="352" y="368" width="48" height="16"/>
+  <object id="199" type="collision" x="384" y="320" width="192" height="16"/>
+  <object id="200" type="collision" x="400" y="464" width="48" height="16"/>
+  <object id="201" type="collision-line" x="400" y="384">
+   <polyline points="0,0 0,80"/>
+  </object>
+  <object id="202" type="collision" x="240" y="592" width="304" height="16"/>
+  <object id="203" type="collision" x="512" y="528" width="96" height="32"/>
+  <object id="204" type="collision" x="512" y="560" width="32" height="32"/>
+  <object id="205" type="collision" x="304" y="608" width="256" height="32"/>
+  <object id="206" type="collision" x="608" y="288" width="32" height="256"/>
+  <object id="207" type="collision" x="624" y="256" width="16" height="32"/>
+  <object id="208" type="collision" x="464" y="208" width="160" height="64"/>
+  <object id="209" type="collision" x="400" y="224" width="32" height="48"/>
+  <object id="210" type="collision" x="432" y="240" width="32" height="32"/>
+  <object id="211" type="collision" x="432" y="176" width="32" height="32"/>
+  <object id="212" type="collision" x="112" y="224" width="96" height="32"/>
+  <object id="213" type="collision" x="112" y="256" width="64" height="16"/>
+  <object id="214" type="collision" x="224" y="224" width="80" height="32"/>
+  <object id="215" type="collision" x="192" y="256" width="112" height="16"/>
+  <object id="216" type="collision" x="320" y="224" width="80" height="32"/>
+  <object id="217" type="collision" x="384" y="256" width="16" height="16"/>
+  <object id="218" type="collision" x="144" y="336" width="16" height="32"/>
+  <object id="219" type="collision" x="112" y="512" width="80" height="32"/>
+  <object id="220" type="collision" x="112" y="544" width="32" height="16"/>
+  <object id="221" type="collision" x="160" y="544" width="32" height="16"/>
+  <object id="222" type="collision" x="0" y="480" width="16" height="160"/>
+  <object id="223" type="collision" x="16" y="592" width="96" height="16"/>
+  <object id="224" type="collision" x="592" y="128" width="16" height="80"/>
+  <object id="225" type="collision" x="592" y="0" width="48" height="112"/>
+  <object id="226" type="collision" x="464" y="0" width="128" height="48"/>
+  <object id="227" type="collision" x="496" y="48" width="32" height="16"/>
+  <object id="228" type="collision" x="560" y="48" width="32" height="16"/>
+  <object id="234" type="collision" x="32" y="304" width="16" height="16"/>
+  <object id="235" type="collision" x="48" y="272" width="16" height="16"/>
+  <object id="237" type="collision-line" x="16" y="640">
+   <polyline points="0,0 144,0"/>
+  </object>
+  <object id="238" type="collision" x="512" y="448" width="16" height="16"/>
+  <object id="241" type="collision" x="608" y="144" width="32" height="16"/>
+  <object id="242" type="collision" x="368" y="16" width="96" height="144"/>
+  <object id="243" type="collision" x="352" y="16" width="16" height="128"/>
+  <object id="250" type="collision" x="320" y="256" width="64" height="16"/>
+  <object id="261" type="collision" x="288" y="320" width="16" height="16"/>
+ </objectgroup>
+ <layer name="Above Player" width="40" height="40">
+  <data encoding="base64" compression="zlib">
+   eJztl1sKgzAQRUeZLscup92ZXYS2Ls8+frw/gdIyFJk0hvEeuMhI0MkJhESkPKoiB7Vr612pvjrkqHa9FamPE3JWu36fS0k+/5n6suqaqcEfWUckf5Hmkos1TujPB/3ZJDe/niQuXGMf9OdjT/76VuTS5v3mnvz9A/rzQX8+IvibG5E78kCeyKv5HjNg3xuRK3JDpkz7YC3+eHYmJC6135UX1LEQpg==
+  </data>
+ </layer>
+ <layer name="Above Player" width="40" height="40">
+  <data encoding="base64" compression="zlib">
+   eJzt1lkKwjAUheGToY5PVl2Tuht1a+7MeXjxCIrSxjYWIQrngx8pRQwlvREQkVgDA+RsyEZsbJ732hbosC7rsb5Nt04RkRvvgcyXr4ufnzKcb5Y55lnGWveZ925O/uOMbPp8RH5J3btX9d8m5vsiIaF98zpT6/bVmvtww7Zsx/am/Bsp6FyQolVefS3ycOAcO7ITO7NLYK7pzI03ccCUzVzqlYTNua4FW35xfTqDRJq7AmXCEMk=
+  </data>
+ </layer>
+</map>


### PR DESCRIPTION
Made a pretty good improvement to the performance of path-finding.

- Stopped the game from crashing when you tried to path-find too far (about halfway) across the cotton-town map.
- After fixing that, it would take 6s to plot the path from one corner to another.
- Now it takes 0.01s!

See pathfind-wip for a more granular break-down of the time saves, if you like.

No change to the algorithm itself, the main thing was to use a set, instead of a list, for storing visited nodes. Also fixed an issue where the pathfinding would wander out of bounds, causing it to analyse extra nodes.