### PR TITLE
Fix "map freeze" when we exit a map immediately

### DIFF
--- a/tuxemon/core/components/event/actions/screen_transition.py
+++ b/tuxemon/core/components/event/actions/screen_transition.py
@@ -35,8 +35,12 @@ class ScreenTransitionAction(EventAction):
     ]
 
     def start(self):
+        pass
+
+    def update(self):
         world = self.game.get_state_name("WorldState")
 
         if world is not None:
             if not world.in_transition:
                 world.fade_and_teleport(self.parameters.transition_time)
+                self.stop()

--- a/tuxemon/core/components/event/actions/transition_teleport.py
+++ b/tuxemon/core/components/event/actions/transition_teleport.py
@@ -54,11 +54,16 @@ class TransitionTeleportAction(EventAction):
     ]
 
     def start(self):
-        # Get transition parameters
-        transition_time = self.parameters.transition_time
-
         # Start the screen transition
-        self.game.event_engine.execute_action("screen_transition", [transition_time])
+        params = [self.parameters.transition_time]
+        self.transition = self.game.event_engine.get_action("screen_transition", params)
+        self.transition.start()
 
-        # set the delayed teleport
-        self.game.event_engine.execute_action("delayed_teleport", self.raw_parameters[:-1])
+    def update(self):
+        if not self.transition.done:
+            self.transition.update()
+        if self.transition.done:
+            self.transition.cleanup()
+            # set the delayed teleport
+            self.game.event_engine.execute_action("delayed_teleport", self.raw_parameters[:-1])
+            self.stop()


### PR DESCRIPTION
https://github.com/Tuxemon/Tuxemon/issues/474

This was an interesting bug! When we are transitioning to a new map we unlock the controls before the transition is complete; this helps the movement feel a bit more fluid. 

This means we're able to pass through the triggering tile whilst the transition is still taking place. The event is triggered multiple times but never does anything, as we don't allow two transitions to take place at the same time. We pass all the way through, and end up out of bounds, on a tile that can no longer trigger the transition.

From now on we should wait until the previous transition is completed, and then start the next one. I can't think of any issues this could cause.