### PR TITLE
add_monster creates monster with full health

### DIFF
--- a/tuxemon/core/components/event/actions/add_monster.py
+++ b/tuxemon/core/components/event/actions/add_monster.py
@@ -44,5 +44,6 @@ class AddMonsterAction(EventAction):
         current_monster = monster.Monster()
         current_monster.load_from_db(monster_slug)
         current_monster.set_level(monster_level)
+        current_monster.current_hp = current_monster.hp
 
         self.game.player1.add_monster(current_monster)


### PR DESCRIPTION
#495 
Probably a regression from my combat update.

FYI, monsters were able to enter battle with 0hp as we have an explicit "fainted" status, which is added when lethal damage is done in battle.

It might be worth simplifying this in the future, but I don't think it's urgent.