### PR TITLE
Remove additional effects from dollfins moves

### DIFF
--- a/tuxemon/resources/db/technique/flood.json
+++ b/tuxemon/resources/db/technique/flood.json
@@ -1,10 +1,9 @@
 {
-  "accuracy": 1.5,
+  "accuracy": 0.5,
   "animation": "Shot",
   "category": "physical",
   "effects": [
-    "damage",
-    "poison"
+    "damage"
   ],
   "execute_trans": "combat_used_x",
   "failure_trans": "combat_miss",
@@ -13,7 +12,6 @@
   "is_area": true,
   "is_fast": false,
   "name_trans": "technique_flood_name",
-  "potency": 1,
   "power": 1.5,
   "range": "ranged",
   "recharge": 1,

--- a/tuxemon/resources/db/technique/flow.json
+++ b/tuxemon/resources/db/technique/flow.json
@@ -1,10 +1,9 @@
 {
-  "accuracy": 1.5,
+  "accuracy": 0.5,
   "animation": "Spurt",
   "category": "physical",
   "effects": [
-    "damage",
-    "recover"
+    "damage"
   ],
   "execute_trans": "combat_used_x",
   "failure_trans": "combat_miss",
@@ -13,7 +12,6 @@
   "is_area": true,
   "is_fast": false,
   "name_trans": "technique_flow_name",
-  "potency": 1,
   "power": 1.5,
   "range": "melee",
   "recharge": 1,

--- a/tuxemon/resources/db/technique/goad.json
+++ b/tuxemon/resources/db/technique/goad.json
@@ -3,8 +3,7 @@
   "animation": "Rage",
   "category": "physical",
   "effects": [
-    "damage",
-    "lifeleech"
+    "damage"
   ],
   "execute_trans": "combat_used_x",
   "failure_trans": "combat_miss",


### PR DESCRIPTION
When I was testing my combat update I made some changes to dollfins moves. Looks like I forget to reset them.