### PR TITLE
Stop menu misbehaviour after trying to run

### DIFF
--- a/tuxemon/core/states/combat/combat_menus.py
+++ b/tuxemon/core/states/combat/combat_menus.py
@@ -57,10 +57,8 @@ class MainCombatMenuState(PopUpMenu):
         if combat_state.is_trainer_battle:
             def open_menu():
                 combat_state.task(
-                    partial(combat_state.show_monster_action_menu, self.monster)
-                )
-                combat_state.task(
-                    partial(combat_state.game.push_state, "WaitForInputState")
+                    partial(combat_state.show_monster_action_menu, self.monster),
+                    1
                 )
             combat_state.alert(T.translate("combat_can't_run_from_trainer"), open_menu)
         else:


### PR DESCRIPTION
Fixes an issue where the menus would go slightly crazy after trying to run from a trainer battle.
