### PR TITLE
build translations on install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,10 @@ from setuptools import setup
 import fnmatch
 import os
 
+#build the translations
+from tuxemon.core.components.locale import T
+
+
 # Find all the python modules
 modules = []
 matches = []

--- a/tuxemon/core/components/locale.py
+++ b/tuxemon/core/components/locale.py
@@ -76,7 +76,7 @@ class TranslatorPo(object):
             outfile = os.path.join(os.path.dirname(infile), "base.mo")
 
             # build only complete translations
-            if os.path.exists(infile):
+            if os.path.exists(infile) and not os.path.exists(outfile):
                 with open(infile, "r") as po_file, open(outfile, "wb") as mo_file:
                     catalog = read_po(po_file)
                     write_mo(mo_file, catalog)


### PR DESCRIPTION
Fix issue #535 
-Build all translations in setup.py
-Check that compiled translations do not exist in tuxemon/core/components/locale.py