### PR TITLE
Fix encoding problem reading with po files

### DIFF
--- a/tuxemon/core/components/locale.py
+++ b/tuxemon/core/components/locale.py
@@ -77,7 +77,7 @@ class TranslatorPo(object):
 
             # build only complete translations
             if os.path.exists(infile):
-                with open(infile, "r") as po_file, open(outfile, "wb") as mo_file:
+                with open(infile, "r", encoding="UTF8") as po_file, open(outfile, "wb") as mo_file:
                     catalog = read_po(po_file)
                     write_mo(mo_file, catalog)
 


### PR DESCRIPTION
Python was guessing the wrong enconding while reading the po files, this solution seems to fix it.

**Console output** 
`Traceback (most recent call last):
  File "tuxemon.py", line 42, in <module>
    import tuxemon.core.main
  File "C:\Users\someusername\Desktop\tuxemon\Tuxemon\tuxemon\core\main.py", line 36, in <module>
    from .components.player import Player
  File "C:\Users\someusername\Desktop\tuxemon\Tuxemon\tuxemon\core\components\player.py", line 35, in <module>
    from tuxemon.core.components.npc import NPC
  File "C:\Users\someusername\Desktop\tuxemon\Tuxemon\tuxemon\core\components\npc.py", line 38, in <module>
    from tuxemon.core.components.item import decode_inventory, encode_inventory
  File "C:\Users\someusername\Desktop\tuxemon\Tuxemon\tuxemon\core\components\item.py", line 39, in <module>
    from tuxemon.core.components.locale import T
  File "C:\Users\someusername\Desktop\tuxemon\Tuxemon\tuxemon\core\components\locale.py", line 273, in <module>
    T = TranslatorPo()
  File "C:\Users\someusername\Desktop\tuxemon\Tuxemon\tuxemon\core\components\locale.py", line 56, in __init__
    self.build_translations()
  File "C:\Users\someusername\Desktop\tuxemon\Tuxemon\tuxemon\core\components\locale.py", line 81, in build_translations
    catalog = read_po(po_file)
  File "C:\Program Files (x86)\Python36-32\lib\site-packages\babel\messages\pofile.py", line 377, in read_po
    parser.parse(fileobj)
  File "C:\Program Files (x86)\Python36-32\lib\site-packages\babel\messages\pofile.py", line 298, in parse
    for lineno, line in enumerate(fileobj):
  File "C:\Program Files (x86)\Python36-32\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8d in position 763: character maps to <undefined>`