### PR TITLE
Display a message when a monster has leveled up

### DIFF
--- a/tuxemon/core/components/monster.py
+++ b/tuxemon/core/components/monster.py
@@ -349,8 +349,8 @@ class Monster(object):
 
         :type amount: Integer
 
-        :rtype: None
-        :returns: None
+        :rtype: Boolean
+        :returns: True if the monster has leveled up.
 
         **Example:**
 
@@ -360,6 +360,9 @@ class Monster(object):
         if self.total_experience >= (self.experience_required_modifier * (self.level + 1) ** 3):
             #Level up worthy monsters
             self.level_up()
+            return True
+
+        return False
 
     def apply_status(self, status):
         """ Apply a status to the monster

--- a/tuxemon/core/states/combat/combat.py
+++ b/tuxemon/core/states/combat/combat.py
@@ -726,7 +726,8 @@ class CombatState(CombatAnimations):
             # Award Experience
             awarded_exp = monster.total_experience / monster.level / len(self._damage_map[monster])
             for winners in self._damage_map[monster]:
-                winners.give_experience(awarded_exp)
+                if winners.give_experience(awarded_exp):
+					self.alert(T.format('level_up', {"name": winners.name, "level": winners.level}))
 
             # Remove monster from damage map
             del self._damage_map[monster]

--- a/tuxemon/resources/l18n/cs_CZ/LC_MESSAGES/base.po
+++ b/tuxemon/resources/l18n/cs_CZ/LC_MESSAGES/base.po
@@ -177,6 +177,9 @@ msgstr "Pokus o chycení..."
 msgid "gotcha"
 msgstr "Mám tě!"
 
+msgid "level_up"
+msgstr "{name} has reached level {level}"
+
 msgid "item_cannot_use_here"
 msgstr "{name} nemůže tady být použito!"
 

--- a/tuxemon/resources/l18n/de_DE/LC_MESSAGES/base.po
+++ b/tuxemon/resources/l18n/de_DE/LC_MESSAGES/base.po
@@ -177,6 +177,9 @@ msgstr "Versuche zu fangen..."
 msgid "gotcha"
 msgstr "Geschnappt!"
 
+msgid "level_up"
+msgstr "{name} has reached level {level}"
+
 msgid "item_cannot_use_here"
 msgstr "{name} kann hier nicht benutzt werden!"
 

--- a/tuxemon/resources/l18n/en_US/LC_MESSAGES/base.po
+++ b/tuxemon/resources/l18n/en_US/LC_MESSAGES/base.po
@@ -219,6 +219,9 @@ msgstr "Attempting capture..."
 msgid "gotcha"
 msgstr "Gotcha!"
 
+msgid "level_up"
+msgstr "{name} has reached level {level}"
+
 msgid "not_implemented"
 msgstr "This feature is not yet implemented."
 

--- a/tuxemon/resources/l18n/eo/LC_MESSAGES/base.po
+++ b/tuxemon/resources/l18n/eo/LC_MESSAGES/base.po
@@ -177,6 +177,9 @@ msgstr "Kaptado..."
 msgid "gotcha"
 msgstr "Bone!"
 
+msgid "level_up"
+msgstr "{name} has reached level {level}"
+
 msgid "item_cannot_use_here"
 msgstr "{name} ne uzeblas ĉi tie!"
 

--- a/tuxemon/resources/l18n/es_ES/LC_MESSAGES/base.po
+++ b/tuxemon/resources/l18n/es_ES/LC_MESSAGES/base.po
@@ -177,6 +177,9 @@ msgstr "Intentando capturar..."
 msgid "gotcha"
 msgstr "¡Atrapado!"
 
+msgid "level_up"
+msgstr "{name} has reached level {level}"
+
 msgid "item_cannot_use_here"
 msgstr "¡No puede usarse ${{name}} aquí!"
 

--- a/tuxemon/resources/l18n/es_MX/LC_MESSAGES/base.po
+++ b/tuxemon/resources/l18n/es_MX/LC_MESSAGES/base.po
@@ -177,6 +177,9 @@ msgstr "Attempting capture..."
 msgid "gotcha"
 msgstr "Gotcha!"
 
+msgid "level_up"
+msgstr "{name} has reached level {level}"
+
 msgid "item_cannot_use_here"
 msgstr "{name} cannot be used here!"
 

--- a/tuxemon/resources/l18n/fr_FR/LC_MESSAGES/base.po
+++ b/tuxemon/resources/l18n/fr_FR/LC_MESSAGES/base.po
@@ -177,6 +177,9 @@ msgstr "Attempting capture..."
 msgid "gotcha"
 msgstr "Gotcha!"
 
+msgid "level_up"
+msgstr "{name} has reached level {level}"
+
 msgid "item_cannot_use_here"
 msgstr "{name} cannot be used here!"
 

--- a/tuxemon/resources/l18n/it_IT/LC_MESSAGES/base.po
+++ b/tuxemon/resources/l18n/it_IT/LC_MESSAGES/base.po
@@ -215,6 +215,9 @@ msgstr "Cattura in corso..."
 msgid "gotcha"
 msgstr "Evvai!"
 
+msgid "level_up"
+msgstr "{name} has reached level {level}"
+
 msgid "not_implemented"
 msgstr "Questa funzione non è ancora stata implementata."
 


### PR DESCRIPTION
It's difficult to tell when a monster has leveled up after battle. For this reason I attempted to implement a message that will inform you when this happens. At the moment this pull request works but contains a few issues, I will need someone else to help with the following problems:

- The message is displayed immediately after the enemy monster faints. Because of this messages containing other information, such as what move was just used or that the enemy monster fainted, are being hidden. Also if multiple tuxemon are leveling up at the same time, the messages will likely cover one another and only the last one will be displayed.
- Ideally this message should be shown by the level_up function in core/components/monster.py not faint_monster in core/states/combat/combat.py: That way it would also work if something else makes monsters level up in the future. I wasn't able to place it there as monster.py doesn't have access to the original self object, only the monster (defined as self), the alert method requires the player.
- I don't know how to do the translations for other languages, so currently I used the english version in all language files. We should fix the rest before committing this.

![Screenshot_20200102_234215](https://user-images.githubusercontent.com/825418/71695076-b3628780-2db9-11ea-814d-a0a28db7e05b.png)