### PR TITLE
Implement monster evolutions

### DIFF
--- a/tuxemon/core/components/event/actions/evolve_monster.py
+++ b/tuxemon/core/components/event/actions/evolve_monster.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+#
+# Tuxemon
+# Copyright (c) 2014-2017 William Edwards <shadowapex@gmail.com>,
+#                         Benjamin Bean <superman2k5@gmail.com>
+#
+# This file is part of Tuxemon
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from tuxemon.core.components import monster
+from tuxemon.core.components.event.eventaction import EventAction
+
+
+class EvolveMonsterAction(EventAction):
+    """Evolves all monsters in the player's party for the specified evolutionary path.
+
+    Valid Parameters: path
+    """
+    name = "evolve_monsters"
+    valid_parameters = [
+        (str, "path")
+    ]
+
+    def start(self):
+        player = self.game.player1
+        for slot in range(len(player.monsters)):
+            current_monster = player.monsters[slot]
+            for evolution in current_monster.evolutions:
+                if evolution['name'] == self.parameters.path and current_monster.level >= evolution['at_level']:
+                    # TODO: implement an evolution animation
+
+                    # Add the new monster
+                    new_monster = monster.Monster()
+                    new_monster.load_from_db(evolution['slug'])
+                    new_monster.set_level(current_monster.level)
+                    new_monster.current_hp = min(current_monster.current_hp, new_monster.hp)
+                    new_monster.name = current_monster.name
+                    player.add_monster(new_monster)
+
+                    # Put the new monster in the slot of the old monster
+                    player.switch_monsters(slot, len(player.monsters) - 1)
+
+                    # Remove the old monster
+                    player.remove_monster(current_monster)
+
+                    # We executed an evolution for this monster, don't keep looking
+                    break

--- a/tuxemon/core/components/event/actions/evolve_monster.py
+++ b/tuxemon/core/components/event/actions/evolve_monster.py
@@ -43,22 +43,23 @@ class EvolveMonsterAction(EventAction):
         for slot in range(len(player.monsters)):
             current_monster = player.monsters[slot]
             for evolution in current_monster.evolutions:
-                if evolution['name'] == self.parameters.path and current_monster.level >= evolution['at_level']:
-                    # TODO: implement an evolution animation
+                if evolution['path'] == self.parameters.path:
+                    if current_monster.level >= evolution['at_level'] or current_monster.level <= -evolution['at_level']:
+                        # TODO: implement an evolution animation
 
-                    # Add the new monster
-                    new_monster = monster.Monster()
-                    new_monster.load_from_db(evolution['slug'])
-                    new_monster.set_level(current_monster.level)
-                    new_monster.current_hp = min(current_monster.current_hp, new_monster.hp)
-                    new_monster.name = current_monster.name
-                    player.add_monster(new_monster)
+                        # Add the new monster
+                        new_monster = monster.Monster()
+                        new_monster.load_from_db(evolution['slug'])
+                        new_monster.set_level(current_monster.level)
+                        new_monster.current_hp = min(current_monster.current_hp, new_monster.hp)
+                        new_monster.name = current_monster.name
+                        player.add_monster(new_monster)
 
-                    # Put the new monster in the slot of the old monster
-                    player.switch_monsters(slot, len(player.monsters) - 1)
+                        # Put the new monster in the slot of the old monster
+                        player.switch_monsters(slot, len(player.monsters) - 1)
 
-                    # Remove the old monster
-                    player.remove_monster(current_monster)
+                        # Remove the old monster
+                        player.remove_monster(current_monster)
 
-                    # We executed an evolution for this monster, don't keep looking
-                    break
+                        # We executed an evolution for this monster, don't keep looking
+                        break

--- a/tuxemon/core/components/event/actions/evolve_monsters.py
+++ b/tuxemon/core/components/event/actions/evolve_monsters.py
@@ -28,7 +28,7 @@ from tuxemon.core.components import monster
 from tuxemon.core.components.event.eventaction import EventAction
 
 
-class EvolveMonsterAction(EventAction):
+class EvolveMonstersAction(EventAction):
     """Evolves all monsters in the player's party for the specified evolutionary path.
 
     Valid Parameters: path

--- a/tuxemon/core/components/event/actions/evolve_monsters.py
+++ b/tuxemon/core/components/event/actions/evolve_monsters.py
@@ -64,9 +64,9 @@ class EvolveMonstersAction(EventAction):
                         player.add_monster(new_monster)
 
                         # Removing the old monster caused all monsters in front to move a slot back
-                        # Bring our new monster from the end of the list to its previous slot
+                        # Bring our new monster from the end of the list to its previous position
                         for i in range(len(player.monsters) - 1, slot, -1):
                             player.switch_monsters(i, i - 1)
 
-                        # We executed an evolution for this monster, don't keep looking
-                        break
+                    # We found the desired evolution, don't keep looking
+                    break

--- a/tuxemon/core/components/event/actions/evolve_monsters.py
+++ b/tuxemon/core/components/event/actions/evolve_monsters.py
@@ -40,36 +40,29 @@ class EvolveMonstersAction(EventAction):
 
     def start(self):
         player = self.game.player1
-        for slot in range(len(player.monsters)):
-            current_monster = player.monsters[slot]
-            for evolution in current_monster.evolutions:
-                if evolution['path'] == self.parameters.path:
-                    level_over = evolution['at_level'] > 0 and current_monster.level >= evolution['at_level']
-                    level_under = evolution['at_level'] < 0 and current_monster.level <= -evolution['at_level']
-                    if level_over or level_under:
-                        # TODO: implement an evolution animation
+        for slot, current_monster in enumerate(player.monsters):
+            new_slug = current_monster.get_evolution(self.parameters.path)
+            if new_slug:
+                # TODO: implement an evolution animation
 
-                        # Store the properties of the old monster then remove it
-                        old_level = current_monster.level
-                        old_current_hp = current_monster.current_hp
-                        old_name = current_monster.name
-                        player.remove_monster(current_monster)
+                # Store the properties of the old monster then remove it
+                old_level = current_monster.level
+                old_current_hp = current_monster.current_hp
+                old_name = current_monster.name
+                player.remove_monster(current_monster)
 
-                        # Add the new monster and load the old properties
-                        new_monster = monster.Monster()
-                        new_monster.load_from_db(evolution['slug'])
-                        new_monster.set_level(old_level)
-                        new_monster.current_hp = min(old_current_hp, new_monster.hp)
-                        new_monster.name = old_name
-                        player.add_monster(new_monster)
+                # Add the new monster and load the old properties
+                new_monster = monster.Monster()
+                new_monster.load_from_db(new_slug)
+                new_monster.set_level(old_level)
+                new_monster.current_hp = min(old_current_hp, new_monster.hp)
+                new_monster.name = old_name
+                player.add_monster(new_monster)
 
-                        # Removing the old monster caused all monsters in front to move a slot back
-                        # Bring our new monster from the end of the list to its previous position
-                        for i in range(len(player.monsters) - 1, slot, -1):
-                            player.switch_monsters(i, i - 1)
+                # Removing the old monster caused all monsters in front to move a slot back
+                # Bring our new monster from the end of the list to its previous position
+                for i in range(len(player.monsters) - 1, slot, -1):
+                    player.switch_monsters(i, i - 1)
 
-                        # Only do one evolution per call
-                        return
-
-                    # We found the desired evolution, don't keep looking
-                    break
+                # Only do one evolution per call
+                return

--- a/tuxemon/core/components/event/actions/evolve_monsters.py
+++ b/tuxemon/core/components/event/actions/evolve_monsters.py
@@ -44,7 +44,9 @@ class EvolveMonstersAction(EventAction):
             current_monster = player.monsters[slot]
             for evolution in current_monster.evolutions:
                 if evolution['path'] == self.parameters.path:
-                    if current_monster.level >= evolution['at_level'] or current_monster.level <= -evolution['at_level']:
+                    level_over = evolution['at_level'] > 0 and current_monster.level >= evolution['at_level']
+                    level_under = evolution['at_level'] < 0 and current_monster.level <= -evolution['at_level']
+                    if level_over or level_under:
                         # TODO: implement an evolution animation
 
                         # Store the properties of the old monster then remove it

--- a/tuxemon/core/components/event/actions/evolve_monsters.py
+++ b/tuxemon/core/components/event/actions/evolve_monsters.py
@@ -47,19 +47,24 @@ class EvolveMonstersAction(EventAction):
                     if current_monster.level >= evolution['at_level'] or current_monster.level <= -evolution['at_level']:
                         # TODO: implement an evolution animation
 
-                        # Add the new monster
+                        # Store the properties of the old monster then remove it
+                        old_level = current_monster.level
+                        old_current_hp = current_monster.current_hp
+                        old_name = current_monster.name
+                        player.remove_monster(current_monster)
+
+                        # Add the new monster and load the old properties
                         new_monster = monster.Monster()
                         new_monster.load_from_db(evolution['slug'])
-                        new_monster.set_level(current_monster.level)
-                        new_monster.current_hp = min(current_monster.current_hp, new_monster.hp)
-                        new_monster.name = current_monster.name
+                        new_monster.set_level(old_level)
+                        new_monster.current_hp = min(old_current_hp, new_monster.hp)
+                        new_monster.name = old_name
                         player.add_monster(new_monster)
 
-                        # Put the new monster in the slot of the old monster
-                        player.switch_monsters(slot, len(player.monsters) - 1)
-
-                        # Remove the old monster
-                        player.remove_monster(current_monster)
+                        # Removing the old monster caused all monsters in front to move a slot back
+                        # Bring our new monster from the end of the list to its previous slot
+                        for i in range(len(player.monsters) - 1, slot, -1):
+                            player.switch_monsters(i, i - 1)
 
                         # We executed an evolution for this monster, don't keep looking
                         break

--- a/tuxemon/core/components/event/actions/evolve_monsters.py
+++ b/tuxemon/core/components/event/actions/evolve_monsters.py
@@ -68,5 +68,8 @@ class EvolveMonstersAction(EventAction):
                         for i in range(len(player.monsters) - 1, slot, -1):
                             player.switch_monsters(i, i - 1)
 
+                        # Only do one evolution per call
+                        return
+
                     # We found the desired evolution, don't keep looking
                     break

--- a/tuxemon/core/components/event/conditions/evolve_monsters.py
+++ b/tuxemon/core/components/event/conditions/evolve_monsters.py
@@ -48,10 +48,7 @@ class EvolveMonstersCondition(EventCondition):
         """
         player = game.player1
         for monster in player.monsters:
-            for evolution in monster.evolutions:
-                if evolution['path'] == condition.parameters[0]:
-                    level_over = evolution['at_level'] > 0 and monster.level >= evolution['at_level']
-                    level_under = evolution['at_level'] < 0 and monster.level <= -evolution['at_level']
-                    if level_over or level_under:
-                        return True
+            new_slug = monster.get_evolution(condition.parameters[0])
+            if new_slug:
+                return True
         return False

--- a/tuxemon/core/components/event/conditions/evolve_monsters.py
+++ b/tuxemon/core/components/event/conditions/evolve_monsters.py
@@ -47,12 +47,11 @@ class EvolveMonstersCondition(EventCondition):
 
         """
         player = game.player1
-        for slot in range(len(player.monsters)):
-            current_monster = player.monsters[slot]
-            for evolution in current_monster.evolutions:
+        for monster in player.monsters:
+            for evolution in monster.evolutions:
                 if evolution['path'] == condition.parameters[0]:
-                    level_over = evolution['at_level'] > 0 and current_monster.level >= evolution['at_level']
-                    level_under = evolution['at_level'] < 0 and current_monster.level <= -evolution['at_level']
+                    level_over = evolution['at_level'] > 0 and monster.level >= evolution['at_level']
+                    level_under = evolution['at_level'] < 0 and monster.level <= -evolution['at_level']
                     if level_over or level_under:
                         return True
         return False

--- a/tuxemon/core/components/event/conditions/evolve_monsters.py
+++ b/tuxemon/core/components/event/conditions/evolve_monsters.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# Tuxemon
+# Copyright (c) 2014-2017 William Edwards <shadowapex@gmail.com>,
+#                         Benjamin Bean <superman2k5@gmail.com>
+#
+# This file is part of Tuxemon
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from tuxemon.core.components.event.eventcondition import EventCondition
+
+
+class EvolveMonstersCondition(EventCondition):
+    """ Checks to see if monsters can be evolved on the specified evolutionary path
+    """
+    name = "evolve_monsters"
+
+    def test(self, game, condition):
+        """Checks to see if a monster can be evolved on the specified evolutionary path
+
+        :param game: The main game object that contains all the game's variables.
+        :param condition: A dictionary of condition details. See :py:func:`core.components.map.Map.loadevents`
+            for the format of the dictionary.
+
+        :type game: core.control.Control
+        :type condition: Dictionary
+
+        :rtype: Boolean
+        :returns: True or False
+
+        """
+        player = game.player1
+        for slot in range(len(player.monsters)):
+            current_monster = player.monsters[slot]
+            for evolution in current_monster.evolutions:
+                if evolution['path'] == condition.parameters[0]:
+                    if current_monster.level >= evolution['at_level'] or current_monster.level <= -evolution['at_level']:
+                        return True
+
+        return False

--- a/tuxemon/core/components/event/conditions/evolve_monsters.py
+++ b/tuxemon/core/components/event/conditions/evolve_monsters.py
@@ -51,7 +51,8 @@ class EvolveMonstersCondition(EventCondition):
             current_monster = player.monsters[slot]
             for evolution in current_monster.evolutions:
                 if evolution['path'] == condition.parameters[0]:
-                    if current_monster.level >= evolution['at_level'] or current_monster.level <= -evolution['at_level']:
+                    level_over = evolution['at_level'] > 0 and current_monster.level >= evolution['at_level']
+                    level_under = evolution['at_level'] < 0 and current_monster.level <= -evolution['at_level']
+                    if level_over or level_under:
                         return True
-
         return False

--- a/tuxemon/core/components/monster.py
+++ b/tuxemon/core/components/monster.py
@@ -419,6 +419,20 @@ class Monster(object):
         """
         return self.experience_required_modifier * (self.level + level_ofs) ** 3
 
+    def get_evolution(self, path):
+        """Checks if an evolution is valid and gets the resulting monster.
+
+        :rtype: String
+        :returns: New monster slug if valid, None otherwise
+        """
+        for evolution in self.evolutions:
+            if evolution['path'] == path:
+                level_over = evolution['at_level'] > 0 and self.level >= evolution['at_level']
+                level_under = evolution['at_level'] < 0 and self.level <= -evolution['at_level']
+                if level_over or level_under:
+                    return evolution['monster_slug']
+        return None
+
     def get_sprite_path(self, sprite):
         '''
         Paths are set up by convention, so the file extension is unknown.

--- a/tuxemon/core/components/monster.py
+++ b/tuxemon/core/components/monster.py
@@ -207,6 +207,7 @@ class Monster(object):
 
         self.moves = []         # A list of technique objects. Used in combat.
         self.moveset = []       # A list of possible technique objects.
+        self.evolutions = []    # A list of possible evolution objects.
         self.ai = None
 
         # The multiplier for experience
@@ -275,11 +276,19 @@ class Monster(object):
         self.weight = results['weight']
 
         # Look up the moves that this monster can learn AND LEARN THEM.
-        for move in results["moveset"]:
-            self.moveset.append(move)
-            if move['level_learned'] >= self.level:
-                technique = Technique(move['technique'])
-                self.learn(technique)
+        moveset = results.get("moveset")
+        if moveset:
+            for move in moveset:
+                self.moveset.append(move)
+                if move['level_learned'] >= self.level:
+                    technique = Technique(move['technique'])
+                    self.learn(technique)
+
+        # Look up the evolutions for this monster.
+        evolutions = results.get("evolutions")
+        if evolutions:
+            for evolution in evolutions:
+                self.evolutions.append(evolution)
 
         # Look up the monster's sprite image paths
         self.front_battle_sprite = self.get_sprite_path(results['sprites']['battle1'])


### PR DESCRIPTION
I'm happy to announce the implementation of monster evolutions in Tuxemon! This initial code doesn't contain animations or notifications, but fully implements the ability to define an evolution for a tuxemon which replaces that monster when triggered. Branching evolutionary paths are supported using keywords... for standard evolutions just define and call the tag "default". This should fix #540

Evolutions are called by an event action and don't occur automatically, offering flexibility for game designers while allowing existing dialog choices to select a path. This model allows the following scenario: The player must interact with a device located in the healing center, upon doing so a dialog will ask if they wish to evolve their tuxemon on the "fire" "water" "air" or "ground" path... picking any option will cause all tuxemon in your party that have a path for the given keyword defined to morph into the replacement tuxemon, granted they've reached the level required for that evolution.

This only contains the feature implementation. Once it's merged I can do a separate MR implementing the default tuxemon evolutions as documented on the wiki.

Example of defining this in tuxemon/resources/db/monster/my_monster.json:

```
{
    "slug": "fruitera",
    ...
    "evolutions": [
        {
            "path": "default",
            "slug": "bursa",
            "at_level": 10
        }
}
```
To actually carry out the evolution, use the following act on an event in your map:

`act1: evolve_monsters default`

If you had a Fruitera in your party which reached at least level 10, you should now see a Bursa in its place. It will have inherited the same monster slot, name, level, and HP.