### PR TITLE
Allow gaining multiple levels at once

### DIFF
--- a/tuxemon/core/components/monster.py
+++ b/tuxemon/core/components/monster.py
@@ -369,7 +369,7 @@ class Monster(object):
         self.speed = shape["speed"] * multiplier
 
     def level_up(self, levels):
-        """Increases a Monster's level by one and increases stats
+        """Increases a Monster's level and stats
         accordingly
 
         :rtype: None

--- a/tuxemon/core/components/monster.py
+++ b/tuxemon/core/components/monster.py
@@ -369,8 +369,7 @@ class Monster(object):
         self.speed = shape["speed"] * multiplier
 
     def level_up(self, levels):
-        """Increases a Monster's level and stats
-        accordingly
+        """Increases a Monster's level and stats accordingly
 
         :rtype: None
         :returns: None

--- a/tuxemon/core/components/monster.py
+++ b/tuxemon/core/components/monster.py
@@ -330,9 +330,13 @@ class Monster(object):
         >>> bulbatux.give_experience(20)
         """
         self.total_experience += amount
-        if self.total_experience >= self.experience_required(1):
-            #Level up worthy monsters
-            self.level_up()
+
+        # Level up worthy monsters
+        levels = 0
+        while self.total_experience >= self.experience_required(levels + 1):
+            levels += 1
+        if levels > 0:
+            self.level_up(levels)
 
     def apply_status(self, status):
         """ Apply a status to the monster
@@ -364,16 +368,16 @@ class Monster(object):
         self.ranged = shape["ranged"] * multiplier
         self.speed = shape["speed"] * multiplier
 
-    def level_up(self):
+    def level_up(self, levels):
         """Increases a Monster's level by one and increases stats
         accordingly
 
         :rtype: None
         :returns: None
         """
-        logger.info("Leveling %s from %i to %i!" % (self.name, self.level, self.level + 1))
+        logger.info("Leveling %s from %i to %i!" % (self.name, self.level, self.level + levels))
         # Increase Level and stats
-        self.level += 1
+        self.level += levels
         self.set_stats()
 
         # Learn New Moves

--- a/tuxemon/core/components/monster.py
+++ b/tuxemon/core/components/monster.py
@@ -332,11 +332,8 @@ class Monster(object):
         self.total_experience += amount
 
         # Level up worthy monsters
-        levels = 0
-        while self.total_experience >= self.experience_required(levels + 1):
-            levels += 1
-        if levels > 0:
-            self.level_up(levels)
+        while self.total_experience >= self.experience_required(1):
+            self.level_up()
 
     def apply_status(self, status):
         """ Apply a status to the monster
@@ -368,15 +365,16 @@ class Monster(object):
         self.ranged = shape["ranged"] * multiplier
         self.speed = shape["speed"] * multiplier
 
-    def level_up(self, levels):
-        """Increases a Monster's level and stats accordingly
+    def level_up(self):
+        """Increases a Monster's level by one and increases stats
+        accordingly
 
         :rtype: None
         :returns: None
         """
-        logger.info("Leveling %s from %i to %i!" % (self.name, self.level, self.level + levels))
+        logger.info("Leveling %s from %i to %i!" % (self.name, self.level, self.level + 1))
         # Increase Level and stats
-        self.level += levels
+        self.level += 1
         self.set_stats()
 
         # Learn New Moves


### PR DESCRIPTION
Should fix #579 Previously monsters could only gain one level per call, now they should get the full amount their exp increase allows for.