### PR TITLE
Reference the correct player when updating the exp bar

### DIFF
--- a/tuxemon/core/states/combat/combat.py
+++ b/tuxemon/core/states/combat/combat.py
@@ -791,9 +791,8 @@ class CombatState(CombatAnimations):
                     # If a monster fainted, exp was given, thus the exp bar should be updated
                     # The exp bar must only be animated for the player's monsters
                     # Enemies don't have a bar, doing it for them will cause a crash
-                    for player in self.human_players:
-                        for player_monster in self.monsters_in_play[player]:
-                            self.animate_exp(player_monster)
+                    for monster in self.monsters_in_play[self.game.player1]:
+                        self.animate_exp(monster)
 
     def get_technique_animation(self, technique):
         """ Return a sprite usable as a technique animation


### PR DESCRIPTION
Fixes an oversight on the exp bar: The update should only be done for the local player, not to all connected players as they don't have a HUD object in your client... previous functionality might cause crashes with multiplayer in the future. Tested and the change works fine.