### PR TITLE
Npc speed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 before_install:
   - pip install -r requirements.txt
   - pip install setuptools
-  - sudo apt-get install -y git curl squashfs-tools sed debmake debhelper python-all python3-all python-setuptools python3-setuptools
+  - sudo apt-get install -y fakeroot git curl squashfs-tools sed debmake debhelper python-all python3-all python-setuptools python3-setuptools
   - mkdir -p ./build
 script:
   # Debian

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cbor
 lxml>=4.2.5
 neteria
 pillow
-pygame>=1.9.4
+pygame>=1.9.6
 pyscroll>=2.19.2
 pytmx>=3.20.17
 requests>=2.19.1

--- a/tuxemon/core/components/event/__init__.py
+++ b/tuxemon/core/components/event/__init__.py
@@ -78,7 +78,7 @@ def get_npc(game, slug):
     :type game: core.control.Control
     :type slug: str
 
-    :rtype: core.components.player.Player
+    :rtype: tuxemon.core.components.player.Player
     :returns: The NPC object or None if the NPC is not found.
     """
     if slug == "player":

--- a/tuxemon/core/components/event/actions/npc_run.py
+++ b/tuxemon/core/components/event/actions/npc_run.py
@@ -29,17 +29,15 @@ from tuxemon.core.components.event.eventaction import EventAction
 
 
 class NpcRun(EventAction):
-    """ Sets the NPC movement speed to a custom value
+    """ Sets the NPC movement speed to the global run speed
 
     Valid Parameters: npc_slug
     """
     name = "npc_run"
     valid_parameters = [
         (str, "npc_slug"),
-        (float, "move_speed"),
     ]
 
     def start(self):
         npc = get_npc(self.game, self.parameters.npc_slug)
-        npc.moverate = self.parameters.move_speed
-        assert 0 < npc.moverate < 20  # just set some sane limit to avoid losing sprites
+        npc.moverate = self.game.config.player_runrate

--- a/tuxemon/core/components/event/actions/npc_speed.py
+++ b/tuxemon/core/components/event/actions/npc_speed.py
@@ -28,18 +28,18 @@ from tuxemon.core.components.event import get_npc
 from tuxemon.core.components.event.eventaction import EventAction
 
 
-class NpcRun(EventAction):
+class NpcSpeed(EventAction):
     """ Sets the NPC movement speed to a custom value
 
     Valid Parameters: npc_slug
     """
-    name = "npc_run"
+    name = "npc_speed"
     valid_parameters = [
         (str, "npc_slug"),
-        (float, "move_speed"),
+        (float, "speed"),
     ]
 
     def start(self):
         npc = get_npc(self.game, self.parameters.npc_slug)
-        npc.moverate = self.parameters.move_speed
+        npc.moverate = self.parameters.speed
         assert 0 < npc.moverate < 20  # just set some sane limit to avoid losing sprites

--- a/tuxemon/core/components/event/actions/npc_walk.py
+++ b/tuxemon/core/components/event/actions/npc_walk.py
@@ -28,18 +28,16 @@ from tuxemon.core.components.event import get_npc
 from tuxemon.core.components.event.eventaction import EventAction
 
 
-class NpcRun(EventAction):
-    """ Sets the NPC movement speed to a custom value
+class NpcWalk(EventAction):
+    """ Sets the NPC movement speed to the global walk speed
 
     Valid Parameters: npc_slug
     """
-    name = "npc_run"
+    name = "npc_walk"
     valid_parameters = [
         (str, "npc_slug"),
-        (float, "move_speed"),
     ]
 
     def start(self):
         npc = get_npc(self.game, self.parameters.npc_slug)
-        npc.moverate = self.parameters.move_speed
-        assert 0 < npc.moverate < 20  # just set some sane limit to avoid losing sprites
+        npc.moverate = self.game.config.player_walkrate

--- a/tuxemon/core/components/event/eventaction.py
+++ b/tuxemon/core/components/event/eventaction.py
@@ -33,6 +33,9 @@ from collections import namedtuple
 
 from six.moves import zip_longest
 
+from tuxemon.core.control import Control  # for type introspection
+assert Control
+
 logger = logging.getLogger(__name__)
 
 
@@ -103,10 +106,9 @@ class EventAction(object):
     def __init__(self, game, parameters):
         """
 
-        :type game: core.control.Control
+        :type game: tuxemon.core.control.Control
         :type parameters: list
         """
-
         self.game = game
 
         # TODO: METACLASS

--- a/tuxemon/core/components/npc.py
+++ b/tuxemon/core/components/npc.py
@@ -140,11 +140,7 @@ class NPC(Entity):
         # movement related
         self.move_direction = None  # Set this value to move the npc (see below)
         self.facing = "down"  # Set this value to change the facing direction
-        self.walking = False  # Whether or not the player is walking
-        self.running = False  # Whether or not the player is running
-        self.walkrate = CONFIG.player_walkrate
-        self.runrate = CONFIG.player_runrate
-        self.moverate = self.walkrate  # walk by default
+        self.moverate = CONFIG.player_walkrate  # walk by default
         self.ignore_collisions = False
 
         # What is "move_direction"?
@@ -222,7 +218,7 @@ class NPC(Entity):
 
         # avoid cutoff frames when steps don't line up with tile movement
         frames = 3
-        frame_duration = (1000 / self.walkrate) / frames / 1000 * 2
+        frame_duration = (1000 / CONFIG.player_walkrate) / frames / 1000 * 2
 
         # Load all of the player's sprite animations
         anim_types = ['front_walk', 'back_walk', 'left_walk', 'right_walk']
@@ -260,7 +256,7 @@ class NPC(Entity):
             frame = d[ani]
             try:
                 surface = frame.getCurrentFrame()
-                frame.rate = self.moverate / self.walkrate
+                frame.rate = self.moverate / CONFIG.player_walkrate
                 return surface
             except AttributeError:
                 return frame
@@ -348,7 +344,6 @@ class NPC(Entity):
         :type time_passed_seconds: Float
         """
         # update physics.  eventually move to another class
-        self.moverate = self.runrate if self.running else self.walkrate
         self.update_physics(time_passed_seconds)
 
         if self.pathfinding and not self.path:

--- a/tuxemon/core/states/world/worldstate.py
+++ b/tuxemon/core/states/world/worldstate.py
@@ -337,11 +337,9 @@ class WorldState(state.State):
 
         if event.button == intentions.RUN:
             if event.held:
-                self.player1.running = True
-                self.player1.walking = False
+                self.player1.moverate = self.game.config.player_runrate
             else:
-                self.player1.running = False
-                self.player1.walking = True
+                self.player1.moverate = self.game.config.player_walkrate
 
         # If we receive an arrow key press, set the facing and
         # moving direction to that direction


### PR DESCRIPTION
npc_walk: set npc to the default walk speed (3.75 default)
npc_run: set npc to the default run speed (7.35 default)
npc_speed: set arbitrary speed in tiles/second

run/walk commands are available so that NPC speeds are consistent and easy to remember.  the speed command is available to use when more control is needed