### PR TITLE
NPC wandering

### DIFF
--- a/tuxemon/core/components/event/actions/npc_wander.py
+++ b/tuxemon/core/components/event/actions/npc_wander.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+#
+# Tuxemon
+# Copyright (c) 2014-2017 William Edwards <shadowapex@gmail.com>,
+#                         Benjamin Bean <superman2k5@gmail.com>
+#
+# This file is part of Tuxemon
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import random
+
+from tuxemon.core.components.event import get_npc
+from tuxemon.core.components.event.eventaction import EventAction
+from tuxemon.core.components.map import dirs2
+
+
+def single_dir(origin, direction, tiles, collisions):
+    origin = tuple(origin) # make copy to prevent modifying the npc
+    for i in range(tiles):
+        origin_ofs = dirs2[direction]
+        if tuple(origin + origin_ofs) in collisions:
+            break
+        origin += origin_ofs
+    return origin
+
+
+class NpcWanderAction(EventAction):
+    """ Makes an NPC wander
+
+    Valid Parameters: npc_slug, time, distance
+    """
+    name = "npc_wander"
+    valid_parameters = [
+        (str, "npc_slug"),
+        (float, "time"),
+        (int, "tiles")
+    ]
+
+    def start(self):
+        npc = get_npc(self.game, self.parameters.npc_slug)
+        world = self.game.get_state_name("WorldState")
+        collisions = world.get_collision_map()
+
+        def move():
+            # Don't interrupt existing movement
+            if npc.moving or npc.path:
+                return
+
+            # Choose a direction
+            direction_random = random.random()
+            direction = "up"
+            if direction_random > 0.75:
+                direction = "down"
+            elif direction_random > 0.5:
+                direction = "left"
+            elif direction_random > 0.25:
+                direction = "right"
+
+            # Choose a distance
+            tiles_max = 4
+            if self.parameters.tiles:
+                tiles_max = self.parameters.tiles
+            tiles = int(round(tiles_max * random.random(), 0))
+
+            # Move is there's at least one tile, change direction otherwise
+            if tiles > 0:
+                parameters = [direction + " " + str(tiles)]
+                npc.pathfind((single_dir(npc.tile_pos, direction, tiles, collisions)))
+            else:
+                npc.facing = direction
+
+        def next():
+            # Check that the NPC still exists
+            if npc is None:
+                return
+
+            # Issue the move command
+            move()
+
+            # Run this function again between time / 2 and time
+            time_max = 2
+            if self.parameters.time:
+                time_max = self.parameters.time
+            time = min(10, max(0.1, (time_max / 2) + ((time_max / 2) * random.random())))
+
+            # Schedule the next move
+            world.task(next, time)
+
+        # Initialize the schedule function
+        next()

--- a/tuxemon/core/components/event/actions/npc_wander.py
+++ b/tuxemon/core/components/event/actions/npc_wander.py
@@ -78,6 +78,7 @@ class NpcWanderAction(EventAction):
         def schedule():
             # Check that the NPC still exists
             if npc is None:
+                world.remove_animations_of(schedule)
                 return
 
             move()

--- a/tuxemon/core/components/event/actions/npc_wander.py
+++ b/tuxemon/core/components/event/actions/npc_wander.py
@@ -44,14 +44,14 @@ def pick_target(origin, tiles, collisions):
 
 
 class NpcWanderAction(EventAction):
-    """ Makes an NPC wander
+    """ Makes an NPC wander around the map
 
-    Valid Parameters: npc_slug, time, distance
+    Valid Parameters: npc_slug, frequency, tiles
     """
     name = "npc_wander"
     valid_parameters = [
         (str, "npc_slug"),
-        (float, "time"),
+        (float, "frequency"),
         (int, "tiles")
     ]
 
@@ -66,7 +66,7 @@ class NpcWanderAction(EventAction):
                 return
 
             # Choose a random distance
-            tiles_max = 8
+            tiles_max = 4
             if self.parameters.tiles:
                 tiles_max = self.parameters.tiles
             tiles = int(max(1, math.ceil(tiles_max * random.random())))
@@ -83,12 +83,12 @@ class NpcWanderAction(EventAction):
 
             move()
 
-            # Run this function again between time / 2 and time
+            # Randomly repeat between time / 2 and time
             time_max = 2
-            if self.parameters.time:
-                time_max = self.parameters.time
-            time = min(10, max(0.1, (time_max / 2) + ((time_max / 2) * random.random())))
-            world.task(next, time)
+            if self.parameters.frequency:
+                time_max = self.parameters.frequency
+            time = (time_max / 2) + ((time_max / 2) * random.random())
+            world.task(next, min(10, max(0.5, time)))
 
         # Initialize the schedule function
         next()

--- a/tuxemon/core/components/event/actions/npc_wander.py
+++ b/tuxemon/core/components/event/actions/npc_wander.py
@@ -59,13 +59,21 @@ class NpcWanderAction(EventAction):
                 if state.name == "DialogState":
                     return
 
-            # Choose a random direction: Go there if the tile is free, look toward it if not
+            # Choose a random direction
             direction = random.choice(["up", "down", "left", "right"])
             origin = (int(npc.tile_pos[0] + dirs2[direction][0]), int(npc.tile_pos[1] + dirs2[direction][1]))
-            if origin not in collisions:
-                npc.move_one_tile(direction)
-            else:
+
+            # Check if either a collision, the player or another NPC are blocking the way
+            blocked = origin in collisions
+            for ent in world.npcs.values():
+                if origin[0] == int(ent.tile_pos[0]) and origin[1] == int(ent.tile_pos[1]):
+                    blocked = True
+
+            # Go to the chosen position if the tile is free, look toward it if not
+            if blocked:
                 npc.facing = direction
+            else:
+                npc.move_one_tile(direction)
 
         def schedule():
             # Check that the NPC still exists

--- a/tuxemon/core/components/event/actions/npc_wander.py
+++ b/tuxemon/core/components/event/actions/npc_wander.py
@@ -29,7 +29,6 @@ import random
 
 from tuxemon.core.components.event import get_npc
 from tuxemon.core.components.event.eventaction import EventAction
-from tuxemon.core.components.map import dirs2
 
 
 class NpcWanderAction(EventAction):

--- a/tuxemon/core/components/event/actions/npc_wander.py
+++ b/tuxemon/core/components/event/actions/npc_wander.py
@@ -53,6 +53,12 @@ class NpcWanderAction(EventAction):
             if npc.moving or npc.path:
                 return
 
+            # Suspend wandering if a dialog window is open
+            # TODO: this should only be done for the NPC the player is conversing with, not everyone
+            for state in self.game.active_states:
+                if state.name == "DialogState":
+                    return
+
             # Choose a random direction: Go there if the tile is free, look toward it if not
             direction = random.choice(["up", "down", "left", "right"])
             origin = (int(npc.tile_pos[0] + dirs2[direction][0]), int(npc.tile_pos[1] + dirs2[direction][1]))

--- a/tuxemon/resources/maps/maple_house.tmx
+++ b/tuxemon/resources/maps/maple_house.tmx
@@ -54,6 +54,7 @@
    <properties>
     <property name="act1" value="create_npc npc_wife,9,7,girl1,stand"/>
     <property name="act2" value="npc_face npc_wife,down"/>
+    <property name="act3" value="npc_wander npc_wife"/>
     <property name="cond1" value="is player_facing up"/>
     <property name="cond2" value="not npc_exists npc_wife"/>
    </properties>


### PR DESCRIPTION
Support for making an NPC randomly wander around the map. Uses pathfinding with randomly selected targets. To make your NPC move around simply use the following function:

`npc_wander npc_slug,2,4`

The first paramater is the NPC slug, the second is the frequency (how often to walk), the third is the distance the NPC may travel in one go (bigger values good for larger spaces).

A default use case is already included into the game: If you go into the maple house next to yours, you will see the professor's wife walking around the room.