### PR TITLE
Extra monster and battle info

### DIFF
--- a/tuxemon/core/event/conditions/monster_property.py
+++ b/tuxemon/core/event/conditions/monster_property.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+#
+# Tuxemon
+# Copyright (c) 2014-2017 William Edwards <shadowapex@gmail.com>,
+#                         Benjamin Bean <superman2k5@gmail.com>
+#
+# This file is part of Tuxemon
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from tuxemon.core.event.eventcondition import EventCondition
+
+
+class MonsterPropertyCondition(EventCondition):
+    """ Checks to see if a monster has a given property
+    """
+    name = "monster_property"
+
+    def test(self, game, condition):
+        """Checks to see if a monster has a given property
+
+        :param game: The main game object that contains all the game's variables.
+        :param condition: A dictionary of condition details. See :py:func:`core.map.Map.loadevents`
+            for the format of the dictionary.
+
+        :type game: core.control.Control
+        :type condition: Dictionary
+
+        :rtype: Boolean
+        :returns: True or False
+
+        """
+        slot = condition.parameters[0]
+        prop = condition.parameters[1]
+        val = condition.parameters[2]
+        monster = game.player1.monsters[slot]
+
+        if prop == "name":
+            return monster.name == val
+        elif prop == "level":
+            return str(monster.level) == val
+        elif prop == "slug":
+            return monster.slug == val
+        elif prop == "category":
+            return monster.category == val
+        elif prop == "shape":
+            return monster.shape == val
+        else:
+            return False

--- a/tuxemon/core/event/conditions/monster_property.py
+++ b/tuxemon/core/event/conditions/monster_property.py
@@ -28,12 +28,12 @@ from tuxemon.core.event.eventcondition import EventCondition
 
 
 class MonsterPropertyCondition(EventCondition):
-    """ Checks to see if a monster has a given property
+    """ Checks to see if a monster property or condition is as asked
     """
     name = "monster_property"
 
     def test(self, game, condition):
-        """Checks to see if a monster has a given property
+        """Checks to see if a monster property or condition is as asked
 
         :param game: The main game object that contains all the game's variables.
         :param condition: A dictionary of condition details. See :py:func:`core.map.Map.loadevents`
@@ -55,6 +55,8 @@ class MonsterPropertyCondition(EventCondition):
             return monster.name == val
         elif prop == "level":
             return str(monster.level) == val
+        elif prop == "level_reached":
+            return monster.level >= int(val)
         elif prop == "slug":
             return monster.slug == val
         elif prop == "category":

--- a/tuxemon/core/event/conditions/monster_property.py
+++ b/tuxemon/core/event/conditions/monster_property.py
@@ -57,7 +57,7 @@ class MonsterPropertyCondition(EventCondition):
             return str(monster.level) == val
         elif prop == "level_reached":
             return monster.level >= int(val)
-        elif prop == "slug":
+        elif prop == "type":
             return monster.slug == val
         elif prop == "category":
             return monster.category == val

--- a/tuxemon/core/event/conditions/monster_property.py
+++ b/tuxemon/core/event/conditions/monster_property.py
@@ -49,8 +49,11 @@ class MonsterPropertyCondition(EventCondition):
         slot = condition.parameters[0]
         prop = condition.parameters[1]
         val = condition.parameters[2]
-        monster = game.player1.monsters[slot]
 
+        if int(slot) >= len(game.player1.monsters):
+            return False
+
+        monster = game.player1.monsters[slot]
         if prop == "name":
             return monster.name == val
         elif prop == "level":

--- a/tuxemon/core/locale.py
+++ b/tuxemon/core/locale.py
@@ -302,6 +302,8 @@ def replace_text(game, text):
         text = text.replace("${{monster_" + str(i) + "_name}}", monster.name)
         text = text.replace("${{monster_" + str(i) + "_desc}}", monster.description)
         text = text.replace("${{monster_" + str(i) + "_type}}", monster.slug)
+        text = text.replace("${{monster_" + str(i) + "_category}}", monster.category)
+        text = text.replace("${{monster_" + str(i) + "_shape}}", monster.shape)
         text = text.replace("${{monster_" + str(i) + "_hp}}", str(monster.current_hp))
         text = text.replace("${{monster_" + str(i) + "_hp_max}}", str(monster.hp))
         text = text.replace("${{monster_" + str(i) + "_level}}", str(monster.level))

--- a/tuxemon/core/states/combat/combat.py
+++ b/tuxemon/core/states/combat/combat.py
@@ -292,6 +292,7 @@ class CombatState(CombatAnimations):
             pass
 
         elif phase == "ran away":
+            self.players[0].game_variables['battle_last_status'] = 'ran'
             self.alert(T.translate('combat_player_run'))
 
             # after 3 seconds, push a state that blocks until enter is pressed
@@ -301,6 +302,8 @@ class CombatState(CombatAnimations):
             self.suppress_phase_change(3)
 
         elif phase == "draw match":
+            self.players[0].game_variables['battle_last_status'] = 'draw'
+
             # it is a draw match; both players were defeated in same round
             self.alert(T.translate('combat_draw'))
 
@@ -313,10 +316,10 @@ class CombatState(CombatAnimations):
             # TODO: proper match check, etc
             # This assumes that player[0] is the human playing in single player
             if self.remaining_players[0] == self.players[0]:
-                self.players[0].game_variables['battle_last_won'] = 'true'
+                self.players[0].game_variables['battle_last_status'] = 'won'
                 self.alert(T.translate('combat_victory'))
             else:
-                self.players[0].game_variables['battle_last_won'] = 'false'
+                self.players[0].game_variables['battle_last_status'] = 'lost'
                 self.players[0].game_variables['battle_lost_faint'] = 'true'
                 self.alert(T.translate('combat_defeat'))
 

--- a/tuxemon/core/states/combat/combat.py
+++ b/tuxemon/core/states/combat/combat.py
@@ -262,7 +262,7 @@ class CombatState(CombatAnimations):
             if monster_record in self.active_monsters:
                 self.players[0].game_variables['battle_last_monster_name'] = monster_record.name
                 self.players[0].game_variables['battle_last_monster_level'] = monster_record.level
-                self.players[0].game_variables['battle_last_monster_slug'] = monster_record.slug
+                self.players[0].game_variables['battle_last_monster_type'] = monster_record.slug
                 self.players[0].game_variables['battle_last_monster_category'] = monster_record.category
                 self.players[0].game_variables['battle_last_monster_shape'] = monster_record.shape
 

--- a/tuxemon/core/states/combat/combat.py
+++ b/tuxemon/core/states/combat/combat.py
@@ -292,7 +292,7 @@ class CombatState(CombatAnimations):
             pass
 
         elif phase == "ran away":
-            self.players[0].game_variables['battle_last_status'] = 'ran'
+            self.players[0].game_variables['battle_last_result'] = 'ran'
             self.alert(T.translate('combat_player_run'))
 
             # after 3 seconds, push a state that blocks until enter is pressed
@@ -302,7 +302,7 @@ class CombatState(CombatAnimations):
             self.suppress_phase_change(3)
 
         elif phase == "draw match":
-            self.players[0].game_variables['battle_last_status'] = 'draw'
+            self.players[0].game_variables['battle_last_result'] = 'draw'
 
             # it is a draw match; both players were defeated in same round
             self.alert(T.translate('combat_draw'))
@@ -316,10 +316,10 @@ class CombatState(CombatAnimations):
             # TODO: proper match check, etc
             # This assumes that player[0] is the human playing in single player
             if self.remaining_players[0] == self.players[0]:
-                self.players[0].game_variables['battle_last_status'] = 'won'
+                self.players[0].game_variables['battle_last_result'] = 'won'
                 self.alert(T.translate('combat_victory'))
             else:
-                self.players[0].game_variables['battle_last_status'] = 'lost'
+                self.players[0].game_variables['battle_last_result'] = 'lost'
                 self.players[0].game_variables['battle_lost_faint'] = 'true'
                 self.alert(T.translate('combat_defeat'))
 

--- a/tuxemon/core/states/combat/combat.py
+++ b/tuxemon/core/states/combat/combat.py
@@ -257,6 +257,15 @@ class CombatState(CombatAnimations):
             # fill all battlefield positions, but on round 1, don't ask
             self.fill_battlefield_positions(ask=self._round > 1)
 
+            # record the useful properties of the last monster we fought
+            monster_record = self.monsters_in_play[self.players[1]][0]
+            if monster_record in self.active_monsters:
+                self.players[0].game_variables['battle_last_monster_name'] = monster_record.name
+                self.players[0].game_variables['battle_last_monster_level'] = monster_record.level
+                self.players[0].game_variables['battle_last_monster_slug'] = monster_record.slug
+                self.players[0].game_variables['battle_last_monster_category'] = monster_record.category
+                self.players[0].game_variables['battle_last_monster_shape'] = monster_record.shape
+
         if phase == "decision phase":
             self.reset_status_icons()
             if not self._decision_queue:
@@ -304,8 +313,10 @@ class CombatState(CombatAnimations):
             # TODO: proper match check, etc
             # This assumes that player[0] is the human playing in single player
             if self.remaining_players[0] == self.players[0]:
+                self.players[0].game_variables['battle_last_won'] = 'true'
                 self.alert(T.translate('combat_victory'))
             else:
+                self.players[0].game_variables['battle_last_won'] = 'false'
                 self.players[0].game_variables['battle_lost_faint'] = 'true'
                 self.alert(T.translate('combat_defeat'))
 


### PR DESCRIPTION
Adds 3 features that allow mappers to make better use of monster and battle data. I'm planning to use such checks in my game / mod and wanted to suggest this in preparation. What it changes:

- The combat state now records the relevant properties of the last monster you've battled using game variables: Name, level, slug, category, shape. They're primarily intended for random battles, to be used both in conditional checks as well as NPC dialogues (eg: A man standing near the patch of grass watching you fight can say "wow Player, I can't believe you defeated a ${{battle_last_monster_level}} especially a ${{battle_last_monster_slug}}!")
- Monster category and shape can now be translated as well for dialogues.
- A conditional to check similar properties for the player's monster on a specific slot was added, allowing certain events to execute if a given Tuxemon matches an expectation. For example: If you want an event to run only if the monster in the first slot is tiny_bat you can now use the syntax: `cond1: monster_property 0 category tiny_bat`