### PR TITLE
Monster flairs with visual customization

### DIFF
--- a/tuxemon/core/event/actions/evolve_monsters.py
+++ b/tuxemon/core/event/actions/evolve_monsters.py
@@ -63,8 +63,8 @@ class EvolveMonstersAction(EventAction):
                 # If the new monster has a flair matching that of the old monster, copy it
                 for new_flair in new_monster.flairs:
                     for old_flair in old_flairs:
-                        if new_flair['name'] == old_flair['name']:
-                            new_monster.flairs[new_flair]['value'] = old_flair['value']
+                        if new_flair.category == old_flair.category:
+                            new_monster.flairs[new_flair].name = old_flair.name
 
                 # Removing the old monster caused all monsters in front to move a slot back
                 # Bring our new monster from the end of the list to its previous position

--- a/tuxemon/core/event/actions/evolve_monsters.py
+++ b/tuxemon/core/event/actions/evolve_monsters.py
@@ -49,6 +49,7 @@ class EvolveMonstersAction(EventAction):
                 old_level = current_monster.level
                 old_current_hp = current_monster.current_hp
                 old_name = current_monster.name
+                old_flairs = current_monster.flairs
                 player.remove_monster(current_monster)
 
                 # Add the new monster and load the old properties
@@ -58,6 +59,12 @@ class EvolveMonstersAction(EventAction):
                 new_monster.current_hp = min(old_current_hp, new_monster.hp)
                 new_monster.name = old_name
                 player.add_monster(new_monster)
+
+                # If the new monster has a flair matching that of the old monster, copy it
+                for new_flair in new_monster.flairs:
+                    for old_flair in old_flairs:
+                        if new_flair['name'] == old_flair['name']:
+                            new_monster.flairs[new_flair] = old_flair
 
                 # Removing the old monster caused all monsters in front to move a slot back
                 # Bring our new monster from the end of the list to its previous position

--- a/tuxemon/core/event/actions/evolve_monsters.py
+++ b/tuxemon/core/event/actions/evolve_monsters.py
@@ -61,10 +61,10 @@ class EvolveMonstersAction(EventAction):
                 player.add_monster(new_monster)
 
                 # If the new monster has a flair matching that of the old monster, copy it
-                for new_flair in new_monster.flairs:
-                    for old_flair in old_flairs:
+                for new_flair in new_monster.flairs.values():
+                    for old_flair in old_flairs.values():
                         if new_flair.category == old_flair.category:
-                            new_monster.flairs[new_flair].name = old_flair.name
+                            new_monster.flairs[new_flair.category] = old_flair
 
                 # Removing the old monster caused all monsters in front to move a slot back
                 # Bring our new monster from the end of the list to its previous position

--- a/tuxemon/core/event/actions/evolve_monsters.py
+++ b/tuxemon/core/event/actions/evolve_monsters.py
@@ -64,7 +64,7 @@ class EvolveMonstersAction(EventAction):
                 for new_flair in new_monster.flairs:
                     for old_flair in old_flairs:
                         if new_flair['name'] == old_flair['name']:
-                            new_monster.flairs[new_flair] = old_flair
+                            new_monster.flairs[new_flair]['value'] = old_flair['value']
 
                 # Removing the old monster caused all monsters in front to move a slot back
                 # Bring our new monster from the end of the list to its previous position

--- a/tuxemon/core/event/actions/monster_flair.py
+++ b/tuxemon/core/event/actions/monster_flair.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# Tuxemon
+# Copyright (c) 2014-2017 William Edwards <shadowapex@gmail.com>,
+#                         Benjamin Bean <superman2k5@gmail.com>
+#
+# This file is part of Tuxemon
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from tuxemon.core import monster
+from tuxemon.core.event.eventaction import EventAction
+
+
+class MonsterFlairAction(EventAction):
+    """Sets a monster's flair to the given value
+
+    Valid Parameters: slot, name, value
+    """
+    name = "monster_flair"
+    valid_parameters = [
+        (int, "slot"),
+        (str, "name"),
+        (str, "value"),
+    ]
+
+    def start(self):
+        monster = game.player1.monsters[self.parameters.slot]
+        for flair in monster.flairs:
+            if flair['name'] == self.parameters.name:
+                monster.flairs[flair]['value'] = self.parameters.value

--- a/tuxemon/core/event/actions/monster_flair.py
+++ b/tuxemon/core/event/actions/monster_flair.py
@@ -43,5 +43,5 @@ class MonsterFlairAction(EventAction):
     def start(self):
         monster = game.player1.monsters[self.parameters.slot]
         for flair in monster.flairs:
-            if flair['name'] == self.parameters.name:
-                monster.flairs[flair]['value'] = self.parameters.value
+            if flair.category == self.parameters.name:
+                monster.flairs[flair].name = self.parameters.value

--- a/tuxemon/core/event/actions/set_monster_flair.py
+++ b/tuxemon/core/event/actions/set_monster_flair.py
@@ -36,11 +36,11 @@ class SetMonsterFlairAction(EventAction):
     name = "set_monster_flair"
     valid_parameters = [
         (int, "slot"),
+        (str, "category"),
         (str, "name"),
-        (str, "value"),
     ]
 
     def start(self):
         monster = game.player1.monsters[self.parameters.slot]
-        if self.parameters.name in monster.flairs:
-            monster.flairs[self.parameters.name] = Flair(self.parameters.name, self.parameters.value)
+        if self.parameters.category in monster.flairs:
+            monster.flairs[self.parameters.category] = Flair(self.parameters.category, self.parameters.name)

--- a/tuxemon/core/event/actions/set_monster_flair.py
+++ b/tuxemon/core/event/actions/set_monster_flair.py
@@ -28,12 +28,12 @@ from tuxemon.core import monster
 from tuxemon.core.event.eventaction import EventAction
 
 
-class MonsterFlairAction(EventAction):
+class SetMonsterFlairAction(EventAction):
     """Sets a monster's flair to the given value
 
     Valid Parameters: slot, name, value
     """
-    name = "monster_flair"
+    name = "set_monster_flair"
     valid_parameters = [
         (int, "slot"),
         (str, "name"),
@@ -42,6 +42,5 @@ class MonsterFlairAction(EventAction):
 
     def start(self):
         monster = game.player1.monsters[self.parameters.slot]
-        for flair in monster.flairs:
-            if flair.category == self.parameters.name:
-                monster.flairs[flair].name = self.parameters.value
+        if self.parameters.name in monster.flairs:
+            monster.flairs[self.parameters.name] = Flair(self.parameters.name, self.parameters.value)

--- a/tuxemon/core/event/conditions/monster_flair.py
+++ b/tuxemon/core/event/conditions/monster_flair.py
@@ -52,6 +52,6 @@ class MonsterFlairCondition(EventCondition):
 
         monster = game.player1.monsters[slot]
         for flair in monster.flairs:
-            if flair['name'] == name:
-                return flair['value'] == value
+            if flair.category == name:
+                return flair.name == value
         return False

--- a/tuxemon/core/event/conditions/monster_flair.py
+++ b/tuxemon/core/event/conditions/monster_flair.py
@@ -51,7 +51,8 @@ class MonsterFlairCondition(EventCondition):
         value = condition.parameters[2]
 
         monster = game.player1.monsters[slot]
-        for flair in monster.flairs:
-            if flair.category == name:
-                return flair.name == value
+        try:
+            return monster.flairs[name].name == value
+        except KeyError:
+            return False
         return False

--- a/tuxemon/core/event/conditions/monster_flair.py
+++ b/tuxemon/core/event/conditions/monster_flair.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# Tuxemon
+# Copyright (c) 2014-2017 William Edwards <shadowapex@gmail.com>,
+#                         Benjamin Bean <superman2k5@gmail.com>
+#
+# This file is part of Tuxemon
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from tuxemon.core.event.eventcondition import EventCondition
+
+
+class MonsterFlairCondition(EventCondition):
+    """ Checks to see if the given monster flair matches the expected value
+    """
+    name = "monster_flair"
+
+    def test(self, game, condition):
+        """Checks to see if the given monster flair matches the expected value
+
+        :param game: The main game object that contains all the game's variables.
+        :param condition: A dictionary of condition details. See :py:func:`core.map.Map.loadevents`
+            for the format of the dictionary.
+
+        :type game: core.control.Control
+        :type condition: Dictionary
+
+        :rtype: Boolean
+        :returns: True or False
+
+        """
+        slot = condition.parameters[0]
+        name = condition.parameters[1]
+        value = condition.parameters[2]
+
+        monster = game.player1.monsters[slot]
+        for flair in monster.flairs:
+            if flair['name'] == name:
+                return flair['value'] == value
+        return False

--- a/tuxemon/core/event/conditions/monster_flair.py
+++ b/tuxemon/core/event/conditions/monster_flair.py
@@ -47,12 +47,12 @@ class MonsterFlairCondition(EventCondition):
 
         """
         slot = condition.parameters[0]
-        name = condition.parameters[1]
-        value = condition.parameters[2]
+        category = condition.parameters[1]
+        name = condition.parameters[2]
 
         monster = game.player1.monsters[slot]
         try:
-            return monster.flairs[name].name == value
+            return monster.flairs[category].name == name
         except KeyError:
             return False
         return False

--- a/tuxemon/core/monster.py
+++ b/tuxemon/core/monster.py
@@ -454,7 +454,7 @@ class Monster(object):
 
         # Apply flairs to the monster sprite
         for flair in self.flairs:
-            flair_path = self.get_sprite_path("gfx/sprites/battle/" + self.slug + "-" + sprite + "-" + flair['value'])
+            flair_path = self.get_sprite_path("gfx/sprites/battle/{}-{}-{}".format(self.slug, sprite, flair['value']))
             if flair_path != MISSING_IMAGE:
                 flair_sprite = tools.load_sprite(flair_path, **kwargs)
                 surface.image.blit(flair_sprite.image, (0, 0))
@@ -496,6 +496,7 @@ class Monster(object):
                 if full_path:
                     return full_path
         except IOError:
+            logger.debug("Could not find monster sprite {}".format(sprite))
             return MISSING_IMAGE
 
     def load_sprites(self):

--- a/tuxemon/core/monster.py
+++ b/tuxemon/core/monster.py
@@ -54,6 +54,7 @@ SIMPLE_PERSISTANCE_ATTRIBUTES = (
     'slug',
     'status',
     'total_experience',
+    'flairs',
 )
 
 SHAPES = {
@@ -206,6 +207,7 @@ class Monster(object):
         self.moves = []         # A list of technique objects. Used in combat.
         self.moveset = []       # A list of possible technique objects.
         self.evolutions = []    # A list of possible evolution objects.
+        self.flairs = []        # A list of flairs, one is picked randomly.
         self.ai = None
 
         # The multiplier for experience
@@ -242,6 +244,7 @@ class Monster(object):
 
         self.set_state(save_data)
         self.set_stats()
+        self.set_flairs()
 
     def load_from_db(self, slug):
         """Loads and sets this monster's attributes from the monster.db database.
@@ -446,6 +449,24 @@ class Monster(object):
             return tools.load_sprite(self.menu_sprite, **kwargs)
         else:
             raise ValueError("Cannot find sprite for: {}".format(sprite))
+
+    def set_flairs(self):
+        """Sets the flairs of this monster if they were not already configured
+
+        :rtype: None
+        :returns: None
+        """
+        if len(self.flairs) > 0 or self.slug == "":
+            return
+
+        results = monsters.lookup(self.slug)
+        flairs = results.get("flairs")
+        if flairs:
+            for flair in flairs:
+                self.flairs.append({
+                    "name": flair['name'],
+                    "value": random.choice(flair['values'])
+                })
 
     def get_sprite_path(self, sprite):
         '''

--- a/tuxemon/core/monster.py
+++ b/tuxemon/core/monster.py
@@ -481,7 +481,7 @@ class Monster(object):
         flairs = results.get("flairs")
         if flairs:
             for flair in flairs:
-                flair = Flair(flair['name'], random.choice(flair['values']))
+                flair = Flair(flair['category'], random.choice(flair['names']))
                 self.flairs[flair.category] = flair
 
     def get_sprite_path(self, sprite):

--- a/tuxemon/core/monster.py
+++ b/tuxemon/core/monster.py
@@ -442,13 +442,26 @@ class Monster(object):
         :returns: The surface of the monster sprite
         """
         if sprite == "front":
-            return tools.load_sprite(self.front_battle_sprite, **kwargs)
+            surface = tools.load_sprite(self.front_battle_sprite, **kwargs)
         elif sprite == "back":
-            return tools.load_sprite(self.back_battle_sprite, **kwargs)
+            surface = tools.load_sprite(self.back_battle_sprite, **kwargs)
         elif sprite == "menu":
-            return tools.load_sprite(self.menu_sprite, **kwargs)
+            surface = tools.load_sprite(self.menu_sprite, **kwargs)
         else:
             raise ValueError("Cannot find sprite for: {}".format(sprite))
+
+        # Apply flairs to the monster sprite
+        for flair in self.flairs:
+            try:
+                flair_local = "gfx/sprites/battle/" + self.slug + "-" + sprite + "-" + flair['value']
+                flair_path = self.get_sprite_path(flair_local)
+                if flair_path != "gfx/sprites/battle/missing.png":
+                    flair_sprite = tools.load_sprite(flair_path, **kwargs)
+                    surface.image.blit(flair_sprite.image, (0, 0))
+            except IOError:
+                pass
+
+        return surface
 
     def set_flairs(self):
         """Sets the flairs of this monster if they were not already configured
@@ -477,13 +490,15 @@ class Monster(object):
         rtype: String
         returns: path to sprite or placeholder image
         '''
-        exts = ["png", "gif", "jpg", "jpeg"]
-        for ext in exts:
-            path = "%s.png" % sprite
-            full_path = tools.transform_resource_filename(path)
-            if full_path:
-                return full_path
-        return "gfx/sprites/battle/missing.png"
+        try:
+            exts = ["png", "gif", "jpg", "jpeg"]
+            for ext in exts:
+                path = "%s.png" % sprite
+                full_path = tools.transform_resource_filename(path)
+                if full_path:
+                    return full_path
+        except IOError:
+            return "gfx/sprites/battle/missing.png"
 
     def load_sprites(self):
         """Loads the monster's sprite images as Pygame surfaces.

--- a/tuxemon/core/monster.py
+++ b/tuxemon/core/monster.py
@@ -438,15 +438,14 @@ class Monster(object):
         :rtype: Pygame surface
         :returns: The surface of the monster sprite
         """
-        load_sprite = ""
         if sprite == "front":
-            load_sprite = self.front_battle_sprite
+            return tools.load_sprite(self.front_battle_sprite, **kwargs)
         elif sprite == "back":
-            load_sprite = self.back_battle_sprite
+            return tools.load_sprite(self.back_battle_sprite, **kwargs)
         elif sprite == "menu":
-            load_sprite = self.menu_sprite
-
-        return tools.load_sprite(load_sprite, **kwargs)
+            return tools.load_sprite(self.menu_sprite, **kwargs)
+        else:
+            raise ValueError("Cannot find sprite for: {}".format(sprite))
 
     def get_sprite_path(self, sprite):
         '''

--- a/tuxemon/core/monster.py
+++ b/tuxemon/core/monster.py
@@ -460,8 +460,7 @@ class Monster(object):
             raise ValueError("Cannot find sprite for: {}".format(sprite))
 
         # Apply flairs to the monster sprite
-        for flair in self.flairs:
-            print(flair.name)
+        for flair in self.flairs.values():
             flair_path = self.get_sprite_path("gfx/sprites/battle/{}-{}-{}".format(self.slug, sprite, flair.name))
             if flair_path != MISSING_IMAGE:
                 flair_sprite = tools.load_sprite(flair_path, **kwargs)
@@ -482,8 +481,8 @@ class Monster(object):
         flairs = results.get("flairs")
         if flairs:
             for flair in flairs:
-                flair_info = Flair(flair['name'], random.choice(flair['values']))
-                self.flairs[flair_info.category] = flair_info
+                flair = Flair(flair['name'], random.choice(flair['values']))
+                self.flairs[flair.category] = flair
 
     def get_sprite_path(self, sprite):
         '''

--- a/tuxemon/core/monster.py
+++ b/tuxemon/core/monster.py
@@ -175,6 +175,13 @@ SHAPES = {
 MISSING_IMAGE = "gfx/sprites/battle/missing.png"
 
 
+# class definition for tuxemon flairs:
+class Flair(object):
+   def __init__(self, category, name):
+      self.category = category
+      self.name = name
+
+
 # class definition for first active tuxemon to use in combat:
 class Monster(object):
     """A class for a Tuxemon monster object. This class acts as a skeleton for
@@ -209,7 +216,7 @@ class Monster(object):
         self.moves = []         # A list of technique objects. Used in combat.
         self.moveset = []       # A list of possible technique objects.
         self.evolutions = []    # A list of possible evolution objects.
-        self.flairs = []        # A list of flairs, one is picked randomly.
+        self.flairs = {}        # A dictionary of flairs, one is picked randomly.
         self.ai = None
 
         # The multiplier for experience
@@ -454,7 +461,8 @@ class Monster(object):
 
         # Apply flairs to the monster sprite
         for flair in self.flairs:
-            flair_path = self.get_sprite_path("gfx/sprites/battle/{}-{}-{}".format(self.slug, sprite, flair['value']))
+            print(flair.name)
+            flair_path = self.get_sprite_path("gfx/sprites/battle/{}-{}-{}".format(self.slug, sprite, flair.name))
             if flair_path != MISSING_IMAGE:
                 flair_sprite = tools.load_sprite(flair_path, **kwargs)
                 surface.image.blit(flair_sprite.image, (0, 0))
@@ -474,10 +482,8 @@ class Monster(object):
         flairs = results.get("flairs")
         if flairs:
             for flair in flairs:
-                self.flairs.append({
-                    "name": flair['name'],
-                    "value": random.choice(flair['values'])
-                })
+                flair_info = Flair(flair['name'], random.choice(flair['values']))
+                self.flairs[flair_info.category] = flair_info
 
     def get_sprite_path(self, sprite):
         '''

--- a/tuxemon/core/monster.py
+++ b/tuxemon/core/monster.py
@@ -172,6 +172,8 @@ SHAPES = {
     },
 }
 
+MISSING_IMAGE = "gfx/sprites/battle/missing.png"
+
 
 # class definition for first active tuxemon to use in combat:
 class Monster(object):
@@ -452,14 +454,10 @@ class Monster(object):
 
         # Apply flairs to the monster sprite
         for flair in self.flairs:
-            try:
-                flair_local = "gfx/sprites/battle/" + self.slug + "-" + sprite + "-" + flair['value']
-                flair_path = self.get_sprite_path(flair_local)
-                if flair_path != "gfx/sprites/battle/missing.png":
-                    flair_sprite = tools.load_sprite(flair_path, **kwargs)
-                    surface.image.blit(flair_sprite.image, (0, 0))
-            except IOError:
-                pass
+            flair_path = self.get_sprite_path("gfx/sprites/battle/" + self.slug + "-" + sprite + "-" + flair['value'])
+            if flair_path != MISSING_IMAGE:
+                flair_sprite = tools.load_sprite(flair_path, **kwargs)
+                surface.image.blit(flair_sprite.image, (0, 0))
 
         return surface
 
@@ -498,7 +496,7 @@ class Monster(object):
                 if full_path:
                     return full_path
         except IOError:
-            return "gfx/sprites/battle/missing.png"
+            return MISSING_IMAGE
 
     def load_sprites(self):
         """Loads the monster's sprite images as Pygame surfaces.

--- a/tuxemon/core/monster.py
+++ b/tuxemon/core/monster.py
@@ -432,6 +432,22 @@ class Monster(object):
                     return evolution['monster_slug']
         return None
 
+    def get_sprite(self, sprite, **kwargs):
+        """Gets a specific type of sprite for the monster.
+
+        :rtype: Pygame surface
+        :returns: The surface of the monster sprite
+        """
+        load_sprite = ""
+        if sprite == "front":
+            load_sprite = self.front_battle_sprite
+        elif sprite == "back":
+            load_sprite = self.back_battle_sprite
+        elif sprite == "menu":
+            load_sprite = self.menu_sprite
+
+        return tools.load_sprite(load_sprite, **kwargs)
+
     def get_sprite_path(self, sprite):
         '''
         Paths are set up by convention, so the file extension is unknown.

--- a/tuxemon/core/prepare.py
+++ b/tuxemon/core/prepare.py
@@ -188,4 +188,4 @@ def fetch(*args):
         if os.path.exists(path):
             return path
 
-    raise FileNotFoundError(relative_path)
+    raise IOError(relative_path)

--- a/tuxemon/core/states/combat/combat_animations.py
+++ b/tuxemon/core/states/combat/combat_animations.py
@@ -147,7 +147,8 @@ class CombatAnimations(Menu):
 
         # load monster and set in final position
         monster_sprite = monster.get_sprite("back" if npc.isplayer else "front",
-                                            midbottom = feet)
+                                            midbottom=feet)
+        self.sprites.add(monster_sprite)
         self._monster_sprite_map[monster] = monster_sprite
 
         # position monster_sprite off screen and set animation to move it back to final spot
@@ -467,8 +468,9 @@ class CombatAnimations(Menu):
                                        bottom=opp_home.bottom + y_mod, right=0)
 
         monster1 = right_monster.get_sprite("front",
-                                            bottom = back_island.rect.bottom - scale(12),
-                                            centerx = back_island.rect.centerx)
+                                            bottom=back_island.rect.bottom - scale(12),
+                                            centerx=back_island.rect.centerx)
+        self.sprites.add(monster1)
         self.build_hud(self._layout[opponent]['hud'][0], right_monster)
         self.monsters_in_play[opponent].append(right_monster)
         self._monster_sprite_map[right_monster] = monster1

--- a/tuxemon/core/states/combat/combat_animations.py
+++ b/tuxemon/core/states/combat/combat_animations.py
@@ -146,10 +146,8 @@ class CombatAnimations(Menu):
         self.task(capdev.kill, fall_time + delay + fade_duration)
 
         # load monster and set in final position
-        monster_sprite = self.load_sprite(
-            monster.back_battle_sprite if npc.isplayer else monster.front_battle_sprite,
-            midbottom=feet,
-        )
+        monster_sprite = monster.get_sprite("back" if npc.isplayer else "front",
+                                            midbottom = feet)
         self._monster_sprite_map[monster] = monster_sprite
 
         # position monster_sprite off screen and set animation to move it back to final spot
@@ -468,9 +466,9 @@ class CombatAnimations(Menu):
         back_island = self.load_sprite('gfx/ui/combat/' + self.graphics['island_back'],
                                        bottom=opp_home.bottom + y_mod, right=0)
 
-        monster1 = self.load_sprite(right_monster.front_battle_sprite,
-                                    bottom=back_island.rect.bottom - scale(12),
-                                    centerx=back_island.rect.centerx)
+        monster1 = right_monster.get_sprite("front",
+                                            bottom = back_island.rect.bottom - scale(12),
+                                            centerx = back_island.rect.centerx)
         self.build_hud(self._layout[opponent]['hud'][0], right_monster)
         self.monsters_in_play[opponent].append(right_monster)
         self._monster_sprite_map[right_monster] = monster1


### PR DESCRIPTION
Implements randomized monster flairs. This allows monsters to wear random things, have varying colors, use randomized facial expressions, or anything else the game wishes to use this for.

To define a set of monster flairs, add the following entry into the db of your monster:

```
"flairs": [
    {
        "name": "foo",
        "values": ["1", "2", "3"]
    },
    {
        "name": "bar",
        "values": ["a", "b", "c"]
    }
],
```

In this example, the monster's "foo" flair will randomly get a value of either 1 2 or 3, while their "bar" value would be either a b or c. This allows random graphical overlays to appear on the monster based on the value randomly chosen, so for example: If inside mods/tuxemon/gfx/sprites/battle you have the image file mymonster-front-a.png that image will get overlayed over the monster's front sprite... whereas if you have mymonster-back-b.png and mymonster-back-3.png, both of those images will be overlayed on top of the back sprite.

Actions and conditionals are included: You can check and change your monster's flairs per slot as with other monster actions. A simple example based on the scenario above:

```
act1: monster_flair 0 foo 3 // Set the foo flair of the monster on slot 0 to 3
cond1: monster_flair 0 bar a // Check if the bar flair of the monster on slot 0 is a
```