### PR TITLE
Allow dialogs to contain avatars

### DIFF
--- a/mods/tuxemon/maps/downstairs_test.tmx
+++ b/mods/tuxemon/maps/downstairs_test.tmx
@@ -54,7 +54,7 @@
   </object>
   <object id="24" name="Watch TV" type="event" x="32" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog You watch some TV with your beloved Lv ${{monster_0_level}} ${{monster_0_name}}.,monster 0"/>
+    <property name="act1" value="dialog You watch some TV with your beloved Lv ${{monster_0_level}} ${{monster_0_name}}.,0"/>
     <property name="cond1" value="is party_size greater_than,0"/>
     <property name="cond2" value="is player_at 2,6"/>
     <property name="cond3" value="is player_facing up"/>

--- a/mods/tuxemon/maps/downstairs_test.tmx
+++ b/mods/tuxemon/maps/downstairs_test.tmx
@@ -54,7 +54,7 @@
   </object>
   <object id="24" name="Watch TV" type="event" x="32" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog You watch some TV with your beloved Lv ${{monster_0_level}} ${{monster_0_name}}."/>
+    <property name="act1" value="dialog You watch some TV with your beloved Lv ${{monster_0_level}} ${{monster_0_name}}.,monster 0"/>
     <property name="cond1" value="is party_size greater_than,0"/>
     <property name="cond2" value="is player_at 2,6"/>
     <property name="cond3" value="is player_facing up"/>

--- a/mods/tuxemon/maps/sphalian_town_house.tmx
+++ b/mods/tuxemon/maps/sphalian_town_house.tmx
@@ -54,7 +54,7 @@
   </object>
   <object id="24" name="Watch TV" type="event" x="32" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog You watch some TV with your beloved Lv ${{monster_0_level}} ${{monster_0_name}}.,monster 0"/>
+    <property name="act1" value="dialog You watch some TV with your beloved Lv ${{monster_0_level}} ${{monster_0_name}}.,0"/>
     <property name="cond1" value="is party_size greater_than,0"/>
     <property name="cond2" value="is player_at 2,6"/>
     <property name="cond3" value="is player_facing up"/>

--- a/mods/tuxemon/maps/sphalian_town_house.tmx
+++ b/mods/tuxemon/maps/sphalian_town_house.tmx
@@ -54,7 +54,7 @@
   </object>
   <object id="24" name="Watch TV" type="event" x="32" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog You watch some TV with your beloved Lv ${{monster_0_level}} ${{monster_0_name}}."/>
+    <property name="act1" value="dialog You watch some TV with your beloved Lv ${{monster_0_level}} ${{monster_0_name}}.,monster 0"/>
     <property name="cond1" value="is party_size greater_than,0"/>
     <property name="cond2" value="is player_at 2,6"/>
     <property name="cond3" value="is player_facing up"/>

--- a/tuxemon/core/event/actions/dialog.py
+++ b/tuxemon/core/event/actions/dialog.py
@@ -55,17 +55,18 @@ class DialogAction(EventAction):
     """
     name = "dialog"
     valid_parameters = [
-        (str, "text")
+        (str, "text"),
+        (str, "avatar")
     ]
 
     def start(self):
         text = replace_text(self.game, self.parameters.text)
-        self.open_dialog(text)
+        self.open_dialog(text, self.parameters.avatar)
 
     def update(self):
         if self.game.get_state_name("DialogState") is None:
             self.stop()
 
-    def open_dialog(self, initial_text):
+    def open_dialog(self, initial_text, avatar):
         logger.info("Opening dialog window")
-        open_dialog(self.game, [initial_text])
+        open_dialog(self.game, [initial_text], avatar)

--- a/tuxemon/core/event/actions/dialog.py
+++ b/tuxemon/core/event/actions/dialog.py
@@ -28,7 +28,7 @@ import logging
 
 from tuxemon.core.locale import replace_text
 from tuxemon.core.event.eventaction import EventAction
-from tuxemon.core.tools import open_dialog
+from tuxemon.core.tools import open_dialog, get_avatar
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +61,8 @@ class DialogAction(EventAction):
 
     def start(self):
         text = replace_text(self.game, self.parameters.text)
-        self.open_dialog(text, self.parameters.avatar)
+        avatar = get_avatar(self.game, self.parameters.avatar)
+        self.open_dialog(text, avatar)
 
     def update(self):
         if self.game.get_state_name("DialogState") is None:

--- a/tuxemon/core/event/actions/dialog_chain.py
+++ b/tuxemon/core/event/actions/dialog_chain.py
@@ -56,7 +56,10 @@ class DialogChainAction(EventAction):
 
     """
     name = "dialog_chain"
-    valid_parameters = [(str, "text")]
+    valid_parameters = [
+        (str, "text"),
+        (str, "avatar")
+    ]
 
     def start(self):
         # hack to allow unescaped commas in the dialog string
@@ -75,7 +78,7 @@ class DialogChainAction(EventAction):
                 dialog.text_queue.append(text)
             else:
                 # no, so create new dialog with this line
-                self.open_dialog(text)
+                self.open_dialog(text, self.parameters.avatar)
 
     def update(self):
         # hack to allow unescaped commas in the dialog string
@@ -84,6 +87,6 @@ class DialogChainAction(EventAction):
             if self.game.get_state_name("DialogState") is None:
                 self.stop()
 
-    def open_dialog(self, initial_text):
+    def open_dialog(self, initial_text, avatar):
         logger.info("Opening chain dialog window")
-        open_dialog(self.game, [initial_text])
+        open_dialog(self.game, [initial_text], avatar)

--- a/tuxemon/core/event/actions/dialog_chain.py
+++ b/tuxemon/core/event/actions/dialog_chain.py
@@ -28,7 +28,7 @@ import logging
 
 from tuxemon.core.locale import replace_text
 from tuxemon.core.event.eventaction import EventAction
-from tuxemon.core.tools import open_dialog
+from tuxemon.core.tools import open_dialog, get_avatar
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +78,8 @@ class DialogChainAction(EventAction):
                 dialog.text_queue.append(text)
             else:
                 # no, so create new dialog with this line
-                self.open_dialog(text, self.parameters.avatar)
+                avatar = get_avatar(self.game, self.parameters.avatar)
+                self.open_dialog(text, avatar)
 
     def update(self):
         # hack to allow unescaped commas in the dialog string

--- a/tuxemon/core/event/actions/translated_dialog.py
+++ b/tuxemon/core/event/actions/translated_dialog.py
@@ -28,7 +28,7 @@ import logging
 
 from tuxemon.core.locale import process_translate_text
 from tuxemon.core.event.eventaction import EventAction
-from tuxemon.core.tools import open_dialog
+from tuxemon.core.tools import open_dialog, get_avatar
 
 logger = logging.getLogger(__name__)
 
@@ -63,12 +63,13 @@ class TranslatedDialogAction(EventAction):
     ]
 
     def start(self):
+        avatar = get_avatar(self.game, self.parameters.avatar)
         self.open_dialog(
             process_translate_text(
                 self.game,
                 self.parameters.key,
                 self.raw_parameters[1:],
-            ), self.parameters.avatar
+            ), avatar
         )
 
     def update(self):

--- a/tuxemon/core/event/actions/translated_dialog.py
+++ b/tuxemon/core/event/actions/translated_dialog.py
@@ -58,7 +58,8 @@ class TranslatedDialogAction(EventAction):
     name = "translated_dialog"
 
     valid_parameters = [
-        (str, "key")
+        (str, "key"),
+        (str, "avatar")
     ]
 
     def start(self):
@@ -67,13 +68,13 @@ class TranslatedDialogAction(EventAction):
                 self.game,
                 self.parameters.key,
                 self.raw_parameters[1:],
-            )
+            ), self.parameters.avatar
         )
 
     def update(self):
         if self.game.get_state_name("DialogState") is None:
             self.stop()
 
-    def open_dialog(self, pages):
+    def open_dialog(self, pages, avatar):
         logger.info("Opening dialog window")
-        open_dialog(self.game, pages)
+        open_dialog(self.game, pages, avatar)

--- a/tuxemon/core/event/actions/translated_dialog_chain.py
+++ b/tuxemon/core/event/actions/translated_dialog_chain.py
@@ -28,7 +28,7 @@ import logging
 
 from tuxemon.core.locale import process_translate_text
 from tuxemon.core.event.eventaction import EventAction
-from tuxemon.core.tools import open_dialog
+from tuxemon.core.tools import open_dialog, get_avatar
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +80,8 @@ class TranslatedDialogChainAction(EventAction):
         if dialog:
             dialog.text_queue += pages
         else:
-            self.open_dialog(pages, self.parameters.avatar)
+            avatar = get_avatar(self.game, self.parameters.avatar)
+            self.open_dialog(pages, avatar)
 
     def update(self):
         if self.parameters.key == "${{end}}":

--- a/tuxemon/core/event/actions/translated_dialog_chain.py
+++ b/tuxemon/core/event/actions/translated_dialog_chain.py
@@ -56,7 +56,10 @@ class TranslatedDialogChainAction(EventAction):
 
     """
     name = "translated_dialog_chain"
-    valid_parameters = [(str, "key")]
+    valid_parameters = [
+        (str, "key"),
+        (str, "avatar")
+    ]
 
     def start(self):
         key = self.parameters.key
@@ -77,13 +80,13 @@ class TranslatedDialogChainAction(EventAction):
         if dialog:
             dialog.text_queue += pages
         else:
-            self.open_dialog(pages)
+            self.open_dialog(pages, self.parameters.avatar)
 
     def update(self):
         if self.parameters.key == "${{end}}":
             if self.game.get_state_name("DialogState") is None:
                 self.stop()
 
-    def open_dialog(self, pages):
+    def open_dialog(self, pages, avatar):
         logger.info("Opening chain dialog window")
-        open_dialog(self.game, pages)
+        open_dialog(self.game, pages, avatar)

--- a/tuxemon/core/event/contexts/dialogcontext.py
+++ b/tuxemon/core/event/contexts/dialogcontext.py
@@ -41,11 +41,15 @@ class DialogContext(EventContext):
     def add_dialog(self, text):
         self._dialog_chain_queue.append(text)
 
+    def add_avatar(self, avatar):
+        self._avatar = avatar
+
     def add_menu(self, menu):
         self._menu = menu
 
     def execute(self, game):
         # Open a dialog window in the current scene.
-        open_dialog(game, self._dialog_chain_queue, self._menu)
+        open_dialog(game, self._dialog_chain_queue, self._avatar, self._menu)
         self._dialog_chain_queue = list()
+        self._avatar = None
         self._menu = None

--- a/tuxemon/core/monster.py
+++ b/tuxemon/core/monster.py
@@ -39,6 +39,8 @@ from tuxemon.core import tools
 from tuxemon.core import ai, db, fusion
 from tuxemon.core.locale import T
 from tuxemon.core.technique import Technique
+from tuxemon.core.sprite import Sprite
+from tuxemon.core.pyganim import PygAnimation
 
 logger = logging.getLogger(__name__)
 
@@ -451,11 +453,11 @@ class Monster(object):
         :returns: The surface of the monster sprite
         """
         if sprite == "front":
-            surface = tools.load_sprite(self.front_battle_sprite, **kwargs)
+            surface = tools.load_and_scale(self.front_battle_sprite)
         elif sprite == "back":
-            surface = tools.load_sprite(self.back_battle_sprite, **kwargs)
+            surface = tools.load_and_scale(self.back_battle_sprite)
         elif sprite == "menu":
-            surface = tools.load_sprite(self.menu_sprite, **kwargs)
+            surface = tools.load_and_scale(self.menu_sprite)
         else:
             raise ValueError("Cannot find sprite for: {}".format(sprite))
 
@@ -463,10 +465,16 @@ class Monster(object):
         for flair in self.flairs.values():
             flair_path = self.get_sprite_path("gfx/sprites/battle/{}-{}-{}".format(self.slug, sprite, flair.name))
             if flair_path != MISSING_IMAGE:
-                flair_sprite = tools.load_sprite(flair_path, **kwargs)
-                surface.image.blit(flair_sprite.image, (0, 0))
+                flair_sprite = tools.load_and_scale(flair_path)
+                surface.blit(flair_sprite, (0, 0))
 
-        return surface
+        images = [(surface, .1)]
+        tech = PygAnimation(images, False)
+        sprite = Sprite()
+        sprite.image = tech
+        sprite.rect = surface.get_rect(**kwargs)
+
+        return sprite
 
     def set_flairs(self):
         """Sets the flairs of this monster if they were not already configured

--- a/tuxemon/core/monster.py
+++ b/tuxemon/core/monster.py
@@ -39,8 +39,6 @@ from tuxemon.core import tools
 from tuxemon.core import ai, db, fusion
 from tuxemon.core.locale import T
 from tuxemon.core.technique import Technique
-from tuxemon.core.sprite import Sprite
-from tuxemon.core.pyganim import PygAnimation
 
 logger = logging.getLogger(__name__)
 
@@ -470,8 +468,8 @@ class Monster(object):
         for flair in self.flairs.values():
             flair_path = self.get_sprite_path("gfx/sprites/battle/{}-{}-{}".format(self.slug, sprite, flair.name))
             if flair_path != MISSING_IMAGE:
-                flair_sprite = tools.load_and_scale(flair_path)
-                surface.image.blit(flair_sprite, (0, 0))
+                flair_sprite = tools.load_sprite(flair_path, **kwargs)
+                surface.image.blit(flair_sprite.image, (0, 0))
 
         return surface
 

--- a/tuxemon/core/monster.py
+++ b/tuxemon/core/monster.py
@@ -468,11 +468,13 @@ class Monster(object):
                 flair_sprite = tools.load_and_scale(flair_path)
                 surface.blit(flair_sprite, (0, 0))
 
-        images = [(surface, .1)]
-        tech = PygAnimation(images, False)
+        images = [(surface, 0.1)]
+        anim = PygAnimation(images, True)
+        anim.play()
         sprite = Sprite()
-        sprite.image = tech
-        sprite.rect = surface.get_rect(**kwargs)
+        sprite.image = anim
+        sprite.rect = anim.get_rect(**kwargs)
+        sprite.image.blit(anim, (0, 0))
 
         return sprite
 

--- a/tuxemon/core/monster.py
+++ b/tuxemon/core/monster.py
@@ -251,7 +251,8 @@ class Monster(object):
         self.sprites = {}
         self.front_battle_sprite = ""
         self.back_battle_sprite = ""
-        self.menu_sprite = ""
+        self.menu_sprite_1 = ""
+        self.menu_sprite_2 = ""
 
         self.set_state(save_data)
         self.set_stats()
@@ -305,7 +306,8 @@ class Monster(object):
         # Look up the monster's sprite image paths
         self.front_battle_sprite = self.get_sprite_path(results['sprites']['battle1'])
         self.back_battle_sprite = self.get_sprite_path(results['sprites']['battle2'])
-        self.menu_sprite = self.get_sprite_path(results['sprites']['menu1'])
+        self.menu_sprite_1 = self.get_sprite_path(results['sprites']['menu1'])
+        self.menu_sprite_2 = self.get_sprite_path(results['sprites']['menu2'])
 
         # Load the monster AI
         # TODO: clean up AI 'core' loading and what not
@@ -453,11 +455,14 @@ class Monster(object):
         :returns: The surface of the monster sprite
         """
         if sprite == "front":
-            surface = tools.load_and_scale(self.front_battle_sprite)
+            surface = tools.load_sprite(self.front_battle_sprite, **kwargs)
         elif sprite == "back":
-            surface = tools.load_and_scale(self.back_battle_sprite)
+            surface = tools.load_sprite(self.back_battle_sprite, **kwargs)
         elif sprite == "menu":
-            surface = tools.load_and_scale(self.menu_sprite)
+            surface = tools.load_animated_sprite([
+                self.menu_sprite_1, 
+                self.menu_sprite_2],
+                0.25, **kwargs)
         else:
             raise ValueError("Cannot find sprite for: {}".format(sprite))
 
@@ -466,17 +471,9 @@ class Monster(object):
             flair_path = self.get_sprite_path("gfx/sprites/battle/{}-{}-{}".format(self.slug, sprite, flair.name))
             if flair_path != MISSING_IMAGE:
                 flair_sprite = tools.load_and_scale(flair_path)
-                surface.blit(flair_sprite, (0, 0))
+                surface.image.blit(flair_sprite, (0, 0))
 
-        images = [(surface, 0.1)]
-        anim = PygAnimation(images, True)
-        anim.play()
-        sprite = Sprite()
-        sprite.image = anim
-        sprite.rect = anim.get_rect(**kwargs)
-        sprite.image.blit(anim, (0, 0))
-
-        return sprite
+        return surface
 
     def set_flairs(self):
         """Sets the flairs of this monster if they were not already configured
@@ -531,7 +528,7 @@ class Monster(object):
 
         self.sprites["front"] = tools.load_and_scale(self.front_battle_sprite)
         self.sprites["back"] = tools.load_and_scale(self.back_battle_sprite)
-        self.sprites["menu"] = tools.load_and_scale(self.menu_sprite)
+        self.sprites["menu"] = tools.load_and_scale(self.menu_sprite_1)
         return False
 
     def get_state(self):

--- a/tuxemon/core/states/dialog/__init__.py
+++ b/tuxemon/core/states/dialog/__init__.py
@@ -3,7 +3,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from tuxemon.core import tools, monster
 from tuxemon.core.menu.menu import PopUpMenu
 from tuxemon.core.ui.text import TextArea
 from tuxemon.core.platform.const import buttons
@@ -28,9 +27,13 @@ class DialogState(PopUpMenu):
         self.text_area.rect = self.calc_internal_rect()
         self.sprites.add(self.text_area)
 
+        if self.avatar:
+            avatar_rect = self.calc_final_rect()
+            self.avatar.rect.bottomleft = avatar_rect.left, avatar_rect.top
+            self.sprites.add(self.avatar)
+
     def on_open(self):
         self.next_text()
-        self.draw_avatar()
 
     def process_event(self, event):
         """ Handles player input events. This function is only called when the
@@ -63,29 +66,3 @@ class DialogState(PopUpMenu):
             return text
         except IndexError:
             return None
-
-    def draw_avatar(self):
-        if not self.avatar:
-            return
-
-        # If the prefix is "monster" the second parameter refers to a monster
-        # If this parameter is a number, we're referring to a monster slot in the party
-        # If this parameter is a string, we're referring to a monster name
-        # If there's no prefix, the parameter represents the path to a sprite file
-        params = self.avatar.split(" ")
-        if params[0] == "monster":
-            if params[1].isdigit():
-                player = self.game.player1
-                slot = int(params[1])
-                avatar_sprite = player.monsters[slot].get_sprite("menu")
-            else:
-                avatar_monster = monster.Monster()
-                avatar_monster.load_from_db(params[1])
-                avatar_monster.flairs = {} # Don't use random flair graphics
-                avatar_sprite = avatar_monster.get_sprite("menu")
-        else:
-            avatar_sprite = tools.load_sprite(self.avatar)
-
-        avatar_rect = self.calc_final_rect()
-        avatar_sprite.rect.bottomleft = avatar_rect.left, avatar_rect.top
-        self.sprites.add(avatar_sprite)

--- a/tuxemon/core/states/dialog/__init__.py
+++ b/tuxemon/core/states/dialog/__init__.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from tuxemon.core import tools
 from tuxemon.core.menu.menu import PopUpMenu
 from tuxemon.core.ui.text import TextArea
 from tuxemon.core.platform.const import buttons
@@ -21,6 +22,7 @@ class DialogState(PopUpMenu):
     def startup(self, **kwargs):
         super(DialogState, self).startup(**kwargs)
         self.text_queue = kwargs.get("text", list())
+        self.avatar = kwargs.get("avatar", None)
         self.menu = kwargs.get("menu", None)
         self.text_area = TextArea(self.font, self.font_color)
         self.text_area.rect = self.calc_internal_rect()
@@ -28,6 +30,7 @@ class DialogState(PopUpMenu):
 
     def on_open(self):
         self.next_text()
+        self.draw_avatar()
 
     def process_event(self, event):
         """ Handles player input events. This function is only called when the
@@ -60,3 +63,27 @@ class DialogState(PopUpMenu):
             return text
         except IndexError:
             return None
+
+    def draw_avatar(self):
+        if not self.avatar:
+            return
+
+        # If the prefix is "monster" the second parameter refers to a monster
+        # If this parameter is a number, we're referring to a monster slot in the party
+        # If this parameter is a string, we're referring to a monster name
+        # If there's no prefix, the parameter represents the path to a sprite file
+        params = self.avatar.split(" ")
+        if params[0] == "monster":
+            if params[1].isdigit():
+                player = self.game.player1
+                slot = int(params[1])
+                avatar_sprite = player.monsters[slot].menu_sprite
+            else:
+                avatar_sprite = "gfx/sprites/battle/{}-menu01.png".format(params[1])
+        else:
+            avatar_sprite = self.avatar
+
+        avatar_rect = self.calc_final_rect()
+        avatar_sprite = tools.load_sprite(avatar_sprite)
+        avatar_sprite.rect.bottomleft = avatar_rect.left, avatar_rect.top
+        self.sprites.add(avatar_sprite)

--- a/tuxemon/core/states/dialog/__init__.py
+++ b/tuxemon/core/states/dialog/__init__.py
@@ -3,7 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from tuxemon.core import tools
+from tuxemon.core import tools, monster
 from tuxemon.core.menu.menu import PopUpMenu
 from tuxemon.core.ui.text import TextArea
 from tuxemon.core.platform.const import buttons
@@ -79,7 +79,10 @@ class DialogState(PopUpMenu):
                 slot = int(params[1])
                 avatar_sprite = player.monsters[slot].get_sprite("menu")
             else:
-                avatar_sprite = tools.load_sprite("gfx/sprites/battle/{}-menu01.png".format(params[1]))
+                avatar_monster = monster.Monster()
+                avatar_monster.load_from_db(params[1])
+                avatar_monster.flairs = {} # Don't use random flair graphics
+                avatar_sprite = avatar_monster.get_sprite("menu")
         else:
             avatar_sprite = tools.load_sprite(self.avatar)
 

--- a/tuxemon/core/states/dialog/__init__.py
+++ b/tuxemon/core/states/dialog/__init__.py
@@ -77,13 +77,12 @@ class DialogState(PopUpMenu):
             if params[1].isdigit():
                 player = self.game.player1
                 slot = int(params[1])
-                avatar_sprite = player.monsters[slot].menu_sprite
+                avatar_sprite = player.monsters[slot].get_sprite("menu")
             else:
-                avatar_sprite = "gfx/sprites/battle/{}-menu01.png".format(params[1])
+                avatar_sprite = tools.load_sprite("gfx/sprites/battle/{}-menu01.png".format(params[1]))
         else:
-            avatar_sprite = self.avatar
+            avatar_sprite = tools.load_sprite(self.avatar)
 
         avatar_rect = self.calc_final_rect()
-        avatar_sprite = tools.load_sprite(avatar_sprite)
         avatar_sprite.rect.bottomleft = avatar_rect.left, avatar_rect.top
         self.sprites.add(avatar_sprite)

--- a/tuxemon/core/tools.py
+++ b/tuxemon/core/tools.py
@@ -39,6 +39,7 @@ import re
 import pygame
 
 import tuxemon.core.sprite
+import tuxemon.core.monster
 from tuxemon.core import prepare
 from tuxemon.core import pyganim
 from tuxemon.core.platform import mixer
@@ -385,6 +386,27 @@ def calc_dialog_rect(screen_rect):
     return rect
 
 
+def get_dialog_avatar(game, avatar):
+    """Gets the avatar sprite of a monster or NPC.
+
+    If avatar is a number, we're referring to a monster slot in the player's party
+    If avatar is a string, we're referring to a monster by name
+    TODO: If the monster name isn't found, we're referring to an NPC on the map
+
+    :rtype: Pygame surface
+    :returns: The surface of the monster or NPC avatar sprite
+    """
+    if avatar.isdigit():
+        player = game.player1
+        slot = int(avatar)
+        return player.monsters[slot].get_sprite("menu")
+    else:
+        avatar_monster = tuxemon.core.monster.Monster()
+        avatar_monster.load_from_db(avatar)
+        avatar_monster.flairs = {} # Don't use random flair graphics
+        return avatar_monster.get_sprite("menu")
+
+
 def open_dialog(game, text, avatar=None, menu=None):
     """ Open a dialog with the standard window size
 
@@ -394,6 +416,7 @@ def open_dialog(game, text, avatar=None, menu=None):
     :rtype: core.states.dialog.DialogState
     """
     rect = calc_dialog_rect(game.screen.get_rect())
+    avatar = get_dialog_avatar(game, avatar)
     return game.push_state("DialogState", text=text, avatar=avatar, rect=rect, menu=menu)
 
 

--- a/tuxemon/core/tools.py
+++ b/tuxemon/core/tools.py
@@ -180,8 +180,9 @@ def load_animated_sprite(filenames, delay, **rect_kwargs):
     """
     anim = []
     for filename in filenames:
-        image = load_and_scale(filename)
-        anim.append((image, delay))
+        if os.path.exists(filename):
+            image = load_and_scale(filename)
+            anim.append((image, delay))
 
     tech = pyganim.PygAnimation(anim, True)
     tech.play()

--- a/tuxemon/core/tools.py
+++ b/tuxemon/core/tools.py
@@ -410,7 +410,7 @@ def get_avatar(game, avatar):
             slot = int(avatar)
             return player.monsters[slot].get_sprite("menu")
         except IndexError:
-            logger.error("invalid avatar monster slot")
+            logger.debug("invalid avatar monster slot")
             return None
     else:
         try:
@@ -419,7 +419,7 @@ def get_avatar(game, avatar):
             avatar_monster.flairs = {} # Don't use random flair graphics
             return avatar_monster.get_sprite("menu")
         except KeyError:
-            logger.error("invalid avatar monster name")
+            logger.debug("invalid avatar monster name")
             return None
 
 

--- a/tuxemon/core/tools.py
+++ b/tuxemon/core/tools.py
@@ -175,7 +175,8 @@ def load_animated_sprite(filenames, delay, **rect_kwargs):
     Any keyword arguments will be passed to the get_rect method
     of the image for positioning the rect.
 
-    :param filename: Filename to load
+    :param filenames: Filenames to load
+    :param delay: Frame interval; time between each frame
     :rtype: core.sprite.Sprite
     """
     anim = []
@@ -446,6 +447,8 @@ def open_dialog(game, text, avatar=None, menu=None):
 
     :param game:
     :param text: list of strings
+    :param avatar: optional avatar sprite
+    :param menu: optional menu object
 
     :rtype: core.states.dialog.DialogState
     """

--- a/tuxemon/core/tools.py
+++ b/tuxemon/core/tools.py
@@ -176,7 +176,7 @@ def load_animated_sprite(filenames, delay, **rect_kwargs):
     of the image for positioning the rect.
 
     :param filenames: Filenames to load
-    :param delay: Frame interval; time between each frame
+    :param int delay: Frame interval; time between each frame
     :rtype: core.sprite.Sprite
     """
     anim = []

--- a/tuxemon/core/tools.py
+++ b/tuxemon/core/tools.py
@@ -399,11 +399,14 @@ def load_sound(filename):
 def get_avatar(game, avatar):
     """Gets the avatar sprite of a monster or NPC.
 
+    Used to parse the string values for dialog event actions
     If avatar is a number, we're referring to a monster slot in the player's party
     If avatar is a string, we're referring to a monster by name
     TODO: If the monster name isn't found, we're referring to an NPC on the map
 
-    :rtype: Pygame surface
+    :param avatar: the avatar to be used
+    :type avatar: string
+    :rtype: Optional[pygame.Surface]
     :returns: The surface of the monster or NPC avatar sprite
     """
     if avatar and avatar.isdigit():

--- a/tuxemon/core/tools.py
+++ b/tuxemon/core/tools.py
@@ -166,6 +166,31 @@ def load_sprite(filename, **rect_kwargs):
     return sprite
 
 
+def load_animated_sprite(filenames, delay, **rect_kwargs):
+    """ Load a set of images and return an animated pygame sprite
+
+    Image name will be transformed and converted
+    Rect attribute will be set
+
+    Any keyword arguments will be passed to the get_rect method
+    of the image for positioning the rect.
+
+    :param filename: Filename to load
+    :rtype: core.sprite.Sprite
+    """
+    anim = []
+    for filename in filenames:
+        image = load_and_scale(filename)
+        anim.append((image, delay))
+
+    tech = pyganim.PygAnimation(anim, True)
+    tech.play()
+    sprite = tuxemon.core.sprite.Sprite()
+    sprite.image = tech
+    sprite.rect = sprite.image.get_rect(**rect_kwargs)
+    return sprite
+
+
 def new_scaled_rect(*args, **kwargs):
     """ Create a new rect and scale it
 
@@ -379,7 +404,7 @@ def get_avatar(game, avatar):
     :rtype: Pygame surface
     :returns: The surface of the monster or NPC avatar sprite
     """
-    if avatar.isdigit():
+    if avatar and avatar.isdigit():
         try:
             player = game.player1
             slot = int(avatar)

--- a/tuxemon/core/tools.py
+++ b/tuxemon/core/tools.py
@@ -369,24 +369,7 @@ def load_sound(filename):
         return DummySound()
 
 
-def calc_dialog_rect(screen_rect):
-    """ Return a rect that is the area for a dialog box on the screen
-
-    :param screen_rect:
-    :return:
-    """
-    rect = screen_rect.copy()
-    if prepare.CONFIG.large_gui:
-        rect.height *= .4
-        rect.bottomleft = screen_rect.bottomleft
-    else:
-        rect.height *= .25
-        rect.width *= .8
-        rect.center = screen_rect.centerx, screen_rect.bottom - rect.height
-    return rect
-
-
-def get_dialog_avatar(game, avatar):
+def get_avatar(game, avatar):
     """Gets the avatar sprite of a monster or NPC.
 
     If avatar is a number, we're referring to a monster slot in the player's party
@@ -407,6 +390,23 @@ def get_dialog_avatar(game, avatar):
         return avatar_monster.get_sprite("menu")
 
 
+def calc_dialog_rect(screen_rect):
+    """ Return a rect that is the area for a dialog box on the screen
+
+    :param screen_rect:
+    :return:
+    """
+    rect = screen_rect.copy()
+    if prepare.CONFIG.large_gui:
+        rect.height *= .4
+        rect.bottomleft = screen_rect.bottomleft
+    else:
+        rect.height *= .25
+        rect.width *= .8
+        rect.center = screen_rect.centerx, screen_rect.bottom - rect.height
+    return rect
+
+
 def open_dialog(game, text, avatar=None, menu=None):
     """ Open a dialog with the standard window size
 
@@ -416,7 +416,6 @@ def open_dialog(game, text, avatar=None, menu=None):
     :rtype: core.states.dialog.DialogState
     """
     rect = calc_dialog_rect(game.screen.get_rect())
-    avatar = get_dialog_avatar(game, avatar)
     return game.push_state("DialogState", text=text, avatar=avatar, rect=rect, menu=menu)
 
 

--- a/tuxemon/core/tools.py
+++ b/tuxemon/core/tools.py
@@ -385,7 +385,7 @@ def calc_dialog_rect(screen_rect):
     return rect
 
 
-def open_dialog(game, text, menu=None):
+def open_dialog(game, text, avatar=None, menu=None):
     """ Open a dialog with the standard window size
 
     :param game:
@@ -394,7 +394,7 @@ def open_dialog(game, text, menu=None):
     :rtype: core.states.dialog.DialogState
     """
     rect = calc_dialog_rect(game.screen.get_rect())
-    return game.push_state("DialogState", text=text, rect=rect, menu=menu)
+    return game.push_state("DialogState", text=text, avatar=avatar, rect=rect, menu=menu)
 
 
 def nearest(l):

--- a/tuxemon/core/tools.py
+++ b/tuxemon/core/tools.py
@@ -380,14 +380,22 @@ def get_avatar(game, avatar):
     :returns: The surface of the monster or NPC avatar sprite
     """
     if avatar.isdigit():
-        player = game.player1
-        slot = int(avatar)
-        return player.monsters[slot].get_sprite("menu")
+        try:
+            player = game.player1
+            slot = int(avatar)
+            return player.monsters[slot].get_sprite("menu")
+        except IndexError:
+            logger.error("invalid avatar monster slot")
+            return None
     else:
-        avatar_monster = tuxemon.core.monster.Monster()
-        avatar_monster.load_from_db(avatar)
-        avatar_monster.flairs = {} # Don't use random flair graphics
-        return avatar_monster.get_sprite("menu")
+        try:
+            avatar_monster = tuxemon.core.monster.Monster()
+            avatar_monster.load_from_db(avatar)
+            avatar_monster.flairs = {} # Don't use random flair graphics
+            return avatar_monster.get_sprite("menu")
+        except KeyError:
+            logger.error("invalid avatar monster name")
+            return None
 
 
 def calc_dialog_rect(screen_rect):


### PR DESCRIPTION
Dialog event actions may now specify an optional additional parameter, which can be used to draw any avatar you'd like that dialog to have. This avatar will be displayed in the upper-left corner of the box, next to the name of the person speaking.

Avatars may currently be specified in 3 ways: A monster slot, a monster name, or the full path to the sprite file. Later on we can add the ability to give NPC's avatars and specify those by name, but for now the automatic translation only works for monsters. Examples:

```
act1: dialog 'Whatever I'm saying',monster 0
act1: dialog 'Whatever I'm saying',monster fruitera
act1: dialog 'Whatever I'm saying',gfx/sprites/battle/fruitera-menu01.png
```

![Screenshot_20200121_185255](https://user-images.githubusercontent.com/825418/72827291-2e191700-3c83-11ea-9c69-c124b22627bb.png)