### PR TITLE
Ensure mods are set before loading locale and database paths

### DIFF
--- a/tuxemon/core/db.py
+++ b/tuxemon/core/db.py
@@ -61,18 +61,8 @@ class JSONDatabase(object):
 
     """
 
-    def __init__(self, dir=None):
-        self.database = {
-            "item": {},
-            "monster": {},
-            "npc": {},
-            "technique": {},
-            "encounter": {},
-            "inventory": {},
-            "environment": {},
-        }
-        if dir:
-            self.load(dir)
+    def __init__(self):
+        self.database = {}
 
     def load(self, directory="all"):
         """Loads all data from JSON files located under our data path.
@@ -84,6 +74,16 @@ class JSONDatabase(object):
         :returns: None
 
         """
+
+        self.database = {
+            "item": {},
+            "monster": {},
+            "npc": {},
+            "technique": {},
+            "encounter": {},
+            "inventory": {},
+            "environment": {},
+        }
 
         self.path = prepare.fetch("db")
         if directory == "all":
@@ -193,27 +193,5 @@ def set_defaults(results, table):
 
     return results
 
-# Database storage class
-class Databases(object):
-    def __init__(self):
-        self.item = JSONDatabase()
-        self.monster = JSONDatabase()
-        self.npc = JSONDatabase()
-        self.technique = JSONDatabase()
-        self.encounter = JSONDatabase()
-        self.inventory = JSONDatabase()
-        self.environment = JSONDatabase()
-        self.all = JSONDatabase()
-
-    def collect_databases(self):
-        self.item.load("item")
-        self.monster.load("monster")
-        self.npc.load("npc")
-        self.technique.load("technique")
-        self.encounter.load("encounter")
-        self.inventory.load("inventory")
-        self.environment.load("environment")
-        self.all.load("all")
-
-# Register default databases
-databases = Databases()
+# Global database container
+databases = JSONDatabase()

--- a/tuxemon/core/db.py
+++ b/tuxemon/core/db.py
@@ -62,7 +62,6 @@ class JSONDatabase(object):
     """
 
     def __init__(self, dir=None):
-        self.path = prepare.fetch("db")
         self.database = {
             "item": {},
             "monster": {},
@@ -86,6 +85,7 @@ class JSONDatabase(object):
 
         """
 
+        self.path = prepare.fetch("db")
         if directory == "all":
             self.load_json("item")
             self.load_json("monster")
@@ -192,3 +192,22 @@ def set_defaults(results, table):
                 )
 
     return results
+
+# Register default databases
+env_db = JSONDatabase()
+techniques_db = JSONDatabase()
+items_db = JSONDatabase()
+inventory_db = JSONDatabase()
+npc_db = JSONDatabase()
+monster_db = JSONDatabase()
+encounter_db = JSONDatabase()
+
+# Load default databases
+def collect_databases():
+    env_db.load("environment")
+    techniques_db.load("technique")
+    items_db.load("item")
+    inventory_db.load("inventory")
+    npc_db.load("npc")
+    monster_db.load("monster")
+    encounter_db.load("encounter")

--- a/tuxemon/core/db.py
+++ b/tuxemon/core/db.py
@@ -61,8 +61,19 @@ class JSONDatabase(object):
 
     """
 
-    def __init__(self):
-        self.database = {}
+    def __init__(self, dir=None):
+        self.path = None
+        self.database = {
+            "item": {},
+            "monster": {},
+            "npc": {},
+            "technique": {},
+            "encounter": {},
+            "inventory": {},
+            "environment": {},
+        }
+        if dir:
+            self.load(dir)
 
     def load(self, directory="all"):
         """Loads all data from JSON files located under our data path.
@@ -74,16 +85,6 @@ class JSONDatabase(object):
         :returns: None
 
         """
-
-        self.database = {
-            "item": {},
-            "monster": {},
-            "npc": {},
-            "technique": {},
-            "encounter": {},
-            "inventory": {},
-            "environment": {},
-        }
 
         self.path = prepare.fetch("db")
         if directory == "all":
@@ -194,4 +195,4 @@ def set_defaults(results, table):
     return results
 
 # Global database container
-databases = JSONDatabase()
+db = JSONDatabase()

--- a/tuxemon/core/db.py
+++ b/tuxemon/core/db.py
@@ -89,8 +89,8 @@ class JSONDatabase(object):
         if directory == "all":
             self.load_json("item")
             self.load_json("monster")
-            self.load_json("technique")
             self.load_json("npc")
+            self.load_json("technique")
             self.load_json("encounter")
             self.load_json("inventory")
             self.load_json("environment")
@@ -193,21 +193,27 @@ def set_defaults(results, table):
 
     return results
 
-# Register default databases
-env_db = JSONDatabase()
-techniques_db = JSONDatabase()
-items_db = JSONDatabase()
-inventory_db = JSONDatabase()
-npc_db = JSONDatabase()
-monster_db = JSONDatabase()
-encounter_db = JSONDatabase()
+# Database storage class
+class Databases(object):
+    def __init__(self):
+        self.item = JSONDatabase()
+        self.monster = JSONDatabase()
+        self.npc = JSONDatabase()
+        self.technique = JSONDatabase()
+        self.encounter = JSONDatabase()
+        self.inventory = JSONDatabase()
+        self.environment = JSONDatabase()
+        self.all = JSONDatabase()
 
-# Load default databases
-def collect_databases():
-    env_db.load("environment")
-    techniques_db.load("technique")
-    items_db.load("item")
-    inventory_db.load("inventory")
-    npc_db.load("npc")
-    monster_db.load("monster")
-    encounter_db.load("encounter")
+    def collect_databases(self):
+        self.item.load("item")
+        self.monster.load("monster")
+        self.npc.load("npc")
+        self.technique.load("technique")
+        self.encounter.load("encounter")
+        self.inventory.load("inventory")
+        self.environment.load("environment")
+        self.all.load("all")
+
+# Register default databases
+databases = Databases()

--- a/tuxemon/core/event/actions/create_npc.py
+++ b/tuxemon/core/event/actions/create_npc.py
@@ -73,7 +73,7 @@ class CreateNpcAction(EventAction):
                 slug
             )
         else:
-            sprite = databases.npc[slug].get('sprite_name')
+            sprite = databases.npc.database['npc'][slug].get('sprite_name')
 
         # Create a new NPC object
         npc = tuxemon.core.npc.NPC(slug, sprite_name=sprite)

--- a/tuxemon/core/event/actions/create_npc.py
+++ b/tuxemon/core/event/actions/create_npc.py
@@ -73,7 +73,7 @@ class CreateNpcAction(EventAction):
                 slug
             )
         else:
-            sprite = databases.npc.database['npc'][slug].get('sprite_name')
+            sprite = databases.database['npc'][slug].get('sprite_name')
 
         # Create a new NPC object
         npc = tuxemon.core.npc.NPC(slug, sprite_name=sprite)

--- a/tuxemon/core/event/actions/create_npc.py
+++ b/tuxemon/core/event/actions/create_npc.py
@@ -72,7 +72,7 @@ class CreateNpcAction(EventAction):
                 slug
             )
         else:
-            sprite = db.JSONDatabase('npc').database['npc'][slug].get('sprite_name')
+            sprite = db.databases.npc[slug].get('sprite_name')
 
         # Create a new NPC object
         npc = tuxemon.core.npc.NPC(slug, sprite_name=sprite)

--- a/tuxemon/core/event/actions/create_npc.py
+++ b/tuxemon/core/event/actions/create_npc.py
@@ -27,7 +27,8 @@ from __future__ import unicode_literals
 import logging
 
 import tuxemon.core.npc
-from tuxemon.core import ai, db
+from tuxemon.core import ai
+from tuxemon.core.db import databases
 from tuxemon.core.event.eventaction import EventAction
 
 logger = logging.getLogger(__name__)
@@ -72,7 +73,7 @@ class CreateNpcAction(EventAction):
                 slug
             )
         else:
-            sprite = db.databases.npc[slug].get('sprite_name')
+            sprite = databases.npc[slug].get('sprite_name')
 
         # Create a new NPC object
         npc = tuxemon.core.npc.NPC(slug, sprite_name=sprite)

--- a/tuxemon/core/event/actions/create_npc.py
+++ b/tuxemon/core/event/actions/create_npc.py
@@ -28,7 +28,7 @@ import logging
 
 import tuxemon.core.npc
 from tuxemon.core import ai
-from tuxemon.core.db import databases
+from tuxemon.core.db import db
 from tuxemon.core.event.eventaction import EventAction
 
 logger = logging.getLogger(__name__)
@@ -73,7 +73,7 @@ class CreateNpcAction(EventAction):
                 slug
             )
         else:
-            sprite = databases.database['npc'][slug].get('sprite_name')
+            sprite = db.database['npc'][slug].get('sprite_name')
 
         # Create a new NPC object
         npc = tuxemon.core.npc.NPC(slug, sprite_name=sprite)

--- a/tuxemon/core/event/actions/random_encounter.py
+++ b/tuxemon/core/event/actions/random_encounter.py
@@ -29,7 +29,7 @@ import random
 
 from tuxemon.core import tools
 from tuxemon.core import ai, monster
-from tuxemon.core.db import databases
+from tuxemon.core.db import db
 from tuxemon.core.combat import check_battle_legal
 from tuxemon.core.event.eventaction import EventAction
 from tuxemon.core.npc import NPC
@@ -62,7 +62,7 @@ class RandomEncounterAction(EventAction):
             return False
 
         slug = self.parameters.encounter_slug
-        encounters = databases.database['encounter'][slug]['monsters']
+        encounters = db.database['encounter'][slug]['monsters']
         encounter = _choose_encounter(encounters, self.parameters.total_prob)
 
         # If a random encounter was successfully rolled, look up the monster and start the
@@ -80,7 +80,7 @@ class RandomEncounterAction(EventAction):
             env_slug = "grass"
             if 'environment' in player.game_variables:
                 env_slug = player.game_variables['environment']
-            env = databases.lookup(env_slug, table="environment")
+            env = db.lookup(env_slug, table="environment")
 
             # Add our players and setup combat
             # "queueing" it will mean it starts after the top of the stack is popped (or replaced)

--- a/tuxemon/core/event/actions/random_encounter.py
+++ b/tuxemon/core/event/actions/random_encounter.py
@@ -62,7 +62,7 @@ class RandomEncounterAction(EventAction):
             return False
 
         slug = self.parameters.encounter_slug
-        encounters = databases.encounter.database['encounter'][slug]['monsters']
+        encounters = databases.database['encounter'][slug]['monsters']
         encounter = _choose_encounter(encounters, self.parameters.total_prob)
 
         # If a random encounter was successfully rolled, look up the monster and start the
@@ -80,7 +80,7 @@ class RandomEncounterAction(EventAction):
             env_slug = "grass"
             if 'environment' in player.game_variables:
                 env_slug = player.game_variables['environment']
-            env = databases.environment.lookup(env_slug, table="environment")
+            env = databases.lookup(env_slug, table="environment")
 
             # Add our players and setup combat
             # "queueing" it will mean it starts after the top of the stack is popped (or replaced)

--- a/tuxemon/core/event/actions/random_encounter.py
+++ b/tuxemon/core/event/actions/random_encounter.py
@@ -60,18 +60,14 @@ class RandomEncounterAction(EventAction):
         if not check_battle_legal(player):
             return False
 
-        monsters = db.JSONDatabase()
-        monsters.load("encounter")
-
         slug = self.parameters.encounter_slug
-        encounters = monsters.database['encounter'][slug]['monsters']
+        encounters = db.encounter_db.database['encounter'][slug]['monsters']
         encounter = _choose_encounter(encounters, self.parameters.total_prob)
 
         # If a random encounter was successfully rolled, look up the monster and start the
         # battle.
         if encounter:
             logger.info("Starting random encounter!")
-            monsters.load("monster")
 
             # Stop movement and keypress on the server.
             if self.game.isclient or self.game.ishost:
@@ -80,12 +76,10 @@ class RandomEncounterAction(EventAction):
             npc = _create_monster_npc(encounter)
 
             # Lookup the environment
-            env_db = db.JSONDatabase()
-            env_db.load("environment")
             env_slug = "grass"
             if 'environment' in player.game_variables:
                 env_slug = player.game_variables['environment']
-            env = env_db.lookup(env_slug, table="environment")
+            env = db.env_db.lookup(env_slug, table="environment")
 
             # Add our players and setup combat
             # "queueing" it will mean it starts after the top of the stack is popped (or replaced)

--- a/tuxemon/core/event/actions/random_encounter.py
+++ b/tuxemon/core/event/actions/random_encounter.py
@@ -61,7 +61,7 @@ class RandomEncounterAction(EventAction):
             return False
 
         slug = self.parameters.encounter_slug
-        encounters = db.encounter_db.database['encounter'][slug]['monsters']
+        encounters = db.databases.encounter.database['encounter'][slug]['monsters']
         encounter = _choose_encounter(encounters, self.parameters.total_prob)
 
         # If a random encounter was successfully rolled, look up the monster and start the
@@ -79,7 +79,7 @@ class RandomEncounterAction(EventAction):
             env_slug = "grass"
             if 'environment' in player.game_variables:
                 env_slug = player.game_variables['environment']
-            env = db.env_db.lookup(env_slug, table="environment")
+            env = db.databases.environment.lookup(env_slug, table="environment")
 
             # Add our players and setup combat
             # "queueing" it will mean it starts after the top of the stack is popped (or replaced)

--- a/tuxemon/core/event/actions/random_encounter.py
+++ b/tuxemon/core/event/actions/random_encounter.py
@@ -28,7 +28,8 @@ import logging
 import random
 
 from tuxemon.core import tools
-from tuxemon.core import ai, db, monster
+from tuxemon.core import ai, monster
+from tuxemon.core.db import databases
 from tuxemon.core.combat import check_battle_legal
 from tuxemon.core.event.eventaction import EventAction
 from tuxemon.core.npc import NPC
@@ -61,7 +62,7 @@ class RandomEncounterAction(EventAction):
             return False
 
         slug = self.parameters.encounter_slug
-        encounters = db.databases.encounter.database['encounter'][slug]['monsters']
+        encounters = databases.encounter.database['encounter'][slug]['monsters']
         encounter = _choose_encounter(encounters, self.parameters.total_prob)
 
         # If a random encounter was successfully rolled, look up the monster and start the
@@ -79,7 +80,7 @@ class RandomEncounterAction(EventAction):
             env_slug = "grass"
             if 'environment' in player.game_variables:
                 env_slug = player.game_variables['environment']
-            env = db.databases.environment.lookup(env_slug, table="environment")
+            env = databases.environment.lookup(env_slug, table="environment")
 
             # Add our players and setup combat
             # "queueing" it will mean it starts after the top of the stack is popped (or replaced)

--- a/tuxemon/core/event/actions/set_inventory.py
+++ b/tuxemon/core/event/actions/set_inventory.py
@@ -24,7 +24,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from tuxemon.core import db
+from tuxemon.core.db import databases
 from tuxemon.core.event import get_npc
 from tuxemon.core.event.eventaction import EventAction
 from tuxemon.core.item import decode_inventory
@@ -45,5 +45,5 @@ class SetInventoryAction(EventAction):
             npc.inventory = {}
             return
 
-        entry = db.databases.inventory.database["inventory"][self.parameters.inventory_slug]
+        entry = databases.inventory.database["inventory"][self.parameters.inventory_slug]
         npc.inventory = decode_inventory(entry)

--- a/tuxemon/core/event/actions/set_inventory.py
+++ b/tuxemon/core/event/actions/set_inventory.py
@@ -45,5 +45,5 @@ class SetInventoryAction(EventAction):
             npc.inventory = {}
             return
 
-        entry = db.inventory_db.database["inventory"][self.parameters.inventory_slug]
+        entry = db.databases.inventory.database["inventory"][self.parameters.inventory_slug]
         npc.inventory = decode_inventory(entry)

--- a/tuxemon/core/event/actions/set_inventory.py
+++ b/tuxemon/core/event/actions/set_inventory.py
@@ -45,5 +45,5 @@ class SetInventoryAction(EventAction):
             npc.inventory = {}
             return
 
-        entry = databases.inventory.database["inventory"][self.parameters.inventory_slug]
+        entry = databases.database["inventory"][self.parameters.inventory_slug]
         npc.inventory = decode_inventory(entry)

--- a/tuxemon/core/event/actions/set_inventory.py
+++ b/tuxemon/core/event/actions/set_inventory.py
@@ -24,7 +24,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from tuxemon.core.db import databases
+from tuxemon.core.db import db
 from tuxemon.core.event import get_npc
 from tuxemon.core.event.eventaction import EventAction
 from tuxemon.core.item import decode_inventory
@@ -45,5 +45,5 @@ class SetInventoryAction(EventAction):
             npc.inventory = {}
             return
 
-        entry = databases.database["inventory"][self.parameters.inventory_slug]
+        entry = db.database["inventory"][self.parameters.inventory_slug]
         npc.inventory = decode_inventory(entry)

--- a/tuxemon/core/event/actions/set_inventory.py
+++ b/tuxemon/core/event/actions/set_inventory.py
@@ -24,9 +24,10 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from tuxemon.core import db
 from tuxemon.core.event import get_npc
 from tuxemon.core.event.eventaction import EventAction
-from tuxemon.core.item import inventory_db, decode_inventory
+from tuxemon.core.item import decode_inventory
 
 
 class SetInventoryAction(EventAction):
@@ -44,5 +45,5 @@ class SetInventoryAction(EventAction):
             npc.inventory = {}
             return
 
-        entry = inventory_db.database["inventory"][self.parameters.inventory_slug]
+        entry = db.inventory_db.database["inventory"][self.parameters.inventory_slug]
         npc.inventory = decode_inventory(entry)

--- a/tuxemon/core/event/actions/start_battle.py
+++ b/tuxemon/core/event/actions/start_battle.py
@@ -80,7 +80,7 @@ class StartBattleAction(EventAction):
         env_slug = "grass"
         if 'environment' in player.game_variables:
             env_slug = player.game_variables['environment']
-        env = databases.environment.lookup(env_slug, table="environment")
+        env = databases.lookup(env_slug, table="environment")
 
         # Add our players and setup combat
         logger.debug("Starting battle!")

--- a/tuxemon/core/event/actions/start_battle.py
+++ b/tuxemon/core/event/actions/start_battle.py
@@ -27,7 +27,7 @@ from __future__ import unicode_literals
 import logging
 
 from tuxemon.core import tools
-from tuxemon.core import db
+from tuxemon.core.db import databases
 from tuxemon.core.combat import check_battle_legal
 from tuxemon.core.event.eventaction import EventAction
 from tuxemon.core.platform import mixer
@@ -80,7 +80,7 @@ class StartBattleAction(EventAction):
         env_slug = "grass"
         if 'environment' in player.game_variables:
             env_slug = player.game_variables['environment']
-        env = db.databases.environment.lookup(env_slug, table="environment")
+        env = databases.environment.lookup(env_slug, table="environment")
 
         # Add our players and setup combat
         logger.debug("Starting battle!")

--- a/tuxemon/core/event/actions/start_battle.py
+++ b/tuxemon/core/event/actions/start_battle.py
@@ -77,12 +77,10 @@ class StartBattleAction(EventAction):
         npc.load_party()
 
         # Lookup the environment
-        env_db = db.JSONDatabase()
-        env_db.load("environment")
         env_slug = "grass"
         if 'environment' in player.game_variables:
             env_slug = player.game_variables['environment']
-        env = env_db.lookup(env_slug, table="environment")
+        env = db.env_db.lookup(env_slug, table="environment")
 
         # Add our players and setup combat
         logger.debug("Starting battle!")

--- a/tuxemon/core/event/actions/start_battle.py
+++ b/tuxemon/core/event/actions/start_battle.py
@@ -80,7 +80,7 @@ class StartBattleAction(EventAction):
         env_slug = "grass"
         if 'environment' in player.game_variables:
             env_slug = player.game_variables['environment']
-        env = db.env_db.lookup(env_slug, table="environment")
+        env = db.databases.environment.lookup(env_slug, table="environment")
 
         # Add our players and setup combat
         logger.debug("Starting battle!")

--- a/tuxemon/core/event/actions/start_battle.py
+++ b/tuxemon/core/event/actions/start_battle.py
@@ -27,7 +27,7 @@ from __future__ import unicode_literals
 import logging
 
 from tuxemon.core import tools
-from tuxemon.core.db import databases
+from tuxemon.core.db import db
 from tuxemon.core.combat import check_battle_legal
 from tuxemon.core.event.eventaction import EventAction
 from tuxemon.core.platform import mixer
@@ -80,7 +80,7 @@ class StartBattleAction(EventAction):
         env_slug = "grass"
         if 'environment' in player.game_variables:
             env_slug = player.game_variables['environment']
-        env = databases.lookup(env_slug, table="environment")
+        env = db.lookup(env_slug, table="environment")
 
         # Add our players and setup combat
         logger.debug("Starting battle!")

--- a/tuxemon/core/event/actions/start_pseudo_battle.py
+++ b/tuxemon/core/event/actions/start_pseudo_battle.py
@@ -54,12 +54,10 @@ class StartPseudoBattleAction(EventAction):
             self.game.client.update_player(player.facing, event_type="CLIENT_START_BATTLE")
 
         # Lookup the environment
-        env_db = db.JSONDatabase()
-        env_db.load("environment")
         env_slug = "grass"
         if 'environment' in player.game_variables:
             env_slug = player.game_variables['environment']
-        env = env_db.lookup(env_slug, table="environment")
+        env = db.env_db.lookup(env_slug, table="environment")
 
         # Add our players and setup combat
         self.game.push_state("CombatState", players=(player, npc), combat_type="trainer", graphics=env['battle_graphics'])

--- a/tuxemon/core/event/actions/start_pseudo_battle.py
+++ b/tuxemon/core/event/actions/start_pseudo_battle.py
@@ -57,7 +57,7 @@ class StartPseudoBattleAction(EventAction):
         env_slug = "grass"
         if 'environment' in player.game_variables:
             env_slug = player.game_variables['environment']
-        env = databases.environment.lookup(env_slug, table="environment")
+        env = databases.lookup(env_slug, table="environment")
 
         # Add our players and setup combat
         self.game.push_state("CombatState", players=(player, npc), combat_type="trainer", graphics=env['battle_graphics'])

--- a/tuxemon/core/event/actions/start_pseudo_battle.py
+++ b/tuxemon/core/event/actions/start_pseudo_battle.py
@@ -26,7 +26,7 @@ from __future__ import unicode_literals
 
 import logging
 
-from tuxemon.core import db
+from tuxemon.core.db import databases
 from tuxemon.core.combat import check_battle_legal
 from tuxemon.core.event.eventaction import EventAction
 
@@ -57,7 +57,7 @@ class StartPseudoBattleAction(EventAction):
         env_slug = "grass"
         if 'environment' in player.game_variables:
             env_slug = player.game_variables['environment']
-        env = db.databases.environment.lookup(env_slug, table="environment")
+        env = databases.environment.lookup(env_slug, table="environment")
 
         # Add our players and setup combat
         self.game.push_state("CombatState", players=(player, npc), combat_type="trainer", graphics=env['battle_graphics'])

--- a/tuxemon/core/event/actions/start_pseudo_battle.py
+++ b/tuxemon/core/event/actions/start_pseudo_battle.py
@@ -57,7 +57,7 @@ class StartPseudoBattleAction(EventAction):
         env_slug = "grass"
         if 'environment' in player.game_variables:
             env_slug = player.game_variables['environment']
-        env = db.env_db.lookup(env_slug, table="environment")
+        env = db.databases.environment.lookup(env_slug, table="environment")
 
         # Add our players and setup combat
         self.game.push_state("CombatState", players=(player, npc), combat_type="trainer", graphics=env['battle_graphics'])

--- a/tuxemon/core/event/actions/start_pseudo_battle.py
+++ b/tuxemon/core/event/actions/start_pseudo_battle.py
@@ -26,7 +26,7 @@ from __future__ import unicode_literals
 
 import logging
 
-from tuxemon.core.db import databases
+from tuxemon.core.db import db
 from tuxemon.core.combat import check_battle_legal
 from tuxemon.core.event.eventaction import EventAction
 
@@ -57,7 +57,7 @@ class StartPseudoBattleAction(EventAction):
         env_slug = "grass"
         if 'environment' in player.game_variables:
             env_slug = player.game_variables['environment']
-        env = databases.lookup(env_slug, table="environment")
+        env = db.lookup(env_slug, table="environment")
 
         # Add our players and setup combat
         self.game.push_state("CombatState", players=(player, npc), combat_type="trainer", graphics=env['battle_graphics'])

--- a/tuxemon/core/event/actions/update_inventory.py
+++ b/tuxemon/core/event/actions/update_inventory.py
@@ -24,7 +24,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from tuxemon.core.db import databases
+from tuxemon.core.db import db
 from tuxemon.core.event import get_npc
 from tuxemon.core.event.eventaction import EventAction
 from tuxemon.core.item import decode_inventory
@@ -47,6 +47,6 @@ class UpdateInventoryAction(EventAction):
 
 		npc.inventory.update(
 			decode_inventory(
-				databases.database["inventory"][self.parameters.inventory_slug]
+				db.database["inventory"][self.parameters.inventory_slug]
 			)
 		)

--- a/tuxemon/core/event/actions/update_inventory.py
+++ b/tuxemon/core/event/actions/update_inventory.py
@@ -24,9 +24,10 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from tuxemon.core import db
 from tuxemon.core.event import get_npc
 from tuxemon.core.event.eventaction import EventAction
-from tuxemon.core.item import inventory_db, decode_inventory
+from tuxemon.core.item import decode_inventory
 
 
 class UpdateInventoryAction(EventAction):
@@ -46,6 +47,6 @@ class UpdateInventoryAction(EventAction):
 
 		npc.inventory.update(
 			decode_inventory(
-				inventory_db.database["inventory"][self.parameters.inventory_slug]
+				db.inventory_db.database["inventory"][self.parameters.inventory_slug]
 			)
 		)

--- a/tuxemon/core/event/actions/update_inventory.py
+++ b/tuxemon/core/event/actions/update_inventory.py
@@ -47,6 +47,6 @@ class UpdateInventoryAction(EventAction):
 
 		npc.inventory.update(
 			decode_inventory(
-				db.inventory_db.database["inventory"][self.parameters.inventory_slug]
+				db.databases.inventory.database["inventory"][self.parameters.inventory_slug]
 			)
 		)

--- a/tuxemon/core/event/actions/update_inventory.py
+++ b/tuxemon/core/event/actions/update_inventory.py
@@ -47,6 +47,6 @@ class UpdateInventoryAction(EventAction):
 
 		npc.inventory.update(
 			decode_inventory(
-				databases.inventory.database["inventory"][self.parameters.inventory_slug]
+				databases.database["inventory"][self.parameters.inventory_slug]
 			)
 		)

--- a/tuxemon/core/event/actions/update_inventory.py
+++ b/tuxemon/core/event/actions/update_inventory.py
@@ -24,7 +24,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from tuxemon.core import db
+from tuxemon.core.db import databases
 from tuxemon.core.event import get_npc
 from tuxemon.core.event.eventaction import EventAction
 from tuxemon.core.item import decode_inventory
@@ -47,6 +47,6 @@ class UpdateInventoryAction(EventAction):
 
 		npc.inventory.update(
 			decode_inventory(
-				db.databases.inventory.database["inventory"][self.parameters.inventory_slug]
+				databases.inventory.database["inventory"][self.parameters.inventory_slug]
 			)
 		)

--- a/tuxemon/core/item.py
+++ b/tuxemon/core/item.py
@@ -39,7 +39,8 @@ import logging
 import pprint
 import random
 
-from tuxemon.core import db, tools
+from tuxemon.core import tools
+from tuxemon.core.db import databases, process_targets
 from tuxemon.core.locale import T
 
 logger = logging.getLogger(__name__)
@@ -111,7 +112,7 @@ class Item(object):
         }
         """
 
-        results = db.databases.item.lookup(slug, table="item")
+        results = databases.item.lookup(slug, table="item")
 
         self.slug = results["slug"]                                         # short English identifier
         self.name = T.translate(self.slug)                                  # translated name
@@ -128,7 +129,7 @@ class Item(object):
         self.power = results["power"]
         self.sprite = results["sprite"]
         self.usable_in = results["usable_in"]
-        self.target = db.process_targets(results["target"])
+        self.target = process_targets(results["target"])
         self.effect = results["effects"]
         self.surface = tools.load_and_scale(self.sprite)
         self.surface_size_original = self.surface.get_size()

--- a/tuxemon/core/item.py
+++ b/tuxemon/core/item.py
@@ -112,7 +112,7 @@ class Item(object):
         }
         """
 
-        results = databases.item.lookup(slug, table="item")
+        results = databases.lookup(slug, table="item")
 
         self.slug = results["slug"]                                         # short English identifier
         self.name = T.translate(self.slug)                                  # translated name

--- a/tuxemon/core/item.py
+++ b/tuxemon/core/item.py
@@ -44,14 +44,6 @@ from tuxemon.core.locale import T
 
 logger = logging.getLogger(__name__)
 
-# Load the monster database
-items_db = db.JSONDatabase()
-items_db.load("item")
-
-# Load the inventory database
-inventory_db = db.JSONDatabase()
-inventory_db.load("inventory")
-
 
 class Item(object):
     """An item object is an item that can be used either in or out of combat.
@@ -119,7 +111,7 @@ class Item(object):
         }
         """
 
-        results = items_db.lookup(slug, table="item")
+        results = db.items_db.lookup(slug, table="item")
 
         self.slug = results["slug"]                                         # short English identifier
         self.name = T.translate(self.slug)                                  # translated name

--- a/tuxemon/core/item.py
+++ b/tuxemon/core/item.py
@@ -111,7 +111,7 @@ class Item(object):
         }
         """
 
-        results = db.items_db.lookup(slug, table="item")
+        results = db.databases.item.lookup(slug, table="item")
 
         self.slug = results["slug"]                                         # short English identifier
         self.name = T.translate(self.slug)                                  # translated name

--- a/tuxemon/core/item.py
+++ b/tuxemon/core/item.py
@@ -40,7 +40,7 @@ import pprint
 import random
 
 from tuxemon.core import tools
-from tuxemon.core.db import databases, process_targets
+from tuxemon.core.db import db, process_targets
 from tuxemon.core.locale import T
 
 logger = logging.getLogger(__name__)
@@ -112,7 +112,7 @@ class Item(object):
         }
         """
 
-        results = databases.lookup(slug, table="item")
+        results = db.lookup(slug, table="item")
 
         self.slug = results["slug"]                                         # short English identifier
         self.name = T.translate(self.slug)                                  # translated name

--- a/tuxemon/core/locale.py
+++ b/tuxemon/core/locale.py
@@ -56,21 +56,20 @@ class TranslatorPo(object):
     def __init__(self):
         self.locale = prepare.CONFIG.locale
         self.translate = None
-        self.languages = self.collect_languages()
-        self.build_translations()
-        self.load_locale(prepare.CONFIG.locale)
+        self.languages = []
 
     def collect_languages(self):
         """Collect languages/locales with available translation files."""
-        languages = []
+        self.languages = []
 
         for ld in os.listdir(prepare.fetch("l18n")):
             ld_full_path = os.path.join(prepare.fetch("l18n"), ld)
 
             if os.path.isdir(ld_full_path):
-                languages.append(ld)
+                self.languages.append(ld)
 
-        return languages
+        self.build_translations()
+        self.load_locale(prepare.CONFIG.locale)
 
     def build_translations(self):
         """Create MO files for existing PO translation files."""

--- a/tuxemon/core/monster.py
+++ b/tuxemon/core/monster.py
@@ -42,11 +42,6 @@ from tuxemon.core.technique import Technique
 
 logger = logging.getLogger(__name__)
 
-# Load the monster database
-monsters = db.JSONDatabase()
-monsters.load("monster")
-monsters.load("technique")
-
 SIMPLE_PERSISTANCE_ATTRIBUTES = (
     'current_hp',
     'level',
@@ -266,7 +261,7 @@ class Monster(object):
         """
 
         # Look up the monster by name and set the attributes in this instance
-        results = monsters.lookup(slug)
+        results = db.monster_db.lookup(slug)
 
         if results is None:
             logger.error("monster {} is not found".format(slug))
@@ -477,7 +472,7 @@ class Monster(object):
         if len(self.flairs) > 0 or self.slug == "":
             return
 
-        results = monsters.lookup(self.slug)
+        results = db.monster_db.lookup(self.slug)
         flairs = results.get("flairs")
         if flairs:
             for flair in flairs:

--- a/tuxemon/core/monster.py
+++ b/tuxemon/core/monster.py
@@ -262,7 +262,7 @@ class Monster(object):
         """
 
         # Look up the monster by name and set the attributes in this instance
-        results = db.lookup(slug)
+        results = db.lookup(slug, table="monster")
 
         if results is None:
             logger.error("monster {} is not found".format(slug))
@@ -473,7 +473,7 @@ class Monster(object):
         if len(self.flairs) > 0 or self.slug == "":
             return
 
-        results = db.lookup(self.slug)
+        results = db.lookup(self.slug, table="monster")
         flairs = results.get("flairs")
         if flairs:
             for flair in flairs:

--- a/tuxemon/core/monster.py
+++ b/tuxemon/core/monster.py
@@ -262,7 +262,7 @@ class Monster(object):
         """
 
         # Look up the monster by name and set the attributes in this instance
-        results = databases.monster.lookup(slug)
+        results = databases.lookup(slug)
 
         if results is None:
             logger.error("monster {} is not found".format(slug))
@@ -473,7 +473,7 @@ class Monster(object):
         if len(self.flairs) > 0 or self.slug == "":
             return
 
-        results = databases.monster.lookup(self.slug)
+        results = databases.lookup(self.slug)
         flairs = results.get("flairs")
         if flairs:
             for flair in flairs:

--- a/tuxemon/core/monster.py
+++ b/tuxemon/core/monster.py
@@ -38,7 +38,7 @@ import random
 from tuxemon.core import tools
 from tuxemon.core import ai, fusion
 from tuxemon.core.locale import T
-from tuxemon.core.db import databases
+from tuxemon.core.db import db
 from tuxemon.core.technique import Technique
 
 logger = logging.getLogger(__name__)
@@ -262,7 +262,7 @@ class Monster(object):
         """
 
         # Look up the monster by name and set the attributes in this instance
-        results = databases.lookup(slug)
+        results = db.lookup(slug)
 
         if results is None:
             logger.error("monster {} is not found".format(slug))
@@ -473,7 +473,7 @@ class Monster(object):
         if len(self.flairs) > 0 or self.slug == "":
             return
 
-        results = databases.lookup(self.slug)
+        results = db.lookup(self.slug)
         flairs = results.get("flairs")
         if flairs:
             for flair in flairs:

--- a/tuxemon/core/monster.py
+++ b/tuxemon/core/monster.py
@@ -261,7 +261,7 @@ class Monster(object):
         """
 
         # Look up the monster by name and set the attributes in this instance
-        results = db.monster_db.lookup(slug)
+        results = db.databases.monster.lookup(slug)
 
         if results is None:
             logger.error("monster {} is not found".format(slug))
@@ -472,7 +472,7 @@ class Monster(object):
         if len(self.flairs) > 0 or self.slug == "":
             return
 
-        results = db.monster_db.lookup(self.slug)
+        results = db.databases.monster.lookup(self.slug)
         flairs = results.get("flairs")
         if flairs:
             for flair in flairs:

--- a/tuxemon/core/monster.py
+++ b/tuxemon/core/monster.py
@@ -36,8 +36,9 @@ import logging
 import random
 
 from tuxemon.core import tools
-from tuxemon.core import ai, db, fusion
+from tuxemon.core import ai, fusion
 from tuxemon.core.locale import T
+from tuxemon.core.db import databases
 from tuxemon.core.technique import Technique
 
 logger = logging.getLogger(__name__)
@@ -261,7 +262,7 @@ class Monster(object):
         """
 
         # Look up the monster by name and set the attributes in this instance
-        results = db.databases.monster.lookup(slug)
+        results = databases.monster.lookup(slug)
 
         if results is None:
             logger.error("monster {} is not found".format(slug))
@@ -472,7 +473,7 @@ class Monster(object):
         if len(self.flairs) > 0 or self.slug == "":
             return
 
-        results = db.databases.monster.lookup(self.slug)
+        results = databases.monster.lookup(self.slug)
         flairs = results.get("flairs")
         if flairs:
             for flair in flairs:

--- a/tuxemon/core/npc.py
+++ b/tuxemon/core/npc.py
@@ -39,7 +39,8 @@ from math import hypot
 
 import pygame
 
-from tuxemon.core import db, monster, pyganim
+from tuxemon.core import monster, pyganim
+from tuxemon.core.db import databases
 from tuxemon.core.entity import Entity
 from tuxemon.core.item import Item
 from tuxemon.core.item import decode_inventory, encode_inventory
@@ -90,7 +91,7 @@ class NPC(Entity):
         super(NPC, self).__init__()
 
         # load initial data from the npc database
-        npc_data = db.databases.npc.lookup(npc_slug, table="npc")
+        npc_data = databases.npc.lookup(npc_slug, table="npc")
 
         self.slug = npc_slug
 
@@ -593,7 +594,7 @@ class NPC(Entity):
         self.monsters = []
 
         # Look up the NPC's details from our NPC database
-        npc_details = db.databases.npc.database['npc'][self.slug]
+        npc_details = databases.npc.database['npc'][self.slug]
         for npc_monster_details in npc_details['monsters']:
             current_monster = monster.Monster(save_data=npc_monster_details)
             current_monster.experience_give_modifier = npc_monster_details['exp_give_mod']

--- a/tuxemon/core/npc.py
+++ b/tuxemon/core/npc.py
@@ -91,7 +91,7 @@ class NPC(Entity):
         super(NPC, self).__init__()
 
         # load initial data from the npc database
-        npc_data = databases.npc.lookup(npc_slug, table="npc")
+        npc_data = databases.lookup(npc_slug, table="npc")
 
         self.slug = npc_slug
 
@@ -594,7 +594,7 @@ class NPC(Entity):
         self.monsters = []
 
         # Look up the NPC's details from our NPC database
-        npc_details = databases.npc.database['npc'][self.slug]
+        npc_details = databases.database['npc'][self.slug]
         for npc_monster_details in npc_details['monsters']:
             current_monster = monster.Monster(save_data=npc_monster_details)
             current_monster.experience_give_modifier = npc_monster_details['exp_give_mod']

--- a/tuxemon/core/npc.py
+++ b/tuxemon/core/npc.py
@@ -40,7 +40,7 @@ from math import hypot
 import pygame
 
 from tuxemon.core import monster, pyganim
-from tuxemon.core.db import databases
+from tuxemon.core.db import db
 from tuxemon.core.entity import Entity
 from tuxemon.core.item import Item
 from tuxemon.core.item import decode_inventory, encode_inventory
@@ -91,7 +91,7 @@ class NPC(Entity):
         super(NPC, self).__init__()
 
         # load initial data from the npc database
-        npc_data = databases.lookup(npc_slug, table="npc")
+        npc_data = db.lookup(npc_slug, table="npc")
 
         self.slug = npc_slug
 
@@ -594,7 +594,7 @@ class NPC(Entity):
         self.monsters = []
 
         # Look up the NPC's details from our NPC database
-        npc_details = databases.database['npc'][self.slug]
+        npc_details = db.database['npc'][self.slug]
         for npc_monster_details in npc_details['monsters']:
             current_monster = monster.Monster(save_data=npc_monster_details)
             current_monster.experience_give_modifier = npc_monster_details['exp_give_mod']

--- a/tuxemon/core/npc.py
+++ b/tuxemon/core/npc.py
@@ -90,7 +90,7 @@ class NPC(Entity):
         super(NPC, self).__init__()
 
         # load initial data from the npc database
-        npc_data = db.npc_db.lookup(npc_slug, table="npc")
+        npc_data = db.databases.npc.lookup(npc_slug, table="npc")
 
         self.slug = npc_slug
 
@@ -593,7 +593,7 @@ class NPC(Entity):
         self.monsters = []
 
         # Look up the NPC's details from our NPC database
-        npc_details = db.npc_db.database['npc'][self.slug]
+        npc_details = db.databases.npc.database['npc'][self.slug]
         for npc_monster_details in npc_details['monsters']:
             current_monster = monster.Monster(save_data=npc_monster_details)
             current_monster.experience_give_modifier = npc_monster_details['exp_give_mod']

--- a/tuxemon/core/npc.py
+++ b/tuxemon/core/npc.py
@@ -51,10 +51,6 @@ from tuxemon.core.tools import nearest, load_and_scale, trunc
 
 logger = logging.getLogger(__name__)
 
-# Load the NPC database
-npc_db = db.JSONDatabase()
-npc_db.load("npc")
-
 # reference direction and movement states to animation names
 # this dictionary is kinda wip, idk
 animation_mapping = {
@@ -94,7 +90,7 @@ class NPC(Entity):
         super(NPC, self).__init__()
 
         # load initial data from the npc database
-        npc_data = npc_db.lookup(npc_slug, table="npc")
+        npc_data = db.npc_db.lookup(npc_slug, table="npc")
 
         self.slug = npc_slug
 
@@ -597,9 +593,7 @@ class NPC(Entity):
         self.monsters = []
 
         # Look up the NPC's details from our NPC database
-        npcs = db.JSONDatabase()
-        npcs.load("npc")
-        npc_details = npcs.database['npc'][self.slug]
+        npc_details = db.npc_db.database['npc'][self.slug]
         for npc_monster_details in npc_details['monsters']:
             current_monster = monster.Monster(save_data=npc_monster_details)
             current_monster.experience_give_modifier = npc_monster_details['exp_give_mod']

--- a/tuxemon/core/prepare.py
+++ b/tuxemon/core/prepare.py
@@ -133,8 +133,8 @@ def pygame_init():
     T.collect_languages()
 
     # Configure databases
-    from tuxemon.core.db import databases
-    databases.load()
+    from tuxemon.core.db import db
+    db.load()
 
     logger.debug("pygame init")
     pg.init()

--- a/tuxemon/core/prepare.py
+++ b/tuxemon/core/prepare.py
@@ -128,6 +128,14 @@ def pygame_init():
 
     import pygame as pg
 
+    # Configure locale
+    from tuxemon.core.locale import T
+    T.collect_languages()
+
+    # Configure databases
+    from tuxemon.core import db
+    db.collect_databases()
+
     logger.debug("pygame init")
     pg.init()
     pg.display.set_caption(ORIGINAL_CAPTION)

--- a/tuxemon/core/prepare.py
+++ b/tuxemon/core/prepare.py
@@ -134,7 +134,7 @@ def pygame_init():
 
     # Configure databases
     from tuxemon.core.db import databases
-    databases.collect_databases()
+    databases.load()
 
     logger.debug("pygame init")
     pg.init()

--- a/tuxemon/core/prepare.py
+++ b/tuxemon/core/prepare.py
@@ -133,8 +133,8 @@ def pygame_init():
     T.collect_languages()
 
     # Configure databases
-    from tuxemon.core import db
-    db.collect_databases()
+    from tuxemon.core.db import databases
+    databases.collect_databases()
 
     logger.debug("pygame init")
     pg.init()

--- a/tuxemon/core/technique.py
+++ b/tuxemon/core/technique.py
@@ -99,7 +99,7 @@ class Technique(object):
         :rtype: None
         """
 
-        results = databases.technique.lookup(slug, table="technique")
+        results = databases.lookup(slug, table="technique")
         self.slug = results["slug"]                             # a short English identifier
         self.name = T.translate(self.slug)                      # locale-specific string
 

--- a/tuxemon/core/technique.py
+++ b/tuxemon/core/technique.py
@@ -46,11 +46,6 @@ from tuxemon.core.locale import T
 
 logger = logging.getLogger(__name__)
 
-
-# Load the technique database
-techniques_db = db.JSONDatabase()
-techniques_db.load("technique")
-
 tech_ret_value = namedtuple("use", "name success properties")
 
 
@@ -104,7 +99,7 @@ class Technique(object):
         :rtype: None
         """
 
-        results = techniques_db.lookup(slug, table="technique")
+        results = db.techniques_db.lookup(slug, table="technique")
         self.slug = results["slug"]                             # a short English identifier
         self.name = T.translate(self.slug)                      # locale-specific string
 

--- a/tuxemon/core/technique.py
+++ b/tuxemon/core/technique.py
@@ -40,9 +40,9 @@ import random
 from collections import namedtuple
 
 from tuxemon.core import prepare
-from tuxemon.core import db
 from tuxemon.core import formula
 from tuxemon.core.locale import T
+from tuxemon.core.db import databases, process_targets
 
 logger = logging.getLogger(__name__)
 
@@ -99,7 +99,7 @@ class Technique(object):
         :rtype: None
         """
 
-        results = db.databases.technique.lookup(slug, table="technique")
+        results = databases.technique.lookup(slug, table="technique")
         self.slug = results["slug"]                             # a short English identifier
         self.name = T.translate(self.slug)                      # locale-specific string
 
@@ -133,7 +133,7 @@ class Technique(object):
         self.accuracy = results.get("accuracy")
         self.potency = results.get("potency")
         self.effect = results["effects"]
-        self.target = db.process_targets(results["target"])
+        self.target = process_targets(results["target"])
 
         # Load the animation sprites that will be used for this technique
         self.animation = results["animation"]

--- a/tuxemon/core/technique.py
+++ b/tuxemon/core/technique.py
@@ -99,7 +99,7 @@ class Technique(object):
         :rtype: None
         """
 
-        results = db.techniques_db.lookup(slug, table="technique")
+        results = db.databases.technique.lookup(slug, table="technique")
         self.slug = results["slug"]                             # a short English identifier
         self.name = T.translate(self.slug)                      # locale-specific string
 

--- a/tuxemon/core/technique.py
+++ b/tuxemon/core/technique.py
@@ -42,7 +42,7 @@ from collections import namedtuple
 from tuxemon.core import prepare
 from tuxemon.core import formula
 from tuxemon.core.locale import T
-from tuxemon.core.db import databases, process_targets
+from tuxemon.core.db import db, process_targets
 
 logger = logging.getLogger(__name__)
 
@@ -99,7 +99,7 @@ class Technique(object):
         :rtype: None
         """
 
-        results = databases.lookup(slug, table="technique")
+        results = db.lookup(slug, table="technique")
         self.slug = results["slug"]                             # a short English identifier
         self.name = T.translate(self.slug)                      # locale-specific string
 


### PR DESCRIPTION
Fixes #620

Due to the fact that locale and database paths were read instantly at startup, they did not have time to catch the mods being added to the mod list. As a result some resources could only be read from mods/tuxemon and never mods/<my_game> making the mod loaded unusable.

This required a bit of refractoring to locale and databases, which now receive the signal to load their data from pygame_init after the base settings have been set. As a bonus, this PR cleans up the database code and also removes several cases of databases being pointlessly loaded more than once.

I tested this as thoroughly as I could and am not seeing any issues: This PR loads fine for both stock Tuxemon as well as my custom game directory. Further testing is encouraged still.