### PR TITLE
Don't allow collision tiles with explicit exits to push the player into other solids

### DIFF
--- a/tuxemon/core/states/world/worldstate.py
+++ b/tuxemon/core/states/world/worldstate.py
@@ -588,7 +588,7 @@ class WorldState(state.State):
         # does the tile explicitly define exits?
         try:
             adjacent_tiles = list()
-            for direction in tile["exit"]:
+            for direction in tile['exit']:
                 exit_tile = tuple(dirs2[direction] + position)
                 if exit_tile in skip_nodes:
                     continue
@@ -617,14 +617,11 @@ class WorldState(state.State):
         if skip_nodes is None:
             skip_nodes = set()
 
-        # if there are explicit way to exit this position use that
-        # information only and do not check surrounding tiles.
+        # if there are explicit way to exit this position use that information,
         # handles 'continue' and 'exits'
         tile_data = collision_map.get(position)
         if tile_data:
             exits = self.get_explicit_tile_exits(position, tile_data, skip_nodes)
-            if exits:
-                return exits
 
         # get exits by checking surrounding tiles
         adjacent_tiles = list()
@@ -634,6 +631,11 @@ class WorldState(state.State):
                 ("up", (position[0], position[1] - 1)),
                 ("left", (position[0] - 1, position[1])),
         ):
+            # if exits are defined make sure the neighbor is present there
+            if exits and not neighbor in exits:
+                continue
+
+            # check if the neighbor region is present in skipped nodes
             if neighbor in skip_nodes:
                 continue
 

--- a/tuxemon/core/states/world/worldstate.py
+++ b/tuxemon/core/states/world/worldstate.py
@@ -641,7 +641,7 @@ class WorldState(state.State):
 
             # We only need to check the perimeter,
             # as there is no way to get further out of bounds
-            if position[0] in self.invalid_x or position[1] in self.invalid_y:
+            if neighbor[0] in self.invalid_x or neighbor[1] in self.invalid_y:
                 continue
 
             # check to see if this tile is separated by a wall
@@ -921,8 +921,8 @@ class WorldState(state.State):
         self.map_size = map_data["map_size"]
 
         # The first coordinates that are out of bounds.
-        self.invalid_x = (-1, self.map_size[0] + 1)
-        self.invalid_y = (-1, self.map_size[1] + 1)
+        self.invalid_x = (-1, self.map_size[0])
+        self.invalid_y = (-1, self.map_size[1])
 
         # TODO: remove this monkey [patching!] business for the main control/game
         self.game.events = map_data["events"]

--- a/tuxemon/core/states/world/worldstate.py
+++ b/tuxemon/core/states/world/worldstate.py
@@ -581,14 +581,14 @@ class WorldState(state.State):
 
         # does the tile define continue movements?
         try:
-            return [tuple(dirs2[tile['continue']] + position)]
+            return [tuple(dirs2[tile["continue"]] + position)]
         except KeyError:
             pass
 
         # does the tile explicitly define exits?
         try:
             adjacent_tiles = list()
-            for direction in tile['exit']:
+            for direction in tile["exit"]:
                 exit_tile = tuple(dirs2[direction] + position)
                 if exit_tile in skip_nodes:
                     continue
@@ -662,7 +662,7 @@ class WorldState(state.State):
                     continue
 
                 try:
-                    if pairs[direction] not in tile_data['enter']:
+                    if pairs[direction] not in tile_data["enter"]:
                         continue
                 except KeyError:
                     continue


### PR DESCRIPTION
Fixes #617 and now also fixes #629

Previously collision tiles with the "exit_to" property would always let the player exit in that direction, even if another collision was present which doesn't allow entry from that position. This resulted in the player walking into walls and getting stuck or ending up in out of bounds areas, if stepping onto such a tile which neighbored another solid. Collisions with the exit_to parameter will now only allow the player to exit there if that direction isn't itself blocked.

Tested on my maps which make use of complex enter_from and exit_to statements and collision mixtures. Everything seems to be working exactly as intended after this change.