### PR TITLE
Fix transition_teleport being triggered twice when teleporting to the same map

### DIFF
--- a/tuxemon/core/event/actions/transition_teleport.py
+++ b/tuxemon/core/event/actions/transition_teleport.py
@@ -57,15 +57,19 @@ class TransitionTeleportAction(EventAction):
     ]
 
     def start(self):
-        # Start the screen transition
-        params = [self.parameters.transition_time]
-        self.transition = self.game.event_engine.get_action("screen_transition", params)
-        self.transition.start()
+        # Start the screen transition if one isn't already underway
+        world = self.game.get_state_name("WorldState")
+        if not world.in_transition:
+            params = [self.parameters.transition_time]
+            self.transition = self.game.event_engine.get_action("screen_transition", params)
+            self.transition.start()
 
     def update(self):
-        if not self.transition.done:
+        if not hasattr(self, 'transition'):
+            self.stop()
+        elif not self.transition.done:
             self.transition.update()
-        if self.transition.done:
+        else:
             self.transition.cleanup()
             # set the delayed teleport
             self.game.event_engine.execute_action("delayed_teleport", self.raw_parameters[:-1])


### PR DESCRIPTION
Fixes #621

When transition_teleport takes you to the same map the event was run on, it will trigger two times instead of just once as it does otherwise. I fixed this by ensuring the event doesn't execute again if a transition is still registered as running.

I don't know if this is considered the cleanest solution. I tried everything I could think of from transition_teleport.py but nothing else worked. This solves the issue without breaking anything else.