### PR TITLE
Fix crash when event objects don't have a name set

### DIFF
--- a/tuxemon/core/states/world/worldstate.py
+++ b/tuxemon/core/states/world/worldstate.py
@@ -940,7 +940,7 @@ class WorldState(state.State):
 
         # move to spawn position, if any
         for eo in self.game.events:
-            if eo.name.lower() == "player spawn":
+            if eo.name and eo.name.lower() == "player spawn":
                 self.player1.set_position((eo.x, eo.y))
 
     def load_map(self, map_name):


### PR DESCRIPTION
Fixes #622

Prevents the engine from crashing if an event object lacks a name. Tested both the fix as well as ensuring Player Start objects still work in new games.