### PR TITLE
Prevent crashing when loading a map that contains no tilesets

### DIFF
--- a/tuxemon/core/map.py
+++ b/tuxemon/core/map.py
@@ -253,7 +253,7 @@ class Map(object):
         self.size = self.data.width, self.data.height
 
         # Get the tile size of the map
-        self.tile_size = self.size
+        self.tile_size = 16, 16
         if len(self.data.tilesets) > 0:
             self.tile_size = self.data.tilesets[0].tilewidth, self.data.tilesets[0].tileheight
 

--- a/tuxemon/core/map.py
+++ b/tuxemon/core/map.py
@@ -253,7 +253,9 @@ class Map(object):
         self.size = self.data.width, self.data.height
 
         # Get the tile size of the map
-        self.tile_size = self.data.tilesets[0].tilewidth, self.data.tilesets[0].tileheight
+        self.tile_size = self.size
+        if len(self.data.tilesets) > 0:
+            self.tile_size = self.data.tilesets[0].tilewidth, self.data.tilesets[0].tileheight
 
         # Load all objects from the map file and sort them by their type.
         for obj in self.data.objects:

--- a/tuxemon/core/map.py
+++ b/tuxemon/core/map.py
@@ -253,9 +253,10 @@ class Map(object):
         self.size = self.data.width, self.data.height
 
         # Get the tile size of the map
-        self.tile_size = 16, 16
         if len(self.data.tilesets) > 0:
             self.tile_size = self.data.tilesets[0].tilewidth, self.data.tilesets[0].tileheight
+        else:
+            self.tile_size = 16, 16
 
         # Load all objects from the map file and sort them by their type.
         for obj in self.data.objects:

--- a/tuxemon/core/map.py
+++ b/tuxemon/core/map.py
@@ -253,10 +253,10 @@ class Map(object):
         self.size = self.data.width, self.data.height
 
         # Get the tile size of the map
-        if len(self.data.tilesets) > 0:
+        if self.data.tilesets:
             self.tile_size = self.data.tilesets[0].tilewidth, self.data.tilesets[0].tileheight
         else:
-            self.tile_size = 16, 16
+            self.tile_size = prepare.TILE_SIZE
 
         # Load all objects from the map file and sort them by their type.
         for obj in self.data.objects:


### PR DESCRIPTION
I noticed that if you load a map which has no tiles painted on it, the engine will crash when attempting to get the tileset height / width (even when a tile layer does exist). While normally no one should ever be doing this, it does hinder a few testing cases. As a solution was simple I tested and submitted a fix.