### PR TITLE
Prefix saves with their mod path

### DIFF
--- a/tuxemon/core/prepare.py
+++ b/tuxemon/core/prepare.py
@@ -108,7 +108,7 @@ else:
     SCALE = 1
 
 # Reference user save dir
-SAVE_PATH = os.path.join(paths.USER_GAME_SAVE_DIR, "slot")
+SAVE_PATH = paths.USER_GAME_SAVE_DIR
 SAVE_METHOD = "JSON"
 # SAVE_METHOD = "CBOR"
 

--- a/tuxemon/core/save.py
+++ b/tuxemon/core/save.py
@@ -37,6 +37,7 @@ import base64
 import datetime
 import json
 import logging
+import os.path
 from operator import itemgetter
 
 import pygame
@@ -97,7 +98,7 @@ def save(save_data, slot):
 
     """
     # Save a screenshot of the current frame
-    save_path = prepare.SAVE_PATH + str(slot) + '.save'
+    save_path = get_save_path(slot)
     if prepare.SAVE_METHOD == "CBOR":
         text = cbor.dumps(save_data)
     else:
@@ -123,7 +124,7 @@ def load(slot):
 
     """
 
-    save_path = '{}{}.save'.format(prepare.SAVE_PATH, slot)
+    save_path = get_save_path(slot)
     save_data = open_save_file(save_path)
     if save_data:
         return upgrade_save(save_data)
@@ -178,7 +179,7 @@ def upgrade_save(save_data):
 def get_index_of_latest_save():
     times = []
     for slot_index in range(3):
-        save_path = '{}{}.save'.format(prepare.SAVE_PATH, slot_index + 1)
+        save_path = get_save_path(slot_index + 1)
         save_data = open_save_file(save_path)
         if save_data is not None:
             time_of_save = datetime.datetime.strptime(save_data['time'], TIME_FORMAT)
@@ -189,3 +190,10 @@ def get_index_of_latest_save():
     else:
         return None
 
+
+def get_save_path(slot):
+    # append the mod name if this is a custom game	
+    if len(prepare.CONFIG.mods) > 1:
+        return os.path.join(prepare.SAVE_PATH, '{}-slot{}.save'.format(prepare.CONFIG.mods[0], slot))
+    else:
+        return os.path.join(prepare.SAVE_PATH, 'slot{}.save'.format(slot))

--- a/tuxemon/core/save.py
+++ b/tuxemon/core/save.py
@@ -192,9 +192,10 @@ def get_index_of_latest_save():
 
 
 def get_save_path(slot):
-    # append the mod names if this is a custom game	
-    mods = ""
-    if len(prepare.CONFIG.mods) > 1:
-        for i in range(0, len(prepare.CONFIG.mods) - 1):
-            mods += prepare.CONFIG.mods[i] + "-"
-    return os.path.join(prepare.SAVE_PATH, '{}slot{}.save'.format(mods, slot))
+    # The last element is always "tuxemon", ignore it
+    mods = prepare.CONFIG.mods[:-1]
+    if mods:
+        mod_prefix = "-".join(mods) + "-"
+    else:
+        mod_prefix = ""
+    return os.path.join(prepare.SAVE_PATH, '{}slot{}.save'.format(mod_prefix, slot))

--- a/tuxemon/core/save.py
+++ b/tuxemon/core/save.py
@@ -192,8 +192,9 @@ def get_index_of_latest_save():
 
 
 def get_save_path(slot):
-    # append the mod name if this is a custom game	
+    # append the mod names if this is a custom game	
+    mods = ""
     if len(prepare.CONFIG.mods) > 1:
-        return os.path.join(prepare.SAVE_PATH, '{}-slot{}.save'.format(prepare.CONFIG.mods[0], slot))
-    else:
-        return os.path.join(prepare.SAVE_PATH, 'slot{}.save'.format(slot))
+        for i in range(0, len(prepare.CONFIG.mods) - 1):
+            mods += prepare.CONFIG.mods[i] + "-"
+    return os.path.join(prepare.SAVE_PATH, '{}slot{}.save'.format(mods, slot))

--- a/tuxemon/core/states/persistance/save_menu.py
+++ b/tuxemon/core/states/persistance/save_menu.py
@@ -35,7 +35,7 @@ class SaveMenuState(PopUpMenu):
         slot_rect = pygame.Rect(0, 0, rect.width * 0.80, rect.height // 6)
         for i in range(self.number_of_slots):
             # Check to see if a save exists for the current slot
-            if os.path.exists(prepare.SAVE_PATH + str(i + 1) + ".save"):
+            if os.path.exists(save.get_save_path(i + 1)):
                 image = self.render_slot(slot_rect, i + 1)
                 item = MenuItem(image, T.translate('menu_save'), None, None)
                 self.add(item)


### PR DESCRIPTION
An attempted solution for #614 Tested and seems to be working as intended in all circumstances.

I tried addressing the issue of saves with mods in the way I found most elegant. Currently slots can be saved and loaded indiscriminately between mods, which is guaranteed to cause trouble as mod directories contain different assets. Save files need to be per-mod in some form.

@bitcraft proposed storing the mod as a property of the save. As I mentioned on the issue, the results of this would be rather ugly with the current system: If you made a save to a slot in one mod then looked at that slot from another mod, you'd need to see a field saying "slot incompatible" which would essentially mean you're unable to make use of it. 3 slots is also little as it is, the user couldn't store saves for more than 3 mods at a time in this scenario.

The PR adds a common function for fetching save paths, which prefixes the save file with the name of the mod(s) in use. This always excludes the default mod: Existing saves for vanilla Tuxemon will require no changes and still work as they have until now. So if you're running the stock game your save will still be called `slot1.save` but if you're running mymod it will now be `mymod-slot1.save`

I understand if this approach may be questioned, though IMO it is the cleanest way available at the moment. The alternative would be a new save system not based on slots, which would require large scale refractoring and be its own project for later down the road.