### PR TITLE
Fix crash when setting statuses due to missing technique name

### DIFF
--- a/tuxemon/core/locale.py
+++ b/tuxemon/core/locale.py
@@ -134,6 +134,16 @@ class TranslatorPo(object):
         else:
             return text
 
+    def maybe_translate(self, text):
+        """ Try to translate the text. If None, return empty string
+
+        :param Optional[str] text: Text to translate
+        :rtype: str
+        """
+        if text is None:
+            return ""
+        else:
+            return self.translate(text)
 
 class Translator(object):
 

--- a/tuxemon/core/states/combat/combat.py
+++ b/tuxemon/core/states/combat/combat.py
@@ -677,7 +677,7 @@ class CombatState(CombatAnimations):
 
                 for status in result.get("statuses", []):
                     m = T.format(status.use_item,
-                                 {"user": status.link.name if status.link else "", "target": status.carrier.name})
+                                 {"name": technique.name, "user": status.link.name if status.link else "", "target": status.carrier.name})
                     message += "\n" + m
 
             else:  # assume this was an item used

--- a/tuxemon/core/technique.py
+++ b/tuxemon/core/technique.py
@@ -83,6 +83,9 @@ class Technique(object):
         self.slug = slug
         self.type1 = "aether"
         self.type2 = None
+        self.use_item = ""
+        self.use_success = ""
+        self.use_failure = ""
 
         # If a slug of the technique was provided, autoload it.
         if slug:
@@ -107,9 +110,12 @@ class Technique(object):
 
         # technique use notifications (translated!)
         # NOTE: should be `self.use_tech`, but Technique and Item have overlapping checks
-        self.use_item = T.translate(results["use_tech"])
-        self.use_success = T.translate(results["use_success"])
-        self.use_failure = T.translate(results["use_failure"])
+        try:
+            self.use_item = T.translate(results["use_tech"])
+            self.use_success = T.translate(results["use_success"])
+            self.use_failure = T.translate(results["use_failure"])
+        except KeyError:
+            logger.debug("Missing technique dialog")
 
         self.category = results["category"]
         self.icon = results["icon"]

--- a/tuxemon/core/technique.py
+++ b/tuxemon/core/technique.py
@@ -112,10 +112,16 @@ class Technique(object):
         # NOTE: should be `self.use_tech`, but Technique and Item have overlapping checks
         try:
             self.use_item = T.translate(results["use_tech"])
+        except KeyError:
+            logger.debug("Missing technique dialog use_tech")
+        try:
             self.use_success = T.translate(results["use_success"])
+        except KeyError:
+            logger.debug("Missing technique dialog use_success")
+        try:
             self.use_failure = T.translate(results["use_failure"])
         except KeyError:
-            logger.debug("Missing technique dialog")
+            logger.debug("Missing technique dialog use_failure")
 
         self.category = results["category"]
         self.icon = results["icon"]

--- a/tuxemon/core/technique.py
+++ b/tuxemon/core/technique.py
@@ -83,9 +83,9 @@ class Technique(object):
         self.slug = slug
         self.type1 = "aether"
         self.type2 = None
-        self.use_item = ""
-        self.use_success = ""
-        self.use_failure = ""
+        self.use_item = None
+        self.use_success = None
+        self.use_failure = None
 
         # If a slug of the technique was provided, autoload it.
         if slug:
@@ -110,18 +110,9 @@ class Technique(object):
 
         # technique use notifications (translated!)
         # NOTE: should be `self.use_tech`, but Technique and Item have overlapping checks
-        try:
-            self.use_item = T.translate(results["use_tech"])
-        except KeyError:
-            logger.debug("Missing technique dialog use_tech")
-        try:
-            self.use_success = T.translate(results["use_success"])
-        except KeyError:
-            logger.debug("Missing technique dialog use_success")
-        try:
-            self.use_failure = T.translate(results["use_failure"])
-        except KeyError:
-            logger.debug("Missing technique dialog use_failure")
+        self.use_item = T.maybe_translate(results.get("use_tech"))
+        self.use_success = T.maybe_translate(results.get("use_success"))
+        self.use_failure = T.maybe_translate(results.get("use_failure"))
 
         self.category = results["category"]
         self.icon = results["icon"]


### PR DESCRIPTION
A crash occurs when a technique sets a monster status, such as poison:

```
Traceback (most recent call last):
  File "./tuxemon.py", line 62, in <module>
    main.main(load_slot=args.slot)
  File "/home/mircea/Games/Small/Python/Tuxemon/Tuxemon_GIT/tuxemon/core/main.py", line 106, in main
    control.main()
  File "/home/mircea/Games/Small/Python/Tuxemon/Tuxemon_GIT/tuxemon/core/control.py", line 250, in main
    update(clock_tick)
  File "/home/mircea/Games/Small/Python/Tuxemon/Tuxemon_GIT/tuxemon/core/control.py", line 304, in update
    self.update_states(time_delta)
  File "/home/mircea/Games/Small/Python/Tuxemon/Tuxemon_GIT/tuxemon/core/control.py", line 328, in update_states
    state.update(dt)
  File "/home/mircea/Games/Small/Python/Tuxemon/Tuxemon_GIT/tuxemon/core/states/combat/combat.py", line 149, in update
    self.update_phase()
  File "/home/mircea/Games/Small/Python/Tuxemon/Tuxemon_GIT/tuxemon/core/states/combat/combat.py", line 402, in update_phase
    self.handle_action_queue()
  File "/home/mircea/Games/Small/Python/Tuxemon/Tuxemon_GIT/tuxemon/core/states/combat/combat.py", line 414, in handle_action_queue
    self.perform_action(*action)
  File "/home/mircea/Games/Small/Python/Tuxemon/Tuxemon_GIT/tuxemon/core/states/combat/combat.py", line 680, in perform_action
    {"user": status.link.name if status.link else "", "target": status.carrier.name})
  File "/home/mircea/Games/Small/Python/Tuxemon/Tuxemon_GIT/tuxemon/core/locale.py", line 134, in format
    return text.format(**parameters)
KeyError: u'name'
```

I fixed by adding the missing technique name parameter. Tested and poison status works again.