### PR TITLE
Fix avatar conflicting with value translation parameters in translated dialog events

### DIFF
--- a/tuxemon/core/event/actions/translated_dialog.py
+++ b/tuxemon/core/event/actions/translated_dialog.py
@@ -43,6 +43,11 @@ class TranslatedDialogAction(EventAction):
 
     * ${{name}} - The current player's name.
 
+    Parameters following the translation name may represent one of two things:
+    If a parameter is var1=value1, it represents a value replacement.
+    If it's a single value (an integer or a string), it will be used as an avatar image.
+    TODO: This is a hack and should be fixed later on, ideally without overloading the parameters.
+
     **Examples:**
 
     >>> action.__dict__
@@ -57,18 +62,21 @@ class TranslatedDialogAction(EventAction):
     """
     name = "translated_dialog"
 
-    valid_parameters = [
-        (str, "key"),
-        (str, "avatar")
-    ]
-
     def start(self):
-        avatar = get_avatar(self.game, self.parameters.avatar)
+        key = self.raw_parameters[0]
+        replace = []
+        avatar = None
+        for param in self.raw_parameters[1:]:
+            if "=" in param:
+                replace.append(param)
+            else:
+                avatar = get_avatar(self.game, param)
+
         self.open_dialog(
             process_translate_text(
                 self.game,
-                self.parameters.key,
-                self.raw_parameters[1:],
+                key,
+                replace,
             ), avatar
         )
 

--- a/tuxemon/core/event/actions/translated_dialog_chain.py
+++ b/tuxemon/core/event/actions/translated_dialog_chain.py
@@ -43,6 +43,11 @@ class TranslatedDialogChainAction(EventAction):
     * ${{name}} - The current player's name.
     * ${{end}} - Ends the dialog chain.
 
+    Parameters following the translation name may represent one of two things:
+    If a parameter is var1=value1, it represents a value replacement.
+    If it's a single value (an integer or a string), it will be used as an avatar image.
+    TODO: This is a hack and should be fixed later on, ideally without overloading the parameters.
+
     **Examples:**
 
     >>> action.__dict__
@@ -56,13 +61,16 @@ class TranslatedDialogChainAction(EventAction):
 
     """
     name = "translated_dialog_chain"
-    valid_parameters = [
-        (str, "key"),
-        (str, "avatar")
-    ]
 
     def start(self):
-        key = self.parameters.key
+        key = self.raw_parameters[0]
+        replace = []
+        avatar = None
+        for param in self.raw_parameters[1:]:
+            if "=" in param:
+                replace.append(param)
+            else:
+                avatar = get_avatar(self.game, param)
 
         # If text is "${{end}}, then close the current dialog
         if key == "${{end}}":
@@ -73,18 +81,18 @@ class TranslatedDialogChainAction(EventAction):
         pages = process_translate_text(
             self.game,
             key,
-            self.raw_parameters[1:],
+            replace,
         )
 
         dialog = self.game.get_state_name("DialogState")
         if dialog:
             dialog.text_queue += pages
         else:
-            avatar = get_avatar(self.game, self.parameters.avatar)
             self.open_dialog(pages, avatar)
 
     def update(self):
-        if self.parameters.key == "${{end}}":
+        key = self.raw_parameters[0]
+        if key == "${{end}}":
             if self.game.get_state_name("DialogState") is None:
                 self.stop()
 


### PR DESCRIPTION
translated_dialog and translated_dialog_chain used parameters following the text to replace certain variables. This conflicts with avatars, which added a second parameter oblivious to this. The issue is resolved by treating params containing var1=val1 as replacements and everything else as an avatar.