### PR TITLE
Choice menus have an optional escape_key_exists parameter

### DIFF
--- a/tuxemon/core/event/actions/open_shop.py
+++ b/tuxemon/core/event/actions/open_shop.py
@@ -58,4 +58,4 @@ class OpenShopAction(EventAction):
             ("Sell", "Sell", sell_menu),
         ]
 
-        return self.game.push_state("ChoiceState", menu=var_menu)
+        return self.game.push_state("ChoiceState", menu=var_menu, escape_key_exits=True)

--- a/tuxemon/core/states/choice/__init__.py
+++ b/tuxemon/core/states/choice/__init__.py
@@ -16,11 +16,12 @@ class ChoiceState(PopUpMenu):
     * if there are no more messages, then the dialog will close
     """
     shrink_to_items = True
+    escape_key_exits = None
 
     def startup(self, **kwargs):
         super(ChoiceState, self).startup(**kwargs)
         self.menu = kwargs.get("menu", list())
-        self.escape_key_exits = kwargs.get("escape_key_exits",False)
+        self.escape_key_exits = kwargs.get("escape_key_exits", False)
 
     def initialize_items(self):
         for key, label, callback in self.menu:

--- a/tuxemon/core/states/choice/__init__.py
+++ b/tuxemon/core/states/choice/__init__.py
@@ -16,11 +16,11 @@ class ChoiceState(PopUpMenu):
     * if there are no more messages, then the dialog will close
     """
     shrink_to_items = True
-    escape_key_exits = False
 
     def startup(self, **kwargs):
         super(ChoiceState, self).startup(**kwargs)
         self.menu = kwargs.get("menu", list())
+        self.escape_key_exits = kwargs.get("escape_key_exits",False)
 
     def initialize_items(self):
         for key, label, callback in self.menu:


### PR DESCRIPTION
This is both a 'learning assignment' for me and a player UX thing.
I personally found it very annoying that at the shop, you need to either pick 'buy' or 'sell' and you can't just exit without picking either one
I think that there will probably be may choices like this where you will just want to exit the conversation, and so I added an optional parameter to enable that
All other existing usages of ChoiceState are unchanged