### PR TITLE
Only print "way is blocked" errors for NPC's

### DIFF
--- a/tuxemon/core/npc.py
+++ b/tuxemon/core/npc.py
@@ -467,12 +467,14 @@ class NPC(Entity):
 
             if self.pathfinding:
                 # since we are pathfinding, just try a new path
-                logger.error('{} finding new path!'.format(self.slug))
+                if not self.isplayer:
+                    logger.error('{} finding new path!'.format(self.slug))
                 self.pathfind(self.pathfinding)
 
             else:
                 # give up and wait until the target is clear again
-                logger.error('{} waiting because way is blocked!'.format(self.slug))
+                if not self.isplayer:
+                    logger.error('{} waiting because way is blocked!'.format(self.slug))
 
     def check_waypoint(self):
         """ Check if the waypoint is reached and sets new waypoint if so

--- a/tuxemon/core/npc.py
+++ b/tuxemon/core/npc.py
@@ -467,12 +467,12 @@ class NPC(Entity):
 
             if self.pathfinding:
                 # since we are pathfinding, just try a new path
-                if not self.isplayer:
-                    logger.error('{} finding new path!'.format(self.slug))
+                logger.error('{} finding new path!'.format(self.slug))
                 self.pathfind(self.pathfinding)
 
             else:
                 # give up and wait until the target is clear again
+                # don't log errors for the player, this causes console spam when walking into a wall
                 if not self.isplayer:
                     logger.error('{} waiting because way is blocked!'.format(self.slug))
 


### PR DESCRIPTION
One very annoying issue has been around for a long time: Whenever the player is walking into a wall, the console is spammed each frame with the following message:

`2020-02-04 03:56:39,613 - tuxemon.core.npc - ERROR - npc_red waiting because way is blocked!`

![Screenshot_20200204_034814](https://user-images.githubusercontent.com/825418/73706896-6fd5a300-4702-11ea-9502-06f25e926275.png)

This is quite bothersome and makes looking at other things harder. Sometimes I need to avoid bumping into anything just to keep the console output clean and notice other logs.

For the time being I added a simple fix: Don't print the message for the player, just for other NPC's on the map. It appears those logs were intended to debug pathfinding and characters getting stuck... printing them over the player hitting a wall was probably a side effect altogether?

I'm not sure if that entire code block should be put inside of a `if not self.isplayer:`. Let me know if and how I can better change or format this if the modification itself is okay.