### PR TITLE
Fix crashes in worldstate.py and variable_math.py

### DIFF
--- a/tuxemon/core/event/actions/variable_math.py
+++ b/tuxemon/core/event/actions/variable_math.py
@@ -40,7 +40,7 @@ class VariableMathAction(EventAction):
     valid_parameters = [
         (str, "var"),
         (str, "operation"),
-        (float, "value")
+        (str, "value")
     ]
 
     def start(self):
@@ -49,9 +49,9 @@ class VariableMathAction(EventAction):
 
         # Read the parameters
         var = self.parameters.var
-        operand1 = number_or_variable(game, var)
+        operand1 = number_or_variable(self.game, var)
         operation = self.parameters.operation
-        operand2 = number_or_variable(game, self.parameters.value)
+        operand2 = number_or_variable(self.game, self.parameters.value)
 
         # Preform the operation on the variable
         if operation == "+":

--- a/tuxemon/core/states/world/worldstate.py
+++ b/tuxemon/core/states/world/worldstate.py
@@ -622,6 +622,8 @@ class WorldState(state.State):
         tile_data = collision_map.get(position)
         if tile_data:
             exits = self.get_explicit_tile_exits(position, tile_data, skip_nodes)
+        else:
+            exits = None
 
         # get exits by checking surrounding tiles
         adjacent_tiles = list()


### PR DESCRIPTION
Two crashes were discovered by myself and other users, introduced by some of the recent changes I worked on. I fixed both and tested the fixes.

One was caused in worldstate.py by my change to collision exits causing a variable to be accessed before being referenced. The other fixes a type error in variable_math.py, as well as calling a function with `game` rather than `self.game`.