### PR TITLE
Collisions NPC filter

### DIFF
--- a/tuxemon/core/map.py
+++ b/tuxemon/core/map.py
@@ -451,6 +451,8 @@ class Map(object):
                                 tile_conditions['exit'] = exits
                             if "continue" in key:
                                 tile_conditions['continue'] = collision_region.properties[key]
+                            if "blocks" in key:
+                                tile_conditions['blocks'] = collision_region.properties[key]
                         collision_map[collision_tile] = tile_conditions
 
         # Similar to collisions, except we need to identify the tiles

--- a/tuxemon/core/map.py
+++ b/tuxemon/core/map.py
@@ -452,7 +452,7 @@ class Map(object):
                             if "continue" in key:
                                 tile_conditions['continue'] = collision_region.properties[key]
                             if "blocks" in key:
-                                tile_conditions['blocks'] = collision_region.properties[key]
+                                tile_conditions['blocks'] = collision_region.properties[key].split()
                         collision_map[collision_tile] = tile_conditions
 
         # Similar to collisions, except we need to identify the tiles

--- a/tuxemon/core/map.py
+++ b/tuxemon/core/map.py
@@ -41,6 +41,7 @@ import pytmx
 from pytmx.util_pygame import load_pygame
 
 from tuxemon.core import prepare
+from tuxemon.core.db import db
 from tuxemon.core.euclid import Vector2, Vector3, Point2
 from tuxemon.core.event import EventObject
 from tuxemon.core.event import MapAction
@@ -452,7 +453,14 @@ class Map(object):
                             if "continue" in key:
                                 tile_conditions['continue'] = collision_region.properties[key]
                             if "blocks" in key:
-                                tile_conditions['blocks'] = collision_region.properties[key].split()
+                                # make sure each block parameter is valid before adding it
+                                tile_conditions['blocks'] = []
+                                for block in collision_region.properties[key].split():
+                                    if block == "players" or block == "npcs" or block in db.database['npc']:
+                                        tile_conditions['blocks'].append(block)
+                                    else:
+                                        logger.error("invalid collision block {}".format(block))
+                                        raise ValueError
                         collision_map[collision_tile] = tile_conditions
 
         # Similar to collisions, except we need to identify the tiles

--- a/tuxemon/core/states/world/worldstate.py
+++ b/tuxemon/core/states/world/worldstate.py
@@ -619,18 +619,12 @@ class WorldState(state.State):
         """
         if entity and tile and 'blocks' in tile:
             for block in tile['blocks']:
-                if block == 'players':
-                    if entity.isplayer:
-                        return True
-                elif block == 'npcs':
-                    if not entity.isplayer:
-                        return True
-                elif block in self.npcs:
-                    if block == entity.slug:
-                        return True
-                else:
-                    logger.error("invalid collision block {}".format(block))
-                    raise ValueError
+                if block == 'players' and entity.isplayer:
+                    return True
+                if block == 'npcs' and not entity.isplayer:
+                    return True
+                if block == entity.slug:
+                    return True
             return False
         return True
 

--- a/tuxemon/core/states/world/worldstate.py
+++ b/tuxemon/core/states/world/worldstate.py
@@ -618,13 +618,19 @@ class WorldState(state.State):
         :rtype: bool
         """
         if entity and tile and 'blocks' in tile:
-            for block in tile['blocks'].split():
-                if block == 'players' and entity.isplayer:
-                    return True
-                if block == 'npcs' and not entity.isplayer:
-                    return True
-                if block == entity.slug:
-                    return True
+            for block in tile['blocks']:
+                if block == 'players':
+                    if entity.isplayer:
+                        return True
+                elif block == 'npcs':
+                    if not entity.isplayer:
+                        return True
+                elif block in self.npcs:
+                    if block == entity.slug:
+                        return True
+                else:
+                    logger.error("invalid collision block {}".format(block))
+                    raise ValueError
             return False
         return True
 

--- a/tuxemon/core/states/world/worldstate.py
+++ b/tuxemon/core/states/world/worldstate.py
@@ -607,10 +607,10 @@ class WorldState(state.State):
     def tile_blocks(self, entity, tile):
         """ Verifies if a collision tile is supposed to block a given type of NPC
 
-        Three checks are preformed in the following order:
-        If the slug of the NPC is present in the blocks string, return True
-        If the NPC is a player, return True if "players" exists in the blocks string
-        If the NPC isn't a player, return True if "npcs" exists in the blocks string
+        Three checks are preformed:
+        If the NPC is a player, return True if "players" exists in the blocks
+        If the NPC isn't a player, return True if "npcs" exists in the blocks
+        If the slug of the NPC is present in the blocks, return True
 
         :param entity: the player or NPC being checked
         :param tile: the data of the tile being checked
@@ -618,12 +618,14 @@ class WorldState(state.State):
         :rtype: bool
         """
         if entity and tile and 'blocks' in tile:
-            if entity.slug in tile['blocks']:
-                return True
-            elif entity.isplayer:
-                return 'players' in tile['blocks']
-            else:
-                return 'npcs' in tile['blocks']
+            for block in tile['blocks'].split():
+                if block == 'players' and entity.isplayer:
+                    return True
+                if block == 'npcs' and not entity.isplayer:
+                    return True
+                if block == entity.slug:
+                    return True
+            return False
         return True
 
     def get_exits(self, position, collision_map=None, skip_nodes=None):

--- a/tuxemon/core/states/world/worldstate.py
+++ b/tuxemon/core/states/world/worldstate.py
@@ -605,11 +605,25 @@ class WorldState(state.State):
             pass
 
     def tile_blocks(self, entity, tile):
+        """ Verifies if a collision tile is supposed to block a given type of NPC
+
+        Three checks are preformed in the following order:
+        If the slug of the NPC is present in the blocks string, return True
+        If the NPC is a player, return True if "players" exists in the blocks string
+        If the NPC isn't a player, return True if "npcs" exists in the blocks string
+
+        :param entity: the player or NPC being checked
+        :param tile: the data of the tile being checked
+
+        :rtype: bool
+        """
         if entity and tile and 'blocks' in tile:
-            if entity.isplayer and not 'player' in tile['blocks']:
-                return False
-            if not entity.isplayer and not 'npc' in tile['blocks']:
-                return False
+            if entity.slug in tile['blocks']:
+                return True
+            elif entity.isplayer:
+                return 'players' in tile['blocks']
+            else:
+                return 'npcs' in tile['blocks']
         return True
 
     def get_exits(self, position, collision_map=None, skip_nodes=None):
@@ -649,10 +663,8 @@ class WorldState(state.State):
                 ("up", (position[0], position[1] - 1)),
                 ("left", (position[0] - 1, position[1])),
         ):
-            self_blocks = self.tile_blocks(entity, collision_map.get(position))
-            neighbor_blocks = self.tile_blocks(entity, collision_map.get(neighbor))
-
             # if exits are defined make sure the neighbor is present there
+            self_blocks = self.tile_blocks(entity, collision_map.get(position))
             if self_blocks and exits and not neighbor in exits:
                 continue
 
@@ -683,6 +695,7 @@ class WorldState(state.State):
                     continue
 
                 # if entries are defined make sure the neighbor is present there
+                neighbor_blocks = self.tile_blocks(entity, collision_map.get(neighbor))
                 try:
                     if neighbor_blocks and pairs[direction] not in tile_data["enter"]:
                         continue

--- a/tuxemon/core/states/world/worldstate.py
+++ b/tuxemon/core/states/world/worldstate.py
@@ -502,13 +502,19 @@ class WorldState(state.State):
         # TODO: overlapping tiles/objects by returning a list
         collision_dict = dict()
 
+        # tile layout must be set first
+        collision_dict.update(self.collision_map)
+
         # Get all the NPCs' tile positions
         for npc in self.get_all_entities():
             pos = nearest(npc.tile_pos)
-            collision_dict[pos] = {"entity": npc}
 
-        # tile layout takes precedence
-        collision_dict.update(self.collision_map)
+            # make sure the data for this position exists
+            if not pos in collision_dict or not collision_dict[pos]:
+                collision_dict[pos] = {}
+
+            # append the NPC entity to the tile data
+            collision_dict[pos]['entity'] = npc
 
         return collision_dict
 
@@ -598,6 +604,14 @@ class WorldState(state.State):
         except KeyError:
             pass
 
+    def tile_blocks(self, entity, tile):
+        if entity and tile and 'blocks' in tile:
+            if entity.isplayer and not 'player' in tile['blocks']:
+                return False
+            if not entity.isplayer and not 'npc' in tile['blocks']:
+                return False
+        return True
+
     def get_exits(self, position, collision_map=None, skip_nodes=None):
         """ Return list of tiles which can be moved into
 
@@ -622,8 +636,10 @@ class WorldState(state.State):
         tile_data = collision_map.get(position)
         if tile_data:
             exits = self.get_explicit_tile_exits(position, tile_data, skip_nodes)
+            entity = tile_data['entity'] if 'entity' in tile_data else None
         else:
             exits = None
+            entity = None
 
         # get exits by checking surrounding tiles
         adjacent_tiles = list()
@@ -633,8 +649,11 @@ class WorldState(state.State):
                 ("up", (position[0], position[1] - 1)),
                 ("left", (position[0] - 1, position[1])),
         ):
+            self_blocks = self.tile_blocks(entity, collision_map.get(position))
+            neighbor_blocks = self.tile_blocks(entity, collision_map.get(neighbor))
+
             # if exits are defined make sure the neighbor is present there
-            if exits and not neighbor in exits:
+            if self_blocks and exits and not neighbor in exits:
                 continue
 
             # check if the neighbor region is present in skipped nodes
@@ -663,11 +682,13 @@ class WorldState(state.State):
                 if tile_data is None:
                     continue
 
+                # if entries are defined make sure the neighbor is present there
                 try:
-                    if pairs[direction] not in tile_data["enter"]:
+                    if neighbor_blocks and pairs[direction] not in tile_data["enter"]:
                         continue
                 except KeyError:
-                    continue
+                    if neighbor_blocks:
+                        continue
 
             # no tile data, so assume it is free to move into
             adjacent_tiles.append(neighbor)


### PR DESCRIPTION
Now that NPC wandering has been implemented, it's important to have the ability to customize collisions as to only filter certain types of entities. Mappers may want to block just NPC's from wandering in a given area, or just the player from doing so. This PR implements that ability.

Collisions may contain an optional "blocks" parameter. The collision will of course block everyone if the parameter isn't set. It can take a list of values which may contain the following entries:

- The slug of an NPC. This is checked first and applies to both players and other characters. It's used to create a collision that interacts with only specific NPC definitions.
- The keyword "players". If present, the collision will block all players but let NPC's pass.
- The keyword "npcs". If present, the collision will block all NPC's but let the player through.

I tested this on my maps, in combination with other parameters such as `enter_from` or `exit_to`: Results indicate that everything is functioning as intended and there are no crashes either. Further testing is recommended for certainty.