### PR TITLE
Healing items blocked if your Tuxemon is fainted

### DIFF
--- a/mods/tuxemon/db/inventory/basic_store.json
+++ b/mods/tuxemon/db/inventory/basic_store.json
@@ -2,8 +2,7 @@
   "slug": "inv_basic_store",
   "inventory": {
     "capture_device": null,
-    "potion": 20,
-    "apple": null
+    "potion": 20
   }
 }
 

--- a/mods/tuxemon/db/inventory/basic_store.json
+++ b/mods/tuxemon/db/inventory/basic_store.json
@@ -2,7 +2,8 @@
   "slug": "inv_basic_store",
   "inventory": {
     "capture_device": null,
-    "potion": 20
+    "potion": 20,
+    "apple": null
   }
 }
 

--- a/tuxemon/core/item.py
+++ b/tuxemon/core/item.py
@@ -213,7 +213,6 @@ class Item(object):
             return {"success": False}
 
         # don't heal if fainted
-        print(check_status(target, 'status_faint'))
         if check_status(target, 'status_faint'):
             return {"success": False}
 

--- a/tuxemon/core/item.py
+++ b/tuxemon/core/item.py
@@ -211,6 +211,10 @@ class Item(object):
         if target.current_hp == target.hp:
             return {"success": False}
 
+        # don't heal if fainted
+        if target.current_hp <= 0:
+            return {"success": False}
+
         # Heal the target monster by "self.power" number of hitpoints.
         target.current_hp += self.power
 

--- a/tuxemon/core/item.py
+++ b/tuxemon/core/item.py
@@ -41,6 +41,7 @@ import random
 
 from tuxemon.core import tools
 from tuxemon.core import prepare
+from tuxemon.core.combat import check_status, fainted
 from tuxemon.core.db import db, process_targets
 from tuxemon.core.locale import T
 
@@ -212,7 +213,8 @@ class Item(object):
             return {"success": False}
 
         # don't heal if fainted
-        if target.current_hp <= 0:
+        print(check_status(target, 'status_faint'))
+        if check_status(target, 'status_faint'):
             return {"success": False}
 
         # Heal the target monster by "self.power" number of hitpoints.


### PR DESCRIPTION
Closes #672 

Healing items are no longer usable on fainted Tuxemons. Previously, using healing items would increase their health points but not remove the "fainted" status, meaning they would still be unusable in battles.