### PR TITLE
Renumber events in all maps for natural number order

### DIFF
--- a/mods/tuxemon/maps/37707_tower.tmx
+++ b/mods/tuxemon/maps/37707_tower.tmx
@@ -58,41 +58,41 @@
  <objectgroup color="#ffff00" id="6" name="Events">
   <object id="27" name="Go Outside" type="event" x="192" y="352" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport 37707_town.tmx,24,6,0.5"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
-    <property name="cond3" value="not variable_set 37707_tower:activated"/>
+    <property name="act10" value="transition_teleport 37707_town.tmx,24,6,0.5"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
+    <property name="cond30" value="not variable_set 37707_tower:activated"/>
    </properties>
   </object>
   <object id="28" name="Player Spawn" type="event" x="192" y="336" width="16" height="16"/>
   <object id="53" name="Change" type="event" x="192" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_computer"/>
-    <property name="act2" value="set_variable 37707_tower:activated"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
-    <property name="cond3" value="not variable_set 37707_tower:activated"/>
+    <property name="act10" value="translated_dialog 37707_computer"/>
+    <property name="act20" value="set_variable 37707_tower:activated"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="not variable_set 37707_tower:activated"/>
    </properties>
   </object>
   <object id="54" name="Go Outside Glitched" type="event" x="192" y="352" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport 37707_town_missing.tmx,24,6,0.5"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
-    <property name="cond3" value="is variable_set 37707_tower:activated"/>
+    <property name="act10" value="transition_teleport 37707_town_missing.tmx,24,6,0.5"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
+    <property name="cond30" value="is variable_set 37707_tower:activated"/>
    </properties>
   </object>
   <object id="55" name="Enter" type="event" x="16" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="set_variable 37707_tower:entered"/>
-    <property name="cond1" value="not variable_set 37707_tower:entered"/>
-    <property name="cond2" value="not variable_set 37707_tower:activated"/>
+    <property name="act10" value="set_variable 37707_tower:entered"/>
+    <property name="cond10" value="not variable_set 37707_tower:entered"/>
+    <property name="cond20" value="not variable_set 37707_tower:activated"/>
    </properties>
   </object>
   <object id="57" name="Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="fadeout_music 1000"/>
-    <property name="cond1" value="is music_playing music_mystic_island"/>
+    <property name="act10" value="fadeout_music 1000"/>
+    <property name="cond10" value="is music_playing music_mystic_island"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/37707_town.tmx
+++ b/mods/tuxemon/maps/37707_town.tmx
@@ -144,228 +144,228 @@
   <object id="124" name="Player Spawn" type="event" x="384" y="448" width="16" height="16"/>
   <object id="173" name="Teleport to Back" type="event" x="384" y="464" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport map1.tmx,35,1,0.5"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport map1.tmx,35,1,0.5"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="174" name="Teleport to Tower" type="event" x="384" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport 37707_tower.tmx,12,21,0.5"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport 37707_tower.tmx,12,21,0.5"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="181" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_mystic_island"/>
-    <property name="cond1" value="not music_playing music_mystic_island"/>
+    <property name="act10" value="play_music music_mystic_island"/>
+    <property name="cond10" value="not music_playing music_mystic_island"/>
    </properties>
   </object>
   <object id="182" name="Environment" type="event" x="16" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="set_variable environment:grass"/>
-    <property name="cond1" value="not variable_set environment:grass"/>
+    <property name="act10" value="set_variable environment:grass"/>
+    <property name="cond10" value="not variable_set environment:grass"/>
    </properties>
   </object>
   <object id="183" name="Random Battle 1" type="event" x="96" y="96" width="112" height="64">
    <properties>
-    <property name="act1" value="random_encounter 37707_town"/>
-    <property name="act2" value="play_map_animation grass,0.1,noloop,player"/>
-    <property name="cond1" value="is player_moved"/>
-    <property name="cond2" value="is player_at"/>
+    <property name="act10" value="random_encounter 37707_town"/>
+    <property name="act20" value="play_map_animation grass,0.1,noloop,player"/>
+    <property name="cond10" value="is player_moved"/>
+    <property name="cond20" value="is player_at"/>
    </properties>
   </object>
   <object id="184" name="Random Battle 2" type="event" x="576" y="128" width="128" height="64">
    <properties>
-    <property name="act1" value="random_encounter 37707_town"/>
-    <property name="act2" value="play_map_animation grass,0.1,noloop,player"/>
-    <property name="cond1" value="is player_moved"/>
-    <property name="cond2" value="is player_at"/>
+    <property name="act10" value="random_encounter 37707_town"/>
+    <property name="act20" value="play_map_animation grass,0.1,noloop,player"/>
+    <property name="cond10" value="is player_moved"/>
+    <property name="cond20" value="is player_at"/>
    </properties>
   </object>
   <object id="185" name="Give Tuxemon" type="event" x="368" y="400" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog You got a Fruitera for testing purposes. This will be removed later!"/>
-    <property name="act2" value="add_monster fruitera,10"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog You got a Fruitera for testing purposes. This will be removed later!"/>
+    <property name="act20" value="add_monster fruitera,10"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="186" name="Villager Male" type="event" x="528" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc 37707_male,33,8"/>
-    <property name="act2" value="npc_face 37707_male,down"/>
-    <property name="act3" value="npc_speed 37707_male,3"/>
-    <property name="act4" value="npc_wander 37707_male,3"/>
-    <property name="cond1" value="not npc_exists 37707_male"/>
+    <property name="act10" value="create_npc 37707_male,33,8"/>
+    <property name="act20" value="npc_face 37707_male,down"/>
+    <property name="act30" value="npc_speed 37707_male,3"/>
+    <property name="act40" value="npc_wander 37707_male,3"/>
+    <property name="cond10" value="not npc_exists 37707_male"/>
    </properties>
   </object>
   <object id="187" name="Villager Female" type="event" x="192" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc 37707_female,12,15"/>
-    <property name="act2" value="npc_face 37707_female,down"/>
-    <property name="act3" value="npc_speed 37707_female,3"/>
-    <property name="act4" value="npc_wander 37707_female,3"/>
-    <property name="cond1" value="not npc_exists 37707_female"/>
+    <property name="act10" value="create_npc 37707_female,12,15"/>
+    <property name="act20" value="npc_face 37707_female,down"/>
+    <property name="act30" value="npc_speed 37707_female,3"/>
+    <property name="act40" value="npc_wander 37707_female,3"/>
+    <property name="cond10" value="not npc_exists 37707_female"/>
    </properties>
   </object>
   <object id="188" name="Sign Welcome" type="event" x="400" y="368" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_sign_welcome"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_sign_welcome"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="189" name="Sign Tower" type="event" x="480" y="160" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_sign_tower"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_sign_tower"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="191" name="Sign Foreign" type="event" x="432" y="256" width="48" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_sign_foreign"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_sign_foreign"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="192" name="Sign Hidden" type="event" x="624" y="64" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_sign_hidden"/>
-    <property name="act2" value="set_variable 37707_sign:read"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_sign_hidden"/>
+    <property name="act20" value="set_variable 37707_sign:read"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="193" name="Villager Female Talk 1" type="event" x="192" y="256" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_villager_female_1"/>
-    <property name="act2" value="set_variable 37707_female:spoke"/>
-    <property name="behav1" value="talk 37707_female"/>
-    <property name="cond1" value="not variable_set 37707_female:spoke"/>
+    <property name="act10" value="translated_dialog 37707_villager_female_1"/>
+    <property name="act20" value="set_variable 37707_female:spoke"/>
+    <property name="behav10" value="talk 37707_female"/>
+    <property name="cond10" value="not variable_set 37707_female:spoke"/>
    </properties>
   </object>
   <object id="196" name="Villager Female Talk 2" type="event" x="208" y="256" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_villager_female_2"/>
-    <property name="act2" value="set_variable 37707_female:spoke"/>
-    <property name="behav1" value="talk 37707_female"/>
-    <property name="cond1" value="is variable_set 37707_female:spoke"/>
-    <property name="cond2" value="not variable_set 37707_tower:entered"/>
+    <property name="act10" value="translated_dialog 37707_villager_female_2"/>
+    <property name="act20" value="set_variable 37707_female:spoke"/>
+    <property name="behav10" value="talk 37707_female"/>
+    <property name="cond10" value="is variable_set 37707_female:spoke"/>
+    <property name="cond20" value="not variable_set 37707_tower:entered"/>
    </properties>
   </object>
   <object id="197" name="Villager Male Talk 1" type="event" x="528" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_villager_male_1"/>
-    <property name="act2" value="set_variable 37707_male:spoke"/>
-    <property name="behav1" value="talk 37707_male"/>
-    <property name="cond1" value="not variable_set 37707_male:spoke"/>
+    <property name="act10" value="translated_dialog 37707_villager_male_1"/>
+    <property name="act20" value="set_variable 37707_male:spoke"/>
+    <property name="behav10" value="talk 37707_male"/>
+    <property name="cond10" value="not variable_set 37707_male:spoke"/>
    </properties>
   </object>
   <object id="198" name="Villager Male Talk 2" type="event" x="544" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_villager_male_2"/>
-    <property name="act2" value="set_variable 37707_male:spoke"/>
-    <property name="behav1" value="talk 37707_male"/>
-    <property name="cond1" value="is variable_set 37707_male:spoke"/>
-    <property name="cond2" value="not variable_set 37707_tower:entered"/>
+    <property name="act10" value="translated_dialog 37707_villager_male_2"/>
+    <property name="act20" value="set_variable 37707_male:spoke"/>
+    <property name="behav10" value="talk 37707_male"/>
+    <property name="cond10" value="is variable_set 37707_male:spoke"/>
+    <property name="cond20" value="not variable_set 37707_tower:entered"/>
    </properties>
   </object>
   <object id="199" name="Villager Female Talk 3" type="event" x="224" y="256" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_villager_female_3"/>
-    <property name="act2" value="set_variable 37707_female:spoke"/>
-    <property name="behav1" value="talk 37707_female"/>
-    <property name="cond1" value="is variable_set 37707_female:spoke"/>
-    <property name="cond2" value="is variable_set 37707_tower:entered"/>
+    <property name="act10" value="translated_dialog 37707_villager_female_3"/>
+    <property name="act20" value="set_variable 37707_female:spoke"/>
+    <property name="behav10" value="talk 37707_female"/>
+    <property name="cond10" value="is variable_set 37707_female:spoke"/>
+    <property name="cond20" value="is variable_set 37707_tower:entered"/>
    </properties>
   </object>
   <object id="200" name="Villager Male Talk 3" type="event" x="560" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_villager_male_3"/>
-    <property name="act2" value="set_variable 37707_male:spoke"/>
-    <property name="behav1" value="talk 37707_male"/>
-    <property name="cond1" value="is variable_set 37707_male:spoke"/>
-    <property name="cond2" value="is variable_set 37707_tower:entered"/>
+    <property name="act10" value="translated_dialog 37707_villager_male_3"/>
+    <property name="act20" value="set_variable 37707_male:spoke"/>
+    <property name="behav10" value="talk 37707_male"/>
+    <property name="cond10" value="is variable_set 37707_male:spoke"/>
+    <property name="cond20" value="is variable_set 37707_tower:entered"/>
    </properties>
   </object>
   <object id="201" name="House" type="event" x="128" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_house"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_house"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="202" name="Mail" type="event" x="112" y="336" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_mail"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_mail"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="203" name="Mail" type="event" x="208" y="336" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_mail"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_mail"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="204" name="Mail" type="event" x="320" y="336" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_mail"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_mail"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="205" name="Mail" type="event" x="528" y="304" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_mail"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_mail"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="206" name="Mail" type="event" x="560" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_mail"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_mail"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="207" name="House" type="event" x="240" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_house"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_house"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="208" name="House" type="event" x="176" y="336" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_house"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_house"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="209" name="House" type="event" x="288" y="336" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_house"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_house"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="210" name="House" type="event" x="608" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_house"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_house"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="211" name="Flower" type="event" x="384" y="176" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_flower"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_flower"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/37707_town_missing.tmx
+++ b/mods/tuxemon/maps/37707_town_missing.tmx
@@ -398,201 +398,201 @@
   <object id="124" name="Player Spawn" type="event" x="384" y="96" width="16" height="16"/>
   <object id="173" name="Exit" type="event" x="64" y="432" width="16" height="16">
    <properties>
-    <property name="act1" value="set_variable 37707_tower:visited"/>
-    <property name="act2" value="set_variable environment:grass"/>
-    <property name="act3" value="translated_dialog 37707_exit_missing"/>
-    <property name="act4" value="transition_teleport bedroom_test.tmx,1,3,1"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
-    <property name="cond3" value="is variable_set 37707_tower:activated"/>
+    <property name="act10" value="set_variable 37707_tower:visited"/>
+    <property name="act20" value="set_variable environment:grass"/>
+    <property name="act30" value="translated_dialog 37707_exit_missing"/>
+    <property name="act40" value="transition_teleport bedroom_test.tmx,1,3,1"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
+    <property name="cond30" value="is variable_set 37707_tower:activated"/>
    </properties>
   </object>
   <object id="178" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_mystic_island_reverse"/>
-    <property name="cond1" value="not music_playing music_mystic_island_reverse"/>
+    <property name="act10" value="play_music music_mystic_island_reverse"/>
+    <property name="cond10" value="not music_playing music_mystic_island_reverse"/>
    </properties>
   </object>
   <object id="179" name="Environment" type="event" x="16" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="set_variable environment:37707"/>
-    <property name="cond1" value="not variable_set environment:37707"/>
-    <property name="cond2" value="is variable_set 37707_tower:activated"/>
+    <property name="act10" value="set_variable environment:37707"/>
+    <property name="cond10" value="not variable_set environment:37707"/>
+    <property name="cond20" value="is variable_set 37707_tower:activated"/>
    </properties>
   </object>
   <object id="180" name="Random Battle 1" type="event" x="96" y="96" width="112" height="64">
    <properties>
-    <property name="act1" value="random_encounter 37707_town_missing"/>
-    <property name="act2" value="play_map_animation grass_red,0.1,noloop,player"/>
-    <property name="cond1" value="is player_moved"/>
-    <property name="cond2" value="is player_at"/>
+    <property name="act10" value="random_encounter 37707_town_missing"/>
+    <property name="act20" value="play_map_animation grass_red,0.1,noloop,player"/>
+    <property name="cond10" value="is player_moved"/>
+    <property name="cond20" value="is player_at"/>
    </properties>
   </object>
   <object id="181" name="Random Battle 2" type="event" x="576" y="128" width="128" height="64">
    <properties>
-    <property name="act1" value="random_encounter 37707_town_missing"/>
-    <property name="act2" value="play_map_animation grass_red,0.1,noloop,player"/>
-    <property name="cond1" value="is player_moved"/>
-    <property name="cond2" value="is player_at"/>
+    <property name="act10" value="random_encounter 37707_town_missing"/>
+    <property name="act20" value="play_map_animation grass_red,0.1,noloop,player"/>
+    <property name="cond10" value="is player_moved"/>
+    <property name="cond20" value="is player_at"/>
    </properties>
   </object>
   <object id="183" name="Villager Male" type="event" x="528" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc 37707_male_missing,33,8"/>
-    <property name="act2" value="npc_face 37707_male_missing,down"/>
-    <property name="act3" value="npc_speed 37707_male_missing,1"/>
-    <property name="act4" value="npc_wander 37707_male_missing,0.5"/>
-    <property name="cond1" value="not npc_exists 37707_male_missing"/>
+    <property name="act10" value="create_npc 37707_male_missing,33,8"/>
+    <property name="act20" value="npc_face 37707_male_missing,down"/>
+    <property name="act30" value="npc_speed 37707_male_missing,1"/>
+    <property name="act40" value="npc_wander 37707_male_missing,0.5"/>
+    <property name="cond10" value="not npc_exists 37707_male_missing"/>
    </properties>
   </object>
   <object id="184" name="Villager Female" type="event" x="192" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc 37707_female_missing,12,15"/>
-    <property name="act2" value="npc_face 37707_female_missing,down"/>
-    <property name="act3" value="npc_speed 37707_female_missing,5"/>
-    <property name="act4" value="npc_wander 37707_female_missing,5"/>
-    <property name="cond1" value="not npc_exists 37707_female_missing"/>
+    <property name="act10" value="create_npc 37707_female_missing,12,15"/>
+    <property name="act20" value="npc_face 37707_female_missing,down"/>
+    <property name="act30" value="npc_speed 37707_female_missing,5"/>
+    <property name="act40" value="npc_wander 37707_female_missing,5"/>
+    <property name="cond10" value="not npc_exists 37707_female_missing"/>
    </properties>
   </object>
   <object id="185" name="Villager Female Talk Missing" type="event" x="192" y="256" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_villager_female_missing"/>
-    <property name="behav1" value="talk 37707_female_missing"/>
+    <property name="act10" value="translated_dialog 37707_villager_female_missing"/>
+    <property name="behav10" value="talk 37707_female_missing"/>
    </properties>
   </object>
   <object id="186" name="Villager Male Talk Missing" type="event" x="528" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_villager_male_missing"/>
-    <property name="behav1" value="talk 37707_male_missing"/>
+    <property name="act10" value="translated_dialog 37707_villager_male_missing"/>
+    <property name="behav10" value="talk 37707_male_missing"/>
    </properties>
   </object>
   <object id="187" name="Sign Welcome" type="event" x="400" y="368" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_sign_missing_welcome"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_sign_missing_welcome"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="188" name="Sign Tower" type="event" x="480" y="160" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_sign_missing_tower"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_sign_missing_tower"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="189" name="Sign Foreign" type="event" x="432" y="256" width="48" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_sign_missing_foreign"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_sign_missing_foreign"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="190" name="Sign Hidden Unread" type="event" x="624" y="64" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_sign_missing_hidden_unread"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
-    <property name="cond3" value="not variable_set 37707_sign:read"/>
+    <property name="act10" value="translated_dialog 37707_sign_missing_hidden_unread"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="not variable_set 37707_sign:read"/>
    </properties>
   </object>
   <object id="191" name="Sign Hidden Read" type="event" x="624" y="64" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_sign_missing_hidden_read"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
-    <property name="cond3" value="is variable_set 37707_sign:read"/>
+    <property name="act10" value="translated_dialog 37707_sign_missing_hidden_read"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is variable_set 37707_sign:read"/>
    </properties>
   </object>
   <object id="193" name="House" type="event" x="128" y="304" width="80" height="48">
    <properties>
-    <property name="act1" value="translated_dialog 37707_house_missing"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_house_missing"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="194" name="Mail" type="event" x="112" y="336" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_mail_missing"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_mail_missing"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="195" name="House" type="event" x="240" y="304" width="80" height="48">
    <properties>
-    <property name="act1" value="translated_dialog 37707_house_missing"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_house_missing"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="196" name="House" type="event" x="96" y="208" width="80" height="48">
    <properties>
-    <property name="act1" value="translated_dialog 37707_house_missing"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_house_missing"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="197" name="House" type="event" x="208" y="208" width="80" height="48">
    <properties>
-    <property name="act1" value="translated_dialog 37707_house_missing"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_house_missing"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="198" name="House" type="event" x="544" y="240" width="96" height="48">
    <properties>
-    <property name="act1" value="translated_dialog 37707_house_missing"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_house_missing"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="199" name="House" type="event" x="560" y="80" width="80" height="48">
    <properties>
-    <property name="act1" value="translated_dialog 37707_house_missing"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_house_missing"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="200" name="Mail" type="event" x="208" y="336" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_mail_missing"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_mail_missing"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="201" name="Mail" type="event" x="320" y="336" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_mail_missing"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_mail_missing"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="202" name="Mail" type="event" x="528" y="304" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_mail_missing"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_mail_missing"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="203" name="Mail" type="event" x="560" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_mail_missing"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_mail_missing"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="204" name="Tower" type="event" x="384" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_tower_missing"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_tower_missing"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="211" name="Flower" type="event" x="384" y="176" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog 37707_flower_missing"/>
-    <property name="act2" value="set_monster_health ,"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog 37707_flower_missing"/>
+    <property name="act20" value="set_monster_health ,"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/BuddhaMountain.tmx
+++ b/mods/tuxemon/maps/BuddhaMountain.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="100" height="100" tilewidth="16" tileheight="16" nextobjectid="227">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="100" height="100" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="227">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -18,46 +18,46 @@
  <tileset firstgid="235" name="KelvinShadewing_Terrain" tilewidth="16" tileheight="16" tilecount="285" columns="19">
   <image source="../gfx/tilesets/KelvinShadewing_Terrain.png" width="304" height="240"/>
  </tileset>
- <layer name="Layer1 Mountain Terrain" width="100" height="100">
+ <layer id="1" name="Layer1 Mountain Terrain" width="100" height="100">
   <data encoding="base64" compression="zlib">
-   eJztm7uOEzEUhi0RoNlki+UiBEKioWG1Ha+YlhJeBrqljZaCWwFTLTwGYxEr5uTY5/gyY4f5i0/JJtloxl/+Y/tkcmGMed4ZD0auFsqrDo6BctnBMbT2cWH6yQV89JGTS3K7RKiPFjmhuYCPtjmhHuCjTU5CuYCPNjkJeYCPeXMi5QI+5s2J5AE+5smJNhfwMU9OtB7gAz56YU4fLxJvlwh89AXqVV/AR19oPTwdeRnhyZ7Ya57BRzUfNYGPfB9SLlLykZqTJYJ+Yl+U5iInH9qcLBF8H9UXpbkoyYeUkyWC6xn6ojQXNfIRyskS6SEXlCX7KM1FzXzQnIA+OO/gGAB89MrSfXxpwFf4YPkx8rMB3yJe4KMdA3yofNyM/CJ8go/J+Z4wTrcZbm6E19u6RWvWkn2Exu+38H+3SifW687E6+IAH0EfdGwkJ1JW3LwdyiF8hH3YbEi5CHkpmVvg49hHrgtHyToNPg64+bnEhaUkI/AxDbnrL/pZgI8Dn01+nyPkJoZ1sYOPINI8MGS+704APmQf783fz/CHCj4kJ/Ah+xjM8V6O+pDqm6bPCx86H9f7MfvoPeb2d47YPk+7toIPnY8SuH5kaD6nxwAfB0r32n7/6+7IPYb7wjHAx7GT3B77sH+P1yPrzPGGjzC0fkl1yK8/8DGtj9Qe18ORRwyP4SMbv3aV9rh87gRcaXwtGX9/oe2VaDzYMUcOeGL9qdheMIdzQutz7w06X9PrcGr6sNlwuYAPnQ/qxd9/l/qg2YCPsA+ud1irtwsf6T7sWKdeBwIf0/ngeod0/1e63oUPvY+pMgEfaUj9w9h1z/AxnRPpOl3/e49cN/AhQ3sVKyPXsNzMwEc6a4WP3LkFPmRcD3bl+eCu1QnVsJSMwIeeNbml32mH5v2UeQU+0n3YvKwCr9HMK9LvAuEjzQe9n+JDmlPgI9/H25F3HlvD1yy3f3d9L/iYxkfoeZoRO/5+3ws+5vVBM+L6Xq4vDx/1fdA1MH0+1mOBjzpw6yrOkWW7h3MCH9M5Ca2z7ONvDL9vjPXk4aPMCXf91Mrw6y8f//Ub8+91PPBR5oSyNuHcaICPuk6ojy18zOrEr1POh7/+4upWqF5xNav1OZ4qtN9I76cAH/V8+NmgPrS1Cz7K4dbC1Idfu0L1yj7n16zW53XK0FrFzS9a4KMcbm/iz/Pw0daJ78HPysYc7yPpGgy/N6hHjTXWFXxM4oPrqWyYx7g9Cn4HVd8HaI/GR+i35ym0Ps9TIVajctdbYBq4vgqYF782ncFHc9zYc15AOx/IRB/AR1/ARx+4+eJsfx9zRnsP7m+4aOOArp3goi7a3oWrSdzjrc/hf+IP9qitCQ==
+   eAHtmzuPLDUQhUcCLgksweUhBEIiIQGR8RdJCeHPQAbpCgJeAUwE/Axcuvupz9S6bfe4Z6Z7XIFVfj/O8SnbvbMvD4fDJxsL76b5fDlo+HyD6/5ig3O61v6Aj5cJg1vrBF0EH4cDvFxrH+TGgQdsrs6958ED9hY68boIPiZ9wMs19yH4e3vNOWxlLPD39ho6mdMFvGwFo2vOw/Pg05ecC7jP2UuOvdW+Pf4+fQmd1HQBP1vF7JLz8vjPpdecA3jX7Jpj7qWvOfx9/ho6adUFPO0FwzXn6XGvpXvGBudW2zPWXtvW8PflPets5YF6PWPtta3Hu5buWeenT9+lWm3PWHttW8Pfl/ess5UH6vWMtde2Hu9aumed+KFW2zPWXtvW8PflPets5YF6PWPtta3Hey79UfL9nxXCh6nMQqnOx6nccALvmt0rpj3znsPf5/eM4dvWeKDctxsh7XH36Zou0EOLPqjbqpMR8Pdr9Pj7tK+/ZhodzNk1x9pLXx5/0q26YM8v0QdtajrZC4ZrzhP8vV1zjFpfoY/p9zSeh6W6YK+fow/azumkxuM9lns+brlGr5NbzuVWY8PHubpgj/fogz68Tm6FyS3HhY9bzsGPjU58/gjpXl2wt9fQB32hkxHw38Ma33n6rrKHuY4wx+Bjuv9uge/R+fgt+Ydrh98LPmlkPv5KuPx9g/DH0x7I8RJ83IYT2wfHFLyPDD6e8/FzwulfF35J6bW1dEx9Bh8TBn/OYJzD6Z9UF45auYHXufrmt7zPGlkffr+D338JJ79vNW3czGGsfR5TvccUSueU1dG+g4/JD3lsFCcfRy8lXji353SYO0OCj1d8mDZquvCcWLpVK6objfs9EHwcDudyAT8lf6TY5+LBx+SvOZ/P0QVc9Gok+Jj4UEx745wnxnHpTFGN5HQ5sr/yHPyasCx9O/F3U9+etHKDBnPWdPmYAu3MBh8THrVz4OiwUxxLccO8FLRt8JHn4/uEoe3pH1LAxxxTXLFbEg8+lmOn+jDsDUOfpxzU/FvJ91mZ+T8bQ/sMfUx4KPY/JpwMs59SQB+878C59M6jTckeU9/Bx4S/7kuLKx8lHGtlfHfJneGal7tnhz4mfnrf2vBgOL+RwotMeDPl+X2g6eDjFB+9q7a+I9DL8Qnrr5J9ewb3Gt61cuVutLj3X+x/9TkaV/8TfJzu8zX2jvKRe0uXxngv6eP9TPhgRjf0FfqY51F9l+59sDvXvpbhCe5qfJ075j200/dF67eS0rrhwTAPHeR1wFvCrMdc/dUxlZewbikzDjS0tBmpjuJtdyTee/Ci5b18mDbQBZyMhHXLWhVv7qzKi76/e/mAA7UtcxypDnzkvh0qPxYPPvr9dW1vwYdh/ZgCac9F8HF5Lowr8M99OzQO9P3Xe99VP0W8tl9GK4ePnB7W0ITiCQdqtTzi9d/q+PtWD2bKA/Ge/u61rb7B7VtU7hsivOTeKK24wIHa1raj1OMbBfZ1OVPmfBjc8EZpxUp5IN7adtR69k22dqbA0zHVXYITHKhd0n6EunyDNV3Yeo0P779KPmyJRpQH4iNgfM4a+VsF9tHtfeOo91yBA7XnzHWENvBgekErft01P2bnSkkvygNxP0akJz8FFnBDGlvjo/ZegQO19B329CxWDiz+bQrfSfg6xXM+i/f7D6k8+DjFtGePeT58X5R7jRwTD48pkG9p35a06oI4ZWFPcQNvw0Xj4ESe1wjfvfguH3yc4gp+Sy14Wzt/B7Y8Lfec8B4Jf7UOF3Dg71XKARzZO97OEgu5++8x5c/tBXyU2rm6kf9KF8qJ8qH4WP43KZhO9LdXFi99k1ceiGu/EX++l/X9oZrQ71vGh79/6V2MumYfUiDt/3ZunAQHdQyUE4+XcTGnG183l0YX2FydyHvO0Rwnng87R5bgBw/YJW1Hr6v+inPF+CDf8nJ+C//k/ZWlvc8aHeNz14+Pwlo/Gl/SL9owu6Rd1J3wAnvVBnng1Oq7go8JV7Bbav15Ylx4PtR34bMeUj3iZu0epj5r6Tyi/sSl4m9xtGI4c7604oVGWutHvYkHsFCNwAU8KFfUL9ng4zm+JbzmypQTqwMP8GNaeUhBfRR+St+M+Ky5cSK/nS84UD7OwS/uV+2Yl/BVPlQXaOKhQR9W1zRSGifK2vBRPgKzNswuiVMLH3P/e/4iaaI1XHIN99R3yUede9+6J3y2tBa0g93S3EaZi/qmt57O6ODjducK2Od4GWVPbmmd8IHd0txGnAs8YEfEYEtrhgfsluY20lw4L+wMtzhn+UgYbGGtyoPNJ7i4/l0KDuxtrToILtblovXbBT7J11dutqDdvc/hf/aorQk=
   </data>
  </layer>
- <layer name="Layer2 Signs, Plants, Statues" width="100" height="100">
+ <layer id="2" name="Layer2 Signs, Plants, Statues" width="100" height="100">
   <data encoding="base64" compression="zlib">
-   eJztnEFygzAMRblOeooue5feIWfvMLQThxqMbUlfQv/NMO0CguVnGdmkXRbijSe6AQWe2kJICXJsMi9IFCzHKvOCREVz7DIvyF2QHMvMC3JXno2fV88hhJA78mF4ED9EdHL353k0HxmI4KQ1tmv5MfpZaCL4yIRnH1fHck9+9J5njWcfGfFYZ/WO3ZH8GD3fAm8+suPFx+hYncmP2es08OKDbKB9zI5NifyQul4CtA/yAl1fWe6fRthn9XB/bwcK9P3LNng6EHhwgcabD7KB9sHceMeDD/IC6SNSblj2E9JHFKRqoCtrbvo4x7oupY9jEOsF+qiDWsPRx3+Qa2rWVxuzextS/Yhef3hxMtKnGm6QPsr7o9HygZz7RkHfv2wDfWyg29Dqi9paTrrvPPlY8TBvZm9DDWS9Rx91rNuE7AuPz48jrNqm0R+P4vezv8uJ5GPFon3IWieajz802zniQ6pmjepjRau9vf0aYQ1hiXbtL+UjmyfNGOljHG0vZ/eji2OsYqaP61jETR99zMTd+z0Q+mijHTt99CMd+2xNRR96n0sffXiuszJiHTd9HIOImT7qIOOlj/+MxvtY3t8flZ830pf0MRevtI/atRl9jHLkY4bMPmZjpQ85JOKU8LHf98roQyrGHh893uhiDI35auXuPrTi0/JxZzTH2GPRcxLpf1NfwSLfv34P5sk5VvPu50InLSyfgV+7Q9LJHeYr61pk74N58gJRG9Z8lE4yu0HU6Zo+Is9XqDXTkY+9k0wg17BnPjI6Qe8nSPuIPkeh93ZaPjLlCNrFSq+PlhPmxxxXfGTLEc/Pj4zrRM/11RUfkeeoM7y/w/lGNwBItvfP0dBy0zNfZX2etJB0Qx/yzHxvdtYFffTRcjXrgj7kGPGxd0EfsjAvfEEPvqjNP5yTCNn4Ac727SQ=
+   eAHtWeuN3jAM6zrtFP3ZXbpDZ+8JB+IjBDvxQ7bkRAYKyraeZJLD9X78yBWNgX+BGorUSyBaspUADHg+m561A1CfLRzEwM5ndWetgyTIVg9gYOWzuzL3AdRmiw9iwPJZtsz1IIpzlAcwgGe7hjJi7Q7nD6AhR0gGkoFkoMjAr6/TXf+KDeShCwPQ3KX4YFH8TK6hpK3d4Xyw9JYw0SRXLAZO0OTu2eZ7tktM392XYnaenaDHTj68a0XWo/VZZj+2r7ht9bvKseIush4r5o2eU/SIpknvs8v+bLdw3+vfknPWJ5oes/OcHh9Fj9FnlePY7tFlNK6nRqtvFD1a+326n7ces88mx7M9otts/EhNHeOth+7nzXvRwlMP1I+Ens+DpxYydyQd0IuXHt71U4+P8hG0+HTjY4EDjR7dSA+5vhnw1gP1U484eqQWHwbwfAI/N+stj5qjU6FX4GieljjUENy5dtebmY050nZP3pbfuTl/T+5Z31P0YH5q9iwXHM81+Hy1fYIezE2LbcEZ17HI15ojuh7MS4/dOn/Nj2vVfFacR9aDOem1Z7nierO5euJRtydmpS/6scCZPrn+TJ6RWNQeibWOQS/AlvzwvcKWPOzDufh8l436u+rV6qAPYM2Pz+G7CrnWThvz7Kypa6EHoL4v7eG7Cks1d51hpl31dB3UB+r70u9y8BW0WJzPKudMX+hnJsdoLGoDR/PMxKE2cCaXZaxHP6gJtJynNRdqA1vjdvjt7gn1gDtmRA3U1Ij7SIgeV/eEOoyzNX9SAvz80SguXJNtCg9loseVTaFGDT1qr6xpkRtcWeTSOZC7htpf9jVfPi/F6TP2Z1v7Rdyv6pfzlmzNRcmndKbjnrrn2S1m5HwlW9co+fSc6XxP2TMH1jNd5ea7Edu612j5mBPr3iS3Xlyv19a5nrwHN6tnRJ0RXN1btPzgaGVfqDGCK/uKmlt4Gl34ne0qfkQHxFzlferd6tmRfwSfyvndXMKV5RrhvhRj2dNJuaz1wOwljnvOkOdNCH5Wz4w6Pbi6p4j5hZ+dK/Wos71bC+kk9Sjr4aEFOmnVBP5vwFE95G9H/PcjcKU5xvkd6jje38U+5R4zj8xjrYf0gH40jvR3YozMPbpqeozmkzitA/YzOU+JnZ019bBTelYL6cRCD/3/XuhLo93k8TJh1tnOevQQ39aF/oCtcSf6Wc7Yo0cPV+gR2BN7gi/mAlr1vEoPq/4i5rHWgGeEHj3fIo6/svFzBXjle8IddBBctf58JZZ/0GVVndPzQovVc/z+KpCaXLO8SwvpAloALd8TfKeA11PHvF35bSpNDB0YLTUp1TzlbOd7AU5YB7ahCRD+b8Ld74ZwyxqwDR2AIzrgOwUcyeEV46GFzMoaaBtaCL5peXynwK/WQO/fpomnFqKJ5l/ve/XAtwkI3U9Aby1a9BB9ejU5gftSj14/M7gX/T6U9qyH2FcL7wXwyjfa3Snvx9veEc/3pPQ+1M7wnkR7rq378XxPatyXzmt64NsEtObHKx90AXr1Uav7t3bxgnNowviCsY8ZkXUR22qVvkutZ7Xvl1Vvp+Sx1KaV+5Jf6lF+YrQ+el+O+j4t8dxyBi0Ec7UzoLXR+xbutQ9rkXq0a3HnKdporu/2WovU447lvvs7/vlea9FXKb1bGGC+a3bq0MKkjY/mura3qZZZkoGzGPgPzvbtJA==
   </data>
  </layer>
- <layer name="Layer3 Extra Mountain" width="100" height="100">
+ <layer id="3" name="Layer3 Extra Mountain" width="100" height="100">
   <data encoding="base64" compression="zlib">
-   eJzt27ENg0AUBUHOLRj3354T5BYgB5zeSsxIL/+6jW9ZAAAAAAAAAAAAAAAAAAAAAIB/vrMPAAAAAE62Y+u43m/2cU90vPu42WvMPu6B9GjRo0WPFj1a9GjRo0WPFj1a9GjRo0WPFj1a9GjRo0WPFj1a9GjRo0WPFj1a9GjRo0WPFj1a9GjRo0WPFj1a9GjRo0WPFj1S3uP+f9RHDwAAAADI2AHJagX7
+   eAHt2zFOA1EUBEGbKwD3vx6JxRX4ztkJ3UjUSpv4BWNVx3u7eQgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQWAJf6+hGgAABAgQIECBAgAABAgQIJAKPs/px//39Tv7RPx89Le4X79v53fNigYsWz0Z6vLjFc06PAH1M6jFwgpMeAfqY1GPgBCc9AvQxqcfACU56BOhjUo+BE5z0CNDHpB4DJzjpEaCPST0GTnDSI0Afk3oMnOCkR4A+JvUYOMFJjwB9TOoxcIKTHgH6mNRj4AQnPQL0ManHwAlOegToY1KPgROc9AjQx6QeAyc46RGgj0k9Bk5w0iNAH5N6DJzgpEeAfj35fnpcfR/1eW4eAgQIECBAgAABAgQIECBAgAABAgT+hsAPyWoF+w==
   </data>
  </layer>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="4" name="Events">
   <object id="2" name="Welcome Sign" type="event" x="176" y="1440" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog Welcome to Buddha Mountain!"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog Welcome to Buddha Mountain!"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="3" name="Play Music" type="event" x="0" y="1584" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_adventure_begins"/>
-    <property name="cond1" value="not music_playing music_adventure_begins"/>
+    <property name="act10" value="play_music music_adventure_begins"/>
+    <property name="cond10" value="not music_playing music_adventure_begins"/>
    </properties>
   </object>
   <object id="225" name="Teleport to map1" type="event" x="32" y="1424" width="16" height="32">
    <properties>
-    <property name="act1" value="transition_teleport sphalian_town.tmx,22,14,1.5"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
+    <property name="act10" value="transition_teleport sphalian_town.tmx,22,14,1.5"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
    </properties>
   </object>
   <object id="226" name="Player Spawn" type="event" x="64" y="1440" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ff0000" name="Collisions">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="4" type="collision" x="400" y="1296" width="80" height="16"/>
   <object id="8" type="collision" x="304" y="1296" width="80" height="16"/>
   <object id="9" type="collision" x="368" y="1280" width="16" height="16"/>

--- a/mods/tuxemon/maps/candy_town.tmx
+++ b/mods/tuxemon/maps/candy_town.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="40" height="40" tilewidth="16" tileheight="16" nextobjectid="211">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="211">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -82,27 +82,27 @@
  <tileset firstgid="7734" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="1000" columns="40">
   <image source="../gfx/tilesets/Cave_Tiles_by_ArMM1998_(Tuxemon_Style).png" width="640" height="400"/>
  </tileset>
- <layer name="Tile Layer 1" width="40" height="40">
+ <layer id="1" name="Tile Layer 1" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJzt2FkOwiAQBmBuQN/cDuJ6NO9gtQdxe/UQ+uhyEZcHaSyRTBAGZlQ0bfInxFT6tR1oy0IKsVQ5quxVDom1F7Xv730rlWlCJujT1zAV0y/69D3m6PescgnM1eMzjVRfKxOiHZhO5vdxjZW+OtYAmWagTxtzxrjuSSvCxx19vrb6TsHnqu9Y30xlW4WywX7hsyrUV7p2YD/KVjD6tA3uR9nKfgoGn7bZ5guqb26pwVCf6/nG6YPHqn3v99nGLLZt9g/3mcjHvLwm+ijvz9DncqXgmzhc3/ZhbLCWPumD48B8RurA+d/ne/XM4PBhvhl8Pur3gX4XHQIfvI8jZl8eEbP2fDWzifRhahwTbE2H+mANcfhuiflCxhzVZ5sjfLG9p52M9pjJh7kOZ/n8vjZ/x84DFN9S+tcCelX/3Sx8zcD8f6wvZi0gJlRfI8OvCcRkSPS9Or93t2vff/vuVpWKTg==
+   eAHtmFlOw0AQRH0D+GM7CAQ4GncggYMkhF8OkXyyXCQJH1RLLqnUatszHkOM5EilmXi2N9U9k2V1UlUv0Cf0Dn2MrL4Cz8TXPz7/wb81YryAxpp/9HDiy78fzDsTYzzE/bLDfPtMHdA/uuPIp4xRvxzui9OquszUFfpH6yqfMpbk4gxr3SbqvN5HKh8Z5/B7KNndEHljMaHXOXzGOKQst22vxunzZAx83CvPoHrZl+8Je93UqgpeZGPpP+tz+YxrC+n5KMCrnjEX2aws4SOb+m/1kpftUxn78pHN5+8QfEvxcI36AmJ8UuNr++KYof1TPsaYa0187dlpPpX6x9yj5z6+bc81Pj53H8E2h14hf4Y5p46P1mU+RG1+vaiPzm/9TU1cZNRc1/HR/EPzGZv3i1wsj8WXwuZz6S/9W7o8M5aN0xbvNY5dfNyPjsmp6/yeT+PYNKeOj/rwHEVtKedjVn8PvUOpfNw357+Hb6zrWn355pgvV3ouzDvl8PU3tNv+c/lScpznsK3s4qOXuXwao7b1u9qU77vFy2PwMfd8TOmZPi/li+6IDfxo07bOLeX4wjPyPUi9hC/Fhx3W2kMHWdO4Us5+n/Oh+Wc5xPWNIdJN/fv1GmXU3vWM45t+X9JzxsLz0f/c/wNy+5fyndX3cOr/Arn97H6nRx+IFeup/jXtT+f6jfrEl36WGVONw9j9+wFWlYpO
   </data>
  </layer>
- <layer name="Tile Layer 4" width="40" height="40">
+ <layer id="2" name="Tile Layer 4" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJzt10tPE1EYgOEPUGkxJCRKoReictGoa12r3HQhLYWFgjv5FQRva/wF4ErRxAsXo/9DxYQWUBdqVG664KoR8UU8oTnMDD0DmU5Cv+RJOhxgXoY5nVRkY8rLREI4g7Nl9sdupz24+bqF13EkMBwQGQls//PbdaljN5MMbu1Sk6ItjfmIyAIWsYRlrEQ2vifz2ugdO+kymaNRkWMYQwppjEe9bXCay7S0oCgmsg/7cQBHSnLb5WYKaC5E0S62O91fVtMWtF87SdcpnN7FPnV/VaMGtaiLuvtdH2n/hM8Of4PpqPsrjgRakXTZl5+tM8i1HMIwRvDcZ9d2gp5JvMN7fPBZXzHvdQEEUYKDsVwX7Z1Z5Fr/1CxhGSsWa8ovj/5H1VUixzU1qEWdxZpyoir7c0zxLJnGDGYx5/Bs0SfOedo0CbQiabGmtBv0hdivFahEGBGD/dvDeW5rbuAmblmsKXcM+urpaUAjmtBs0PeY8wxqnuApnlmsKUMGfTuZMc4zoUkhjXGLNWXSo778iNznfnuAATzEI589317R8xpvMIq3Bn2FBu9Fbuc3Pav4g7X1tvzz99908Lmw08a1HH9mXJ9uh4Yen/VdLxXpKt08zuz7Ehb5im+YwnTY+75e2u7a9B1iDx5GOUKo8GBP6n0vaHtp03eOnvO4gHo05KBPH7/df/r4oa+Phn5cyWi5+v9r93zQl+3MsF9nMYfv+OHR/s12KtkPYUQQRcyj/ZHtNNLThGZcxCWf9eVnb85froejcg==
+   eAHt10lPU1EYxvFXQAWMiYlQaMGojFHXulaZdCEthYXTDj6FQcC1fgJ1JWjiwGDgeyia0ALqQo3KpAtl0Dj9b+iNJ29u29sGDzehT/IDzkDvw+HeBkQ2U3lAJISTOIV049T2nD/1lP37lk6+jiKG8VKRCWRLtl7uerbX8VqPp7qZvdx9Cbol8TUi8g2rWMM6NuDEPSvna91Dj509/yNHakSOYgYJJDELJ7Y6bF7N++MFunSiuFakBLuxB4fLvfcHeXYXnYtQvIXdM91fXmfRnbpnvdaO0es4TmxhP/f+quN3WI8GNCKfvKX7O7zP8DPk+rru/RWlUwxdiOfZL9dr74T9o5zlGMYxgacIUuboM49XeI03CFL28l5XijKUYx8KsXMCq5z1d2WN8To21Ly57wdrNlJ3SKRJqWfcgEY1b+5rZs1vFvhbZRFLWMYK/CbKdbqVGOMuxNW8ua+HNb8J8bxWoRphROA3/VxnSLnOeACDat7cd4M1v2mhTyva0I4O+M1DrjOqPGL8GE/UvLlvjDUbmeE6c0qCcRKzat7cN89aIXZO4B732zBGcB8PEKQ8o89zTOMFXsJvinJ4L/L7mnrfT/r8wm/8cbpZem/XPYI2vsz/+lfSuMr8dudahg79GdZs9Tb79e4X6YMbs9+HsMhHfMICFmEjZr+bdLuVpt9BnsEKVCKEKtiI2W+SblNp+p2mzxmcRQtaYSNmP3098/er12yNg97vNs/oHVw0ntVLqbm7xpyt88r3Oks8r8tYwWd8QZBSzfMQRgQ1qEWQ0kafdnTgHM6jkMIJbPcJ/AWuh6Ny
   </data>
  </layer>
- <layer name="Tile Layer 2" width="40" height="40">
+ <layer id="3" name="Tile Layer 2" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJztl0lLw0AYhkdFsV6sS8Uu8aQXKyqKnsTtJ4ig/8RW3H6AXvWi4g5uJ4v7TQ8uICju28ntqCjoxeUNzdBhiI1JM5MefOEhpG0yT76ZL0kJMZcVnzGrYA2sgw2fyQESzJ3PmHvwAB7Bk2S/HL8xuSAP5AOPX65fvd+YBtAImkCzZD+Z66/FZf4YWevvM0DIV8D8cbLWX6lCSFAxf5ys9dcGt3YLfjIzmem0wX/syj43l1b7V1ReOb94/etxE1Lgjm2dSLz+rYFTrTu2dSp6z4/+LEIGOJIhdC4j8BnOJmSwkJAhjhEwWuiMH53LK61eW/DY5tgD+5pfnxJDRIz69xkeLxzv4EPzW1SizIFULyELNnvy/Uvnd0mrn4IxiziKQYk3+v2lEuUMVOCzC5v9+P6l8xvR/DowZgiEQRfoBj2gV/NbltA3B9o9kb3PUb8peEyDGTAL5sC8Oo8S/WjY+xz1O4THETgGJ+AUnKvz6ICfGvb+ouYLHt8gBe+/LpAG0kGGT44f37/8+gvCowyUg1pQCapAtSC/gzjPX731p2Yz+/fzia4f7d8Ct/7600sd8yymfiE8I8Og08J/LaO8ZUa92PpdY9ybP3Cr+Y3BaxxMCPBTw9bPyvuUaD/Wy8r7lCg/2r/JWj/av4nWbwdeu2DPZj+9/nXyfV4vra7E6yc6yVw/NclaP7v6V1Ts6l87rknvHIn2L39N/LFm9vlzsFur9eN/y49hdp89B7v9ATopzkw=
+   eAHtl0uPDUEUxw9CjI3niNdYsTGCkJmVeH0EkZhvYka8PgBbNoh3YowV8d6xYCaREIPxWnktCQkbw+/k9klKpbvr9u2qdhdO8rt1q6v61L9PnVO3r0g1u7lCJMQt5tyGO3AXmrT3rBfiA3M+wif4DE3awpUiIRYxZzEsgV5o0raxXojtzNkBO2EXNGmh3NPxWPm3u6f6k4VyT8dj5N+vVSLTUNVCuafjMfJvXZ9IP1S1UO7peIz824u2oQ70VX2eOvPPz61z9/97uykCE95edlq/qZ7pm6evrH57F4gsBWtTaSrzW1a/A2gbBGvL/KQcy/v9ODpP5JhHSg3t+ra9vI62k/NFji8TOeFxiv5p+Bdme/kafWr30fHAY5z+RKbvCGe70boj7meofr+g46vHD/o/M31X0aeMwszlImO0Mc2vX9vfa1n8+lhztcca+mtB7RV6lBewkWtTkfX59Wv7q/mnto81h2EEDsBBOASHQe1GNq/VS/P5ODsTLXa6ium7gI6LcAkuwyhcgTFQa0Jfa6W/zznT9wQdT+EZTMJzeAlToNakPl3PYmj6ptHxG2bwPtwDs2A2zAG11Pr8+vXzrx8d62EDDMIm2AxbIIU+y7WWdxG3fi12Ombx0+/3OKeLLHX8rH71PcBip1pcfb62rcw1M33D/Mcagf0d/NcyX0Xtd+pX3wPc+L3h3HjbBu+y8+UMus7CuQT6VLcbP1dn0TP511Prc+Pn7rOvo6ifSp/Vb7fGz+q3bvweknePYDxy/uXVbyf5V7TvMa7v4Znrxi+GjjIfdfOvzHeMsW6NX6z6jRGjPB+x6jdGTeX5qFu/5nOA30c3RywWNt5O3/dh92rr+rZ55rOs9edaX33m1VxoXNeyOW77Bzopzkw=
   </data>
  </layer>
- <layer name="Above Player" width="40" height="40">
+ <layer id="4" name="Above Player" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJzt1TkOg0AQRNFKsPERWK7pfQcfCy+h1zv5B+QQWAxY9aQvTdhBj1rqh1UmrWlDW9rRPgs9lf0L75f12YFdPFJBJZ28mzYQ91x60JNe9K7fTX3y0JP/TpVKZ7rQlW5p6InMrK0p93ZGc1rQ0vfXbDCiRBrRmGKaJKEnMrO2/H/NrGtfNh0f+w==
+   eAHt1ckKggAYReG7aXqE0te02WzwsZqWWvZOncB1K4N+uRc+MISIk4P0H1sn0gZb5NihgOcCXRTw9dVFRX/HrwrsedYdcMQJJTwXiFCgSqUaDzzRtMefz9+8ON+XnWfSBVfccIfnAi4Qo0DG+3aOBZZYwXMBF4hRYDCVhhhhjAk8F3CBGAV8/8b4n/wrXaBPBd42HR/7
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collision">
   <object id="118" type="collision" x="0" y="416" width="80" height="224"/>
   <object id="119" type="collision" x="224" y="624" width="416" height="16"/>
   <object id="120" type="collision" x="32" y="0" width="384" height="32"/>
@@ -189,75 +189,75 @@
   <object id="207" type="collision" x="432" y="448" width="32" height="32"/>
   <object id="208" type="collision" x="624" y="128" width="16" height="448"/>
  </objectgroup>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="6" name="Events">
   <object id="196" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_town_theme"/>
-    <property name="cond1" value="not music_playing music_town_theme"/>
+    <property name="act10" value="play_music music_town_theme"/>
+    <property name="cond10" value="not music_playing music_town_theme"/>
    </properties>
   </object>
   <object id="197" name="Teleport to Route 6" type="event" x="112" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route6.tmx,7,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route6.tmx,7,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="198" name="Teleport to Route 6" type="event" x="128" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route6.tmx,8,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route6.tmx,8,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="199" name="Teleport to Route 6" type="event" x="144" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route6.tmx,9,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route6.tmx,9,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="200" name="Teleport to Route 6" type="event" x="160" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route6.tmx,10,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route6.tmx,10,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="201" name="Teleport to Route 6" type="event" x="176" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route6.tmx,11,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route6.tmx,11,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="202" name="Teleport to Route 6" type="event" x="192" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route6.tmx,12,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route6.tmx,12,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="203" name="Teleport to Route 6" type="event" x="208" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route6.tmx,13,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route6.tmx,13,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="209" name="Teleport to Sea Route" type="event" x="128" y="496" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport routec.tmx,38,5,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport routec.tmx,38,5,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="210" name="Player Spawn" type="event" x="144" y="576" width="16" height="16"/>

--- a/mods/tuxemon/maps/city1_mart_junkyard.tmx
+++ b/mods/tuxemon/maps/city1_mart_junkyard.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.2.0" orientation="orthogonal" renderorder="right-down" width="21" height="35" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="46">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="21" height="35" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="46">
  <tileset firstgid="1" name="KelvinShadewing_Terrain" tilewidth="16" tileheight="16" tilecount="285" columns="19">
   <image source="../gfx/tilesets/KelvinShadewing_Terrain.png" width="304" height="240"/>
  </tileset>
@@ -15,27 +15,27 @@
  <tileset firstgid="1758" name="items" tilewidth="16" tileheight="16" tilecount="100" columns="10">
   <image source="../gfx/tilesets/items.png" width="160" height="160"/>
  </tileset>
- <tileset firstgid="1858" name="KelvinShadewing_Buildings" tilewidth="16" tileheight="16" tilecount="500" columns="20">
-  <image source="../gfx/tilesets/KelvinShadewing_Buildings.png" width="320" height="400"/>
+ <tileset firstgid="1858" name="KelvinShadewing_Buildings" tilewidth="16" tileheight="16" tilecount="680" columns="20">
+  <image source="../gfx/tilesets/KelvinShadewing_Buildings.png" width="320" height="544"/>
  </tileset>
  <layer id="1" name="Tile Layer 1" width="21" height="35">
   <data encoding="base64" compression="zlib">
-   eJztyzERACAMBMGviJUowiQBLJKWIYOCK7Zcl+QAAAAALr29hknxMdNK2+p/AOw6et8=
+   eAHTYGBg0BjFo2EwmgZG08BoGhhNA6NpYDQNjKaB0TQwmgZQ0kAYGwMDOl7NzsCwBg9eC5RbB8TrgRhdL4gPAOw6et8=
   </data>
  </layer>
  <layer id="2" name="Tile Layer 2" width="21" height="35">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFIxnMY2NwmA/EC4B4oN0CA9vYqW/mKTQza8mwI4gG7hoF5IGbLAwMt1gIq4shIc6YWBkYmIF4KwFzCwiYuZODgWEXEXg3B/FuOwtU+4ANvxqQ/FkSzXxFwMxXRJgZhhQexNpPSF0WhWZOJBBH1HLncDUTVNahq2Nhxa4O2Uxsaki1m1S19DSTlRWBB9rMzSyo6gqBcVGEJ90jq63BU8bhsjuUA4GxqV1KAzPxAXR1+Op0SuNIAwsmBWDTDwBmRTo9
+   eAHtlU0KwkAMhYO21aN4DM8g6MoTuFLXeggvoG48gSioNxA8gK5cewqTxYMwdCapPyhoIKSdfPMypG1K9Ldf7sC8oPaCfcn+LX3YNl5/kmOgOQ3uPRU7D+zx6P6Z6h04Z0QXdsv6FZ5ZLSeqs28M3aGhuWsS7R1+YMZrJ2avRZqWvHBeE/ZmaEre0uypflgszmZxgyc1Z2o/aupo1Qfr5YT3sl7uk5oy68JzZvxthIaZCLaM0XvA6bXYtZf1clLHy8a4nHsAx7ljLPKIMQ56EmExFnmJa55TmhvxMxsn3nvNThIzTnO6XpfnBRzrml29QRN1yqKuLfnUPz1ky/RkLca1OBd6TKNsPdwr93dmRTo9
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="21" height="35">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUjIJRMApGwSgYBcMBOHIg8GA2cyQDAItOAbc=
+   eAFjYBgFoyEwGgKjITAaAqMhMBoCoyEwGgLDIQQcORgYYJha/oGZB6JHAeUhAACLTgG3
   </data>
  </layer>
  <layer id="4" name="Above Player" width="21" height="35">
   <data encoding="base64" compression="zlib">
-   eJztzjEBAAAIA6B9ptT+MWyhDyQgAQDgQlcy9b3g0wKfDQDK
+   eAFjYBgFoyEwGgKjITAaAqMhMBoCoyEwGgL0CIFYdgaGOCAeBSM3BACfDQDK
   </data>
  </layer>
  <objectgroup color="#ff0000" id="5" name="Collision">
@@ -61,26 +61,26 @@
   <object id="24" type="collision" x="224" y="272" width="16" height="16"/>
   <object id="25" type="event" x="224" y="272" width="16" height="16">
    <properties>
-    <property name="act1" value="add_monster txmn_fruitera,10"/>
-    <property name="act2" value="set_variable got_Fruitera:true"/>
-    <property name="act3" value="dialog ${{name}}: I got a Fruitera!"/>
-    <property name="act4" value="set_variable got_first_tuxemon:true"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
-    <property name="cond3" value="not variable_set got_first_tuxemon:true"/>
-    <property name="cond4" value="is variable_set maple_bedroom1:true"/>
+    <property name="act10" value="add_monster txmn_fruitera,10"/>
+    <property name="act20" value="set_variable got_Fruitera:true"/>
+    <property name="act30" value="dialog ${{name}}: I got a Fruitera!"/>
+    <property name="act40" value="set_variable got_first_tuxemon:true"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="not variable_set got_first_tuxemon:true"/>
+    <property name="cond40" value="is variable_set maple_bedroom1:true"/>
    </properties>
   </object>
   <object id="26" type="event" x="96" y="272" width="16" height="16">
    <properties>
-    <property name="act1" value="add_monster txmn_bamboon,10"/>
-    <property name="act2" value="set_variable got_Bamboon:true"/>
-    <property name="act3" value="dialog ${{name}}: I got a Bamboon!"/>
-    <property name="act4" value="set_variable got_first_tuxemon:true"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
-    <property name="cond3" value="not variable_set got_first_tuxemon:true"/>
-    <property name="cond4" value="is variable_set maple_bedroom1:true"/>
+    <property name="act10" value="add_monster txmn_bamboon,10"/>
+    <property name="act20" value="set_variable got_Bamboon:true"/>
+    <property name="act30" value="dialog ${{name}}: I got a Bamboon!"/>
+    <property name="act40" value="set_variable got_first_tuxemon:true"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="not variable_set got_first_tuxemon:true"/>
+    <property name="cond40" value="is variable_set maple_bedroom1:true"/>
    </properties>
   </object>
   <object id="27" type="collision" x="224" y="464" width="16" height="16"/>
@@ -88,144 +88,144 @@
  <objectgroup color="#ffff00" id="6" name="Events">
   <object id="15" type="event" x="160" y="304" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc maple_girl,10,6,girl1,wander"/>
-    <property name="cond1" value="is variable_set maple_bedroom1:true"/>
+    <property name="act10" value="create_npc maple_girl,10,6,girl1,wander"/>
+    <property name="cond10" value="is variable_set maple_bedroom1:true"/>
    </properties>
   </object>
   <object id="16" type="event" x="160" y="528" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport tuxe_mart.tmx,11,4,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport tuxe_mart.tmx,11,4,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="29" type="event" x="144" y="512" width="48" height="16">
    <properties>
-    <property name="act1" value="dialog_chain Hey, {name}! I found some Tuxballs in this junkyard!"/>
-    <property name="act2" value="dialog_chain You can have one. I'll take the other"/>
-    <property name="act3" value="dialog_chain ${{end}}"/>
-    <property name="act4" value="set_variable talked_to_maple_junkyard:true"/>
-    <property name="cond1" value="is variable_set maple_bedroom1:true"/>
-    <property name="cond2" value="is player_at"/>
-    <property name="cond3" value="not variable_set talked_to_maple_junkyard:true"/>
+    <property name="act10" value="dialog_chain Hey, {name}! I found some Tuxballs in this junkyard!"/>
+    <property name="act20" value="dialog_chain You can have one. I'll take the other"/>
+    <property name="act30" value="dialog_chain ${{end}}"/>
+    <property name="act40" value="set_variable talked_to_maple_junkyard:true"/>
+    <property name="cond10" value="is variable_set maple_bedroom1:true"/>
+    <property name="cond20" value="is player_at"/>
+    <property name="cond30" value="not variable_set talked_to_maple_junkyard:true"/>
    </properties>
   </object>
   <object id="30" type="event" x="144" y="528" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog_chain Hey, {name}! I found some Tuxballs in this junkyard!"/>
-    <property name="act2" value="dialog_chain You can have one. I'll take the other"/>
-    <property name="act3" value="dialog_chain ${{end}}"/>
-    <property name="act4" value="set_variable talked_to_maple_junkyard:true"/>
-    <property name="cond1" value="is variable_set maple_bedroom1:true"/>
-    <property name="cond2" value="is player_at"/>
-    <property name="cond3" value="not variable_set talked_to_maple_junkyard:true"/>
+    <property name="act10" value="dialog_chain Hey, {name}! I found some Tuxballs in this junkyard!"/>
+    <property name="act20" value="dialog_chain You can have one. I'll take the other"/>
+    <property name="act30" value="dialog_chain ${{end}}"/>
+    <property name="act40" value="set_variable talked_to_maple_junkyard:true"/>
+    <property name="cond10" value="is variable_set maple_bedroom1:true"/>
+    <property name="cond20" value="is player_at"/>
+    <property name="cond30" value="not variable_set talked_to_maple_junkyard:true"/>
    </properties>
   </object>
   <object id="31" type="event" x="176" y="528" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog_chain Hey, {name}! I found some Tuxballs in this junkyard!"/>
-    <property name="act2" value="dialog_chain You can have one. I'll take the other"/>
-    <property name="act3" value="dialog_chain ${{end}}"/>
-    <property name="act4" value="set_variable talked_to_maple_junkyard:true"/>
-    <property name="cond1" value="is variable_set maple_bedroom1:true"/>
-    <property name="cond2" value="is player_at"/>
-    <property name="cond3" value="not variable_set talked_to_maple_junkyard:true"/>
+    <property name="act10" value="dialog_chain Hey, {name}! I found some Tuxballs in this junkyard!"/>
+    <property name="act20" value="dialog_chain You can have one. I'll take the other"/>
+    <property name="act30" value="dialog_chain ${{end}}"/>
+    <property name="act40" value="set_variable talked_to_maple_junkyard:true"/>
+    <property name="cond10" value="is variable_set maple_bedroom1:true"/>
+    <property name="cond20" value="is player_at"/>
+    <property name="cond30" value="not variable_set talked_to_maple_junkyard:true"/>
    </properties>
   </object>
   <object id="32" type="event" x="80" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="pathfind maple_girl,6,18"/>
-    <property name="act2" value="dialog MAPLE: I got a Bamboon!"/>
-    <property name="act3" value="set_variable maple_got_tuxemon1:true"/>
-    <property name="cond1" value="is variable_set got_Fruitera:true"/>
-    <property name="cond2" value="not variable_set maple_got_tuxemon1:true"/>
+    <property name="act10" value="pathfind maple_girl,6,18"/>
+    <property name="act20" value="dialog MAPLE: I got a Bamboon!"/>
+    <property name="act30" value="set_variable maple_got_tuxemon1:true"/>
+    <property name="cond10" value="is variable_set got_Fruitera:true"/>
+    <property name="cond20" value="not variable_set maple_got_tuxemon1:true"/>
    </properties>
   </object>
   <object id="34" type="event" x="240" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="pathfind maple_girl,14,18"/>
-    <property name="act2" value="dialog MAPLE: I got a Fruitera!"/>
-    <property name="act3" value="set_variable maple_got_tuxemon1:true"/>
-    <property name="cond1" value="is variable_set got_Bamboon:true"/>
-    <property name="cond2" value="not variable_set maple_got_tuxemon1:true"/>
+    <property name="act10" value="pathfind maple_girl,14,18"/>
+    <property name="act20" value="dialog MAPLE: I got a Fruitera!"/>
+    <property name="act30" value="set_variable maple_got_tuxemon1:true"/>
+    <property name="cond10" value="is variable_set got_Bamboon:true"/>
+    <property name="cond20" value="not variable_set maple_got_tuxemon1:true"/>
    </properties>
   </object>
   <object id="35" type="event" x="256" y="368" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc cfanatic1,12,33,player,stand"/>
-    <property name="act2" value="set_variable fanatics_in_junkyard:true"/>
-    <property name="cond1" value="is variable_set maple_got_tuxemon1:true"/>
-    <property name="cond2" value="not variable_set fanatics_in_junkyard:true"/>
+    <property name="act10" value="create_npc cfanatic1,12,33,player,stand"/>
+    <property name="act20" value="set_variable fanatics_in_junkyard:true"/>
+    <property name="cond10" value="is variable_set maple_got_tuxemon1:true"/>
+    <property name="cond20" value="not variable_set fanatics_in_junkyard:true"/>
    </properties>
   </object>
   <object id="36" type="event" x="64" y="368" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc cfanatic2,8,33,player,stand"/>
-    <property name="act2" value="set_variable fanatics_in_junkyard:true"/>
-    <property name="cond1" value="is variable_set maple_got_tuxemon1:true"/>
-    <property name="cond2" value="not variable_set fanatics_in_junkyard:true"/>
+    <property name="act10" value="create_npc cfanatic2,8,33,player,stand"/>
+    <property name="act20" value="set_variable fanatics_in_junkyard:true"/>
+    <property name="cond10" value="is variable_set maple_got_tuxemon1:true"/>
+    <property name="cond20" value="not variable_set fanatics_in_junkyard:true"/>
    </properties>
   </object>
   <object id="37" type="event" x="64" y="352" width="16" height="16">
    <properties>
-    <property name="act1" value="cfanatic2 pathfind,8,21"/>
-    <property name="act2" value="set_variable fanatics_in_junkyard2:true"/>
-    <property name="cond1" value="is variable_set fanatics_in_junkyard:true"/>
-    <property name="cond2" value="not variable_set fanatics_in_junkyard2:true"/>
+    <property name="act10" value="cfanatic2 pathfind,8,21"/>
+    <property name="act20" value="set_variable fanatics_in_junkyard2:true"/>
+    <property name="cond10" value="is variable_set fanatics_in_junkyard:true"/>
+    <property name="cond20" value="not variable_set fanatics_in_junkyard2:true"/>
    </properties>
   </object>
   <object id="38" type="event" x="256" y="352" width="16" height="16">
    <properties>
-    <property name="act1" value="cfanatic1 pathfind,11,21"/>
-    <property name="act2" value="set_variable fanatics_in_junkyard2:true"/>
-    <property name="cond1" value="is variable_set fanatics_in_junkyard:true"/>
-    <property name="cond2" value="not variable_set fanatics_in_junkyard2:true"/>
+    <property name="act10" value="cfanatic1 pathfind,11,21"/>
+    <property name="act20" value="set_variable fanatics_in_junkyard2:true"/>
+    <property name="cond10" value="is variable_set fanatics_in_junkyard:true"/>
+    <property name="cond20" value="not variable_set fanatics_in_junkyard2:true"/>
    </properties>
   </object>
   <object id="39" type="event" x="256" y="304" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog_chain GARY: Well, well, well. Look who we have here!"/>
-    <property name="act2" value="dialog_chain CARY: You know you're stealing those Tuxballs without signing the End User License Agreement, right?"/>
-    <property name="act3" value="dialog_chain MAPLE: These are trash! You don't have to sign the EULA for trash!"/>
-    <property name="act4" value="dialog_chain GARY: That's what you think. But you're gonna have to pay."/>
-    <property name="act5" value="dialog_chain GARY: People like you shouldn't be able to get Tuxemon like this!"/>
-    <property name="act6" value="dialog_chain CARY: It's your own fault. Let's get them, Gary."/>
-    <property name="act7" value="dialog_chain ${{end}}"/>
-    <property name="act8" value="set_variable fanatics_in_junkyard3:true"/>
-    <property name="cond1" value="is variable_set fanatics_in_junkyard2:true"/>
-    <property name="cond2" value="not variable_set fanatics_in_junkyard3:true"/>
+    <property name="act10" value="dialog_chain GARY: Well, well, well. Look who we have here!"/>
+    <property name="act20" value="dialog_chain CARY: You know you're stealing those Tuxballs without signing the End User License Agreement, right?"/>
+    <property name="act30" value="dialog_chain MAPLE: These are trash! You don't have to sign the EULA for trash!"/>
+    <property name="act40" value="dialog_chain GARY: That's what you think. But you're gonna have to pay."/>
+    <property name="act50" value="dialog_chain GARY: People like you shouldn't be able to get Tuxemon like this!"/>
+    <property name="act60" value="dialog_chain CARY: It's your own fault. Let's get them, Gary."/>
+    <property name="act70" value="dialog_chain ${{end}}"/>
+    <property name="act80" value="set_variable fanatics_in_junkyard3:true"/>
+    <property name="cond10" value="is variable_set fanatics_in_junkyard2:true"/>
+    <property name="cond20" value="not variable_set fanatics_in_junkyard3:true"/>
    </properties>
   </object>
   <object id="40" type="event" x="256" y="288" width="16" height="16">
    <properties>
-    <property name="act1" value="start_battle 2"/>
-    <property name="act2" value="set_variable fought_fanatics_in_junkyard:true"/>
-    <property name="cond1" value="is variable_set fanatics_in_junkyard3:true"/>
+    <property name="act10" value="start_battle 2"/>
+    <property name="act20" value="set_variable fought_fanatics_in_junkyard:true"/>
+    <property name="cond10" value="is variable_set fanatics_in_junkyard3:true"/>
    </properties>
   </object>
   <object id="41" type="event" x="288" y="208" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog CARY: Well, you won this time. But next time, we'll win."/>
-    <property name="act2" value="set_variable fanatics_in_junkyard4:true"/>
-    <property name="cond1" value="is variable_set fought_fanatics_in_junkyard:true"/>
-    <property name="cond2" value="not variable_set fanatics_in_junkyard4:true"/>
+    <property name="act10" value="dialog CARY: Well, you won this time. But next time, we'll win."/>
+    <property name="act20" value="set_variable fanatics_in_junkyard4:true"/>
+    <property name="cond10" value="is variable_set fought_fanatics_in_junkyard:true"/>
+    <property name="cond20" value="not variable_set fanatics_in_junkyard4:true"/>
    </properties>
   </object>
   <object id="42" type="event" x="304" y="224" width="16" height="16">
    <properties>
-    <property name="act1" value="cfanatic1 pathfind,11,32"/>
-    <property name="act2" value="set_variable fanatics_in_junkyard5:true"/>
-    <property name="cond1" value="is variable_set fanatics_in_junkyard4:true"/>
-    <property name="cond2" value="not variable_set fanatics_in_junkyard5:true"/>
+    <property name="act10" value="cfanatic1 pathfind,11,32"/>
+    <property name="act20" value="set_variable fanatics_in_junkyard5:true"/>
+    <property name="cond10" value="is variable_set fanatics_in_junkyard4:true"/>
+    <property name="cond20" value="not variable_set fanatics_in_junkyard5:true"/>
    </properties>
   </object>
   <object id="44" type="event" x="272" y="224" width="16" height="16">
    <properties>
-    <property name="act1" value="cfanatic2 pathfind,8,33"/>
-    <property name="act2" value="set_variable fanatics_in_junkyard5:true"/>
-    <property name="cond1" value="is variable_set fought_fanatics_in_junkyard:true"/>
-    <property name="cond2" value="not variable_set fanatics_in_junkyard4:true"/>
+    <property name="act10" value="cfanatic2 pathfind,8,33"/>
+    <property name="act20" value="set_variable fanatics_in_junkyard5:true"/>
+    <property name="cond10" value="is variable_set fought_fanatics_in_junkyard:true"/>
+    <property name="cond20" value="not variable_set fanatics_in_junkyard4:true"/>
    </properties>
   </object>
   <object id="45" name="Player Spawn" type="event" x="160" y="480" width="16" height="16"/>

--- a/mods/tuxemon/maps/citypark.tmx
+++ b/mods/tuxemon/maps/citypark.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.3.1" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="123">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="123">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -113,372 +113,372 @@
  <objectgroup color="#ffff00" id="6" name="Events">
   <object id="33" name="random encounter 1" type="event" x="208" y="176" width="128" height="32">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="34" name="encounter 2" type="event" x="144" y="144" width="16" height="48">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="35" name="encounter 3" type="event" x="32" y="176" width="112" height="16">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="48" name="encounter 5" type="event" x="304" y="304">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
    <polygon points="0,0 0,128 128,128 128,0"/>
   </object>
   <object id="60" name="encounter" type="event" x="480" y="496" width="96" height="16">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="61" name="encounter" type="event" x="464" y="512" width="128" height="32">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="62" name="encounter" type="event" x="560" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="63" name="encounter" type="event" x="592" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="64" name="encounter" type="event" x="576" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="65" name="encounter" type="event" x="560" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="66" name="encounter" type="event" x="592" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="67" name="encounter" type="event" x="576" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="68" name="encounter" type="event" x="576" y="176" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="69" name="encounter" type="event" x="592" y="160" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="70" name="encounter" type="event" x="560" y="160" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="71" name="encounter" type="event" x="576" y="208" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="72" name="encounter" type="event" x="592" y="192" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="73" name="encounter" type="event" x="560" y="192" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="74" name="encounter" type="event" x="576" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="75" name="encounter" type="event" x="592" y="224" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="76" name="encounter" type="event" x="560" y="224" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="77" name="encounter" type="event" x="576" y="272" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="78" name="encounter" type="event" x="592" y="256" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="79" name="encounter" type="event" x="560" y="256" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="80" name="encounter" type="event" x="576" y="304" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="81" name="encounter" type="event" x="592" y="288" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="82" name="encounter" type="event" x="560" y="288" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="83" name="encounter" type="event" x="576" y="336" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="84" name="encounter" type="event" x="592" y="320" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="85" name="encounter" type="event" x="560" y="320" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="86" name="Teleport to Route 2" type="event" x="176" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route2.tmx,11,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route2.tmx,11,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="87" name="Teleport to Route 2" type="event" x="160" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route2.tmx,10,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route2.tmx,10,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="88" name="Teleport to Leather Town" type="event" x="624" y="160" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport leather_town.tmx,0,31,0.3"/>
-    <property name="act2" value="player_face right"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="transition_teleport leather_town.tmx,0,31,0.3"/>
+    <property name="act20" value="player_face right"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="89" name="Teleport to Leather Town" type="event" x="624" y="176" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport leather_town.tmx,0,32,0.3"/>
-    <property name="act2" value="player_face right"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="transition_teleport leather_town.tmx,0,32,0.3"/>
+    <property name="act20" value="player_face right"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="90" name="Teleport to Leather Town" type="event" x="624" y="192" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport leather_town.tmx,0,33,0.3"/>
-    <property name="act2" value="player_face right"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="transition_teleport leather_town.tmx,0,33,0.3"/>
+    <property name="act20" value="player_face right"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="91" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_city_park"/>
-    <property name="cond1" value="not music_playing music_city_park"/>
+    <property name="act10" value="play_music music_city_park"/>
+    <property name="cond10" value="not music_playing music_city_park"/>
    </properties>
   </object>
   <object id="101" name="Sign: Achievement Maniac's House" type="event" x="512" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog_chain Achievement Maniac's House: Closed"/>
-    <property name="act4" value="dialog_chain ${{end}}"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog_chain Achievement Maniac's House: Closed"/>
+    <property name="act20" value="dialog_chain ${{end}}"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="102" name="Sign: Leather Town" type="event" x="608" y="160" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog_chain Leather Town: Proof Beauty and Mining Can Coexist"/>
-    <property name="act2" value="dialog_chain &lt;- City Park ---- Leather Town ---&gt;"/>
-    <property name="act4" value="dialog_chain ${{end}}"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog_chain Leather Town: Proof Beauty and Mining Can Coexist"/>
+    <property name="act20" value="dialog_chain &lt;- City Park ---- Leather Town ---&gt;"/>
+    <property name="act30" value="dialog_chain ${{end}}"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="103" name="Player Spawn" type="event" x="80" y="592" width="16" height="16"/>
   <object id="111" name="ripjimmy" type="event" x="32" y="400" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog ripjimmy"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog ripjimmy"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="112" name="make npcs" type="event" x="48" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc knight1,12,13,knight,stand"/>
-    <property name="act2" value="npc_face knight1,right"/>
-    <property name="act3" value="set_variable firstgo:no"/>
-    <property name="cond1" value="not npc_exists knight1"/>
-    <property name="cond2" value="not variable_set firstgo:gone"/>
+    <property name="act10" value="create_npc knight1,12,13,knight,stand"/>
+    <property name="act20" value="npc_face knight1,right"/>
+    <property name="act30" value="set_variable firstgo:no"/>
+    <property name="cond10" value="not npc_exists knight1"/>
+    <property name="cond20" value="not variable_set firstgo:gone"/>
    </properties>
   </object>
   <object id="113" name="hurrytalk" type="event" x="176" y="208" width="16" height="16">
    <properties>
-    <property name="act1" value="npc_face knight1,left"/>
-    <property name="act2" value="translated_dialog iamknight"/>
-    <property name="act3" value="set_variable firstgo:yes"/>
-    <property name="act4" value="translated_dialog iamknight2"/>
-    <property name="act5" value="translated_dialog_choice mistaken:thats_me,cityparkchoice"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
-    <property name="cond4" value="is variable_set firstgo:no"/>
+    <property name="act10" value="npc_face knight1,left"/>
+    <property name="act20" value="translated_dialog iamknight"/>
+    <property name="act30" value="set_variable firstgo:yes"/>
+    <property name="act40" value="translated_dialog iamknight2"/>
+    <property name="act50" value="translated_dialog_choice mistaken:thats_me,cityparkchoice"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond40" value="is variable_set firstgo:no"/>
    </properties>
   </object>
   <object id="115" name="hurrytalkmistaken" type="event" x="176" y="208" width="16" height="16">
    <properties>
-    <property name="act2" value="translated_dialog mistakenknight"/>
-    <property name="act3" value="set_variable firstgo:gone"/>
-    <property name="act4" value="set_variable secondgo:yes"/>
-    <property name="cond1" value="is variable_set firstgo:yes"/>
-    <property name="cond2" value="is variable_set cityparkchoice:mistaken"/>
+    <property name="act10" value="translated_dialog mistakenknight"/>
+    <property name="act20" value="set_variable firstgo:gone"/>
+    <property name="act30" value="set_variable secondgo:yes"/>
+    <property name="cond10" value="is variable_set firstgo:yes"/>
+    <property name="cond20" value="is variable_set cityparkchoice:mistaken"/>
    </properties>
   </object>
   <object id="116" name="hurrytalkyes" type="event" x="176" y="208" width="16" height="16">
    <properties>
-    <property name="act1" value="set_variable firstgo:gone"/>
-    <property name="act2" value="translated_dialog thatsmeknight"/>
-    <property name="act3" value="set_variable secondgo:yes"/>
-    <property name="cond1" value="is variable_set firstgo:yes"/>
-    <property name="cond2" value="is variable_set cityparkchoice:thats_me"/>
+    <property name="act10" value="set_variable firstgo:gone"/>
+    <property name="act20" value="translated_dialog thatsmeknight"/>
+    <property name="act30" value="set_variable secondgo:yes"/>
+    <property name="cond10" value="is variable_set firstgo:yes"/>
+    <property name="cond20" value="is variable_set cityparkchoice:thats_me"/>
    </properties>
   </object>
   <object id="117" name="hurrytalknow" type="event" x="176" y="208" width="16" height="16">
    <properties>
-    <property name="act1" value="npc_face knight1,up"/>
-    <property name="act2" value="wait 0.4"/>
-    <property name="act3" value="npc_face knight1,down"/>
-    <property name="act4" value="wait 0.4"/>
-    <property name="act5" value="npc_face knight1,left"/>
-    <property name="act6" value="translated_dialog quicklyknight"/>
-    <property name="act7" value="set_variable secondgo:gone"/>
-    <property name="act8" value="set_variable iamsecret:yes"/>
-    <property name="cond1" value="is variable_set secondgo:yes"/>
+    <property name="act10" value="npc_face knight1,up"/>
+    <property name="act20" value="wait 0.4"/>
+    <property name="act30" value="npc_face knight1,down"/>
+    <property name="act40" value="wait 0.4"/>
+    <property name="act50" value="npc_face knight1,left"/>
+    <property name="act60" value="translated_dialog quicklyknight"/>
+    <property name="act70" value="set_variable secondgo:gone"/>
+    <property name="act80" value="set_variable iamsecret:yes"/>
+    <property name="cond10" value="is variable_set secondgo:yes"/>
    </properties>
   </object>
   <object id="118" name="hurrytalksecret" type="event" x="176" y="208" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog quicklyknight2"/>
-    <property name="act2" value="npc_face knight1,up"/>
-    <property name="act3" value="wait 0.2"/>
-    <property name="act4" value="npc_face knight1,down"/>
-    <property name="act5" value="wait 0.2"/>
-    <property name="act6" value="npc_face knight1,left"/>
-    <property name="act7" value="translated_dialog quicklyknight3"/>
-    <property name="act8" value="npc_face knight1,right"/>
-    <property name="act9" value="wait 0.3"/>
-    <property name="act91" value="npc_face knight1,left"/>
-    <property name="act92" value="translated_dialog quicklyknight4"/>
-    <property name="act93" value="set_variable iamsecret:ohno"/>
-    <property name="cond1" value="is variable_set iamsecret:yes"/>
+    <property name="act010" value="translated_dialog quicklyknight2"/>
+    <property name="act020" value="npc_face knight1,up"/>
+    <property name="act030" value="wait 0.2"/>
+    <property name="act040" value="npc_face knight1,down"/>
+    <property name="act050" value="wait 0.2"/>
+    <property name="act060" value="npc_face knight1,left"/>
+    <property name="act070" value="translated_dialog quicklyknight3"/>
+    <property name="act080" value="npc_face knight1,right"/>
+    <property name="act090" value="wait 0.3"/>
+    <property name="act100" value="npc_face knight1,left"/>
+    <property name="act110" value="translated_dialog quicklyknight4"/>
+    <property name="act120" value="set_variable iamsecret:ohno"/>
+    <property name="cond10" value="is variable_set iamsecret:yes"/>
    </properties>
   </object>
   <object id="119" name="hurrytalkohno" type="event" x="176" y="208" width="16" height="16">
    <properties>
-    <property name="act2" value="npc_speed knight1, 5"/>
-    <property name="act3" value="pathfind knight1, 3,15"/>
-    <property name="act4" value="translated_dialog omnichannelarrives"/>
-    <property name="act5" value="set_variable omnichannelhere:here"/>
-    <property name="act6" value="player_face left"/>
-    <property name="cond1" value="is variable_set iamsecret:ohno"/>
+    <property name="act10" value="npc_speed knight1, 5"/>
+    <property name="act20" value="pathfind knight1, 3,15"/>
+    <property name="act30" value="translated_dialog omnichannelarrives"/>
+    <property name="act40" value="set_variable omnichannelhere:here"/>
+    <property name="act50" value="player_face left"/>
+    <property name="cond10" value="is variable_set iamsecret:ohno"/>
    </properties>
   </object>
   <object id="122" name="omnichannel npc 1" type="event" x="0" y="256" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc "/>
-    <property name="cond1" value="is variable_set omnichannelhere:here"/>
-    <property name="cond2" value="not npc_exists"/>
+    <property name="act10" value="create_npc "/>
+    <property name="cond10" value="is variable_set omnichannelhere:here"/>
+    <property name="cond20" value="not npc_exists"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/cotton_cafe.tmx
+++ b/mods/tuxemon/maps/cotton_cafe.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="12" height="12" tilewidth="16" tileheight="16" nextobjectid="15">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="12" height="12" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="15">
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>
  </tileset>
@@ -57,27 +57,27 @@
  <tileset firstgid="7682" name="Interiors by Redshrike" tilewidth="16" tileheight="16" tilecount="84" columns="7">
   <image source="../gfx/tilesets/Interiors by Redshrike.png" width="112" height="192"/>
  </tileset>
- <layer name="Tile Layer 1" width="12" height="12">
+ <layer id="1" name="Tile Layer 1" width="12" height="12">
   <data encoding="base64" compression="zlib">
-   eJz7L87A8J8EzCVBGhYlEWuN4iGFAc36LJU=
+   eAH7L87A8J8EzCXBwEAKFgWqJwVrAdWP4qETBgDN+iyV
   </data>
  </layer>
- <layer name="Tile Layer 5" width="12" height="12">
+ <layer id="2" name="Tile Layer 5" width="12" height="12">
   <data encoding="base64" compression="zlib">
-   eJxjYCAdMAsRz5bkZmCQAuLFwgwMS4DYTg4ibiWHUAsTaxJkYHADqnUH4u1AtTuA2BUq5w+kA4A4EIiDoWI9gphu85HDFEMGQUjmBCGZBQMSchAMA/pcqDQykAKq2wUU3w3EkjjsRTYPpP45UO0LHOqJMQ9dPT7zyAGGeMxhBcqxATE7VE0gDwMDAL9NFi8=
+   eAFjYCAdMAsh9BBiS3IzMEgB8WJhBoYlQGwnB9FrBaVBPJhYkyADgxtQrTsQbweq3QHErlB1/kA6AIgDgTgYKtYDVI8OfKBy6OIwfhBQHmYOiA0zCyYvARQDYRjQ54KwYDRMHERLAdXtAsrvBmJJJD3IapDNA6l/DlT7Aod6YsxDNpuQechqiWUb4vAHSD8rUI4NiNmhagJ5GBgAv00WLw==
   </data>
  </layer>
- <layer name="Tile Layer 4" width="12" height="12">
+ <layer id="3" name="Tile Layer 4" width="12" height="12">
   <data encoding="base64" compression="zlib">
-   eJxjYKAvmCdLmvoVRKifj6Smjouw+pUkumEggbgcBA9W8wDRtQRf
+   eAFjYKAvmCdLmn0riFA/H0lNHRdh81ciqSesemBViMsxMIAwtQC1zQMA0bUEXw==
   </data>
  </layer>
- <layer name="Above Player" width="12" height="12">
+ <layer id="4" name="Above Player" width="12" height="12">
   <data encoding="base64" compression="zlib">
-   eJxjYBjeQFAOgokBwkjqhHDoQTaPkHps8gJyEEyu/egAn3mkAk0e0vUAAM7+Ay4=
+   eAFjYBjeQFCOgQGEiQHCSOqEkNjIepHNI6Qem7wA0FwQxgawqcemDlkMn3nI6ohha/IQowpVDQDO/gMu
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collisions">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="1" type="collision" x="0" y="80" width="80" height="16"/>
   <object id="2" type="collision" x="64" y="48" width="16" height="48"/>
   <object id="3" type="collision" x="0" y="0" width="192" height="48"/>
@@ -90,19 +90,19 @@
   <object id="10" type="collision" x="128" y="96" width="32" height="32"/>
   <object id="11" type="collision" x="176" y="176" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="6" name="Events">
   <object id="12" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_cathedral_theme"/>
-    <property name="cond1" value="not music_playing music_cathedral_theme"/>
+    <property name="act10" value="play_music music_cathedral_theme"/>
+    <property name="cond10" value="not music_playing music_cathedral_theme"/>
    </properties>
   </object>
   <object id="13" name="Teleport to Cotton Town" type="event" x="112" y="176" width="48" height="16">
    <properties>
-    <property name="act1" value="transition_teleport cotton_town.tmx,11,17,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport cotton_town.tmx,11,17,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="14" name="Player Spawn" type="event" x="112" y="144" width="16" height="16"/>

--- a/mods/tuxemon/maps/cotton_cathedral.tmx
+++ b/mods/tuxemon/maps/cotton_cathedral.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.2.0" orientation="orthogonal" renderorder="right-down" width="15" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="28">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="28">
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>
  </tileset>
@@ -14,22 +14,22 @@
  </tileset>
  <layer id="1" name="Tile Layer 1" width="15" height="15">
   <data encoding="base64" compression="zlib">
-   eJxjYBg4wEQGhgFeMjAMSJCBYcCADDyqd+joHQgAAK/YFXw=
+   eAFjYBg4wAS0mlQMcy0vkEEqhumVADJIxTC9BkAGqXhUL/FhNtBhBbOfnjQAr9gVfA==
   </data>
  </layer>
  <layer id="2" name="Tile Layer 2" width="15" height="15">
   <data encoding="base64" compression="zlib">
-   eJxjYBjZgJmVgYEXiPlYMcW5WBgYuFlw670LlDMDqjNH0lvLAhE3BmITPHrxAXMi9NUC7bzNgsD1rIT1kAtA7tkGxNtZiHMbut77QPyADL3kgovs2MVxBREu9fQCAM0+DTc=
+   eAFjYBjZgJmVgYEXiPmAGBmAxLlYGBi4gRgXuAuUMwOqM0fSWwsUA4kbA7EJEJMDzInQVwu08zZQHQzXI7mBHDvx6QG5ZxsQbwdiYtyGbBZI/X0gfkCGXmRzSGFfZMeuGlcQ4VKP3RTqiwIAzT4NNw==
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="15" height="15">
   <data encoding="base64" compression="zlib">
-   eJxjYBgF5IJwVtLEkYEODjW4xEfB8AUAYq4BGw==
+   eAFjYBgF5IZAOCt2nbjEkVXr4NCLSxxZ7yh7eIUAAGKuARs=
   </data>
  </layer>
  <layer id="4" name="Above player" width="15" height="15">
   <data encoding="base64" compression="zlib">
-   eJxjYBgcIIuNgSGbjbAYNjAJqGYyG2GxwQY2sjAwbELCm1kG2kWDB6xkp636wQQA3n8JEw==
+   eAFjYBgcIIuNgSEbiJEBNjFkeRh7ElDfZDS92MRg6gcLvZGFgWETEt4MZI8CSAisZCctJEhVT5rptFUNAN5/CRM=
   </data>
  </layer>
  <objectgroup color="#ff0000" id="5" name="Collision">
@@ -48,47 +48,47 @@
  <objectgroup color="#ffff00" id="6" name="Events">
   <object id="17" name="Go outside" type="event" x="112" y="192" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport cotton_town.tmx,19,27,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport cotton_town.tmx,19,27,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="24" name="Play Music" type="event" x="16" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_cathedral_theme"/>
-    <property name="cond1" value="not music_playing music_cathedral_theme"/>
+    <property name="act10" value="play_music music_cathedral_theme"/>
+    <property name="cond10" value="not music_playing music_cathedral_theme"/>
    </properties>
   </object>
   <object id="25" name="Player Spawn" type="event" x="112" y="144" width="16" height="16"/>
   <object id="26" name="create npcs" type="event" x="0" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc cottonnurse,6,6,nurse,stand"/>
-    <property name="cond1" value="not npc_exists cottonnurse"/>
+    <property name="act10" value="create_npc cottonnurse,6,6,nurse,stand"/>
+    <property name="cond10" value="not npc_exists cottonnurse"/>
    </properties>
   </object>
   <object id="27" name="get those tuxemon healed" type="event" x="96" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog cottonnurse_dialog"/>
-    <property name="act2" value="translated_dialog healmytuxemon"/>
-    <property name="act3" value="translated_dialog_choice yes:no,healme"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
-    <property name="cond4" value="not variable_set healme:yes"/>
+    <property name="act10" value="translated_dialog cottonnurse_dialog"/>
+    <property name="act20" value="translated_dialog healmytuxemon"/>
+    <property name="act30" value="translated_dialog_choice yes:no,healme"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond40" value="not variable_set healme:yes"/>
    </properties>
   </object>
   <object id="28" name="Heal Tuxemon" type="event" x="96" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="set_monster_health ,"/>
-    <property name="act2" value="set_monster_status ,"/>
-    <property name="act20" value="translated_dialog okaythen"/>
-    <property name="act3" value="npc_face cottonnurse,up"/>
-    <property name="act4" value="wait 1"/>
-    <property name="act5" value="npc_face cottonnurse,down"/>
-    <property name="act6" value="translated_dialog okaythen2"/>
-    <property name="act7" value="set_variable healme:none"/>
-    <property name="cond1" value="is variable_set healme:yes"/>
+    <property name="act10" value="set_monster_health ,"/>
+    <property name="act20" value="set_monster_status ,"/>
+    <property name="act30" value="translated_dialog okaythen"/>
+    <property name="act40" value="npc_face cottonnurse,up"/>
+    <property name="act50" value="wait 1"/>
+    <property name="act60" value="npc_face cottonnurse,down"/>
+    <property name="act70" value="translated_dialog okaythen2"/>
+    <property name="act80" value="set_variable healme:none"/>
+    <property name="cond10" value="is variable_set healme:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/cotton_scoop.tmx
+++ b/mods/tuxemon/maps/cotton_scoop.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="13" height="11" tilewidth="16" tileheight="16" nextobjectid="17">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="17">
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>
  </tileset>
@@ -54,22 +54,22 @@
  <tileset firstgid="7582" name="items" tilewidth="16" tileheight="16" tilecount="100" columns="10">
   <image source="../gfx/tilesets/items.png" width="160" height="160"/>
  </tileset>
- <layer name="Layer 1" width="13" height="11">
+ <layer id="1" name="Layer 1" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eJwzk2BgMCMRO5KBfcjA2qN4UGMAVowoyA==
+   eAEzk2BgMCMROwLVk4p9gHpIxdpAPaN48IYBAFaMKMg=
   </data>
  </layer>
- <layer name="Layer 2" width="13" height="11">
+ <layer id="2" name="Layer 2" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eJxjYICA/xJAQpIBK8Alpw4U08ChB13uPzeErhOG0IuA9GIgXiKMm63Ow8DABMSToHq2AentQLxDGDcbBLSQ9JACSNFTDVRbI4zQc08Qgu9DaRCAsWH8fqDaCUA8kQy34QP6XAwMu4B4NxeErcmDKq8nCxSHYgNZhJ7nQPwCqicQTY85UJ0FFFvKYrcXADhuJoA=
+   eAFjYICA/xJAWhLKQaNwyakD1Wvg0IMu958bYmidMIReBKQXA/ESIMbFVudhYGAC4klQPduA9HYg3gHEuNgg07WQ9EBsI46E2UOM6mqgG2qAGKbnniADAwjfh9IgM2BskDgI9APVTwDiiUBMTaDPxcCwC4h3AzGIrQn0PzLQkwWKQ7EBkAYBkLrnQPwCqicQTY85UJ0FFFtC9UB0IkgAOG4mgA==
   </data>
  </layer>
- <layer name="Layer 3" width="13" height="11">
+ <layer id="3" name="Layer 3" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eJxjYKAv4OcmXU+d8PDSM1wAABxyAl8=
+   eAFjYKAv4Ocm3b464eGlh3TfDE4dABxyAl8=
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collisions">
+ <objectgroup color="#ff0000" id="4" name="Collisions">
   <object id="2" type="collision" x="64" y="96">
    <polygon points="0,0 0,16 64,16 64,0"/>
   </object>
@@ -89,12 +89,12 @@
   <object id="12" type="collision" x="208" y="48" width="16" height="128"/>
   <object id="14" type="collision" x="64" y="48" width="144" height="16"/>
  </objectgroup>
- <layer name="Above Player" width="13" height="11">
+ <layer id="5" name="Above Player" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eJxjYKAvmC9Lup6VZOihBFwRhOCrUBoEYGwYHwbquOjrNlxAXArB1uShj50AKrkItg==
+   eAFjYKAvmC9Lun0rydBDui0IHVcEGRhA+CqUBsnA2CBxZFDHhcwbOLa4FMJuTR4Em5YsACq5CLY=
   </data>
  </layer>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="6" name="Events">
   <properties>
    <property name="act1" value="transition_teleport cotton_town.tmx,9,35,0.3"/>
    <property name="act2" value="player_face down"/>
@@ -103,16 +103,16 @@
   </properties>
   <object id="13" name="Teleport to Cotton Town" type="event" x="80" y="160" width="32" height="16">
    <properties>
-    <property name="act1" value="transition_teleport cotton_town.tmx,9,35,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport cotton_town.tmx,9,35,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="15" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_cathedral_theme"/>
-    <property name="cond1" value="not music_playing music_cathedral_theme"/>
+    <property name="act10" value="play_music music_cathedral_theme"/>
+    <property name="cond10" value="not music_playing music_cathedral_theme"/>
    </properties>
   </object>
   <object id="16" name="Player Spawn" type="event" x="80" y="128" width="16" height="16"/>

--- a/mods/tuxemon/maps/cotton_town.tmx
+++ b/mods/tuxemon/maps/cotton_town.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.3.1" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="280">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="280">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -183,336 +183,336 @@
  <objectgroup color="#ffff00" id="5" name="Events">
   <object id="144" name="Teleport to Route 2" type="event" x="0" y="464" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route2.tmx,39,9,0.3"/>
-    <property name="act2" value="player_face left"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
+    <property name="act10" value="transition_teleport route2.tmx,39,9,0.3"/>
+    <property name="act20" value="player_face left"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
    </properties>
   </object>
   <object id="145" name="Teleport to Route 1" type="event" x="160" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route1_sanglorian.tmx,10,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route1_sanglorian.tmx,10,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="146" name="Teleport to Cotton Cathedral" type="event" x="304" y="416" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport cotton_cathedral.tmx,7,12,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport cotton_cathedral.tmx,7,12,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="147" name="Teleport to Cotton Mart" type="event" x="144" y="544" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport cotton_scoop.tmx,5,10,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport cotton_scoop.tmx,5,10,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="148" name="Teleport to Omnichannel HQ almost" type="event" x="352" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog itslockedboi"/>
-    <property name="act2" value="translated_dialog hellothere"/>
-    <property name="act3" value="create_npc aeble,14,10,,stand"/>
-    <property name="act4" value="npc_face aeble,right"/>
-    <property name="act5" value="translated_dialog kmere"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
-    <property name="cond4" value="not npc_exists aeble"/>
-    <property name="cond5" value="not variable_set donewithyou:yes"/>
+    <property name="act10" value="translated_dialog itslockedboi"/>
+    <property name="act20" value="translated_dialog hellothere"/>
+    <property name="act30" value="create_npc aeble,14,10,,stand"/>
+    <property name="act40" value="npc_face aeble,right"/>
+    <property name="act50" value="translated_dialog kmere"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond40" value="not npc_exists aeble"/>
+    <property name="cond50" value="not variable_set donewithyou:yes"/>
    </properties>
   </object>
   <object id="149" name="Teleport to Dryad's Grove" type="event" x="624" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport dryadsgrove.tmx,0,7,0.3"/>
-    <property name="act2" value="player_face right"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="transition_teleport dryadsgrove.tmx,0,7,0.3"/>
+    <property name="act20" value="player_face right"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="160" name="Teleport to Route 1" type="event" x="176" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route1_sanglorian.tmx,11,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route1_sanglorian.tmx,11,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="161" name="Teleport to Route 1" type="event" x="192" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route1_sanglorian.tmx,12,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route1_sanglorian.tmx,12,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="162" name="Teleport to Route 1" type="event" x="208" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route1_sanglorian.tmx,13,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route1_sanglorian.tmx,13,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="163" name="Teleport to Route 1" type="event" x="224" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route1_sanglorian.tmx,14,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route1_sanglorian.tmx,14,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="164" name="Teleport to Route 1" type="event" x="240" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route1_sanglorian.tmx,15,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route1_sanglorian.tmx,15,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="165" name="Teleport to Route 1" type="event" x="256" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route1_sanglorian.tmx,16,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route1_sanglorian.tmx,16,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="166" name="Teleport to Route 1" type="event" x="272" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route1_sanglorian.tmx,17,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route1_sanglorian.tmx,17,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="167" name="Teleport to Route 1" type="event" x="288" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route1_sanglorian.tmx,18,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route1_sanglorian.tmx,18,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="232" name="Teleport to Route 2" type="event" x="0" y="448" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route2.tmx,39,8,0.3"/>
-    <property name="act2" value="player_face left"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
+    <property name="act10" value="transition_teleport route2.tmx,39,8,0.3"/>
+    <property name="act20" value="player_face left"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
    </properties>
   </object>
   <object id="236" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_town_theme"/>
-    <property name="cond1" value="not music_playing music_town_theme"/>
+    <property name="act10" value="play_music music_town_theme"/>
+    <property name="cond10" value="not music_playing music_town_theme"/>
    </properties>
   </object>
   <object id="239" name="Teleport to Dryad's Grove" type="event" x="624" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport dryadsgrove.tmx,0,8,0.3"/>
-    <property name="act2" value="player_face right"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="transition_teleport dryadsgrove.tmx,0,8,0.3"/>
+    <property name="act20" value="player_face right"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="245" name="Sign: Cotton Town" type="event" x="240" y="608" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog Cotton_Town_Sign\n"/>
-    <property name="cond1" value="is player_facing up"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
-    <property name="cond3" value="is player_at"/>
+    <property name="act10" value="translated_dialog Cotton_Town_Sign\n"/>
+    <property name="cond10" value="is player_facing up"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is player_at"/>
    </properties>
   </object>
   <object id="246" name="Sign: Cotton Scoop" type="event" x="192" y="576" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog Cotton_Mart"/>
-    <property name="cond1" value="is player_facing up"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
-    <property name="cond3" value="is player_at"/>
+    <property name="act10" value="translated_dialog Cotton_Mart"/>
+    <property name="cond10" value="is player_facing up"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is player_at"/>
    </properties>
   </object>
   <object id="247" name="Sign: Omnichannel HQ" type="event" x="272" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog_chain Omnichannel HQ: We Make Headlines"/>
-    <property name="act4" value="dialog_chain ${{end}}"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog_chain Omnichannel HQ: We Make Headlines"/>
+    <property name="act20" value="dialog_chain ${{end}}"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="248" name="Sign: Cathedral Centre" type="event" x="352" y="432" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog Cathedral_Center"/>
-    <property name="cond1" value="is player_facing up"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
-    <property name="cond3" value="is player_at"/>
+    <property name="act10" value="translated_dialog Cathedral_Center"/>
+    <property name="cond10" value="is player_facing up"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is player_at"/>
    </properties>
   </object>
   <object id="249" name="Teleport to Cafe" type="event" x="176" y="256" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport cotton_cafe.tmx,8,11,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport cotton_cafe.tmx,8,11,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="252" name="create allie" type="event" x="0" y="352" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc allie,22,10,,stand"/>
-    <property name="cond1" value="not npc_exists allie"/>
-    <property name="cond2" value="not variable_set npcs_are_created:yes"/>
+    <property name="act10" value="create_npc allie,22,10,,stand"/>
+    <property name="cond10" value="not npc_exists allie"/>
+    <property name="cond20" value="not variable_set npcs_are_created:yes"/>
    </properties>
   </object>
   <object id="253" name="Hiya" type="event" x="352" y="176" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog mwah\n"/>
-    <property name="act11" value="set_variable npcs_are_created:yes"/>
-    <property name="act9" value="npc_face allie,up"/>
-    <property name="act91" value="translated_dialog mwah2"/>
-    <property name="act92" value="remove_npc allie"/>
-    <property name="behav0" value="talk allie"/>
+    <property name="act10" value="translated_dialog mwah\n"/>
+    <property name="act20" value="set_variable npcs_are_created:yes"/>
+    <property name="act30" value="npc_face allie,up"/>
+    <property name="act40" value="translated_dialog mwah2"/>
+    <property name="act50" value="remove_npc allie"/>
+    <property name="behav10" value="talk allie"/>
    </properties>
   </object>
   <object id="257" name="learn from me" type="event" x="240" y="160" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog theinfo\n"/>
-    <property name="act2" value="npc_move aeble, down 1, right 8, up 1"/>
-    <property name="act3" value="npc_speed aeble, 0.5"/>
-    <property name="act4" value="pathfind aeble, 22, 10"/>
-    <property name="act5" value="remove_npc aeble"/>
-    <property name="act6" value="remove_npc grace"/>
-    <property name="act7" value="remove_npc tallon"/>
-    <property name="act8" value="set_variable donewithyou:yes"/>
-    <property name="act9" value="set_variable killgrace:yes"/>
-    <property name="behav1" value="talk aeble"/>
-    <property name="cond4" value="not variable_set donewithyou:yes"/>
+    <property name="act10" value="translated_dialog theinfo\n"/>
+    <property name="act20" value="npc_move aeble, down 1, right 8, up 1"/>
+    <property name="act30" value="npc_speed aeble, 0.5"/>
+    <property name="act40" value="pathfind aeble, 22, 10"/>
+    <property name="act50" value="remove_npc aeble"/>
+    <property name="act60" value="remove_npc grace"/>
+    <property name="act70" value="remove_npc tallon"/>
+    <property name="act80" value="set_variable donewithyou:yes"/>
+    <property name="act90" value="set_variable killgrace:yes"/>
+    <property name="behav10" value="talk aeble"/>
+    <property name="cond10" value="not variable_set donewithyou:yes"/>
    </properties>
   </object>
   <object id="259" name="Create liela" type="event" x="16" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc liela,38,17,,stand"/>
-    <property name="act2" value="npc_face liela,up"/>
-    <property name="cond1" value="not npc_exists liela"/>
+    <property name="act10" value="create_npc liela,38,17,,stand"/>
+    <property name="act20" value="npc_face liela,up"/>
+    <property name="cond10" value="not npc_exists liela"/>
    </properties>
   </object>
   <object id="260" name="door problems" type="event" x="112" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog door_problems"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog door_problems"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="262" name="it's an empty pot" type="event" x="160" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog empty_pot"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog empty_pot"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="263" name="purple flowers1" type="event" x="128" y="320" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog purple_flowers"/>
-    <property name="cond1" value="is to_use_tile"/>
+    <property name="act10" value="translated_dialog purple_flowers"/>
+    <property name="cond10" value="is to_use_tile"/>
    </properties>
   </object>
   <object id="264" name="purple flowers2" type="event" x="160" y="320" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog purple_flowers"/>
-    <property name="cond1" value="is to_use_tile"/>
+    <property name="act10" value="translated_dialog purple_flowers"/>
+    <property name="cond10" value="is to_use_tile"/>
    </properties>
   </object>
   <object id="265" name="purple flowers3" type="event" x="256" y="320" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog purple_flowers"/>
-    <property name="cond1" value="is to_use_tile"/>
+    <property name="act10" value="translated_dialog purple_flowers"/>
+    <property name="cond10" value="is to_use_tile"/>
    </properties>
   </object>
   <object id="266" name="purple flowers4" type="event" x="288" y="320" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog purple_flowers"/>
-    <property name="cond1" value="is to_use_tile"/>
+    <property name="act10" value="translated_dialog purple_flowers"/>
+    <property name="cond10" value="is to_use_tile"/>
    </properties>
   </object>
   <object id="267" name="purple flowers5" type="event" x="384" y="320" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog purple_flowers"/>
-    <property name="cond1" value="is to_use_tile"/>
+    <property name="act10" value="translated_dialog purple_flowers"/>
+    <property name="cond10" value="is to_use_tile"/>
    </properties>
   </object>
   <object id="269" name="orange flowers" type="event" x="208" y="272" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog orange_flowers"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog orange_flowers"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="270" name="talk to liela" type="event" x="592" y="272" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog liela_goes_to_battle"/>
-    <property name="act2" value="start_battle liela"/>
-    <property name="behav1" value="talk liela"/>
+    <property name="act10" value="translated_dialog liela_goes_to_battle"/>
+    <property name="act20" value="start_battle liela"/>
+    <property name="behav10" value="talk liela"/>
    </properties>
   </object>
   <object id="271" name="statue1" type="event" x="448" y="464" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog famous_statue"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog famous_statue"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="272" name="statue2" type="event" x="512" y="464" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog famous_statue2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog famous_statue2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="273" name="fountain" type="event" x="464" y="368" width="48" height="32">
    <properties>
-    <property name="act1" value="translated_dialog cotton_town_fountain"/>
-    <property name="cond1" value="is to_use_tile"/>
+    <property name="act10" value="translated_dialog cotton_town_fountain"/>
+    <property name="cond10" value="is to_use_tile"/>
    </properties>
   </object>
   <object id="274" name="tree" type="event" x="144" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog tree"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog tree"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="276" name="personhere" type="event" x="16" y="448" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog waithere"/>
-    <property name="behav1" value="talk tallon"/>
+    <property name="act10" value="translated_dialog waithere"/>
+    <property name="behav10" value="talk tallon"/>
    </properties>
   </object>
   <object id="277" name="personhere" type="event" x="16" y="464" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog waithere2"/>
-    <property name="behav1" value="talk grace"/>
+    <property name="act10" value="translated_dialog waithere2"/>
+    <property name="behav10" value="talk grace"/>
    </properties>
   </object>
   <object id="278" name="create grace and tallon" type="event" x="0" y="368" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc grace,0,29,,stand"/>
-    <property name="act2" value="create_npc tallon,0,28,,stand"/>
-    <property name="act3" value="npc_face grace,left"/>
-    <property name="act4" value="npc_face tallon,left"/>
-    <property name="cond1" value="not npc_exists grace"/>
-    <property name="cond2" value="not variable_set npcs_are_created:yes"/>
-    <property name="cond3" value="not npc_exists tallon"/>
-    <property name="cond4" value="not variable_set killgrace:yes"/>
+    <property name="act10" value="create_npc grace,0,29,,stand"/>
+    <property name="act20" value="create_npc tallon,0,28,,stand"/>
+    <property name="act30" value="npc_face grace,left"/>
+    <property name="act40" value="npc_face tallon,left"/>
+    <property name="cond10" value="not npc_exists grace"/>
+    <property name="cond20" value="not variable_set npcs_are_created:yes"/>
+    <property name="cond30" value="not npc_exists tallon"/>
+    <property name="cond40" value="not variable_set killgrace:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/cotton_town_spyder.tmx
+++ b/mods/tuxemon/maps/cotton_town_spyder.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" tiledversion="1.0.3" orientation="orthogonal" renderorder="right-down" width="40" height="40" tilewidth="16" tileheight="16" nextobjectid="275">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="275">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -61,22 +61,22 @@
  <tileset firstgid="5037" name="Furniture_and_Fittings_by_George" tilewidth="16" tileheight="16" tilecount="110" columns="10">
   <image source="../gfx/tilesets/Furniture_and_Fittings_by_George.png" width="160" height="176"/>
  </tileset>
- <layer name="Tile Layer 1" width="40" height="40">
+ <layer id="1" name="Tile Layer 1" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJztl0sOgjAQQNnA8coKWShh4Ycr6Eo9gXoIo95Cb+Y0wWQwbZnSKW2Uxcs0GWge/UyLSJMkB8QUp8gcJQUwQ5QoF9pPuq2AY5Yke+AALJFjSL+Pm3TCfrJdt8+E9KvSrhNuL9F8x+iH2zH6zSG3acHvnSB3ZuaS6T0XluvvBrk7Mw+DX2XwUz1P9cN9ufit0TxiGoLfFXgy8DL42UbsVzP0xx3xnvoFP0Hsdyhj+eUO6PzwGROC0uBHOXd8t/H82Z6JPtsqPxm3mb5ejoX0MPntsm7sywuL96n7NaQfpQ7o1h9nnaKOm6qe+PBz+a7Jbxw/Uy2Pwc9XzY3dr2bw6zs3vvuljM2Q8cP/6y77w8aP637wb37U/atbU00kfpT7s4oiAj/qOA2pbS7OgujnG9O/0OTH4/cGmHllbw==
+   eAHtmE1OxDAMhbuB4w0rYAGIBX9XmFkBJwAOgYBbwM3GT8yTnqw4Tar0R6MuLDeJE3+x3aQzm5OuOzPZrHqNQ+M6QE2dm1yIXB58LKHewHZv8nradc8mLyZ31ibjnO8F2cCkfHi+NUawzcl3Y/4ZM8+HGDLnc+U5x6fcS+S7svg9HkT53iz3743lw9aL6ujaGGrq78vW+m4sPxk+5Dji07hxf6V8Wh99+8nxPUgemU/oJ5M+vk/b928D+cvEj3Ep1Ro/nkGpfZSu19pO3/lj4ENsS+JLu1rt418bP/rz66Ta6Bsiun/l0zuGd82UGt8Ifp/k0/Njrmetf8aQfKkzcypO+lY+xHFr51R0XurZOeYzOHJ8O2MEJ7XmX/s5ru9Halzn0zan5+bzvGyTOeLj+FBNP5GO1oW9l1R+o/lj93s2tFe+/zuvJPY18cvdDSW+htjU8I11/ua4l8CHeyBiLOXruzf8+vy96vu1XWLj+fBfQov3t8Q3beivtn70/tV9lzzTd86WNkvly7FzDPmNvjfwGw7jtK3RjE3NnJStr79UOzUPffh/KRqbii/yz35yRDVEu5aaOaVuuXbtWj6fmE8u6to1W9ofA98emHllbw==
   </data>
  </layer>
- <layer name="Tile Layer 2" width="40" height="40">
+ <layer id="2" name="Tile Layer 2" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJzNmGdPFEEcxvfKnpqYkOhLG01ABATUxNjiCwtdjNIlKk1jYqEKxApoNLF9Bztqom98oy/8BFZA3/g5rIC/DTdh7pi5LbegT/LLsDe7Mw/P/ndu9gzDMF5HDONNxHtrKQBBCEEYTLC6FsFiWAL5dBRALdSF9cey7jHI/UjybS5jrYc8ywcUwAYohCIoNmZ9CCU6Fl6TzU60BxnzENRY80Ad1EMDNEKToc5HJ+F1i5l8dpbOwwW4CJfgMlyBIRiGEUVeiST/L37U3wN4CI/gMTyBUXgKz+C5x/xUWXjRO3gPH+AjfILPMAbjMGF4y0+VhRd9hx/wE37Bb/gDkzAF04a3/CzpsusIOPeXyrlpkA4ZkAlrIQuyISfgLj9Zuuy+uRijlPnLoBwqoBKqYD9Uw4GAu/yE/Ki/jczZxfzd0AO90AfnoB8GYNBlfn7Xn98S/8tRM/ln16lEJiWm83MtLVR2dvc3TJ8Zjj3Xr/UvkeKfC3Gsa+VzFqL+RBYiH3Gsa8NhZ+ufW+2Kr6vQTGOXl661fFpjznf92eWla/MXqP68qvY/Xv/in6m3y/+dF5XEPc6TPBbyAlEExTAOm+DVspk+q93Kd9Q22A47YGcgtj/R9U50WHq+RH41kr8GxmuEJpiC5mBsXbbipw3aAzN7m+PR/U1LRH+90PUUw7iRkthfs+RPld8Q4w3DCGSzNlwLxtblTfzcgttwB+7G7b9U1wu9wNtLF/5U+clqMGdJ1K+T3fXFimdRl99YtF4m4At8DcZeZ9e/guOVsApWw5q4fqfS5TcZrZfp6At2IBR7nV3/bj7fA3thH5TAUg/7ZF1+WaGZesmBdZAbN79d/yn8nIYzcBY6YbMLf6ORuf7k/Gps9mO1pnfqHOz1hFT5xX/ut4549Cd/f8ynPzeyW/906jBnkdf4JjO2T3VOq4taaNPUX7/He6C7d37cDzm/Ts14qTyHaZAOGZAZnOtPtTb64U/OT+evlLnKoBwqoFLhT7U2tmvuuwrd3tlJfl3M2Q090At9Cn92a6NKVdExrLF0e2ehRPnZ1bCbtUOlZnPuPrSQz6qlcXX5OamhZP1ZkvM6IY1XH/3bym9AMY+TGrrKtS20gx44KXEsOr/8u4J4FxTrX73Co1u5fX9Uyfq9JUfyotv/eZHb90cn+guyKzOG
+   eAHNmMduFFkUhosMEhISLMnZgAFjBgmRxAIYchBjG2MQOQiJnBEZBoFEegfiMCDBZjaw4AnIYTY8Bzl8h+4fHZXqVmi3kY/0+dy64dy//rpdbTuKouhh1yh6BJVmSkQdoCN0gs7QBSgZdYPu0APGMjAOGqEJQtdM/RXXKHIdWptHU3EM1MJYGAfjoQ4mQD1IF82fkXYt7ZV6Fl+3nB3/ggZohCZYAc2wElpAe9LMDGmfzINorXe22VE4BsfhBJyEU3AazsBZ0J40M8PfS9yLote22Q24CbfgNvwDd+BfuAv3wO/JZWroXuLepS5KGXzC2FN4Bs/hBbyEV/Aa3oD2pJkZupe4V5kLAxPe0/8BPsIn+Axf4Ct8g++gPWlmhr8XeRhftNleGjljEHMHwxAYCsNgOIyAkVADfs+cZX9Ok4fxNe/iHSnX89h/PiyAhbAIFsMSWArLoIh/2kreKau/SJ7Iu3YP+++FfbAfDsBBOASH4QgU8U/3Iu+Ui+hqy7m6l7Xu/deW+1lteTLXvvwyQnNt2u/yTp6EpHXmnHQBC83VuVMujVb3p/fCKus6lP0ceadcXWWlavJC/ug6lG2exqxCtbybGT9X9ssWEfIpq990Ws229M70yYui2fTLO2Wr117C7kfeKbcXbXr20vO4j1rtI+ss1OKhoo4/ICZAPbyGP+C/3qVRy1P4jpoK02A6zAA/nrZee6TlVe7zJf8anL5m9KyEFvgGq8Gfyw3o2QibwH632QIW6+0PISJpfWkkis73iqILkBarnb4k/06j5wychZG8G86R/bm8iJ5LcBmuwFXwkbRe4/fR9qCAviT/VMtyM/cifL/aaWN51teXPVc9yyH/XuGTnbc38Bb+Bx9Z432Z3w/6wwAYCJWE1+f9+0o9O2/frS7PtUP5va89ssZnsW42zIE/YS70dOdadbKy1+fP3wj02HmrgVEwGnxkjW9Hzw7YCbtgN0wqoO9O+Vl7fd6/Bve58brUbmS8UpoyamsPy16f/Iv3+/nVaK+pUJ/8a2t9Re4xyT///RGqtRkPhH/Ht7h+jVv2czZwnfdsbGSuQv7Z98ch16/xUPb3GHp2fk6oTla/zp/5tzugbxCfw8EwBIbCMPB7m76kd6Ofk6UjNO79C+mbh575sAAWwiLwe5u+pHfjJvr9805rS0c85/FvD3r2wj7YDwcgri/r3Zjkz+Ly87Ja0hHPWmfnL+Rf0rn2Zzh0/lQ7K5s++aa5dfQtLeu3vtD58z5pbTy3Vp/Vk2/W3up0rSi3zb/Drt/mWeQ5Q3+zdj1rj1TANtaIdeX9/f8V9Leg3n/SW1JX2U89q7w5aRf7f0tNWa+Nm3/VCj2rvDnPvj8Asiszhg==
   </data>
  </layer>
- <layer name="Tile Layer 3" width="40" height="40">
+ <layer id="3" name="Tile Layer 3" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJztlklLw0AYhqdN46099BeI4IpKXQ7idhdBPKh1QXBfj55UBLXiye3kUn+BetWjuPQutsX/4FIvetCK21s6waS0mTQLmUpfeJhMJsm88yXz5SOEP3W77HagrkrO/eXjZ0w8xu9d/DtWi98u2AP74AAEZWM+JyE1oBbUgXqnJVZV43cBLsEV7YdAuzt53Ac//WAg4UsgZNAEf6+isv8ipr9O0j14AI+0HwNz8HfqJWQVfgJgDZTD37pF8eNtf8RpzD5oy+P+kIu3+KUqHz9j0hq/G+zPW0oYRECU7tlGByFNoBm0gFZH8rw8R95ZmCMTesOzu0Cc4gefdL5R+BkD42ACTFJ/Xxj/Bj80RzoE6/wV4tlLmKdISLKM42K0Z8iFG/CzCbbANtih/kowXgrKhGSOrLDQX15sRd12O7Bf0/hvLWhgllEbWKWnAvXxIN7hIXhmXGeVWP6u4S2UpT8Xcrho0n8m1d+KB7UaCHiU57PxVwVv1WAowzfRILLX4BPT+zuCr2NwYsBfD+b1g94M/hJzS2tgKdVfGL4iIGrAnxZJa2CJ9f1J4nV/SOLB37lXOSbv2+Vvnubf4Qzf8ggdX7QpP5uptn+whlxXrr+DDlHZmqmYifU6y598fErnWjo13Kf32XLNiEoy5So1SfWC3pY3SfWF1jrDiPTsWam+UKszfgGhJ1/o
+   eAHtl01PE0EYx6davOnBT2BMVDRqqnAgiN4JifGgVjQkvgCCHD0JIVExnEA9+VI/gXDVIwHtndg2fgeBcsEDlgD6mzAThkl3t7vd7W5Nn+TXZ2Zndp//PDM7OxUieXYrnTxNpqLzCdfXyp85W/7LSczfn7b9cbitv3d0ew8f4CPkQFvmkBCX4DJ0QCdEYW75WyTgEnxTgfP4vqN7lX703IV7UtdhIQZC0PfbyJuMsmHV9yLv//6iuAKr6lIZ/xR9X44L8RI9U/AKzqJvOgR9KswB5za/Bzo2qFJROdtS3m1+GyTJNUzS8meLbeXPzoi/eq35W+b9/KEo4ItQAmndKSGuQA9chWsgzdwjf9I3qj1Sxtrk+Tehosjit0HaI/QMwhAMw2OQtkP7LvyV/diDUhCVneDZk8Q5iZc8p3wK/5W9cAY9s/Aa3sBbkHaa9jPQDnKPPActiy8DJfVtjU9B/JFH+W6N18CY+r41WvHaEfeIOebwE6x79HN/SvBWL33f0Zb3qS/Nf6i2kP5H2fpeHOOsBlNgmp/8XUDbRbjvsCa6uO41hoy619b3GV1zMF+Hvttoy8IdB30yth6DmYNqZVtfAV1FKNWhr1oc+5oeg33drtv67HZd9zO/+p4wfDPpW+DbbZpZjyt/z1ircn9+4LCWH6r2CYd2czxJL/f+B2NIeo699DX7HFxXa0h7r/H6aS+HeF730me2jwR8L27UcF/QZ5t5e0IcE6e9yrzHLuvzQlBvPy/uuj5faB+lniDvrD5faF9N3z+hJ1/o
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collisions">
+ <objectgroup color="#ff0000" id="4" name="Collisions">
   <object id="124" type="collision" x="256" y="512">
    <polygon points="0,0 0,48 80,48 80,0"/>
   </object>
@@ -180,331 +180,331 @@
   <object id="250" type="collision" x="320" y="256" width="64" height="16"/>
   <object id="261" type="collision" x="288" y="320" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="5" name="Events">
   <object id="144" name="Teleport to Route 2" type="event" x="0" y="464" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route2.tmx,39,9,0.3"/>
-    <property name="act2" value="player_face left"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
+    <property name="act10" value="transition_teleport route2.tmx,39,9,0.3"/>
+    <property name="act20" value="player_face left"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
    </properties>
   </object>
   <object id="145" name="Teleport to Route 1" type="event" x="160" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route1_sanglorian.tmx,10,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route1_sanglorian.tmx,10,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="146" name="Teleport to Cotton Cathedral" type="event" x="304" y="416" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport cotton_cathedral.tmx,7,12,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport cotton_cathedral.tmx,7,12,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="147" name="Teleport to Cotton Mart" type="event" x="144" y="544" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport cotton_scoop.tmx,5,10,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport cotton_scoop.tmx,5,10,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="148" name="Teleport to Omnichannel HQ almost" type="event" x="352" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog itslockedboi"/>
-    <property name="act2" value="translated_dialog hellothere"/>
-    <property name="act3" value="create_npc npc_aeble,14,10,,stand"/>
-    <property name="act4" value="npc_face npc_aeble,right"/>
-    <property name="act5" value="translated_dialog kmere"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
-    <property name="cond4" value="not npc_exists npc_aeble"/>
-    <property name="cond5" value="not variable_set donewithyou:yes"/>
+    <property name="act10" value="translated_dialog itslockedboi"/>
+    <property name="act20" value="translated_dialog hellothere"/>
+    <property name="act30" value="create_npc npc_aeble,14,10,,stand"/>
+    <property name="act40" value="npc_face npc_aeble,right"/>
+    <property name="act50" value="translated_dialog kmere"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond40" value="not npc_exists npc_aeble"/>
+    <property name="cond50" value="not variable_set donewithyou:yes"/>
    </properties>
   </object>
   <object id="149" name="Teleport to Dryad's Grove" type="event" x="624" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport dryadsgrove.tmx,0,7,0.3"/>
-    <property name="act2" value="player_face right"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="transition_teleport dryadsgrove.tmx,0,7,0.3"/>
+    <property name="act20" value="player_face right"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="160" name="Teleport to Route 1" type="event" x="176" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route1_sanglorian.tmx,11,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route1_sanglorian.tmx,11,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="161" name="Teleport to Route 1" type="event" x="192" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route1_sanglorian.tmx,12,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route1_sanglorian.tmx,12,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="162" name="Teleport to Route 1" type="event" x="208" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route1_sanglorian.tmx,13,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route1_sanglorian.tmx,13,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="163" name="Teleport to Route 1" type="event" x="224" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route1_sanglorian.tmx,14,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route1_sanglorian.tmx,14,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="164" name="Teleport to Route 1" type="event" x="240" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route1_sanglorian.tmx,15,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route1_sanglorian.tmx,15,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="165" name="Teleport to Route 1" type="event" x="256" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route1_sanglorian.tmx,16,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route1_sanglorian.tmx,16,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="166" name="Teleport to Route 1" type="event" x="272" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route1_sanglorian.tmx,17,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route1_sanglorian.tmx,17,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="167" name="Teleport to Route 1" type="event" x="288" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route1_sanglorian.tmx,18,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route1_sanglorian.tmx,18,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="232" name="Teleport to Route 2" type="event" x="0" y="448" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route2.tmx,39,8,0.3"/>
-    <property name="act2" value="player_face left"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
+    <property name="act10" value="transition_teleport route2.tmx,39,8,0.3"/>
+    <property name="act20" value="player_face left"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
    </properties>
   </object>
   <object id="236" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_town_theme"/>
-    <property name="cond1" value="not music_playing music_town_theme"/>
+    <property name="act10" value="play_music music_town_theme"/>
+    <property name="cond10" value="not music_playing music_town_theme"/>
    </properties>
   </object>
   <object id="239" name="Teleport to Dryad's Grove" type="event" x="624" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport dryadsgrove.tmx,0,8,0.3"/>
-    <property name="act2" value="player_face right"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="transition_teleport dryadsgrove.tmx,0,8,0.3"/>
+    <property name="act20" value="player_face right"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="240" name="Teleport to Dryad's Grove" type="event" x="576" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport dryadsgrove.tmx,0,8,0.3"/>
-    <property name="act2" value="player_face right"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="transition_teleport dryadsgrove.tmx,0,8,0.3"/>
+    <property name="act20" value="player_face right"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="245" name="Sign: Cotton Town" type="event" x="240" y="608" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog Cotton_Town_Sign"/>
-    <property name="cond1" value="is player_facing up"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
-    <property name="cond3" value="is player_at"/>
+    <property name="act10" value="translated_dialog Cotton_Town_Sign"/>
+    <property name="cond10" value="is player_facing up"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is player_at"/>
    </properties>
   </object>
   <object id="246" name="Sign: Cotton Scoop" type="event" x="192" y="576" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog Cotton_Mart"/>
-    <property name="cond1" value="is player_facing up"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
-    <property name="cond3" value="is player_at"/>
+    <property name="act10" value="translated_dialog Cotton_Mart"/>
+    <property name="cond10" value="is player_facing up"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is player_at"/>
    </properties>
   </object>
   <object id="247" name="Sign: Omnichannel HQ" type="event" x="272" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog_chain Omnichannel HQ: We Make Headlines"/>
-    <property name="act4" value="dialog_chain ${{end}}"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog_chain Omnichannel HQ: We Make Headlines"/>
+    <property name="act20" value="dialog_chain ${{end}}"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="248" name="Sign: Cathedral Centre" type="event" x="352" y="432" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog Cathedral_Center"/>
-    <property name="cond1" value="is player_facing up"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
-    <property name="cond3" value="is player_at"/>
+    <property name="act10" value="translated_dialog Cathedral_Center"/>
+    <property name="cond10" value="is player_facing up"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is player_at"/>
    </properties>
   </object>
   <object id="249" name="Teleport to Cafe" type="event" x="176" y="256" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport cotton_cafe.tmx,8,11,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport cotton_cafe.tmx,8,11,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="252" name="create allie" type="event" x="0" y="352" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc npc_allie,22,10,,stand"/>
-    <property name="cond1" value="not npc_exists npc_allie"/>
-    <property name="cond2" value="not variable_set npcs_are_created:yes"/>
+    <property name="act10" value="create_npc npc_allie,22,10,,stand"/>
+    <property name="cond10" value="not npc_exists npc_allie"/>
+    <property name="cond20" value="not variable_set npcs_are_created:yes"/>
    </properties>
   </object>
   <object id="253" name="Hiya" type="event" x="352" y="176" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog mwah"/>
-    <property name="act11" value="set_variable npcs_are_created:yes"/>
-    <property name="act9" value="npc_face npc_allie,up"/>
-    <property name="act91" value="translated_dialog mwah2"/>
-    <property name="act92" value="remove_npc npc_allie"/>
-    <property name="behav0" value="talk npc_allie"/>
+    <property name="act10" value="translated_dialog mwah"/>
+    <property name="act20" value="set_variable npcs_are_created:yes"/>
+    <property name="act30" value="npc_face npc_allie,up"/>
+    <property name="act40" value="translated_dialog mwah2"/>
+    <property name="act50" value="remove_npc npc_allie"/>
+    <property name="behav10" value="talk npc_allie"/>
    </properties>
   </object>
   <object id="257" name="learn from me" type="event" x="240" y="160" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog theinfo"/>
-    <property name="act93" value="npc_move npc_aeble, down 1, right 8, up 1"/>
-    <property name="act94" value="npc_speed npc_aeble, 0.5"/>
-    <property name="act95" value="pathfind npc_aeble, 22, 10"/>
-    <property name="act96" value="remove_npc npc_aeble"/>
-    <property name="act97" value="set_variable donewithyou:yes"/>
-    <property name="cond4" value="not variable_set donewithyou:yes"/>
-    <property name="behav1" value="talk npc_aeble"/>
+    <property name="act10" value="translated_dialog theinfo"/>
+    <property name="act20" value="npc_move npc_aeble, down 1, right 8, up 1"/>
+    <property name="act30" value="npc_speed npc_aeble, 0.5"/>
+    <property name="act40" value="pathfind npc_aeble, 22, 10"/>
+    <property name="act50" value="remove_npc npc_aeble"/>
+    <property name="act60" value="set_variable donewithyou:yes"/>
+    <property name="behav10" value="talk npc_aeble"/>
+    <property name="cond10" value="not variable_set donewithyou:yes"/>
    </properties>
   </object>
   <object id="259" name="Create liela" type="event" x="16" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc npc_liela,38,17,,stand"/>
-    <property name="act2" value="npc_face npc_liela,up"/>
-    <property name="cond1" value="not npc_exists npc_liela"/>
+    <property name="act10" value="create_npc npc_liela,38,17,,stand"/>
+    <property name="act20" value="npc_face npc_liela,up"/>
+    <property name="cond10" value="not npc_exists npc_liela"/>
    </properties>
   </object>
   <object id="260" name="door problems" type="event" x="112" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog door_problems"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog door_problems"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="262" name="it's an empty pot" type="event" x="160" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog empty_pot"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog empty_pot"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="263" name="purple flowers1" type="event" x="128" y="320" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog purple_flowers"/>
-    <property name="cond1" value="is to_use_tile"/>
+    <property name="act10" value="translated_dialog purple_flowers"/>
+    <property name="cond10" value="is to_use_tile"/>
    </properties>
   </object>
   <object id="264" name="purple flowers2" type="event" x="160" y="320" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog purple_flowers"/>
-    <property name="cond1" value="is to_use_tile"/>
+    <property name="act10" value="translated_dialog purple_flowers"/>
+    <property name="cond10" value="is to_use_tile"/>
    </properties>
   </object>
   <object id="265" name="purple flowers3" type="event" x="256" y="320" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog purple_flowers"/>
-    <property name="cond1" value="is to_use_tile"/>
+    <property name="act10" value="translated_dialog purple_flowers"/>
+    <property name="cond10" value="is to_use_tile"/>
    </properties>
   </object>
   <object id="266" name="purple flowers4" type="event" x="288" y="320" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog purple_flowers"/>
-    <property name="cond1" value="is to_use_tile"/>
+    <property name="act10" value="translated_dialog purple_flowers"/>
+    <property name="cond10" value="is to_use_tile"/>
    </properties>
   </object>
   <object id="267" name="purple flowers5" type="event" x="384" y="320" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog purple_flowers"/>
-    <property name="cond1" value="is to_use_tile"/>
+    <property name="act10" value="translated_dialog purple_flowers"/>
+    <property name="cond10" value="is to_use_tile"/>
    </properties>
   </object>
   <object id="269" name="orange flowers" type="event" x="208" y="272" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog orange_flowers"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog orange_flowers"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="270" name="talk to liela" type="event" x="592" y="272" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog liela_goes_to_battle"/>
-    <property name="act2" value="start_battle npc_liela"/>
-    <property name="behav1" value="talk npc_liela"/>
+    <property name="act10" value="translated_dialog liela_goes_to_battle"/>
+    <property name="act20" value="start_battle npc_liela"/>
+    <property name="behav10" value="talk npc_liela"/>
    </properties>
   </object>
   <object id="271" name="statue1" type="event" x="448" y="464" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog famous_statue"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog famous_statue"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="272" name="statue2" type="event" x="512" y="464" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog famous_statue2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog famous_statue2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="273" name="fountain" type="event" x="464" y="368" width="48" height="32">
    <properties>
-    <property name="act1" value="translated_dialog cotton_town_fountain"/>
-    <property name="cond1" value="is to_use_tile"/>
+    <property name="act10" value="translated_dialog cotton_town_fountain"/>
+    <property name="cond10" value="is to_use_tile"/>
    </properties>
   </object>
   <object id="274" name="tree" type="event" x="144" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog tree"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog tree"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
  </objectgroup>
- <layer name="Above Player" width="40" height="40">
+ <layer id="6" name="Above Player" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJztl1sKgzAQRUeZLscup92ZXYS2Ls8+frw/gdIyFJk0hvEeuMhI0MkJhESkPKoiB7Vr612pvjrkqHa9FamPE3JWu36fS0k+/5n6suqaqcEfWUckf5Hmkos1TujPB/3ZJDe/niQuXGMf9OdjT/76VuTS5v3mnvz9A/rzQX8+IvibG5E78kCeyKv5HjNg3xuRK3JDpkz7YC3+eHYmJC6135UX1LEQpg==
+   eAHtlF0OgkAMhKvB4+hx9GZ6CP+OJ+iLw8O8NDYbsOzC0iaTpgu2028jIvmjaUR2EEPX/fmvM74/VebMPbwdIKuean6qL30d4e0EWXXfh95TPT2f65n0yRm65vkcs94lh8cSM3PslWtGTfxq2sXr/ocwGfKul7+a+gQ/+zbJJpXtDvFk6QR490vfo5T/4Pcf+TXxO29FLpBnrImfJzf2Cn4kMS4Hv3Hc+Ksa+L02Ii3UQW/oA+m44rt3g+7QA3pCHjEXfvShs8eO0SMIBIGyBPT/2qpLufwC1LEQpg==
   </data>
  </layer>
- <layer name="Above Player" width="40" height="40">
+ <layer id="7" name="Above Player" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJzt1lkKwjAUheGToY5PVl2Tuht1a+7MeXjxCIrSxjYWIQrngx8pRQwlvREQkVgDA+RsyEZsbJ732hbosC7rsb5Nt04RkRvvgcyXr4ufnzKcb5Y55lnGWveZ925O/uOMbPp8RH5J3btX9d8m5vsiIaF98zpT6/bVmvtww7Zsx/am/Bsp6FyQolVefS3ycOAcO7ITO7NLYK7pzI03ccCUzVzqlYTNua4FW35xfTqDRJq7AmXCEMk=
+   eAHtllsOgjAQRQcBn1+irkndjbo1d+b78eMxpklpIPBhAoQ7yaGZlCbTAx0wU8iADNQ1MI/MMljAElbgYjQwG8MEpjADhQzIgAw0aSBJzFJw4fJwdPN1x4j+NoAYEkhhCN8o65Nd7JHO029nuspANw1Unb2yM+t2W7Xe3adRBnwDRe+N31OL5v31J/6xz3CBK9ygDeHvoQ31qIbmDRyzfA1hnp9V1mcDd/rYA57wgjeEUdUbw/v7nK9jsw1soY2xo649HP5Yn75BbXzSqqkrBj5lwhDJ
   </data>
  </layer>
 </map>

--- a/mods/tuxemon/maps/daycare.tmx
+++ b/mods/tuxemon/maps/daycare.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="12" height="9" tilewidth="16" tileheight="16" nextobjectid="20">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="12" height="9" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="20">
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>
  </tileset>
@@ -54,27 +54,27 @@
  <tileset firstgid="7582" name="items" tilewidth="16" tileheight="16" tilecount="100" columns="10">
   <image source="../gfx/tilesets/items.png" width="160" height="160"/>
  </tileset>
- <layer name="Layer 1" width="12" height="9">
+ <layer id="1" name="Layer 1" width="12" height="9">
   <data encoding="base64" compression="zlib">
-   eJz7L87A8J8EzCVBGhYlEdeNYrwYAL/zOu0=
+   eAH7L87A8J8EzCXBwEAKFgWqJwXXAdWPYtxhAAC/8zrt
   </data>
  </layer>
- <layer name="Layer 2" width="12" height="9">
+ <layer id="2" name="Layer 2" width="12" height="9">
   <data encoding="base64" compression="zlib">
-   eJxjYBhcQECWgUGQSCwExJJALEUklh6E6pWAWJlIrALEAGYoD3k=
+   eAFjYBhcQECWgUGQSCwEVCcJxFJEYulBqF4J6CZlIrEKUB0AZigPeQ==
   </data>
  </layer>
- <layer name="Layer 3" width="12" height="9">
+ <layer id="3" name="Layer 3" width="12" height="9">
   <data encoding="base64" compression="zlib">
-   eJxjYCAM/ksACUlUMTMpBgYLKezq1YFqNdDUWwLVWqOpZ5WEYGwgEag2GU29riQEEwO6gW7ugeJeCfxq9YBmbgaq2QLFW4HYAI89YUC520A1d6D4LhBHIKnXk2Vg0IdiA1nCbjUHqrGAYksC6gFPvBJA
+   eAFjYCAM/ksA1UiiqjOTYmCwAGJsQB2oVgNNvSVQrTWaelagGhDGBhKBapPR1OsC1YIwMaAb6OYeKO4FuR8P0AOauRmoZgsUbwXSBnjsCQPK3QaquQPFd4F0BJJ6PVkGBn0oNgDShIA5UI0FFFsSUA8AT7wSQA==
   </data>
  </layer>
- <layer name="Above Player" width="12" height="9" opacity="0.97">
+ <layer id="4" name="Above Player" width="12" height="9" opacity="0.97">
   <data encoding="base64" compression="zlib">
-   eJxjYBh+gE0SwQ6EsjkksatFBiFANZmitHETLvARi7skpXCrBwBXpwLT
+   eAFjYBh+gE0S4adAKJsDSQwhi8oKAarJFEUVozXvIxZ3SUrhthUAV6cC0w==
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collisions">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="2" type="collision" x="96" y="64">
    <polygon points="0,0 0,32 64,32 64,0"/>
   </object>
@@ -95,19 +95,19 @@
   <object id="16" type="collision" x="112" y="48" width="32" height="16"/>
   <object id="18" type="collision" x="80" y="128" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="6" name="Events">
   <object id="14" name="Teleport to Cotton Town" type="event" x="32" y="128" width="32" height="16">
    <properties>
-    <property name="act1" value="transition_teleport paper_town.tmx,21,5,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport paper_town.tmx,21,5,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="17" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_cathedral_theme"/>
-    <property name="cond1" value="not music_playing music_cathedral_theme"/>
+    <property name="act10" value="play_music music_cathedral_theme"/>
+    <property name="cond10" value="not music_playing music_cathedral_theme"/>
    </properties>
   </object>
   <object id="19" name="Player Spawn" type="event" x="48" y="80" width="16" height="16"/>

--- a/mods/tuxemon/maps/daycare_centre.tmx
+++ b/mods/tuxemon/maps/daycare_centre.tmx
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="15" height="15" tilewidth="16" tileheight="16" nextobjectid="4">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="3" nextobjectid="4">
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>
  </tileset>
- <layer name="Tile Layer 1" width="15" height="15">
+ <layer id="1" name="Tile Layer 1" width="15" height="15">
   <data encoding="base64" compression="zlib">
-   eJzTY2Bg0BvFo3gUU4Ql8WBCagBHcSde
+   eAHTY2Bg0BvFo2EwmgYoSgOSwPDDhWH5C5c8AEdxJ14=
   </data>
  </layer>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="2" name="Events">
   <object id="2" type="event" x="112" y="224" width="32" height="16">
    <properties>
-    <property name="act1" value="transition_teleport taba_town.tmx,25,4,0.3"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport taba_town.tmx,25,4,0.3"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="3" name="Player Spawn" type="event" x="112" y="176" width="16" height="16"/>

--- a/mods/tuxemon/maps/dojo1.tmx
+++ b/mods/tuxemon/maps/dojo1.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="24" height="12" tilewidth="16" tileheight="16" nextobjectid="30">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="24" height="12" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="30">
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>
  </tileset>
@@ -60,52 +60,52 @@
  <tileset firstgid="7822" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>
  </tileset>
- <layer name="Tile Layer 1" width="24" height="12">
+ <layer id="1" name="Tile Layer 1" width="24" height="12">
   <data encoding="base64" compression="zlib">
-   eJyzk2FgyEHDCTjEKmQYEkAYlzy6mAMQ+wJxNRrOwyF2H4pxyaOL+UPND5dgYIiA4kgJiFpsYsjmE6MHZn49kB0FxNFA3AhViy52GMnfQHYDMXqQzW8C4mY0tehiyGFBjB5k8xugGFktuthMSQaGWZK45dHFSDX/GpC+jkcen/nI4ZaPQ2wdkF6PR57Y8K/DIQZzPy55XOG/HMheAcUrQWolsIvB3I9LHl0MZn6dBHEY7n4iManmI7ufWPMBYrGnrg==
+   eAGdkM0JAjEUhFOGwtYiNiAe/btsAaJXQVhXrUIbUC9ahD3o0VacgTx5DAlkPQzZzCTfTt6gCmEpqmXPnN6mCjWVy5UzxJ0RtBWtZM+c3icqlytnjPPkT3ohTKNmWHk/5Xl+KlfP+Dsw59AC2ke+ek/8096P71ZzdlLP8w/gHoWvnr3fWJqT7z3Pb5FRvr96p34IZ8j4mpPvva78F+6/oX/4fv7rxCzp3cF+QLm8dP5N5PtZ0rP+uTw3/ws6XaNuWBso5Vn/XK53bP48X6Jf/8LzXfm+f0kf8r9isaeu
   </data>
  </layer>
- <layer name="Tile Layer 2" width="24" height="12">
+ <layer id="2" name="Tile Layer 2" width="24" height="12">
   <data encoding="base64" compression="zlib">
-   eJxjYKA9eCTLwPBYlrAYpXpGwSgYBUMLAACliQf9
+   eAFjYKA9eCTLwPAYiJEBNjFC8oT0IOsfZY+GwGgIDP4QAACliQf9
   </data>
  </layer>
- <layer name="Tile Layer 3" width="24" height="12">
+ <layer id="3" name="Tile Layer 3" width="24" height="12">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFgwWs5GZgWMVNWIxcPdeAYte58Ysdk2VoIFXPYHA3NfSMAvoDACn3GsQ=
+   eAFjYBgFgyUEVnIzMKwCYmSATYyQPC4914BmX0czH13smCxDA7L56PIgOXQxbPZhE0M2F5s8NjFs9uESQzYf3Y3E6EHWP8qmTwgAACn3GsQ=
   </data>
  </layer>
- <layer name="Above Player" width="24" height="12">
+ <layer id="4" name="Above Player" width="24" height="12">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFgwmskcUvtl+WoYFUPchgMxZxbGKk6CHFfnL00MLNo2BwAACmww4l
+   eAFjYBgFgykE1shiugZZbL8sQwO6CmR5mBw2MZDcZizmYxODmUOMHmx2YRNDNhObPDYxYuxHNhfGxuYnbGIw9aP0wIQAAKbDDiU=
   </data>
  </layer>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="5" name="Events">
   <object id="1" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_dojo_theme"/>
-    <property name="cond1" value="not music_playing music_dojo_theme"/>
+    <property name="act10" value="play_music music_dojo_theme"/>
+    <property name="cond10" value="not music_playing music_dojo_theme"/>
    </properties>
   </object>
   <object id="2" name="Teleport to Flower City" type="event" x="176" y="176" width="32" height="16">
    <properties>
-    <property name="act1" value="transition_teleport flower_city.tmx,3,18,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport flower_city.tmx,3,18,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="28" name="Teleport to Dojo 2" type="event" x="192" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport dojo2.tmx,10,9,0.3"/>
-    <property name="act2" value="player_face right"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="transition_teleport dojo2.tmx,10,9,0.3"/>
+    <property name="act20" value="player_face right"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="29" name="Player Spawn" type="event" x="80" y="160" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ff0000" name="Collisions">
+ <objectgroup color="#ff0000" id="6" name="Collisions">
   <object id="3" type="collision" x="0" y="0" width="16" height="192"/>
   <object id="4" type="collision" x="0" y="0" width="384" height="32"/>
   <object id="5" type="collision" x="368" y="0" width="16" height="192"/>

--- a/mods/tuxemon/maps/dojo2.tmx
+++ b/mods/tuxemon/maps/dojo2.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="24" height="12" tilewidth="16" tileheight="16" nextobjectid="20">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="24" height="12" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="20">
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>
  </tileset>
@@ -63,52 +63,52 @@
  <tileset firstgid="7922" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>
  </tileset>
- <layer name="Layer 1" width="24" height="12">
+ <layer id="1" name="Layer 1" width="24" height="12">
   <data encoding="base64" compression="zlib">
-   eJxjYKAvsJNhYMhBwtQGvkAzq5EwLcw3lSUPk2I+CBCrhxi1sHDvlUFVKyuLHxNrPizca2Qw1VLLfHxhictcZPPxxYMvFnfjAoTsoZb52AA1zMcHaGk+tvAHANLtGxs=
+   eAG9kNENgCAMRG8QGcNfN3ATN8AV3Fku5pKmEVBTJDmaEvquLfDvWSZgM4p2Xws7G43gzwn4oie9sH+yeRSvrH33/mrvh+GTmIpXS3Lt8bX33fF7Hm/47EFSnaKfQe+KqqvNYfeumlq0Xv5PJN+zmUfw77h6G8kn2/NP0u0bGw==
   </data>
  </layer>
- <layer name="Layer 2" width="24" height="12">
+ <layer id="2" name="Layer 2" width="24" height="12">
   <data encoding="base64" compression="zlib">
-   eJxjYBhYYC/DwJCDA6PLOciQbr4fUE81Dowu50+k+cKyDAwiJGJRII4j0nwZoFpZErEcBebjAujmdxEZD+SaX0UgHmDhTmrYwDCheCAl3NHdT0w84DLfUA5TTEuOoYFa5lMrHdHCfABkMzEE
+   eAFjYBhYYC/DwJCDA6PLOQDVkQr8gHqqcWB0OX8izReWZWAQIRGLAtXHEWm+DFCtLIlYjgLzcYUpshtA5ncB3Q+KK0LxgO5+Ys2vApoNiitc8QALd2R3kcIGxRm+eEB3Nz6zQX7CJo8vHnCZbyiHaZaWHEMDtczHZg4uMXLcj8ssbOLo5gMAZDMxBA==
   </data>
  </layer>
- <layer name="Layer 3" width="24" height="12">
+ <layer id="3" name="Layer 3" width="24" height="12">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUjIKBAQAEgAAB
+   eAFjYBgFoyEwGgKjITAwIQAABIAAAQ==
   </data>
  </layer>
- <layer name="Above Player" width="24" height="12">
+ <layer id="4" name="Above Player" width="24" height="12">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUkAqU5RgaBtoNwwEAAPoqAMI=
+   eAFjYBgFoyEwGgKkhoCyHEMDqXpG1WOGAAD6KgDC
   </data>
  </layer>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="5" name="Events">
   <object id="9" name="Play Music" type="event" x="0" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_dojo_theme"/>
-    <property name="cond1" value="not music_playing music_dojo_theme"/>
+    <property name="act10" value="play_music music_dojo_theme"/>
+    <property name="cond10" value="not music_playing music_dojo_theme"/>
    </properties>
   </object>
   <object id="10" name="Teleport to Lower Floor" type="event" x="144" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport dojo1.tmx,11,5,0.3"/>
-    <property name="act2" value="player_face left"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
+    <property name="act10" value="transition_teleport dojo1.tmx,11,5,0.3"/>
+    <property name="act20" value="player_face left"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
    </properties>
   </object>
   <object id="11" name="Teleport to Upper Floor" type="event" x="224" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport dojo3.tmx,10,9,0.3"/>
-    <property name="act2" value="player_face right"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="transition_teleport dojo3.tmx,10,9,0.3"/>
+    <property name="act20" value="player_face right"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="19" name="Player Spawn" type="event" x="192" y="160" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ff0000" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collision">
   <object id="1" type="collision" x="32" y="80" width="16" height="112"/>
   <object id="2" type="collision" x="32" y="80" width="48" height="32"/>
   <object id="3" type="collision" x="64" y="16" width="16" height="96"/>

--- a/mods/tuxemon/maps/dojo3.tmx
+++ b/mods/tuxemon/maps/dojo3.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="24" height="12" tilewidth="16" tileheight="16" nextobjectid="20">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="24" height="12" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="20">
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>
  </tileset>
@@ -63,39 +63,39 @@
  <tileset firstgid="7922" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>
  </tileset>
- <layer name="Tile Layer 1" width="24" height="12">
+ <layer id="1" name="Tile Layer 1" width="24" height="12">
   <data encoding="base64" compression="zlib">
-   eJxjYKAvsJNhYMhBwtQGvkAzq5EwLcw3lSUPk2I+CBCrhxi1sHDvlUFVKyuLHxNrPizca2Qw1VLLfHxhictcZPPxxYMvFnfjAoTsoZb52AA1zMcHaGk+tvAHANLtGxs=
+   eAG9kNENgCAMRG8QGcNfN3ATN8AV3Fku5pKmEVBTJDmaEvquLfDvWSZgM4p2Xws7G43gzwn4oie9sH+yeRSvrH33/mrvh+GTmIpXS3Lt8bX33fF7Hm/47EFSnaKfQe+KqqvNYfeumlq0Xv5PJN+zmUfw77h6G8kn2/NP0u0bGw==
   </data>
  </layer>
- <layer name="Tile Layer 2" width="24" height="12">
+ <layer id="2" name="Tile Layer 2" width="24" height="12">
   <data encoding="base64" compression="zlib">
-   eJxjYBhYYC/DwJCDA6PLOciQbr4fUE81Dowu50+k+cKyDAwiJGJRII4j0nwZoFpZErEcBebjAujmdxEZD+SaX0UgHmDhTmrYwDCheCAl3NHdT0w84DLfUI625lMrHdHCfACwgjA8
+   eAFjYBhYYC/DwJCDA6PLOQDVkQr8gHqqcWB0OX8izReWZWAQIRGLAtXHEWm+DFCtLIlYjgLzcYUpshtA5ncB3Q+KK0LxgO5+Ys2vApoNiitc8QALd2R3kcIGxRm+eEB3Nz6zQX7CJo8vHnCZbyiHaRY1zcfmTlxi5Lgfl1nYxNHNBwCwgjA8
   </data>
  </layer>
- <layer name="Above Player" width="24" height="12">
+ <layer id="3" name="Above Player" width="24" height="12">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUjIKBAQAEgAAB
+   eAFjYBgFoyEwGgKjITAwIQAABIAAAQ==
   </data>
  </layer>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="4" name="Events">
   <object id="9" name="Play Music" type="event" x="0" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_dojo_theme"/>
-    <property name="cond1" value="not music_playing music_dojo_theme"/>
+    <property name="act10" value="play_music music_dojo_theme"/>
+    <property name="cond10" value="not music_playing music_dojo_theme"/>
    </properties>
   </object>
   <object id="10" name="Teleport to Lower Floor" type="event" x="144" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport dojo2.tmx,13,9,0.3"/>
-    <property name="act2" value="player_face left"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
+    <property name="act10" value="transition_teleport dojo2.tmx,13,9,0.3"/>
+    <property name="act20" value="player_face left"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
    </properties>
   </object>
   <object id="19" name="Player Spawn" type="event" x="176" y="144" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ff0000" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collision">
   <object id="1" type="collision" x="32" y="80" width="16" height="112"/>
   <object id="2" type="collision" x="32" y="80" width="48" height="32"/>
   <object id="3" type="collision" x="64" y="16" width="16" height="96"/>

--- a/mods/tuxemon/maps/dragonscave.tmx
+++ b/mods/tuxemon/maps/dragonscave.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="20" height="40" tilewidth="16" tileheight="16" nextobjectid="61">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="61">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -18,27 +18,27 @@
  <tileset firstgid="2925" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
   <image source="../gfx/tilesets/boxfont.png" width="208" height="192"/>
  </tileset>
- <layer name="Tile Layer 1" width="20" height="40">
+ <layer id="1" name="Tile Layer 1" width="20" height="40">
   <data encoding="base64" compression="zlib">
-   eJztyqEBAAAEADD+v8o5vlAVSV1YW2VEAQAAPPVynQHDLl7X
+   eAE7yMjAcHAUj4bBaBoYTQOjaWA0DYymgdE0MJoGRtPAaBoYTQMUpoGXQP0wjKuPAQDDLl7X
   </data>
  </layer>
- <layer name="Tile Layer 2" width="20" height="40">
+ <layer id="2" name="Tile Layer 2" width="20" height="40">
   <data encoding="base64" compression="zlib">
-   eJxjYBheYAITA8NEJuqZtwNo1k4qmocOQO7tp5KbQWZNAuLtVHIzrf0+CkbBKBgF1AJpo2XVKMAB7EfTxihAA31Epgm70bRDMwAAH2YJ2Q==
+   eAFjYBheYAITA8NEIKYW2AE0aycVzUN3F8i9/UBMDTeDzJoExNuBmBpuprXf0cNilD8aAqMhMBoC5IZAGrDcGwWjIYAtBOxH0wa2YBnRYn1Epgk7ItWN6MAk0/MAH2YJ2Q==
   </data>
  </layer>
- <layer name="Filler" width="20" height="40">
+ <layer id="3" name="Filler" width="20" height="40">
   <data encoding="base64" compression="zlib">
-   eJztwTEBAAAAwqD1T20LL6AAAAA+BgyAAAE=
+   eAHt0DEBAAAAwqD1T20LL4hAYcCAAQMGDBgwYMCAgc/AAAyAAAE=
   </data>
  </layer>
- <layer name="Above Player" width="20" height="40">
+ <layer id="4" name="Above Player" width="20" height="40">
   <data encoding="base64" compression="zlib">
-   eJztllEOgjAQRAtfcBP0NPU2clP0NIAR02xnpttG4w9N9kfM2+mws9qNIXR/qLjVRdStktdvJc/JO3k/5N23egy4nkM9r6idPCvlCtVV8PZeC7mXqrlB+7e9qK349mIa6/cPY6WnlYlYi/DYzoHta2cfsewcpf2tP1mWHPpV3vYsvTJDtB39FpsxoeGjkWizfbwaAmChPgeTZePgzeCz0rv25oJ50MJL7zqZWfH8hlte6jc7KpfyvpVMtgc8GhFTvUcvMxiemgmUjywjBe/S/KN8ZP46Z4X5UOJNRo9iRfC9TJ/DZ7a71K5QPOQD2weIafv2I3+Gyv5HYbPYsm9q9lBaK7eFac0=
+   eAHtlV1uwkAMhANP9CbQ09DbtDeFngbPthNNBttNEFJfQIrys+vPs2Pvsnubpt0/XOfIeWquj42a9jG//b14bZ1f/ln3bOyXz5h/PeTXd3yfNvK6PTlqVfD+2lfZnnsPVqUPuS7Fuqr14vtXoa/T3q25GnsmD97Bi2NcW88f10eWdtWjzIyFmlQeQ4v2gecdnomwjKXx6JnRI78x7o/zvJcy/ZL+5zFy0EPspbFnYiTTxnzal5w/c4UHLmMqbZ5nrQblLdZp+aGBZ0RWN+rTMX5zbfSpu49Y00Ceau4YOuY8XSv6ITtXvO86nvo919AevO86Hsbm9RpHXzMm1+ZjazSC7XHUkdVxLVNrBl7Goh+aT8/oxR6R3hjz5R0ceMCaYu9n+Zhn+CnxzqOf9D1j3dXLePBU9XQsatczy/1j/N1d8tKHBScCXH9bQ+FlPlT/lRnT86r/PsZe0DuY2g961mAec65hKbd79l7wuTe3hWnN
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collision">
   <object id="2" type="collision" x="240" y="336">
    <polygon points="0,0 0,16 16,16 16,0"/>
   </object>
@@ -94,27 +94,27 @@
   <object id="58" type="collision" x="48" y="560" width="16" height="16"/>
   <object id="59" type="collision" x="208" y="560" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="6" name="Events">
   <object id="55" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_dragons_cave"/>
-    <property name="cond1" value="not music_playing music_dragons_cave"/>
+    <property name="act10" value="play_music music_dragons_cave"/>
+    <property name="cond10" value="not music_playing music_dragons_cave"/>
    </properties>
   </object>
   <object id="56" name="Teleport to Sea Route" type="event" x="208" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport routec.tmx,6,3,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport routec.tmx,6,3,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="57" name="Teleport to Sea Route" type="event" x="192" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport routec.tmx,6,3,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport routec.tmx,6,3,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="60" name="Player Spawn" type="event" x="208" y="592" width="16" height="16"/>

--- a/mods/tuxemon/maps/dryadsgrove.tmx
+++ b/mods/tuxemon/maps/dryadsgrove.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="40" height="20" tilewidth="16" tileheight="16" nextobjectid="40">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="40">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -52,27 +52,27 @@
    </animation>
   </tile>
  </tileset>
- <layer name="Tile Layer 1" width="40" height="20">
+ <layer id="1" name="Tile Layer 1" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eJzNll0OgjAQhMsB0EP6dxAFD6I8gidRTyJcwSVpk804CwVq9GGSRtvu12Vn29o514huovqL41qJzTmKTl6F/69JFHsp30Z0nsB3Fz1Ez0R8WmyOzl0M30vUijr4vT/ndoJ2M/lKvzaGr1HCfcZUzOTTOWRr8sy5lWid/Z7vQfSEvDG+vehKdEjM1xJ1fj3WG/OY9hKegfEF/26MfbEGV9mn+u+KPcn6dlirjA+9bOXMisFyPlZvMXyls72NOevr5WDEiOHDeqsi+GK19/uxPhjLV5A5S/nCmStj7Tf4Lo772vL3UP9KzRe8rPsUetd6BwSx/qTjWb63+HQvD6zYpyw+fY+F+xNjDr1zMNdj74Cc9KmhHo8eR0+n5rPqZM4dGTw9xKd7SjWTD8foH+x5mo29D2I8kXKM+dRs/8CH+dRsvd5T0Obh
+   eAHNld1twkAQhJ0CkhSJSQpJQgrBPAKVYCqxaSEzEiONRmdjE6zkYXSL2Z9vd8+wr6rqAB2h/YI2c0ulWh/4/vOqrysHuZZkcg6x8fTntFfQNzSV7wTfFjpDmeuefpyttCufHRlvza+DTw9dgo991jO0hq+zDfWWfBvEMXZov85HHynzaB9DJ+dwD5/PsNTT81NVvUCvkNh4/gVfi7op3jvnku18b/BpCnrHM83zEfPrkS/Fe8e5rqDaVHrHTvi+hdST91DiY94j5Lk9r3rTHeQeU9wr83gtxelU7Q5+7I89HSJGPnxOJuYU31jurOHxsrOWYnSq9hgfZ1APKGfG++J3g3VUQ0zsTXby5X3bwZf+Y3zq5dbJ3MyXM53DR1/tSD38lk89ky3nMXd+U/m2qNWMyHfInOSSlp7fCbVa0xk2Z+xyhuQjZ/Izls+1uxXs+iq/w0Pz89/yDnG96QLb2Wg73waf1xDrU6ydNZPP4/1eD/F5b2LV71X+/9A385OxNA/WZs1H8jmrbJ6u5PMZuK13eoxP71eDGjtId0C1M3bK8y3yMJ/k9018YmO+rOH9TdnpFKYxH69HPmf7D3w5T+6JXNIPU9Dm4Q==
   </data>
  </layer>
- <layer name="Tile Layer 2" width="40" height="20">
+ <layer id="2" name="Tile Layer 2" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eJzFlusJwyAUhSX+7eNvJmmWCe0m3aF0iDadxu7Q7lGFCOZw7iNQyAHRGB+f13vV1IfwzqnokfNnv11+iCEc47K+lovSzLpVfspsQ1zW13LL+YJUJdUHqGN9pDFwnCq0beVk80pzSpysndSGfRehbS0m1DkqPwVGbV+Y0P/YeBbnWj5k0vY4Cfuq8Y1Ou2l8nrWj3aQxvfN7+Biv1J/5nWc+bMu+P10I304e17v+1v88MeXVLvvAnviBJyZaJYhfz7qkf2vsXmTF/xhl+0lzWX7j5cMYm+aEQvtpbIxB2y8v/ySUi9B+Vtxb54PVlzFrfMx+mjx3L9Z72kn7W213JfFrMbKyxrLmTK1ibxeLzWK0eL187N3XanCcX/+4nyWh7Wp+m8/9S+a7d9u/qdk7qz07t35T/wA/Nx3M
+   eAHFlslNBFEMRFtwZbkSCSSDIBNyQATBEs2QA+SBC/GkJ6vdM+LSX/rjrVyuMT0tDjfL8lk357XsW9297NX5slzX9Xz86Dv8ad3L3pa2u7qej2+dH6XVN9pznIvvQy0515ynRg5rHnz0YNFpbvhs8eGe8B2XmLPVAwY9WPKx9GNdw3+ov8MpJxzTpX+ak92xP2PNl/zUT8+WNZd58KmvcWR37A98cPSQw6Z2f+Legs0xFzzkqP8C20ffm8v0w+da98H2PDF1uBzbB49lb8RYeoi3LDPBEH+dLct3XR/z4oM3zr6fv47tsfuO+Rf1DFyuPAfmtD/x+fkLJj3cqWfiPdbX+Y79/vOcT/ubZpG39dzkTzn9N/ZeTbn99P2lzuyOJbaGyZ94jIfPuuyn3vdnbWtc5Cac68zH0gOGvDXZT31tf/St2WkG+d7TtUy46OrawsU78Kne052rzyL2jO6DiXXN8alz0sM7EJ3JbR24PXvLNxc4OFxb860Jncbl/7B+zM28YJzvPf+N0YRO7PPfe/+x9L2UT34vi05svq/fneT3sj8/Nx3M
   </data>
  </layer>
- <layer name="Tile Layer 3" width="40" height="20">
+ <layer id="3" name="Tile Layer 3" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eJyrk2BgqAfiwQ7qBpk7Ye4ZbO4aSqBuNPxGwQCCutF0RxEYzb+UgdHwowyMhh35YKiEHS53DnTZPVTCb7ADABp7D94=
+   eAGrk2BgqAfiwQ7qBpk7Ye6B0YM9/Aaj+0BhNxp+gzFmRoabQGlvFJAfAqP5l/ywA+kcDT/Kw28otF0o8yVtdA+VeheXO0HiAwlwuWsg3TQU7QYAGnsP3g==
   </data>
  </layer>
- <layer name="Above Player" width="40" height="20">
+ <layer id="4" name="Above Player" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUDDVQJ8HAUC8x0K4Y+mA0HEfBKBgFtASjZQzlAFcYwsTpTY8C6gAA2D0WWA==
+   eAFjYBgFoyEwGgJDLQTqJBgY6oF4FFAWAqPhSFn4jeoeDYHREMAfAqNlDP7wIUYWVxjCxOlNE+PmUTWEQwAA2D0WWA==
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collisions">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="1" type="collision" x="0" y="0" width="640" height="32"/>
   <object id="2" type="collision" x="96" y="288" width="544" height="32"/>
   <object id="3" type="collision" x="0" y="32" width="32" height="80"/>
@@ -109,27 +109,27 @@
   <object id="34" type="collision" x="576" y="144" width="16" height="64"/>
   <object id="35" type="collision" x="576" y="240" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="6" name="Events">
   <object id="36" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_mystic_island"/>
-    <property name="cond1" value="not music_playing music_mystic_island"/>
+    <property name="act10" value="play_music music_mystic_island"/>
+    <property name="cond10" value="not music_playing music_mystic_island"/>
    </properties>
   </object>
   <object id="37" name="Teleport to Cotton Town" type="event" x="0" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport cotton_town.tmx,39,7,0.3"/>
-    <property name="act2" value="player_face left"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
+    <property name="act10" value="transition_teleport cotton_town.tmx,39,7,0.3"/>
+    <property name="act20" value="player_face left"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
    </properties>
   </object>
   <object id="38" name="Teleport to Cotton Town" type="event" x="0" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport cotton_town.tmx,39,8,0.3"/>
-    <property name="act2" value="player_face left"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
+    <property name="act10" value="transition_teleport cotton_town.tmx,39,8,0.3"/>
+    <property name="act20" value="player_face left"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
    </properties>
   </object>
   <object id="39" name="Player Spawn" type="event" x="32" y="112" width="16" height="16"/>

--- a/mods/tuxemon/maps/flower_city.tmx
+++ b/mods/tuxemon/maps/flower_city.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="40" height="40" tilewidth="16" tileheight="16" nextobjectid="206">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="206">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -55,32 +55,32 @@
  <tileset firstgid="5537" name="Set_Pieces_by_Kelvin_Shadewing" tilewidth="16" tileheight="16" tilecount="1440" columns="45">
   <image source="../gfx/tilesets/Set_Pieces_by_Kelvin_Shadewing.png" width="720" height="512"/>
  </tileset>
- <layer name="Layer 1" width="40" height="40">
+ <layer id="1" name="Layer 1" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJztlksOgjAQQNmgG3sKQQ8C6iH9HUTRg6hL5BqOiQ1NLWRa+pnFLF4yCGMepPNpF1n2BjqgJRhT8WC/MPFMuDEXcfxWwo11JL+tsKOI7GebU7JfUD9ZO9T8criulXup/SpDz/n+vgR2BPxi9R3bnM1I76HgF7uufftVop9LFP1M55GC39C5nFrLMWYA+7FfCj+1J7JfH5fI3kbNL9f2mTqxn75jSR/TDEnhh8W0K2J3bBe/oVlWWDhj57LPmh3bDV3nsu+esgcOCI4Bz99YfAGuCBrku/n+Nnek3w2ZG+Lb+CS03wl4Ameifo1lrnwfyRQ//b9MvH65D8Sz6vMu9av7mWow5f7Hfv/xB4dlOmU=
+   eAHtl0tOAzEQRGeTyQZOAYSDQIZDQuAg/A4CLAPXoFpKSxWrW2p/5rOYRSmOY7tfl92eyfGi636hP+i4wPYSmdivla/u/PSXXVeiLeZN4f0OcUp0OxHfgDg5uj7lMxVf7h7drHxn93Fr/3r4K7XDd1hNuxXfBkz3tPc1TDy3lO8OLOIVa4fvV9ADxDFq2qV8wmKpdV3n8u3BNTgS3rn5vHzGune8eLn9yifnUuaKly3e2XI5vPHKl55J2e8p68Pj885lbS178ZbSvxQO7wysfMuoD2sftKalhkvvGmvd0rXSMzQXH8dNmTg3Hsf9Oe0S/zgu822wjz2J37dymHjNGr70HUt5rGfIHHwph/c9zUM83kLsk9cu8W+PtQdD+t/O4+T+6HO5hM/L1eO2cok+l1vyCfcj9BTQAWO8PLm/Nd8r4r4F9G7wWbnl8FnzU68+A2zC/wFF5ubwRb2J+BcdMzbfM3z6hl6gKBOPG5tPz1nUe81HchLV8KVr6Zr8+YMYUo9fp3j8m9XW8fq8qeFTb3QtvhdatVe+2D3s+f0Ph2U6ZQ==
   </data>
  </layer>
- <layer name="Layer 2" width="40" height="40">
+ <layer id="2" name="Layer 2" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJzt0LENgDAMBVF3QBGlAxYImQSYlD3xALhALmJZd9Kv/WQRIorWVEVmY0sdrRNZ1bAZ2/Hhw4cvsa+p4TDWA/iy1Yr+VtfLaMl3+Hzh84XPFz5fI3zPj1vR/3eq69LdQX1ERESZegFMfxQf
+   eAHt1cENgCAMheHe1IPxpi6ATKJO6p52AdoQDpb4k7yLQFK+EhRhIIBANIFhERkLmfT712PVGrZCdupz24OfS2QuwM/kcSfxc4nMBUnfuKOQHOD9M4vvcDLN6q3JmoiD+tq6gh9+bQJtu7l//fk9Ff+C6P099SyX5q44U1vH2I0AAggggMB/BV5MfxQf
   </data>
  </layer>
- <layer name="Layer 3" width="40" height="40">
+ <layer id="3" name="Layer 3" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJztl8tOE1Ech0/bhGrSMt0pZSOlRl7AG+AFZIGgT2CkAnJZeyFhSViIUC7xDYQNLyAYl6JbBH0Cd/oE3lj4TUrD9GRmzjlzYcbEX/JlQjPt+fqb/+kMQrSmkBGiCO1gQSkjIktXMfxnXMbnClyFa3A9Qr8oMoZPDR7BOEwo/N5F0IlJXuCzBC9hGVYUfvOGfmet4G5B0vR7UG4cH5bdGYManHf49ZxC902/pWO/5bI7K1CHSwn355eaxjlesfd+pXhy1I3cn1/qIfwGWGeweHLUjen+CJop5mIaZmDW0u/xNedsnoLjKk7rx2xY5j3GnfclIfbgA3wsNV4zmcWhmL+L7DdbSFeHsp/pfq46zunlntMH/XADbkZwD5f9gu5nO5P4PIYpmIaZGPzsuHW3nxXiExzAIXyGL9nWc+r4rMIarMOGod+rtta/vxfc/dy6+4HLT/gFv+EPHEl+ceQNvyk7sAtvLe/5u5DjNahAN1ThYi46D3tf6iTM/MUd1d494+OrM5+m2abTDDOXhVzIvauaz3E+b0LBpMaanvPHWl1QgW6oSt2o5nNBY+1FjXO8OryLzwiMwj24b3jtvPy+OvaFm5/z+vrN3xN8nsIzeA5zEfk5o+ov6b2rc32DPk+HzbeC+vraiaPDc3n+f4MOKENnvvFsK7OlWC+u7m7hcxsGYBDu5PXeJ3v4dbetef+JMk6PpOZON0nt3WGN6yJ3l7YO5e7+xWeXJOJ0SWN3skuaumvGrcM0JY1O/xM+fwGFBYju
+   eAHVl8lOVEEUhi+QOCQg7BTYQNNGX8ARFRtdOD6BEQRkWCuSsDQuRAYhvoG68QUc4tJh6/gE7vQJHBd+FfmTolJ9b92puZ7ky2luVZ3666+q200UbY3Otijqgj3QDT1QVAx25a90CD2H4QgchWNQpRhDzzhcgwmYhLh4WYAncfXdtrvoWYJ7sAwrEBeLKfXt7o6rVnyb9F3p+1f7KtnHGM/HYZ+l72DKtWVRL31Lm/qWyT5WeL4KByx9WeZLO0b65F/ceONf1jB3vwbKoXWkT/7FjTP+ZY0G2kZBObSO9IX2z9pvmnMxA7MwB6E+PmRNj6DsWEPT+iYb5LQ+lq3vVU8UvYY38BZMhHpo+p4t2UNX31xntTx09ck7ZeNRXNQt/47znTMMJ+AknIK84erT+VNOU38KPddhGmZgFvKGq8/U83n3rj2K3sMH+Aif4DPYsYqeNbgP67ABaeLBjq29v3HWfPp83n1Hyw/4Cb/gN/yBsuMp75Rn8BxegLxT1vwDHbRBDYagDvuhqDD3MiTknXLImFb1kWfK7ry7rLvqtoWcT3dM0t9P8LSNd3I7dIA8U04ab7cnnc8J1jaZwFTM+jWXvFPW8wHuwiDUYAjqYEfS+bwdMPedgD4N+vh+z5xHzwW4CJfgMqSJZvq+WPfCp8/eX3mmbM9/Az03YR5uwQKkiWb67Bo+fXZ7o4l3dp8yPyfpM3PLO+Uy9di1v7LPPn32/pr+ZXi4dyf/v0Ev9EE/mN+2Lo8T7oc8U7bXl+fzCHpOQwNG4QyEhKsjzjvzrmx1SI+ZV1qVW60laT5pVU7qX1T7uYB9kWduLkpD3jryzM156xY5voreSZNZZxW9kybtg61Xz7Y725pcvdutzcxfRU1V8OV/1/AXhQWI7g==
   </data>
  </layer>
- <layer name="Above Player" width="40" height="40">
+ <layer id="4" name="Above Player" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJztwQENAAAAwqD3T20PBxQAAAAAAMCXARkAAAE=
+   eAHt0AENAAAAwqD3T20PBxEoDBgwYMCAAQMGDBgwYMCAAQMGDBgwYMCAAQNfAwMZAAAB
   </data>
  </layer>
- <layer name="Above Player" width="40" height="40">
+ <layer id="5" name="Above Player" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJzVmL1OG0EUha+NF9xYdgsd7hEILKjhMVCUtJDwHgiBACGKdEngFfjLEyR2yohEBIlg/lp+UiSBhjPYI65H652Z3bu2OdKnq/Gud4+P747HQ0Q0XCAqg3Yyj+sxr98HiQ7BD/CTVf7abab1fUrVgKgWPF+bj+vNOo1zZyL8mcf1mFcaIsqCPpBjlb8WDLW+b26g4eEsePZljvlnUefHFvPCMf21k/Zljm3ZuWoE9x4FYxGMR/gLUzWwn+OqWdz7tYU3nv7qgv4Wce9lCyse/sL6L4lUfq8s+OQn3X8qvyULPvkpqQwlslPawb13wR7YBwchfAYb/e7XVBlKZPd0Ldz7DJyDC3AZwlUzPxePuv+k8nOVa366/6Ty85GrR8n+45oD8+AteAcW2LFu9Z+PXDxO5BrVN79MFr+poA/kQAD6s7LeuLqZX7vKVS4kXLfElM2jnl/M/IololKpMx6jpOcX6ec3aX9yVVl+R0WiX+C4KOc1qeox8vuL/xD/wH9wDx4y6XjT66puPL8u0uuqcg9/v8Mdzu8D5o6P4BPYAtuWuXpaaO3sqi/w8xVUQQ18i/Bn9l8nvt9r+LkBt+AO/InwZ/ZfL0qi/zY9f+99JNF/71Py99LmP0mtYj20BtYTrovSmv/24GsfHCT0l9b8dwJfv8FpQn+VfO/231S+UWuCe0TtFHePZzLfuieYluLs8ej/HEn3r8L2oiWr72erNPtislnD9qIlK98DtFWdue7dtLNTle8B2qqptLNT9REBE7t3
+   eAHNmM1OGzEUhS8kATYItnRH96gIKljDY6CqbKHte1RVESDEorvS8gpAwhNQYFkV1FbqD9BuS2DB34ZzNT2KZc2PHXsSrvTFGY/te3xyM5mMiMjooMhjkBX2eR6b7ecRkS/gCBwbrdnX7EnycJ7m26+JHACGefz7f/8MtM3m6LPP89hs5ZFIL6iAqtGafTX0ax7OW+gXUQ0ngLrs41GMp3c6vu1AbmpRjYR9qln1ZQV18TyPuRf2t9uOIfcTMJ7DRI6+tLzqaayYQ+7nBcx76lMPY8Vr5H5bwJKHPtajWX8hWtW/ZwX4+Be7/tS/NwX4+KdeqYf87oZ4p3O3oG0b7IA6aKSwi761PvdM6mHedc99JVzHkPsEnIIz8CeFv+jTcNHI+ovlX5K5+NVFm67C+ovlX7Gy1ghXjTHrr5VdZAEHi+AFeAleAYarNh0fs/6Y36V10ThZTVbyrb+eXvzOggqoghroA67hos1cq5v1R612a+pT/4LuW8zFPN7bmuxjXl9s/4aGRYZBt4PXF9/6K9IdWp/m+uoh/fs6JPINfAcPJdRDX/+u8B/iGtyAW3AHygjeV9G/MnKErMn7evr3ED9f9bCT/r3HvdUG+AA+gk2QF+oh/csbF+vcHvR8AvvgAByCrLDrrxOf7z/oOQdNcAEuQVbY9Zc1rpv9MepvPceD0L3FqL93Jemz6y90r7Hnl1l/y3iOswJWQ57nYMMx6i/Ntx3oqoNGoL4Y9Zem7wd0/QS/AvU9Hejs70faXrL6pqFNw3x2mfTEf+V30XflKWjUZ5dlB7+LPnn4n6PdvTEX55fV+u5Na1ZDvdfg/LJarT/XvdNz1q7rvJBxWn+ue08ca726zgsZdw8BE7t3
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collision">
   <object id="120" type="collision" x="0" y="608" width="640" height="32"/>
   <object id="121" type="collision" x="0" y="96" width="32" height="32"/>
   <object id="122" type="collision" x="0" y="128" width="16" height="480"/>
@@ -162,67 +162,67 @@
    <polyline points="0,0 0,48 0,0"/>
   </object>
  </objectgroup>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="7" name="Events">
   <object id="118" name="Teleport to Route 4" type="event" x="0" y="64" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route4.tmx,19,3,0.3"/>
-    <property name="act2" value="player_face left"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
+    <property name="act10" value="transition_teleport route4.tmx,19,3,0.3"/>
+    <property name="act20" value="player_face left"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
    </properties>
   </object>
   <object id="119" name="Teleport to Route 4" type="event" x="0" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route4.tmx,19,4,0.3"/>
-    <property name="act2" value="player_face left"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
+    <property name="act10" value="transition_teleport route4.tmx,19,4,0.3"/>
+    <property name="act20" value="player_face left"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
    </properties>
   </object>
   <object id="195" name="Teleport to Side Route A" type="event" x="176" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport routea.tmx,12,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport routea.tmx,12,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="196" name="Teleport to Side Route A" type="event" x="192" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport routea.tmx,13,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport routea.tmx,13,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="199" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_town_theme"/>
-    <property name="cond1" value="not music_playing music_town_theme"/>
+    <property name="act10" value="play_music music_town_theme"/>
+    <property name="cond10" value="not music_playing music_town_theme"/>
    </properties>
   </object>
   <object id="201" name="Teleport to Route 5" type="event" x="624" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route5.tmx,0,15,0.3"/>
-    <property name="act2" value="player_face right"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="transition_teleport route5.tmx,0,15,0.3"/>
+    <property name="act20" value="player_face right"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="203" name="Teleport to Route 5" type="event" x="592" y="256" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route5.tmx,0,15,0.3"/>
-    <property name="act2" value="player_face right"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="transition_teleport route5.tmx,0,15,0.3"/>
+    <property name="act20" value="player_face right"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="204" name="Teleport to Dojo" type="event" x="48" y="272" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport dojo1.tmx,11,11,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport dojo1.tmx,11,11,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="205" name="Player Spawn" type="event" x="32" y="80" width="16" height="16"/>

--- a/mods/tuxemon/maps/gadget_store1.tmx
+++ b/mods/tuxemon/maps/gadget_store1.tmx
@@ -1,54 +1,54 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="20" height="13" tilewidth="16" tileheight="16" nextobjectid="12">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="13" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="12">
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>
  </tileset>
  <tileset firstgid="89" name="electronics" tilewidth="16" tileheight="16" tilecount="16" columns="4">
   <image source="../gfx/tilesets/electronics.png" width="64" height="64"/>
  </tileset>
- <tileset firstgid="105" name="KelvinShadewing_Buildings" tilewidth="16" tileheight="16" tilecount="500" columns="20">
-  <image source="../gfx/tilesets/KelvinShadewing_Buildings.png" width="320" height="400"/>
+ <tileset firstgid="105" name="KelvinShadewing_Buildings" tilewidth="16" tileheight="16" tilecount="680" columns="20">
+  <image source="../gfx/tilesets/KelvinShadewing_Buildings.png" width="320" height="544"/>
  </tileset>
- <tileset firstgid="605" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
+ <tileset firstgid="785" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>
  </tileset>
- <layer name="Tile Layer 1" width="20" height="13">
+ <layer id="1" name="Tile Layer 1" width="20" height="13">
   <data encoding="base64" compression="zlib">
-   eJxjZGBgYKQi5qEyFqcyNhjFo3gYYUk8mBg16BgAQDAmsw==
+   eAFjZGBgYKQi5gGaRU0sDjSPmtgAaN4oHg2D4ZIGJIHpGReG+RGXPDZxAEAwJrM=
   </data>
  </layer>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="2" name="Events">
   <object id="2" type="event" x="112" y="192" width="32" height="16">
    <properties>
-    <property name="act1" value="transition_teleport taba_town.tmx,40,11,0.3"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport taba_town.tmx,40,11,0.3"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="10" name="Play Music" type="event" x="16" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_gadget_store"/>
-    <property name="cond1" value="not music_playing music_gadget_store"/>
+    <property name="act10" value="play_music music_gadget_store"/>
+    <property name="cond10" value="not music_playing music_gadget_store"/>
    </properties>
   </object>
   <object id="11" name="Player Spawn" type="event" x="128" y="160" width="16" height="16"/>
  </objectgroup>
- <layer name="Tile Layer 2" width="20" height="13">
+ <layer id="3" name="Tile Layer 2" width="20" height="13">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFwxXED7QDRsGQAwDVXABg
+   eAFjYBgFwzUE4oerx0b9RbMQAADVXABg
   </data>
  </layer>
- <layer name="Tile Layer 3" width="20" height="13">
+ <layer id="4" name="Tile Layer 3" width="20" height="13">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUjAIIAAAEEAAB
+   eAFjYBgFoyEwGgKjIQAJAQAEEAAB
   </data>
  </layer>
- <layer name="Above Player" width="20" height="13">
+ <layer id="5" name="Above Player" width="20" height="13">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFgwVED7QDRsGIBwDo/ABc
+   eAFjYBgFgyUEogeLQ0bdMWJDAADo/ABc
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collision">
   <object id="3" type="collision" x="0" y="192" width="112" height="16"/>
   <object id="4" type="collision" x="144" y="192" width="176" height="16"/>
   <object id="5" type="collision" x="0" y="0" width="320" height="48"/>

--- a/mods/tuxemon/maps/gaming_hall.tmx
+++ b/mods/tuxemon/maps/gaming_hall.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="19" height="16" tilewidth="16" tileheight="16" nextobjectid="8">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="19" height="16" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="8">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -24,22 +24,22 @@
  <tileset firstgid="2860" name="Terrain_by_KelvinShadewing" tilewidth="16" tileheight="16" tilecount="285" columns="19">
   <image source="../gfx/tilesets/Terrain_by_KelvinShadewing.png" width="304" height="240"/>
  </tileset>
- <layer name="Layer 1" width="19" height="16">
+ <layer id="1" name="Layer 1" width="19" height="16">
   <data encoding="base64" compression="zlib">
-   eJyzZmBgsCYBh+PAEUD8ikgzJkPpNBw4nQSzCOGyUbNGzcJi1msgZqaCWe1A/ItK7ppGJXMGM25loB6YAsQAflROtg==
+   eAGzZmBgsCYBhwPVYsMRQPFXRJozGaouDUhjw+kkmEXI7WWjZpEUvyMlvF4D0wUzEBNKP4Tk24Fm/KKCOSB7plHJHEJuHkj5VqAfqQWmAA0CAH5UTrY=
   </data>
  </layer>
- <layer name="Layer 2" width="19" height="16">
+ <layer id="2" name="Layer 2" width="19" height="16">
   <data encoding="base64" compression="zlib">
-   eJydk88OwUAQh8e/lt2rm5sLXoirC0/Q4NqgD4CLmxfwDLwHLkhwwSOYSaexxnaTdpIv0253v8yvabsA0EthYllz1QAZphAa13Udd1cFiI+UkAJSRDzuobGvof/PHhTAETmpr4scY7FPCVeTXTcVQ3XGfkGuhqvEvWLMlszVQkcb6bDrqWKo7uo/o+JeFLOF4K6XxVU1spKPRvAcroeyrwd8LhDrZeEy3+fb4arAN6vP9zVkisyYecqM0qW5l8WzBbJkVinnzXmT7yt5b+QrcCf2GjZbDX0Cr/vSFXEfsSPSv3myMBeutf7Nk4WVcO0s/0fWIlfebLasebPZsn4AZEBXIQ==
+   eAGlkT1OAzEQhZ0Q/rItHR0N5ELQpoETIJIWAXsAoKHjAjkD3ANoAAloIEfI+9gZabDiEG2e9DQe2/tpnvcwpXRU8HjOvraKOtbJScHnYX+nau4VQTo4lTflNbkjd+UNq7Bcu2Lleuqn9Cy/yAgWjBFNEMeRtWesDx1g9Kr6Jr9bD4uZqOuyz8Z8sPbFOJAHxvrWdxh9Wm26hsEWLL6PinPFfV//zGFt6dCzwmME3qzE+soYuvorGHxHjeqpiaz4ntMFLN4JFlf4p/Tb8oV8ab5S/U8wyERllqhrNTfm23gQ1nFeGMxC5d3gdayyfqzS/aRKQ6z1UFt/VFt3pgqj1mAxj+dapnp2Z92JFfN4rmWqZ3fWAw+2omC1zZbnJ2vbbHl+ss4AZEBXIQ==
   </data>
  </layer>
- <layer name="Layer 3" width="19" height="16">
+ <layer id="3" name="Layer 3" width="19" height="16">
   <data encoding="base64" compression="zlib">
-   eJxjYKAMtDNSpn85F4K9nkKzNnLhl99CmfFkgVdAN73mQtCUgI9A/Z+4EDS13EYu2IzEJsdNh8i3miywmbASokE6Fc0aBeQDABuoEYg=
+   eAFjYKAMtDNSpn85F0L/egrN2ohkFsJUBGsLgkk31iugm14DMYymxOKPQHM+ATGMpsQskF5K3bQZyQHkuOkQkn56MJHdS6l96ZQaMKqfKiEAABuoEYg=
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collisions">
+ <objectgroup color="#ff0000" id="4" name="Collisions">
   <object id="1" type="collision" x="16" y="32">
    <polygon points="0,0 96,0 96,128 160,128 160,80 144,80 144,96 112,96 112,48 160,48 160,0 192,0 192,16 208,16 208,0 240,0 240,-16 256,-16 256,0 272,0 272,192 0,192 0,0 -16,0 -16,224 288,224 288,-32 0,-32 -16,-32 -16,0"/>
   </object>
@@ -56,7 +56,7 @@
    <polygon points="0,0 0,16 32,16 48,16 48,0 0,0"/>
   </object>
  </objectgroup>
- <objectgroup name="Events">
+ <objectgroup id="5" name="Events">
   <object id="7" name="Player Spawn" type="event" x="256" y="48" width="16" height="16"/>
  </objectgroup>
 </map>

--- a/mods/tuxemon/maps/healing_center.tmx
+++ b/mods/tuxemon/maps/healing_center.tmx
@@ -44,81 +44,81 @@
   <object id="22" name="Player Spawn" type="event" x="112" y="160" width="16" height="16"/>
   <object id="25" name="create npcs" type="event" x="16" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc tabanurse,6,6,,stand"/>
-    <property name="act2" value="create_npc shady_guy,9,10,,stand"/>
-    <property name="act3" value="npc_face shady_guy,right"/>
-    <property name="act4" value="create_npc happy_guy,12,10,,stand"/>
-    <property name="act5" value="npc_face happy_guy,left"/>
-    <property name="cond1" value="not npc_exists tabanurse"/>
+    <property name="act10" value="create_npc tabanurse,6,6,,stand"/>
+    <property name="act20" value="create_npc shady_guy,9,10,,stand"/>
+    <property name="act30" value="npc_face shady_guy,right"/>
+    <property name="act40" value="create_npc happy_guy,12,10,,stand"/>
+    <property name="act50" value="npc_face happy_guy,left"/>
+    <property name="cond10" value="not npc_exists tabanurse"/>
    </properties>
   </object>
   <object id="26" name="hello there" type="event" x="96" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog tabanurse_dialog\n"/>
-    <property name="act3" value="translated_dialog_choice yes:no,chooses"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
-    <property name="cond4" value="not variable_set chooses:yes"/>
+    <property name="act10" value="translated_dialog tabanurse_dialog\n"/>
+    <property name="act20" value="translated_dialog_choice yes:no,chooses"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond40" value="not variable_set chooses:yes"/>
    </properties>
   </object>
   <object id="27" name="Heal Tuxemon" type="event" x="96" y="128" width="16" height="16">
-    <properties>
-     <property name="act1" value="set_monster_health ,"/>
-     <property name="act2" value="set_monster_status ,"/>
-     <property name="act20" value="translated_dialog okaythen"/>
-     <property name="act3" value="npc_face tabanurse,up"/>
-     <property name="act4" value="wait 1"/>
-     <property name="act5" value="npc_face tabanurse,down"/>
-     <property name="act6" value="translated_dialog okaythen2"/>
-     <property name="act7" value="set_variable chooses:none"/>
-     <property name="cond1" value="is variable_set chooses:yes"/>
-    </properties>
-   </object>
-   <object id="30" name="howdy" type="event" x="192" y="160" width="16" height="16">
-    <properties>
-     <property name="act0" value="npc_face happy_guy,player"/>
-     <property name="act1" value="translated_dialog happy_guy_dialog"/>
-     <property name="act2" value="translated_dialog_choice yes:no,happy"/>
-     <property name="cond1" value="is player_facing_npc happy_guy"/>
-     <property name="cond2" value="is button_pressed K_RETURN"/>
-     <property name="cond3" value="not variable_set happy:yes"/>
-    </properties>
-   </object>
+   <properties>
+    <property name="act10" value="set_monster_health ,"/>
+    <property name="act20" value="set_monster_status ,"/>
+    <property name="act30" value="translated_dialog okaythen"/>
+    <property name="act40" value="npc_face tabanurse,up"/>
+    <property name="act50" value="wait 1"/>
+    <property name="act60" value="npc_face tabanurse,down"/>
+    <property name="act70" value="translated_dialog okaythen2"/>
+    <property name="act80" value="set_variable chooses:none"/>
+    <property name="cond10" value="is variable_set chooses:yes"/>
+   </properties>
+  </object>
+  <object id="30" name="howdy" type="event" x="192" y="160" width="16" height="16">
+   <properties>
+    <property name="act10" value="npc_face happy_guy,player"/>
+    <property name="act20" value="translated_dialog happy_guy_dialog"/>
+    <property name="act30" value="translated_dialog_choice yes:no,happy"/>
+    <property name="cond10" value="is player_facing_npc happy_guy"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="not variable_set happy:yes"/>
+   </properties>
+  </object>
   <object id="31" name="Rename Monster" type="event" x="192.205" y="159.583" width="16" height="16">
-    <properties>
-     <property name="act1" value="rename_monster"/>
-     <property name="act2" value="translated_dialog happy_rename"/>
-     <property name="act25" value="npc_face happy_guy,left"/>
-     <property name="act3" value="set_variable happy:no"/>
-     <property name="cond1" value="is variable_set happy:yes"/>
-    </properties>
-   </object>
-   <object id="32" name="whats up" type="event" x="144" y="160" width="16" height="16">
-    <properties>
-      <property name="act0" value="npc_face shady_guy,player"/>
-     <property name="act1" value="translated_dialog shady_guy_dialog"/>
-     <property name="act2" value="translated_dialog_choice yes:no,shady"/>
-     <property name="cond1" value="is player_facing_npc shady_guy"/>
-     <property name="cond2" value="is button_pressed K_RETURN"/>
-     <property name="cond3" value="not variable_set shady:yes"/>
-    </properties>
-   </object>
-   <object id="33" name="Rename Player" type="event" x="144" y="160" width="16" height="16">
-     <properties>
-      <property name="act1" value="rename_player"/>
-      <property name="act2" value="translated_dialog shady_rename"/>
-      <property name="act25" value="npc_face shady_guy,right"/>
-      <property name="act3" value="set_variable shady:no"/>
-      <property name="cond1" value="is variable_set shady:yes"/>
-     </properties>
-    </object>
+   <properties>
+    <property name="act10" value="rename_monster"/>
+    <property name="act20" value="translated_dialog happy_rename"/>
+    <property name="act30" value="npc_face happy_guy,left"/>
+    <property name="act40" value="set_variable happy:no"/>
+    <property name="cond10" value="is variable_set happy:yes"/>
+   </properties>
+  </object>
+  <object id="32" name="whats up" type="event" x="144" y="160" width="16" height="16">
+   <properties>
+    <property name="act10" value="npc_face shady_guy,player"/>
+    <property name="act20" value="translated_dialog shady_guy_dialog"/>
+    <property name="act30" value="translated_dialog_choice yes:no,shady"/>
+    <property name="cond10" value="is player_facing_npc shady_guy"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="not variable_set shady:yes"/>
+   </properties>
+  </object>
+  <object id="33" name="Rename Player" type="event" x="144" y="160" width="16" height="16">
+   <properties>
+    <property name="act10" value="rename_player"/>
+    <property name="act20" value="translated_dialog shady_rename"/>
+    <property name="act30" value="npc_face shady_guy,right"/>
+    <property name="act40" value="set_variable shady:no"/>
+    <property name="cond10" value="is variable_set shady:yes"/>
+   </properties>
+  </object>
   <object id="28" name="Go outside" type="event" x="112" y="192" width="16" height="16">
-    <properties>
-     <property name="act1" value="transition_teleport taba_town.tmx,40,4,0.3"/>
-     <property name="cond1" value="is player_at"/>
-     <property name="cond2" value="is player_facing down"/>
-    </properties>
-   </object>
+   <properties>
+    <property name="act10" value="transition_teleport taba_town.tmx,40,4,0.3"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
+   </properties>
+  </object>
  </objectgroup>
 </map>

--- a/mods/tuxemon/maps/healing_center_sphalian.tmx
+++ b/mods/tuxemon/maps/healing_center_sphalian.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="15" height="15" tilewidth="16" tileheight="16" nextobjectid="23">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="23">
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>
  </tileset>
@@ -9,27 +9,27 @@
  <tileset firstgid="161" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>
  </tileset>
- <layer name="Tile Layer 1" width="15" height="15">
+ <layer id="1" name="Tile Layer 1" width="15" height="15">
   <data encoding="base64" compression="zlib">
-   eJxjYBg4wEQGhgFeMjAMSJCBYcCADDyqd+joHQgAAK/YFXw=
+   eAFjYBg4wAS0mlQMcy0vkEEqhumVADJIxTC9BkAGqXhUL/FhNtBhBbOfnjQAr9gVfA==
   </data>
  </layer>
- <layer name="Tile Layer 2" width="15" height="15">
+ <layer id="2" name="Tile Layer 2" width="15" height="15">
   <data encoding="base64" compression="zlib">
-   eJxjYBi6gJkCvXwwM1gZGHiBmI8VzWwgn4uFgYGbBbcZd4FyZkB15kh6a1kg4sZAbIJHLz5gToS+WqCdt1kQuJ6VsB5ywBXaGAsGIH9uA+LtLMT5GV3vfSB+QIJeGgURxQAAsc0MbA==
+   eAFjYBi6gJkCp/NB9TKzMjDwAjEfECMDkDgXCwMDNxDjAneBcmZAdeZIemuBYiBxYyA2AWJygDkR+mqBdt4GqoPheiQ3kGMnLj1XcElQQRzkz21AvB2IifEzspUg9feB+AEJemkURMjOIosNALHNDGw=
   </data>
  </layer>
- <layer name="Tile Layer 3" width="15" height="15">
+ <layer id="3" name="Tile Layer 3" width="15" height="15">
   <data encoding="base64" compression="zlib">
-   eJxjYBgF5IJwVtLEkYEODjW4xEfB8AUAYq4BGw==
+   eAFjYBgF5IZAOCt2nbjEkVXr4NCLSxxZ7yh7eIUAAGKuARs=
   </data>
  </layer>
- <layer name="Above player" width="15" height="15">
+ <layer id="4" name="Above player" width="15" height="15">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFAwU2sjAwbELCm1loY89q2hg7CqgEADW4BDo=
+   eAFjYBgFAxUCG1kYGDYh4c1ANi3AaloYOmom1UIAADW4BDo=
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collision">
   <object id="4" type="collision" x="16" y="208" width="208" height="32"/>
   <object id="5" type="collision" x="160" y="160" width="32" height="32"/>
   <object id="6" type="collision" x="176" y="80" width="32" height="16"/>
@@ -46,29 +46,29 @@
    </properties>
   </object>
  </objectgroup>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="6" name="Events">
   <object id="16" name="Heal Tuxemon" type="event" x="112" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="set_monster_health ,"/>
-    <property name="act2" value="set_monster_status ,"/>
-    <property name="act3" value="dialog Your tuxemon are now at full health!"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="set_monster_health ,"/>
+    <property name="act20" value="set_monster_status ,"/>
+    <property name="act30" value="dialog Your tuxemon are now at full health!"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="17" name="Go outside" type="event" x="112" y="192" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport sphalian_town.tmx,17,7,0.3"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport sphalian_town.tmx,17,7,0.3"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="18" name="Go upstairs" type="event" x="32" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog It says that it is under repair"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
+    <property name="act10" value="dialog It says that it is under repair"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
    </properties>
   </object>
   <object id="22" name="Player Spawn" type="event" x="112" y="160" width="16" height="16"/>

--- a/mods/tuxemon/maps/leather_scoop.tmx
+++ b/mods/tuxemon/maps/leather_scoop.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="13" height="11" tilewidth="16" tileheight="16" nextobjectid="17">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="17">
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>
  </tileset>
@@ -54,27 +54,27 @@
  <tileset firstgid="7582" name="items" tilewidth="16" tileheight="16" tilecount="100" columns="10">
   <image source="../gfx/tilesets/items.png" width="160" height="160"/>
  </tileset>
- <layer name="Layer 1" width="13" height="11">
+ <layer id="1" name="Layer 1" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eJwzk2BgMCMRO5KBfcjA2qN4UGMAVowoyA==
+   eAEzk2BgMCMROwLVk4p9gHpIxdpAPaN48IYBAFaMKMg=
   </data>
  </layer>
- <layer name="Layer 2" width="13" height="11">
+ <layer id="2" name="Layer 2" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eJxjYCAfsAiRxgeBOmEIvQhIXxFkYLgqCGEvBuIlaHIwMAkqvg1I3wOK3xeEsLcD8Q40OXQ9pABcevS5GBh2AfFuLggbBKqBamuE8et5DsQvkPT0A9VOAOKJwrjNJQSwmUvIHD1ZoDgUG8hiN0eLB4HTRRkYzIHqLKDYEoh1eDDNBQBDgiQy
+   eAFjYCAfsAih6iXEB6muE4boWQSkrwgyMFwFYhB7MRAvQZODmT4JKr4NSN8Dqr8PxCD2diDegSaHrgfGJ4aG2YOuVp+LgWEXEO8GYhAbBKqB9tYAMT49z4FqXyDp6QeqnwDEE4EYBLCZC5HBTYL0oJtLyBw9WaBdUGwApEEA3RwtHgYGGE4XZWAwB6qzgGJLIK0DlEcHAEOCJDI=
   </data>
  </layer>
- <layer name="Layer 3" width="13" height="11">
+ <layer id="3" name="Layer 3" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eJxjYKAv4OcmXU+d8PDSM1wAABxyAl8=
+   eAFjYKAv4Ocm3b464eGlh3TfDE4dABxyAl8=
   </data>
  </layer>
- <layer name="Above Player" width="13" height="11">
+ <layer id="4" name="Above Player" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eJxjYKAvmC9Lup6VZOihNhCXwi5ex0UbcykBTDwITEsAAH5FApc=
+   eAFjYKAvmC9Lun0rydBDui34dYhLYZev48IuTqwoLnOJ1Y9NHRMPAwMMY5OnlhgAfkUClw==
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collisions">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="3" type="collision" x="80" y="112">
    <polygon points="0,0 0,32 32,32 32,0"/>
   </object>
@@ -99,13 +99,13 @@
   <object id="13" type="collision" x="0" y="0" width="48" height="128"/>
   <object id="14" type="collision" x="48" y="0" width="160" height="48"/>
  </objectgroup>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="6" name="Events">
   <object id="15" name="Teleport to Leather Town" type="event" x="80" y="160" width="32" height="16">
    <properties>
-    <property name="act1" value="transition_teleport leather_town.tmx,24,10,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport leather_town.tmx,24,10,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="16" name="Player Spawn" type="event" x="96" y="96" width="16" height="16"/>

--- a/mods/tuxemon/maps/leather_town.tmx
+++ b/mods/tuxemon/maps/leather_town.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="40" height="40" tilewidth="16" tileheight="16" nextobjectid="93">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="93">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -27,27 +27,27 @@
  <tileset firstgid="5361" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
   <image source="../gfx/tilesets/boxfont.png" width="208" height="192"/>
  </tileset>
- <layer name="Layer 1" width="40" height="40">
+ <layer id="1" name="Layer 1" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJztlktSwzAMhpU1rxyCA3CU3IFHDwKFbe9Au0yai0BzDyjhCDhDNNFoZFtx3MTMsPinTuLan39bskoAqIz2RmWC7bnmqxfmu/nj/vnat0Z3grBfMxPHxvL+0ehJUCr+TeUrTryPL4TpwWjbKxWfqNak/z+fnY/uI9UuEb61pU+dOF/s/Iy/b0bvRgfQxencfEejL6MWxsfBFD7pnfT/JfnoM+4j13nm56Mxu/PMy/lsNQjnQ59scvFxz3z3foh/F8anS6LPnusDfp+vMj1fzPNn64N+nmVD/Lr4pHM8B592fzkfnuc9DOvT8PFxfHza/eXjHtmYrYWhEea28dMYpnGL/V5hiNNVJD5X7uXfpRjGcXM2P7/Tyr7PVD7Xdx7DuK9SHpf4JP+KEXwV0RiPQ/hwrV2brzMGn6ut4RuTXxriOZ6pmP49g1zXdLpX8PHzH5vPVy/E5isgLb6N0r+aPNNcyOXKjaH+hYjn9UP/3hU7Jch1HL8TqE9jWbm/fN2+2Ln2SOJz+S5JyyeJ3wG8pmsdTFK+9OUzylcp+GLkF1s7V/C5Ymer4MOaM5boudas08d3KlG+7wA+qT6Jqa4GCPEvF2qkJdupcNjaP090DaU=
+   eAHtV1tyEzEQNN+8fAgOkKPkDgQ4CAF+c4eYz4AvsuvcA7SbI9Bdpa5qVCN5194N/uCjS6PRqKdnJPnxsNlsfgA/gYcLtJ9L0/7E+pfSd7VS75fSdy7Pe9R3E0C8jyf2f+7dvUOe6K5/hv82gPRFe+bmPif+XH3Xlbrnaqqd4zfr3UfYu4zn7l+tT362X6wX//X9/fnv/fNz1Hly/H4h/fNz9Hu8v3B9rnWJ+yeODnX3wAGY8k5r/VtLX4KuARgBv2f+Nt1eSp/XI1uf5+od5/9Sn+vooKUP8OrF8f75m/V3qro9D22fX2EexdHncQnzoYHW+ZZn+lhwex7a5XyKvtfo0xvD76z1F0b63wK1+1fq0z2J8s7RR54aV8r6XkJXD/sAtPR5T2qc8ntszVZt2qO54lPWN+RxnKmvQzzrIj/HQ7bJrxxRbl/jehRDrQmgtqnnW/JyP3nEP5rtsbyrHkfb193usNZn+LtVjnus6Tv1E2x97vH+OQ/jE+B5a/p8n2yNyisecg4FxLu1fNznd1H6GMM1glziZT7x0CZ8ze3WevmG9W6Zzzk5j/Qpj+u7znun6ON+wfNFtvtO0adaubes07ndljaO7p9rM+ex/rU4yzW+EXImYABGoIyhZsbIr5E+92vu+r4i5qaCD8YpHud2OyF2DX16x9Got+P1uya3p+rTnRan6va59y/SJd8S+u7QV+VWPRp1npzvAc3vYe8qaH02kse53U5YG4AxiNG+OaNq6sDXA4fM672N+sfYCP6dQB3klx7a7I3mrVH7tCdh3wCobtcXvZ13iG1BPMrjWpSTPtnUXcLXW/p0D33033Fu6zed9EmXdJRz+n2tZrs+xnj/XJds5om4nKcWc8y/BXcZ47zM23o7u2C/tIpHvzl7xC4Bv9fKVdbg/tqa9A3QtQZ4b6TjyexSTznXHn1n+51c0uZ/FOWqaaC/XNtiH99f6Z/CtUbMpeio1fYHT3QNpQ==
   </data>
  </layer>
- <layer name="Layer 2" width="40" height="40">
+ <layer id="2" name="Layer 2" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJztl1tqwkAYhSdC1QjJFiz6qoLbqNtwc0Jfa9fhGqStl6dordqnHtoJeJn7pVH4PziocaJfJnNkZKw6XjLGpshrph7Xzu0SigJeH8jWws/EOaTfwtLPJI/ccZ75ZYcsHedP5V5e+xeyRw7IEflGNvyeLfh3r5A1P/6Ac+tIA2kiaf533NZPdJ9PX/+Cx+Qi79zjLbt+T5WaZs3YdEK1/so51c2HDR1NL0TXovLbB/aTebl0teBrMaSfyMfVb8d78nnS0RiOpn4F74Osx2VffefT+bfYsL+6fkbzk/j6+oj8ZJ46lsgqrM4VPn5pwlgrie8Xey/gA/n5McjFz++J2D0de3ZM1dNZw++zifukkzLWTau2kPMEt9EN+xHnDJv6MT2M6SMDg7EEQVSD635m8k97Cd3/jmeJB+11CCIcP86Raxk=
+   eAHtl1lKA0EQhjuCJiPoFZT4qgGvodfwcoKv6jk8g7hMfHJfnvxL58dKM9NLOp0M2A1/qpfqqi81KZgYs7pxvmXMBXQJucbOtjExcsWKOXsE1x30HMHH+C5e+qRa4buP5HNx8WwX9ZZxjdgpesX9OpLvN/PfJ5m0lVP57m/QO/QBfUJf0BMkz0zqIrmn0AMk++v4XhvQEBpBFST7sc9XWDjIpdc/c/gMLN02HDew9plrvabyMY+2ZHBZ+mt27tGypr560D/EjsGuc9qMdgzta58JnzzvRfIxh83FNc9DrPDJb3GRfOSgFQ7OxcYM6UfpkxeIfR1zv8tX89jzrjuyL/WS/uvqY/Zraj1tJr128ZnA/vX1pzMHDjWPPffdnTlveFN5ZmI2fLJns8naN2o4TH1OiefkmIevGhizCeUcbVzcy5k3NDZZ2mxojJx+bVzcy5k3NPZE9YGeh97vg1/uPj1J7DFXn14N+1DBwrDsCowrY/agvo4jsB33mK+vdVsV1+HIn3kfPgfQJMDXH614lAqUCuSoQI2g8/zvOF3Su4TrfUbqcdbBUd51cvxaSsz/WoFvzpFrGQ==
   </data>
  </layer>
- <layer name="Layer 3" width="40" height="40">
+ <layer id="3" name="Layer 3" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJzF2ElwFFUcx/E3yWxJMJEMEBRIEFygNAmGxYuSZRIQghoXcIlWTpZiZrKBkqASSKA86cmDa6kHMpBFT3r24F6lB/ftJCQhO4u7Vum3a/rV9Lx50z2dTPRVferR9KTfL//ufu9NigqFuNyl6hwhalCLOoRR6YmzO7cJ6/KEWA+1VfmFmKCfFIneaKWMN1csxPkMXUKEMaNoQzs6chLj2J1rIt9usjVq8rWQL4/z+Z5EL/OVhIQoo+8LxHvJOG6ljyCKNqzisy8y5kt4Ga/gVUsGu3NNntRc6ZqsoTXfoJLPOO6k78IBHDTzfcCYH+IjfIxP0Mzv/4jH/tyjLvLJGsp87wWFeD+YnM9wCN3owWEz39rCzMdx246T4UQwcSzzTfN/M5p86j1f7HzDZBjR5JPj+wqE8Bck32Ndvp9yhTiDsxjFWG7yOOMcn8MEJjGlnHdq8vkz3smwJV852SrMfLr3OmzmK/Iy12ApihHyJl9/GcfLsQIlWOlNzXAmn98PoxjDeH7inHz+ZK7X8DresNTKqGsxfYWiEjcz3i3YjmrUKOPXclyHMOrRoMlXQB2W4DIUoqhAXz9jTjvJmAOImdl6A/F86Z61/Yz3GFoRQVQZv43jdnSgE12afJvJswVbsQ03WfLJ+oXMOg3RD2PEzBdzyJeN1kyeB/EQXuDetmjqZ30/1LnYmu8Cz/dFXMLP+AW/pnnmjfkuk9ZPnuM4gXfJ94ymftZ8urlY5ivl/pRhLa7COqzX3DM3bYg8wxjBm3jLoX52c3EjWfbgNtyOO9C0wHx2TVc/lTVfN1l6cBhP4ik8vUj5VgdT62esE3KtkGvdYq0Va7h2qbFWBfXn64Op9TPWCblWyLVusfI1cO0d2JkmX0SpX3VIv9cLa/JNsB+ZxBSmMZOjG2Fh7XlL/crNuViuDf2B1LXC2lYwp5RgJa7AlWnmmPsZ4wFTc5o62TXrHtqYi43Wa95juxYmTz0asAM70+Q7RqY+U79Dvo3mvvAzPMy/r1f20EYz3o1YIPlY1zrI04kuHMDBNPlOk2nQNOSQbxc5ZkVCoyf1u4haN6c6ZrPp8um+iyykzWY5n+673HzbtHndORc/U2VZo93W7yTrwgBiOIXTGLRZK2bmka/Fkm8/40dQiChaHer3OVm+wJf4Cl/jGzPft/Tf4Xv8gB+988vn1Ozq94+RxSeEBznIhdcXP+ej9yOAIPJ87vLt412+F/c5vNN29buBMctRgUpswo1mvir6zdiCrdjmMt8RcvXiqEM+p/f3UxGfLzOxxJP9fLr6VWn2vbMuZJJvgFwxnJpH/Vo0+aZE/L3KRFEW5lHZ3Mx7Z9mjjGIM4zin7Fl+Y437HX/gT/xlrnmzfG4O53EBF13sddysG0sZrxghLMNyZc29mvf9GlyL67DBnItW8bnVWINSlGX4N4S/Xe53tnPdatSgFnXKOHeS5y7cjXuw18x3K5/bhd1oxB4Xf+PYwLO20Z/ZfW7luhFE0YZ2ZZwj5OnFURxDn5nvcT73BA6hGz0u8u0l2z5/9vYH2W59ZOvPsH7/R1Pr91/klM+U07HRy/rJtpD7rM71av8se93nAomayBzpjmWf6fWdenWuV/u3yfZOIFETOX66Y2vt/gW/RXRK
+   eAG110lwFFUcx/HHkkAAE0mAoECC4AKlSZDNi5KdLaC4gEu0OFmKmckGSoJKIIHypCcPolDKgQSy6AnPHtyr5OC+nYQkZCMs7lql378z//JVV/fM62TmX/WZN93T6febf2+TnGxjrg+pdKoxZShHBSpRMiUm0Wer2GZZljHL4a3VmcYMsXIYOso2BWQbzzXmsqNrbBchTxT1aEAjtBJ9toN8W8lW45NvN/my+HwWdJR9Sr78PGMKGdtnxEZ5r8t1vI8ginosYttj5Hkdb+A4TkAr0WeSz7W0h3a+bk8+WW4iUzP2Yl8834fk+Qgf4xN8ilq+/1PMn+izp0Pk0x5qvvdnGvMBtHc67idTC1pxIJ5vKWO66ggZjkJL842ybswnn/eYy/FNZ75eMvT55NN+Zcw2JhO67D3mmu+nacacxwX0YwB2DbJ8EUMYxgjClJ5/ct1Wxq8PyVREtuJ4Pr/rWraV/uVM576EuchFHuyax/J8LEA+FsJb52fx/dCPAQxCS88/7dObzPkWTkLXyXWdy3KxRwnLdzPfPdiAUpTBrnKWK1CJKlTDW7Ppwxxch2zkQMvun9zTTjFnJ7og+dq4diVf0Lm2h/meQR0iiMKuepYb0IgmNMNba8izFuuwHndBS/uXRxbJ0cPYiz5Ivq4k+XQ/kxlryfM4nsBrHNvdVj7tn16/ksl7L7b7d4Xz+yqu4Wf8gl/hV3IvdKkO8hzBUbxHvpesfNo/O5/fvViPbwHHpxBLcROWYTkmUz3k6UUf3sY70PLrX6J7cQ1ZtmE77sV92IF0lV//9LrVUe91kqGFLK04gOfxAl5EOmox92dv/+Q5oc8KfdbZ+VKZYwnzF6DQek7Y+69ivbd/8pzQZ4U+69KVr5r5N2JTQL4I6+3+lXJ/8fv9p88K+7sN8VtlGCMYxRhSXa+ST/tXxH1F7sX6jOiw3ss6eVbYtYB7Sj4W4gbcCL96lDkei6tlDFvaP/k7uRdLSU45xomqkjxVqMZGbIJfHSZTe1xHknwr478Lz7GjJ3l/O7R/um+5NjSnrJNlv2okTxOasRf74FdnyNQd15Mk3xbyXGInqoZl7Z+O3r55l/0ypGqdXz7tn46TnUu++0TLL5/2TceJ7lv+bhSSb1wWHEv+n9Tyy6d901G3lfEUz4VOdOE0zqAbQTXGB2Hzyf+TWns43yLIRhR10L7pqNvK+DlZvsCX+Apf4xtIfcv4Hb7HD/gRE8kX21vwq/ZNR3vLf5jTZBgzBVMxDdMhlcGYiRmYiSyEybeLa/lhPJLkmta+6RibPfZ6B3MWoRglWIU7IbWacQ3WYh3WI0y+g+Rqw6Ek+bRvOsZm///1M96eczSH88X1/HPNp33TUZLZ15QsS8m8rlyu30761oXTE+iffU39F46XEch15SKH7VJVdt+S7fMCv1H6MYBBXIRdv/GM+x1/4E/8BalLbDeOy7iCq3CtoPPO7+/nMl8u8jAP82HXzVzvt+BW3IYVkFrEdouxBAUohEv9neTYe/exgf2WogzlqIBd95PnATyIh7ATUpvZbgu2ogbb4ForuH+vhMtxrmO/EURRjwbYdZA8bTiEw2iH1LNs9xz2owWtcK2dZNuFMMfZdd+p2K6dbB2O/UvFfGH34e2fy3EOO4d3ez2ndH3QsqzX/um2kznO+t2Cxpf5Lf4KtCeaK2hZ12u2oP26rtfvFjSeJdu70J7o/EHLul7y/Qu/RXRK
   </data>
  </layer>
- <layer name="Above Player" width="40" height="40">
+ <layer id="4" name="Above Player" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJztltkKgkAYhQ86GGjLa9Rr9hDty23RY2Xabft204luRtEkCUfp/+BDxh/lcAaGAQRB+Dd6CujTAR3SkYrOx1xP6JTO6Fwl/6fMrF3Apxsa0NA1nSiK5wF12qBN2vJMJxIEQSgv3drnuW/xvKcBDenWKiZXmVlona0y+ktimeObb3ntq54za5+LJt5bnh6FarCzgT090CM90bP9nl34vNIbvdOHbTarIAjVJuvOknbmyF3n9xRx1xGAtgN0HNMpqol0l0y8l7S1/v4J7LIxKQ==
+   eAHtlskKwjAURR8qCtbhN/Q3/QjnYav4WWrr1nnaeLoIhNLSWrAoeRcOaUJfmp5AiIhGDagB1wz0KyIDGMIIxmBnQn8KM5jDAv4tm7rIFnbgQwC/FM8TaUATWtAGjRpQA2pADcQb6NXix83otsR5Dz4EsAfXs7Scra3nrF5WOWqyzm3eC/fVXmfaPpu6otqot2i/qHXod75v4FAWOcIJznCBK4S50d7hAU94gUYNqAE1kNdA2p0l6cxJq8u7HpfrirjruOzX/HunKtIFzecG1F28s6iXpL49/gbssjEp
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collisions">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="1" type="collision" x="0" y="336" width="32" height="160"/>
   <object id="2" type="collision" x="272" y="608" width="192" height="32"/>
   <object id="3" type="collision" x="80" y="400" width="96" height="48"/>
@@ -120,100 +120,100 @@
   <object id="87" type="collision" x="592" y="240" width="16" height="32"/>
   <object id="88" type="collision" x="272" y="320" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ffff00" name="Event">
+ <objectgroup color="#ffff00" id="6" name="Event">
   <object id="75" name="Teleport to City Park" type="event" x="0" y="512" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport citypark.tmx,39,11,0.3"/>
-    <property name="act2" value="player_face left"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
+    <property name="act10" value="transition_teleport citypark.tmx,39,11,0.3"/>
+    <property name="act20" value="player_face left"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
    </properties>
   </object>
   <object id="76" name="Teleport to City Park" type="event" x="0" y="496" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport citypark.tmx,39,10,0.3"/>
-    <property name="act2" value="player_face left"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
+    <property name="act10" value="transition_teleport citypark.tmx,39,10,0.3"/>
+    <property name="act20" value="player_face left"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
    </properties>
   </object>
   <object id="77" name="Teleport to City Park" type="event" x="0" y="528" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport citypark.tmx,39,12,0.3"/>
-    <property name="act2" value="player_face left"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
+    <property name="act10" value="transition_teleport citypark.tmx,39,12,0.3"/>
+    <property name="act20" value="player_face left"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
    </properties>
   </object>
   <object id="78" name="Play Music" type="event" x="0" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_town_theme"/>
-    <property name="cond1" value="not music_playing music_town_theme"/>
+    <property name="act10" value="play_music music_town_theme"/>
+    <property name="cond10" value="not music_playing music_town_theme"/>
    </properties>
   </object>
   <object id="79" name="Teleport to Route 3" type="event" x="480" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route3.tmx,30,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport route3.tmx,30,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="81" name="Teleport to Route 3" type="event" x="496" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route3.tmx,31,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport route3.tmx,31,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="82" name="Teleport to Route 3" type="event" x="512" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route3.tmx,32,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport route3.tmx,32,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="83" name="Teleport to Route 3" type="event" x="528" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route3.tmx,33,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport route3.tmx,33,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="84" name="Teleport to Route 3" type="event" x="544" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route3.tmx,34,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport route3.tmx,34,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="89" name="Teleport to Leather Mart" type="event" x="384" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport leather_scoop.tmx,5,10,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport leather_scoop.tmx,5,10,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="90" name="Sign: Route 3" type="event" x="544" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog_chain Route 3: Rehabilitation will begin as soon as possible. Please stop nagging us."/>
-    <property name="act2" value="dialog_chain v Leather Town --- Route 3 ^"/>
-    <property name="act4" value="dialog_chain ${{end}}"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog_chain Route 3: Rehabilitation will begin as soon as possible. Please stop nagging us."/>
+    <property name="act20" value="dialog_chain v Leather Town --- Route 3 ^"/>
+    <property name="act30" value="dialog_chain ${{end}}"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="91" name="Sign: Route 3" type="event" x="480" y="384" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog_chain Open Air Cafe and Marketplace"/>
-    <property name="act4" value="dialog_chain ${{end}}"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog_chain Open Air Cafe and Marketplace"/>
+    <property name="act20" value="dialog_chain ${{end}}"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="92" name="Player Spawn" type="event" x="32" y="528" width="16" height="16"/>

--- a/mods/tuxemon/maps/mansion.tmx
+++ b/mods/tuxemon/maps/mansion.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="18" height="18" tilewidth="16" tileheight="16" nextobjectid="37">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="18" height="18" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="37">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -31,27 +31,27 @@
  <tileset firstgid="4145" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
   <image source="../gfx/tilesets/boxfont.png" width="208" height="192"/>
  </tileset>
- <layer name="Tile Layer 1" width="18" height="18">
+ <layer id="1" name="Tile Layer 1" width="18" height="18">
   <data encoding="base64" compression="zlib">
-   eJyzZmBgsKYyLhmm5oziUTyKhzcGAKKES1g=
+   eAGzZmBgsKYyLqGSeYPNHGqH06h51E97o2E6GqaUpAEAooRLWA==
   </data>
  </layer>
- <layer width="18" height="18">
+ <layer id="2" width="18" height="18">
   <data encoding="base64" compression="zlib">
-   eJzFkz0OgCAMhbsxeFw9goO6sngK8QTGn4sJA4l5eQWJGpu8gfblozRF5P+oK5Gmes7pPGPwaiGP51QE7+QZ84ccW8CxmX6YtHqqHyatrnHC/PsCOYWz+dxO5C7C2lEwnwnuTs0wcnAGjMM8yMFgHObJcQQ4LBhnMe9wmCf1rtHc48R9ixz8OyvhsP8VcttlVzTPCfn2Wl0=
+   eAHFkjEOwkAMBK+j4LnwBApIS8MrgBcgIB/DU1hylr0gQAhLVmJ7b+yzrrX/22rZ2jr8W9sGYwjfCEhjKU9CtMdgnH/I2U86zgdo5+ZhXvUkar7HoYfz5Gitx2H/uzf81NnzLfJ34+jTtT5GjftW0/tnzPy1d+brVzm6A7TKcRrl1Jh/x3GamuOMszqPq+s54sviWfkJRymv7nWIvm4e5bDTOg9xtavhqAY9uXxXvJWe5gH59lpd
   </data>
  </layer>
- <layer name="Tile Layer 3" width="18" height="18">
+ <layer id="3" name="Tile Layer 3" width="18" height="18">
   <data encoding="base64" compression="zlib">
-   eJyt0r1qAkEQB/Dp7i5a62uYPIC+hcGztwyBHJJSPE57CWLlJ5FIXiFIOrkEBGsbtbPxGfwvrjiO63kcDvxhZtn9sfcREtFbishDiuifY+ad9S4SMsdD37WJekgfGSMVOmVlEa2RDVJl6552fBiBdgY4O0RGyBzhZWN2kAf74Bzr6ExgfGsnxJ4/5F8YqnJYe0SetLNNH2Jy4tat+9zD8Q37P1k/ZH0Q4bQMzgfrW1fWpbNLRzxIRElH1SyBJZ2SYY8rZrXHxXcvs/9iQVTjTsPgNA1zHYavHfXPN8R91PxinZ9r0+X8hbMT7cyvOG3hxKl7OK/WyfmBMdXOVDhLip65k3GIso75Pcs1OXeYk4dRSOj8amcPAJZhhg==
+   eAGtk71KA2EQRaczUWt9DfUB9C0UY28pgkEsxSXaiwQrfyKKwVeQYCerIFjbqJ2Nz+C5uAPDsFFZHLjsnfm+OZkks6WZbU2ZddEyfuWP2gn3OvgSOaeLP2mZnaIzdIXWqbleJ8ze0DvaDnX1iVMwS08z4c/pHaAL9IRitMjbaBKJ4+GcIYybilNy5wE9ohxz1ObRAhLnY/pbdZzcOy7/bZ5xfbn+E6fIl8kvQ20QfC/4/L0Ow5nbIzc843msZ84nv1uTyBwx7huwMme1Zhjtagzd6fC/ryGPZ7Nd7aHvz74fhOdB8LLK92AUFUc7r77M2WDnY/Rjgld+Te+w4mjn6zj9xEmY2vQ/OJt8rnNuebdGSPkozfOSJsh55My0zWaRODlyLefHYZ5FGEsNOXcV5wsAlmGG
   </data>
  </layer>
- <layer name="Above Player" width="18" height="18">
+ <layer id="4" name="Above Player" width="18" height="18">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AU0AvksQ8ucwYKFAxS9wMApwoBYg==
+   eAFjYBgFoyEwGgL0CoE8durYRC1zqOMa0k0poFI4kG4zfh0ApwoBYg==
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collision">
   <object id="1" type="collision" x="48" y="0" width="16" height="128"/>
   <object id="2" type="collision" x="64" y="0" width="224" height="32"/>
   <object id="3" type="collision" x="64" y="96" width="80" height="32"/>
@@ -80,83 +80,83 @@
   <object id="34" type="collision" x="64" y="32" width="64" height="16"/>
   <object id="35" type="collision" x="176" y="32" width="48" height="16"/>
  </objectgroup>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="6" name="Events">
   <object id="22" name="Teleport to Top" type="event" x="16" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport mansion_top.tmx,1,16,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport mansion_top.tmx,1,16,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="23" name="Teleport to Basement" type="event" x="16" y="256" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport mansion_basement.tmx,6,20,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing bottom"/>
+    <property name="act10" value="transition_teleport mansion_basement.tmx,6,20,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing bottom"/>
    </properties>
   </object>
   <object id="24" name="Teleport to Basement" type="event" x="32" y="256" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport mansion_basement.tmx,7,20,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport mansion_basement.tmx,7,20,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="25" name="Teleport to Top" type="event" x="32" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport mansion_top.tmx,2,16,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport mansion_top.tmx,2,16,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="27" name="Teleport to Side Route" type="event" x="144" y="272" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport routea.tmx,6,13,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport routea.tmx,6,13,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="28" name="Teleport to Side Route" type="event" x="160" y="272" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport routea.tmx,7,13,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport routea.tmx,7,13,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="29" name="Teleport to Basement" type="event" x="240" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport mansion_basement.tmx,13,3,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport mansion_basement.tmx,13,3,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="30" name="Play Music" type="event" x="0" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_mansion_theme"/>
-    <property name="cond1" value="not music_playing music_mansion_theme"/>
+    <property name="act10" value="play_music music_mansion_theme"/>
+    <property name="cond10" value="not music_playing music_mansion_theme"/>
    </properties>
   </object>
   <object id="32" name="Teleport to Side Route" type="event" x="176" y="272" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport routea.tmx,7,13,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport routea.tmx,7,13,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="33" name="Teleport to Basement" type="event" x="256" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport mansion_basement.tmx,13,3,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport mansion_basement.tmx,13,3,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="36" name="Player Spawn" type="event" x="160" y="160" width="16" height="16"/>

--- a/mods/tuxemon/maps/mansion_basement.tmx
+++ b/mods/tuxemon/maps/mansion_basement.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="24" height="22" tilewidth="16" tileheight="16" nextobjectid="40">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="24" height="22" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="40">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -31,27 +31,27 @@
  <tileset firstgid="4145" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
   <image source="../gfx/tilesets/boxfont.png" width="208" height="192"/>
  </tileset>
- <layer name="Tile Layer 1" width="24" height="22">
+ <layer id="1" name="Tile Layer 1" width="24" height="22">
   <data encoding="base64" compression="zlib">
-   eJxjYIAAaxphBjqYTyuz6WH+KB7Fo3joYnQwav6o+SPJfAD8KXDv
+   eAFjYIAAayBFCww1niZmg9wLArRwN8xMWpsPs2eUpm08jobvaPjSIg2ACyAkgtp2IBkNZo6aj5qOR8MHNTzQ0wetwwcA/Clw7w==
   </data>
  </layer>
- <layer name="Tile Layer 2" width="24" height="22">
+ <layer id="2" name="Tile Layer 2" width="24" height="22">
   <data encoding="base64" compression="zlib">
-   eJzFlM0NwjAMhc1OwK1wAyZAhXvVFTgigcqdvwEQLMIGbIQRWDWvTtrQHyw9VXGdT+2zkzkRbUErI2flXXWiJSthHUCZkbPyrjpR8hFGZuQk32cNWENPncQv/Ig1Yo0r8q/09urm4F8o9/NBtJ7wc8qaBXz/y6ujg7+nb7/xfzDSXpGP4fOnrC5qma8D+eL1iXLPdV92sP9OxZnX9cjXXot0X87AL6t3+dNUdMHfUPU7JYb9C0+tnBf00HenWPPju3+s+fLNXOh8/pMvfYmNd03wpS9pS3wJzcfzi+u6fDy/uK7LD40u+E88/21S
+   eAG9lE1Ow1AQgx93AnaFHe0JELBHvQJLJFC75+8ACC7SG3Aj7BaL0ccjQUQw0mRqj8dN5yU9ba3dIq+A0ydPHF3qhXwulffIFXD65ImjS7W3k+G5XpjfVx4oD5Xf6dTaxm/8Z5o8Uh4rf+L/Ip339apM1LlnkdnnW2vXJ8Jz5UJZdYJfIvfvfT2Ubp27E599Vt5yYnPLPV93Ef/g1N6ce+SJrZn9sb+/I8H7z64fJcjO67msM/hRN0XX09O/7jo7r+fyBP8xPf0xPhn+h/8Ndjj0n3KGX3SO2ZxBqt8X7tDPXHbPyudxSOtZ6n17Pc68gz3inerz2uv3uEywRxxdaq8fLudSd57e0Hx6rtRXLueyLAPUExfp9mOvT6768/0lnurP95d4qj/nxzB3YT25up8xP/bt9Q48/21S
   </data>
  </layer>
- <layer name="Tile Layer 3" width="24" height="22">
+ <layer id="3" name="Tile Layer 3" width="24" height="22">
   <data encoding="base64" compression="zlib">
-   eJxjYCANJDCSqAEKLPHoQ5bbgEUdul58Zonxkuau4QJsGCHYnsz4wQeO8TAwpDBCMMiOTiLs6EZTAzKDGGCLw+zjPNSJW1zmY3MfLK0fJ9LtpAJsaR0G3tPIzsEC3g2w//CVIZsJlDf49OICuOLTjhGBQXkLlg7tqJyPQebhSvvYwCIy7EihQdlDLijmZmAo4aa/+fjSNS3KZmTgQGPz0xkx0zEAVoAXew==
+   eAFjYCANJDCSph6m2hKPPmS5DVjUIcuDzEPnw+wA0WK8yLyRw7YBhhsI22MJP0pD4RgPA0MK0FwQBtnRSYQd3WhqQGYQA2zR9MH0HAfqp0bc4jIfm/tgaR1kNy0AtrQOs+c9jeyEmT/Q9LsB9h++MmQzWhpEV4vOJyYsccWnHdAuGAblLVg6BIlRE4DMw5X2sdmzCJsgATFQ+TBYQDE3A0MJENMK4DIfX7qmRdmM7D8HGod/OtB89HQMAFaAF3s=
   </data>
  </layer>
- <layer name="Above Player" width="24" height="22">
+ <layer id="4" name="Above Player" width="24" height="22">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFwwHYMEKwPeNAu2QUjIJRMApGAToYjmUzAO20APs=
+   eAFjYBgFwyEEbBgZGEDYHohHwWgIjIbAaAiMhsDgCoHhWDYDAO20APs=
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collision">
   <object id="1" type="collision" x="0" y="0" width="16" height="224"/>
   <object id="2" type="collision" x="16" y="0" width="368" height="32"/>
   <object id="3" type="collision" x="368" y="32" width="16" height="320"/>
@@ -92,27 +92,27 @@
    <polyline points="0,0 288,0"/>
   </object>
  </objectgroup>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="6" name="Events">
   <object id="35" name="Teleport to Middle" type="event" x="96" y="304" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport mansion.tmx,1,15,0.3"/>
-    <property name="act2" value="player_face top"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing top"/>
+    <property name="act10" value="transition_teleport mansion.tmx,1,15,0.3"/>
+    <property name="act20" value="player_face top"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing top"/>
    </properties>
   </object>
   <object id="36" name="Teleport to Middle" type="event" x="112" y="304" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport mansion.tmx,2,15,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport mansion.tmx,2,15,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="37" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_mansion_theme"/>
-    <property name="cond1" value="not music_playing music_mansion_theme"/>
+    <property name="act10" value="play_music music_mansion_theme"/>
+    <property name="cond10" value="not music_playing music_mansion_theme"/>
    </properties>
   </object>
   <object id="39" name="Player Spawn" type="event" x="96" y="336" width="16" height="16"/>

--- a/mods/tuxemon/maps/mansion_top.tmx
+++ b/mods/tuxemon/maps/mansion_top.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="23" height="19" tilewidth="16" tileheight="16" nextobjectid="29">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="23" height="19" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="29">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -31,47 +31,47 @@
  <tileset firstgid="4145" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
   <image source="../gfx/tilesets/boxfont.png" width="208" height="192"/>
  </tileset>
- <layer name="Tile Layer 1" width="23" height="19">
+ <layer id="1" name="Tile Layer 1" width="23" height="19">
   <data encoding="base64" compression="zlib">
-   eJxTZmBgUB7Fo3gUjxhcQgIebGbTMkxGzR4eZgMAILdEnA==
+   eAFTZmBgUB7Fo2EwmgZGTBooAcY1sZjUsoFYc0HqyDGbVD3EqifHPaNmkx6HsDCjZXgDACC3RJw=
   </data>
  </layer>
- <layer name="Tile Layer 4" width="23" height="19">
+ <layer id="2" name="Tile Layer 4" width="23" height="19">
   <data encoding="base64" compression="zlib">
-   eJzzYWBgqKIA5+EQ9wPiaCDupADX4BCPBeISBspADQ5xdLP3sjMwfGGD0OgAlxyxZjsD9bkAsSsWs3HJ1RJpNjmgh4Zm4wIgs2cxUJYGA/CYTWkajMZjNqVhUonkh9lUNruDAeGHLjSziQ3vZUC8HIhXMEDyMyFASnjD3NQB1UeM2eQAZH25UHoGA6o/Z1LBbFieRw73TgZMd+cisdHdgYyrsZiNz350dejuwBb2xJgtxsnAIM6JWx0+QMhsO6C59hSYHcmB3WwAU/Vekw==
+   eAGtkz1uAkEMhV0RuAC5TSiADqG0CHEEqGj46wHlAAF6wiW4FQfgPbGWLGvMTjRr6cm7M37feq2ZkYisC7QIvGOsT6FDgbaBd4b1JVQSZKfCs+8fIo+WCLOPaC+X3QdzAA0T7Ghv55uo3n3fQdnb5Z9gtwl2gBayz1DJGfwO4GSXnkH6U9HETFYA639fzEeaYO/B07t3dOzceV/h+4NuEO9zXfxn3toT+6SvLnJqUgzrm1cFv8g6d+ZTypixZtl65+3cOX9bQ6T2wGffh+1pw4IqlK3vmj3b1vk+9Cww6+zJsR7lMiu72xH5hKI66/HPkUfZX+D2CtiTtv/iq+8nU/Vekw==
   </data>
  </layer>
- <layer name="Tile Layer 3" width="23" height="19">
+ <layer id="3" name="Tile Layer 3" width="23" height="19">
   <data encoding="base64" compression="zlib">
-   eJxjYKAPyGVHpYmVm8fBwDAfiBdw4DZ7KjsqTUiuEWrWQiB9HIgX4zH7MxsDwxcg/sqGXQ4EsMmdBJr5HohP4zF7FNAPLKNhPJwb5HE8Uv3eMIjdRgkA+esnljKHWkARSzlKLeBJQ7NhAAB1/hXu
+   eAFjYKAPyGWH2AOjkW2FicFoZLl5HAwM84F4ARDjAlOhZsNoZHUwMRgNkmuEmrUQSB8H4sV4zP7MxsDwBYi/AjE6AMmBADa5k0Az3wPxaTxmQ3SPkvQIgWU0jIdzNDSbGmEzUv3eMMjjhdy4BfnrJ5byiFzz0PUpQstTdHFq8D1paDbMfQB1/hXu
   </data>
  </layer>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="4" name="Events">
   <object id="25" name="Teleport to Middle" type="event" x="16" y="272" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport mansion.tmx,1,2,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport mansion.tmx,1,2,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="26" name="Teleport to Middle" type="event" x="32" y="272" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport mansion.tmx,2,2,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport mansion.tmx,2,2,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="27" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_mansion_theme"/>
-    <property name="cond1" value="not music_playing music_mansion_theme"/>
+    <property name="act10" value="play_music music_mansion_theme"/>
+    <property name="cond10" value="not music_playing music_mansion_theme"/>
    </properties>
   </object>
   <object id="28" name="Player Spawn" type="event" x="32" y="224" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ff0000" name="Collision" visible="0">
+ <objectgroup color="#ff0000" id="5" name="Collision" visible="0">
   <object id="1" type="collision" x="0" y="0" width="16" height="304"/>
   <object id="2" type="collision" x="352" y="0" width="16" height="304"/>
   <object id="3" type="collision" x="16" y="176" width="160" height="32"/>

--- a/mods/tuxemon/maps/map1_apartment1.tmx
+++ b/mods/tuxemon/maps/map1_apartment1.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="18" height="16" tilewidth="16" tileheight="16" nextobjectid="16">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="18" height="16" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="16">
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>
  </tileset>
@@ -15,33 +15,33 @@
  <tileset firstgid="193" name="stairs" tilewidth="16" tileheight="16" tilecount="24" columns="8">
   <image source="../gfx/tilesets/stairs.png" width="128" height="48"/>
  </tileset>
- <tileset firstgid="217" name="KelvinShadewing_Buildings" tilewidth="16" tileheight="16" tilecount="500" columns="20">
-  <image source="../gfx/tilesets/KelvinShadewing_Buildings.png" width="320" height="400"/>
+ <tileset firstgid="217" name="KelvinShadewing_Buildings" tilewidth="16" tileheight="16" tilecount="680" columns="20">
+  <image source="../gfx/tilesets/KelvinShadewing_Buildings.png" width="320" height="544"/>
  </tileset>
- <tileset firstgid="717" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
+ <tileset firstgid="897" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>
  </tileset>
- <layer name="Tile Layer 1" width="18" height="16">
+ <layer id="1" name="Tile Layer 1" width="18" height="16">
   <data encoding="base64" compression="zlib">
-   eJxjYKAO4KUSliAThzKj8q2ohMl1Dy3cMopH8WDBkkRgYtQBAMtlM2w=
+   eAFjYKAO4AUaQw0sATSHHMzJgqrPCmgONTA5bkHXQw13jJpBnfgcDUfqhKMkMH8RwqCwJqQGALRtMyE=
   </data>
  </layer>
- <layer name="Tile Layer 2" width="18" height="16">
+ <layer id="2" name="Tile Layer 2" width="18" height="16">
   <data encoding="base64" compression="zlib">
-   eJxjYmBgYKICJhfoMFOgmQ7gNRXMOAfE/6lgzkgE6kCsgYY1yTDHCIiN0bDJEDIHVzokxRyQGbjSoS0Q26FhexxqiU3LrESoAQD57g4R
+   eAFjYmBgYKICBhpBFnjATJY2uml6TQWbzgHN+E8Fc0aiEepAT2ugYU0yAsIIqMcYDZsMIXNwpUNS/AUyA1c6tAXK2aFhexzhg8sMdOWs6AJY+ADKGw7F
   </data>
  </layer>
- <layer name="Tile Layer 3" width="18" height="16">
+ <layer id="3" name="Tile Layer 3" width="18" height="16">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUjIKBAQAEgAAB
+   eAFjYBgFoyEwGgKjITAwIQAABIAAAQ==
   </data>
  </layer>
- <layer name="Above Player" width="18" height="16">
+ <layer id="4" name="Above Player" width="18" height="16">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUjIKBAQAEgAAB
+   eAFjYBgFoyEwGgKjITAwIQAABIAAAQ==
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collision">
   <object id="1" type="collision" x="0" y="64" width="272" height="16"/>
   <object id="4" type="collision" x="0" y="0" width="224" height="48"/>
   <object id="5" type="collision" x="224" y="0" width="16" height="32"/>
@@ -52,25 +52,25 @@
   <object id="10" type="collision" x="-16" y="48" width="16" height="192"/>
   <object id="14" type="collision" x="144" y="256" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="6" name="Events">
   <object id="11" type="event" x="144" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport taba_town.tmx,55,44,0.3"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
-    <property name="cond3" value="is player_moved"/>
+    <property name="act10" value="transition_teleport taba_town.tmx,55,44,0.3"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
+    <property name="cond30" value="is player_moved"/>
    </properties>
   </object>
   <object id="12" type="event" x="224" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport taba_town.tmx,55,39,0.3 "/>
-    <property name="cond1" value="is player_at"/>
+    <property name="act10" value="transition_teleport taba_town.tmx,55,39,0.3 "/>
+    <property name="cond10" value="is player_at"/>
    </properties>
   </object>
   <object id="13" type="event" x="48" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc Tuxemon_Collector,3,8,boss,stand"/>
-    <property name="cond1" value="not npc_exists Tuxemon_Collector"/>
+    <property name="act10" value="create_npc Tuxemon_Collector,3,8,boss,stand"/>
+    <property name="cond10" value="not npc_exists Tuxemon_Collector"/>
    </properties>
   </object>
   <object id="15" name="Player Spawn" type="event" x="144" y="192" width="16" height="16"/>

--- a/mods/tuxemon/maps/map1_apartment2.tmx
+++ b/mods/tuxemon/maps/map1_apartment2.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="18" height="16" tilewidth="16" tileheight="16" nextobjectid="32">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="18" height="16" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="32">
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>
  </tileset>
@@ -15,45 +15,45 @@
  <tileset firstgid="193" name="stairs" tilewidth="16" tileheight="16" tilecount="24" columns="8">
   <image source="../gfx/tilesets/stairs.png" width="128" height="48"/>
  </tileset>
- <tileset firstgid="217" name="KelvinShadewing_Buildings" tilewidth="16" tileheight="16" tilecount="500" columns="20">
-  <image source="../gfx/tilesets/KelvinShadewing_Buildings.png" width="320" height="400"/>
+ <tileset firstgid="217" name="KelvinShadewing_Buildings" tilewidth="16" tileheight="16" tilecount="680" columns="20">
+  <image source="../gfx/tilesets/KelvinShadewing_Buildings.png" width="320" height="544"/>
  </tileset>
- <tileset firstgid="717" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
+ <tileset firstgid="897" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>
  </tileset>
- <tileset firstgid="2029" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
+ <tileset firstgid="2209" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>
  </tileset>
- <tileset firstgid="2117" name="KelvinShadewing_Buildings" tilewidth="16" tileheight="16" tilecount="500" columns="20">
-  <image source="../gfx/tilesets/KelvinShadewing_Buildings.png" width="320" height="400"/>
+ <tileset firstgid="2297" name="KelvinShadewing_Buildings" tilewidth="16" tileheight="16" tilecount="680" columns="20">
+  <image source="../gfx/tilesets/KelvinShadewing_Buildings.png" width="320" height="544"/>
  </tileset>
- <tileset firstgid="2617" name="electronics" tilewidth="16" tileheight="16" tilecount="16" columns="4">
+ <tileset firstgid="2977" name="electronics" tilewidth="16" tileheight="16" tilecount="16" columns="4">
   <image source="../gfx/tilesets/electronics.png" width="64" height="64"/>
  </tileset>
- <tileset firstgid="2633" name="furniture" tilewidth="16" tileheight="16" tilecount="72" columns="12">
+ <tileset firstgid="2993" name="furniture" tilewidth="16" tileheight="16" tilecount="72" columns="12">
   <image source="../gfx/tilesets/furniture.png" width="192" height="96"/>
  </tileset>
- <layer name="Tile Layer 1" width="18" height="16">
+ <layer id="1" name="Tile Layer 1" width="18" height="16">
   <data encoding="base64" compression="zlib">
-   eJxjYBgF9AB8HKN4FA8fzEoEJkYdAF1GEGw=
+   eAFjYBgF9AiBQxwMDKN4NAyGSxrYCUzPhDDIr4TUAADa/puk
   </data>
  </layer>
- <layer name="Tile Layer 2" width="18" height="16">
+ <layer id="2" name="Tile Layer 2" width="18" height="16">
   <data encoding="base64" compression="zlib">
-   eJxjYBgF9AI+XAwMvkDsx0WZOSlA/alAnEamOZUU2g8DrVQyBx8Q5mBgEEHDohykmyMH1COPhhWIMMcazY/kmmNPpjlynEA5Tsr81QW02whohjHUnEAgPwiIg5HcpAnUo4WGtckIZ2TwkZ2wGgB0eAzV
+   eAFjYBgF9AqBLdwMDFuBeBsQUwLOAPWfBeJzZJrzkEx96G5+SyVz0M1F5h/nYGA4gYZPAvmkgktAPZfR8BUizFmM5kdyzVlOpjmXOIHuBmJcgBj3fALa/QxoxnOoOTuB/F1AvBvJTXeBYXEPDd8nInxwuQskvpQI/QA4ty5o
   </data>
  </layer>
- <layer name="Tile Layer 3" width="18" height="16">
+ <layer id="3" name="Tile Layer 3" width="18" height="16">
   <data encoding="base64" compression="zlib">
-   eJxjYBgF9ASWXAwMVlyUm9NGBTNGwSgYaAAAMW8BGA==
+   eAFjYBgF9AyBhdwMDIuAmFLwjgpmUOqGUf2jIUBpCAAA1x0CUw==
   </data>
  </layer>
- <layer name="Above Player" width="18" height="16">
+ <layer id="4" name="Above Player" width="18" height="16">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFQwXkcg20C0bBKKAuAABVEQB4
+   eAFjYBgFQyUErnIPFZeOunM0BIgLAQB+EwDh
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collision">
   <object id="20" type="collision" x="0" y="64" width="288" height="16"/>
   <object id="21" type="collision" x="0" y="240" width="144" height="16"/>
   <object id="22" type="collision" x="160" y="240" width="128" height="16"/>
@@ -66,32 +66,32 @@
   <object id="29" type="collision" x="240" y="208" width="48" height="16"/>
   <object id="30" type="collision" x="256" y="192" width="32" height="16"/>
  </objectgroup>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="6" name="Events">
   <object id="15" name="go outside" type="event" x="144" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport taba_town.tmx,60,44,0.3"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport taba_town.tmx,60,44,0.3"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="16" name="make dad" type="event" x="208" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc Rival_Dad,14,8,boss,stand"/>
-    <property name="cond1" value="not npc_exists Rival_Dad"/>
+    <property name="act10" value="create_npc Rival_Dad,14,8,boss,stand"/>
+    <property name="cond10" value="not npc_exists Rival_Dad"/>
    </properties>
   </object>
   <object id="18" name="computer" type="event" x="32" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog RIVAL'S DAD's watching a Tuxemon game show!"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog RIVAL'S DAD's watching a Tuxemon game show!"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="19" type="event" x="32" y="192" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog It's an animated Tuxemon movie!"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog It's an animated Tuxemon movie!"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="31" name="Player Spawn" type="event" x="144" y="176" width="16" height="16"/>

--- a/mods/tuxemon/maps/map1_apartment3.tmx
+++ b/mods/tuxemon/maps/map1_apartment3.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="18" height="11" tilewidth="16" tileheight="16" nextobjectid="25">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="18" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="25">
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>
  </tileset>
@@ -15,33 +15,33 @@
  <tileset firstgid="193" name="stairs" tilewidth="16" tileheight="16" tilecount="24" columns="8">
   <image source="../gfx/tilesets/stairs.png" width="128" height="48"/>
  </tileset>
- <tileset firstgid="217" name="KelvinShadewing_Buildings" tilewidth="16" tileheight="16" tilecount="500" columns="20">
-  <image source="../gfx/tilesets/KelvinShadewing_Buildings.png" width="320" height="400"/>
+ <tileset firstgid="217" name="KelvinShadewing_Buildings" tilewidth="16" tileheight="16" tilecount="680" columns="20">
+  <image source="../gfx/tilesets/KelvinShadewing_Buildings.png" width="320" height="544"/>
  </tileset>
- <tileset firstgid="717" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
+ <tileset firstgid="897" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>
  </tileset>
- <layer name="Tile Layer 1" width="18" height="11">
+ <layer id="1" name="Tile Layer 1" width="18" height="11">
   <data encoding="base64" compression="zlib">
-   eJxTYmBgUBrFo3iYYEkiMDHqANDQGbQ=
+   eAFTYmBgUBrFo2EwTNKAJNAfhDAovRNSAwDQ0Bm0
   </data>
  </layer>
- <layer name="Tile Layer 2" width="18" height="11">
+ <layer id="2" name="Tile Layer 2" width="18" height="11">
   <data encoding="base64" compression="zlib">
-   eJxjYCAfKDEyMCgDsQojqngDibQZUL85EFugmdNDIo0LZABxJpE4iw7mlABxKZG4jIDfRgHpgJUINQDYfBa2
+   eAFjYCAfKDEyMCgDsQoQI4MGKIdY2gyo3xyILdDM6YGaQywNVY5BZQBFMonEWRi6EQLUMqcEaGQpkbgMYf0oi0ohwEqEOQDYfBa2
   </data>
  </layer>
- <layer name="Tile Layer 3" width="18" height="11">
+ <layer id="3" name="Tile Layer 3" width="18" height="11">
   <data encoding="base64" compression="zlib">
-   eJxjYBi8IAaIFwNxLAEMUhNHwKzlaPyFQLyIgBpagQYSaVygh0R6FBAPABweDcI=
+   eAFjYBi8IAbotMVAHEsAg9TEATE+sBxNciGQvwhNDF0NmjTVuA1Qk4ilcVncA5UglsZlzqg4ZggAABweDcI=
   </data>
  </layer>
- <layer name="Above Player" width="18" height="11">
+ <layer id="4" name="Above Player" width="18" height="11">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUoAMAAxgAAQ==
+   eAFjYBgFoyEwGgLoIQAAAxgAAQ==
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collision">
   <object id="1" type="collision" x="0" y="-16" width="288" height="16"/>
   <object id="7" type="collision" x="0" y="160" width="144" height="16"/>
   <object id="8" type="collision" x="160" y="160" width="128" height="16"/>
@@ -51,24 +51,24 @@
   <object id="17" type="collision" x="240" y="0" width="48" height="32"/>
   <object id="20" x="144" y="176" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="6" name="Events">
   <object id="11" type="event" x="144" y="160" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport taba_town.tmx,63,44,0.3"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport taba_town.tmx,63,44,0.3"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="12" type="event" x="0" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc Student1,3,7,player,stand"/>
-    <property name="cond1" value="not npc_exists Student1"/>
+    <property name="act10" value="create_npc Student1,3,7,player,stand"/>
+    <property name="cond10" value="not npc_exists Student1"/>
    </properties>
   </object>
   <object id="22" type="event" x="256" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc Student2,16,7,player,stand"/>
-    <property name="cond1" value="not npc_exists Student2"/>
+    <property name="act10" value="create_npc Student2,16,7,player,stand"/>
+    <property name="cond10" value="not npc_exists Student2"/>
    </properties>
   </object>
   <object id="24" name="Player Spawn" type="event" x="144" y="128" width="16" height="16"/>

--- a/mods/tuxemon/maps/maple_bedroom.tmx
+++ b/mods/tuxemon/maps/maple_bedroom.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.2.0" orientation="orthogonal" renderorder="right-down" width="11" height="9" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="31">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="11" height="9" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="31">
  <tileset firstgid="1" name="floors and walls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>
  </tileset>
@@ -17,22 +17,22 @@
  </tileset>
  <layer id="1" name="Tile Layer 1" width="11" height="9">
   <data encoding="base64" compression="zlib">
-   eJxjYCANMBKBYUCcCAwDxjiwMhQbE6FWD4qJUYuMaa2WWAAASEoJpg==
+   eAFjYCANMAKVE8IwE8WBDEIYptYYyMCGlYHiIAySgwFs6kBielBMjFpkMwiZS6lamPmEaABISgmm
   </data>
  </layer>
  <layer id="2" name="Tile Layer 2" width="11" height="9">
   <data encoding="base64" compression="zlib">
-   eJxjYKAuYMYhHgPEcWhifDjUlgBxGZR9EohPEWn3RSC+hCZWS6ReEOgkQe1UJHYiECcBcTIJ+rEBAIa3B60=
+   eAFjYKAuYMZhXAxQPA5Njg+ND+OWABllUM5JIH0KJkGAvgiUv4SmphaNj4/biU8STW4qEj8RyE4C4mQkMXKYAIa3B60=
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="11" height="9">
   <data encoding="base64" compression="zlib">
-   eJxjYKAPWAjEi4hUOx2KSQWXgfgKGfoGCwAAy8EEGQ==
+   eAFjYKAPWAi0ZhGRVk0HqgNhUsFloIYrpGoaROoBy8EEGQ==
   </data>
  </layer>
  <layer id="4" name="Above player" width="11" height="9">
   <data encoding="base64" compression="zlib">
-   eJxjYKA/OAzER3DI1aDxTwPxGdo6h+ZAkggMAgCtfQR8
+   eAFjYKA/OAy08ggOa2vQxE8D+WfQxIYaVxLoYEIY5CcArX0EfA==
   </data>
  </layer>
  <objectgroup color="#ff0000" id="5" name="Collision">
@@ -46,61 +46,61 @@
  <objectgroup color="#ffff00" id="6" name="Events">
   <object id="9" name="Go Downstairs" type="event" x="128" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport maple_house_downstairs.tmx,4,2,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
+    <property name="act10" value="transition_teleport maple_house_downstairs.tmx,4,2,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
    </properties>
   </object>
   <object id="19" name="Create Maple" type="event" x="0" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc maple_girl,3,4,boss,stand"/>
-    <property name="act2" value="set_variable maple_bedroom1:true"/>
-    <property name="cond1" value="not variable_set maple_bedroom1:true"/>
-    <property name="cond2" value="not npc_exists maple_girl"/>
+    <property name="act10" value="create_npc maple_girl,3,4,boss,stand"/>
+    <property name="act20" value="set_variable maple_bedroom1:true"/>
+    <property name="cond10" value="not variable_set maple_bedroom1:true"/>
+    <property name="cond20" value="not npc_exists maple_girl"/>
    </properties>
   </object>
   <object id="22" name="Maple Pathfind to Player" type="event" x="128" y="80" width="16" height="48">
    <properties>
-    <property name="act1" value="remove_npc maple_girl"/>
-    <property name="act2" value="player_stop"/>
-    <property name="act3" value="set_variable maple_bedroom2:true"/>
-    <property name="cond1" value="is variable_set maple_bedroom1:true"/>
-    <property name="cond2" value="is player_at"/>
-    <property name="cond3" value="not variable_set maple_bedroom2:true"/>
-    <property name="cond4" value="is npc_exists maple_girl"/>
+    <property name="act10" value="remove_npc maple_girl"/>
+    <property name="act20" value="player_stop"/>
+    <property name="act30" value="set_variable maple_bedroom2:true"/>
+    <property name="cond10" value="is variable_set maple_bedroom1:true"/>
+    <property name="cond20" value="is player_at"/>
+    <property name="cond30" value="not variable_set maple_bedroom2:true"/>
+    <property name="cond40" value="is npc_exists maple_girl"/>
    </properties>
   </object>
   <object id="25" name="Maple talk to Player" type="event" x="96" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog_chain Hey, {name}! Guess what?"/>
-    <property name="act2" value="dialog_chain I know you can't afford your own Tuxemon."/>
-    <property name="act3" value="dialog_chain I know where you can get one!!"/>
-    <property name="act4" value="dialog_chain Go to the junkyard behind the Tuxmart. I'll meet you there."/>
-    <property name="act5" value="dialog_chain ${{end}}"/>
-    <property name="act6" value="set_variable maple_bedroom3:true"/>
-    <property name="act7" value="npc_face maple_girl,right"/>
-    <property name="cond1" value="is variable_set maple_bedroom2:true"/>
-    <property name="cond2" value="is npc_at maple_girl"/>
-    <property name="cond3" value="not variable_set maple_bedroom3:true"/>
-    <property name="cond4" value="is npc_exists maple_girl"/>
+    <property name="act10" value="dialog_chain Hey, {name}! Guess what?"/>
+    <property name="act20" value="dialog_chain I know you can't afford your own Tuxemon."/>
+    <property name="act30" value="dialog_chain I know where you can get one!!"/>
+    <property name="act40" value="dialog_chain Go to the junkyard behind the Tuxmart. I'll meet you there."/>
+    <property name="act50" value="dialog_chain ${{end}}"/>
+    <property name="act60" value="set_variable maple_bedroom3:true"/>
+    <property name="act70" value="npc_face maple_girl,right"/>
+    <property name="cond10" value="is variable_set maple_bedroom2:true"/>
+    <property name="cond20" value="is npc_at maple_girl"/>
+    <property name="cond30" value="not variable_set maple_bedroom3:true"/>
+    <property name="cond40" value="is npc_exists maple_girl"/>
    </properties>
   </object>
   <object id="28" name="Maple Pathfind to stairs" type="event" x="95.75" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="pathfind maple_girl,8,3"/>
-    <property name="act2" value="player_stop"/>
-    <property name="cond1" value="is variable_set maple_bedroom3:true"/>
-    <property name="cond2" value="not dialog_open"/>
-    <property name="cond3" value="is npc_exists maple_girl"/>
+    <property name="act10" value="pathfind maple_girl,8,3"/>
+    <property name="act20" value="player_stop"/>
+    <property name="cond10" value="is variable_set maple_bedroom3:true"/>
+    <property name="cond20" value="not dialog_open"/>
+    <property name="cond30" value="is npc_exists maple_girl"/>
    </properties>
   </object>
   <object id="29" name="Maple go downstairs" type="event" x="128" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="remove_npc maple_girl"/>
-    <property name="act2" value="player_resume"/>
-    <property name="cond1" value="is variable_set maple_bedroom3:true"/>
-    <property name="cond2" value="is npc_at maple_girl"/>
+    <property name="act10" value="remove_npc maple_girl"/>
+    <property name="act20" value="player_resume"/>
+    <property name="cond10" value="is variable_set maple_bedroom3:true"/>
+    <property name="cond20" value="is npc_at maple_girl"/>
    </properties>
   </object>
   <object id="30" name="Player Spawn" type="event" x="64" y="80" width="16" height="16"/>

--- a/mods/tuxemon/maps/maple_house.tmx
+++ b/mods/tuxemon/maps/maple_house.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.3.1" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="13" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="41">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="13" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="41">
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>
  </tileset>
@@ -39,56 +39,56 @@
  <objectgroup color="#ffff00" id="5" name="Events">
   <object id="9" name="Go Outside" type="event" x="112" y="176" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport taba_town.tmx,33,44,0.5"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport taba_town.tmx,33,44,0.5"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="30" name="talkHouse" type="event" x="144" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog professorswife"/>
-    <property name="act2" value="set_variable thewifedidspeak:yes"/>
-    <property name="behav1" value="talk npc_wife"/>
-    <property name="cond1" value="not variable_set thewifedidspeak:yes"/>
+    <property name="act10" value="translated_dialog professorswife"/>
+    <property name="act20" value="set_variable thewifedidspeak:yes"/>
+    <property name="behav10" value="talk npc_wife"/>
+    <property name="cond10" value="not variable_set thewifedidspeak:yes"/>
    </properties>
   </object>
   <object id="32" name="wife appears" type="event" x="112" y="176" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc npc_wife,9,7,,stand"/>
-    <property name="act2" value="npc_face npc_wife,down"/>
-    <property name="act3" value="npc_wander npc_wife"/>
-    <property name="cond1" value="is player_facing up"/>
-    <property name="cond2" value="not npc_exists npc_wife"/>
+    <property name="act10" value="create_npc npc_wife,9,7,,stand"/>
+    <property name="act20" value="npc_face npc_wife,down"/>
+    <property name="act30" value="npc_wander npc_wife"/>
+    <property name="cond10" value="is player_facing up"/>
+    <property name="cond20" value="not npc_exists npc_wife"/>
    </properties>
   </object>
   <object id="39" name="nodrinkpls" type="event" x="96" y="32" width="32" height="16">
    <properties>
-    <property name="act1" value="npc_face npc_wife, up"/>
-    <property name="act2" value="translated_dialog nodrink"/>
-    <property name="act3" value="npc_face npc_wife,down"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="npc_face npc_wife, up"/>
+    <property name="act20" value="translated_dialog nodrink"/>
+    <property name="act30" value="npc_face npc_wife,down"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="40" name="create knight" type="event" x="192" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc knight3,7,11,,stand"/>
-    <property name="act2" value="npc_face knight3,up"/>
-    <property name="act3" value="wait 0.7"/>
-    <property name="act4" value="npc_face knight3,left"/>
-    <property name="act5" value="wait 0.7"/>
-    <property name="act6" value="npc_face knight3,right"/>
-    <property name="act7" value="wait 0.7"/>
-    <property name="act8" value="npc_face knight3,up"/>
-    <property name="act81" value="wait 0.2"/>
-    <property name="act9" value="translated_dialog bothofyou"/>
-    <property name="act91" value="wait 0.8"/>
-    <property name="act92" value="npc_face knight3,down"/>
-    <property name="act93" value="wait 0.5"/>
-    <property name="act94" value="set_variable goodbyeoldknight:yes"/>
-    <property name="act95" value="remove_npc knight3"/>
-    <property name="cond1" value="is variable_set thewifedidspeak:yes"/>
-    <property name="cond2" value="not variable_set goodbyeoldknight:yes"/>
+    <property name="act010" value="create_npc knight3,7,11,,stand"/>
+    <property name="act020" value="npc_face knight3,up"/>
+    <property name="act030" value="wait 0.7"/>
+    <property name="act040" value="npc_face knight3,left"/>
+    <property name="act050" value="wait 0.7"/>
+    <property name="act060" value="npc_face knight3,right"/>
+    <property name="act070" value="wait 0.7"/>
+    <property name="act080" value="npc_face knight3,up"/>
+    <property name="act090" value="wait 0.2"/>
+    <property name="act100" value="translated_dialog bothofyou"/>
+    <property name="act110" value="wait 0.8"/>
+    <property name="act120" value="npc_face knight3,down"/>
+    <property name="act130" value="wait 0.5"/>
+    <property name="act140" value="set_variable goodbyeoldknight:yes"/>
+    <property name="act150" value="remove_npc knight3"/>
+    <property name="cond10" value="is variable_set thewifedidspeak:yes"/>
+    <property name="cond20" value="not variable_set goodbyeoldknight:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/maple_house_downstairs.tmx
+++ b/mods/tuxemon/maps/maple_house_downstairs.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="14" height="9" tilewidth="16" tileheight="16" nextobjectid="37">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="14" height="9" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="37">
  <tileset firstgid="1" name="floors and walls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>
  </tileset>
@@ -15,27 +15,27 @@
  <tileset firstgid="201" name="kitchen" tilewidth="16" tileheight="16" tilecount="16" columns="4">
   <image source="../gfx/tilesets/kitchen.png" width="64" height="64"/>
  </tileset>
- <layer name="Tile Layer 1" width="14" height="9">
+ <layer id="1" name="Tile Layer 1" width="14" height="9">
   <data encoding="base64" compression="zlib">
-   eJxjYCAfMCHhZWh8bBgGJJDwOjQ+NgwDuiTikaJPEgkTCwDtVQ1K
+   eAFjYCAfMAG1wvAyJDZMDJ2G2SQBZMDwOiQ2TAydhunTBTJIwSNFnyTQozAM8zMhGgDtVQ1K
   </data>
  </layer>
- <layer name="Tile Layer 2" width="14" height="9">
+ <layer id="2" name="Tile Layer 2" width="14" height="9">
   <data encoding="base64" compression="zlib">
-   eJxjYKAeYCZTHx8V3cAGxOxAzIFFrhEJowNBIBYCYmEc5rYAcS8WcRkglgViOTz6SAX9QDwBiCciibFC6UQgTgLiZBx6exmwuxMdAAB26AfB
+   eAFjYKAeYCbTKD4y9WHTxgYUZAdiDiySjUAxGEaXFgQKCAGxMLoElN8CpHuxyMkAxWSBWA6LHEgIpI9U0A/UMAGIJyJpZIWyE4F0EhAnI8khM0FuxOZOZDUgNgB26AfB
   </data>
  </layer>
- <layer name="Tile Layer 3" width="14" height="9">
+ <layer id="3" name="Tile Layer 3" width="14" height="9">
   <data encoding="base64" compression="zlib">
-   eJxjYBgc4CQQnwLi00B8hgR9Z4H4HBCfB+ILULHdZLphPw7xciiuJNG8ZihuJdM96OAilcwBAQAo0Aui
+   eAFjYBgc4CTQGaeA+DQQnyHBSWeBas8B8XkgvgDVtxtKk0rtx6GhHCgOwpU45HEJNwMlQLgVlwISxS+SqB6fcgAo0Aui
   </data>
  </layer>
- <layer name="Above player" width="14" height="9">
+ <layer id="4" name="Above player" width="14" height="9">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFwwlIomFcYgAUuADJ
+   eAFjYBgFwykEJIGeQcYgvyHzQWwQAAAUuADJ
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collision">
   <object id="2" type="collision" x="80" y="32" width="128" height="16"/>
   <object id="3" type="collision" x="208" y="48" width="16" height="80"/>
   <object id="7" type="collision" x="64" y="16" width="16" height="16"/>
@@ -47,40 +47,40 @@
   <object id="32" type="collision" x="0" y="48" width="16" height="80"/>
   <object id="33" type="collision" x="16" y="32" width="48" height="16"/>
  </objectgroup>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="6" name="Events">
   <object id="23" name="Play Music" type="event" x="192" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_house_downstairs"/>
-    <property name="cond1" value="not music_playing music_house_downstairs"/>
+    <property name="act10" value="play_music music_house_downstairs"/>
+    <property name="cond10" value="not music_playing music_house_downstairs"/>
    </properties>
   </object>
   <object id="25" name="Read Sign" type="event" x="80" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog My Wonderful Home!"/>
-    <property name="cond1" value="is player_at 5,3"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog My Wonderful Home!"/>
+    <property name="cond10" value="is player_at 5,3"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="26" name="Go Upstairs" type="event" x="64" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport maple_bedroom.tmx,9,3,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at 4,2"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport maple_bedroom.tmx,9,3,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at 4,2"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="27" name="Go Outside" type="event" x="128" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport taba_town.tmx,33,43,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at "/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport taba_town.tmx,33,43,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at "/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="34" name="create mother" type="event" x="32" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc npc_maples_mom,2,5,girl1,stand"/>
+    <property name="act10" value="create_npc npc_maples_mom,2,5,girl1,stand"/>
    </properties>
   </object>
   <object id="36" name="Player Spawn" type="event" x="128" y="80" width="16" height="16"/>

--- a/mods/tuxemon/maps/meet_misa.tmx
+++ b/mods/tuxemon/maps/meet_misa.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.2.0" orientation="orthogonal" renderorder="right-down" width="15" height="13" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="45">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="13" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="45">
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>
  </tileset>
@@ -11,17 +11,17 @@
  </tileset>
  <layer id="1" name="Tile Layer 1" width="15" height="13">
   <data encoding="base64" compression="zlib">
-   eJyTZGBgYCIDS0IxLxkYpleCDAzT+wyIpwHxVCLpZ0h684A4l0QappcUO2H0qL2k2/uMRHuR45dcDADldENE
+   eAGTZGBgYCIDSwL1gDAvGRimVwKol1QM0/sMqHcaEE8lkgaph+nNA7JzgZgUGqaXFDthboPpJcU+mPtgekeavaD4goUfMTRy/MLCjFQaAOV0Q0Q=
   </data>
  </layer>
  <layer id="2" name="Tile Layer 2" width="15" height="13">
   <data encoding="base64" compression="zlib">
-   eJxjYKAcXGdkYLgBxDcZEWICQLYglF8OxBU49P4HqWFiYGBkQohZAMUsGXFoQALqQD0aQKwJxIlkun0gQCPQb014cDMev68Eyq3Cg1fj0XsRKHcJD75MRJgPZwAAUBUX/g==
+   eAFjYKAcXGdkYLgBxDeBGAYEgGxBKL8cKFgBk0Cj/4PUMDEwMAIxDFgAxSyhemFi2Gh1oB4NINYE4kRsCgapWCPQb014cDMev68Eyq3Cg1fj0XsRKHcJD76MR+8gDUqqOgsAUBUX/g==
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="15" height="13">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUgAAAAwwAAQ==
+   eAFjYBgFoyEwGgKgEAAAAwwAAQ==
   </data>
  </layer>
  <objectgroup color="#ff0000" id="4" name="Collisions">
@@ -33,42 +33,42 @@
  <objectgroup color="#ffff00" id="5" name="Event">
   <object id="33" name="music!" type="event" x="0" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_the_emperor"/>
-    <property name="cond1" value="not music_playing music_the_emperor"/>
+    <property name="act10" value="play_music music_the_emperor"/>
+    <property name="cond10" value="not music_playing music_the_emperor"/>
    </properties>
   </object>
   <object id="34" name="doors galores" type="event" x="112" y="48" width="32" height="16">
    <properties>
-    <property name="act1" value="translated_dialog youcantleave"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog youcantleave"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="35" name="something" type="event" x="48" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog discovered_a_person"/>
-    <property name="act2" value="teleport meet_misa.tmx,3,4"/>
-    <property name="act3" value="create_npc misa,3,3,misa,stand"/>
-    <property name="act4" value="set_variable flag:0"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
-    <property name="cond4" value="not variable_set flag:0"/>
+    <property name="act10" value="translated_dialog discovered_a_person"/>
+    <property name="act20" value="teleport meet_misa.tmx,3,4"/>
+    <property name="act30" value="create_npc misa,3,3,misa,stand"/>
+    <property name="act40" value="set_variable flag:0"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond40" value="not variable_set flag:0"/>
    </properties>
   </object>
   <object id="37" name="time to talk" type="event" x="48" y="64" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog a_serious_discussion\n"/>
-    <property name="act2" value="teleport meet_misa.tmx,3,5"/>
-    <property name="act3" value="translated_dialog oops\n"/>
-    <property name="act4" value="translated_dialog backstory\n"/>
-    <property name="act5" value="translated_dialog backstory9"/>
-    <property name="act6" value="translated_dialog_choice yes,questioning"/>
-    <property name="act7" value="translated_dialog sorryfurthis"/>
-    <property name="act8" value="transition_teleport route1.tmx,33,12,0.7"/>
-    <property name="act9" value="set_variable flag:1"/>
-    <property name="cond1" value="is variable_set flag:0"/>
+    <property name="act10" value="translated_dialog a_serious_discussion\n"/>
+    <property name="act20" value="teleport meet_misa.tmx,3,5"/>
+    <property name="act30" value="translated_dialog oops\n"/>
+    <property name="act40" value="translated_dialog backstory\n"/>
+    <property name="act50" value="translated_dialog backstory9"/>
+    <property name="act60" value="translated_dialog_choice yes,questioning"/>
+    <property name="act70" value="translated_dialog sorryfurthis"/>
+    <property name="act80" value="transition_teleport route1.tmx,33,12,0.7"/>
+    <property name="act90" value="set_variable flag:1"/>
+    <property name="cond10" value="is variable_set flag:0"/>
    </properties>
   </object>
   <object id="44" name="Player Spawn" type="event" x="112" y="112" width="16" height="16"/>

--- a/mods/tuxemon/maps/omnichannel1.tmx
+++ b/mods/tuxemon/maps/omnichannel1.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="14" height="21" tilewidth="16" tileheight="16" nextobjectid="24">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="14" height="21" tilewidth="16" tileheight="16" infinite="0" nextlayerid="5" nextobjectid="24">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -31,17 +31,17 @@
  <tileset firstgid="4145" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
   <image source="../gfx/tilesets/boxfont.png" width="208" height="192"/>
  </tileset>
- <layer name="Tile Layer 1" width="14" height="21">
+ <layer id="1" name="Tile Layer 1" width="14" height="21">
   <data encoding="base64" compression="zlib">
-   eJzzYWBg8CER+wFxNBk4FkrvY0PFPljEkDEufdjEiNFHS/tmDaD/PjBQbl80mtwMJPZMHPqw4Q6guk4G/PYRwkNJH7Z4H4zuHCr6AKrZwUw=
+   eAHzYWBg8CER+wHVR5OBY6F69rExMCBjkP3IfHQ2Ln0gN6CrRebj0kdL+2ZhcRMt7UMOgw9QuymxDxavsHCcgeSfmUA2sn0wNdjoDqDaTqheXPGATR+y2FDShy3ekf2CjT2U/EdsvCP7kxL/AQCq2cFM
   </data>
  </layer>
- <layer name="Tile Layer 2" width="14" height="21">
+ <layer id="2" name="Tile Layer 2" width="14" height="21">
   <data encoding="base64" compression="zlib">
-   eJxjYGBgqELDeVjEkDEMdKLhGixiyBgXqMEjhw8MVn2wcPIjUR8snGJJ1FfMzcBQAsQfyNTXA+X/Y4C4ezaSmhkMmPGODjoYIO7uwiKGL95pDcQ4GRjEgdifAXda9sOizw6ox54TEg+40nIsFn0wM6vxuCkHixjMzC4scvj0YQNFSOwZBNyCDBqR2B0E3IJLHymAkD4Aw/ssnw==
+   eAFjYGBgqELDeWh8dHmgNBh0AklkXIPGR5YDsXEBkD5ywGDVBwsvP6iniHUnLLxiSdRXzM3AUALEH8jU1wPV9w9Ig9w+G8oHUTOAGOYfJGEUZgeQB3J7F5IoTAxfvCMppwlTjJOBQRyI/YGmw/yATsPiCNkBdkA99kAMiodOHBgWR8j6YGZXIwuisXPQ+CAuzA7k8ENXhk0fuhoQvwhJEBR3+NyCpJShEYkDijt8bkFSiqIPWZwQG9k+bGoBw/ssnw==
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collision">
+ <objectgroup color="#ff0000" id="3" name="Collision">
   <object id="1" type="collision" x="0" y="0" width="16" height="336"/>
   <object id="2" type="collision" x="16" y="0" width="208" height="16"/>
   <object id="4" type="collision" x="208" y="16" width="16" height="320"/>
@@ -60,32 +60,32 @@
    <polyline points="0,0 224,0 0,0"/>
   </object>
  </objectgroup>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="4" name="Events">
   <object id="18" name="Teleport to Omnichannel 2" type="event" x="16" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport omnichannel2.tmx,1,12,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
+    <property name="act10" value="transition_teleport omnichannel2.tmx,1,12,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
    </properties>
   </object>
   <object id="19" name="Teleport to Omnichannel 2" type="event" x="32" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport omnichannel2.tmx,2,12,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
+    <property name="act10" value="transition_teleport omnichannel2.tmx,2,12,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
    </properties>
   </object>
   <object id="21" name="Teleport to Omnichannel 1" type="event" x="16" y="208" width="32" height="16">
    <properties>
-    <property name="act1" value="transition_teleport cotton_town.tmx,22,10,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
+    <property name="act10" value="transition_teleport cotton_town.tmx,22,10,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
    </properties>
   </object>
   <object id="22" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_omnichannel"/>
-    <property name="cond1" value="not music_playing music_omnichannel"/>
+    <property name="act10" value="play_music music_omnichannel"/>
+    <property name="cond10" value="not music_playing music_omnichannel"/>
    </properties>
   </object>
   <object id="23" name="Player Spawn" type="event" x="32" y="176" width="16" height="16"/>

--- a/mods/tuxemon/maps/omnichannel2.tmx
+++ b/mods/tuxemon/maps/omnichannel2.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="14" height="21" tilewidth="16" tileheight="16" nextobjectid="13">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="14" height="21" tilewidth="16" tileheight="16" infinite="0" nextlayerid="5" nextobjectid="13">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -31,17 +31,17 @@
  <tileset firstgid="4145" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
   <image source="../gfx/tilesets/boxfont.png" width="208" height="192"/>
  </tileset>
- <layer name="Tile Layer 1" width="14" height="21">
+ <layer id="1" name="Tile Layer 1" width="14" height="21">
   <data encoding="base64" compression="zlib">
-   eJzzYWBg8CER+wFxNBk4FkrvYyMNDyV9s8jQN3MI+W8466MkHsiJ96ESLgOhDwDptsZV
+   eAHzYWBg8CER+wHVR5OBY6F69rExMJCCh5K+WUA/kuI3kNqZIyBcQOmF1HChd7xTEg/kxDu9/TeU7AMA6bbGVQ==
   </data>
  </layer>
- <layer name="Tile Layer 2" width="14" height="21">
+ <layer id="2" name="Tile Layer 2" width="14" height="21">
   <data encoding="base64" compression="zlib">
-   eJxjYGBgqCIRw0AniZhWYDOZ+mJppA8WTnkMqOE2E0nNDAbc4VnDgBpuyPZ1MGCGZzE3A0MJN0QfKe6E6atFE/9AQB8M9BDgDzQQ42RgEAdiHwbUeJiNpAZbPNgB9dgDcTQDajx0IanBFg8wc+JJdCc289FBEZFmofv1P5H68PmVkD5yACF9AP6lLxg=
+   eAFjYGBgqCIRA5WDQSeQJAVDtVGd2kymibE00gcLzzyg+TA2iJ6JZN8MJDmYMCwsa4ACMDaIRnZnB5IcTF8xNwNDCRCD9CEDZH3I4jA2TF8tTABKf0Dj4+L2oEmg89Gk6c4V42RgEAdiH6DNyPEwG8kl2OLBDqjHHoijgeo6kXAXkj5s8QCzIx5JHTFMmB3I5qPrK0IXwMFH9+t/HOrQhfH5FV0tMh+kjxxASB8A/qUvGA==
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collision">
+ <objectgroup color="#ff0000" id="3" name="Collision">
   <object id="1" type="collision" x="0" y="0" width="224" height="32"/>
   <object id="2" type="collision-line" x="0" y="336">
    <polyline points="0,0 224,0"/>
@@ -56,39 +56,39 @@
    <polygon points="0,0 0,-64 64,-64 64,-80 80,-80 80,-32 16,-32 16,0"/>
   </object>
  </objectgroup>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="4" name="Events">
   <object id="6" name="Teleport to Omnichannel 3" type="event" x="16" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport omnichannel3.tmx,1,12,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
+    <property name="act10" value="transition_teleport omnichannel3.tmx,1,12,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
    </properties>
   </object>
   <object id="7" name="Teleport to Omnichannel 3" type="event" x="32" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport omnichannel3.tmx,1,12,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
+    <property name="act10" value="transition_teleport omnichannel3.tmx,1,12,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
    </properties>
   </object>
   <object id="9" name="Teleport to Omnichannel 1" type="event" x="32" y="208" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport omnichannel1.tmx,2,10,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
+    <property name="act10" value="transition_teleport omnichannel1.tmx,2,10,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
    </properties>
   </object>
   <object id="10" name="Teleport to Omnichannel 1" type="event" x="16" y="208" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport omnichannel1.tmx,1,10,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
+    <property name="act10" value="transition_teleport omnichannel1.tmx,1,10,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
    </properties>
   </object>
   <object id="11" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_omnichannel"/>
-    <property name="cond1" value="not music_playing music_omnichannel"/>
+    <property name="act10" value="play_music music_omnichannel"/>
+    <property name="cond10" value="not music_playing music_omnichannel"/>
    </properties>
   </object>
   <object id="12" name="Player Spawn" type="event" x="32" y="176" width="16" height="16"/>

--- a/mods/tuxemon/maps/omnichannel3.tmx
+++ b/mods/tuxemon/maps/omnichannel3.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="14" height="21" tilewidth="16" tileheight="16" nextobjectid="9">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="14" height="21" tilewidth="16" tileheight="16" infinite="0" nextlayerid="5" nextobjectid="9">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -31,54 +31,54 @@
  <tileset firstgid="4145" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
   <image source="../gfx/tilesets/boxfont.png" width="208" height="192"/>
  </tileset>
- <layer name="Tile Layer 1" width="14" height="21">
+ <layer id="1" name="Tile Layer 1" width="14" height="21">
   <data encoding="base64" compression="zlib">
-   eJzzYWBg8CER+wFxNBk4FkrvYyMNDyV9s8jQN3MI+Y+e+oZSuJAT76PhiVsfACxVxpE=
+   eAHzYWBg8CER+wHVR5OBY6F69rExMJCCh5K+WUA/kuI3kNqZIyBcQOllOIcLOfFO73Q9lNIZACxVxpE=
   </data>
  </layer>
- <layer name="Tile Layer 2" width="14" height="21">
+ <layer id="2" name="Tile Layer 2" width="14" height="21">
   <data encoding="base64" compression="zlib">
-   eJxjYGBgqMKD87CIwUAnHlyDRYwYUEukOnTQQ6S6zWSaH0uCWuSwmokk7sOAPYxhADmskO3LYsAexjBQzM3AUMINYX9AEo8m4E5kfcjhR0gfLkCuvlkMkHCYDeXPYEANF3z2gcKhC8rvYEANFzFOBgZxTgh7M5o+fMAOqMceqg85HgjpwxXvhPThindSwhM53isZiA9P5HiHhR+u8KQnAACZ9i/B
+   eAFjYGBgqMKD87DIAYXAoBNI4sI1WOQguvCTtfilccr24JRBldiMyiWaF0u0StTwnImkzwfIxhbWMCXIYYlsXxZQAbIcjA3TV8zNwFACxCDwAUKByWgkNjYmsj7k8COkD5tZIDFy9c0C6gWFy2yQIUAwA4hBfEIAZB8oLLqgCjugfCiXQYyTgUEciEEAOd4JudMOqMceqg85HgjpQ45b5HgnpK8T6D4YJsU+sMegBHK8VwLFiA1P5HiHhR+u8ES2j9ZsAJn2L8E=
   </data>
  </layer>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="3" name="Events">
   <object id="3" name="Teleport to Omnichannel 2" type="event" x="16" y="208" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport omnichannel2.tmx,1,10,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
+    <property name="act10" value="transition_teleport omnichannel2.tmx,1,10,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
    </properties>
   </object>
   <object id="4" name="Teleport to Omnichannel 2" type="event" x="32" y="208" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport omnichannel2.tmx,2,10,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
+    <property name="act10" value="transition_teleport omnichannel2.tmx,2,10,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
    </properties>
   </object>
   <object id="5" name="Teleport to Omnichannel 4" type="event" x="16" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport omnichannel4.tmx,1,12,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
+    <property name="act10" value="transition_teleport omnichannel4.tmx,1,12,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
    </properties>
   </object>
   <object id="6" name="Teleport to Omnichannel 4" type="event" x="32" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport omnichannel4.tmx,2,12,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
+    <property name="act10" value="transition_teleport omnichannel4.tmx,2,12,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
    </properties>
   </object>
   <object id="7" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_omnichannel"/>
-    <property name="cond1" value="not music_playing music_omnichannel"/>
+    <property name="act10" value="play_music music_omnichannel"/>
+    <property name="cond10" value="not music_playing music_omnichannel"/>
    </properties>
   </object>
   <object id="8" name="Player Spawn" type="event" x="32" y="176" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ff0000" name="Collision">
+ <objectgroup color="#ff0000" id="4" name="Collision">
   <object id="1" type="collision" x="0" y="336">
    <polygon points="0,0 0,-336 224,-336 224,0 208,0 208,-32 176,-32 176,-64 208,-64 208,-128 176,-128 176,-160 208,-160 208,-208 128,-208 128,-160 160,-160 160,-128 128,-128 128,-64 160,-64 160,-32 112,-32 112,-240 208,-240 208,-304 144,-304 144,-272 128,-272 128,-304 16,-304 16,-240 64,-240 64,-272 80,-272 80,-176 64,-176 64,-208 48,-208 16,-208 16,-96 64,-96 64,-128 80,-128 80,-32 64,-32 64,-64 16,-64 16,0 0,0"/>
   </object>

--- a/mods/tuxemon/maps/omnichannel4.tmx
+++ b/mods/tuxemon/maps/omnichannel4.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="14" height="21" tilewidth="16" tileheight="16" nextobjectid="19">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="14" height="21" tilewidth="16" tileheight="16" infinite="0" nextlayerid="5" nextobjectid="19">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -31,17 +31,17 @@
  <tileset firstgid="4145" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
   <image source="../gfx/tilesets/boxfont.png" width="208" height="192"/>
  </tileset>
- <layer name="Tile Layer 1" width="14" height="21">
+ <layer id="1" name="Tile Layer 1" width="14" height="21">
   <data encoding="base64" compression="zlib">
-   eJxjYGBg8CERw0A0iRgG9rGRhkf1jeob1Tey9AEAcmq2ZQ==
+   eAFjYGBg8CERA5WDQTSQJAVDtTHsY2MgCY/qwx5eo+EyGi6k5KWhlF4Acmq2ZQ==
   </data>
  </layer>
- <layer name="Tile Layer 2" width="14" height="21">
+ <layer id="2" name="Tile Layer 2" width="14" height="21">
   <data encoding="base64" compression="zlib">
-   eJzzYWBgqMKC83CIg7AfEEcDcScWXINDHIRjofqwgRoc4gwDpG8WA8K/s5HkapHYMxhQw2UmA2q4dCGp7UFidzAQHy74ALX1ofsHHc/EoQ/dP6TEOznuJFafGCcDgzgnQjyXSH12QD32SPrwpRWYPuT0AsPdDJC8AgM+DPjTCzL+gKTvPQPx4dmDg43sP1LBQOgDAGr7O68=
+   eAHFU8ENwkAMy5cFYBtYoGKBihFgAAT/ljIAlCFhBBwJV1aa3gvpIlmx7uxTHLWNmZ0TnJIz6va4a4E+wSU5o+7w86HNyn1LVcM3YhjmfclgV+EP0bj2CehebqK9C+/AuRPvpXxim9F/+2Ie5mdnvjhIzKPZauZbr8w2AOtIstC5zy08O/GVvk1/yn0jwD2xDzjzf4XVgPDOO/fZg0d8aEJ/h3vOKZKJ6nem3AUl3/RAQmr4vmr7O68=
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collisions">
+ <objectgroup color="#ff0000" id="3" name="Collisions">
   <object id="1" type="collision" x="0" y="0" width="16" height="336"/>
   <object id="2" type="collision" x="208" y="0" width="16" height="336"/>
   <object id="3" type="collision" x="16" y="0" width="192" height="32"/>
@@ -58,25 +58,25 @@
    <polyline points="0,0 192,0"/>
   </object>
  </objectgroup>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="4" name="Events">
   <object id="14" name="Teleport to Omnichannel 3" type="event" x="16" y="208" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport omnichannel3.tmx,1,10,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
+    <property name="act10" value="transition_teleport omnichannel3.tmx,1,10,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
    </properties>
   </object>
   <object id="15" name="Teleport to Omnichannel 3" type="event" x="32" y="208" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport omnichannel3.tmx,2,10,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
+    <property name="act10" value="transition_teleport omnichannel3.tmx,2,10,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
    </properties>
   </object>
   <object id="17" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_omnichannel"/>
-    <property name="cond1" value="not music_playing music_omnichannel"/>
+    <property name="act10" value="play_music music_omnichannel"/>
+    <property name="cond10" value="not music_playing music_omnichannel"/>
    </properties>
   </object>
   <object id="18" name="Player Spawn" type="event" x="32" y="160" width="16" height="16"/>

--- a/mods/tuxemon/maps/paper_scoop.tmx
+++ b/mods/tuxemon/maps/paper_scoop.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.2.0" orientation="orthogonal" renderorder="right-down" width="15" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="59">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="59">
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>
  </tileset>
@@ -14,27 +14,27 @@
  </tileset>
  <layer id="1" name="Tile Layer 1" width="15" height="15">
   <data encoding="base64" compression="zlib">
-   eJxjYBg4YEkGhgEXMjAM+JOBYUCPDDyqd+joHQgAADE2HQ0=
+   eAFjYBg4YAm0mlQMc60LkEEqhun1BzJIxTC9ekAGqXhUL/FhNtBhBbOfnjQAMTYdDQ==
   </data>
  </layer>
  <layer id="2" name="Tile Layer 2" width="15" height="15">
   <data encoding="base64" compression="zlib">
-   eJxjYBi5gJmVdD0dLAwM7UB8l4V8e2mhtxbol9tAuXo8frpJhr3EmEsuoKXZ2ACdrCEZAAA8MApU
+   eAFjYBi5gJmVdL93sDAwtAPxXSAmF9BCby3QL7eBbqrH46ebZLiZGHPJDQdamo3NTXiCBptyuokBADwwClQ=
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="15" height="15">
   <data encoding="base64" compression="zlib">
-   eJxjYBgF5IBw1oHRu4GFfL2bKdA7CmgHAAF2AiQ=
+   eAFjYBgF5IRAOCs5uiB6KNG7gYV8ezdToJd8W0d1EgoBAAF2AiQ=
   </data>
  </layer>
  <layer id="4" name="Above player" width="15" height="15">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFgwVsZGFg2ATEm1loYy4tAK3cPJIAACPLBbA=
+   eAFjYBgFgyUENrIwMGwC4s1ATE0AM5eaZsLMgplNbTfDzB8JNAAjywWw
   </data>
  </layer>
  <layer id="5" name="Above player" width="15" height="15">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFgwUcYoXgg6yk6z3DCsGnydBLKTjMCsHkgLOsEDySAQBcNgf7
+   eAFjYBgFgyUEDrEyMIDwQSAmFZwB6gHh02ToJdUudPWHgXaCMDngLFAfCI9kAABcNgf7
   </data>
  </layer>
  <objectgroup color="#ff0000" id="6" name="Collision">
@@ -50,92 +50,92 @@
  <objectgroup color="#ffff00" id="7" name="Events">
   <object id="17" name="Go outside" type="event" x="112" y="192" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport paper_town.tmx,20,13,0.3"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport paper_town.tmx,20,13,0.3"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="27" name="Receive capture device" type="event" x="64" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="add_item capture_device"/>
-    <property name="act2" value="add_item capture_device"/>
-    <property name="act3" value="add_item capture_device"/>
-    <property name="act4" value="add_item capture_device"/>
-    <property name="act5" value="add_item capture_device"/>
-    <property name="act6" value="dialog Received capture device (x5)!"/>
-    <property name="act7" value="set_variable donegot:yes"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
-    <property name="cond4" value="not variable_set donegot:yes"/>
+    <property name="act10" value="add_item capture_device"/>
+    <property name="act20" value="add_item capture_device"/>
+    <property name="act30" value="add_item capture_device"/>
+    <property name="act40" value="add_item capture_device"/>
+    <property name="act50" value="add_item capture_device"/>
+    <property name="act60" value="dialog Received capture device (x5)!"/>
+    <property name="act70" value="set_variable donegot:yes"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond40" value="not variable_set donegot:yes"/>
    </properties>
   </object>
   <object id="37" name="Talk to the professor" type="event" x="112" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog professor_dialog\n"/>
-    <property name="act7" value="translated_dialog_choice hydrone:rockitten:fruitera,tuxchoice"/>
-    <property name="cond5" value="is variable_set tuxchoice:welcome"/>     
-    <property name="behav1" value="talk professor"/>
+    <property name="act10" value="translated_dialog professor_dialog\n"/>
+    <property name="act20" value="translated_dialog_choice hydrone:rockitten:fruitera,tuxchoice"/>
+    <property name="behav10" value="talk professor"/>
+    <property name="cond10" value="is variable_set tuxchoice:welcome"/>
    </properties>
   </object>
   <object id="42" name="hello Professor" type="event" x="144" y="192" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc professor,7,7,professor,stand"/>
-    <property name="act2" value="set_variable tuxchoice:welcome"/>
-    <property name="cond1" value="not variable_set tuxchoice:end"/>
-    <property name="cond2" value="not npc_exists professor"/>
-    <property name="cond3" value="not variable_set tuxchoice:hydrone"/>
-    <property name="cond4" value="not variable_set tuxchoice:rockitten"/>
-    <property name="cond5" value="not variable_set tuxchoice:fruitera"/>
+    <property name="act10" value="create_npc professor,7,7,professor,stand"/>
+    <property name="act20" value="set_variable tuxchoice:welcome"/>
+    <property name="cond10" value="not variable_set tuxchoice:end"/>
+    <property name="cond20" value="not npc_exists professor"/>
+    <property name="cond30" value="not variable_set tuxchoice:hydrone"/>
+    <property name="cond40" value="not variable_set tuxchoice:rockitten"/>
+    <property name="cond50" value="not variable_set tuxchoice:fruitera"/>
    </properties>
   </object>
   <object id="46" name="choiceHydrone" type="event" x="112" y="127.667" width="16" height="16">
    <properties>
-    <property name="act1" value="add_monster hydrone,5"/>
-    <property name="act2" value="set_variable tuxchoice:end"/>
-    <property name="act3" value="translated_dialog_chain professor_dialog6.1"/>
-    <property name="act4" value="translated_dialog_chain professor_dialog7"/>
-    <property name="act45" value="translated_dialog_chain ${{end}}"/>
-    <property name="act5" value="screen_transition 3"/>
-    <property name="act6" value="remove_npc professor"/>
-    <property name="cond1" value="is variable_set tuxchoice:hydrone"/>
+    <property name="act10" value="add_monster hydrone,5"/>
+    <property name="act20" value="set_variable tuxchoice:end"/>
+    <property name="act30" value="translated_dialog_chain professor_dialog6.1"/>
+    <property name="act40" value="translated_dialog_chain professor_dialog7"/>
+    <property name="act50" value="translated_dialog_chain ${{end}}"/>
+    <property name="act60" value="screen_transition 3"/>
+    <property name="act70" value="remove_npc professor"/>
+    <property name="cond10" value="is variable_set tuxchoice:hydrone"/>
    </properties>
   </object>
   <object id="47" name="choiceRockitten" type="event" x="111.333" y="127.667" width="16" height="16">
    <properties>
-    <property name="act1" value="add_monster rockitten,5"/>
-    <property name="act2" value="set_variable tuxchoice:end"/>
-    <property name="act3" value="translated_dialog_chain professor_dialog6.2"/>
-    <property name="act4" value="translated_dialog_chain professor_dialog7"/>
-    <property name="act45" value="translated_dialog_chain ${{end}}"/>
-    <property name="act5" value="screen_transition 3"/>
-    <property name="act6" value="remove_npc professor"/>
-    <property name="cond1" value="is variable_set tuxchoice:rockitten"/>
+    <property name="act10" value="add_monster rockitten,5"/>
+    <property name="act20" value="set_variable tuxchoice:end"/>
+    <property name="act30" value="translated_dialog_chain professor_dialog6.2"/>
+    <property name="act40" value="translated_dialog_chain professor_dialog7"/>
+    <property name="act50" value="translated_dialog_chain ${{end}}"/>
+    <property name="act60" value="screen_transition 3"/>
+    <property name="act70" value="remove_npc professor"/>
+    <property name="cond10" value="is variable_set tuxchoice:rockitten"/>
    </properties>
   </object>
   <object id="51" name="choiceFruitera" type="event" x="111.667" y="127.667" width="16" height="16">
    <properties>
-    <property name="act1" value="add_monster fruitera,5"/>
-    <property name="act2" value="set_variable tuxchoice:end"/>
-    <property name="act3" value="translated_dialog_chain professor_dialog6.3"/>
-    <property name="act4" value="translated_dialog_chain professor_dialog7"/>
-    <property name="act45" value="translated_dialog_chain ${{end}}"/>
-    <property name="act5" value="screen_transition 3"/>
-    <property name="act6" value="remove_npc professor"/>
-    <property name="cond1" value="is variable_set tuxchoice:fruitera"/>
+    <property name="act10" value="add_monster fruitera,5"/>
+    <property name="act20" value="set_variable tuxchoice:end"/>
+    <property name="act30" value="translated_dialog_chain professor_dialog6.3"/>
+    <property name="act40" value="translated_dialog_chain professor_dialog7"/>
+    <property name="act50" value="translated_dialog_chain ${{end}}"/>
+    <property name="act60" value="screen_transition 3"/>
+    <property name="act70" value="remove_npc professor"/>
+    <property name="cond10" value="is variable_set tuxchoice:fruitera"/>
    </properties>
   </object>
   <object id="56" name="employee" type="event" x="48" y="176" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc tuxemart_keeper,2,7,tuxemartemployee,stand"/>
-    <property name="act2" value="npc_face tuxemart_keeper,right"/>
-    <property name="cond1" value="not npc_exists tuxemart_keeper"/>
+    <property name="act10" value="create_npc tuxemart_keeper,2,7,tuxemartemployee,stand"/>
+    <property name="act20" value="npc_face tuxemart_keeper,right"/>
+    <property name="cond10" value="not npc_exists tuxemart_keeper"/>
    </properties>
   </object>
   <object id="57" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_cathedral_theme"/>
-    <property name="cond1" value="not music_playing music_cathedral_theme"/>
+    <property name="act10" value="play_music music_cathedral_theme"/>
+    <property name="cond10" value="not music_playing music_cathedral_theme"/>
    </properties>
   </object>
   <object id="58" name="Player Spawn" type="event" x="112" y="160" width="16" height="16"/>

--- a/mods/tuxemon/maps/paper_town.tmx
+++ b/mods/tuxemon/maps/paper_town.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="40" height="20" tilewidth="16" tileheight="16" nextobjectid="214">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="214">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -133,32 +133,32 @@
  <tileset firstgid="8023" name="My_tuxemon_sheet_OLD" tilewidth="16" tileheight="16" tilecount="104" columns="8">
   <image source="../gfx/tilesets/My_tuxemon_sheet.png" width="128" height="208"/>
  </tileset>
- <layer name="Tile Layer 1" width="40" height="20">
+ <layer id="1" name="Tile Layer 1" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eJzzY2Vg8BsmuJQNOzZgw60nFIjDoDh8gNxXisd9sUj64kfdN6jdRw4eLO6D5YMUqHuS0fgD7T7kcMKFYW7Gh2mVx1OBOA0LjiHC3cSkY3qEazQOP8DwQLuPUPobdd/gdh9yXQvDlJQvH6jsXkJlDMh9/iS4jdruw1XGwHA61H13gPguGoa5Bx3TOv2BgB/UXTD8BI976Ok+bOEEwg8GiftICaeh6j4Ak/hDAA==
+   eAHtlE0KAjEMRrvR83iScaUuVFz4dwJvq+DCA3gEE+gnoZNExEaLzEDItDOU19ek3Sil7k/iNE5JiwnNW3uc0d7nORbBHjQ2zFl8a2LCP5uB7+kCTpBb8GcxePPfPF+PA32wy/W2pcx9gTF7jq4/j096wpmXGczoZy1H9fieXB2UWNFcyemNPQcR36TXpcIv98TcEQzempLvVf0NfP3zackf7hjZl5/cL/fK9ShdaT3K9Tel8OoV35itNp91x6BHj5nvTPlSBHjKDN6onOjhtdkb4kbvJYc1juLidTVP7O3aCN87nn7hrwbfA5P4QwA=
   </data>
  </layer>
- <layer name="Tile Layer 2" width="40" height="20">
+ <layer id="2" name="Tile Layer 2" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eJzTZWFg0ANiXQJ0KxsDQxse3A7EhEABK245XPaGAXE4EfRcPPYbAOXm45DPQHNTAA434rKXULjBaHzuAwFc7iMW0DL8qOG+4R5+W4H2b8ODt1PgPgtWysMPRtMakBt+MJrWgNLwywHGRS4WnIenbCMHUBJ+yhwMDCocCLPUgOwyVkg6ohagZvoz4MAuTgmgJPxU0dyjRgP3URJ++mjuoUX43QGmlQd4yh1i8i96OqS2295zDo7yD+Seu0j4ATSffeSkffm3WJ6BoZYVgnGVQQ9wiH8gI/xIpZHbUy9IrAPfkRF+lIS3ODtp7vtIh/BDBguA9i3kJOyuMqCacqg6eobfCaCdJzkh6QoUNqD4ew/lv4fyQeLzgHg+1H0AMmiQEg==
+   eAG1lj1OxEAMhafg9wSUFPx0C1tyDCq4AgUgqqWiBE4BC+IMwBXgDiBRUvFzA94TPGlkxbFJNpa8jsczed96ZrMZzZWyBR8F8XyhlIsWv0QtspN5f4anvweufXgUr1r0x6hNnfqBYdo1uYg9fY/bjrfxUcPjk34UrZ5yj9uOD81n9ZSLM4pD83n64oziPc7XQ4s/Oucv2lfWd3AmPX2P2xvP6PWZY3U9bm+8j3ZmrdW1vFF+iL04avBj57mRYWqaIw7LG+W819pSKetw2SauJ+DjOZqViUOc2dikP65Ym+pdxsQjzmyk1obhYf9mbeIRZzaSY9vwDNG/F5yVN7g4s7Hukz2Hda3Ptdg+l+P3FtvXPrreWvK8Vs6+0b7Bl+2b5v2uzH/erZZyBj269wwSj73rV4f+2X5Gef0+9f7P/8CPDv1TH7Ox7snKYp3F19zf6Pv3rdcUN9C7hUc2wZzTv3nZPnSdV7M8QfMZznPF3nD/+Btlzsic49fwKZz2AzJokBI=
   </data>
  </layer>
- <layer name="Tile Layer 3" width="40" height="20">
+ <layer id="3" name="Tile Layer 3" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eJzN1jlOw0AUxvFRsIPS+ApAQsXawRnCUoFtChAVUCEktiphuQEJULEV3IKtYi04BGJrWEsQBf8gRbHjie2RcOJP+snJxPZ7fhkpESJ8bpJCfEv84BazutecXrne0ILPqY7GNboWfCzlLqnwMCSTcr/v19T7UIlffwUUsYktbPvcx6KuHbL2f83vCMc4wSnOwpX/ixlQN2y+fPbfPZ8/4BFPeBby73MHu9jDPg4CaoadX/mYTnnvkXXsb5PXFuwae/4cF7jEFa4D+qlnSvN85fiGd3zgM+Aa1fnVI4ZP3UbM1ZlJ3b1v4zK/cb3SnxFBvdaEEG1II4P2hPy8DtY70YVu9KAXE47+ophflhoDGMQQhmv0N8L6KExYsDFW1Z8Rwfc0T40FLGIJy3hpcp/TR90c63msYBVrWJfMr/zbGJf9N0Vf05jx+a/Q6Gw0e9dU55fj+fIKDlvC91eQ9BenyPpTnV+U+7UY8/nJEqf5yfIL5LpRKQ==
+   eAHNlblOAzEQhleQgGh4BSCh4uzgGcJRQRIKEBVQISSuKuF4A8JRcRW8BVfFWfAQiKvhLEEUfJZiydm1HW+0AUb65PV47Pl3PJt4nrtd13nel4ZvfDcwHQ8yg09aYyy4LvaoMTJWjjH2xKHcKOJv0RDGkg2l0b3kMZkpvyle57fpK7BhHTZgE7bAZBl0Zi1a1X0m3X6/2GPTd8j6ERzDCZyCq6Ut9+d6hoj71PSe6EfRf3es38MDPMIT6O5zG/8O7MIe7IPN/HUqN0/4ekqcnVK+gTTPGcgqPjX/GZNzuIBLuALV/PnVtWo/i3q+kOQV3uAdPsBmfr3l5razoloTv0N+HfJs6Zfz3x7H6Qu1b6Ue17FaekeL/Sr0qfWLKl9zjee1QAKS0Ao6a8PfDh3QCV3QDWOKvmrUL0WOPuiHARgEnQ3hH4Y0ZCALI6DqE/WL2mbJMQfzsACL8FxbmqWHvDn8eViCZViBVVD1ifrJ/0bXvpNxpRmjm01wv5MwVbzn6E6O7qS1+uBZsi6uY473y4fgoCmY0+QpaPSZYv/Cr9PnWrdK48K85/o/r5/uXSqti+s+Xc4wvh/kulEp
   </data>
  </layer>
- <layer name="Above Player" width="40" height="20">
+ <layer id="4" name="Above Player" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eJxjYKA/YGFhYGBloa+dGUCcCcRZQJwNxDl41OoC3aZHZ/dRAnQGkVtJCedRMApGwSgYBaNgFGAHsLYSLpoUIMVBGzeOglFALgAAV0sFLw==
+   eAFjYKA/YGFhYGAFYnqCDKBlmUCcBcTZQJwDxLiALtBtenR2Hy63ECOuM4jcSko4E+O3UTWjITAaAqMhMBoCoyEwEkMA1lbCRZMSJlIcpKgeVTsaArQPAQBXSwUv
   </data>
  </layer>
- <layer name="Above Player" width="40" height="20">
+ <layer id="5" name="Above Player" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eJxjYKAOKGClkkGjYMgAPpaBdsHwAqPhOQooBU/ksIu3CjAwtAFxOxB3AHGnAHZ1wWIMDCFAHArEYUAcDsQRYrR3HzpwZ2Zg8ABiT2bq2U0MINZ9BUB3FQJxEZL7eOmQf4l130CBUfeNglEwCogFACRfDmw=
+   eAFjYKAOKGCljjmjpgydEOBjGTpuHQouHQ3PoRBLg9uNT+Swu69VgIGhDYjbgbgDiDuBGBsIFmNgCAHiUCAOA+JwII4AYmoBXO5DN9+dmYHBA4g9gZiegFj3FQDdVQjERUju46VDeUis++gZZsh2jboPOTRG2aMhMBoC+EIAACRfDmw=
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collision">
   <properties>
    <property name="Collision" value=""/>
   </properties>
@@ -219,150 +219,150 @@
   <object id="210" type="collision" x="288" y="160" width="32" height="48"/>
   <object id="211" type="collision" x="320" y="160" width="16" height="32"/>
  </objectgroup>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="7" name="Events">
   <object id="167" name="Sign for Mart" type="event" x="368" y="192">
    <properties>
-    <property name="act1" value="dialog_chain Buy things here"/>
-    <property name="act4" value="dialog_chain ${{end}}"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog_chain Buy things here"/>
+    <property name="act20" value="dialog_chain ${{end}}"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
    <polygon points="0,0 16,0 16,16 0,16"/>
   </object>
   <object id="170" name="Teleport to Protagonist House" type="event" x="496" y="96">
    <properties>
-    <property name="act1" value="transition_teleport player_house_downstairs.tmx,5,7,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
+    <property name="act10" value="transition_teleport player_house_downstairs.tmx,5,7,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
    </properties>
    <polygon points="0,0 0,16 16,16 16,0"/>
   </object>
   <object id="171" name="Sign for Protagonist House" type="event" x="432" y="96">
    <properties>
-    <property name="act1" value="dialog_chain Home sweet home"/>
-    <property name="act4" value="dialog_chain ${{end}}"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog_chain Home sweet home"/>
+    <property name="act20" value="dialog_chain ${{end}}"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
    <polygon points="0,0 0,16 16,16 16,0"/>
   </object>
   <object id="173" name="Sign for Boat" type="event" x="560" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog_chain Under repairs"/>
-    <property name="act4" value="dialog_chain ${{end}}"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog_chain Under repairs"/>
+    <property name="act20" value="dialog_chain ${{end}}"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="177" name="Sign for Route 1" type="event" x="432" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog_chain ^ Route 1 --- Paper Town v"/>
-    <property name="act4" value="dialog_chain ${{end}}"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog_chain ^ Route 1 --- Paper Town v"/>
+    <property name="act20" value="dialog_chain ${{end}}"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="178" name="Sign for Sunnyside Manor" type="event" x="432" y="192" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog_chain Sunnyside Manor: If we are not home leave a message with our housekeeper"/>
-    <property name="act4" value="dialog_chain ${{end}}"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog_chain Sunnyside Manor: If we are not home leave a message with our housekeeper"/>
+    <property name="act20" value="dialog_chain ${{end}}"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="179" name="Sign for Daycare" type="event" x="368" y="64" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog_chain Daycare Centre: Under construction"/>
-    <property name="act4" value="dialog_chain ${{end}}"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog_chain Daycare Centre: Under construction"/>
+    <property name="act20" value="dialog_chain ${{end}}"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="180" name="Teleport to Route 1" type="event" x="416" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route1_sanglorian.tmx,26,19,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport route1_sanglorian.tmx,26,19,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="190" name="Teleport to Route 1" type="event" x="400" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route1_sanglorian.tmx,25,19,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport route1_sanglorian.tmx,25,19,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="191" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_town_theme"/>
-    <property name="cond1" value="not music_playing music_town_theme"/>
+    <property name="act10" value="play_music music_town_theme"/>
+    <property name="cond10" value="not music_playing music_town_theme"/>
    </properties>
   </object>
   <object id="197" name="Teleport to Daycare" type="event" x="336" y="64" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport daycare.tmx,3,8,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
+    <property name="act10" value="transition_teleport daycare.tmx,3,8,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
    </properties>
   </object>
   <object id="198" name="Teleport to Leather Town" type="event" x="592" y="144">
    <properties>
-    <property name="act1" value="transition_teleport leather_town.tmx,20,21,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
+    <property name="act10" value="transition_teleport leather_town.tmx,20,21,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
    </properties>
    <polygon points="0,0 0,16 16,16 16,0"/>
   </object>
   <object id="199" name="Sign for Leather" type="event" x="592" y="128">
    <properties>
-    <property name="act1" value="dialog_chain Teleport to Leather Town below"/>
-    <property name="act4" value="dialog_chain ${{end}}"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog_chain Teleport to Leather Town below"/>
+    <property name="act20" value="dialog_chain ${{end}}"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
    <polygon points="0,0 0,16 16,16 16,0"/>
   </object>
   <object id="200" name="Teleport to Flower City" type="event" x="592" y="176">
    <properties>
-    <property name="act1" value="transition_teleport flower_city.tmx,20,24,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
+    <property name="act10" value="transition_teleport flower_city.tmx,20,24,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
    </properties>
    <polygon points="0,0 0,16 16,16 16,0"/>
   </object>
   <object id="201" name="Teleport to Candy Town" type="event" x="592" y="208">
    <properties>
-    <property name="act1" value="transition_teleport candy_town.tmx,9,36,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
+    <property name="act10" value="transition_teleport candy_town.tmx,9,36,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
    </properties>
    <polygon points="0,0 0,16 16,16 16,0"/>
   </object>
   <object id="202" name="Sign for Flower" type="event" x="592" y="160">
    <properties>
-    <property name="act1" value="dialog_chain Teleport to Flower City below"/>
-    <property name="act4" value="dialog_chain ${{end}}"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog_chain Teleport to Flower City below"/>
+    <property name="act20" value="dialog_chain ${{end}}"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
    <polygon points="0,0 0,16 16,16 16,0"/>
   </object>
   <object id="203" name="Sign for Candy" type="event" x="592" y="192">
    <properties>
-    <property name="act1" value="dialog_chain Teleport to Candy Town below"/>
-    <property name="act4" value="dialog_chain ${{end}}"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog_chain Teleport to Candy Town below"/>
+    <property name="act20" value="dialog_chain ${{end}}"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
    <polygon points="0,0 0,16 16,16 16,0"/>
   </object>
   <object id="212" name="Teleport to Mart" type="event" x="320" y="192">
    <properties>
-    <property name="act1" value="transition_teleport paper_scoop.tmx,7,12,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
+    <property name="act10" value="transition_teleport paper_scoop.tmx,7,12,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
    </properties>
    <polygon points="0,0 0,16 16,16 16,0"/>
   </object>

--- a/mods/tuxemon/maps/player_house_bedroom.tmx
+++ b/mods/tuxemon/maps/player_house_bedroom.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" tiledversion="1.0.3" orientation="orthogonal" renderorder="right-down" width="11" height="9" tilewidth="16" tileheight="16" nextobjectid="27">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="11" height="9" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="27">
  <tileset firstgid="1" name="floors and walls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>
  </tileset>
@@ -15,27 +15,27 @@
  <tileset firstgid="193" name="stairs" tilewidth="16" tileheight="16" tilecount="24" columns="8">
   <image source="../gfx/tilesets/stairs.png" width="128" height="48"/>
  </tileset>
- <layer name="Tile Layer 1" width="11" height="9">
+ <layer id="1" name="Tile Layer 1" width="11" height="9">
   <data encoding="base64" compression="zlib">
-   eJxjYCANMBGBYUCCCAwDykRgGNAjgAebWmIBAIbzCHI=
+   eAFjYCANMAGVE8IwEyWADEIYplYZyCCEYWr1gAx8GGQODOBTB5Kjh1qYWwjRAIbzCHI=
   </data>
  </layer>
- <layer name="Tile Layer 2" width="11" height="9">
+ <layer id="2" name="Tile Layer 2" width="11" height="9">
   <data encoding="base64" compression="zlib">
-   eJxjYKAeYEHj1wJxE5QdA8RxSHL8aGo7gbgPiGcBcQkQl0HFTwLxKTS1U6E0JxBzQTE3EF8E4ks43CYCxKJQLEbAH/JArADFigTUUhMAAFmMCS8=
+   eAFjYKAeYEEzqhbIb4KKxQDpOCR5fiQ2iNkJxH1APAuIS4C4DIhB4CQQnwKzEMRUKJMTSHNBMTeQvgjEl4AYGxABCopCsRg2BUhi8kC2AhQrIonTmgkAWYwJLw==
   </data>
  </layer>
- <layer name="Tile Layer 3" width="11" height="9">
+ <layer id="3" name="Tile Layer 3" width="11" height="9">
   <data encoding="base64" compression="zlib">
-   eJxjYKAtWAqlFwLxIiL11JFp12UgvkKm3sEAAOT5BA4=
+   eAFjYKAtWAo1fiGQXkSkVXVEqkNXdhkocAVdcAjxAeT5BA4=
   </data>
  </layer>
- <layer name="Above player" width="11" height="9">
+ <layer id="4" name="Above player" width="11" height="9">
   <data encoding="base64" compression="zlib">
-   eJxjYKA/OAzER3DI1aDxTwPxGdo6h2iwkQS1W5HYkkRgEAAAFLAF4g==
+   eAFjYKA/OAy08ggOa2vQxE8D+WfQxAaKu5EEi7ciqZUEsglhkHIAFLAF4g==
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collision">
   <object id="1" type="collision" x="16" y="32" width="144" height="16"/>
   <object id="2" type="collision" x="160" y="48" width="16" height="80"/>
   <object id="3" type="collision" x="16" y="128" width="144" height="16"/>
@@ -45,20 +45,20 @@
   <object id="7" type="collision" x="112" y="48" width="16" height="16"/>
   <object id="8" type="collision" x="144" y="112" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="6" name="Events">
   <object id="9" name="Go Downstairs" type="event" x="128" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport player_house_downstairs.tmx,1,3,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
+    <property name="act10" value="transition_teleport player_house_downstairs.tmx,1,3,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
    </properties>
   </object>
   <object id="10" name="Use Computer" type="event" x="64" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="change_state PCState"/>
-    <property name="cond1" value="is player_at 4,3"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="change_state PCState"/>
+    <property name="cond10" value="is player_at 4,3"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="16" name="Lord Lampy" type="interact" x="32" y="32" width="16" height="16">
@@ -71,12 +71,12 @@
   </object>
   <object id="17" name="Lord or Filth" type="event" x="48" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog_chain ${{name}}:\n Why the hell are you talking to a trashcan?!"/>
-    <property name="act2" value="dialog_chain Did Lord Lampy tell you about me? "/>
-    <property name="act3" value="dialog_chain Find me again and I shall grant you grand powers."/>
-    <property name="act4" value="dialog_chain ${{end}}"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog_chain ${{name}}:\n Why the hell are you talking to a trashcan?!"/>
+    <property name="act20" value="dialog_chain Did Lord Lampy tell you about me? "/>
+    <property name="act30" value="dialog_chain Find me again and I shall grant you grand powers."/>
+    <property name="act40" value="dialog_chain ${{end}}"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="26" name="Player Spawn" type="event" x="64" y="80" width="16" height="16"/>

--- a/mods/tuxemon/maps/player_house_downstairs.tmx
+++ b/mods/tuxemon/maps/player_house_downstairs.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.3.1" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="11" height="9" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="31">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="11" height="9" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="31">
  <tileset firstgid="1" name="floors and walls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>
  </tileset>
@@ -48,56 +48,56 @@
  <objectgroup color="#ffff00" id="6" name="Events">
   <object id="23" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_home"/>
-    <property name="cond1" value="not music_playing music_home"/>
+    <property name="act10" value="play_music music_home"/>
+    <property name="cond10" value="not music_playing music_home"/>
    </properties>
   </object>
   <object id="24" name="Watch TV" type="event" x="32" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog You watch some TV with your beloved Lv ${{monster_0_level}} ${{monster_0_name}}.,0"/>
-    <property name="cond1" value="is party_size greater_than,0"/>
-    <property name="cond2" value="is player_at 2,6"/>
-    <property name="cond3" value="is player_facing up"/>
-    <property name="cond4" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog You watch some TV with your beloved Lv ${{monster_0_level}} ${{monster_0_name}}.,0"/>
+    <property name="cond10" value="is party_size greater_than,0"/>
+    <property name="cond20" value="is player_at 2,6"/>
+    <property name="cond30" value="is player_facing up"/>
+    <property name="cond40" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="25" name="Read Sign" type="event" x="32" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog Home Sweet Home"/>
-    <property name="cond1" value="is player_at 2,3"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog Home Sweet Home"/>
+    <property name="cond10" value="is player_at 2,3"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="26" name="Go Upstairs" type="event" x="16" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport player_house_bedroom.tmx,9,3,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at 1,2"/>
+    <property name="act10" value="transition_teleport player_house_bedroom.tmx,9,3,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at 1,2"/>
    </properties>
   </object>
   <object id="27" name="Go Outside" type="event" x="80" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport taba_town.tmx,43,46,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at 5,7"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport taba_town.tmx,43,46,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at 5,7"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="28" name="Player Spawn" type="event" x="80" y="64" width="16" height="16"/>
   <object id="29" name="create mom" type="event" x="16" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc npc_mom,9,4,,stand"/>
-    <property name="act2" value="npc_face npc_mom,left"/>
-    <property name="act3" value="npc_speed npc_mom, 0.2"/>
-    <property name="act4" value="npc_wander npc_mom"/>
-    <property name="cond1" value="not npc_exists npc_mom"/>
+    <property name="act10" value="create_npc npc_mom,9,4,,stand"/>
+    <property name="act20" value="npc_face npc_mom,left"/>
+    <property name="act30" value="npc_speed npc_mom, 0.2"/>
+    <property name="act40" value="npc_wander npc_mom"/>
+    <property name="cond10" value="not npc_exists npc_mom"/>
    </properties>
   </object>
   <object id="30" name="talkwithmom" type="event" x="144" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog firsts"/>
-    <property name="behav1" value="talk npc_mom"/>
+    <property name="act10" value="translated_dialog firsts"/>
+    <property name="behav10" value="talk npc_mom"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/professor_lab.tmx
+++ b/mods/tuxemon/maps/professor_lab.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="20" height="20" tilewidth="16" tileheight="16" nextobjectid="94">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="94">
  <tileset firstgid="1" name="furniture" tilewidth="16" tileheight="16" tilecount="72" columns="12">
   <image source="../gfx/tilesets/furniture.png" width="192" height="96"/>
  </tileset>
@@ -24,33 +24,33 @@
  <tileset firstgid="1501" name="plants" tilewidth="16" tileheight="16" tilecount="16" columns="4">
   <image source="../gfx/tilesets/plants.png" width="64" height="64"/>
  </tileset>
- <layer name="Tile Layer 1" width="20" height="20">
+ <layer id="1" name="Tile Layer 1" width="20" height="20">
   <data encoding="base64" compression="zlib">
-   eJxjYECADaykY3xgNyvpGB84xko6xgdWsJKOR80bNW/UvFHzBsK8wQgAniChCA==
+   eAFjYECADawMDKRihG5M1m6geaRiTFMQIseA5pGKEboxWSuA5pGKMU1BiJBqFkg9PjBqHuH4GQ0/RAiMppfhnV4QMT14WACeIKEI
   </data>
  </layer>
- <layer name="Tile Layer 2" width="20" height="20">
+ <layer id="2" name="Tile Layer 2" width="20" height="20">
   <data encoding="base64" compression="zlib">
-   eJxjYBg6gAWI2YA4E8jIBuKjQHyMBVPdIWYGhsPMhM2TAWI5IDZlZWAwB+J3QLPeo5nnBMSvgWa9IcI8YoE69YwiCXzCEla0BiArgUELjjdCwIKVsBoBIBYEYiGKXIUAoDQgywBJB/QGoHQ3mQWBzVlJk6c3WAS0fzESXkKhe9YC9a9DwuspNG8HUP9OJLxrgMPrIdB+TiDNBcTcSOK1SO5Cln84wO4lBwAAHSEcKQ==
+   eAFjYBg6gAXoVDYgzgQysoH4KBAfAwmigUPMDAyHgZgQkAEqkANiU1YGBnMgfgc06z2aeU5A+ddAs94QYR4h+2Dy6jAGnelPaH6jh/UgK4FBC443QvZZgBQSAAJAeUEgFiKgjlhpUBqQBWJQOqA3AKW7ycAAgmFQGkQGhOSR1dKDvQjovsVIeAmae0l1w1qg/nVIeD2F5u0A6t+JhHdRaB6p/kFX/xBoPydQkAuIuZEka5HchSwPUj/UAAAdIRwp
   </data>
  </layer>
- <layer name="Tile Layer 3" width="20" height="20">
+ <layer id="3" name="Tile Layer 3" width="20" height="20">
   <data encoding="base64" compression="zlib">
-   eJxjYBg6wBOIvahonhoVzRoFo2AUjIKRBgABaAC6
+   eAFjYBg6wBPoVC8qOleNimaNGjUaAqMhMBoCIy0EAAFoALo=
   </data>
  </layer>
- <layer name="Above player" width="20" height="20">
+ <layer id="4" name="Above player" width="20" height="20">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFgxWcZBloF+AHuwe5+6gNMoH+zULC2SykyY+CwQ1aSIwvUtUPRwAAvfQG6Q==
+   eAFjYBgFgzUETrIMVpdB3LV7kLuP2qGXCfRvFhLORvM/IXlqu2fUPOqGQAtafBIynVT1hMwbivIAvfQG6Q==
   </data>
  </layer>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="5" name="Events">
   <object id="11" name="Teleport to map1" type="event" x="144" y="272" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport taba_town.tmx,44,53,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at 8,17"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport taba_town.tmx,44,53,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at 8,17"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="69" name="Choose Creature 1" x="192" y="96" width="16" height="16"/>
@@ -58,7 +58,7 @@
   <object id="75" name="Choose Creature 3" x="224" y="96" width="16" height="16"/>
   <object id="93" name="Player Spawn" type="event" x="144" y="240" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ff0000" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collision">
   <object id="43" type="collision" x="192" y="112" width="48" height="32"/>
   <object id="56" type="collision" x="192" y="48" width="48" height="16"/>
   <object id="81" type="collision" x="256" y="-16" width="16" height="320"/>

--- a/mods/tuxemon/maps/riverside_boat_centre.tmx
+++ b/mods/tuxemon/maps/riverside_boat_centre.tmx
@@ -1,39 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="15" height="15" tilewidth="16" tileheight="16" nextobjectid="4">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="4">
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>
  </tileset>
  <tileset firstgid="89" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>
  </tileset>
- <layer name="Tile Layer 1" width="15" height="15">
+ <layer id="1" name="Tile Layer 1" width="15" height="15">
   <data encoding="base64" compression="zlib">
-   eJzTY2Bg0BvFo3gUU4QlcWBC8iAMAEgZJ14=
+   eAHTY2Bg0BvFo2EwmgYoSgOSwPDDhmF5C5scTAwASBknXg==
   </data>
  </layer>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="2" name="Events">
   <object id="2" type="event" x="96" y="224" width="32" height="16">
    <properties>
-    <property name="act1" value="transition_teleport taba_town.tmx,11,18,0.3"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport taba_town.tmx,11,18,0.3"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="3" name="Player Spawn" type="event" x="112" y="192" width="16" height="16"/>
  </objectgroup>
- <layer name="Tile Layer 2" width="15" height="15">
+ <layer id="3" name="Tile Layer 2" width="15" height="15">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUDCQAAAOEAAE=
+   eAFjYBgFoyEwGgIDGQIAA4QAAQ==
   </data>
  </layer>
- <layer name="Tile Layer 3" width="15" height="15">
+ <layer id="4" name="Tile Layer 3" width="15" height="15">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUDCQAAAOEAAE=
+   eAFjYBgFoyEwGgIDGQIAA4QAAQ==
   </data>
  </layer>
- <layer name="Above Player" width="15" height="15">
+ <layer id="5" name="Above Player" width="15" height="15">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUDCQAAAOEAAE=
+   eAFjYBgFoyEwGgIDGQIAA4QAAQ==
   </data>
  </layer>
 </map>

--- a/mods/tuxemon/maps/route1.tmx
+++ b/mods/tuxemon/maps/route1.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.3.1" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="59" height="42" tilewidth="16" tileheight="16" infinite="0" nextlayerid="12" nextobjectid="91">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="59" height="42" tilewidth="16" tileheight="16" infinite="0" nextlayerid="12" nextobjectid="91">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -83,132 +83,132 @@
  <objectgroup color="#ffff00" id="6" name="Events">
   <object id="23" name="Teleport to map1 (upper)" type="event" x="736" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="teleport taba_town.tmx,12,11"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="teleport taba_town.tmx,12,11"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="25" name="Teleport to map1 (lower)" type="event" x="736" y="256" width="16" height="16">
    <properties>
-    <property name="act1" value="teleport taba_town.tmx,12,12"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="teleport taba_town.tmx,12,12"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="32" name="Teleport to route1a" type="event" x="528" y="64" width="16" height="16">
    <properties>
-    <property name="act1" value="teleport route1_sanglorian.tmx,25,19"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="teleport route1_sanglorian.tmx,25,19"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="36" name="random battle" type="event" x="624" y="464" width="160" height="160">
    <properties>
-    <property name="act1" value="random_encounter route1"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route1"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="46" name="create Karrianna and grunts" type="event" x="496" y="416" width="64" height="16">
    <properties>
-    <property name="act10" value="create_npc xerogrunt3,26,32,teamxerogrunt1,stand"/>
-    <property name="act11" value="npc_face xerogrunt3,right"/>
-    <property name="act12" value="create_npc xerogrunt4,26,33,teamxerogrunt1,stand"/>
-    <property name="act13" value="npc_face xerogrunt4,right"/>
-    <property name="act14" value="create_npc xerogrunt5,26,34,teamxerogrunt1,stand"/>
-    <property name="act15" value="npc_face xerogrunt5,right"/>
-    <property name="act16" value="create_npc xerogrunt6,26,35,teamxerogrunt1,stand"/>
-    <property name="act17" value="npc_face xerogrunt6,right"/>
-    <property name="act18" value="create_npc xerogrunt7,26,36,teamxerogrunt1,stand"/>
-    <property name="act19" value="npc_face xerogrunt7,right"/>
-    <property name="act20" value="create_npc xerogrunt8,26,37,teamxerogrunt1,stand"/>
-    <property name="act21" value="npc_face xerogrunt8,right"/>
-    <property name="act22" value="create_npc xerogrunt9,26,38,teamxerogrunt1,stand"/>
-    <property name="act23" value="npc_face xerogrunt9,right"/>
-    <property name="act24" value="create_npc xerogrunt10,26,39,teamxerogrunt1,stand"/>
-    <property name="act25" value="npc_face xerogrunt10,right"/>
-    <property name="act7" value="create_npc xerogrunt1,26,30,teamxerogrunt1,stand"/>
-    <property name="act8" value="npc_face xerogrunt1,right"/>
-    <property name="act9" value="create_npc xerogrunt2,26,31,teamxerogrunt1,stand"/>
-    <property name="act91" value="npc_face xerogrunt2,right"/>
+    <property name="act010" value="create_npc xerogrunt3,26,32,teamxerogrunt1,stand"/>
+    <property name="act020" value="npc_face xerogrunt3,right"/>
+    <property name="act030" value="create_npc xerogrunt4,26,33,teamxerogrunt1,stand"/>
+    <property name="act040" value="npc_face xerogrunt4,right"/>
+    <property name="act050" value="create_npc xerogrunt5,26,34,teamxerogrunt1,stand"/>
+    <property name="act060" value="npc_face xerogrunt5,right"/>
+    <property name="act070" value="create_npc xerogrunt6,26,35,teamxerogrunt1,stand"/>
+    <property name="act080" value="npc_face xerogrunt6,right"/>
+    <property name="act090" value="create_npc xerogrunt7,26,36,teamxerogrunt1,stand"/>
+    <property name="act100" value="npc_face xerogrunt7,right"/>
+    <property name="act110" value="create_npc xerogrunt8,26,37,teamxerogrunt1,stand"/>
+    <property name="act120" value="npc_face xerogrunt8,right"/>
+    <property name="act130" value="create_npc xerogrunt9,26,38,teamxerogrunt1,stand"/>
+    <property name="act140" value="npc_face xerogrunt9,right"/>
+    <property name="act150" value="create_npc xerogrunt10,26,39,teamxerogrunt1,stand"/>
+    <property name="act160" value="npc_face xerogrunt10,right"/>
+    <property name="act170" value="create_npc xerogrunt1,26,30,teamxerogrunt1,stand"/>
+    <property name="act180" value="npc_face xerogrunt1,right"/>
+    <property name="act190" value="create_npc xerogrunt2,26,31,teamxerogrunt1,stand"/>
+    <property name="act200" value="npc_face xerogrunt2,right"/>
    </properties>
   </object>
   <object id="57" name="Establish hideout" type="event" x="240" y="352" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog xero_hideout1"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog xero_hideout1"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="62" name="blocking the way" type="event" x="432" y="480" width="16" height="160">
    <properties>
-    <property name="act1" value="translated_dialog xero_grunts_block"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog xero_grunts_block"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="68" name="talk to me" type="event" x="160" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc xerogrund1,32,14,teamxerogrunt1,stand"/>
-    <property name="act2" value="create_npc xerogrund2,33,14,teamxerogrunt1,stand"/>
-    <property name="cond1" value="not npc_exists xerogrund1"/>
-    <property name="cond2" value="not npc_exists xerogrund2"/>
-    <property name="cond3" value="not variable_set jumponwards:booyaa"/>
+    <property name="act10" value="create_npc xerogrund1,32,14,teamxerogrunt1,stand"/>
+    <property name="act20" value="create_npc xerogrund2,33,14,teamxerogrunt1,stand"/>
+    <property name="cond10" value="not npc_exists xerogrund1"/>
+    <property name="cond20" value="not npc_exists xerogrund2"/>
+    <property name="cond30" value="not variable_set jumponwards:booyaa"/>
    </properties>
   </object>
   <object id="69" name="talkin" type="event" x="512" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog waiting_for_misa"/>
-    <property name="act2" value="set_variable been_talking:yes"/>
-    <property name="act3" value="set_variable jumponwards:hi"/>
-    <property name="cond1" value="not variable_set been_talkin:yes"/>
-    <property name="behav1" value="talk xerogrund1"/>
+    <property name="act10" value="translated_dialog waiting_for_misa"/>
+    <property name="act20" value="set_variable been_talking:yes"/>
+    <property name="act30" value="set_variable jumponwards:hi"/>
+    <property name="behav10" value="talk xerogrund1"/>
+    <property name="cond10" value="not variable_set been_talkin:yes"/>
    </properties>
   </object>
   <object id="70" name="teleportin" type="event" x="528" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog teleport?"/>
-    <property name="act2" value="translated_dialog_choice yes:no,jumponwards"/>
-    <property name="cond1" value="is variable_set been_talking:yes"/>
-    <property name="cond2" value="is variable_set jumponwards:hi"/>
-    <property name="behav1" value="talk xerogrund2"/>
+    <property name="act10" value="translated_dialog teleport?"/>
+    <property name="act20" value="translated_dialog_choice yes:no,jumponwards"/>
+    <property name="behav10" value="talk xerogrund2"/>
+    <property name="cond10" value="is variable_set been_talking:yes"/>
+    <property name="cond20" value="is variable_set jumponwards:hi"/>
    </properties>
   </object>
   <object id="82" name="yes we be" type="event" x="528" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog ouch"/>
-    <property name="act2" value="set_variable jumponwards:booyaa"/>
-    <property name="act3" value="transition_teleport meet_misa.tmx,9,7,0.6"/>
-    <property name="cond1" value="is variable_set jumponwards:yes"/>
-    <property name="cond2" value="is player_at"/>
+    <property name="act10" value="translated_dialog ouch"/>
+    <property name="act20" value="set_variable jumponwards:booyaa"/>
+    <property name="act30" value="transition_teleport meet_misa.tmx,9,7,0.6"/>
+    <property name="cond10" value="is variable_set jumponwards:yes"/>
+    <property name="cond20" value="is player_at"/>
    </properties>
   </object>
   <object id="83" name="no we aint" type="event" x="528" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog maybe_sometime_again?"/>
-    <property name="act2" value="set_variable jumponwards:hi"/>
-    <property name="cond1" value="is variable_set jumponwards:no"/>
-    <property name="cond2" value="is player_at"/>
-    <property name="cond3" value="is player_facing up"/>
+    <property name="act10" value="translated_dialog maybe_sometime_again?"/>
+    <property name="act20" value="set_variable jumponwards:hi"/>
+    <property name="cond10" value="is variable_set jumponwards:no"/>
+    <property name="cond20" value="is player_at"/>
+    <property name="cond30" value="is player_facing up"/>
    </properties>
   </object>
   <object id="84" name="Player Spawn" type="event" x="524" y="95" width="16" height="16"/>
   <object id="85" name="Teleport to route1a" type="event" x="512" y="64" width="16" height="16">
    <properties>
-    <property name="act1" value="teleport route1_sanglorian.tmx,24,19"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="teleport route1_sanglorian.tmx,24,19"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="86" name="Teleport to route1a" type="event" x="544" y="64" width="16" height="16">
    <properties>
-    <property name="act1" value="teleport route1_sanglorian.tmx,26,19"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="teleport route1_sanglorian.tmx,26,19"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/route1_sanglorian.tmx
+++ b/mods/tuxemon/maps/route1_sanglorian.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.3.1" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="161">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="161">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -80,137 +80,137 @@
  <objectgroup color="#ffff00" id="6" name="Events">
   <object id="118" name="Teleport to Cotton Town" type="event" x="160" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport cotton_town.tmx,10,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport cotton_town.tmx,10,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="125" name="Route Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_the_wild_places"/>
-    <property name="cond1" value="not music_playing music_the_wild_places"/>
+    <property name="act10" value="play_music music_the_wild_places"/>
+    <property name="cond10" value="not music_playing music_the_wild_places"/>
    </properties>
   </object>
   <object id="129" name="Teleport to Route1" type="event" x="416" y="304" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route1.tmx,34,4,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route1.tmx,34,4,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="130" name="Teleport to Route1" type="event" x="400" y="304" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route1.tmx,33,4,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route1.tmx,33,4,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="133" name="Teleport to Cotton Town" type="event" x="176" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport cotton_town.tmx,11,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport cotton_town.tmx,11,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="134" name="Teleport to Cotton Town" type="event" x="192" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport cotton_town.tmx,12,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport cotton_town.tmx,12,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="135" name="Teleport to Cotton Town" type="event" x="208" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport cotton_town.tmx,13,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport cotton_town.tmx,13,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="136" name="Teleport to Cotton Town" type="event" x="224" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport cotton_town.tmx,14,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport cotton_town.tmx,14,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="137" name="Teleport to Cotton Town" type="event" x="240" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport cotton_town.tmx,15,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport cotton_town.tmx,15,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="138" name="Teleport to Cotton Town" type="event" x="256" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport cotton_town.tmx,16,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport cotton_town.tmx,16,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="139" name="Teleport to Cotton Town" type="event" x="272" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport cotton_town.tmx,17,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport cotton_town.tmx,17,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="140" name="Teleport to Cotton Town" type="event" x="288" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport cotton_town.tmx,18,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport cotton_town.tmx,18,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="151" name="Encounters" type="event" x="320" y="160" width="128" height="80">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="act2" value="play_map_animation grass,0.1,noloop,player"/>
-    <property name="cond1" value="is player_moved"/>
-    <property name="cond2" value="is player_at"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="act20" value="play_map_animation grass,0.1,noloop,player"/>
+    <property name="cond10" value="is player_moved"/>
+    <property name="cond20" value="is player_at"/>
    </properties>
   </object>
   <object id="152" name="Encounters" type="event" x="160" y="160" width="96" height="80">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="act2" value="play_map_animation grass,0.1,noloop,player"/>
-    <property name="cond1" value="is player_moved"/>
-    <property name="cond2" value="is player_at"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="act20" value="play_map_animation grass,0.1,noloop,player"/>
+    <property name="cond10" value="is player_moved"/>
+    <property name="cond20" value="is player_at"/>
    </properties>
   </object>
   <object id="153" name="Encounters" type="event" x="208" y="96" width="112" height="48">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="act2" value="play_map_animation grass,0.1,noloop,player"/>
-    <property name="cond1" value="is player_moved"/>
-    <property name="cond2" value="is player_at"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="act20" value="play_map_animation grass,0.1,noloop,player"/>
+    <property name="cond10" value="is player_moved"/>
+    <property name="cond20" value="is player_at"/>
    </properties>
   </object>
   <object id="154" name="Encounters" type="event" x="160" y="32" width="144" height="48">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="act2" value="play_map_animation grass,0.1,noloop,player"/>
-    <property name="cond1" value="is player_moved"/>
-    <property name="cond2" value="is player_at"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="act20" value="play_map_animation grass,0.1,noloop,player"/>
+    <property name="cond10" value="is player_moved"/>
+    <property name="cond20" value="is player_at"/>
    </properties>
   </object>
   <object id="159" name="Player Spawn" type="event" x="400" y="272" width="16" height="16"/>
   <object id="160" name="Teleport to Route1" type="event" x="384" y="304" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route1.tmx,32,4,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route1.tmx,32,4,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/route2.tmx
+++ b/mods/tuxemon/maps/route2.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.3.1" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="1" nextobjectid="137">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="1" nextobjectid="137">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -160,42 +160,42 @@
  <objectgroup color="#ffff00" id="6" name="Events">
   <object id="30" name="Teleport to City Park" type="event" x="160" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport citypark.tmx,10,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport citypark.tmx,10,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="31" name="Teleport to Cotton Town" type="event" x="624" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport cotton_town.tmx,0,28,0.3"/>
-    <property name="act2" value="player_face right"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="transition_teleport cotton_town.tmx,0,28,0.3"/>
+    <property name="act20" value="player_face right"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="60" name="Play Music" type="event" x="16" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_the_wild_places"/>
-    <property name="act2" value="set_variable sadsong:no"/>
-    <property name="cond1" value="not music_playing music_the_wild_places"/>
-    <property name="cond2" value="not variable_set sadsong:yes"/>
+    <property name="act10" value="play_music music_the_wild_places"/>
+    <property name="act20" value="set_variable sadsong:no"/>
+    <property name="cond10" value="not music_playing music_the_wild_places"/>
+    <property name="cond20" value="not variable_set sadsong:yes"/>
    </properties>
   </object>
   <object id="61" name="Teleport to Cotton Town" type="event" x="624" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport cotton_town.tmx,0,29,0.3"/>
-    <property name="act2" value="player_face right"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="transition_teleport cotton_town.tmx,0,29,0.3"/>
+    <property name="act20" value="player_face right"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="62" name="Teleport to City Park" type="event" x="176" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport citypark.tmx,11,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport citypark.tmx,11,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="82" name="Sign: Route 2" x="592" y="128" width="16" height="16">
@@ -209,346 +209,346 @@
   </object>
   <object id="83" name="Sign: City Park" type="event" x="144" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog cityparksign\n"/>
-    <property name="cond1" value="is player_facing up"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
-    <property name="cond3" value="is player_at"/>
+    <property name="act10" value="translated_dialog cityparksign\n"/>
+    <property name="cond10" value="is player_facing up"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is player_at"/>
    </properties>
   </object>
   <object id="84" name="Sign: Column 1" type="event" x="176" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog column1"/>
-    <property name="cond1" value="is player_facing up"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
-    <property name="cond3" value="is player_at"/>
+    <property name="act10" value="translated_dialog column1"/>
+    <property name="cond10" value="is player_facing up"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is player_at"/>
    </properties>
   </object>
   <object id="85" name="Sign: Column 2" type="event" x="240" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog column2"/>
-    <property name="cond1" value="is player_facing up"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
-    <property name="cond3" value="is player_at"/>
+    <property name="act10" value="translated_dialog column2"/>
+    <property name="cond10" value="is player_facing up"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is player_at"/>
    </properties>
   </object>
   <object id="86" name="Player Spawn" type="event" x="176" y="48" width="16" height="16"/>
   <object id="87" name="create npc" type="event" x="48" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc misa,2,3,misa,stand"/>
-    <property name="act2" value="npc_face misa,up"/>
-    <property name="act3" value="set_variable skadoosh:yes"/>
-    <property name="cond1" value="not npc_exists misa"/>
+    <property name="act10" value="create_npc misa,2,3,misa,stand"/>
+    <property name="act20" value="npc_face misa,up"/>
+    <property name="act30" value="set_variable skadoosh:yes"/>
+    <property name="cond10" value="not npc_exists misa"/>
    </properties>
   </object>
   <object id="88" name="talk to misa" type="event" x="48" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="set_variable sadsong:yes"/>
-    <property name="act2" value="play_music music_the_princess"/>
-    <property name="act3" value="translated_dialog route2speech"/>
-    <property name="act4" value="npc_face misa,right"/>
-    <property name="act5" value="translated_dialog route2speech2\n"/>
-    <property name="act6" value="npc_face misa,up"/>
-    <property name="act7" value="translated_dialog route2speech3\n"/>
-    <property name="act8" value="set_variable skadoosh:no"/>
-    <property name="act9" value="translated_dialog_choice sure_i_do:not_really,route2choice"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
-    <property name="cond4" value="is variable_set skadoosh:yes"/>
-    <property name="cond5" value="not variable_set leavemealone:yes"/>
-    <property name="cond6" value="not variable_set sadsong:yes"/>
+    <property name="act10" value="set_variable sadsong:yes"/>
+    <property name="act20" value="play_music music_the_princess"/>
+    <property name="act30" value="translated_dialog route2speech"/>
+    <property name="act40" value="npc_face misa,right"/>
+    <property name="act50" value="translated_dialog route2speech2\n"/>
+    <property name="act60" value="npc_face misa,up"/>
+    <property name="act70" value="translated_dialog route2speech3\n"/>
+    <property name="act80" value="set_variable skadoosh:no"/>
+    <property name="act90" value="translated_dialog_choice sure_i_do:not_really,route2choice"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond40" value="is variable_set skadoosh:yes"/>
+    <property name="cond50" value="not variable_set leavemealone:yes"/>
+    <property name="cond60" value="not variable_set sadsong:yes"/>
    </properties>
   </object>
   <object id="89" name="yes to talk" type="event" x="48" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog yestalk"/>
-    <property name="act2" value="set_variable route2choice:again"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
-    <property name="cond4" value="is variable_set route2choice:sure_i_do"/>
+    <property name="act10" value="translated_dialog yestalk"/>
+    <property name="act20" value="set_variable route2choice:again"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
+    <property name="cond30" value="is variable_set route2choice:sure_i_do"/>
    </properties>
   </object>
   <object id="90" name="no to talk" type="event" x="48" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="npc_face misa,right"/>
-    <property name="act2" value="translated_dialog notalk"/>
-    <property name="act3" value="set_variable route2choice:again"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
-    <property name="cond4" value="is variable_set route2choice:not_really"/>
+    <property name="act10" value="npc_face misa,right"/>
+    <property name="act20" value="translated_dialog notalk"/>
+    <property name="act30" value="set_variable route2choice:again"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
+    <property name="cond30" value="is variable_set route2choice:not_really"/>
    </properties>
   </object>
   <object id="93" name="spill the beans" type="event" x="48" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="npc_face misa,right"/>
-    <property name="act11" value="set_variable yahoo:maybe"/>
-    <property name="act2" value="translated_dialog spillit\n"/>
-    <property name="act22" value="npc_face misa,up"/>
-    <property name="act23" value="translated_dialog spillit3"/>
-    <property name="act231" value="npc_face misa,right"/>
-    <property name="act24" value="translated_dialog spillit4"/>
-    <property name="act25" value="npc_face misa,left"/>
-    <property name="act26" value="wait 1"/>
-    <property name="act27" value="translated_dialog spillit5"/>
-    <property name="act28" value="npc_face misa, down"/>
-    <property name="act29" value="wait 1"/>
-    <property name="act30" value="translated_dialog spillit6"/>
-    <property name="act31" value="npc_face misa,right"/>
-    <property name="act32" value="translated_dialog spillit7"/>
-    <property name="act33" value="npc_face misa,left"/>
-    <property name="act34" value="set_variable leavemealone:yes"/>
-    <property name="act35" value="wait 1"/>
-    <property name="act36" value="translated_dialog leavemealone"/>
-    <property name="act37" value="play_music music_the_wild_places"/>
-    <property name="act38" value="set_variable sadsong:no"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
-    <property name="cond3" value="not variable_set yahoo:maybe"/>
-    <property name="cond4" value="is variable_set route2choice:again"/>
-    <property name="cond5" value="not variable_set leavemealone:yes"/>
+    <property name="act010" value="npc_face misa,right"/>
+    <property name="act020" value="set_variable yahoo:maybe"/>
+    <property name="act030" value="translated_dialog spillit\n"/>
+    <property name="act040" value="npc_face misa,up"/>
+    <property name="act050" value="translated_dialog spillit3"/>
+    <property name="act060" value="npc_face misa,right"/>
+    <property name="act070" value="translated_dialog spillit4"/>
+    <property name="act080" value="npc_face misa,left"/>
+    <property name="act090" value="wait 1"/>
+    <property name="act100" value="translated_dialog spillit5"/>
+    <property name="act110" value="npc_face misa, down"/>
+    <property name="act120" value="wait 1"/>
+    <property name="act130" value="translated_dialog spillit6"/>
+    <property name="act140" value="npc_face misa,right"/>
+    <property name="act150" value="translated_dialog spillit7"/>
+    <property name="act160" value="npc_face misa,left"/>
+    <property name="act170" value="set_variable leavemealone:yes"/>
+    <property name="act180" value="wait 1"/>
+    <property name="act190" value="translated_dialog leavemealone"/>
+    <property name="act200" value="play_music music_the_wild_places"/>
+    <property name="act210" value="set_variable sadsong:no"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
+    <property name="cond30" value="not variable_set yahoo:maybe"/>
+    <property name="cond40" value="is variable_set route2choice:again"/>
+    <property name="cond50" value="not variable_set leavemealone:yes"/>
    </properties>
   </object>
   <object id="97" name="random battle" type="event" x="160" y="192" width="16" height="48">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="101" name="random battle2" type="event" x="128" y="176" width="32" height="48">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="102" name="random battle3" type="event" x="176" y="208" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="103" name="random battle4" type="event" x="112" y="192" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="104" name="random battle5" type="event" x="512" y="96" width="48" height="64">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="105" name="random battle6" type="event" x="528" y="80" width="32" height="16">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="106" name="random battle7" type="event" x="560" y="128" width="32" height="32">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="107" name="random battle8" type="event" x="512" y="32" width="48" height="16">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="108" name="random battle9" type="event" x="544" y="208" width="32" height="80">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="109" name="random battle10" type="event" x="560" y="192" width="32" height="16">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="111" name="random battle11" type="event" x="576" y="224" width="32" height="32">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="112" name="random battle12" type="event" x="256" y="160" width="32" height="48">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="113" name="random battle13" type="event" x="288" y="144" width="16" height="32">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="114" name="random battle14" type="event" x="336" y="192" width="16" height="32">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="115" name="random battle15" type="event" x="288" y="208" width="48" height="16">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="116" name="random battle16" type="event" x="352" y="224" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="117" name="random battle17" type="event" x="272" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="118" name="random battle18" type="event" x="224" y="176" width="32" height="16">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="119" name="random battle19" type="event" x="528" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="120" name="random battle20" type="event" x="608" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="121" name="random battle21" type="event" x="592" y="144" width="32" height="16">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="122" name="random battle22" type="event" x="464" y="176" width="96" height="16">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="123" name="random battle23" type="event" x="448" y="160" width="48" height="16">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="124" name="random battle24" type="event" x="32" y="112" width="32" height="48">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="125" name="random battle25" type="event" x="64" y="128" width="16" height="48">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="126" name="random battle26" type="event" x="80" y="144" width="16" height="32">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="127" name="random battle27" type="event" x="96" y="160" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="128" name="random battle28" type="event" x="16" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="129" name="random battle29" type="event" x="96" y="112" width="64" height="16">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="130" name="random battle30" type="event" x="128" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="131" name="random battle31" type="event" x="144" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="132" name="random battle32" type="event" x="528" y="256" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="133" name="random battle33" type="event" x="576" y="256" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter route2"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
+    <property name="act10" value="random_encounter route2"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_moved"/>
    </properties>
   </object>
   <object id="134" name="spilledthebeans" type="event" x="48" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="player_stop"/>
-    <property name="act2" value="wait 1"/>
-    <property name="act3" value="translated_dialog leavemealone"/>
-    <property name="act4" value="player_resume"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
-    <property name="cond4" value="is variable_set leavemealone:yes"/>
+    <property name="act10" value="player_stop"/>
+    <property name="act20" value="wait 1"/>
+    <property name="act30" value="translated_dialog leavemealone"/>
+    <property name="act40" value="player_resume"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond40" value="is variable_set leavemealone:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/route3.tmx
+++ b/mods/tuxemon/maps/route3.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="40" height="40" tilewidth="16" tileheight="16" nextobjectid="178">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="178">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -33,32 +33,32 @@
  <tileset firstgid="5215" name="Interiors 2 by Redshrike" tilewidth="16" tileheight="16" tilecount="28" columns="7">
   <image source="../gfx/tilesets/Interiors 2 by Redshrike.PNG" width="112" height="64"/>
  </tileset>
- <layer name="Layer 1" width="40" height="40">
+ <layer id="1" name="Layer 1" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJztmE0SgjAMhTmMB/YioBvK9cRFZzpvXn5LsQsXb6zSNh9Jk4DrsizbqdepdcLxLBx/vjn49lMlKFw7mi+rL9tx6pHka/eon60KsRXhyvLhPpaQj62L/l7l5WP2LXsaE/O7NLb4rLE1j8W9BG1k/Id8VuxaJskH0tmqZzTDp8V9V/hwHuZYe+8t3+a8N42P2fKszfBptcTDyuxpOcTmY/1jtSqTN5gTWoy1+LL8uJJPyw2Nr15j/vOc4yiftK/lPzx/2Pt7+FjvK2RvLaek/nuF/7x8LD/q97v4ClzHeimd8zv50HeePjCaj8XVqjG/5pN6dJQv2jOwbmb4MKdm9d8oPlZj0a+e/SJ8kVh79OeL8Um2NVaLD89PL5/Xtyjr+aqHj/U26z3Xy4dsWb6WzfMe7uGT7GX5DoNJ49sn5qu+H83X5hs+I+wdfNH81X5j6uXL1hTkYnG4yn9abZJUFvse2mt4Fq38QI3839Kz59M5Txu/O9Z6xh+2j19D
+   eAHtl0tOxEAMBecwHJiLDLABrkfeokTJanemMx9mwaLVjv38XDFBiPPpdHrbzvt2zk8YPyOT9/XPd933s7q/z+0b/Vo8/LzoXfnWj/BlzpGT9/rezst2Lp1rHe8XD7wSc5KDizrPsxst9yof3vTD093Ro3Vs/WqeXu8rcc6IbzSfHF65zeG4auoMa2vM99rxVT1c5Otz5eQ5ek566Kc+8+F3aGV/+OPrHdWZeTaTOa2teTz5Ro/w2R8OfDOPuPL5vXhXvHhGY778vKmjx3uUtyZxtPhGTw931TtPjRw+Mz5mpoc+fOjv8qm7Dz23++KJL3l0/v7YH5qjfGbDi5xvuGCJ1vrUzUcdzS34zIM/PDM+auZjf/ZEZ+a9mH505iKHb254rSNXv7/w4oEmHuQuieGjn7l4JE+t40Nb9wcf9fRfwmTNKp9neG7iR/GZmd1xh4/6X/KFgQMTu4P10XyZx0zYcpN7Rr4w3YLPHqsxu0ofveRmfNFQT9+9fz9W+XgX+m7Nh2+3K+9nFuNzCR/amZ9/Jui7G+3Mj95/vt+/ZdlJdsZucne7RNPtLz7eP96dH3l8fVcm1/Zi81kLm+eSi66L7UEvfLmZ5//NHLs/MXr//5F8vPGnp2NyHi0eZjNHF7s/8Yivm+d8F9s/74cu798xOe9+4vR6f3hS53a+i9HmvpYvM+Jzb77MyKx6eJduf3t8qfsb9PMonuXiU8+1fLw3jKP5zPAdPVp6XU8th9w1+8Nj5WY2jKNe18yXuOrr91frtZ/f+VG+9u49Z/bIx/nXTePnI/HH5jHjPuJp7h+2j19D
   </data>
  </layer>
- <layer name="Layer 2" width="40" height="40">
+ <layer id="2" name="Layer 2" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJztmEtSAjEQhht1gTLAgo13APQgysP323N4DI+ABwA36kJdqCdwSZUn0BVLl3Z0UjZdSaYnQ8KGv+qvTIVJ8lVPXg0AwCf6i5RavD5U6RpPabUEsFb6L8FSH6p0jTdvbVUBttEddBfdq/7V89jG1nta9pFnB72L3kPvp3w8tlJV0N2cTli7hPR3gDyH6CP0MfqkYPw2Pdq0Wbs2eT5FnjP0OfoCfWmJH4/LBjGt782YzyYav4rnuBKpcIzQTXQ9reuAey4o0fj5fDOp2infSDiOKbYh+XSsEjZOswaDZfRHFQa292PwUbnmEOelceR83wU51Jyrpa5nvGsT5WuS/qiL9K3nnG/flG+Y9nXL7Pvd1RxKCOPQYBu3dov0ZzsT+HxpLeVjdO0hI4G1Yq0PLRe76Qyke2ds3TUA7tEPjel6vg/GZByT50fkekI/Ez61/lu8EcT/zkovyPWKfiN8tvOZ803KoajckvLNSwu+aQ1yzpNF/OySnEEmvgks4idVHr6VHHcCidYFOa2J7xpk8bvKyeMjE1/IHE6J3qmz7qucLwab6byncuXHIdeFhI0z6Pu36bdZS/JfgYnBlb/NUj58N+V4fOpb8f9w+P2dMui76yz5fO6JWWsgZPzG2a/8jk/zWh++rD2rSC7P+Xg+TNe8LVeW7AtZfbjyb8oXSv2AfSv9ANU9h0k=
+   eAHtWEtS1UAUbZWBinkZOHEP8GAhkBf8ggquw2W4hOcCeEzUgTpQV+DQKlegI4YOOceXWxy60p1OkxeKKm7Vye3b93dyO5CAc879Af6KxvK/+PursmP96Lt3y7n7gGmLN3vVOtbPfFeldwrndoEKmAE1QLGzWlrjX382LffA5zHwBHgKPAModmZLK/26jtBZTzxAvObRNnkOPi+AfeAAeAlQcue3vUzvdZ0iWvNom7wCn9fAIXAEvAEo/vz0/jifLYHOq2ZyT5kiPsQvVErnR245fUO1dZ/jWAAbQNk4Kmi9Z13b2ev89N6aEoMpzo78iJQ+jPclJc/PSbVtVpyL9tmYuPkd4Hfh5lpL421f82xvFbqOFPX56hx9fv8idVJcBYImDcqUhJYY5cdn1+qpvkxtPm9Ebm3ld9zUOoFWbMPOkQpJfN6MI+v7CPG2+WxK43WsZy2oJYbLzdveRsQkx7aa3FPuC9ghWPncOVl+Xx3jbvfEezDhrEszRtYfHjr3EfgEqEzVwHpMjr+k92fw+gJ8FX4F/Pr8WfjY58y+38DrO/BD+PmzC/E7vWuecXUqv3FZnXe74Xc+C67mPZ+Tm/ldnJ9aKe+gtvmdoshV/H5R7rZu40ffdeS31uObwO4/ph/h/xRd0ja/d0hKmd/bruID+Nv48RurHqB2qEQBxySCUhJ9fmNwa3vfC6ULZ+fzSzlXrdVnzbl1cWM95VDB1u8/9TF2SPFnEartc9A83xeqkbOvfWL5yuE93oeap75YjRxfhaQtwL7bTev5sa5xsG/XIfnlfCdqf+XHNUX9xn3pufzVZhCrxP7HwAI4AXwOKfwK5E0SUSKuj/j8+PeP9tKfed9ncRrT1TtUw2r5mrV1fl31c/17uYmJeWfVPYdJ
   </data>
  </layer>
- <layer name="Layer 3" width="40" height="40">
+ <layer id="3" name="Layer 3" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJzNmM1OFEEQx5u9gB5MABefQwjhKTwQFI/c9sbBYIyJDwGEhDPiafe6ZG/CFVcexF2jkYUHsCp2haK2qrt6toP8k8p89Mz0r6uruns6hGk9mQvh6ZxS8Eg0Ahv/bwhFxJXzXzceew/AxEVcs/ivp5zXaAd+Q/rv40KFD1eU1a+98LB9WauuIfj3m7DvlX1usQ5ZfZdKnVh+BXYt7NZg9PaBN/Ynsb4bVhf315UoI53CvS/ifo5tNH93LnNUe++z0UcT5ieNjZ6xyrh2n4eTDtgOmFZeMkf8gfracFwBe+F7ZUqvxPU4+uxHPEpe3s+euFiPxw0nT5Mx9KfSz964TfHxuKTc0OKIj7E51fKfzGMZe9IPOW7vHOvl0/LVI4u76Rxbmy8nzq9pEew42lIDvk/LIUAu3lP3mZ8v5T9ke8+u+wm+SZwztPmtw/gkqxSWY5tIqfg7Y+dbYKsJPmLU8mOXMXUUvh2jnOdKN0yL8/XjkfjWQrMxmli5jzgTbwvPFU0pvlLGr8BzDnaxPF2GTFZMpuIvx0eMKw3M2y4ZfzyPNb43YJkQdynVLmLn8adJ46vJaIlyryT+9sK/8Y+EjNtOK20L8p3E/PfGH6ovruXYbUnGrIePlJo/JB/68B1jkmO3pRJfo72N75XEX04pvqbKxd9LsNfOb6FvPX3NJddSqWcsIeOHhEn+QfD5UltLadLKhgX/rzIGkE/musXnWUdr5bQW8TDKGBgEnw+RDef81PwQlHLJ6NkXoBjgnBZfyl+l+yd8vZTbFyDOzWirRv2pWLP4Spm9fV8iKxab7BF59wZK9dj3k1G/gO+3YJxln63Wnih9p92CNVZr9nq0/wEvC+mgpd8/atl1WJyl/J7n9xU/oQ4V7r8kkfdZ
+   eAHNmLluFEEQhhsSjgAJjOE5ACGeggBxhWRkBAgLIfEQgJCIDURLakQGpFwPgo1AXA9A/TDfqLZcPdO7O0JbUrm6ju7655+envGWsl+OHCjlqOm6yq4B21tDcOAa42/WYX/xn68BXOBcpr3HzBi7zHrM0RrgAue9w2TXw4IrohH2KTiI69b8qXp9MH7fB/04Mec1rPRWv3dJT+U/mf4I+tv8DGPrPWCP1bgl/rPr+8ssAmZxJmw+R80ziz93cxQfw7Z7iNmlsMfAmfH3NKzPbDCLswyb6lRTy7GO7K2TZfum6Q1TH2cMTvwh+916blrBKdPTQ4UDuYsht9dx9rmzES/8aVrGYViunO8CF2Ki4vv1KyX7wl+S+zy2N1hkCJ/flzwb3B9w0gefdWvW163CX3yO494DJ/jw6U8cH0tdDX+M1/jLntc4N/PpDz58LDizuVlsanxZDx8DZ+3eHrfiJ52eMLsovvsbpdjZMSezY3PuoDPEn7Btudk7Nq7h03mndwbvOZ4PTbfzrZeItU90A+V1TQj84Xv70jmXbXzWtIZPpbVz2860XjxWgh6zz8Od7IxiZz0+cScB3zkbL3NGg9Vz5DGRVy+4k81kCJ/qF8H4eqOUN6ZvTaMIU21PwmGcI38Mn2qEUe+7RbWVezhUL4l/jjN8V63GLndlGbousMOdbCYZPtVNhTHrqRjvdrhr2X93bJ7OP0QYrzXqonwL37adVRI4/OfN//X8KbMzny7x7A7p3uWZ7wMjA/hTGRz6fcf0iE8c3jblfbJFodmI3aX+7odWrlV3vZsMdy37z/fLxkP4svqWGNzV9t8ZW+RKy0JWI27h1e/Toemen71KITWVdBHGuwMa8b+y2hYutZ88P7Xfoaix8l70renf730iGcQ9KnzicoxD4ZOO8ZPl+RZpwRj3gPC1cChsM9PIj+JeYp4cGPlewmaY2QP+XtfuccYHPeEUf8z67yV+H6j9LqC1hPNSp/oWi6L+NT5UW8MXOY3reh9eMx593aJjYci4XQQbPYUx/n9GbhU7xO0q604596t9i34L36PLcAimVeb6NVhn86B9S5pGIR/jNV9nwzLi+zx0OHz8cRfPevg6378W9zV+3FL/wOHzcx+5OOv8ASSR91k=
   </data>
  </layer>
- <layer name="Above Player" width="40" height="40">
+ <layer id="4" name="Above Player" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJztz6ENACAMRUGGYD8c+4+ArWjAkJSEO/tFX1sDAIA7Rq8u2Juh79Ra/ctM7sembK/2YhMAAPCvBX+mA7U=
+   eAHt0LEJACAMBECHcD879x/BKpBCsFFicTaCCe9zrTkECBAgQIAAAQIE7giMfifnVcpM/U5dT/NXHSM3d4233Gk3j72q+8dOVRb+JUCAAAECBAgQIECgXmABf6YDtQ==
   </data>
  </layer>
- <layer name="Above Player" width="40" height="40">
+ <layer id="5" name="Above Player" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJztzrENgDAQBMGnBvdfBBAAJZmAGvgMAsfYEjPS6dKNAAAARjGXiCW3lt4lbVt27blj0D4AHjV3vh7g766pdwFfuwGy8QlG
+   eAHt0LENgEAMBEFTA/0XAQRASRBQA5fQAu9gXjp96NVUeQQIECBAgAABAgQIdBFY5qo127KOb0/XkZ1N+zqaaSJAgMAogSuH7+z7R3W4S4AAgS4Cz9SlRMdfAi+y8QlG
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collisions" visible="0">
+ <objectgroup color="#ff0000" id="6" name="Collisions" visible="0">
   <object id="6" type="collision" x="480" y="144">
    <polygon points="0,0 48,0 48,16 0,16"/>
   </object>
@@ -289,99 +289,99 @@
   <object id="175" type="collision" x="272" y="560" width="16" height="16"/>
   <object id="176" type="collision" x="112" y="464" width="112" height="16"/>
  </objectgroup>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="7" name="Events">
   <object id="111" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_the_wild_places"/>
-    <property name="cond1" value="not music_playing music_the_wild_places"/>
+    <property name="act10" value="play_music music_the_wild_places"/>
+    <property name="cond10" value="not music_playing music_the_wild_places"/>
    </properties>
   </object>
   <object id="153" name="Teleport to Leather Town" type="event" x="480" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport leather_town.tmx,30,0,0.3"/>
-    <property name="act2" value="player_face bottom"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing bottom"/>
+    <property name="act10" value="transition_teleport leather_town.tmx,30,0,0.3"/>
+    <property name="act20" value="player_face bottom"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing bottom"/>
    </properties>
   </object>
   <object id="154" name="Teleport to Leather Town" type="event" x="496" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport leather_town.tmx,31,0,0.3"/>
-    <property name="act2" value="player_face bottom"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing bottom"/>
+    <property name="act10" value="transition_teleport leather_town.tmx,31,0,0.3"/>
+    <property name="act20" value="player_face bottom"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing bottom"/>
    </properties>
   </object>
   <object id="155" name="Teleport to Leather Town" type="event" x="512" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport leather_town.tmx,32,0,0.3"/>
-    <property name="act2" value="player_face bottom"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing bottom"/>
+    <property name="act10" value="transition_teleport leather_town.tmx,32,0,0.3"/>
+    <property name="act20" value="player_face bottom"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing bottom"/>
    </properties>
   </object>
   <object id="156" name="Teleport to Leather Town" type="event" x="528" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport leather_town.tmx,33,0,0.3"/>
-    <property name="act2" value="player_face bottom"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing bottom"/>
+    <property name="act10" value="transition_teleport leather_town.tmx,33,0,0.3"/>
+    <property name="act20" value="player_face bottom"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing bottom"/>
    </properties>
   </object>
   <object id="157" name="Teleport to Leather Town" type="event" x="544" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport leather_town.tmx,34,0,0.3"/>
-    <property name="act2" value="player_face bottom"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing bottom"/>
+    <property name="act10" value="transition_teleport leather_town.tmx,34,0,0.3"/>
+    <property name="act20" value="player_face bottom"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing bottom"/>
    </properties>
   </object>
   <object id="161" name="Teleport to Wayfarer Inn" type="event" x="560" y="64" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport wayfarer_inn1.tmx,11,10,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport wayfarer_inn1.tmx,11,10,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="166" name="Teleport to Wayfarer Inn" type="event" x="544" y="464" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport wayfarer_inn1.tmx,11,10,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport wayfarer_inn1.tmx,11,10,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="167" name="Teleport to Wayfarer Inn" type="event" x="544" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport wayfarer_inn1.tmx,12,2,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport wayfarer_inn1.tmx,12,2,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="168" name="Teleport to Wayfarer Inn" type="event" x="528" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport wayfarer_inn1.tmx,11,2,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport wayfarer_inn1.tmx,11,2,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="169" name="Teleport to Route 4" type="event" x="528" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route4.tmx,13,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport route4.tmx,13,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="170" name="Teleport to Route 4" type="event" x="544" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route4.tmx,14,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport route4.tmx,14,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="177" name="Player Spawn" type="event" x="512" y="608" width="16" height="16"/>

--- a/mods/tuxemon/maps/route4.tmx
+++ b/mods/tuxemon/maps/route4.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="20" height="40" tilewidth="16" tileheight="16" nextobjectid="37">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="37">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -18,22 +18,22 @@
  <tileset firstgid="2353" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
   <image source="../gfx/tilesets/boxfont.png" width="208" height="192"/>
  </tileset>
- <layer name="Tile Layer 1" width="20" height="40">
+ <layer id="1" name="Tile Layer 1" width="20" height="40">
   <data encoding="base64" compression="zlib">
-   eJzt1VEOgCAIBmDXgeSGHReuUQ+52T8hMcvWfGCUyrcyUw4h0B585HhcpxDIeXsan2e+4fEDnhTqennrcu7LPXS8XuzgUbA9avwelofP+7Tnfd/Unns4DyUPs8A9rles6e2J09PWfU9P2w9GeDh/05vem95X/g/r3PB62jjc32o8rb/V40LITc86c0q51dPq3vSs+firh3OHdbHCixdBRnjHW47m1azbkXkDz3rMEg==
+   eAHtklEOwjAMQycOBDfkuOMaYGlPMiaZttEPJvFRmbbxqxM2T9N0e6150evyW3utR6ify6d6VzjoHp48o3nKTz6yH+1XfufdL+8z8ndybuzJwL7j+Rx4t9I1Hn3qjYqne88By99x3xae6t0Pk3dG83x+W/N538rn+47nPamGxTl9VTyd+b28+NC9PNV7v3DQ5Omcemn+TyN4cF3Jk7oln3O+nR/+1MzFPvPh032Vy+/lhYP+eZ/fXzVH5pV6tvkpv/pD+T5Ss0/22S8cNDns8aPVt6g7OCj+VDhrdbrDt1bHPJSJ+kqP8OTJxTtHecwOLvtOt37Pyet83Xm+P4JX/Q/8X12O7lz5zsBjblJlzn7VA32opuqXmk7l6Vbl6WrXzslY8ejtV/UJz3rMEg==
   </data>
  </layer>
- <layer name="Tile Layer 2" width="20" height="40">
+ <layer id="2" name="Tile Layer 2" width="20" height="40">
   <data encoding="base64" compression="zlib">
-   eJzNlj0OgkAQhRcS6fEWWnk072PjMcQ7qDV2UHkMIXGS57DzBxS8ZLKEhbffzgwbmjKl+xDNwpHUDtfvcvko+ZN6iFHn6SN/4v45cU+PJL66SGlfxP0kvsPgdQz4Wfmz+D4Cl8XXOfiQaY38Yc+skT9iaiF/j+H+8xevDF9dpXTZTWNf6Xzks5SP73Nr+eNCPk19kO9mePVBPostyufxi/Sf1ndz+LR9z8mftm+Nj3Ogj9QzGh/nIH/rvIrmb2vni5fvBLmV6nsFLs/54uk/4kI+SZH+80jj4/UgaXUgT+TznCPIQtHBHPLlvideA/Tgvkngw3p27Hlpz7n+y9WTrz/K+l+jfSPb5Jso8vPaiGz8TOH3PaO0Vq6mGNJ70lpSvXuDPZofZPfmzxpJufkvhGkbnw==
+   eAGl1k1u2zAQxXG1QLuPb9GserTcp5seo+4d2qyTXbPKMcJn+AcMpqIkwwSIecPh/Pn0Adnnz8vye8zznXG5jpfBeR3z3tj94ItvQ5hZe1KYxO5nbRte4tHBZ9//8GlZTmNi9vos57PXvw3W4w08vsTO2/P33hr4Elt54e/fKOzdv+qp6src81f38hQWXevR/B15HjyFRf8ZjL/X+Txi9/fwdVl+fPl/nsY6T2HRA3EZOPf6w8PBPXK9PK3569wjvHDyTQmXxhGrP2trMeeFk29KWHTf67p/9ULJw8rkKSy6bLtI/vp6zfF4Couu+6L56+s1x+MpLHr2/m29d3g8hUXXc6P527puPJ7CojsPB7fXk+PxFBatX1/lpG9t4PEUFl3704u/970Kk6ew6H4+Pg+9XnOewqJnzxdv6znzFBZdz4ve8/d9/LZk5DyewqJT+zmm+ybyl3ofajyFRdvLl5ie2cDjKSx61rO1jsdTWHR/HjhbzyF7wuQpLPdJ/yzyIua9NHgK131SS9RjTe7dlidmrPnjM3tqX/bPrjm/d/33jT+xnu38MPf+r2VPrjv/oXgTMeW3xPyH4k3MWWHKb4mzszF57XHWNzs7PAMrOT3rW7t/s7Ot48prXLt/s7Ot8y2v8QOEaRuf
   </data>
  </layer>
- <layer name="Tile Layer 1" width="20" height="40">
+ <layer id="3" name="Tile Layer 1" width="20" height="40">
   <data encoding="base64" compression="zlib">
-   eJztzEENACAMBLCbBHAB/gUyEUv4tAKaAAD8sSrZNfedvu7gB8x71TMAew==
+   eAFjYBgFoyEwGgKjITAaAqMhMBoCoyEwMCEgyMjAIATE1AKaQLO0qGgetdw1as5oCIyGACIEANUzAHs=
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collision">
+ <objectgroup color="#ff0000" id="4" name="Collision">
   <object id="1" type="collision" x="0" y="0" width="32" height="640"/>
   <object id="2" type="collision" x="272" y="112" width="48" height="416"/>
   <object id="3" type="collision" x="32" y="0" width="288" height="32"/>
@@ -62,43 +62,43 @@
   <object id="27" type="collision" x="288" y="32" width="32" height="16"/>
   <object id="28" type="collision" x="128" y="304" width="32" height="32"/>
  </objectgroup>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="5" name="Events">
   <object id="30" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_the_wild_places"/>
-    <property name="cond1" value="not music_playing music_the_wild_places"/>
+    <property name="act10" value="play_music music_the_wild_places"/>
+    <property name="cond10" value="not music_playing music_the_wild_places"/>
    </properties>
   </object>
   <object id="31" name="Teleport to Route 3" type="event" x="208" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route3.tmx,33,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route3.tmx,33,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="32" name="Teleport to Route 3" type="event" x="224" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route3.tmx,34,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport route3.tmx,34,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="33" name="Teleport to Flower City" type="event" x="304" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport flower_city.tmx,0,4,0.3"/>
-    <property name="act2" value="player_face right"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="transition_teleport flower_city.tmx,0,4,0.3"/>
+    <property name="act20" value="player_face right"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="35" name="Teleport to Flower City" type="event" x="304" y="64" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport flower_city.tmx,0,5,0.3"/>
-    <property name="act2" value="player_face right"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="transition_teleport flower_city.tmx,0,5,0.3"/>
+    <property name="act20" value="player_face right"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="36" name="Player Spawn" type="event" x="272" y="48" width="16" height="16"/>

--- a/mods/tuxemon/maps/route5.tmx
+++ b/mods/tuxemon/maps/route5.tmx
@@ -1,61 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="40" height="20" tilewidth="16" tileheight="16" nextobjectid="20">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="20">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
  <tileset firstgid="1" name="PastTheFuture_Grass_Sand_Snow" tilewidth="16" tileheight="16" tilecount="360" columns="24">
   <image source="../gfx/tilesets/PastTheFuture_Grass_Sand_Snow.png" width="384" height="240"/>
  </tileset>
- <tileset firstgid="361" name="KelvinShadewing_Buildings" tilewidth="16" tileheight="16" tilecount="500" columns="20">
-  <image source="../gfx/tilesets/KelvinShadewing_Buildings.png" width="320" height="400"/>
+ <tileset firstgid="361" name="KelvinShadewing_Buildings" tilewidth="16" tileheight="16" tilecount="680" columns="20">
+  <image source="../gfx/tilesets/KelvinShadewing_Buildings.png" width="320" height="544"/>
  </tileset>
- <tileset firstgid="861" name="Tileset" tilewidth="16" tileheight="16" tilecount="1120" columns="28">
+ <tileset firstgid="1041" name="Tileset" tilewidth="16" tileheight="16" tilecount="1120" columns="28">
   <image source="../gfx/tilesets/Tileset.png" width="448" height="640"/>
  </tileset>
- <tileset firstgid="1981" name="Sand_n_water" tilewidth="16" tileheight="16" tilecount="104" columns="8">
+ <tileset firstgid="2161" name="Sand_n_water" tilewidth="16" tileheight="16" tilecount="104" columns="8">
   <image source="../gfx/tilesets/Sand_n_water.png" width="128" height="208"/>
  </tileset>
- <tileset firstgid="2085" name="crate opening" tilewidth="16" tileheight="16" tilecount="1" columns="1">
+ <tileset firstgid="2265" name="crate opening" tilewidth="16" tileheight="16" tilecount="1" columns="1">
   <image source="../gfx/tilesets/crate opening.gif" width="16" height="16"/>
  </tileset>
- <tileset firstgid="2086" name="YELLOW BRICK ROAD EXPANDED" tilewidth="16" tileheight="16" tilecount="48" columns="8">
+ <tileset firstgid="2266" name="YELLOW BRICK ROAD EXPANDED" tilewidth="16" tileheight="16" tilecount="48" columns="8">
   <image source="../gfx/tilesets/YELLOW BRICK ROAD EXPANDED.png" width="128" height="96"/>
  </tileset>
- <tileset firstgid="2134" name="Outdoor_Tiles_-_City_and_Country_-_by_ArMM1998" tilewidth="16" tileheight="16" tilecount="1440" columns="40">
+ <tileset firstgid="2314" name="Outdoor_Tiles_-_City_and_Country_-_by_ArMM1998" tilewidth="16" tileheight="16" tilecount="1440" columns="40">
   <image source="../gfx/tilesets/Outdoor_Tiles_-_City_and_Country_-_by_ArMM1998.png" width="640" height="576"/>
  </tileset>
- <tileset firstgid="3574" name="Terrain_by_George" tilewidth="16" tileheight="16" tilecount="360" columns="15">
+ <tileset firstgid="3754" name="Terrain_by_George" tilewidth="16" tileheight="16" tilecount="360" columns="15">
   <image source="../gfx/tilesets/Terrain_by_George.png" width="240" height="384"/>
  </tileset>
- <tileset firstgid="3934" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
+ <tileset firstgid="4114" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
   <image source="../gfx/tilesets/boxfont.png" width="208" height="192"/>
  </tileset>
- <layer name="Tile Layer 1" width="40" height="20">
+ <layer id="1" name="Tile Layer 1" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eJyrY2BgqAfiukGI69HowYZH3TfqvlH3jbpv1H0D7xZS3WfFjYoHm/sGAx51H3Xchw4G2l1DLfxG3Td83QcAm2qHGw==
+   eAHtljEKgEAMBNP75/PHvsGzGIjdpshyRYQwgsntEK5wRcS9ax1YeMHTHPGC41e7R+wNzv5mf847wL2DzmwlCy+ozDh78ILObCULL5hnnisiV/7mescLunLVHLygOufqwwu6ctUcvPav1e9R57v78IPdedXz8YLV+e5+vGB3XvV8vGB1vrv/83oBGfqJ6w==
   </data>
  </layer>
- <layer name="Long Grass" width="40" height="20">
+ <layer id="2" name="Long Grass" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eJztltsKwCAMQ/1t9/W+Dok2DbUiNNCHXYgnbQdrrRSp73IxfGyODryV8/5eLJ+Vkb2/81LzvMI3z4/1QJ6Z/fPuO/stRPOt+qvM9wSf2r8OnrHKnq+6f2wWa95eD8/7u2vkndW/4tP5LN5ozbvr4blR3jynC/0DleI0AGvEu7w=
+   eAHtktsKwzAMQ/vb29evGhwQnuM4dG1fauh8k2U5bNse++cLvHeyO7/ZLdLWMeFe++e3aM7zDhd4uMRRGZzMZV7z3foIO9pTaYMLn2kY8Y7qFVfWU60y38ObR53VfNaL8+TCEuOzea8JJwN/1Fdc30X2w24r/YRgOrpG7+uzWuC5x94jlq9M8zLnORJnXNzlPcUdu0If90oPMX6mEX0zXMbNu7Crw+XYVXzU4LnHcYfnFS7rqVZZxa05+h5Ty3yFy3qqVeY7hBvlsec4jytc1lNtxeKuldkOFn7+u7MZ8Hf5rj7uOVtn3DPT9/TXXuADa8S7vA==
   </data>
  </layer>
- <layer name="Path" width="40" height="20">
+ <layer id="3" name="Path" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eJztVcENwjAMzDsBpkHMgJgBOgOwQjsEYgW6QdmmDEKrYimYi+1E8EE9KWrj1Bc7vrjOzfgmFsG5pWGsAvaL7RYuzmNB7527++n5GEbH5uP7hvGuw6edbBIX59FAnPXwPIDRhGkPFB+3kw1xNSAfa3xo/3h9zPvG6tQCO9kQl7aPFJ907sSLataBGqZiQHlatDj69UJ8+0TdU1pI1RDlaTlLpPNSSDWMdT7mcQKa2fk8zpL4LPpLaeaciA/pv6R30b6IK747Kc1chfOTehbNtTPW+l9JnSiX5nVP6vCuddKLhfsX/Y/nTv5cL5b7ZtWfhK3H2mqZf6xLWtP0Sd9p+pNwNP4fc3SZM9fiu3i5x1Yv/5y+nDMqJb4Z/40nNMitOg==
+   eAHtlc1NRDEMhHMGDkANLC1AEYgWoAPoZikHqAZRA0J4xH7akWXnPQE3NlI2jmOPfzJ5O8Zh/GUHno/HeFkxX8PGB36uRzfDc3vHm8nbiP0YU+tTzIe019l7TB9vOxvXo5thub3jdTKYVydjnBXzOnTKN+PKL+vRVVjCqers8kIPZo7v5+rpXeD7vd3HPuvRVVhLcYiXV/kpToUpW3CrO1P/Mh9yT4lHHK9zDRflJ951+Z1Gn6p7r3SzO6zq7GJSE/35CS8cA5kcqrg6UxxxU3VsQvZeijufRyDt1xnm3mqdJKyOKx4HOXPmMvzzADPX4m8BeYkvxK2w/O10nLlt8hOncy3Vvro3r1f5ya/yFce7t+MYWaYWcUIYfLvgOnxZg03/wPA3BN5SjTk/9tSOP7G0l9zxCn+tMzvHc58sf8QbgU++ih/eI2KJS5y5fSVjt8S/nJPvL6IXHT+8R9Q7s13LW/9f5348J5dvIj/nRZbPo18a8DKf/3YP/neUw+9/68AXqDvJSw==
   </data>
  </layer>
- <layer name="Gravestones" width="40" height="20">
+ <layer id="4" name="Gravestones" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eJzNlkEOwiAQRf+KpPE63kDvUK0n0K2LHqOLnoLewp5MFhDHKZQCVeYlEyasfn8/DDOAl6lZ0ArSa1OT3WsVcKlcN/XRpJnmp0IWpwY4N8t+K1RDr779dDonq+94SNd3N3oezbLPobceOU30v+f6tydOny9/UvTtnb8UqB8+Yvn7NdSPkD5Abv4Go+Gq5OaP8+/8xWitf8630vyF8h47ByH4/VKav1DeY+eAQr+F3y8S8rc231zfmf1RQP74/bKF3CzlEJpvnX3b+EjJUim151uMtfk2CHifujPgm2+a6a21gmh6AyIurqM=
+   eAHNlsGNAjEMRX1D7ABbAVw5UAYHaoUuoJrtAI74a3jIsoIiYLSJpcSJ47F/fpxoLmZ29nbpSDuUJ6ajj08yuAwzs0Xj9uv5wSQNd8K39bVP5Do3u3mTxPFoqfcRw84xMJcWd+AVvr+hHi97rH/MNt4kcTxa3uuFTwKmWHef8jdGnKYHHxyCU9F7wQcmaXD+Fz5yK19JavVX+mZKW+SjFJfzZR+91d/e78cy3GFwai891F/mNPLdA77hwR+85fcv46/NiZP9XtmzX55Tf/D2bf0RJ+d5Zc9+mse9CB9zacbya3W+cS/Cx1ya8crtB2+thfONvNUwveNbi1VbBx+8kVv86d+mJPiW1qa25fqLuVvVX9xjrr/4vujtbv1/yh3gXOP7gq21Fp+c6x0jkJMZ
   </data>
  </layer>
- <layer name="Tile Layer 8" width="40" height="20">
+ <layer id="5" name="Tile Layer 8" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eJztzrEJAAAIwDD//0Sv1A8cBUmgeyPY5FTXEwAA8EADFY0BVA==
+   eAHt0DEBAAAIAkH6N9GU2oACx8pPl1gTmA+2RX4CBAgQIECAAAECBKrAARWNAVQ=
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collisions">
+ <objectgroup color="#ff0000" id="6" name="Collisions">
   <object id="3" type="collision" x="0" y="0" width="32" height="240"/>
   <object id="4" type="collision" x="32" y="0" width="608" height="32"/>
   <object id="5" type="collision" x="576" y="32" width="64" height="112"/>
@@ -71,27 +71,27 @@
   <object id="16" type="collision" x="528" y="192" width="32" height="32"/>
   <object id="17" type="collision" x="144" y="240" width="32" height="32"/>
  </objectgroup>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="7" name="Events">
   <object id="1" name="Teleport to Flower City" type="event" x="0" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport flower_city.tmx,39,15,0.3"/>
-    <property name="act2" value="player_face left"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
+    <property name="act10" value="transition_teleport flower_city.tmx,39,15,0.3"/>
+    <property name="act20" value="player_face left"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
    </properties>
   </object>
   <object id="2" name="Teleport to Timber Town" type="event" x="624" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport timber_town.tmx,0,29,0.3"/>
-    <property name="act2" value="player_face right"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="transition_teleport timber_town.tmx,0,29,0.3"/>
+    <property name="act20" value="player_face right"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="18" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_the_wild_places"/>
-    <property name="cond1" value="not music_playing music_the_wild_places"/>
+    <property name="act10" value="play_music music_the_wild_places"/>
+    <property name="cond10" value="not music_playing music_the_wild_places"/>
    </properties>
   </object>
   <object id="19" name="Player Spawn" type="event" x="32" y="240" width="16" height="16"/>

--- a/mods/tuxemon/maps/route6.tmx
+++ b/mods/tuxemon/maps/route6.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="40" height="20" tilewidth="16" tileheight="16" nextobjectid="71">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="5" nextobjectid="71">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -18,122 +18,122 @@
  <tileset firstgid="2925" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
   <image source="../gfx/tilesets/boxfont.png" width="208" height="192"/>
  </tileset>
- <layer name="Tile Layer 1" width="40" height="20">
+ <layer id="1" name="Tile Layer 1" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eJztlVEKwjAMhtNnnV5y4kHsvIi+bj55DPUgol7BgBZCpDZNap3gwwfpGNvXn7TpAWBAdkiPrBD/pEMuyBW5kXeGijVf//3K+jUOYIbM3fj81kgrYGH0OCDHCO/8pHRGv9BDnH0hP2nOIeuY3xkevUThfhtkK2Cp2EfImvvRHk/1H69Db5zYc03OuVm3Ar/Y/SLN2ZK1N/jl1NqsveD7Jfxysuak7sQa84P2eOp80HUtP/qP3PP7K34TF59BVqbO7lcDjV/jXmfOp9DMj2/XY/GI1Xel6QE5
+   eAHtVltuwkAMXL4L7SWpOAiUi5Rf6BfHCBwEJbkCM1ItWaMN3qzYio9+jOJN/BiPncAxpXQCfoAjsAV2v/jCtQcGYATMx/u3tsnJ1/jnN28OkX6rRUrvwAfwavPdY/brAnzCR/v0OxPZHeIvE9C8fv/sPYmufI80T8TJ+/eIHzI4Z/LW8CvVmbOg1ronxu+GZ9wlD98H7W/gUIANfCJdc8+ptfLzO6589Kxz6ZCPu3GVvDU6k+8crdfwj/j18OFujIDvu1TnA+JqtWY/tfw818iu1Zr8dJ5aa0o/9XvU5xytqbdHro6v9Qx+kQYdONmO+9q0H53JvQdy+5frK+Khtczf11AfPVuM3fexz+Rk+VUDf5+2nqf4veG7eYF/CyyRe0DuMcOnlB/jW6OGn33b/W9OK5v/kVQvPZ+gU6s9q6lVE/OXPdwBpekBOQ==
   </data>
  </layer>
- <layer name="Obstacles" width="40" height="20">
+ <layer id="2" name="Obstacles" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eJy9VlEKwjAMfToYOO/kdbyV+u0BPIJ6Dv3SD/UIBqQQQtK06eqD0IV13ctr2gQAVgtgInvQ85PstgTuZDmkudKXa9X61gg2dxqA9ZDn1crD8q1R6mEhzff8I35WOp/HzkfJX2I3Anuyw+hzT2sdhdXGzkeLV8KZeF3IrgX8pHZe7CWQORjlp2mn7V0tJkfDUn6eRvL9xrkfEry4avY3ilyOe3G/6Js32acjP08DTcNTo/48D1v5tZwv7QzI+8XjmOMXPVfaGtb9wjlq/9P4WXUmAktDzjd3F2o57tWdKKx6H1mf17dabJ3zI2tVBLy+zZGHcyDFPYf+PRHtr/4Jrb+y+mKtn0VnX8u/0r62dx+d/C+WJbB/
+   eAG9lNFtQjEMRU2RkAo7sQ5b0X53gI4AnaP9Kh/QEWp/HMmyEjt5LUSKHDu+NydPARGR55XIVue3ri86P59EvnRmg156yKPXbI5PjHYOXtu1yE5na6Cj979zfGPknBaTr6Gj1svftMFmb7+lh8FH1tEH/XEj8qLzVWc18IKNSL3Sw+Aj6572pFxnnR8DfHhFLuq9M7L6RTez+43y4QGbRc/FfsbS2rPfrfeJPaN8mYd5xv198f8AR3WvUT78lsTsjcd7Rf+rvrubzp+B9xe1o3n1DVrf8P2P39+/w4qz4qu+YebvtdzTs7HOPDI+PDN9tYcHrDBRJzcfat6zxUcfnuReN7rGw/rxMSbqtqZOzXoZrTce+2KOdjbiAw+R+oyfadHP6Kz3UPx+4CHO+lu/adEv5Vxybqbh3vAQ4cy0j9yDhwjnIxmqs4wJrh4n+zHiTf0euTFFrl5OnQjXvfNfliWwfw==
   </data>
  </layer>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="3" name="Events">
   <object id="1" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_the_wild_places"/>
-    <property name="cond1" value="not music_playing music_the_wild_places"/>
+    <property name="act10" value="play_music music_the_wild_places"/>
+    <property name="cond10" value="not music_playing music_the_wild_places"/>
    </properties>
   </object>
   <object id="56" name="Teleport to Tunnel" type="event" x="624" y="64" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport tunnel.tmx,0,4,0.3"/>
-    <property name="act2" value="player_face right"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="transition_teleport tunnel.tmx,0,4,0.3"/>
+    <property name="act20" value="player_face right"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="57" name="Teleport to Tunnel" type="event" x="624" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport tunnel.tmx,0,5,0.3"/>
-    <property name="act2" value="player_face right"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="transition_teleport tunnel.tmx,0,5,0.3"/>
+    <property name="act20" value="player_face right"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="58" name="Teleport to Tunnel" type="event" x="624" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport tunnel.tmx,0,6,0.3"/>
-    <property name="act2" value="player_face right"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="transition_teleport tunnel.tmx,0,6,0.3"/>
+    <property name="act20" value="player_face right"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="59" name="Teleport to Tunnel" type="event" x="624" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport tunnel.tmx,0,7,0.3"/>
-    <property name="act2" value="player_face right"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="transition_teleport tunnel.tmx,0,7,0.3"/>
+    <property name="act20" value="player_face right"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="60" name="Teleport to Tunnel" type="event" x="624" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport tunnel.tmx,0,8,0.3"/>
-    <property name="act2" value="player_face right"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="transition_teleport tunnel.tmx,0,8,0.3"/>
+    <property name="act20" value="player_face right"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="61" name="Teleport to Candy Town" type="event" x="112" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport candy_town.tmx,7,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport candy_town.tmx,7,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="63" name="Teleport to Candy Town" type="event" x="128" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport candy_town.tmx,8,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport candy_town.tmx,8,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="64" name="Teleport to Candy Town" type="event" x="144" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport candy_town.tmx,9,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport candy_town.tmx,9,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="65" name="Teleport to Candy Town" type="event" x="160" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport candy_town.tmx,10,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport candy_town.tmx,10,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="66" name="Teleport to Candy Town" type="event" x="176" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport candy_town.tmx,11,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport candy_town.tmx,11,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="67" name="Teleport to Candy Town" type="event" x="192" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport candy_town.tmx,12,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport candy_town.tmx,12,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="68" name="Teleport to Candy Town" type="event" x="208" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport candy_town.tmx,13,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport candy_town.tmx,13,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="70" name="Player Spawn" type="event" x="144" y="32" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ff0000" name="Collision">
+ <objectgroup color="#ff0000" id="4" name="Collision">
   <object id="2" type="collision" x="0" y="304" width="640" height="16"/>
   <object id="3" type="collision" x="560" y="0" width="80" height="64"/>
   <object id="4" type="collision" x="624" y="176" width="16" height="128"/>

--- a/mods/tuxemon/maps/routea.tmx
+++ b/mods/tuxemon/maps/routea.tmx
@@ -1,85 +1,85 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="20" height="40" tilewidth="16" tileheight="16" nextobjectid="56">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="56">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
  <tileset firstgid="1" name="PastTheFuture_Grass_Sand_Snow" tilewidth="16" tileheight="16" tilecount="360" columns="24">
   <image source="../gfx/tilesets/PastTheFuture_Grass_Sand_Snow.png" width="384" height="240"/>
  </tileset>
- <tileset firstgid="361" name="KelvinShadewing_Buildings" tilewidth="16" tileheight="16" tilecount="500" columns="20">
-  <image source="../gfx/tilesets/KelvinShadewing_Buildings.png" width="320" height="400"/>
+ <tileset firstgid="361" name="KelvinShadewing_Buildings" tilewidth="16" tileheight="16" tilecount="680" columns="20">
+  <image source="../gfx/tilesets/KelvinShadewing_Buildings.png" width="320" height="544"/>
  </tileset>
- <tileset firstgid="861" name="Sand_n_water" tilewidth="16" tileheight="16" tilecount="104" columns="8">
+ <tileset firstgid="1041" name="Sand_n_water" tilewidth="16" tileheight="16" tilecount="104" columns="8">
   <image source="../gfx/tilesets/Sand_n_water.png" width="128" height="208"/>
  </tileset>
- <tileset firstgid="965" name="Outdoor_Tiles_-_City_and_Country_-_by_ArMM1998" tilewidth="16" tileheight="16" tilecount="1440" columns="40">
+ <tileset firstgid="1145" name="Outdoor_Tiles_-_City_and_Country_-_by_ArMM1998" tilewidth="16" tileheight="16" tilecount="1440" columns="40">
   <image source="../gfx/tilesets/Outdoor_Tiles_-_City_and_Country_-_by_ArMM1998.png" width="640" height="576"/>
  </tileset>
- <tileset firstgid="2405" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
+ <tileset firstgid="2585" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
   <image source="../gfx/tilesets/boxfont.png" width="208" height="192"/>
  </tileset>
- <layer name="Layer 1" width="20" height="40">
+ <layer id="1" name="Layer 1" width="20" height="40">
   <data encoding="base64" compression="zlib">
-   eJyrY2BgqAfiulF6lB6lB4xm4WBgYOWgzJwNzAwMG6FYB2iWLgeCv4mZdPN2APXshOJdzJj8UfPoa94BoJ6DUHyIGZM/GNLxKD1Kj9Kj9Cg9ShNDAwAUbZbx
+   eAGrY2BgqAfiulF6NBxG08GA5YMdHAwMO4GYknyYwsLAkArFD4BmPQRiGD8NKE5qPs8B6smF4jwgjc4fNQ9/fKGHFzqf1PArAcZBKRSXAWl0PqnmjarHH3+j4TMaPpSUx6PpZzT9jKYf/O0OAGE8ie8=
   </data>
  </layer>
- <layer name="Layer 2" width="20" height="40">
+ <layer id="2" name="Layer 2" width="20" height="40">
   <data encoding="base64" compression="zlib">
-   eJzFlr9OAkEQxjfhIPcSKL3Q+wgqpdppqfbS4Z9YaI+K0aidf97BUioLRXv1NYyls2FHPiczsCsX/ZIv4djZ393uzM6dc/+nhYpzTXK/7Nyz8Es5nXdBrEvyhzL3U/nvteTcm+F38iaxWgm8UuZcZrhMXiGvZgNe2/30b3j75ANytVIMz4tzUhSPc9IOc/6SN0Nz6oYbgicleccUv0heMrycyPPaojnbwVlOa8yH1zvk3WxYgzG8K4q/Dq4Tq5EPr2/It1CDMTyvx0z3E7kPNWjxZnXst+5KA/M6uf40Xg7XVhzzeDw2H9Y+y+dLyW+MUvI7iVJ4ewXzYlQUT+sHWv/W1BV1jL3Q4p3CmfLx58E8jxk+DmtH43EsnylfG73gVuBhvYzjYa+0fAJrZvZZJK9Dcw/BR2L/sNdoPKv2LWGvkTx+JinMCeaGx5rG/nWMdfk9uIe89BLyweoKHr7PvB7E2CiefF9rPHmvUTzOCfLmYd+w1ufG8DgW603WtKx1vrfG41iuWyvnqHH9gMdxHyfhsXgf5RnhelqjmPXgjQiepZrxP/Km6DmmI4zf3P6bHMdqCeeUVa3ov1FfGxfNPQ==
+   eAHFlrlOA0EMhqcAEjp4AyooOarQcwoJ6Dh6oKKEgioEeqDjGRA9yRvQcvQk78H1/2H/YFkzZDZCYMnZGY/97YztzW4I/yfvIyF8QBvQM6fnmJeVjUoIm9CbSOxtxHYxFMJlQq9gnwRrqgTvDjHNhLZgHxsOYRzK/Z3gcFZj++vHq4E1D334JR7zrZrYvXE8yP7IU03IoIj7F7wX5Lyd0A7sFO3va/b96/e3jDxXoNWEjsJOyeXRdxoxM4U2qyG0oJrPwj4HVQ/S34rfH9e24L9daBusDlTzHdh3oepBy+I4xqO9jpiYnsLegKoH6WtFvJo1RsaHqANV51T/eVfycJyepPzE03puPXT/3g2KgXhaz+V5Tmourl9X/rx90HkZXj3jJmV4Gbhk/+XEWp/Y/0vsfWBjNF5BP1tRD/n/P8tbQ4yeKfqv431B5XuNcWLQz/aOzZ948tUzxd44LpTvIfJsv/TjaV05iV1XzZnFvsZ9YvvzvAXELhpdMizmUXnhOMbT/bieI8oLfT1PZ/McWxNbG/op3xx7nj2bPRdzcGTqwvqwNhTlh2PPo01i+0wx3L/kvhhojdMUT2fQ+RVjeeJq7SeeamJ5b0Vfs6dVU973FcrvrRRPvmLxSr7tadVUdvV57LzyJYd9K253A4kf+cR4DNG6zWMC1TXLP8VTrPJo+0jPCvtpD477hR7g2o8nrr9OeEMxt7xH1OkpQ+03N7/Jbcwz5mWF36USO5aN109tus6W
   </data>
  </layer>
- <layer name="Layer 3" width="20" height="40">
+ <layer id="3" name="Layer 3" width="20" height="40">
   <data encoding="base64" compression="zlib">
-   eJztkrkNgDAQBE+ykUwJPB0A1QDV8DTD0wxPA0AvbEB0oQ8ibqQJd2TLJvqWwxCdzMv494wlsszA+vcybHNmIeiV2FbMWtBrsG2ZHew9mwN2I3OCs2dvwW5lbnAX3PmPWId/7N7r5WgVwt7yvGEUEsUwgWkoP5uiKIqiKP/mBq0JGEg=
+   eAHtkbERwjAQBC8wg1QNtpuxoRlsN2CoxlIRBjpA6oRT+uELAmb+Zjb44C7YB36btQFugjtvbTZ2gyBW7L3ZTYJcsXc8AE7geWtzYrcVdLx75ebA3ig4874o967sTYKZ96Lc03r6915wQCTfSuJWrtwrvy3ZPfAgT/IiFjNgBsyAGTADZsAM1Bj4AOqhHGI=
   </data>
  </layer>
- <layer name="Above Player" width="20" height="40">
+ <layer id="4" name="Above Player" width="20" height="40">
   <data encoding="base64" compression="zlib">
-   eJxjYBh54BwrA4MbG/XM+8ZKPbOwmafHgp1NrnlhQDOWcjAwLOOAsCk1DwTOAs06x4Ff31cc4YTNvK9As74RMO8HCeYRA4g1byHQXYuAeDEQL8HjRmLMYwbqP4lkxhkOiBi55mkD9X5E0v+FAyJGqnlewPzhjSePYJPHZ14RUG0xiXluoOKXGua1AXE7iebiMy8OiOOHgHmuwDiWJxIr4EgPIPPWAfF6Kpero2AUjIJRMAoGDwAAwjM1Xg==
+   eAHtlE0KwjAUhGfh/1LvoHfQc/i71HMI2rsItrj3ILoXvIUu1HmL0lCSZwJFKGZg6OOl+ZjOosD/KWkBT7oqZRWyJFOZd28USc252OpTmddrAssusKJlDlWZJ/f3ZCW0ptTRk42XkpV94Z0CeFqu/MyXN2WuGT2nF0pGH965A2wNxo6z7Gzy4d1492DwjpxlZ5PGe7Hbt6NfYdnONd6wDYzoEGm8EE7+7i95Y3Y3UfrLM5lPLV+frEENeA9mvHj66vge+R+s6Y3j3OwszrGB2EBsIDZQzwY+xsEz9g==
   </data>
  </layer>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="5" name="Events">
   <object id="44" name="Teleport to Flower City" type="event" x="192" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport flower_city.tmx,11,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport flower_city.tmx,11,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="45" name="Teleport to Flower City" type="event" x="208" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport flower_city.tmx,12,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport flower_city.tmx,12,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="46" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_the_wild_places"/>
-    <property name="cond1" value="not music_playing music_the_wild_places"/>
+    <property name="act10" value="play_music music_the_wild_places"/>
+    <property name="cond10" value="not music_playing music_the_wild_places"/>
    </properties>
   </object>
   <object id="52" name="Teleport to Mansion" type="event" x="112" y="192" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport mansion.tmx,10,17,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport mansion.tmx,10,17,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="53" name="Teleport to Mansion" type="event" x="96" y="192" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport mansion.tmx,10,17,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport mansion.tmx,10,17,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="55" name="Player Spawn" type="event" x="208" y="608" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ff0000" name="Collisions">
+ <objectgroup color="#ff0000" id="6" name="Collisions">
   <object id="2" type="collision" x="128" y="208" width="32" height="80"/>
   <object id="3" type="collision" x="64" y="208" width="32" height="80"/>
   <object id="5" type="collision" x="128" y="448" width="32" height="96"/>

--- a/mods/tuxemon/maps/routec.tmx
+++ b/mods/tuxemon/maps/routec.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="40" height="20" tilewidth="16" tileheight="16" nextobjectid="151">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="151">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -64,17 +64,17 @@
  <tileset firstgid="5981" name="Set_Pieces_by_Kelvin_Shadewing" tilewidth="16" tileheight="16" tilecount="1440" columns="45">
   <image source="../gfx/tilesets/Set_Pieces_by_Kelvin_Shadewing.png" width="720" height="512"/>
  </tileset>
- <layer name="Tile Layer 1" width="40" height="20">
+ <layer id="1" name="Tile Layer 1" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eJzlldENgCAMRJ0AthJ1EBEnYANnUZeURkmM0aI0UBJJ7kMN9tFeqRVVZZ1gLQIXLCt4NMh7nvPzKPn4jIutnJoLZ32852TD8tgjXK371n3g1vL7nqc8qkDeIM4cUXN/fgpjSJ4Nyy12/lBdqDJET5pjr07IePdvqrdSKtaPuWQI9c6hlF76o8CPU8H94u9h6JkQI0ffA9/b2c3RW7ljluwnYFvFrj7xXIqtFbDVBd/BXPNhAxH9oBE=
+   eAHdlYkNwjAMRTsBbMU1CNcE3YBZgCXxk/hSZJrSpDSJQLJSEh/f33bSr7quN+H3sHVM0EG3hpzXn9g85qvp1MBGzIvF3prsHM7Ne78mtpATz+PR8IXn4ffezg4j56Eu3yfTTbXxPsQjXCIx3ohzt5ixc+9X/5V/Sl6ynboK2xi3MV/kzwzm2MZ8+n1xnMqd/GCPLfXW3q/XId/wumTd5uQAtpx+nBMzxVY1S7EpqTtU75Lx/y0W/XhreF50DzMz32a6xtyDb+rbXWO2SsdsuZ/A9rQ+Qng3W7tLqBXY6KfcN3fp+6l0PymfFxH9oBE=
   </data>
  </layer>
- <layer width="40" height="20">
+ <layer id="2" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eJxjYIAATT4GgkCbCDW0Ap5Au72gmAPqDnYkMRD2HkD3IQOQW1cNsHvYOIHhwzlw9hMCekC36Q9i942CUTAKRsEoGAWjYBSMAtoAABsrBPo=
+   eAFjYIAATT4oAw+lTYQaPNopkvIE2u0FxRxQd7AjiYHkvKHiFFlEBc0gt64aYPewcTIwsAPxYAV6QLfpD2L3DdZwG3XXaAiMhsBoCIyGwGgIjIbAaAgM9RAAABsrBPo=
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collisions">
+ <objectgroup color="#ff0000" id="3" name="Collisions">
   <object id="118" type="collision" x="0" y="304" width="640" height="16"/>
   <object id="119" type="collision" x="0" y="0" width="640" height="16"/>
   <object id="120" type="collision" x="0" y="16" width="16" height="288"/>
@@ -106,26 +106,26 @@
   <object id="146" type="collision" x="144" y="288" width="16" height="16"/>
   <object id="147" type="collision" x="176" y="288" width="16" height="16"/>
  </objectgroup>
- <objectgroup name="Events">
+ <objectgroup id="4" name="Events">
   <object id="148" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music lunar_joyride.mp3"/>
-    <property name="cond1" value="not music_playing lunar_joyride.mp3"/>
+    <property name="act10" value="play_music lunar_joyride.mp3"/>
+    <property name="cond10" value="not music_playing lunar_joyride.mp3"/>
    </properties>
   </object>
   <object id="149" name="Teleport to Dragon's Cave" type="event" x="96" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport dragonscave.tmx,12,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport dragonscave.tmx,12,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="150" name="Player Spawn" type="event" x="96" y="48" width="16" height="16"/>
  </objectgroup>
- <layer name="Tile Layer 2" width="40" height="20">
+ <layer id="5" name="Tile Layer 2" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eJxjYCANhHNC6DscDAx3gTgEymcD0uyc1JcnB4QCzWABYlaoWWFAWg+I9TlpIw/zAzJYgEVsIEDYIHEHLgCL98EKkON9MILwQew2GAgdxG6kpJyhB0AuZ0DAk5+BoR2IvfgHzk3IAL3sywC6yw2IswaJ+0AAVgaCwq4DiNMGkduQyz9Q2K3iG1zuQy7/MqHuaxtE6Q+9/AO50R2IPQaRG7GVf5mDJI8MtfJvMAJCbdtOaPh2cGCXp2XbmZi2LQh0c+CWp2XbGQBL6jUO
+   eAHVll0KwjAQhPPg74veRG/h37M/NxD1IFrxEj57pnoXZ8guhCDUSsBxYZq2ScnXZXdICO1iN4zr60EIT2htzz2Mfaj0fDu6uHoDjg7UhRhbjBNoas+l5z0Hcbd4vdte6btf3PPflcPrRpUxrRtFRu83RTZnYr+phvuYKl/qY2RcjkO4QCtIIXLvO4BrBp1E+Jgj90DmroL2Qmyp/zF3j5EWX+p/R+M7Y1Spv9z/yDiHFkKM7/yPnAo98m/+p+B5OYP3sNei59S98YpzMqOyMZ9v+v7bee75ydmX627GVvps3LT/C0vqNQ4=
   </data>
  </layer>
 </map>

--- a/mods/tuxemon/maps/rubberduck_cave_01.tmx
+++ b/mods/tuxemon/maps/rubberduck_cave_01.tmx
@@ -40,9 +40,9 @@
  <objectgroup color="#ffff00" id="6" name="Events" visible="0">
   <object id="64" name="teleport to map1" type="event" x="1088" y="432" width="16" height="16">
    <properties>
-    <property name="act1" value="teleport map1.tmx,49,12"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="teleport map1.tmx,49,12"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="65" name="Play Music" type="init" x="160" y="112" width="16" height="16">
@@ -53,41 +53,41 @@
   </object>
   <object id="172" name="Item hint" type="event" x="432" y="848" width="16" height="32">
    <properties>
-    <property name="act1" value="dialog A good place to hide an item"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog A good place to hide an item"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="174" name="Item hint" type="event" x="448" y="832" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog A good place to hide an item"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog A good place to hide an item"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="175" name="If I could Swim" type="event" x="592" y="880" width="64" height="16">
    <properties>
-    <property name="act1" value="dialog if i could swim..."/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog if i could swim..."/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="176" name="If I could Swim" type="event" x="544" y="864" width="48" height="16">
    <properties>
-    <property name="act1" value="dialog if i could swim..."/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog if i could swim..."/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="177" name="Ladder" type="event" x="160" y="752" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog This ladder leads to nowhere"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog This ladder leads to nowhere"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/rubberduck_city_01.tmx
+++ b/mods/tuxemon/maps/rubberduck_city_01.tmx
@@ -201,149 +201,149 @@
  <objectgroup color="#ffff00" id="7" name="Events">
   <object id="1" name="Teleport to map1 (lower)" type="event" x="672" y="80" width="128" height="16">
    <properties>
-    <property name="act1" value="teleport map1.tmx,12,12"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="teleport map1.tmx,12,12"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="2" name="Teleport to map1 (lower)" type="event" x="112" y="624" width="16" height="80">
    <properties>
-    <property name="act1" value="teleport route_rbd_01.tmx,37,10"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
+    <property name="act10" value="teleport route_rbd_01.tmx,37,10"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
    </properties>
   </object>
   <object id="134" name="empty house" type="event" x="624" y="304" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog The door won't open"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog The door won't open"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="135" name="empty house" type="event" x="720" y="352" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog Maybe some good guys here"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog Maybe some good guys here"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="136" name="empty house" type="event" x="800" y="496" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog The door won't open"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog The door won't open"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="137" name="empty house" type="event" x="624" y="496" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog a mart ..."/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog a mart ..."/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="138" name="empty house" type="event" x="432" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog here you should be able to heal your monsters ... but no one here ..."/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog here you should be able to heal your monsters ... but no one here ..."/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="139" name="empty house" type="event" x="208" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog Maybe some good guys here"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog Maybe some good guys here"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="140" name="empty house" type="event" x="384" y="784" width="32" height="16">
    <properties>
-    <property name="act1" value="dialog Currently no one is living here"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog Currently no one is living here"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="141" name="empty house" type="event" x="432" y="768" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog Currently no one is living here"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog Currently no one is living here"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="142" name="empty house" type="event" x="448" y="784" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog Currently no one is living here"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog Currently no one is living here"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="143" name="empty house" type="event" x="416" y="752" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog Currently no one is living here"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog Currently no one is living here"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="144" name="empty house" type="event" x="432" y="464" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog maybe someone evil / bad should be here"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog maybe someone evil / bad should be here"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="145" name="empty house" type="event" x="864" y="688" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog maybe make this door opened and put someone here"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog maybe make this door opened and put someone here"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="146" name="empty house" type="event" x="240" y="416" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog Maybe some good guys here"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog Maybe some good guys here"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="150" name="cave route" type="event" x="480" y="272" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog place for a cave route... maybe cave_01.tmx"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog place for a cave route... maybe cave_01.tmx"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="151" name="where_to_go" type="event" x="992" y="704" width="16" height="32">
    <properties>
-    <property name="act1" value="dialog where should this lead to??"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="dialog where should this lead to??"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="156" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music JRPG_town_loop.ogg"/>
-    <property name="cond1" value="not music_playing JRPG_town_loop.ogg"/>
+    <property name="act10" value="play_music JRPG_town_loop.ogg"/>
+    <property name="cond10" value="not music_playing JRPG_town_loop.ogg"/>
    </properties>
   </object>
   <object id="169" name="secret place" type="event" x="480" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog this is a secret place that can't be reached yet..."/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog this is a secret place that can't be reached yet..."/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/rubberduck_route_01.tmx
+++ b/mods/tuxemon/maps/rubberduck_route_01.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" tiledversion="1.0.3" orientation="orthogonal" renderorder="right-down" width="46" height="53" tilewidth="16" tileheight="16" nextobjectid="107">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="46" height="53" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="107">
  <tileset firstgid="1" name="PastTheFuture_Grass_Sand_Snow" tilewidth="16" tileheight="16" tilecount="360" columns="24">
   <image source="../gfx/tilesets/PastTheFuture_Grass_Sand_Snow.png" width="384" height="240"/>
  </tileset>
@@ -12,38 +12,38 @@
  <tileset firstgid="3241" name="updated_ground_tiles_by_rubberduck" tilewidth="16" tileheight="16" tilecount="1369" columns="37">
   <image source="../gfx/tilesets/updated_ground_tiles_by_rubberduck.png" width="592" height="592"/>
  </tileset>
- <tileset firstgid="4610" name="People" tilewidth="16" tileheight="16" tilecount="10" columns="5">
+ <tileset firstgid="4610" name="People" tilewidth="16" tileheight="16" tilecount="0" columns="5">
   <image source="../../../../tuxemon/Tuxemon-development/tuxemon/resources/gfx/tilesets/People.png" width="80" height="32"/>
  </tileset>
- <tileset firstgid="4620" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="1000" columns="40">
+ <tileset firstgid="4610" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="0" columns="40">
   <image source="../../../../tuxemon/Tuxemon-development/tuxemon/resources/gfx/tilesets/Cave_Tiles_by_ArMM1998_(Tuxemon_Style).png" width="640" height="400"/>
  </tileset>
- <layer name="Lower_1" width="46" height="53">
+ <layer id="1" name="Lower_1" width="46" height="53">
   <data encoding="base64" compression="zlib">
-   eJy1mEFuGkEQRZEcdj1SlgwnAG6RS+QAiZW75ChJ5ChrR/EREMoFYuUKhn1oMSU+b341GJFFaXDPTPevql+/arzsJpPlYIu9rYZr2HJYW55Zr9dfZTKZYo+VrPOcuv6mu8xi35WcvTC/de3S/RXbUt6bJnucw9I622FdyF4Rq0Vjj6cyfl/fq2vPZYyPz2/F1LfZ3vrBZoPFu+SBxkpzTewV853xIXByH8ezet3sn5t3Bwt8irOXez3819g/l3GuF7IedidYV93Rh6nso7FRDml8dwNu4lRfFLvWj3KtnudiPO1OfVwI1qcyrhXGN3BOuyPOuGqce3Ovl78VM+uf2BcJlrCXAdNTGT+j8SNGrjG+5Mm8G2NZSW7rNX5vyqmvmS5WzC9ljFljRx4r5m25zFgfGt+IudZND5yBgz7oM463rt5cXF3M5+aMqDtef++vX/f2rRzPIFeYB8Xt8Dl907xobpgvxifiq9zWOtyUU79dDem+qy7nq+JV39y+1BbqoOJ+Bo+U52FfJA/kLWPF38yDe4++xTr1SvmhuAO74q7vr4ca/Gt4lGElb7NapVG/2dM13vX+w1DDf4b+oJxYl1Nuq+64vlfvvX97MPqjfFGs9IXaEDhVAxULa34uuOvaVvzqYYGVlvWVHucwb4x18Lhirrn/WY61yP5Vf0ev2Q0+079zuBW70xvyK+7FvBD1uOrGPKeG8Bw1zWULqxpnD9Y2788Qa50FdY5SntAYB33uUtyKnXjJ67jHWZXzf+XKI7SCtf8afC2uMDYaE+qO9jbqHmc71Yp4/xaYGe+ML+pb1KXipmardqvvt8LstJq9iP1fcfGbgHOi6sqtcTsdcr7E/cdB61bdUfc0B/yW0vq7JUdc3bv+pXqieFUPaf+LJ4GdPY0aovez+VW/g6LPa4+/pZY4rrRmNOq39nrFzm9tXqkJ13BI+fzdnMd4R2/Rb53Aq3Gmv5wj1phLruVIzGqO33ouvxWWBm9Lo+aC+1qtYQ7XZXwW+6abXXfFzxvMF9e2EvNr4k2M1Bhd4/+jdBah9lOfWDvKl9diJX/d7KZ/a4/X70cXa2L+vLePe/sxXO+7w1wbddmqz0yf3Uzrvou0V2pPbMU67r1rxP2crjDW7ixX/4Gf///jzNqa3d9143ixfi/B7c5yvUbPoV5vyjgvjnfVPpm4uHeZE1cnGX6n3fPu9H/UgdvtRZ8ZG3KIxhg4v3SPlm7NBHPo9k60M5sZXO/M4ko8We1l9e98ir6j3wUZP1zNZ32IMeOa0xF3jotbPKMzK+dr1hvjluWXe1T70B20knafxNfFX5+LeD9IX8/0lP0+q3/no+svjI/rQ1kfjXrU2SmrI8dtx2enE44nGf6MR3q+8sOdk9W4O9dZxifXd1yOMz3aGn5Qg6hnvNeKI7nh3nOaQq7zWaeNmdZlep3VnKtBx3/HNerQJTrB3GZcbeUy4ynzlfUH1wt4L9MJxw3qLTFmHHLxY6ypJVmN8VynVRmnHOezmiO/3VnOd8bB4WXtu1rP6iW7l+mKqycXA6eBvGZ9ohWjVh4cN5lDV4eOa62/XZ3zHJdzlzfnU4aBeFweyFWnHY7f53Lqcub0LdO2c/y8pE5aeWxxqdVXHGcdBvd+xveWrri6OqdfWT1nPmX12NqrpeHuLJ7L813MM76/Rmsdvn+QrElz
+   eAG12F2OrVMUheFKcEfiEi1AL3RCAxB90RSEuCY0QUQHiC7g3vcm9SQjK9+pc04lLmbm7xhzrLXX3nX46J2Hh48e7cPLf3xZntWrllfLn/Xyn99+eHjr8stRrN4MHvU3r9qrGF5a7KCDJv51+OOmLZ/eNFUXr8aXaXlq9+qmNV/d7vir3e1Oxy+XvmYX747V/rxmcNqph/ufa4Y5X7vfu+z9RyvOYO0tx+Ou2kPHqT3Nb1x9e5yBTvPuFn/79hy/XTwfXLUsjbTSWU2vGD4+91Ctvfnd24x6vSzNtIZ3hnTiCWeej9fd5v991H3q3LOsdudvJ7Mv7vbT7v73jMW0pp9Gd4A/zmq0xpumdPJ7z+Lt0R2GBnvy9Ha34jwNPC1hsr+vmXTR35wZO1dH+9XFzlH97IVVo4Fvf3rL82Lvz1nTA5OnL83p31q76OFpKM/M+Dxe5u3j9377LNPdWeiOfzXRcZ5hZ9wxfXc53XlnWr/Y6u6N7nQWn/73q/7NZd9eZsdq62xyZ8C5+2HXi9PmHjYOv/Xy3UWvt+Lum6Gre29PWHrsXX684XbOTBg4mp7iDceacye0eRd5d97u5prxXnB8fc35HNTokdNVvnE5rfk7nNriit1jmjJaT920r+7wv166w/01+u26063WjHOsJthqp8Hk20mTd1FOd/3vLk19v/+4rL8P9uTT7ex9Js5VjwYe7tN3Hx4yubPId754c7zp8lbSWp7RvVrg83bRXa2zOVf5Gq2nd+dm73K7nKv8vGvvON199j9d5rsI58zh/a1Jb+etlgYz9Jx6Nw+De7Fq9RnedGbp7Aw+83J1umHPPbTZiXu1PRXDx1vM0332q6fNu/ZGNk+/Nwu/3llotbOZp7SeveVcvcWsGT3/Vuqe0yv3OfRWfrzMb11YWvGcGp6TL6czqNFNc3V37E3k973Im3Pvi3+OxjsMre5l/e5Lc700ultvmlY9Pt179rv9z6ktp5i+NG5NTGN+dZf7LPJp9/2EfY7GO0x8dBandfXa14x+b7ffunT53XO/eya64eK40/CcWhrpplnNPt550rZ6u/M03tn/9U46Kz307t2mefNid+qN8N5G+v2d97fQ3cT3nPu9w9BGfzt2j7y5LN1+r9OY7jRXp93vCJ7T09FO96X2qp7eNH1/aaATX3k9edq8Dfrp3XvG47zLE1f/TsFb/qp6m2seNh8XfVsvtrd7pdsbOfU2vxY2Xtx5u8y9rm6ceXdAZ/x48+Xu2BtJe++43s4Xx5nBnrX+Paj3urrD0V68+Wox03/7ppl+b5mmxYhpz+Oh1129THdcqw2nvXL857zvYPdc7G+LOXrgl++ra/7zy3549F9cvn/XNpNu/u4M9OHnl58GNecs7673jdNdLxysuLreJ1e8XHezd5qrwYXBd+LN5O0vznof/g3ovk8eWnk8dO8+vPnmX0X3atodxXYV7x7vw++1923/iZXX/3K41Hm6l6cejXmzZx22OqsGU63vpTfuvuF2B0z+1HJynjiY9pm1Y7nsOLVu3TzN3Xe/2/6WL/+Jw6uex7e97W+9uPn8Ys/55dSDTW/fzb1rnHnz+OU4zVbXo9GOzcW4edj81sRw+Wb8nqTfb0mz5k8Pjx+Punw5mv3ssn4zT+u3s344GLH66Ztz397I7jXfHC7cfHU9vh5sNTGvj6O6eOfP2ubp7o30rsPANVOcP3nNmJfTBXdXh6FhucXw8rwYft/H3Z7mzZ5855loWb/7lqsZ+3h89qgvhxn/b8wMPv0wa9XPXli2fXP1xMsFQ5cZ8+XiczaMWnNMTZ/Hs/mLvnN330H8i99d6jTrldc7vX49/WpnXG4W94mprnfu0VvMHSc8Dc2orcfHn/PVYe1sZufF+vnzjC/KzfJxmVWT5+1SM1NdnN+82Wrs5Cg3gxce5/YXL7bzxOmfvNXV7MBRfXFm15+x+eXAr5evb2Y5tm7/+vr4xDDy+mK7+MWaMV/e3M5WY83V483pP5XX06dh8zjOejW47cHx9V6kQR1XszhPvBymfLlh6xfL8S1ODd78+p3f+uqgYXnCmYGTrzb8sJubh4czoy/Xb75eJtZbzLlzZ06sHj59HOWsWXF9hoOH5XHWX1t89eWGwcFvXQzHm91dG+vnxWF3ZvWI8zDmT7w+rnK6+P8AkKxJcw==
   </data>
  </layer>
- <layer name="Lower_2" width="46" height="53">
+ <layer id="2" name="Lower_2" width="46" height="53">
   <data encoding="base64" compression="zlib">
-   eJztl01PFEEQhifLh27YXYgnPxOO7IInLnhE8DfoLzCe1ItRTEw8g16N0cW7JKtC9CAGLx5kMVEDdyT4ExDj0apMV6am6O7p6elZIPomlZ6d2el5+p3q6p4o+q9/VRONJI6LTh4jVu7vxSPEvVaLooF63PbX09FL0TPHRqJodjiOj7Xkep+6Tud2agl7U8WYCjz/S8Srmv65RYT5h89tKe6Z4YSdB+dHXmRv0X2qpbFI7ZXETc9/AtwViD7Gf0UF/41C7qZixTz+YWAuS7vwvFWID8q/JuM3Bec+7Hqxw7hbLG+b7BzmA8+V1hHiJr734j3Q+TE2LjzG97UL7c8e1xIS+nYH4hPEXYhtNZd4HhE3+c+jl77zOSXXh+1ausbJPCJ+uo7c1yEmIf+vwty9Nqx/5kvoZ8kSLrJ5NNhIOKm+SY+pXuvWReTXsX8NUBNt3ONireb5zcPWxwPBjV5vlczNNc7yocU8ztp/SO4QXqNcue810nntet/kSPp3KO5VVSt0NawD58834pho+O3xZsT/QnGTpH/IfMGRbbDPfA25ea0IkdtckvtPxhpywsLK9buktWjlVNwSd0ftO2fZOAYcGXUqi5tE3N8LvMd+zfh6zb1cYM3m+Y75XcY3g1zrkLs9FB8j+wLENMRmPY6tnP4hd+gagpLzEbm7Qwn7aeA8A3FW8W7WzOyPKlH0uJL8noe+X9fjb51Q32vSZ5qP+6rf7pD5XlOteQvM7xi3rN0oX+9NeyDTfLxUOXiOuG11GxWKe03sVcnjb8znh5r79lTO0zvOqu3zak5gjlyuAn813Zf81pchJWv0fo6x87yZVlwLhppDPt8E3lsQt6v6/7kKufG9Y04sAscLiPvRwTDpnNqrIPNolF6bSOj1CsQzYH0O0YZYrCbzHEXPNrU67o7yeQOuf2Hcc4z7qYV9lB3ruMnrz8C6DtGF2Kim3xc929TquGn+yTG6+C213EhyhmLFkDtZHvPWxi3HmPWudJrKMcYsj3lr45ac8v4pTf0rIl+/qQaa/Nb1HVK+fvN9k2msWfODq+04rjw+6/zW1ZKsHLf53nV8L3l8ln7LHHH1O8t3eV23Fvj6zdd2U25n+f3GbqmV29dvymu5TupyIa/fLvLxm/Z9fD/im9vrntxF8jsrr239F1WReuKb19RizdPlrst+zNdvqn0+XlPb9eSeK+B3Ua9t+92y/O6wb4O8NVu2Ltw+3upa/j3TC799vNW1LjyufZnUDuCvbF14XPtC3dBwdwP4exh+h/Z6sQS/Q9WLrPa4+v0XV+e5fg==
+   eAHtmLluFEEQhke+AHGKiFNyaDBEJCYEm2eAJ0BEQII4JCRijhQhsIkBCXMIAkCQEGAbCZCdAzKPwCFC/t87v7ZUdPXO7K7XtqClcnX3dFd9XV3dM+ui+F/+1Qgc2FIUkrUSg/VgXitFsaU+uIq4X28qisHNRUE9AG2ll7GV35FtRTGxtSFvwKTSX7Kp7yueiX0fnlFGSmH/DyfTxpZsdqqZf/S7n37BPV5yi1+afsTPWJOdc5bmlVpr8Uzfl4lb/m+Cuw/Sb/iPYR0UrYd1FnJzvWRlHn+B5np6VRbh7yXkFYT8ZBE/15ASsol7pe8L7btyhtqK8sHmCvtWC7f4Xrh9UD/PH+tcE+vcr0Xob5CVKIzbOchbyHnIZ/Cw2DzSnaE9Ib+kl3G3Z8q/H8itPCGvzyP22efkPgk5hDNxHGf3RHl+G6tv/r0Puw8y0hwZ13IxGgKD8kH3m2IrTXat3a+b/Cn2D+U+xlStn+S4R8Gt9zWZyKo8sTpn47KLOWO9sMzcdtWjZU6Ql/yKcavvD8/djViTKxcry30B8dZZJHvVecwVW7rFzfcNJXWHPUT/HvBSlC/SPpctm62PY64t3eKWTR8/Mu91PjXW66F+39Nsk9veHd3I7ab1v/f9N3IhV9ZlWO28Xy3s2LF16ve2N0Yr3owzv0EnTKwHKzKm/C4Xt3yJ+xOY2y0DifX1mvuJiXfdddh8Z35PdxCLyLfuYd0PjPfkxsZosl+DHIHMI08pCzXzldzdvkNIp/zQusg9C26x7wDnTsiukncezyP2631FcQOichXMjzCPv3X0u63T2Ps46zz+hA8Wskclumuegfm54fZ3N+21G3vPK7boPB42HBorbpvHemZ1t7jJrDymfcX4I/oV5yvWcVnnPjNvtMfiTgxd6mJ+8EwwR45uwO9SiIrNGeWO1xorrVwWr1j1PKdt3pCJwjObKorzafCegZw13KnxrfrIzX1nTkwhfnchlzDJS2RnN+bzW4XMwxhk302aw1g/hdwG6x3IJGSK2pwX+Y60bEmTm7FmnOdg573hvohB4r+lCQk9bPpS3Ir1O7DOQGYhc9SGW74jbVwsVcmt8+fXKmbqqoX3u3JGmrFOFe8v1/bzLbdfq7fj56baY6nOoM/7y7W9CcvtOb2dscT95+3VaXt/uba1qztQeeI5OdbbsvM7rXt/ubb1xViz2LvEc3pbjRnpv/Z+SI9o9HofVdrWHrn9XeI5I5vWjuq8HzRefSntfVRpy47PEfnzOrIpO15rvPrtnaS691GlTXtiZj3KbfmPbD7m5ApFrFbLdh1NV8pr/570jBwb2eazdov3U6Wt/8nY75GILbIn3hlVaurIX65fLpQfObbIjmy0qyOfuX75EnfElrPBby/eeTZno7r8WR35zPVzvu6+iI1jcjb47cU7L2K1/bRlC7/VIr+5ftroNNayb/miumVWvVVMUs8Va9qQf69T8xhj3x+x2n5vu922/T3jOdSuatvyRXXZ7FTzTLXiqupD++41z2wrH3Wfp/bbc1a1Sd5THhptnllvs9N2L+Jddd11xnU73olwdz3W3Ku1Gu8/c0C5dA==
   </data>
  </layer>
- <layer name="Lower_3" width="46" height="53">
+ <layer id="3" name="Lower_3" width="46" height="53">
   <data encoding="base64" compression="zlib">
-   eJztmctOwkAUhgskQtNSCC6Nrowh0QcwbhTRlbyHGy/gTl9B4xKjgns3Kj6ASw2YEK8L3PoIRqOuPJO2oWAvM/YMU8x8yZ82vc3fw5nLKYoikUgk4pgxuhoWOrnufhz2p43g92jk3I/3U9NMYeLWdtLlmP0eV7r/83Zc1NRMEb4C7qcllWa7fsQl9m5enSI8+fg9R3oXVmh8E07j4du6pMzN1zR9Hrt5jQKVrKKUHNrK9p7v952A9y1DXlc8+uQsQvxpyIPPGChu6SD7+5pVR/6nwHcdPJ9o+GMKy29LfE+5ePWjBV5vtd4xBQMW31WPGPvhjDcmrP0+Nsr2fGe8MeE5BkwY/OLNG8x4047dYblnnIv/wmSCfxthoJn7xpHWsVg53aHMjyUk39hjCA27CN7HBNUfBcPsW0SPA+hjftDmis0H+G3D+vhBF++dlba1rr9jXN+TeoDUC6TGedZx+ukcwxryDdo809l9E7+2929dTD8lfeydwve8qigLoAJoEVRUzeMX1r32vO+15cVnQI6vgc910AZoE1RWe8/b877XlhdBc9Ih+DwCHYNqoLrD936Mn6+wXIPPG1ADPDZh21KD78HGq54s+axl9sDvNmw7VmxfBMSY1GXFDMz7oOUMe40mCtu37d3pO+hbSVjCrLWrVt2esPwP0jcG+SH23Z8nPMGqx4jvYeqXNoP0nURcc1Z9vqtJxLMS8W8DEvFg/BcikUj+L1H/xhwFfgDkoYWx
+   eAHtmM1OFjEUhgskggHFsCWyIoYEL8C4UQRXch9sVMAd3ALEpQYEt+rGnxtwCQESxR8WuvUSCAiueE++OcmxaTvtzGHmg7TJSzud09Onh3bafsbklCOQI5Aj0F4Ebl83htUeRVrPX0f+t58UY6CxuNIbq43Lhuo2Bjvyva9SH9s3j+PzULiXZby2tQNuEqXTkvYdq/K/A9fKbaTFFUfsbU77mdr/DPB+CLyTfWuXbU77mft718ul6vnbyLn5B/+P2LkkeauT6bdcvGHMrNAzlGVycS9gXi8Wc1vaUvmOQvxtn67nCXD2QL2FXlrc1GbOmv+bYH4NaX9TXDFyMVMdcd9ysPrsqX4XzHuQ/KaE7GPfpXC/ALMrxqG+ZLxDdqnvXNyhdf83cj0zh4w312nkLm4Nv+RjDHP9vOKtxejzoxnv2G+3jyW2/lviXhzrV9qN98mn7ivH7H03rW9w1VHQN1sj2WdVn88ZJW4+A/r6OY/6FQX2UQUfVcY2hX5pbZF+NLDGQoyxc4V9HIP3C87H36G22ZkpNiduSvuJ53u6D9B9ge44B5DGOr2bcIY8RJ/voVRu4mX2fyi3sU5pjR2h77J076ox96Ep6AE0DVH6WLTlfd+Xd6z1/56UrM/H4HwCPYXmoQVIJt73fbm01SyX7Ulr4FyHXkEb0CbE6XkPl7ov3wLnNvQJjDvIdwV3U7S+++Rs4CyzCt4lAP4qYvu7hRjTvWx62JgZ6CGUekdrKr52P8zN7JJb3jdk2fZR9bnOWZvuk3R37yvi3iR31fHKdhz3i8hNc1xyy3Fpl+vMEclC8b5I65LZm+TuL9mPmSkm5/WZ+ptPjO9sUz8CjwL7aX3v2cNliEDoN9HLML48hhyBHIF6Eej235jrjU6n9Rl+toXc
   </data>
  </layer>
- <layer name="Above_1" width="46" height="53">
+ <layer id="4" name="Above_1" width="46" height="53">
   <data encoding="base64" compression="zlib">
-   eJztmFFuwjAMhiMNTZOacI6m2y7IMXhm3AOQeN92h0qsFyFWazUtgUSaszhrPsmC8lB9/nGatkIUCvmxCSxu5OoN5OqN5OrNka2juOJyLd7xycnVJlfvJXBRQvzMqlOprfw8r4Wo1Vga3GVqq/tgzp3sfQ/m82jqNBxzBXJGVyjwx6yPjPMG79b4NaovPRQec2G+/jorYz1z5zQn9voDt1aOjo2a5s7N23Zr5ehcq+l3zcj71Xif5ej2ZGql+t9qdZs9JyBzraae6L+a9UHJ5Zd7GWT+NtRZ3q7HxuqDEsgLrq8U+7CrB3vOKcH/+WVNc76PSoh9Ne0BixJcW1TeX8b5u6I5lw9wfyfOY2nk9Cy4s+bKduXu/elYDznkvXT+w7uS4l0IJUX2O4J7hRTerms6QtFTDHxej3qKAd7j+vhrLx8h97ihM+B7Lx9jlh+5hWadwptiDrjlHUrJu1DIA677v49Y++wVU6KVzg==
+   eAHtl2tKBEEMhBsUEXycw+cFPYa/1Xuo4H/1DoLuRTYFW2zRzCO7k5nNyDSEpMd0+ktN9+5ayjIWBeanwIMheyxbZx5m5GQcHvaM3GTq4mfO4n0KPFpabb6V02fVnPV8eiLfjjVnPfdVOVyW8h6OYved58q9e6fzW/F7UcpfZSubZx8nl6VcGSftGj2c56WmzitjBPOr+Tez9808Kzl0Jit4wU+tMc86wP1jfDemNQzMMM6zcPNc8A5CX2pMXrLj3GQZev/AB63hwUiNqXs2bvKRm8zwGuPvWcatneePzXkG45HZsRmeYV5rn4UbHDgr5KMnP3rQPiK5cbeGfJdB87uNQWew80wzZh+R3NAL32VD2MnT1IOec+ZFeL7nU+OPGM9npbyYaQ98HxH1WYN3K4r7y5i/zaYYYL8P0nsK3ox76P8njDNygulJzpWyapyR/VO4yUdm+GXkVEDfkcY5abdUyqrxNiNnpKwa56T9f1SqOeOxu9TP9H33Iqv6fWt51zV9pnNtRE+sFen7uLp6iuRgLf7G5bzNT83VxsHnnt+4fVqzlp7Ztpi5Ub6Lzat1G6s+j+JlHS8b85u88rXFTeuGPOvS21u3jVWfe2t58+aqt7e/JW9RYAwFIu77GFx9NSPue9Mea1Oilc4=
   </data>
  </layer>
- <layer name="Above_2" width="46" height="53">
+ <layer id="5" name="Above_2" width="46" height="53">
   <data encoding="base64" compression="zlib">
-   eJztl0EOgjAQRcfoDrqBi1BOpsfQO+ghvIMbPYJu3HkMS6CxMRpsnU5nCi9pJmzK76OFQSsAbcaj7Gs7jJO5VqZypVH96HI36pW9u+aMdtxaz6WK4/paAdwqnLlsRu14j8WyBljVOHM1g+dGwJ52aZ2zyH1Pu2iiPYJN7LMYCy3Ms0XSWXSR6LpDomtOrAuATZE6xXTI1ffRsx/bIvVvY+TqO2cw+/tQ7gHfFcz+3pfQfb5IlNeyN5kPAs/n2WS+CMydA6n3bCjzt4gO6/pbzZGUa5uyb6o1jjl26z/zciUX35/m5gblOfbxbOvO8//Adz3Uz4W7b6x7cIA6W2zfnFy/3ztFtpi+Ofc5qTLF8v3rfKmgyBPiNjQTR99UebA8z77HwXYt+X2Ss2+OPAFC/cPA
+   eAHtV0FOxDAMzJ3dCy9hednyAvgInPnIXuC0/IAbP0BwwhYaKbLqYkd22nSJFLlJnZnxNFXTw76UA/WP3W+8pWvuJxrvKa613ZA27qybI9fAunm85sY64S183tFchtfn61LeqEc0aGT98D0CdwrjizR/B+lmrewzR/g+xbm2OdaMvvY9XXvH+6PHHqk5I66z38UIjVMY7PVI+wM1jPQuQjPHEb1m3RnfF8a9lHa8KuWO+n/r48BW/X52nmvunfmtT2erfrf6McK6yPN9a73vdP7wtsjzvZe7dZ9/dnoPtXoe6dvzNOD354U0vw6oW3sOI80vvWdbvWp9R1v5LnkdvNbiFr1BrUvUBm4tLqEpm1PW2ptP8tdjj5Z63Zr/BXvrlHxzY4/fnCuxvOuz86U+jDN4ge2JD85zq4at1YN87X70PPhkjOZhPMlhGXt1aJhenIz83to0vrl5T90ajgcjKhdagIexjLifESWXZWzV8ReWFScjT9OWwVVjarxz8/V67XpuPZ9TcF9bnz0PfhkjeSV269iiyYptwYrKqZ+zpi+CS8NunbdosmJbsKJyevhtrduTZ6nfimfBisrZst9RHkXi/ACGpMk4
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collision">
   <object id="1" type="collision" x="128" y="640" width="176" height="208"/>
   <object id="4" type="collision" x="608" y="208" width="96" height="640"/>
   <object id="5" type="collision" x="64" y="240" width="80" height="400"/>
@@ -190,113 +190,113 @@
    <polyline points="0,0 -32,0"/>
   </object>
  </objectgroup>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="7" name="Events">
   <object id="7" name="Route Music" type="event" x="64" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music peasant_kingdom.ogg"/>
-    <property name="cond1" value="not music_playing peasant_kingdom.ogg"/>
+    <property name="act10" value="play_music peasant_kingdom.ogg"/>
+    <property name="cond10" value="not music_playing peasant_kingdom.ogg"/>
    </properties>
   </object>
   <object id="8" name="Teleport to map1 (lower)" type="event" x="608" y="128" width="16" height="80">
    <properties>
-    <property name="act1" value="teleport map1.tmx,12,12"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="teleport map1.tmx,12,12"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="9" name="Random Battle 3" type="event" x="448" y="608" width="80" height="32">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="act2" value="play_map_animation grass,0.1,noloop,player"/>
-    <property name="cond1" value="is player_moved"/>
-    <property name="cond2" value="is player_at"/>
-    <property name="cond3" value="is party_size greater_than,0"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="act20" value="play_map_animation grass,0.1,noloop,player"/>
+    <property name="cond10" value="is player_moved"/>
+    <property name="cond20" value="is player_at"/>
+    <property name="cond30" value="is party_size greater_than,0"/>
    </properties>
   </object>
   <object id="10" name="Random Battle 3" type="event" x="384" y="544" width="96" height="48">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="act2" value="play_map_animation grass,0.1,noloop,player"/>
-    <property name="cond1" value="is player_moved"/>
-    <property name="cond2" value="is player_at"/>
-    <property name="cond3" value="is party_size greater_than,0"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="act20" value="play_map_animation grass,0.1,noloop,player"/>
+    <property name="cond10" value="is player_moved"/>
+    <property name="cond20" value="is player_at"/>
+    <property name="cond30" value="is party_size greater_than,0"/>
    </properties>
   </object>
   <object id="11" name="Random Battle 3" type="event" x="304" y="688" width="144" height="80">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="act2" value="play_map_animation grass,0.1,noloop,player"/>
-    <property name="cond1" value="is player_moved"/>
-    <property name="cond2" value="is player_at"/>
-    <property name="cond3" value="is party_size greater_than,0"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="act20" value="play_map_animation grass,0.1,noloop,player"/>
+    <property name="cond10" value="is player_moved"/>
+    <property name="cond20" value="is player_at"/>
+    <property name="cond30" value="is party_size greater_than,0"/>
    </properties>
   </object>
   <object id="12" name="Random Battle 3" type="event" x="144" y="480" width="80" height="32">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="act2" value="play_map_animation grass,0.1,noloop,player"/>
-    <property name="cond1" value="is player_moved"/>
-    <property name="cond2" value="is player_at"/>
-    <property name="cond3" value="is party_size greater_than,0"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="act20" value="play_map_animation grass,0.1,noloop,player"/>
+    <property name="cond10" value="is player_moved"/>
+    <property name="cond20" value="is player_at"/>
+    <property name="cond30" value="is party_size greater_than,0"/>
    </properties>
   </object>
   <object id="13" name="Random Battle 3" type="event" x="176" y="512" width="48" height="16">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="act2" value="play_map_animation grass,0.1,noloop,player"/>
-    <property name="cond1" value="is player_moved"/>
-    <property name="cond2" value="is player_at"/>
-    <property name="cond3" value="is party_size greater_than,0"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="act20" value="play_map_animation grass,0.1,noloop,player"/>
+    <property name="cond10" value="is player_moved"/>
+    <property name="cond20" value="is player_at"/>
+    <property name="cond30" value="is party_size greater_than,0"/>
    </properties>
   </object>
   <object id="15" name="Random Battle 3" type="event" x="432" y="144" width="128" height="32">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="act2" value="play_map_animation grass,0.1,noloop,player"/>
-    <property name="cond1" value="is player_moved"/>
-    <property name="cond2" value="is player_at"/>
-    <property name="cond3" value="is party_size greater_than,0"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="act20" value="play_map_animation grass,0.1,noloop,player"/>
+    <property name="cond10" value="is player_moved"/>
+    <property name="cond20" value="is player_at"/>
+    <property name="cond30" value="is party_size greater_than,0"/>
    </properties>
   </object>
   <object id="16" name="Random Battle 3" type="event" x="464" y="176" width="48" height="32">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="act2" value="play_map_animation grass,0.1,noloop,player"/>
-    <property name="cond1" value="is player_moved"/>
-    <property name="cond2" value="is player_at"/>
-    <property name="cond3" value="is party_size greater_than,0"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="act20" value="play_map_animation grass,0.1,noloop,player"/>
+    <property name="cond10" value="is player_moved"/>
+    <property name="cond20" value="is player_at"/>
+    <property name="cond30" value="is party_size greater_than,0"/>
    </properties>
   </object>
   <object id="17" name="Random Battle 3" type="event" x="480" y="128" width="80" height="16">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="act2" value="play_map_animation grass,0.1,noloop,player"/>
-    <property name="cond1" value="is player_moved"/>
-    <property name="cond2" value="is player_at"/>
-    <property name="cond3" value="is party_size greater_than,0"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="act20" value="play_map_animation grass,0.1,noloop,player"/>
+    <property name="cond10" value="is player_moved"/>
+    <property name="cond20" value="is player_at"/>
+    <property name="cond30" value="is party_size greater_than,0"/>
    </properties>
   </object>
   <object id="18" name="Random Battle 3" type="event" x="160" y="224" width="48" height="64">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="act2" value="play_map_animation grass,0.1,noloop,player"/>
-    <property name="cond1" value="is player_moved"/>
-    <property name="cond2" value="is player_at"/>
-    <property name="cond3" value="is party_size greater_than,0"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="act20" value="play_map_animation grass,0.1,noloop,player"/>
+    <property name="cond10" value="is player_moved"/>
+    <property name="cond20" value="is player_at"/>
+    <property name="cond30" value="is party_size greater_than,0"/>
    </properties>
   </object>
   <object id="46" name="Teleport to map1 (lower)" type="event" x="304" y="800" width="96" height="16">
    <properties>
-    <property name="act1" value="teleport map1.tmx,12,12"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="teleport map1.tmx,12,12"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="55" name="Teleport to map1 (lower)" type="event" x="528" y="496" width="16" height="16">
    <properties>
-    <property name="act1" value="teleport map1.tmx,12,12"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="teleport map1.tmx,12,12"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/scoop1.tmx
+++ b/mods/tuxemon/maps/scoop1.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="21" height="15" tilewidth="16" tileheight="16" nextobjectid="17">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="21" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="17">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -75,27 +75,27 @@
  <tileset firstgid="8393" name="Land_bird" tilewidth="16" tileheight="16" tilecount="1" columns="1">
   <image source="../gfx/tilesets/Land_bird.gif" width="16" height="16"/>
  </tileset>
- <layer name="Tile Layer 1" width="21" height="15">
+ <layer id="1" name="Tile Layer 1" width="21" height="15">
   <data encoding="base64" compression="zlib">
-   eJxLlGRgSKQy7qQB3kgD7CU7ikfxKB4pGAAhuo1D
+   eAFLlGRgSKQy7gSaR228EWgmtbGXLAPDKB4Ng9E0MDLSAAAhuo1D
   </data>
  </layer>
- <layer name="Tile Layer 2" width="21" height="15">
+ <layer id="2" name="Tile Layer 2" width="21" height="15">
   <data encoding="base64" compression="zlib">
-   eJytU0EOgjAQ3AM3ywlM5MZD9Bea+BgOPIaDF//gDf2V3dAJ67gNEplkAm26MztbEBGpG5F9JPDvWnGM61Oz3XpLPA7Ts0rMoSZWDkun7r6byTgXIpfEa2Sgfd1biy7WPNvpvTea2O8dTfa13iHVKl7tp+aQzt6K76zWdzT9sKbt05upnS37Wm9ocvZAuWw+q+nB6xOAl2aDZ0eapZMjZPpHPcPTXAN7dwrtlTVzMwf0LL57aCKzYnQ0l4Ac3p3a2UCT/78c5cfzb/ylM/A=
+   eAGtkj0OwjAMhT2wARNFgq0HgVuAxGEYOAwDC3dgA26FP5qHLCtQUHmS6+Qlfv5JzcyapdncTRi6R2fleuugOXSv2v7hL4tOZeYOe4fGD6LpfvTTSvB5bCbLx5uR2bbYzv2kXBAP9yv2HnNru6hD0BQPl5HzUpNyc0YsuLdmUfPoPHdP5Vx94qVJ7NXjgHJHTfFwcZZ5zWylqbwxtzRz7/Cap2at/qImdWRIU7zqZ6950ptywkVN1rkPNGv1O/2aM2uhpqmzbzzxgLcD1Jo1c43aPwP8Qx/69+GIV8/smUHWhP8ENAHzAHEmeif+K81T+fs8Wmj23XsA/KUz8A==
   </data>
  </layer>
- <layer name="Tile Layer 5" width="21" height="15">
+ <layer id="3" name="Tile Layer 5" width="21" height="15">
   <data encoding="base64" compression="zlib">
-   eJxjYBi5QEliaJg5CkbBKKAcAAC6gwB1
+   eAFjYBi5QEmC+n6nhZnUd+WoiaMhMPJCAAC6gwB1
   </data>
  </layer>
- <layer name="Above Player" width="21" height="15">
+ <layer id="4" name="Above Player" width="21" height="15">
   <data encoding="base64" compression="zlib">
-   eJxjYBjZYIIwAg93MJL8OgpGAToAAC7BA9M=
+   eAFjYBjZYIIwAwMMD/eQgPkTRI+C0RAYaSEAAC7BA9M=
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collisions">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="1" type="collision" x="0" y="0" width="304" height="48"/>
   <object id="2" type="collision" x="304" y="0" width="32" height="32"/>
   <object id="3" type="collision" x="320" y="32" width="16" height="16"/>
@@ -115,27 +115,27 @@
    <polyline points="0,0 0,192"/>
   </object>
  </objectgroup>
- <objectgroup color="#ffff00" name="Event">
+ <objectgroup color="#ffff00" id="6" name="Event">
   <object id="10" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_omnichannel"/>
-    <property name="cond1" value="not music_playing music_omnichannel"/>
+    <property name="act10" value="play_music music_omnichannel"/>
+    <property name="cond10" value="not music_playing music_omnichannel"/>
    </properties>
   </object>
   <object id="11" name="Teleport to Timber Town" type="event" x="0" y="64" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport timber_town.tmx,10,23,0.3"/>
-    <property name="act2" value="player_face left"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
+    <property name="act10" value="transition_teleport timber_town.tmx,10,23,0.3"/>
+    <property name="act20" value="player_face left"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
    </properties>
   </object>
   <object id="12" name="Teleport to Scoop 2" type="event" x="304" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport scoop2.tmx,0,4,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport scoop2.tmx,0,4,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="16" name="Player Spawn" type="event" x="304" y="64" width="16" height="16"/>

--- a/mods/tuxemon/maps/scoop2.tmx
+++ b/mods/tuxemon/maps/scoop2.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="8" height="5" tilewidth="16" tileheight="16" nextobjectid="15">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="8" height="5" tilewidth="16" tileheight="16" infinite="0" nextlayerid="5" nextobjectid="15">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -72,45 +72,45 @@
  <tileset firstgid="8293" name="Land_bird" tilewidth="16" tileheight="16" tilecount="1" columns="1">
   <image source="../gfx/tilesets/Land_bird.gif" width="16" height="16"/>
  </tileset>
- <layer name="Tile Layer 1" width="8" height="5">
+ <layer id="1" name="Tile Layer 1" width="8" height="5">
   <data encoding="base64" compression="zlib">
-   eJxjYICABEkGhkQgTpJkQAEwsQ4g7gTiLkmE2kQksQ1AvBGINyGp7UQS85JFYJjajWji2DAAucATng==
+   eAFjYICABEkGhkQgTgJiZAAT6wCKdwJxFxDD1ILkYGIbgOyNQLwJiGFqQXIwMS9ZBgYYhqkFycHEcNEAucATng==
   </data>
  </layer>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="2" name="Events">
   <object id="1" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_omnichannel"/>
-    <property name="cond1" value="not music_playing music_omnichannel"/>
+    <property name="act10" value="play_music music_omnichannel"/>
+    <property name="cond10" value="not music_playing music_omnichannel"/>
    </properties>
   </object>
   <object id="2" name="Teleport to Scoop 1" type="event" x="0" y="64" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport scoop1.tmx,19,3,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport scoop1.tmx,19,3,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="3" name="Teleport to Scoop 3" type="event" x="112" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport scoop3.tmx,1,11,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport scoop3.tmx,1,11,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="12" name="Teleport to Timber Town" type="event" x="64" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport timber_town.tmx,14,23,0.3"/>
-    <property name="act2" value="player_face right"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="transition_teleport timber_town.tmx,14,23,0.3"/>
+    <property name="act20" value="player_face right"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="14" name="Player Spawn" type="event" x="32" y="64" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ff0000" name="Collision">
+ <objectgroup color="#ff0000" id="3" name="Collision">
   <object id="4" type="collision" x="0" y="16" width="32" height="48"/>
   <object id="5" type="collision" x="32" y="0" width="48" height="48"/>
   <object id="6" type="collision" x="80" y="16" width="32" height="48"/>
@@ -128,9 +128,9 @@
    <polyline points="0,0 16,0"/>
   </object>
  </objectgroup>
- <layer name="Tile Layer 2" width="8" height="5">
+ <layer id="4" name="Tile Layer 2" width="8" height="5">
   <data encoding="base64" compression="zlib">
-   eJxjYCAeiErgl1cAyl+RZWjAp/Y2VB6k9gAQixMwEwAXIQS7
+   eAFjYCAeiErgV6sAlL8iy9AAUoVL7W2oPEjtASAWJ2AmABchBLs=
   </data>
  </layer>
 </map>

--- a/mods/tuxemon/maps/scoop3.tmx
+++ b/mods/tuxemon/maps/scoop3.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="12" height="12" tilewidth="16" tileheight="16" nextobjectid="14">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="12" height="12" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="14">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -72,56 +72,56 @@
  <tileset firstgid="8293" name="Land_bird" tilewidth="16" tileheight="16" tilecount="1" columns="1">
   <image source="../gfx/tilesets/Land_bird.gif" width="16" height="16"/>
  </tileset>
- <layer name="Tile Layer 1" width="12" height="12">
+ <layer id="1" name="Tile Layer 1" width="12" height="12">
   <data encoding="base64" compression="zlib">
-   eJxLlGRgSCQBd5KIN5KIzSVGBuZhIE+9E5EYpJ5YtZRgAKScONU=
+   eAFLlGRgSCQBdwLVkoI3AtWTgs0lGBhGAuZhIM2fMPVOwPAhBoPUE6OOUjUApJw41Q==
   </data>
  </layer>
- <layer name="Tile Layer 4" width="12" height="12">
+ <layer id="2" name="Tile Layer 4" width="12" height="12">
   <data encoding="base64" compression="zlib">
-   eJxjYGBgsOBhAAMYjQywyXXwoNLJkgwMKUAcLYkphw5AarqBuEcSVYwUYMjPwGAExMb8EP4ZEQaGsyK41UcC1UUBcTRU/QOg2odo6nGZYcuM3UxsZpADwriJwzC1xIBAItXhUi8uQbxeAOHNFaM=
+   eAFjYGBgsOABEkg0hAchscl1QNXD6GRJBoYUII4GYpgYjEY2C8QGqekG4h4ghgGQGCnAkJ+BwQiIjYEYBM6IMDCcBWJcIBKoLgqIo6HqHwDVPkRTj8sMW2bspmIzA7tK/KJh3AwMxGCQKSB1xIBAItXBzEJXLy4BkyFMAwDhzRWj
   </data>
  </layer>
- <layer name="Tile Layer 2" width="12" height="12">
+ <layer id="3" name="Tile Layer 2" width="12" height="12">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFAwH2sBGvVoWbgeElierpBQBYHQIQ
+   eAFjYBgFAxECe9iIt1WFm4HhJYnqiTedMpUAWB0CEA==
   </data>
  </layer>
- <layer name="Tile Layer 4" width="12" height="12">
+ <layer id="4" name="Tile Layer 4" width="12" height="12">
   <data encoding="base64" compression="zlib">
-   eJxjYBgF1ASa3MRhmNqhDgDslgI9
+   eAFjYBgF1AwBTW4GBmIwyE6QuqEOAOyWAj0=
   </data>
  </layer>
- <objectgroup color="#ffff00" name="Event">
+ <objectgroup color="#ffff00" id="5" name="Event">
   <properties>
    <property name="act1" value="play_music music_omnichannel"/>
    <property name="cond1" value="not music_playing music_omnichannel"/>
   </properties>
   <object id="1" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_omnichannel"/>
-    <property name="cond1" value="not music_playing music_omnichannel"/>
+    <property name="act10" value="play_music music_omnichannel"/>
+    <property name="cond10" value="not music_playing music_omnichannel"/>
    </properties>
   </object>
   <object id="2" name="Teleport to Scoop 2" type="event" x="16" y="176" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport scoop2.tmx,7,4,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport scoop2.tmx,7,4,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="3" name="Teleport to Scoop 4" type="event" x="80" y="32" width="32" height="16">
    <properties>
-    <property name="act1" value="transition_teleport scoop4.tmx,9,21,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport scoop4.tmx,9,21,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="13" name="Player Spawn" type="event" x="80" y="160" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ff0000" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collision">
   <object id="4" type="collision" x="0" y="0" width="80" height="48"/>
   <object id="5" type="collision" x="80" y="0" width="112" height="32"/>
   <object id="6" type="collision" x="112" y="32" width="80" height="16"/>

--- a/mods/tuxemon/maps/scoop4.tmx
+++ b/mods/tuxemon/maps/scoop4.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="12" height="22" tilewidth="16" tileheight="16" nextobjectid="30">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="12" height="22" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="30">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -72,52 +72,52 @@
  <tileset firstgid="8293" name="Land_bird" tilewidth="16" tileheight="16" tilecount="1" columns="1">
   <image source="../gfx/tilesets/Land_bird.gif" width="16" height="16"/>
  </tileset>
- <layer name="Tile Layer 1" width="12" height="22">
+ <layer id="1" name="Tile Layer 1" width="12" height="22">
   <data encoding="base64" compression="zlib">
-   eJxLlGRgSCQBd5KIN5KIjWRH8SgexYMFAwDeHF0l
+   eAFLlGRgSCQBdwLVkoI3AtWTgo1kGRhG8WgYjKaBwZEGAN4cXSU=
   </data>
  </layer>
- <layer name="Tile Layer 2" width="12" height="22">
+ <layer id="2" name="Tile Layer 2" width="12" height="22">
   <data encoding="base64" compression="zlib">
-   eJzFkkEOwiAQRf8BIGxA6xn0CBgOobsepydsPY26cRqcFAlDYeVLfsKkj2EaAAB7AhyF2as9ra8d9T/xKqaFUPHWHkFt/dKeZwNczK9b40bu3dSdGqMGZspCeehYrwzCuRN9f1JelLeONfte+KcSef9Dp89YVQ77+b58Ro7kS/D9Svfc2qfHL83LOBUjkc4Zvm76Dvf2tL77nOOwrT+Enxe/
+   eAHFUcsNwlAM8wAgLi2UGWCEIoYoN8ZhQmAa4IItZBE9vdB3I5LlfBy/VAWAbgv0hGOuHqk9BP1cbd9/8LgAhJY4/tDJQ3P7Rc/dCtgTjjhzL/JE7Sno46wlPy+BK3Ej7oRqxZDcf+H8QTyJF6Ha+vg9c3eX/uvkvY97fk/HvRrsb7ZPeaNr68zWZ+z/ay51rT7ea9H7VnGp79kTsoh3KpdWPsrFtYg7maa2F3ub4Vu9AYSfF78=
   </data>
  </layer>
- <layer name="Tile Layer 3" width="12" height="22">
+ <layer id="3" name="Tile Layer 3" width="12" height="22">
   <data encoding="base64" compression="zlib">
-   eJxjYBg84IosQwMp6m+TqH4UDF9gzzPQLhieAACJbAM1
+   eAFjYBg84IosQwMprrlNonpSzB5VO7RCwJ5naLl3qLgWAIlsAzU=
   </data>
  </layer>
- <layer name="Above Player" width="12" height="22">
+ <layer id="4" name="Above Player" width="12" height="22">
   <data encoding="base64" compression="zlib">
-   eJxjYBh8IFkBUywFKibCA8HE6BXHow5khjgPwjx8ZuKToxZYycvAsAqIV/MixPC5HxcQIdJPxAB88UAKQPcHuhuxuZUcvxOylxKAnv6whS0pYY7sNnEkfejhS00/kAMAhjgJ2g==
+   eAHNkV0KgEAIhD1AvQW9dre6XHXJEvpgsFY2ikgQ/8dx1+x/Mg5nTtOR6xoz15LobJ/0OYbXwcsws1qJx9383Jotu667Ihl/eqLVe57y1rdkD/9AXGPjHZEjsWLFGa3V+m9gsIu74Xr1ttSYyaxycx889jCrfeS+tBuGOAna
   </data>
  </layer>
- <layer name="Above Player" width="12" height="22">
+ <layer id="5" name="Above Player" width="12" height="22">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFwwmI8Qy0C4Y3GGnhCwByiABF
+   eAFjYBgFwykExHiGk28Gn19GWvgCAHKIAEU=
   </data>
  </layer>
- <objectgroup color="#ffff00" name="Event">
+ <objectgroup color="#ffff00" id="6" name="Event">
   <object id="1" name="Play Music" type="event" x="0" y="0" width="16" height="16"/>
   <object id="2" name="Teleport to Scoop 3" type="event" x="144" y="336" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport scoop3.tmx,5,3,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport scoop3.tmx,5,3,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="3" name="Teleport to Timber Town" type="event" x="176" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport timber_town.tmx,18,23,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="transition_teleport timber_town.tmx,18,23,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="29" name="Player Spawn" type="event" x="160" y="320" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ff0000" name="Collision">
+ <objectgroup color="#ff0000" id="7" name="Collision">
   <object id="4" type="collision" x="0" y="0" width="192" height="48"/>
   <object id="5" type="collision" x="112" y="160" width="80" height="16"/>
   <object id="7" type="collision-line" x="0" y="352">

--- a/mods/tuxemon/maps/sphalian_town.tmx
+++ b/mods/tuxemon/maps/sphalian_town.tmx
@@ -1,49 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="23" height="25" tilewidth="16" tileheight="16" nextobjectid="38">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="23" height="25" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="38">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
  <tileset firstgid="1" name="Sand_n_water" tilewidth="16" tileheight="16" tilecount="104" columns="8">
   <image source="../gfx/tilesets/Sand_n_water.png" width="128" height="208"/>
  </tileset>
- <tileset firstgid="105" name="KelvinShadewing_Buildings" tilewidth="16" tileheight="16" tilecount="500" columns="20">
-  <image source="../gfx/tilesets/KelvinShadewing_Buildings.png" width="320" height="400"/>
+ <tileset firstgid="105" name="KelvinShadewing_Buildings" tilewidth="16" tileheight="16" tilecount="680" columns="20">
+  <image source="../gfx/tilesets/KelvinShadewing_Buildings.png" width="320" height="544"/>
  </tileset>
- <tileset firstgid="605" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
+ <tileset firstgid="785" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>
  </tileset>
- <tileset firstgid="1917" name="KelvinShadewing_Terrain" tilewidth="16" tileheight="16" tilecount="285" columns="19">
+ <tileset firstgid="2097" name="KelvinShadewing_Terrain" tilewidth="16" tileheight="16" tilecount="285" columns="19">
   <image source="../gfx/tilesets/KelvinShadewing_Terrain.png" width="304" height="240"/>
  </tileset>
- <tileset firstgid="2202" name="buddha-statues" tilewidth="16" tileheight="16" tilecount="10" columns="5">
+ <tileset firstgid="2382" name="buddha-statues" tilewidth="16" tileheight="16" tilecount="10" columns="5">
   <image source="../gfx/tilesets/buddha-statues.png" width="80" height="32"/>
  </tileset>
- <tileset firstgid="2212" name="Route_1a" tilewidth="16" tileheight="16" tilecount="1" columns="40">
+ <tileset firstgid="2392" name="Route_1a" tilewidth="16" tileheight="16" tilecount="0" columns="40">
   <image source="../gfx/tilesets/Route_1a.png" width="640" height="320"/>
  </tileset>
- <layer name="Tile Layer 1" width="23" height="25">
+ <layer id="1" name="Tile Layer 1" width="23" height="25">
   <data encoding="base64" compression="zlib">
-   eJztzLERgCAURMGboT5KM0ClGUGbUcc2eEV8h+SCTTdLymZmZva7kqQVG3bUFHcfXA0dJ67A++Z68GLBF3jPMABC0rNJ
+   eAHt1bsNgDAQBNEN3BgBHwduBQzNYMvNeoo4RLLBSzc4jXRFUjHfwA24ATfgBtzA5w2sSdqw40BG1A8+2bpQceNB1PbLVkPHgoGo7T92Jj9EruQ=
   </data>
  </layer>
- <layer name="Tile Layer 2" width="23" height="25">
+ <layer id="2" name="Tile Layer 2" width="23" height="25">
   <data encoding="base64" compression="zlib">
-   eJzl1TlOw0AUxvEHsWSH3IDtSCQgtgKoAgKSPgFOwdZD4BRA6NmukIKwdBQIEUr+I4w0NjP2JGgKxJN+cgrr85enkaYjIh1PXj3Sv7NeENnAJmqo435IjJPX+aWY/M4uWXvYxwEO8WbJVu9PBSJlVDCNmSCZp88ZWee4QBuXGdlqGmQ1sYVt7ATJ7vp0yXrAI57wjJFhe/YRWcdo4QSnqd6zmHMwb8i+IusaN7jFXar3EpYdrOA9FOnFPkLzf9F795NdjNhRrBTZdzVIb9XXJdtn7+/uvrJ99m5F5uwyKpbsEFGc3wvt1DkyZS9g0ZI9ijGtv03J0ttlJ8pEhslfZA+67/9yBk13yl/orU+18PXst/d46oy1c3pXsepgLXsFPyZ9p+WNurtNv02jen8CPx/PZQ==
+   eAHVlTlSwzAUhkVIGMgJKNh6tlOwVVAkTgqgAkq2nu0UbB0lcAMI3IAAB0jBERgOwPfAmnlmnogMuEAzX6R4pE+/5Ze445zrFMQr3qLQmYfKzg3DCIzCGLz0sLnR9DprfFHNZp7BNQtzMA8L8BZwy72WKs71Qhkq0Af6DHSkTVxbsA07sAsht6wbxzUBkzAF06DvQbuPcZ3AKZzBOVRLekZ2XMNVhwQa0ASdu8b0egRJVvvxbQ/XPhzAIRyBzr3MrJUIVplz2e/cVco1vdV07jzuFr67lPuAW/bz2fO4JXOM22fP447N7bMX5ZbsRbmTAdu9yJ5LoOtH6kTO5AZu03P3NWP1UkdW7gaeZsD9wJp26vbP1eqljiy3zuvHPrf2PLE+xPMv3N/VN7fsQufts+r+a+5ubvn9/PRMurn/qgatd8p/yC3PzrdB/vOl5c39qGpOaqz1qTE/5bzXYD2CDdMQvii58zR5d/umx/6a7iX3O3uN8WE=
   </data>
  </layer>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="3" name="Events">
   <object id="9" name="Go to route 1a" type="event" x="192" y="384" width="16" height="16">
    <properties>
-    <property name="act1" value="teleport route_1a.tmx,18,6,0.3"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="teleport route_1a.tmx,18,6,0.3"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="10" name="Go into the house" type="event" x="320" y="368" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport sphalian_town_house.tmx,5,7,0.3"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport sphalian_town_house.tmx,5,7,0.3"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="11" name="Music playing" type="init" x="32" y="208" width="16" height="16">
@@ -54,41 +54,41 @@
   </object>
   <object id="21" name="Buddha Mountain" type="event" x="352" y="208" width="16" height="48">
    <properties>
-    <property name="act1" value="teleport BuddhaMountain.tmx,3,89,1.5"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="teleport BuddhaMountain.tmx,3,89,1.5"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="22" name="sphalian care" type="event" x="272" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="teleport healing_center_sphalian.tmx,7,12,0.3"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="teleport healing_center_sphalian.tmx,7,12,0.3"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="27" name="Sphalian Town sign" type="event" x="240" y="368" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog Sphalian Town - a quiet\, peaceful place"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog Sphalian Town - a quiet\, peaceful place"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="36" name="go to route1a right" type="event" x="208" y="384" width="16" height="16">
    <properties>
-    <property name="act1" value="teleport route_1a.tmx,19,6,0.3"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="teleport route_1a.tmx,19,6,0.3"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="37" name="Player Spawn" type="event" x="320" y="224" width="16" height="16"/>
  </objectgroup>
- <layer name="Above Player" width="23" height="25">
+ <layer id="4" name="Above Player" width="23" height="25">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUjIJRMApGwVAFKwfaAUMQAADUUACq
+   eAFjYBgFoyEwGgKjITAaAqMhMBoCQzUEVg5Vhw+guwHUUACq
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collision">
   <object id="7" type="collision" x="3" y="96" width="166" height="276"/>
   <object id="12" type="collision" x="272" y="320" width="48" height="48"/>
   <object id="14" type="collision" x="240" y="352" width="16" height="16"/>

--- a/mods/tuxemon/maps/sphalian_town_house.tmx
+++ b/mods/tuxemon/maps/sphalian_town_house.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="11" height="9" tilewidth="16" tileheight="16" nextobjectid="29">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="11" height="9" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="29">
  <tileset firstgid="1" name="floors and walls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>
  </tileset>
@@ -15,27 +15,27 @@
  <tileset firstgid="201" name="kitchen" tilewidth="16" tileheight="16" tilecount="16" columns="4">
   <image source="../gfx/tilesets/kitchen.png" width="64" height="64"/>
  </tileset>
- <layer name="Tile Layer 1" width="11" height="9">
+ <layer id="1" name="Tile Layer 1" width="11" height="9">
   <data encoding="base64" compression="zlib">
-   eJxjYCANLANiRgIYBtYBsTgBDAN6RGBqqtWHYmqbi00tsQAAeKkKLQ==
+   eAFjYCANLAMqZySAYSauAzLECWCYWj0ggxCmplp9oGEgDLITBgjZT65amPmEaAB4qQot
   </data>
  </layer>
- <layer name="Tile Layer 2" width="11" height="9">
+ <layer id="2" name="Tile Layer 2" width="11" height="9">
   <data encoding="base64" compression="zlib">
-   eJxjYCANMAIxM5FqxYGYD4jjgTgBKnYGiE8B8WkgPolFTzYQ5wDxRSC+AMTngPg8EJ9FUqMOxBpArImmdxoUIwMjIDYGYhMksZlI7BlIbFsgtgNiezQz+oF4Iha3IgNWAvLEAAAtFA5C
+   eAGdyz0OQEAQhmEiWq0joEWLo9BzF9EIR/LPjbyb2GSyFSZ5st98mbWsb2Nz7rz84nPnoUQFNStmLJhgTk3R4MKJHQc26AkIISJdPG/Pq8iJWRKkohxFHkTOyDkK0anYojM6c3XN4sd+Ay0UDkI=
   </data>
  </layer>
- <layer name="Tile Layer 3" width="11" height="9">
+ <layer id="3" name="Tile Layer 3" width="11" height="9">
   <data encoding="base64" compression="zlib">
-   eJxjYBj+YD8WsXIgriRS/zQopjUAAH9XAtw=
+   eAFjYBj+YD8WL5YDxSqxiGMTmgYUBGFaAwB/VwLc
   </data>
  </layer>
- <layer name="Above player" width="11" height="9">
+ <layer id="4" name="Above player" width="11" height="9">
   <data encoding="base64" compression="zlib">
-   eJxjYBiaYPcA258IxElAnEyEWkk0jEsMAAsPAqo=
+   eAFjYBiaYPcAOzsRaH8SECcT4Q5JoBpkDNKCzAexQQAACw8Cqg==
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collision">
   <object id="1" type="collision" x="112" y="80" width="32" height="16"/>
   <object id="2" type="collision" x="32" y="32" width="128" height="16"/>
   <object id="3" type="collision" x="160" y="48" width="16" height="80"/>
@@ -45,7 +45,7 @@
   <object id="7" type="collision" x="16" y="16" width="16" height="32"/>
   <object id="8" type="collision" x="16" y="128" width="144" height="16"/>
  </objectgroup>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="6" name="Events">
   <object id="23" name="Play Music" type="init" x="144" y="16" width="16" height="16">
    <properties>
     <property name="act1" value="play_music music_house_downstairs"/>
@@ -54,27 +54,27 @@
   </object>
   <object id="24" name="Watch TV" type="event" x="32" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog You watch some TV with your beloved Lv ${{monster_0_level}} ${{monster_0_name}}.,0"/>
-    <property name="cond1" value="is party_size greater_than,0"/>
-    <property name="cond2" value="is player_at 2,6"/>
-    <property name="cond3" value="is player_facing up"/>
-    <property name="cond4" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog You watch some TV with your beloved Lv ${{monster_0_level}} ${{monster_0_name}}.,0"/>
+    <property name="cond10" value="is party_size greater_than,0"/>
+    <property name="cond20" value="is player_at 2,6"/>
+    <property name="cond30" value="is player_facing up"/>
+    <property name="cond40" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="25" name="Read Sign" type="event" x="32" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog Home Sweet Home"/>
-    <property name="cond1" value="is player_at 2,3"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog Home Sweet Home"/>
+    <property name="cond10" value="is player_at 2,3"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="27" name="Go Outside" type="event" x="80" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport sphalian_town.tmx,20,23,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at 5,7"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport sphalian_town.tmx,20,23,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at 5,7"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="28" name="Player Spawn" type="event" x="80" y="80" width="16" height="16"/>

--- a/mods/tuxemon/maps/taba_town.tmx
+++ b/mods/tuxemon/maps/taba_town.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.3.1" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="64" height="60" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="130">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="64" height="60" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="130">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -206,8 +206,8 @@
  <objectgroup color="#ffff00" id="7" name="Events">
   <object id="67" name="Go to Player's house" type="event" x="688" y="720" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport player_house_downstairs.tmx,5,7,0.5"/>
-    <property name="cond1" value="is player_at"/>
+    <property name="act10" value="transition_teleport player_house_downstairs.tmx,5,7,0.5"/>
+    <property name="cond10" value="is player_at"/>
    </properties>
   </object>
   <object id="68" name="Play Music" type="init" x="0" y="0" width="16" height="16">
@@ -218,420 +218,420 @@
   </object>
   <object id="69" name="Go to Test house" type="event" x="528" y="688" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport maple_house.tmx,7,10,0.5"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport maple_house.tmx,7,10,0.5"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="70" name="Random Battle 1" type="event" x="512" y="432" width="128" height="80">
    <properties>
-    <property name="act1" value="random_encounter new_txmn"/>
-    <property name="act2" value="play_map_animation grass,0.1,noloop,player"/>
-    <property name="cond1" value="is player_moved"/>
-    <property name="cond2" value="is player_at"/>
+    <property name="act10" value="random_encounter new_txmn"/>
+    <property name="act20" value="play_map_animation grass,0.1,noloop,player"/>
+    <property name="cond10" value="is player_moved"/>
+    <property name="cond20" value="is player_at"/>
    </properties>
   </object>
   <object id="71" name="Random Battle 2" type="event" x="352" y="432" width="96" height="80">
    <properties>
-    <property name="act1" value="random_encounter rare_txmn"/>
-    <property name="act2" value="play_map_animation grass,0.1,noloop,player"/>
-    <property name="cond1" value="is player_moved"/>
-    <property name="cond2" value="is player_at"/>
+    <property name="act10" value="random_encounter rare_txmn"/>
+    <property name="act20" value="play_map_animation grass,0.1,noloop,player"/>
+    <property name="cond10" value="is player_moved"/>
+    <property name="cond20" value="is player_at"/>
    </properties>
   </object>
   <object id="72" name="Random Battle 3" type="event" x="400" y="368" width="112" height="48">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="act2" value="play_map_animation grass,0.1,noloop,player"/>
-    <property name="cond1" value="is player_moved"/>
-    <property name="cond2" value="is player_at"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="act20" value="play_map_animation grass,0.1,noloop,player"/>
+    <property name="cond10" value="is player_moved"/>
+    <property name="cond20" value="is player_at"/>
    </properties>
   </object>
   <object id="73" name="Random Battle 4" type="event" x="352" y="304" width="144" height="48">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="act2" value="play_map_animation grass,0.1,noloop,player"/>
-    <property name="cond1" value="is player_moved"/>
-    <property name="cond2" value="is player_at"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="act20" value="play_map_animation grass,0.1,noloop,player"/>
+    <property name="cond10" value="is player_moved"/>
+    <property name="cond20" value="is player_at"/>
    </properties>
   </object>
   <object id="74" name="Random Battle 5" type="event" x="208" y="80" width="64" height="80">
    <properties>
-    <property name="act1" value="random_encounter default_encounter"/>
-    <property name="act2" value="play_map_animation grass,0.1,noloop,player"/>
-    <property name="cond1" value="is player_moved"/>
-    <property name="cond2" value="is player_at"/>
+    <property name="act10" value="random_encounter default_encounter"/>
+    <property name="act20" value="play_map_animation grass,0.1,noloop,player"/>
+    <property name="cond10" value="is player_moved"/>
+    <property name="cond20" value="is player_at"/>
    </properties>
   </object>
   <object id="75" name="Empty Grass 1" type="event" x="464" y="816" width="80" height="32">
    <properties>
-    <property name="act1" value="play_map_animation grass,0.1,noloop,player"/>
-    <property name="cond1" value="is player_moved"/>
-    <property name="cond2" value="is player_at"/>
+    <property name="act10" value="play_map_animation grass,0.1,noloop,player"/>
+    <property name="cond10" value="is player_moved"/>
+    <property name="cond20" value="is player_at"/>
    </properties>
   </object>
   <object id="76" name="Empty Grass 2" type="event" x="464" y="800" width="32" height="16">
    <properties>
-    <property name="act1" value="play_map_animation grass,0.1,noloop,player"/>
-    <property name="cond1" value="is player_moved"/>
-    <property name="cond2" value="is player_at"/>
+    <property name="act10" value="play_map_animation grass,0.1,noloop,player"/>
+    <property name="cond10" value="is player_moved"/>
+    <property name="cond20" value="is player_at"/>
    </properties>
   </object>
   <object id="78" name="Player's House Sign" type="event" x="624" y="720" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog ${{name}}'s &quot;house&quot;"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog ${{name}}'s &quot;house&quot;"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="79" name="Professor's House Sign" type="event" x="560" y="688" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog Tuxemon Professor's House"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog Tuxemon Professor's House"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="80" name="Teleport to Route 1" type="event" x="192" y="176" width="16" height="16">
    <properties>
-    <property name="act1" value="teleport route1.tmx,46,15"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
+    <property name="act10" value="teleport route1.tmx,46,15"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
    </properties>
   </object>
   <object id="81" name="Teleport to Route 1" type="event" x="192" y="192" width="16" height="16">
    <properties>
-    <property name="act1" value="teleport route1.tmx,46,16"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
+    <property name="act10" value="teleport route1.tmx,46,16"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
    </properties>
   </object>
   <object id="95" name="Go to Professor's Lab" type="event" x="704" y="832" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport professor_lab.tmx,9,17,0.5"/>
-    <property name="cond1" value="is player_at"/>
+    <property name="act10" value="transition_teleport professor_lab.tmx,9,17,0.5"/>
+    <property name="cond10" value="is player_at"/>
    </properties>
   </object>
   <object id="96" name="Professor's Lab Sign" type="event" x="624" y="832" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog Tuxemon Professor's Lab"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog Tuxemon Professor's Lab"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="98" name="Teleport to healing center" type="event" x="640" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport healing_center.tmx,7,12,0.3"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport healing_center.tmx,7,12,0.3"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="108" name="Enter mart" type="event" x="480" y="176" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport tuxe_mart.tmx,7,12,0.3"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport tuxe_mart.tmx,7,12,0.3"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="124" name="Tuxemart Sign" type="event" x="528" y="192" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog Tuxemart - A place to buy and sell items"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog Tuxemart - A place to buy and sell items"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="110" name="Tuxecenter Sign" type="event" x="688" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog Tuxecenter - A place to heal your tuxemon"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog Tuxecenter - A place to heal your tuxemon"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="112" name="Startup Town Sign" type="event" x="624" y="640" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog Taba Town - A peaceful refuge"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog Taba Town - A peaceful refuge"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="115" name="Route 0 Sign" type="event" x="576" y="544" width="16" height="16">
    <properties>
-    <property name="act1" value="dialog Route 20"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="dialog Route 20"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="118" name="Preload route1" type="event" x="0" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="preload_map route1.tmx"/>
-    <property name="cond1" value="is true"/>
+    <property name="act10" value="preload_map route1.tmx"/>
+    <property name="cond10" value="is true"/>
    </properties>
   </object>
   <object id="122" name="Player Spawn" type="event" x="608" y="752" width="16" height="16"/>
   <object id="123" name="Check for Healing Center Teleport" type="event" x="208" y="-32" width="16" height="16">
    <properties>
-    <property name="act1" value="set_variable battle_lost_faint:false"/>
-    <property name="act2" value="wait .4"/>
-    <property name="act3" value="teleport_faint"/>
-    <property name="cond1" value="is variable_set battle_lost_faint:true"/>
+    <property name="act10" value="set_variable battle_lost_faint:false"/>
+    <property name="act20" value="wait .4"/>
+    <property name="act30" value="teleport_faint"/>
+    <property name="cond10" value="is variable_set battle_lost_faint:true"/>
    </properties>
   </object>
   <object id="125" name="bring on the nurses" type="event" x="352" y="640" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc nurse1,37,39,,stand"/>
-    <property name="act2" value="create_npc nurse2,38,39,,stand"/>
-    <property name="act3" value="npc_face nurse1,down"/>
-    <property name="act4" value="npc_face nurse2,down"/>
-    <property name="cond1" value="not variable_set thewifedidspeak:yes"/>
+    <property name="act10" value="create_npc nurse1,37,39,,stand"/>
+    <property name="act20" value="create_npc nurse2,38,39,,stand"/>
+    <property name="act30" value="npc_face nurse1,down"/>
+    <property name="act40" value="npc_face nurse2,down"/>
+    <property name="cond10" value="not variable_set thewifedidspeak:yes"/>
    </properties>
   </object>
   <object id="126" name="nopenotyet" type="event" x="592" y="640" width="32" height="16">
    <properties>
-    <property name="act1" value="translated_dialog nopenotyet"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog nopenotyet"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="127" name="bring the cavalry" type="event" x="672" y="752" width="16" height="16">
    <properties>
-    <property name="act1" value="wait 1"/>
-    <property name="act2" value="create_npc allie,37,40,,stand"/>
-    <property name="act3" value="create_npc knight4,37,39,,stand"/>
-    <property name="act4" value="create_npc knight3,38,39,,stand"/>
-    <property name="act5" value="player_stop"/>
-    <property name="act6" value="translated_dialog hellolovelypeople"/>
-    <property name="act7" value="create_npc npc_mom,43,46,,stand"/>
-    <property name="act8" value="npc_face npc_mom, left"/>
-    <property name="act9" value="set_variable goodbyeoldknight:hedead"/>
-    <property name="cond1" value="is variable_set goodbyeoldknight:yes"/>
+    <property name="act10" value="wait 1"/>
+    <property name="act20" value="create_npc allie,37,40,,stand"/>
+    <property name="act30" value="create_npc knight4,37,39,,stand"/>
+    <property name="act40" value="create_npc knight3,38,39,,stand"/>
+    <property name="act50" value="player_stop"/>
+    <property name="act60" value="translated_dialog hellolovelypeople"/>
+    <property name="act70" value="create_npc npc_mom,43,46,,stand"/>
+    <property name="act80" value="npc_face npc_mom, left"/>
+    <property name="act90" value="set_variable goodbyeoldknight:hedead"/>
+    <property name="cond10" value="is variable_set goodbyeoldknight:yes"/>
    </properties>
   </object>
   <object id="124" name="bringthecavalry2" type="event" x="672" y="752" width="16" height="16">
    <properties>
-    <property name="act1" value="pathfind allie,37,44"/>
-    <property name="act2" value="wait 0.5"/>
-    <property name="act3" value="npc_face allie,up"/>
-    <property name="act4" value="wait 0.3"/>
-    <property name="act5" value="npc_face allie,right"/>
-    <property name="act6" value="translated_dialog darnitjohn"/>
-    <property name="act7" value="npc_face allie,up"/>
-    <property name="act8" value="translated_dialog darnitjohn2"/>
-    <property name="act81" value="wait 1"/>
-    <property name="act9" value="pathfind knight4,37,43"/>
-    <property name="act91" value="translated_dialog johnissorry"/>
-    <property name="act92" value="npc_face allie,right"/>
-    <property name="act93" value="translated_dialog uselessnes"/>
-    <property name="act94" value="npc_face allie,down"/>
-    <property name="act99" value="set_variable goodbyeoldknight:heback"/>
-    <property name="cond1" value="is variable_set goodbyeoldknight:hedead"/>
+    <property name="act010" value="pathfind allie,37,44"/>
+    <property name="act020" value="wait 0.5"/>
+    <property name="act030" value="npc_face allie,up"/>
+    <property name="act040" value="wait 0.3"/>
+    <property name="act050" value="npc_face allie,right"/>
+    <property name="act060" value="translated_dialog darnitjohn"/>
+    <property name="act070" value="npc_face allie,up"/>
+    <property name="act080" value="translated_dialog darnitjohn2"/>
+    <property name="act090" value="wait 1"/>
+    <property name="act100" value="pathfind knight4,37,43"/>
+    <property name="act110" value="translated_dialog johnissorry"/>
+    <property name="act120" value="npc_face allie,right"/>
+    <property name="act130" value="translated_dialog uselessnes"/>
+    <property name="act140" value="npc_face allie,down"/>
+    <property name="act150" value="set_variable goodbyeoldknight:heback"/>
+    <property name="cond10" value="is variable_set goodbyeoldknight:hedead"/>
    </properties>
   </object>
   <object id="125" name="cavalrysamewalk" type="event" x="736" y="720" width="16" height="16">
    <properties>
-    <property name="act1" value="pathfind knight3,38,43"/>
-    <property name="act2" value="set_variable foome:ye"/>
-    <property name="cond1" value="is variable_set goodbyeoldknight:hedead"/>
-    <property name="cond2" value="not variable_set foome:ye"/>
+    <property name="act10" value="pathfind knight3,38,43"/>
+    <property name="act20" value="set_variable foome:ye"/>
+    <property name="cond10" value="is variable_set goodbyeoldknight:hedead"/>
+    <property name="cond20" value="not variable_set foome:ye"/>
    </properties>
   </object>
   <object id="126" name="timetowalk" type="event" x="736" y="752" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog cometomepls"/>
-    <property name="act11" value="set_variable talkpls:yes"/>
-    <property name="act2" value="player_stop"/>
-    <property name="act3" value="pathfind player,37,47"/>
-    <property name="act4" value="npc_face player,up"/>
-    <property name="act5" value="player_resume"/>
-    <property name="act6" value="create_npc npc_wife,33,44"/>
-    <property name="act7" value="pathfind npc_wife,36,47"/>
-    <property name="act8" value="npc_face npc_wife,up"/>
-    <property name="act9" value="set_variable goodbyeoldknight:helpme"/>
-    <property name="cond1" value="is variable_set goodbyeoldknight:heback"/>
+    <property name="act010" value="translated_dialog cometomepls"/>
+    <property name="act020" value="set_variable talkpls:yes"/>
+    <property name="act030" value="player_stop"/>
+    <property name="act040" value="pathfind player,37,47"/>
+    <property name="act050" value="npc_face player,up"/>
+    <property name="act060" value="player_resume"/>
+    <property name="act070" value="create_npc npc_wife,33,44"/>
+    <property name="act080" value="pathfind npc_wife,36,47"/>
+    <property name="act090" value="npc_face npc_wife,up"/>
+    <property name="act100" value="set_variable goodbyeoldknight:helpme"/>
+    <property name="cond10" value="is variable_set goodbyeoldknight:heback"/>
    </properties>
   </object>
   <object id="127" name="timetowalk2" type="event" x="736" y="752" width="16" height="16">
    <properties>
-    <property name="act1" value="pathfind npc_mom,38,47"/>
-    <property name="act3" value="npc_face npc_mom,up"/>
-    <property name="act6" value="set_variable talkpls:gone"/>
-    <property name="cond1" value="is variable_set talkpls:yes"/>
+    <property name="act10" value="pathfind npc_mom,38,47"/>
+    <property name="act20" value="npc_face npc_mom,up"/>
+    <property name="act30" value="set_variable talkpls:gone"/>
+    <property name="cond10" value="is variable_set talkpls:yes"/>
    </properties>
   </object>
   <object id="128" name="listentime" type="event" x="736" y="752" width="16" height="16">
    <properties>
-    <property name="act1" value="wait 0.6"/>
-    <property name="act2" value="translated_dialog hellolovelypeople2"/>
-    <property name="act3" value="npc_face allie,left"/>
-    <property name="act31" value="wait 0.5"/>
-    <property name="act32" value="npc_face allie,right"/>
-    <property name="act33" value="wait 0.5"/>
-    <property name="act34" value="npc_face allie,down"/>
-    <property name="act35" value="wait 0.3"/>
-    <property name="act4" value="translated_dialog hellolovelypeople3"/>
-    <property name="act5" value="translated_dialog hellolovelypeople4"/>
-    <property name="act51" value="npc_face allie,right"/>
-    <property name="act52" value="wait 0.3"/>
-    <property name="act53" value="npc_face allie,left"/>
-    <property name="act54" value="wait 0.3"/>
-    <property name="act55" value="npc_face allie,down"/>
-    <property name="act6" value="translated_dialog hellolovelypeople5"/>
-    <property name="act7" value="set_variable goodbyeoldknight:ohwell"/>
-    <property name="cond1" value="is variable_set goodbyeoldknight:helpme"/>
+    <property name="act010" value="wait 0.6"/>
+    <property name="act020" value="translated_dialog hellolovelypeople2"/>
+    <property name="act030" value="npc_face allie,left"/>
+    <property name="act040" value="wait 0.5"/>
+    <property name="act050" value="npc_face allie,right"/>
+    <property name="act060" value="wait 0.5"/>
+    <property name="act070" value="npc_face allie,down"/>
+    <property name="act080" value="wait 0.3"/>
+    <property name="act090" value="translated_dialog hellolovelypeople3"/>
+    <property name="act100" value="translated_dialog hellolovelypeople4"/>
+    <property name="act110" value="npc_face allie,right"/>
+    <property name="act120" value="wait 0.3"/>
+    <property name="act130" value="npc_face allie,left"/>
+    <property name="act140" value="wait 0.3"/>
+    <property name="act150" value="npc_face allie,down"/>
+    <property name="act160" value="translated_dialog hellolovelypeople5"/>
+    <property name="act170" value="set_variable goodbyeoldknight:ohwell"/>
+    <property name="cond10" value="is variable_set goodbyeoldknight:helpme"/>
    </properties>
   </object>
   <object id="129" name="listentime2" type="event" x="736" y="752" width="16" height="16">
    <properties>
-    <property name="act1" value="npc_face allie,up"/>
-    <property name="act2" value="translated_dialog whereismyhairbrush"/>
-    <property name="act3" value="pathfind knight3,43,46"/>
-    <property name="act31" value="npc_face knight3,up"/>
-    <property name="act32" value="npc_face allie,right"/>
-    <property name="act33" value="remove_npc knight3"/>
-    <property name="act4" value="wait 0.3"/>
-    <property name="act41" value="npc_face allie,up"/>
-    <property name="act42" value="translated_dialog darnitjohn3"/>
-    <property name="act43" value="translated_dialog darnitjohn4"/>
-    <property name="act44" value="translated_dialog darnitjohn5"/>
-    <property name="act45" value="translated_dialog darnitjohn6"/>
-    <property name="act46" value="npc_face knight4,right"/>
-    <property name="act47" value="wait 0.1"/>
-    <property name="act48" value="npc_face knight4,left"/>
-    <property name="act49" value="wait 0.1"/>
-    <property name="act491" value="npc_face knight4,down"/>
-    <property name="act5" value="translated_dialog darnitjohn7"/>
-    <property name="act51" value="npc_face allie,down"/>
-    <property name="act52" value="wait 0.6"/>
-    <property name="act6" value="translated_dialog darnitjohn8"/>
-    <property name="act7" value="npc_speed allie,10"/>
-    <property name="act71" value="pathfind allie,38,43"/>
-    <property name="act72" value="npc_face allie,left"/>
-    <property name="act73" value="npc_face knight4,right"/>
-    <property name="act8" value="translated_dialog darnitjohn9"/>
-    <property name="act81" value="wait 0.5"/>
-    <property name="act82" value="translated_dialog darnitjohn10"/>
-    <property name="act83" value="npc_speed knight4,8"/>
-    <property name="act84" value="pathfind knight4,33,44"/>
-    <property name="act85" value="npc_face knight4,up"/>
-    <property name="act86" value="remove_npc knight4"/>
-    <property name="act99" value="set_variable goodbyeoldknight:mamamia"/>
-    <property name="cond1" value="is variable_set goodbyeoldknight:ohwell"/>
+    <property name="act010" value="npc_face allie,up"/>
+    <property name="act020" value="translated_dialog whereismyhairbrush"/>
+    <property name="act030" value="pathfind knight3,43,46"/>
+    <property name="act040" value="npc_face knight3,up"/>
+    <property name="act050" value="npc_face allie,right"/>
+    <property name="act060" value="remove_npc knight3"/>
+    <property name="act070" value="wait 0.3"/>
+    <property name="act080" value="npc_face allie,up"/>
+    <property name="act090" value="translated_dialog darnitjohn3"/>
+    <property name="act100" value="translated_dialog darnitjohn4"/>
+    <property name="act110" value="translated_dialog darnitjohn5"/>
+    <property name="act120" value="translated_dialog darnitjohn6"/>
+    <property name="act130" value="npc_face knight4,right"/>
+    <property name="act140" value="wait 0.1"/>
+    <property name="act150" value="npc_face knight4,left"/>
+    <property name="act160" value="wait 0.1"/>
+    <property name="act170" value="npc_face knight4,down"/>
+    <property name="act180" value="translated_dialog darnitjohn7"/>
+    <property name="act190" value="npc_face allie,down"/>
+    <property name="act200" value="wait 0.6"/>
+    <property name="act210" value="translated_dialog darnitjohn8"/>
+    <property name="act220" value="npc_speed allie,10"/>
+    <property name="act230" value="pathfind allie,38,43"/>
+    <property name="act240" value="npc_face allie,left"/>
+    <property name="act250" value="npc_face knight4,right"/>
+    <property name="act260" value="translated_dialog darnitjohn9"/>
+    <property name="act270" value="wait 0.5"/>
+    <property name="act280" value="translated_dialog darnitjohn10"/>
+    <property name="act290" value="npc_speed knight4,8"/>
+    <property name="act300" value="pathfind knight4,33,44"/>
+    <property name="act310" value="npc_face knight4,up"/>
+    <property name="act320" value="remove_npc knight4"/>
+    <property name="act330" value="set_variable goodbyeoldknight:mamamia"/>
+    <property name="cond10" value="is variable_set goodbyeoldknight:ohwell"/>
    </properties>
   </object>
   <object id="130" name="listentime3" type="event" x="736" y="752" width="16" height="16">
    <properties>
-    <property name="act1" value="pathfind allie,37,45"/>
-    <property name="act11" value="npc_face allie,down"/>
-    <property name="act2" value="translated_dialog oopsie"/>
-    <property name="act3" value="pathfind npc_mom,38,46"/>
-    <property name="act31" value="translated_dialog ourstuffisours"/>
-    <property name="act4" value="npc_face allie,right"/>
-    <property name="act41" value="translated_dialog oopsie2"/>
-    <property name="act42" value="pathfind npc_mom,38,47"/>
-    <property name="act43" value="npc_face npc_mom,up"/>
-    <property name="act5" value="create_npc knight3,43,46"/>
-    <property name="act51" value="npc_face knight3,left"/>
-    <property name="act52" value="translated_dialog maamiexist"/>
-    <property name="act53" value="translated_dialog maamiexist2"/>
-    <property name="act54" value="npc_face knight3,up"/>
-    <property name="act55" value="wait 0.4"/>
-    <property name="act56" value="npc_face knight3,left"/>
-    <property name="act57" value="translated_dialog maamiexist3"/>
-    <property name="act58" value="translated_dialog maamiexist4"/>
-    <property name="act59" value="translated_dialog yesmaam"/>
-    <property name="act6" value="pathfind knight3,44,53"/>
-    <property name="act61" value="npc_face knight3,up"/>
-    <property name="act62" value="remove_npc knight3"/>
-    <property name="act7" value="npc_face allie,down"/>
-    <property name="act99" value="set_variable goodbyeoldknight:herewegoagain"/>
-    <property name="cond1" value="is variable_set goodbyeoldknight:mamamia"/>
+    <property name="act010" value="pathfind allie,37,45"/>
+    <property name="act020" value="npc_face allie,down"/>
+    <property name="act030" value="translated_dialog oopsie"/>
+    <property name="act040" value="pathfind npc_mom,38,46"/>
+    <property name="act050" value="translated_dialog ourstuffisours"/>
+    <property name="act060" value="npc_face allie,right"/>
+    <property name="act070" value="translated_dialog oopsie2"/>
+    <property name="act080" value="pathfind npc_mom,38,47"/>
+    <property name="act090" value="npc_face npc_mom,up"/>
+    <property name="act100" value="create_npc knight3,43,46"/>
+    <property name="act110" value="npc_face knight3,left"/>
+    <property name="act120" value="translated_dialog maamiexist"/>
+    <property name="act130" value="translated_dialog maamiexist2"/>
+    <property name="act140" value="npc_face knight3,up"/>
+    <property name="act150" value="wait 0.4"/>
+    <property name="act160" value="npc_face knight3,left"/>
+    <property name="act170" value="translated_dialog maamiexist3"/>
+    <property name="act180" value="translated_dialog maamiexist4"/>
+    <property name="act190" value="translated_dialog yesmaam"/>
+    <property name="act200" value="pathfind knight3,44,53"/>
+    <property name="act210" value="npc_face knight3,up"/>
+    <property name="act220" value="remove_npc knight3"/>
+    <property name="act230" value="npc_face allie,down"/>
+    <property name="act240" value="set_variable goodbyeoldknight:herewegoagain"/>
+    <property name="cond10" value="is variable_set goodbyeoldknight:mamamia"/>
    </properties>
   </object>
   <object id="125" name="listentime4" type="event" x="736" y="752" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog itsmyaurababe"/>
-    <property name="act11" value="npc_speed allie,1.5"/>
-    <property name="act2" value="pathfind allie,37,46"/>
-    <property name="act3" value="translated_dialog itsmyaurababe2"/>
-    <property name="act4" value="add_item allies_address"/>
-    <property name="act41" value="translated_dialog itsmyduhduhduh"/>
-    <property name="act5" value="translated_dialog itsmyaurababe3"/>
-    <property name="act99" value="set_variable goodbyeoldknight:mama"/>
-    <property name="cond1" value="is variable_set goodbyeoldknight:herewegoagain"/>
+    <property name="act10" value="translated_dialog itsmyaurababe"/>
+    <property name="act20" value="npc_speed allie,1.5"/>
+    <property name="act30" value="pathfind allie,37,46"/>
+    <property name="act40" value="translated_dialog itsmyaurababe2"/>
+    <property name="act50" value="add_item allies_address"/>
+    <property name="act60" value="translated_dialog itsmyduhduhduh"/>
+    <property name="act70" value="translated_dialog itsmyaurababe3"/>
+    <property name="act80" value="set_variable goodbyeoldknight:mama"/>
+    <property name="cond10" value="is variable_set goodbyeoldknight:herewegoagain"/>
    </properties>
   </object>
   <object id="126" name="listentime5" type="event" x="736" y="752" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc knight4,33,44"/>
-    <property name="act2" value="npc_face knight4,right"/>
-    <property name="act3" value="translated_dialog maamnothing"/>
-    <property name="act4" value="npc_face allie,left"/>
-    <property name="act41" value="translated_dialog maamnothing2"/>
-    <property name="act42" value="translated_dialog maamnothing3"/>
-    <property name="act43" value="translated_dialog maamnothing4"/>
-    <property name="act44" value="create_npc knight3,38,53"/>
-    <property name="act45" value="pathfind knight3,39,46"/>
-    <property name="act46" value="npc_face knight3,left"/>
-    <property name="act461" value="npc_face allie,right"/>
-    <property name="act47" value="translated_dialog maamnothing5"/>
-    <property name="act5" value="npc_face allie,left"/>
-    <property name="act51" value="wait 0.4"/>
-    <property name="act52" value="npc_face allie,right"/>
-    <property name="act6" value="translated_dialog maamnothing6"/>
-    <property name="act61" value="npc_speed allie,3"/>
-    <property name="act611" value="npc_face allie,down"/>
-    <property name="act612" value="wait 1"/>
-    <property name="act613" value="translated_dialog seeme"/>
-    <property name="act62" value="pathfind allie,37,44"/>
-    <property name="act63" value="pathfind knight3,38,44"/>
-    <property name="act64" value="npc_face allie,left"/>
-    <property name="act641" value="translated_dialog solongjohn"/>
-    <property name="act65" value="pathfind allie,37,40"/>
-    <property name="act66" value="translated_dialog solongjohn2"/>
-    <property name="act67" value="npc_face knight3,up"/>
-    <property name="act68" value="translated_dialog yesmaam"/>
-    <property name="act7" value="pathfind knight3,38,40"/>
-    <property name="act71" value="remove_npc knight3"/>
-    <property name="act72" value="remove_npc allie"/>
-    <property name="act99" value="set_variable goodbyeoldknight:howcaniresistyou"/>
-    <property name="cond1" value="is variable_set goodbyeoldknight:mama"/>
+    <property name="act010" value="create_npc knight4,33,44"/>
+    <property name="act020" value="npc_face knight4,right"/>
+    <property name="act030" value="translated_dialog maamnothing"/>
+    <property name="act040" value="npc_face allie,left"/>
+    <property name="act050" value="translated_dialog maamnothing2"/>
+    <property name="act060" value="translated_dialog maamnothing3"/>
+    <property name="act070" value="translated_dialog maamnothing4"/>
+    <property name="act080" value="create_npc knight3,38,53"/>
+    <property name="act090" value="pathfind knight3,39,46"/>
+    <property name="act100" value="npc_face knight3,left"/>
+    <property name="act110" value="npc_face allie,right"/>
+    <property name="act120" value="translated_dialog maamnothing5"/>
+    <property name="act130" value="npc_face allie,left"/>
+    <property name="act140" value="wait 0.4"/>
+    <property name="act150" value="npc_face allie,right"/>
+    <property name="act160" value="translated_dialog maamnothing6"/>
+    <property name="act170" value="npc_speed allie,3"/>
+    <property name="act180" value="npc_face allie,down"/>
+    <property name="act190" value="wait 1"/>
+    <property name="act200" value="translated_dialog seeme"/>
+    <property name="act210" value="pathfind allie,37,44"/>
+    <property name="act220" value="pathfind knight3,38,44"/>
+    <property name="act230" value="npc_face allie,left"/>
+    <property name="act240" value="translated_dialog solongjohn"/>
+    <property name="act250" value="pathfind allie,37,40"/>
+    <property name="act260" value="translated_dialog solongjohn2"/>
+    <property name="act270" value="npc_face knight3,up"/>
+    <property name="act280" value="translated_dialog yesmaam"/>
+    <property name="act290" value="pathfind knight3,38,40"/>
+    <property name="act300" value="remove_npc knight3"/>
+    <property name="act310" value="remove_npc allie"/>
+    <property name="act320" value="set_variable goodbyeoldknight:howcaniresistyou"/>
+    <property name="cond10" value="is variable_set goodbyeoldknight:mama"/>
    </properties>
   </object>
   <object id="127" name="listentime6" type="event" x="736" y="752" width="16" height="16">
    <properties>
-    <property name="act1" value="pathfind knight4, 37,44"/>
-    <property name="act2" value="npc_face knight4,down"/>
-    <property name="act21" value="wait 0.4"/>
-    <property name="act3" value="translated_dialog knight4ispoor"/>
-    <property name="act31" value="wait 0.6"/>
-    <property name="act4" value="npc_face knight4,right"/>
-    <property name="act5" value="pathfind knight4,39,44"/>
-    <property name="act6" value="npc_face knight4,left"/>
-    <property name="act7" value="npc_face npc_mom,left"/>
-    <property name="act71" value="translated_dialog wherewasshe"/>
-    <property name="act72" value="pathfind npc_mom,43,46"/>
-    <property name="act73" value="npc_face npc_mom,up"/>
-    <property name="act74" value="remove_npc npc_mom"/>
-    <property name="act75" value="pathfind npc_wife,33,44"/>
-    <property name="act76" value="npc_face npc_wife,up"/>
-    <property name="act77" value="remove_npc npc_wife"/>
-    <property name="act99" value="set_variable goodbyeoldknight:finallydone"/>
-    <property name="cond1" value="is variable_set goodbyeoldknight:howcaniresistyou"/>
+    <property name="act010" value="pathfind knight4, 37,44"/>
+    <property name="act020" value="npc_face knight4,down"/>
+    <property name="act030" value="wait 0.4"/>
+    <property name="act040" value="translated_dialog knight4ispoor"/>
+    <property name="act050" value="wait 0.6"/>
+    <property name="act060" value="npc_face knight4,right"/>
+    <property name="act070" value="pathfind knight4,39,44"/>
+    <property name="act080" value="npc_face knight4,left"/>
+    <property name="act090" value="npc_face npc_mom,left"/>
+    <property name="act100" value="translated_dialog wherewasshe"/>
+    <property name="act110" value="pathfind npc_mom,43,46"/>
+    <property name="act120" value="npc_face npc_mom,up"/>
+    <property name="act130" value="remove_npc npc_mom"/>
+    <property name="act140" value="pathfind npc_wife,33,44"/>
+    <property name="act150" value="npc_face npc_wife,up"/>
+    <property name="act160" value="remove_npc npc_wife"/>
+    <property name="act170" value="set_variable goodbyeoldknight:finallydone"/>
+    <property name="cond10" value="is variable_set goodbyeoldknight:howcaniresistyou"/>
    </properties>
   </object>
   <object id="128" name="imalone" type="event" x="624" y="704" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog frowntime"/>
-    <property name="cond1" value="is variable_set goodbyeoldknight:finallydone"/>
-    <property name="cond2" value="is player_facing_tile"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog frowntime"/>
+    <property name="cond10" value="is variable_set goodbyeoldknight:finallydone"/>
+    <property name="cond20" value="is player_facing_tile"/>
+    <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="129" name="nuuujohnisgone" type="event" x="752" y="704" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc knight4,39,44"/>
-    <property name="act2" value="npc_face knight4,left"/>
-    <property name="cond1" value="not npc_exists knight4"/>
-    <property name="cond2" value="is variable_set goodbyeoldknight:finallydone"/>
+    <property name="act10" value="create_npc knight4,39,44"/>
+    <property name="act20" value="npc_face knight4,left"/>
+    <property name="cond10" value="not npc_exists knight4"/>
+    <property name="cond20" value="is variable_set goodbyeoldknight:finallydone"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/test.tmx
+++ b/mods/tuxemon/maps/test.tmx
@@ -1,43 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="25" height="25" tilewidth="16" tileheight="16" nextobjectid="41">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="25" height="25" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="41">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>
  </tileset>
- <tileset firstgid="1313" name="tileset" tilewidth="16" tileheight="16" tilecount="1" columns="0">
+ <tileset firstgid="1313" name="tileset" tilewidth="16" tileheight="16" tilecount="0" columns="0">
   <image source="../gfx/tileset.png" width="80" height="528"/>
  </tileset>
- <tileset firstgid="1324" name="signs" tilewidth="16" tileheight="16" tilecount="16" columns="4">
+ <tileset firstgid="1313" name="signs" tilewidth="16" tileheight="16" tilecount="16" columns="4">
   <image source="../gfx/tilesets/signs.png" width="64" height="64"/>
  </tileset>
- <layer name="Layer 1" width="25" height="25">
+ <layer id="1" name="Layer 1" width="25" height="25">
   <data encoding="base64" compression="zlib">
-   eJydlMkVwjAMREVILWwFQWdszbB1ELOVwNYCyxw45PlJI8WH/5IY25JmJFJfpAHpj/feZO/aMyl783Xt3vaZ/Ky1rySWhnVWq5fF1HK3atDq9XLU9jJPrDqYjpEcmW9M62i8iF+WZiwntmZpY/UaW4/0OdMj0lOReJ4ObFY8XZkv01pkVvPaSnqM+ej1lxeD3WvFiMTyfvOI5Mj80Dy1ZsybZ68v2s+5iCzAEqzAWsrqYfE2uHMLdmAPDuJ7zjzU+vGGO+/gAZ7gJTz/LnPt/U/k+4+VyAmcwQVcKzt2ZDY0Td648wO+QPDdI/WwfmHaDMAQjMAYTDrWoPVERM/oXLJ6Pb+tHmPf0dnXfPwBXx4CuA==
+   eAGNjtlNA0AQQ5ejFq6CoDOuZgjQAeEqARJa4PBIPOlptCF8WJ7x2N5d7o3xECx/sW2uO55N7C48aMXWmM01A3K+04E223sOD3pnd3HjD9zgfmcv7pl+w4NuPzO3ztzN9JXGbGYm473P7GZm8mZuMDf24g577CsdLzOMbqYH7rfaudHjfaY545kcb7DDM528b9b6+93HTqa/NdPp5EYHWe59t88zfms1k0c3czvdH+MscIdnesiS62wf+W0efD3bc+z42GH0Ys//vc98aDDdf3F5eZ8cbH3WQbb70GGy7MWALIxnlsFTfD7GuAgug6vgOvCdfjN3v+GZO3yTzkVwG9wF9wF+93oma19phv1v6XwPVsE6+AjcYS8daN6Z4dn7M83+x90xnoLn4CV4DWZvWXMnc3XiQWP/TOdX8B2M+Hbk9V/ogMn33Tq3g3QeBkfBcXAS8A88znFDYy+v/czWrfU8PdY9z3o23d3Fm9bI+caddzpzn2Xx/gBfHgK4
   </data>
  </layer>
- <layer name="Layer 2" width="25" height="25">
+ <layer id="2" name="Layer 2" width="25" height="25">
   <data encoding="base64" compression="zlib">
-   eJzlVlsKwjAQLGU9ii9Meg9/fEFsbuLrJt5P//QMbjFLw5p38UcHhpSwnWXSzrZV5YaA9ypxbSB/JezhU/uGe3ekgr6mhfy1gzI9XViM+mttalqrVnjuc8HlwwcF7utYT58PDtuXr/8D+WR6GvJ85MD2leojF/ZZlvoY11U1QU6RM+S89teW+lih5hq5QW6Ru0CPUh8H1DwiT8gz8oK8erTIhy+jIcjIu0YgH5TNJpDLUkj2/PksGKrdOPJB+prt81yngLS+lQ/e69v4Zx/LzHtSfcRmewi/8jw6UB6FI3tDoY0u5VFZfej8Bbi/1bF5Q99dYXT5v4oNZWrsWSkhfXaS/gto7CuF
+   eAHtVUkOwjAMrBB8BIlNAv7BhU1i+QnbT/gf3MobmBEd1YqapE25gaWREzseMylus6zapt1PfAY/B5p6se4LHu3pH4g9gV2R45kD0NSTixz8bTE7FmfYRyaN2od8lQ7feeli3q65D/Wso4McMWPPHHgZrazhHTTREetj81bXt3RYfq7tXabqGHSybAiMgDEwAXyWqmMJzhWwBjbAFvBZqo4TOM/ABbgCN+DuPG/1lA56O8vKh3y/F8qWOemg54ypT3mi/Uo6yKQ+8m3ZdTfSIT7x6/2huP0vKhbz4rI6YjWpeVdHKk+o7pd1LDyz5ruv//Pw3Ux1XPPI74o7e9UV9aPkI6/mkbPs9uGecE01blz7HDX87rKWvPa8+87gnrDvSumuM1vifwNwuCq6
   </data>
  </layer>
- <layer name="Layer 3" width="25" height="25">
+ <layer id="3" name="Layer 3" width="25" height="25">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUjIJRMApGATIIZRk4u/VYB87uUTC0AABk9gCN
+   eAFjYBgFoyEwGgKjITAaAqMhMBoCyCEQyoLMoy9bmZW+9o3aNnRDAABNEgCC
   </data>
  </layer>
- <layer name="Above Player" width="25" height="25">
+ <layer id="4" name="Above Player" width="25" height="25">
   <data encoding="base64" compression="zlib">
-   eJy9VtuNwjAQNGD64Ic7kAx9UIC5Ku6AZni1wKsXxKuYg7uJFCvLYjvZyGKkkW05u+tJsiMr5YfRxVxj3tbFGALfN3lMCJbsDTAf6mL0ncOQfVPhPBzjPC4bv3SRm57Dkn1L6sV0xHRZFmc8eVy9VOA1KSQ6JPDpkuK3odQdfIB/oGo+71NddXV0kfMD/AR7YL9ZHpMCs8B5nY6qPRbDuiSO91jdOj7Q7zEgOoYJaoTeCfcKB8m/eGw956r6X8V6LFQjdZ/HUKbjG/wBJ+AUnJXkcxokmIMLcAmuwLU8RVBH7Bt33vCOR54aG3jJFtyBe/BAvCWV756Q8wxewCt4e5N/UdTxKGmMe17SyyE/8IHeJSy7T+h8bZgnS0ajX+839D7h1pZ5JfdO7tk8PsM/N9wp4w==
+   eAG9VmtOgjEQLIr38A+KiXoPDqCeAoHL+OAKPriLQfAw+JiJTlg2235fhbDJZF/t7DehbUgptvPuut5FfATIrzubke+Tg7WcXZneBeJLQF577HcwVl/c/K62do213Ed/8xdzr/0Oxuoz1rySDj/f89m+1aO65inf1tv5nqtGh99byiNdpfVRb9VJ6RP4Ar6BdLC5yur6r44eOE+AU6APnAH7sAnOUmTSQd/mjkUcqk0zM9TXWZavuTviyHnpYJ/80sM7va2Jy/NIh6/XnMW3w9/d4rI6PK/N7Vm09SjWjF3f82iWak06hlh4C4yAMTABSiYNpTW+d4fCPfAAPAJToNZyOkq/8fEOzlzTdw6CGU94S56BF+AVmAGynA712/o5ON+BBbAEPoB9G7XUvh21e7S+9Dt73brDvh7l5NV63mXmmknPnLBvsu031bnXvhGcxVwzlbMmXv3/8bnq3ov/BzfcKeM=
   </data>
  </layer>
- <layer name="Above Player" width="25" height="25">
+ <layer id="5" name="Above Player" width="25" height="25">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUjBTAwsLAwMoCoUfBKBgFo2AkAuTyD1YmovPRxUkBIH26aHr1kPggOT0WBE0OgOkDACT7Abk=
+   eAFjYBgFoyEwGgIjJQRYWBgYWIEYRI+C0RAYDYHREBiJIYBc/sHKRFg4wPgwGiZOCg0qY3XRylg9JD5IDsSH0aSYDVMLMw8AJPsBuQ==
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collision">
   <object id="1" type="collision" x="208" y="112" width="80" height="32"/>
   <object id="2" type="collision" x="224" y="160" width="16" height="16"/>
   <object id="3" type="collision" x="272" y="304" width="80" height="48"/>
@@ -72,7 +72,7 @@
   <object id="32" type="collision" x="384" y="368" width="16" height="16"/>
   <object id="33" type="collision" x="176" y="304" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ff5500" name="Conditions">
+ <objectgroup color="#ff5500" id="7" name="Conditions">
   <object id="34" name="Teleport Back" type="condition" x="160" y="288" width="16" height="16">
    <properties>
     <property name="action_id" value="100"/>
@@ -101,7 +101,7 @@
    </properties>
   </object>
  </objectgroup>
- <objectgroup name="Actions">
+ <objectgroup id="8" name="Actions">
   <object id="37" name="Teleport Back" type="action" x="160" y="288" width="16" height="16">
    <properties>
     <property name="action_id" value="100"/>

--- a/mods/tuxemon/maps/test_pathfinding.tmx
+++ b/mods/tuxemon/maps/test_pathfinding.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.2.0" orientation="orthogonal" renderorder="right-down" width="15" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="37">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="37">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -8,17 +8,17 @@
  </tileset>
  <layer id="1" name="Tile Layer 1" width="15" height="15" visible="0">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUDCQAAAOEAAE=
+   eAFjYBgFoyEwGgIDGQIAA4QAAQ==
   </data>
  </layer>
  <layer id="2" name="Tile Layer 2" width="15" height="15" visible="0">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUDCQAAAOEAAE=
+   eAFjYBgFoyEwGgIDGQIAA4QAAQ==
   </data>
  </layer>
  <layer id="3" name="TIle Layer 3rd" width="15" height="15">
   <data encoding="base64" compression="zlib">
-   eJzzYWBg8KEAswIxG4mYHaqXlwz7+NH0cpCAseklxk5cepmBWAwPZsGjFyYWCMRBQByM5lZeIvRGAnEUEEeToJcbR3wQoxdXmOLTy8qAGuek6EUXI0WvKBDzAbE4Ab3o6kjxLzL2gZqFLz2I49ALAMOCG2k=
+   eAGlksEOgyAQRElaq4nRnlp/yot6Uv//P5xJmGRDgII9TIDNvN2FZXbOzX+oAfuqVOvrDTfqvgO2w7lUMbbk7swfYx+IfzN6+t5irGILPCu0ea/uwrdJ1RW7w3NAZwXbwxvOi/MoqSuPXdmLzrGe9T80c3m5/mLDfDXsB/lHaII44xQb+vQnrd/ubc82zhrMlfsP7MUy2l/Dghtp
   </data>
  </layer>
  <objectgroup color="#ff0000" id="4" name="collision">
@@ -77,14 +77,14 @@
  <objectgroup color="#ffff00" id="5" name="Events">
   <object id="26" name="Test Pathfinding" type="event" x="112" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="pathfind maple_girl,3,11"/>
-    <property name="cond1" value="is player_at 7,7 "/>
+    <property name="act10" value="pathfind maple_girl,3,11"/>
+    <property name="cond10" value="is player_at 7,7 "/>
    </properties>
   </object>
   <object id="29" name="Create Maple" type="event" x="144" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc maple_girl,9,6,maple,stay"/>
-    <property name="cond1" value="not npc_exists maple_girl"/>
+    <property name="act10" value="create_npc maple_girl,9,6,maple,stay"/>
+    <property name="cond10" value="not npc_exists maple_girl"/>
    </properties>
   </object>
   <object id="36" name="Player Spawn" type="event" x="112" y="96" width="16" height="16"/>

--- a/mods/tuxemon/maps/test_pathfinding_town.tmx
+++ b/mods/tuxemon/maps/test_pathfinding_town.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" tiledversion="1.0.3" orientation="orthogonal" renderorder="right-down" width="40" height="40" tilewidth="16" tileheight="16" nextobjectid="275">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="275">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -61,22 +61,22 @@
  <tileset firstgid="5037" name="Furniture_and_Fittings_by_George" tilewidth="16" tileheight="16" tilecount="110" columns="10">
   <image source="../gfx/tilesets/Furniture_and_Fittings_by_George.png" width="160" height="176"/>
  </tileset>
- <layer name="Tile Layer 1" width="40" height="40">
+ <layer id="1" name="Tile Layer 1" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJztl0sOgjAQQNnA8coKWShh4Ycr6Eo9gXoIo95Cb+Y0wWQwbZnSKW2Uxcs0GWge/UyLSJMkB8QUp8gcJQUwQ5QoF9pPuq2AY5Yke+AALJFjSL+Pm3TCfrJdt8+E9KvSrhNuL9F8x+iH2zH6zSG3acHvnSB3ZuaS6T0XluvvBrk7Mw+DX2XwUz1P9cN9ufit0TxiGoLfFXgy8DL42UbsVzP0xx3xnvoFP0Hsdyhj+eUO6PzwGROC0uBHOXd8t/H82Z6JPtsqPxm3mb5ejoX0MPntsm7sywuL96n7NaQfpQ7o1h9nnaKOm6qe+PBz+a7Jbxw/Uy2Pwc9XzY3dr2bw6zs3vvuljM2Q8cP/6y77w8aP637wb37U/atbU00kfpT7s4oiAj/qOA2pbS7OgujnG9O/0OTH4/cGmHllbw==
+   eAHtmE1OxDAMhbuB4w0rYAGIBX9XmFkBJwAOgYBbwM3GT8yTnqw4Tar0R6MuLDeJE3+x3aQzm5OuOzPZrHqNQ+M6QE2dm1yIXB58LKHewHZv8nradc8mLyZ31ibjnO8F2cCkfHi+NUawzcl3Y/4ZM8+HGDLnc+U5x6fcS+S7svg9HkT53iz3743lw9aL6ujaGGrq78vW+m4sPxk+5Dji07hxf6V8Wh99+8nxPUgemU/oJ5M+vk/b928D+cvEj3Ep1Ro/nkGpfZSu19pO3/lj4ENsS+JLu1rt418bP/rz66Ta6Bsiun/l0zuGd82UGt8Ifp/k0/Njrmetf8aQfKkzcypO+lY+xHFr51R0XurZOeYzOHJ8O2MEJ7XmX/s5ru9Halzn0zan5+bzvGyTOeLj+FBNP5GO1oW9l1R+o/lj93s2tFe+/zuvJPY18cvdDSW+htjU8I11/ua4l8CHeyBiLOXruzf8+vy96vu1XWLj+fBfQov3t8Q3beivtn70/tV9lzzTd86WNkvly7FzDPmNvjfwGw7jtK3RjE3NnJStr79UOzUPffh/KRqbii/yz35yRDVEu5aaOaVuuXbtWj6fmE8u6to1W9ofA98emHllbw==
   </data>
  </layer>
- <layer name="Tile Layer 2" width="40" height="40">
+ <layer id="2" name="Tile Layer 2" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJzNmGdPFEEcxvfKnpqYkOhLG01ABATUxNjiCwtdjNIlKk1jYqEKxApoNLF9Bztqom98oy/8BFZA3/g5rIC/DTdh7pi5LbegT/LLsDe7Mw/P/ndu9gzDMF5HDONNxHtrKQBBCEEYTLC6FsFiWAL5dBRALdSF9cey7jHI/UjybS5jrYc8ywcUwAYohCIoNmZ9CCU6Fl6TzU60BxnzENRY80Ad1EMDNEKToc5HJ+F1i5l8dpbOwwW4CJfgMlyBIRiGEUVeiST/L37U3wN4CI/gMTyBUXgKz+C5x/xUWXjRO3gPH+AjfILPMAbjMGF4y0+VhRd9hx/wE37Bb/gDkzAF04a3/CzpsusIOPeXyrlpkA4ZkAlrIQuyISfgLj9Zuuy+uRijlPnLoBwqoBKqYD9Uw4GAu/yE/Ki/jczZxfzd0AO90AfnoB8GYNBlfn7Xn98S/8tRM/ln16lEJiWm83MtLVR2dvc3TJ8Zjj3Xr/UvkeKfC3Gsa+VzFqL+RBYiH3Gsa8NhZ+ufW+2Kr6vQTGOXl661fFpjznf92eWla/MXqP68qvY/Xv/in6m3y/+dF5XEPc6TPBbyAlEExTAOm+DVspk+q93Kd9Q22A47YGcgtj/R9U50WHq+RH41kr8GxmuEJpiC5mBsXbbipw3aAzN7m+PR/U1LRH+90PUUw7iRkthfs+RPld8Q4w3DCGSzNlwLxtblTfzcgttwB+7G7b9U1wu9wNtLF/5U+clqMGdJ1K+T3fXFimdRl99YtF4m4At8DcZeZ9e/guOVsApWw5q4fqfS5TcZrZfp6At2IBR7nV3/bj7fA3thH5TAUg/7ZF1+WaGZesmBdZAbN79d/yn8nIYzcBY6YbMLf6ORuf7k/Gps9mO1pnfqHOz1hFT5xX/ut4549Cd/f8ynPzeyW/906jBnkdf4JjO2T3VOq4taaNPUX7/He6C7d37cDzm/Ts14qTyHaZAOGZAZnOtPtTb64U/OT+evlLnKoBwqoFLhT7U2tmvuuwrd3tlJfl3M2Q090At9Cn92a6NKVdExrLF0e2ehRPnZ1bCbtUOlZnPuPrSQz6qlcXX5OamhZP1ZkvM6IY1XH/3bym9AMY+TGrrKtS20gx44KXEsOr/8u4J4FxTrX73Co1u5fX9Uyfq9JUfyotv/eZHb90cn+guyKzOG
+   eAHNmMduFFkUhosMEhISLMnZgAFjBgmRxAIYchBjG2MQOQiJnBEZBoFEegfiMCDBZjaw4AnIYTY8Bzl8h+4fHZXqVmi3kY/0+dy64dy//rpdbTuKouhh1yh6BJVmSkQdoCN0gs7QBSgZdYPu0APGMjAOGqEJQtdM/RXXKHIdWptHU3EM1MJYGAfjoQ4mQD1IF82fkXYt7ZV6Fl+3nB3/ggZohCZYAc2wElpAe9LMDGmfzINorXe22VE4BsfhBJyEU3AazsBZ0J40M8PfS9yLote22Q24CbfgNvwDd+BfuAv3wO/JZWroXuLepS5KGXzC2FN4Bs/hBbyEV/Aa3oD2pJkZupe4V5kLAxPe0/8BPsIn+Axf4Ct8g++gPWlmhr8XeRhftNleGjljEHMHwxAYCsNgOIyAkVADfs+cZX9Ok4fxNe/iHSnX89h/PiyAhbAIFsMSWArLoIh/2kreKau/SJ7Iu3YP+++FfbAfDsBBOASH4QgU8U/3Iu+Ui+hqy7m6l7Xu/deW+1lteTLXvvwyQnNt2u/yTp6EpHXmnHQBC83VuVMujVb3p/fCKus6lP0ceadcXWWlavJC/ug6lG2exqxCtbybGT9X9ssWEfIpq990Ws229M70yYui2fTLO2Wr117C7kfeKbcXbXr20vO4j1rtI+ss1OKhoo4/ICZAPbyGP+C/3qVRy1P4jpoK02A6zAA/nrZee6TlVe7zJf8anL5m9KyEFvgGq8Gfyw3o2QibwH632QIW6+0PISJpfWkkis73iqILkBarnb4k/06j5wychZG8G86R/bm8iJ5LcBmuwFXwkbRe4/fR9qCAviT/VMtyM/cifL/aaWN51teXPVc9yyH/XuGTnbc38Bb+Bx9Z432Z3w/6wwAYCJWE1+f9+0o9O2/frS7PtUP5va89ssZnsW42zIE/YS70dOdadbKy1+fP3wj02HmrgVEwGnxkjW9Hzw7YCbtgN0wqoO9O+Vl7fd6/Bve58brUbmS8UpoyamsPy16f/Iv3+/nVaK+pUJ/8a2t9Re4xyT///RGqtRkPhH/Ht7h+jVv2czZwnfdsbGSuQv7Z98ch16/xUPb3GHp2fk6oTla/zp/5tzugbxCfw8EwBIbCMPB7m76kd6Ofk6UjNO79C+mbh575sAAWwiLwe5u+pHfjJvr9805rS0c85/FvD3r2wj7YDwcgri/r3Zjkz+Ly87Ja0hHPWmfnL+Rf0rn2Zzh0/lQ7K5s++aa5dfQtLeu3vtD58z5pbTy3Vp/Vk2/W3up0rSi3zb/Drt/mWeQ5Q3+zdj1rj1TANtaIdeX9/f8V9Leg3n/SW1JX2U89q7w5aRf7f0tNWa+Nm3/VCj2rvDnPvj8Asiszhg==
   </data>
  </layer>
- <layer name="Tile Layer 3" width="40" height="40">
+ <layer id="3" name="Tile Layer 3" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJztlklLw0AYhqdN46099BeI4IpKXQ7idhdBPKh1QXBfj55UBLXiye3kUn+BetWjuPQutsX/4FIvetCK21s6waS0mTQLmUpfeJhMJsm88yXz5SOEP3W77HagrkrO/eXjZ0w8xu9d/DtWi98u2AP74AAEZWM+JyE1oBbUgXqnJVZV43cBLsEV7YdAuzt53Ac//WAg4UsgZNAEf6+isv8ipr9O0j14AI+0HwNz8HfqJWQVfgJgDZTD37pF8eNtf8RpzD5oy+P+kIu3+KUqHz9j0hq/G+zPW0oYRECU7tlGByFNoBm0gFZH8rw8R95ZmCMTesOzu0Cc4gefdL5R+BkD42ACTFJ/Xxj/Bj80RzoE6/wV4tlLmKdISLKM42K0Z8iFG/CzCbbANtih/kowXgrKhGSOrLDQX15sRd12O7Bf0/hvLWhgllEbWKWnAvXxIN7hIXhmXGeVWP6u4S2UpT8Xcrho0n8m1d+KB7UaCHiU57PxVwVv1WAowzfRILLX4BPT+zuCr2NwYsBfD+b1g94M/hJzS2tgKdVfGL4iIGrAnxZJa2CJ9f1J4nV/SOLB37lXOSbv2+Vvnubf4Qzf8ggdX7QpP5uptn+whlxXrr+DDlHZmqmYifU6y598fErnWjo13Kf32XLNiEoy5So1SfWC3pY3SfWF1jrDiPTsWam+UKszfgGhJ1/o
+   eAHtl01PE0EYx6davOnBT2BMVDRqqnAgiN4JifGgVjQkvgCCHD0JIVExnEA9+VI/gXDVIwHtndg2fgeBcsEDlgD6mzAThkl3t7vd7W5Nn+TXZ2Zndp//PDM7OxUieXYrnTxNpqLzCdfXyp85W/7LSczfn7b9cbitv3d0ew8f4CPkQFvmkBCX4DJ0QCdEYW75WyTgEnxTgfP4vqN7lX703IV7UtdhIQZC0PfbyJuMsmHV9yLv//6iuAKr6lIZ/xR9X44L8RI9U/AKzqJvOgR9KswB5za/Bzo2qFJROdtS3m1+GyTJNUzS8meLbeXPzoi/eq35W+b9/KEo4ItQAmndKSGuQA9chWsgzdwjf9I3qj1Sxtrk+Tehosjit0HaI/QMwhAMw2OQtkP7LvyV/diDUhCVneDZk8Q5iZc8p3wK/5W9cAY9s/Aa3sBbkHaa9jPQDnKPPActiy8DJfVtjU9B/JFH+W6N18CY+r41WvHaEfeIOebwE6x79HN/SvBWL33f0Zb3qS/Nf6i2kP5H2fpeHOOsBlNgmp/8XUDbRbjvsCa6uO41hoy619b3GV1zMF+Hvttoy8IdB30yth6DmYNqZVtfAV1FKNWhr1oc+5oeg33drtv67HZd9zO/+p4wfDPpW+DbbZpZjyt/z1ircn9+4LCWH6r2CYd2czxJL/f+B2NIeo699DX7HFxXa0h7r/H6aS+HeF730me2jwR8L27UcF/QZ5t5e0IcE6e9yrzHLuvzQlBvPy/uuj5faB+lniDvrD5faF9N3z+hJ1/o
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collisions">
+ <objectgroup color="#ff0000" id="4" name="Collisions">
   <object id="124" type="collision" x="256" y="512">
    <polygon points="0,0 0,48 80,48 80,0"/>
   </object>
@@ -180,14 +180,14 @@
   <object id="250" type="collision" x="320" y="256" width="64" height="16"/>
   <object id="261" type="collision" x="288" y="320" width="16" height="16"/>
  </objectgroup>
- <layer name="Above Player" width="40" height="40">
+ <layer id="5" name="Above Player" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJztl1sKgzAQRUeZLscup92ZXYS2Ls8+frw/gdIyFJk0hvEeuMhI0MkJhESkPKoiB7Vr612pvjrkqHa9FamPE3JWu36fS0k+/5n6suqaqcEfWUckf5Hmkos1TujPB/3ZJDe/niQuXGMf9OdjT/76VuTS5v3mnvz9A/rzQX8+IvibG5E78kCeyKv5HjNg3xuRK3JDpkz7YC3+eHYmJC6135UX1LEQpg==
+   eAHtlF0OgkAMhKvB4+hx9GZ6CP+OJ+iLw8O8NDYbsOzC0iaTpgu2028jIvmjaUR2EEPX/fmvM74/VebMPbwdIKuean6qL30d4e0EWXXfh95TPT2f65n0yRm65vkcs94lh8cSM3PslWtGTfxq2sXr/ocwGfKul7+a+gQ/+zbJJpXtDvFk6QR490vfo5T/4Pcf+TXxO29FLpBnrImfJzf2Cn4kMS4Hv3Hc+Ksa+L02Ii3UQW/oA+m44rt3g+7QA3pCHjEXfvShs8eO0SMIBIGyBPT/2qpLufwC1LEQpg==
   </data>
  </layer>
- <layer name="Above Player" width="40" height="40">
+ <layer id="6" name="Above Player" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJzt1lkKwjAUheGToY5PVl2Tuht1a+7MeXjxCIrSxjYWIQrngx8pRQwlvREQkVgDA+RsyEZsbJ732hbosC7rsb5Nt04RkRvvgcyXr4ufnzKcb5Y55lnGWveZ925O/uOMbPp8RH5J3btX9d8m5vsiIaF98zpT6/bVmvtww7Zsx/am/Bsp6FyQolVefS3ycOAcO7ITO7NLYK7pzI03ccCUzVzqlYTNua4FW35xfTqDRJq7AmXCEMk=
+   eAHtllsOgjAQRQcBn1+irkndjbo1d+b78eMxpklpIPBhAoQ7yaGZlCbTAx0wU8iADNQ1MI/MMljAElbgYjQwG8MEpjADhQzIgAw0aSBJzFJw4fJwdPN1x4j+NoAYEkhhCN8o65Nd7JHO029nuspANw1Unb2yM+t2W7Xe3adRBnwDRe+N31OL5v31J/6xz3CBK9ygDeHvoQ31qIbmDRyzfA1hnp9V1mcDd/rYA57wgjeEUdUbw/v7nK9jsw1soY2xo649HP5Yn75BbXzSqqkrBj5lwhDJ
   </data>
  </layer>
 </map>

--- a/mods/tuxemon/maps/testmap.tmx
+++ b/mods/tuxemon/maps/testmap.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.3.1" orientation="orthogonal" renderorder="right-down" compressionlevel="-1" width="65" height="65" tilewidth="16" tileheight="16" infinite="0" nextlayerid="5" nextobjectid="27">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="65" height="65" tilewidth="16" tileheight="16" infinite="0" nextlayerid="5" nextobjectid="27">
  <tileset firstgid="1" name="Terrain_by_KelvinShadewing" tilewidth="32" tileheight="32" tilecount="63" columns="9">
   <image source="../gfx/tilesets/Terrain_by_KelvinShadewing.png" width="304" height="240"/>
  </tileset>
@@ -11,12 +11,12 @@
  </tileset>
  <layer id="1" name="Tile Layer 1" width="65" height="65">
   <data encoding="base64" compression="zlib">
-   eJztw0ENAAAMA6Grf9OTsQ8krJqqqqqqqqqqqqqqqqqqqqqqrw9E9xCC
+   eAHt0jERAAAMhDDev+nK6JIBA1xWTR4wwAADDDDAAAMMMMAAAwwwwAADDDDAAAMMMMAAAwwwwAADDDDAAAMMMMAAAwwwwAADDDDAAAMMMMAAAwwwwAADDDDAAAMMMMAAAwwwwAADrwYORPcQgg==
   </data>
  </layer>
  <layer id="3" name="Tile Layer 2" width="65" height="65">
   <data encoding="base64" compression="zlib">
-   eJztmklOw0AQRTvBNuI85ECwZMu0hQvAki3TAhbhAnAAQGKSgEUiLsIk8S1SioRsuafqatP9pa/2oqyoenpd7UyGSk3h9YFSG/AmvAVvwwdFu03jbd7hiG+KqRaUWoQP8XwEH8Mn8GnH75nG27zDEd8Us4z8R/Adnu/hB/gRfur4PdN4m3c44ptiVpD/KvyO5w/4E/6Cv+Glqt2m8TbvcMQ3xewh/304ZV0i/6vE+2Ay40LKIi6kKOIBtSmKeEBtiqLxT5kLNP4pc4HmQcpcoHmQuZC5kLngnwtnqMvOC/NWShxceEE+r4V5KyUOLgxKpYaleSslaS6MBHMn+eKC9Jp2kS8uSK9pF9H472Av2HXYD6TXtIto/MfI/yLRs3KuF+S5EINirReei1+7Soe90dYL5cwB5IsLfVbmQuZCLW4u9OEMrcsF21z6cIbW5YJtLl1n6BjmiS4XuOqBGOaJNBdiqLX+Axdc15MrF2K4B3JdT6HqBc69z3U92dQLNvnYjFWou3ebesEmH5uxCnX3rsOFv+MQai8Pdfeuw4UYGM4pHS5wjUMMZ8RanFzoyjGW+cV5j9SVYwxnxFqc90i+cvS1ZtpYK10v6MjXmmljbR/qBV/zqY21+fuCPRdiqJV8KdrvCwGVvy/0gwvc6gMXuJW5EO9355DKXMhcqJW5MP+fsgkXriulboR8W/nvA/qfMnFBN7+1QsacfUv7wlQwP0m/VfN9IeU+oH0h5T74ASl6yxs=
+   eAHtm0tuFDEQhp0AQZyHHAiWbHlt4QKwZMtrAYtwATgAIPGSgEUiLsJL4rfEJ41Gbrtdtsc9cbf0qyY9VWVX1d/990Qzp4fOnQk3D5y7JdwW7gh3hUcXp5Hr73PlxrTwD+U8uuDcZeGxan4iPBWeCc+FWA9y/X2u3JgW/qGcV1X/sfBBNX8UPgmfhS9CrAe5/j5XbkwL/1DOa6r/uvBTNf8Sfgt/hL/ClaNp5Pr7XLkxLfxDOR+o/ofCyMdr1f9m8B6c/teFkXmALozYA/QAO2IP0APsiD1g/iPrAvMfWRfgwci6AA9WXXAOPox4T4QH2BF7wPxr6sILfTZ8KeTaXv1n/jV14Zvq/y7k2l49gAc1deHgknOHQq7t1QN40EsXjtWr3gc8wFr3w7Vvje8ZBw+w1r1w7Vvje8Yx/3v6/8F9wXpw7Vvje8Yx/xPV/6qgBz1rKF0bHtTUhdI97ToeHvTShV3XG1oPHmBDPj3OfdUzlkfpMUd74QG2dM1q8f65YUfPDsy/VBeq1d4hEfNfdcG5VReca6UL+/AMzf0AO3U5WmvZh2do7gfYqR5Ya0k9Q1t7O7VPy3nmn9KFVC2WtX2MtbfW9UJxzL+XLrTqbajWqXPwYJ91ofR6ggdWXZjzLDrV/1rnS68neICtta/tPKWz2s63+Xfp9QQPsJu5p15b6rHMinWwU/spPc/8U7qwuY6lHsusWAe7uYear5l/TBe252Cpx7Jn1sFacsyJgQcxXWg9hzn7bOkDD2K60GoO2/xqWWcsNzzAxnxz30vVuBR+wQNsbp0x/1SNrfgV21PoPeafowuhPKFztWpM8Sm0dugcebD4MP+YLuDby6b4NHdf5MESBw9iuoBvL1uLT+TBUg88iOkCvufVwgPs3DqX8Flp7l5TfvAAm/I/j+8z/xa6sC/9Yv5L1oXWvYQHS9aF1j2AB6surN9T9b9ngw+tebfE/NwPVl1wbmRd4HvKObrwVr/TfNcJ77Vu7YPvKaMLc+u7oe/J9ECr3vvecl840+setfVe84fqRhdG7gH3hZF78A8pessb
   </data>
  </layer>
  <objectgroup color="#ff0000" id="2" name="Collisions">

--- a/mods/tuxemon/maps/timber_town.tmx
+++ b/mods/tuxemon/maps/timber_town.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="40" height="40" tilewidth="16" tileheight="16" nextobjectid="182">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="182">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -79,84 +79,84 @@
  <tileset firstgid="6294" name="Set_Pieces_by_Kelvin_Shadewing" tilewidth="16" tileheight="16" tilecount="1440" columns="45">
   <image source="../gfx/tilesets/Set_Pieces_by_Kelvin_Shadewing.png" width="720" height="512"/>
  </tileset>
- <layer name="Tile Layer 1" width="40" height="40">
+ <layer id="1" name="Tile Layer 1" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJztl0cOwjAQRQ0Le8mKejSOxIZ2Ay5AOwhlFzgA5Q4UR8LCGbmMnUAmUhZfjKwQv3zmZ0zSYuwkdZZKkPVSavXROvC7tvrCGbtK3Xh2PeZev+B7SS4mGGuImq9qfHdOm4+6f6Za5VWpI2jxKb+gqPE95GdPfNUnxpf65bq+inyJR5DPdW2aA9M6FT7F0RbmvMJ1zPzV7z80PH8MH1aY/BbpX1dk8wn1BDn25XcsNfFoG8A3svSf2lfvQ0z/6d5glHe+VYnvzsP4ZlJ7jw6BTK65G+pfUWcT0znFlFsKfLY890vgw7wLdE0j+WDP2HQD5+SYrMXwYWcA7KF/8flmgK2H/sUX23+/5tu0wvrbNQdt79J5Dr4iZdobelw230lTLN/O8jvk1UHby8U3QP4/OvK4TGDqPP4VUS88z1Y2H3X/MHxNQZuPun81X81XBb433VYfNg==
+   eAHtVklSxDAMNBzgyIn1aTyJCwP8gA+wPYQZbgMPYPkDS6tqumhU3pJJSFI1B1Xk2JHbLbWc5V4Iz7AX2LLSv8G625Xd4dnk29RerzshvMHeYbqmFpN+0we+b+AKuyFswXSvDb6/fCg36g/J3wdyV6rRIfEpTyl/bPioV9Os2QF0MSZ9kC/DpDYW/RLfJ7g7Akba8Uj6C/EZX7kel5tL1XIX/XkdfIY5Zx5fbq3pIDY/FnzEsY88UquqV/++5v7V855Gzt+EP+JTjeb8Gv0qvpjfBN+haJMa1ecXzm94qeOSfs9Re7OCPWBe/69iZ+C7swj/nDP9kV/jLXYH2lrVqXJDDLnnuv9/U8Jn/xGeLz9W/i7B7bxgC8zH8qI5UT9378bi5PCtm7vYfsyn13Cb+usDX0rPptvYefrkr6YXzFAftAv4Ho8fa/2RP18zeg+ob71fOdBYuR7AOdvP4/FjjUl8qZop1ZDGIobcsy2+VM3oPWC+r6H/wuc51n6R8/vGdy+1O2vh6z2Y6qVXiMucN80vv+viGdvbuFeOY2t87nR9F7gYw/Y2PDTuq/vV4HtEjHkPtkBMYjKM9D2+E+jM5tmnuI5jzj2hl9FPrWn7PofPx/TjLjBdF842NL7SmaeAb3tVZ77+/Nn8uIv8lmJOgT+eYcPfb6+qrY1Nfptzpv2/CX8/3VYfNg==
   </data>
  </layer>
- <layer width="40" height="40">
+ <layer id="2" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJxjYBh64BAHcWIDBV5hcQs2sVEwCkbB4ASJ3AwMSVCczD3QrsEEg919nUA3dUFx9yB03ygYBaNgFIyCUTAKRsEoGAWUAktgO9cKCVsT0e5F1lPGRZwecgGozzCPC4GJ6TeA9AgAsSA38XoocR8IgOwBAWLsgvUzNtLJfSA7XgDxSxLtgum9gZZGqIlvkhG/uPwGYiPHOwwjy6OrQWbjMgdZnBT3Ifcn6YVH+62jYBQMbwAAHuVGYA==
+   eAHtl8ENwjAMRX1EcCnjANMAO7ADdIfuwApMARtAp8AWsWSlQXJKFaXoR7JSuXby85xDTDS/cVsMNad8w6gynj6hL+Urowa7gAAI5BLYr4gOwY481zZq13dmZpdgbYX8aqsn9IAACIAACIAACIAACMyPwIbfuVtjO8e71+aclkSenLFkpGfoeA81T18jOQ3bOuR6cn7RJ7miT4ZnL+0zroX0ibYn24vNo+9zEiJlf2ed9o5M+f0IDHLqG+vTs8katu66pv0fx9h4G/fNn8NP66w9ZYkZfaveDswg8J8E3h7lRmA=
   </data>
  </layer>
- <layer width="40" height="40">
+ <layer id="3" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJzFmNlTFEccxxsWkQW2NB4YBRZjNJYaqzwKFe9b40sEfIllRUGTqElU8hQtzyfwvu8qS00qljGJR+KbD94Bb19UQP8AtLwjikdVPlPb47az3TsDO+i36lM9/ZuZ7u/++NHTM/mthRgAlnamCbHLhd1pkWvz0sVbncgSIqONEJkQgpP077QSoj3jZrWObTsFhcgORvs62efU+04x92l4kxFpVezYGSgKvjuWyV++/O3OdjT3jwlG+9NSYv3Z59T76pj7LnTLjLQqduxeWuxYOn+JSM23muOP+E1tXGgbjB3Pb39qvu1jSwXMfYo8DQ7qsc4N8cFfdrIQOZALYchLjr1GV3+Wvzrpb3pIiBlQAqWhSKzOJ39j8TMOxsMEmKjxp6u/AiVX5XiqgJWwKhSN++HvR/zMg/mwAMoc/kz1V8LcpZLDeDoCR+FYKBqfKf39Rnsg2DR/bjLVn6U01pEg3MTTLaiGmlA0busK3q42kz9Ldt5epwrxKjXSWvoKD1Oljz3pEZxxp0z+zvJ3Owfn4V+o1NSZSXbe2rVkzWgZaeP5aIq/+/h5AA/hETw2+KsifgEuwiW4LK+zcqjmzm9/WQEhOsDH0BE6BfT3P8HPU/gPnkG99GflUM2d3/68KhvfOZALYcgLmOuvDx76anyY4n7408lUf/H2FCa9r+ev6ttSZQ712gQu5+jnPcre4hj8Df/Acc1eQ/WgW/9UPWOehibw0uCvGj81UAu34Y7BnyUve0TLX73kuQ/+kpgvGQKQAi00z0pbzj2iTl1yhfhU0hU+80j3XP14PZivJ/SCz6G3wV+8+lP1JfNMlhRCERQrx7qYdTzF4M+r1Ppzrn+qFjPPEslSWAbLlWNdzDpe4cHfz+RuISxyyaG9/ulyeJB5/oTf4RD8IfspYWoHUsP6/l8e/O3F1z7Yb/DnXP90NXiDeWrgJtyCatnvi49+0D+s79cm6E+tP+fzVyfd+1WiiufPa/01pyrxVQUXEqg/S/W8czyHF9AALzObz7MqL/VnKczeOQ86wyfQJdT83hpTf+PxMwEmwhcw6T3409Wf6X9gHn7mwwIog58S9JfE+0IyBNLjX+d1H7UNP9thB+yEXQn664GvntDLxZ+dQy/ri58qxFcRFLv4s/cvH2p9cZO9f3FbXz6U7PpzW1/cdNGwx/w1zt7Ti0z1d4Vx85M4BwNhEBTAL8QH0w6BoTAMhsNT4iNoR8IoGA1j4JLhei9S1z9d/X3NONNhBpRAqRx3Ju0s+Aa+he9kfDbtHJgL38MPLtd7zV2+4flWzjgVsBJWwWo57hratbAO1sMGGd9Iuwk2wxbYGuf6fR7/7n7Vn0n3DeNVOfwVu+z/7PozfWt3+/be2Fb3XnaN/nXDmHb9mb61u317b2yrey97Qb/BMOb/RlRWgQ==
+   eAHFl9lvVVUUxncHEQSiAq3aUVExgCYiuSrgCDL5orS+aIzQ4jww+KTG8YnBeRZMiKjRiKCC+uaDiEPLqC9Ci/wBaHBCCgVN/H25Z6UnJ3vffS/3Fr7k17XP2tN319k999zcGc5dDtKqoc6tjvA2/VLrafmov1/VOzd8lHMjYCR8zfW+052rY916yMaGYc41guUHVhpoWV96/mb2/gb+G56PahuW20KujbXTCvnLJZ89G6czfwZY/vba9Gr5tvWpdtbez96/woUj8lFtw3K/kcvK5y87ppTrulTdra35Z/KZRkUYTX9WlfZn9VK0tvacwt6bqd1Uog/1TauAv8Zq55qgGVqgFbKyuqXPn/ztT/zNH+ncAuiATpBf9VXC3w34mQmzYDbMgaysbunzJ39Wt2V4Wg4rYGXiT32V8PcQfhbBYlgCSyEtq52itdXfwf6dCZ/i6TPYCJvA8gvplz4gfpi0T9T5075DebYMg9142gM90AuW1xhpJ952DZI/rW91+3eIc8dAUboVb7eBtIZnsJDS+Xxm4G+oft9y376D7+EH6IJilePe6uyNOdW50aAohXyE8poT8ncAP7/DH/An/AU+dZPfCttgO+wASTVM1065kI9QXnNC/uprnDsLzoZzoAF8+hs/B+EfOAR9IKmG6dopF/IRymtOyJ/6ilEjvpugGVqgFULn71LO3qTk/KXXDuU1plx/6X2sHTp/5tvGFRMr7c88KFrbfOTI6f9G6mrivB4HO5jj00beLTbB5/AFfAk+mQdFa/vGHWKf/uPgaMBfD356YS/8AvsgpAaerbF3RPnrSzhcgs+Qvyr2rIYaqIVTIKTsO6Jv3Nhm585PuIA4rkguYpxP4/EzASbCxXAJ+FTHfbX3Fmv7xt3EPjcnzCO2QTtY22I6p/YtUI7szClmn3/pdR9nnycSniQ+BU+DtS2mc2o/AzE9Qu0ehcciNbTvX9Uzq4/YZwOsg49hfXJd28LZgSGg/uz1J+Riegdfa+HdgD+roX3/2jMlve7P7NMLu2EP9CTXk/B1GUwG9Wev95KLqZA/O3OK2e9f37q+31e+caXkCvmz2ikWOn+l7Ffq2C7uazdsDdxfq2Gh86c9+/jNcRiOQD8chRMhq2Gh8ycfLbw7t8K5cB6MhcGW1U4xdv5m4Wc2zIG5cCMMtqx2inb+Qv8Di/CzGJbAUngYylEVvxeqoSb53RBay2oY6rf8G/h5E96CVbAaytF4fE2AiRF/VsPY/S3Hi2/uPHy1QXvEn72/2P31rXUyc/b+Enu+nCyPdv5iz5eYv22Bd8z3A/nYetYfOn87WTdXxTs+XAFXwhR4j/xU4jS4Cq6Ga+Ag+WuJ18H1MB1mwPbAeNu/ULTaKfrO3x2sPx8WQAd0grSQeCfcBXfDPSDdS7wP7ocH4EGQQuPzveG/VjtF3/lbxvrLYQWshGdBeo74PLwAL8JLIL1MfAVehdfgdZB849dS12JkNSz3/IX2OsBn96k746898H5gNbTnn/mNRXsuxcaF+rPz9Rl+xONP4Jtj5y/H59U7aizacyk2LtSfnS9/R/DWD745/wNGVFaB
   </data>
  </layer>
- <layer name="Tile Layer 4" width="40" height="40">
+ <layer id="4" name="Tile Layer 4" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJzt08sNgkAYReF/OTVQIa9GEKlHFBB89eXpQSJBz5eczazuJDMR0rpOWURPZ7rQkG29SPq+kXc/0ZVmWnb6D27svtODnvTa6T2kTzQp4kAtHalLWy+SJEmSfl9OBZVUUb3yuaT/8Ab6hhfQ
+   eAHt0sENgkAYBeH/SA1UKGIjCtYDCCqK9sUQW1gPwLxk9sBhs/lChFMgrUCTR7TU0Y16cgrsTWDgv7/Tg5400hr34t1vmuhDX3IK7E3gnEVcqKKaruQUUEABBRRQQAEFFFDgvwIHri/oSCWdaFmq77/bPBVQYOsCM/qGF9A=
   </data>
  </layer>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="5" name="Events">
   <object id="118" name="Teleport to Route 5" type="event" x="0" y="464" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route5.tmx,39,9,0.3"/>
-    <property name="act2" value="player_face left"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
+    <property name="act10" value="transition_teleport route5.tmx,39,9,0.3"/>
+    <property name="act20" value="player_face left"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
    </properties>
   </object>
   <object id="172" name="Teleport to Tunnel" type="event" x="528" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport tunnel.tmx,13,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport tunnel.tmx,13,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="173" name="Teleport to Tunnel" type="event" x="544" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport tunnel.tmx,14,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport tunnel.tmx,14,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="174" name="Teleport to Tunnel" type="event" x="560" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport tunnel.tmx,15,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport tunnel.tmx,15,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="175" name="Teleport to Tunnel" type="event" x="576" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport tunnel.tmx,16,39,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport tunnel.tmx,16,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="176" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_town_theme"/>
-    <property name="cond1" value="not music_playing music_town_theme"/>
+    <property name="act10" value="play_music music_town_theme"/>
+    <property name="cond10" value="not music_playing music_town_theme"/>
    </properties>
   </object>
   <object id="180" name="Teleport to Scoop" type="event" x="160" y="352" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport scoop1.tmx,0,3,0.3"/>
-    <property name="act2" value="player_face right"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport scoop1.tmx,0,3,0.3"/>
+    <property name="act20" value="player_face right"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="181" name="Player Spawn" type="event" x="560" y="48" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ff0000" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collision">
   <object id="119" type="collision" x="0" y="0" width="32" height="464"/>
   <object id="120" type="collision" x="0" y="608" width="640" height="32"/>
   <object id="121" type="collision" x="608" y="0" width="32" height="608"/>

--- a/mods/tuxemon/maps/tunnel.tmx
+++ b/mods/tuxemon/maps/tunnel.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="20" height="40" tilewidth="16" tileheight="16" nextobjectid="103">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="103">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -24,127 +24,127 @@
  <tileset firstgid="4133" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
   <image source="../gfx/tilesets/boxfont.png" width="208" height="192"/>
  </tileset>
- <layer name="Lowest Level" width="20" height="40">
+ <layer id="1" name="Lowest Level" width="20" height="40">
   <data encoding="base64" compression="zlib">
-   eJzN1ksOgkAMBuDO3ugh8XEQRA4iLsGVegrxJnoFS2CSpimTdKboLP4MIeEL05ZHCwAd5oppDY4tDHrc/ch7YnrMS+n1M1k5gDeuH6V3w9wxDxiv59F6axfOxv23v1shuwTvKKTKyGumHIw8v5bEO5E6WnjU1fYm5FFT651ZDXl/tF6BqQ09v9+9cJ8xXs2u5fOj8crp3HBvF2HvMR6dO17HWG8ulp6vgcabmz1vxTwf3PRWyveX7ltTM+4VQl9TPKkfuXpDHxrQzUjIqyKMJT3+bs7Nk+YuxZPmJCevYYl5Byz5v2btfQH3dPxz
+   eAHNlEFOwzAURM2+gkM2LQcB2oMkXbasgFMAN4ErdGYx0ugrrvodL7IY2bX9X8bzrZ5LKRfoHTp3mPdguBd66+mvxvvGd36gXyhzB9bMafNQyh/2/pO8D5z/hL4g1kdleY/wcUtP2M/cN3PW+1ibD7hj1A5rrd95RW3U24p4E7xQz+ZziT/l9GK8A+YDxBxrudfW53jKk9xsb27xyBXzcqdX8Uac9wzlkSPzzPK2qDlCztG8had+7MGMPlt48qZaZ2qt1lNfZ370xjV6O0Hx7i08ZsVeDpC8tuan7FQfx1Z/kcPfyiDzXkbUef7iiqU36rnX5jobmWLV6mrr4nHfc8xk5mzyttAAeV+X8NyXslsrj32YoBN07xuJ+fl9eU/fz87Zj5483mnNvLl3l83Mz+u9aVzaD3E0LuVN6IeL7879Z+f+f9Bj3oPhd7gC93T8cw==
   </data>
  </layer>
- <layer name="Obstacles" width="20" height="40">
+ <layer id="2" name="Obstacles" width="20" height="40">
   <data encoding="base64" compression="zlib">
-   eJy9lv1NAzEMxd3rX3xWgjEoYpL2lmIIprgdGKdlCc4Slt4Z23mJEJaik/LxuxfbcXIRkevaLu47ajc7kdvd7+/DOvZItEPBRm2ntZ1/2n2x5o3Q2mMv0tbp7ZWYU+n8T951Evma+ng+d5D3tBd53vfxfO5orLMY3xE81GjW8mGL53OH5VXny+d3tec50TGiEffaUwMyjcjDODIWaUReb32yOoE6kTdSAxbZ6hz1H1rGY/3n6+sx4Zm29w49Zpp36ssZ+lj/teJqxvqN5f1V3pkxsdVYHIN+uzvw/mj5L2N5M61V/rEs5FX5l9UTyxM7c4tw9a9Vn6IzUvlvhFfFVucvrg9rccSLtNlZjWKBORfxIv9Vd4+t87Gv/BfxPqftOj9Hc/sQaGP0+XpqbxAd68m7TJ+9QaLzrPtieNFdl70RGJ4x8ZxkvOgOi3gf0/b/rTcMW/NYHr7Jrc3FPB37BqveSUI=
+   eAG1lutNAzEQhA384nFEgjIgopLkmqIIqkgPlJPQBDuSRxot4z2DhKWV7/bx3XjtXO7cWruEndMct38at1et3YXleQna44TtiqdSI1IOYcduD3AMxtvADzc1Fik/Qi/hwToqnblonx3mvtKZ0/+Td7lu7Sssj0of94Wz6nu6ae05LI+Kx33hjL0e7fF9B1c8pFBbT2+qkT6dt3jUxppZXtbBeswa21rz2guzDuXl2EijrlXfBcpy1yONytN3gWNkn9OoPO1RrnX30Ij3hJ4f5eUeOUb2ncKhOpX3m/4pd8Sb7d8SMLyXaK8CV33s37vE3aXqYRy/NfRypSPm2f45nuoiEv2bGbM89G9mzPLYv4q5RFD7z1z+d2CPdt251b8Ri0zO7GV1/mZZYJJXnT/XM9TynPA3dxJe1b8Rj1o0Tl/VP82HLg7Wapy+6vwhH2vRgbWu3eF47vwtkY8z4M4IdQDpeK5/moc6HeThmfo8+l3/HO+zfxOwLufgbO/CXP9ybtaHnmoOv0HwLNc/zVUWrp0+foMwpjVY1wzvEEU8z6x3PMRmeMgD8xhG7oiX81DLoTUffY/4fI0xX2fmqc/VMM/FtJY6sSbaqgn9mnmIfQOr3klC
   </data>
  </layer>
- <layer name="Obstacles 2" width="20" height="40">
+ <layer id="3" name="Obstacles 2" width="20" height="40">
   <data encoding="base64" compression="zlib">
-   eJzNlssNwjAMQFO4AQX2AMQkwF587nQIYAXYowMgpsARtWSiOnHiUPokS1QtL67TODFGRgkxJTET/o9jBXGBuELcINbMcy+Poy6+fRTONyqYG05uId9zEPa4Tp8vlg3EhFwvjH5u3ByR2FyxNrl8iOvDcXaJPlvDrfnUcdz8DrkOQ5lXktNe4MrJvOPx+kItWPN94hHZW3Jz//P4UuiepN2PLLS/aPpz1dL/tP0efdI+5QPrtsyQV9l4EPSlrjlaM/uu9D3PCd/lL+aA80nXLT075MyPm4tUfGeW2PNPyJeCxnds2QvpeSDWZzkx+yvmmeP7s2Cemh7AUXXc+9+dVB4V
+   eAHFltsNwjAMRXn8AQX2AMQkpXvx+IchgBVgDwZATIEt9YpLlNZJm0IkK6ljHzsOden1wkYmZlOSWZhbpdVKds4iF5GryFrEN14+Zal79D+byuNRxRuRD9vzWlkW7zlgD3tt8WzCt0UujxNSLWSN+2l6N26OwFfVEvvujNqk4oHv8hCngEHkrDXciGgdx+XaYu2GYmgM5VocRWwDWEaoqO35j+NFJdehMfeJDsMkQ98je0uywCXo9uf4oefJxLBtz+NY3F9iex5zTmX9UvHAVl5on4KPb0bdlrLZ5pzKVpZyMMBr+s5xzfSs3EePDX6XzENuyLXJXMcLfW/x3dL4dbzY/DJx8N1FLAf2nJvquH58Bthbcx3P8vXtt+HtPd/CXILg/4DG4/P64ru6g4epNsgzlufy8Yw8CygSzuhdCZG1qDedVB4V
   </data>
  </layer>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="4" name="Events">
   <object id="88" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_the_wild_places"/>
-    <property name="cond1" value="not music_playing music_the_wild_places"/>
+    <property name="act10" value="play_music music_the_wild_places"/>
+    <property name="cond10" value="not music_playing music_the_wild_places"/>
    </properties>
   </object>
   <object id="89" name="Teleport to Below" type="event" x="224" y="416" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport tunnel_below.tmx,14,25,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport tunnel_below.tmx,14,25,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="90" name="Teleport to Below" type="event" x="208" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport tunnel_below.tmx,13,14,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport tunnel_below.tmx,13,14,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="91" name="Teleport to Below" type="event" x="112" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport tunnel_below.tmx,7,2,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport tunnel_below.tmx,7,2,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="92" name="Teleport to Timber Town" type="event" x="208" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport timber_town.tmx,33,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport timber_town.tmx,33,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="93" name="Teleport to Timber Town" type="event" x="224" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport timber_town.tmx,34,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport timber_town.tmx,34,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="95" name="Teleport to Timber Town" type="event" x="240" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport timber_town.tmx,35,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport timber_town.tmx,35,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="96" name="Teleport to Timber Town" type="event" x="256" y="624" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport timber_town.tmx,36,0,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport timber_town.tmx,36,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="97" name="Teleport to Route 6" type="event" x="0" y="64" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route6.tmx,39,4,0.3"/>
-    <property name="act2" value="player_face left"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
+    <property name="act10" value="transition_teleport route6.tmx,39,4,0.3"/>
+    <property name="act20" value="player_face left"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
    </properties>
   </object>
   <object id="98" name="Teleport to Route 6" type="event" x="0" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route6.tmx,39,5,0.3"/>
-    <property name="act2" value="player_face left"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
+    <property name="act10" value="transition_teleport route6.tmx,39,5,0.3"/>
+    <property name="act20" value="player_face left"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
    </properties>
   </object>
   <object id="99" name="Teleport to Route 6" type="event" x="0" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route6.tmx,39,6,0.3"/>
-    <property name="act2" value="player_face left"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
+    <property name="act10" value="transition_teleport route6.tmx,39,6,0.3"/>
+    <property name="act20" value="player_face left"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
    </properties>
   </object>
   <object id="100" name="Teleport to Route 6" type="event" x="0" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route6.tmx,39,7,0.3"/>
-    <property name="act2" value="player_face left"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
+    <property name="act10" value="transition_teleport route6.tmx,39,7,0.3"/>
+    <property name="act20" value="player_face left"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
    </properties>
   </object>
   <object id="101" name="Teleport to Route 6" type="event" x="0" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route6.tmx,39,8,0.3"/>
-    <property name="act2" value="player_face left"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
+    <property name="act10" value="transition_teleport route6.tmx,39,8,0.3"/>
+    <property name="act20" value="player_face left"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
    </properties>
   </object>
   <object id="102" name="Player Spawn" type="event" x="112" y="64" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ff0000" name="Collisions">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="1" type="collision" x="112" y="400" width="96" height="240"/>
   <object id="2" type="collision" x="272" y="512" width="48" height="128"/>
   <object id="3" type="collision" x="80" y="480" width="32" height="128"/>

--- a/mods/tuxemon/maps/tunnel_below.tmx
+++ b/mods/tuxemon/maps/tunnel_below.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="20" height="40" tilewidth="16" tileheight="16" nextobjectid="42">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="42">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -24,27 +24,27 @@
  <tileset firstgid="4133" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
   <image source="../gfx/tilesets/boxfont.png" width="208" height="192"/>
  </tileset>
- <layer name="Lowest Level" width="20" height="40">
+ <layer id="1" name="Lowest Level" width="20" height="40">
   <data encoding="base64" compression="zlib">
-   eJyTZmJgmAXE0lSiqWmWNAE550HuvsEefrjsH8zuG+zhN+o+yt2HL18PBvcN9vAbdd+o+6iV5waL+wZ7+I26b9R9o+4jnQYATiogmg==
+   eAHN00EOREAABVFxDceZWzotve95olhYiMTvUhWJbV2W/by2l+5vvms0qet3sc9aZs/kuDr/hJ29e/bsieMuO/xq0HbXNc4XRg3aiqswatBWXIVRg7biKoz+6y/0qUFb+RaFUYO24iqMGrQVV2HUoK24CqMGbXL9++fEFFdh1KCtuAqjBm3FVRg1aCuuwqhBW3EVRg3aiqswatBWXIVRwwFOKiCa
   </data>
  </layer>
- <layer name="Pit" width="20" height="40">
+ <layer id="2" name="Pit" width="20" height="40">
   <data encoding="base64" compression="zlib">
-   eJxjYBgF6OAVEwPDSyB+zYQpJ8BMunlCQD2CQCyMRe8BLHaQCo4BzTgBNecgmeYJCCDY74BmfICa84IK7kM2DwRmUGgmyLyPSH6mFIgB4+UUkhuRw4JcgO7nUfNIA6A4kSAjr42CwQ1gZSuu8pVUACtbcZWvgwVQo5xHBuSW8/gANcp6dHCMzHIaVxk8kOUWMWmXFPOQ064IM3YzyfWvEI78QM3wm8FG23LajQ2/PChtHUfD6Gktj4AZMCAoAPGLOBrG5bdpRJpLC/CKiLKzgAT34Uor9AAAmvI4uQ==
+   eAHtlm0KwjAMhoOCvzsV9UQeRzyN7Dj6R8WT+AGiNzCBhcXQrmvsEHGFsGxrnzZZ9rYAfdMZuA4ALmg3NN3cUD+J349xTIE28YzdeuaIE9977JFxrDg7I8+5mnlHxqPinI28mgYgefS8/JBJvCcaxyznsvgz/C4n5HHMMhcWHo3RMVs5PO7fePRNFp7/hfPRX38zA6ytIX1NjYq1NaSvqbyu+ufQebk2q85LhvZzaL1myr1Jv2u6D2nwN3WwTe2mrE/W7hS1znfeSOHJfBLbd96w8iSb/XIE0KVOL5Hf1Ki2Dsr0mWAVYTC/wPMPxTJXFtqDNi25zM95pTr01YqcY52wvlCtSF5X/gua8ji5
   </data>
  </layer>
- <layer name="Layer 3" width="20" height="40">
+ <layer id="3" name="Layer 3" width="20" height="40">
   <data encoding="base64" compression="zlib">
-   eJztwTEBAAAAwqD1T20LL6AAAAA+BgyAAAE=
+   eAHt0DEBAAAAwqD1T20LL4hAYcCAAQMGDBgwYMCAgc/AAAyAAAE=
   </data>
  </layer>
- <layer name="Wall" width="20" height="40">
+ <layer id="4" name="Wall" width="20" height="40">
   <data encoding="base64" compression="zlib">
-   eJzdllsOgyAQRf11O21Xg67Guhq7G9xQIXGSiWWeYEtKcmMicHKReTiNwzAptCU9kV7KfdT+NQmPxciNx/57ej5OLDyC0WfWzPCsPiWex2fvvCjciZWn8fhrnnTmvWEcemKa8+jlUR5reJDX2GcNr+TzH3lUfc31sVXs9RQnPfO28bO/5QG9w9I/KJbHK8W6He+sOSfVJ2tMf4OXz7o35AVinuNBrpbuIqA1q5LH9bLSt7uCtzAx7eFxHjW8Uq+r4QET/29SvPM6ycMs8Kw1SssDn1ilXhGZuVq9AcFK8eU=
+   eAHdlWEKwjAMRvfX66inUU+jnkZvoxeyH+zBR2hnug0cDkZKm7wmTdKed8NwTvyPonOz/5mwcW60vxd7/64jO8t9jfaHIo+B5dxTWXM/MuPLBK/XT+03xcPXHj+3zlNupnKimHvizZzhr3nfYn6vWIe9sVLzLR/n8lp5WcKjr71+lvCI3XvmH3mt+1X341q1t+Tc/Pzn3HnkEbllnnIR3zfFzNuhdzT7zrVYnCEyk5sWa1/80dfbc7UciIMvvs4c+atJ1xeHD1tfZ67GYc71YSlW+sHX5/LcLsujV2s1Ai/minlic+n7EicSu6jDvHMYR11YkthFHdV2q6ajbobne+EXMsOrvXX4DgeZ4UlXTN2n9EmLF/Vq8bK3JPu3eOiitxYPPxUTP73BnpLo1dZcb874A8FK8eU=
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collisions">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="2" type="collision" x="112" y="544" width="112" height="32"/>
   <object id="3" type="collision" x="208" y="464" width="16" height="176"/>
   <object id="4" type="collision" x="224" y="416" width="16" height="80"/>
@@ -84,35 +84,35 @@
   <object id="36" type="collision" x="288" y="176" width="16" height="208"/>
   <object id="37" type="collision" x="256" y="304" width="32" height="80"/>
  </objectgroup>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="6" name="Events">
   <object id="1" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_dragons_cave"/>
-    <property name="cond1" value="not music_playing music_dragons_cave"/>
+    <property name="act10" value="play_music music_dragons_cave"/>
+    <property name="cond10" value="not music_playing music_dragons_cave"/>
    </properties>
   </object>
   <object id="38" name="Teleport to Aboveground" type="event" x="112" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport tunnel.tmx,7,3,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport tunnel.tmx,7,3,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="39" name="Teleport to Aboveground" type="event" x="208" y="224" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport tunnel.tmx,13,16,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport tunnel.tmx,13,16,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="40" name="Teleport to Aboveground" type="event" x="224" y="400" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport tunnel.tmx,14,27,0.3"/>
-    <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport tunnel.tmx,14,27,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="41" name="Player Spawn" type="event" x="160" y="32" width="16" height="16"/>

--- a/mods/tuxemon/maps/tutorial.tmx
+++ b/mods/tuxemon/maps/tutorial.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="14" height="13" tilewidth="16" tileheight="16" nextobjectid="2">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="14" height="13" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="2">
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>
  </tileset>
@@ -15,28 +15,28 @@
  <tileset firstgid="193" name="stairs" tilewidth="16" tileheight="16" tilecount="24" columns="8">
   <image source="../gfx/tilesets/stairs.png" width="128" height="48"/>
  </tileset>
- <layer name="Tile Layer 1" width="14" height="13">
+ <layer id="1" name="Tile Layer 1" width="14" height="13">
   <data encoding="base64" compression="zlib">
-   eJxjYCAfMJGIYUCCRAwDyiRiGNAjAY/qG3z6yAEA68gTxQ==
+   eAFjYCAfMAG1koJhNkkAGaRgmD5lIIMUDNOnB2QQi0HmwwCxekDqRvVhD2NqhAssPkihAevIE8U=
   </data>
  </layer>
- <layer name="Tile Layer 2" width="14" height="13">
+ <layer id="2" name="Tile Layer 2" width="14" height="13">
   <data encoding="base64" compression="zlib">
-   eJxjYKAPYEZi1wBxLRDXAXE9EDfg0ceHxJ4CxFOBeBoQdwNxD5rak0B8CojNSXTbRSC+BMROJOojBagDsQYQaxJQtxWNbwTExkBsQqJ9tkBsB8T2JOobLgAAIsILjQ==
+   eAFjYKAPYEaypgbIrgXiOiCuB+IGIMYF+JAkpgDZU4F4GhB3A3EPECODk0DOKSA2RxYkgn0RqOYSEDsRoZZcJepAjRpArEnAgK1o8kZAvjEQm6CJE+LaAhXYAbE9IYXDVB4AIsILjQ==
   </data>
  </layer>
- <layer name="Tile Layer 3" width="14" height="13">
+ <layer id="3" name="Tile Layer 3" width="14" height="13">
   <data encoding="base64" compression="zlib">
-   eJxjYKA/yATiLCDOxSF/GIiPYBHfRsDc00B8hgz3XAbiK2ToIxVkk6kvn6quoC+IJFNfLIX2AgCYRQhM
+   eAFjYKA/yARamQXEuTisPgwUP4JFbhsWMWSh00DOGWQBItmXgequEKmWEmXZZGrOJ1PfYNAWSaYjYsnUB9MGAJhFCEw=
   </data>
  </layer>
- <layer name="Above Player" width="14" height="13">
+ <layer id="4" name="Above Player" width="14" height="13">
   <data encoding="base64" compression="zlib">
-   eJxjYBgF+MBcMvWtpKorRjaQJBGDAAAxdgJz
+   eAFjYBgF+EJgLj5JPHIr8ciNSpEWApJA5aRgkOkAMXYCcw==
   </data>
  </layer>
- <objectgroup name="Conditions"/>
- <objectgroup name="Events">
+ <objectgroup id="5" name="Conditions"/>
+ <objectgroup id="6" name="Events">
   <object id="1" name="Player Spawn" type="event" x="64" y="96" width="16" height="16"/>
  </objectgroup>
 </map>

--- a/mods/tuxemon/maps/tuxe_mart.tmx
+++ b/mods/tuxemon/maps/tuxe_mart.tmx
@@ -50,138 +50,138 @@
  <objectgroup color="#ffff00" id="7" name="Events">
   <object id="17" name="Go outside" type="event" x="112" y="192" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport taba_town.tmx,30,12,0.3"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing down"/>
+    <property name="act10" value="transition_teleport taba_town.tmx,30,12,0.3"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
   <object id="27" name="open shop" type="event" x="48" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="open_shop tuxemart_keeper"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="open_shop tuxemart_keeper"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="37" name="Talk to the professor" type="event" x="112" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog professor_dialog\n"/>
-    <property name="act2" value="translated_dialog_choice yes:no,serenademe"/>
-    <property name="act3" value="set_variable tuxchoice:herewego"/>
-    <property name="act4" value="set_variable ripmycodingskills:yes"/>
-    <property name="behav1" value="talk professor"/>
-    <property name="cond1" value="not variable_set ripmycodingskills:yes"/>
+    <property name="act10" value="translated_dialog professor_dialog\n"/>
+    <property name="act20" value="translated_dialog_choice yes:no,serenademe"/>
+    <property name="act30" value="set_variable tuxchoice:herewego"/>
+    <property name="act40" value="set_variable ripmycodingskills:yes"/>
+    <property name="behav10" value="talk professor"/>
+    <property name="cond10" value="not variable_set ripmycodingskills:yes"/>
    </properties>
   </object>
   <object id="42" name="hello Professor" type="event" x="144" y="192" width="16" height="16">
    <properties>
     <property name="act10" value="create_npc professor,7,7,professor,stand"/>
-    <property name="act30" value="set_variable tuxchoice:welcome"/>
-    <property name="cond1" value="not variable_set tuxchoice:end"/>
-    <property name="cond2" value="not npc_exists professor"/>
-    <property name="cond3" value="not variable_set tuxchoice:hydrone"/>
-    <property name="cond4" value="not variable_set tuxchoice:rockitten"/>
-    <property name="cond5" value="not variable_set tuxchoice:fruitera"/>
-    <property name="cond6" value="not variable_set serenademe:yes"/>
-    <property name="cond7" value="not variable_set serenademe:no"/>
+    <property name="act20" value="set_variable tuxchoice:welcome"/>
+    <property name="cond10" value="not variable_set tuxchoice:end"/>
+    <property name="cond20" value="not npc_exists professor"/>
+    <property name="cond30" value="not variable_set tuxchoice:hydrone"/>
+    <property name="cond40" value="not variable_set tuxchoice:rockitten"/>
+    <property name="cond50" value="not variable_set tuxchoice:fruitera"/>
+    <property name="cond60" value="not variable_set serenademe:yes"/>
+    <property name="cond70" value="not variable_set serenademe:no"/>
    </properties>
   </object>
   <object id="46" name="choiceHydrone" type="event" x="112.333" y="128.667" width="16" height="16">
    <properties>
-    <property name="act1" value="add_monster hydrone,5"/>
-    <property name="act2" value="set_variable tuxchoice:end"/>
-    <property name="act3" value="translated_dialog_chain professor_dialog6.1"/>
-    <property name="act4" value="translated_dialog_chain professor_dialog7"/>
-    <property name="act45" value="translated_dialog_chain ${{end}}"/>
-    <property name="act5" value="screen_transition 2"/>
-    <property name="act6" value="remove_npc professor"/>
-    <property name="cond1" value="is variable_set tuxchoice:hydrone"/>
+    <property name="act10" value="add_monster hydrone,5"/>
+    <property name="act20" value="set_variable tuxchoice:end"/>
+    <property name="act30" value="translated_dialog_chain professor_dialog6.1"/>
+    <property name="act40" value="translated_dialog_chain professor_dialog7"/>
+    <property name="act50" value="translated_dialog_chain ${{end}}"/>
+    <property name="act60" value="screen_transition 2"/>
+    <property name="act70" value="remove_npc professor"/>
+    <property name="cond10" value="is variable_set tuxchoice:hydrone"/>
    </properties>
   </object>
   <object id="47" name="choiceRockitten" type="event" x="112.333" y="128.333" width="16" height="16">
    <properties>
-    <property name="act1" value="add_monster rockitten,5"/>
-    <property name="act2" value="set_variable tuxchoice:end"/>
-    <property name="act3" value="translated_dialog_chain professor_dialog6.2"/>
-    <property name="act4" value="translated_dialog_chain professor_dialog7"/>
-    <property name="act45" value="translated_dialog_chain ${{end}}"/>
-    <property name="act5" value="screen_transition 2"/>
-    <property name="act6" value="remove_npc professor"/>
-    <property name="cond1" value="is variable_set tuxchoice:rockitten"/>
+    <property name="act10" value="add_monster rockitten,5"/>
+    <property name="act20" value="set_variable tuxchoice:end"/>
+    <property name="act30" value="translated_dialog_chain professor_dialog6.2"/>
+    <property name="act40" value="translated_dialog_chain professor_dialog7"/>
+    <property name="act50" value="translated_dialog_chain ${{end}}"/>
+    <property name="act60" value="screen_transition 2"/>
+    <property name="act70" value="remove_npc professor"/>
+    <property name="cond10" value="is variable_set tuxchoice:rockitten"/>
    </properties>
   </object>
   <object id="51" name="choiceFruitera" type="event" x="112.333" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="add_monster fruitera,5"/>
-    <property name="act2" value="set_variable tuxchoice:end"/>
-    <property name="act3" value="translated_dialog_chain professor_dialog6.3"/>
-    <property name="act4" value="translated_dialog_chain professor_dialog7"/>
-    <property name="act45" value="translated_dialog_chain ${{end}}"/>
-    <property name="act5" value="screen_transition 2"/>
-    <property name="act6" value="remove_npc professor"/>
-    <property name="cond1" value="is variable_set tuxchoice:fruitera"/>
+    <property name="act10" value="add_monster fruitera,5"/>
+    <property name="act20" value="set_variable tuxchoice:end"/>
+    <property name="act30" value="translated_dialog_chain professor_dialog6.3"/>
+    <property name="act40" value="translated_dialog_chain professor_dialog7"/>
+    <property name="act50" value="translated_dialog_chain ${{end}}"/>
+    <property name="act60" value="screen_transition 2"/>
+    <property name="act70" value="remove_npc professor"/>
+    <property name="cond10" value="is variable_set tuxchoice:fruitera"/>
    </properties>
   </object>
   <object id="56" name="employee" type="event" x="32" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc tuxemart_keeper,2,7,tuxemartemployee,stand"/>
-    <property name="act2" value="npc_face tuxemart_keeper,right"/>
-    <property name="act3" value="set_inventory tuxemart_keeper,inv_basic_store"/>
-    <property name="cond1" value="not npc_exists tuxemart_keeper"/>
+    <property name="act10" value="create_npc tuxemart_keeper,2,7,tuxemartemployee,stand"/>
+    <property name="act20" value="npc_face tuxemart_keeper,right"/>
+    <property name="act30" value="set_inventory tuxemart_keeper,inv_basic_store"/>
+    <property name="cond10" value="not npc_exists tuxemart_keeper"/>
    </properties>
   </object>
   <object id="57" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_cathedral_theme"/>
-    <property name="cond1" value="not music_playing music_cathedral_theme"/>
+    <property name="act10" value="play_music music_cathedral_theme"/>
+    <property name="cond10" value="not music_playing music_cathedral_theme"/>
    </properties>
   </object>
   <object id="59" name="yespls" type="event" x="112" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog professor_yes"/>
-    <property name="act2" value="set_variable serenademe:okay"/>
-    <property name="act3" value="set_variable twocanplay:go"/>
-    <property name="cond1" value="is variable_set serenademe:yes"/>
+    <property name="act10" value="translated_dialog professor_yes"/>
+    <property name="act20" value="set_variable serenademe:okay"/>
+    <property name="act30" value="set_variable twocanplay:go"/>
+    <property name="cond10" value="is variable_set serenademe:yes"/>
    </properties>
   </object>
   <object id="60" name="nopls" type="event" x="112" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog professor_no"/>
-    <property name="act2" value="set_variable serenademe:okay"/>
-    <property name="act3" value="set_variable twocanplay:go"/>
-    <property name="cond1" value="is variable_set serenademe:no"/>
+    <property name="act10" value="translated_dialog professor_no"/>
+    <property name="act20" value="set_variable serenademe:okay"/>
+    <property name="act30" value="set_variable twocanplay:go"/>
+    <property name="cond10" value="is variable_set serenademe:no"/>
    </properties>
   </object>
   <object id="61" name="more talk" type="event" x="112" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog professor_dialog2\n"/>
-    <property name="act2" value="npc_face professor,up"/>
-    <property name="act3" value="translated_dialog professor_turn"/>
-    <property name="act4" value="npc_face professor,down"/>
-    <property name="act5" value="translated_dialog professor_select"/>
-    <property name="act6" value="translated_dialog_choice hydrone:fruitera:rockitten,tuxchoice"/>
-    <property name="cond1" value="is variable_set twocanplay:go"/>
-    <property name="cond2" value="not variable_set tuxchoice:end"/>
+    <property name="act10" value="translated_dialog professor_dialog2\n"/>
+    <property name="act20" value="npc_face professor,up"/>
+    <property name="act30" value="translated_dialog professor_turn"/>
+    <property name="act40" value="npc_face professor,down"/>
+    <property name="act50" value="translated_dialog professor_select"/>
+    <property name="act60" value="translated_dialog_choice hydrone:fruitera:rockitten,tuxchoice"/>
+    <property name="cond10" value="is variable_set twocanplay:go"/>
+    <property name="cond20" value="not variable_set tuxchoice:end"/>
    </properties>
   </object>
   <object id="62" name="potions" type="event" x="144" y="112" width="48" height="16">
    <properties>
-    <property name="act1" value="translated_dialog potions_in_shop"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog potions_in_shop"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="64" name="capture devices" type="event" x="160" y="160" width="32" height="16">
    <properties>
-    <property name="act1" value="translated_dialog capture_devices_in_shop"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog capture_devices_in_shop"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="65" name="capture devices" type="event" x="48" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog cash_register"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="act10" value="translated_dialog cash_register"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/wayfarer_inn1.tmx
+++ b/mods/tuxemon/maps/wayfarer_inn1.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="15" height="16" tilewidth="16" tileheight="16" nextobjectid="47">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="16" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="47">
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>
  </tileset>
@@ -60,27 +60,27 @@
  <tileset firstgid="7766" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
   <image source="../gfx/tilesets/boxfont.png" width="208" height="192"/>
  </tileset>
- <layer name="Tile Layer 1" width="15" height="16">
+ <layer id="1" name="Tile Layer 1" width="15" height="16">
   <data encoding="base64" compression="zlib">
-   eJyzk2FgcIFiEMgB0gkyEBqGU5HUwLADEPsCcTAUg0A1kM6XgdAwXIGkBob9oXplZVFxHVDMVBaBK9D4IAzTqyuBitHV4dMLsqsLzY/I/q7FIteNpLcKzY8gnIdFDIax+RcEYOw8LGEBw8h642UQemH6idW7FYufgGINxOjF5t8aIu0lFYP0xuCJIwcZBrwgBo+b/YnUi8tdA6E3joBeAKciTeY=
+   eAHFkjsKAkEQROcYBu4RDE3FwFQMTEVNzERT8Yexnsf7WQX9YFyGcTIbiurt7urP7k6GKc0CSbaXvxXMYBd56sxTYS4sA9Ze5B8FMzhFnjrzQrC2675xV2ysGLAWH0Y7GqSUgzxc03ruU725D+buWyH3Uoydz/K5Dz4UYuTYOb/X74tna/H7nGs3UWetzbWt2re03Akr9ujP4zmfW7r32rgz/VrZc1fRu/SN/N/VDG1pZ/euGdrSrv/Srn/s/AGnIk3m
   </data>
  </layer>
- <layer name="Tile Layer 4" width="15" height="16">
+ <layer id="2" name="Tile Layer 4" width="15" height="16">
   <data encoding="base64" compression="zlib">
-   eJxjYGBgyJFBYHzAT5KBwV8SVaxaBoGV5RgaQGLvxSFyDcIIdWVAfeVoepGBFlTvZ6DeBUB9U6B6gWZiBbKyqFhOFquZBMEmKeLEsIFbQHX5QHsnSqCKWQHtTQKKJQOxHZobZGQR7q8G4p1QvQJAtiAQO8pBaBB2xeJ+KTmEn2FAEsiWAmJ/oFwAEAcBcTAWvcj+grFhepGxNJawvCWFySZWLzagBFSnDMRMQHcyAzELEKvg0EtsfGADt8jQqwd0hz4SNiDSTyBgDlRrgYQtSdDrAIp/JOxEhF4A730m+A==
+   eAGVjztOw0AQQEfAAUAUwY7tIqZKAen4FChGosVRuAG0keigcOMrIOUAnIGOq3AJilyAN7JHXq3Xihnpece783ZmRUQ2SQe/g/EYiZTgRoVr5JnUevY7aSrq02bV7xveu+d2pyLz1t3hfuJtW5c7g5GmIi4Z/35w5974ivslob1+lcgP7it9P866U927pe8zey9w582QtHPq7BV8t+4x+QkU1OuqPHiudonZs3db14jaGErOVrCGJ/DDfZfl5qpvTMn90HdZWD7WNc9dZ/TI4YA5D+EIzgN91bFZXX9sbrOOrde6C+a4dFgMzBW684raa4ebf7hLaguH+xHuH+99Jvg=
   </data>
  </layer>
- <layer name="Tile Layer 5" width="15" height="16">
+ <layer id="3" name="Tile Layer 5" width="15" height="16">
   <data encoding="base64" compression="zlib">
-   eJxjYKAcuElSwZARDjJEIfRpEsLyoQRt3DIcgL4cA4OBHIQ9CRhOk0kIKzOgPnOo3l1AfbvJDOdHQH2PSdArKUW6HQA3pQkg
+   eAFjYKAcuElSbsZINyFDFBICp0kIy4cSIz3UcPtfX46BwQCIQWASMJwmkxBWZkB95lC9u4D6dpOgF2IjhHwE1PeYBL2SUsi6iWMDADelCSA=
   </data>
  </layer>
- <layer name="Above Player" width="15" height="16">
+ <layer id="4" name="Above Player" width="15" height="16">
   <data encoding="base64" compression="zlib">
-   eJxjYBgF9AbCcgPtglEwXAAAdC4AMg==
+   eAFjYBgF9A4BYTl62zhq33ANAQB0LgAy
   </data>
  </layer>
- <objectgroup color="#ff0000" name="Collisions">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="1" type="collision" x="0" y="0" width="16" height="256"/>
   <object id="5" type="collision" x="16" y="0" width="160" height="32"/>
   <object id="8" type="collision" x="32" y="176" width="96" height="16"/>
@@ -113,43 +113,43 @@
    <polyline points="0,0 16,0"/>
   </object>
  </objectgroup>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="6" name="Events">
   <object id="34" name="Go upstairs" type="event" x="64" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport wayfarer_inn2.tmx,5,2,0.3"/>
-    <property name="act2" value="player_face right"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="transition_teleport wayfarer_inn2.tmx,5,2,0.3"/>
+    <property name="act20" value="player_face right"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="35" name="Go to the other upstairs" type="event" x="176" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport wayfarer_inn2.tmx,9,3,0.3"/>
-    <property name="act2" value="player_face left"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
+    <property name="act10" value="transition_teleport wayfarer_inn2.tmx,9,3,0.3"/>
+    <property name="act20" value="player_face left"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
    </properties>
   </object>
   <object id="39" name="Teleport to Route 3" type="event" x="160" y="160" width="48" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route3.tmx,35,5,0.3"/>
-    <property name="act2" value="player_face bottom"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing bottom"/>
+    <property name="act10" value="transition_teleport route3.tmx,35,5,0.3"/>
+    <property name="act20" value="player_face bottom"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing bottom"/>
    </properties>
   </object>
   <object id="40" name="Teleport to Route 3" type="event" x="176" y="16" width="32" height="16">
    <properties>
-    <property name="act1" value="transition_teleport route3.tmx,33,1,0.3"/>
-    <property name="act2" value="player_face up"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
+    <property name="act10" value="transition_teleport route3.tmx,33,1,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
   <object id="45" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_cathedral_theme"/>
-    <property name="cond1" value="not music_playing music_cathedral_theme"/>
+    <property name="act10" value="play_music music_cathedral_theme"/>
+    <property name="cond10" value="not music_playing music_cathedral_theme"/>
    </properties>
   </object>
   <object id="46" name="Player Spawn" type="event" x="176" y="144" width="16" height="16"/>

--- a/mods/tuxemon/maps/wayfarer_inn2.tmx
+++ b/mods/tuxemon/maps/wayfarer_inn2.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="15" height="16" tilewidth="16" tileheight="16" nextobjectid="33">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="16" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="33">
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>
  </tileset>
@@ -60,57 +60,57 @@
  <tileset firstgid="7766" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
   <image source="../gfx/tilesets/boxfont.png" width="208" height="192"/>
  </tileset>
- <layer name="Tile Layer 1" width="15" height="16">
+ <layer id="1" name="Tile Layer 1" width="15" height="16">
   <data encoding="base64" compression="zlib">
-   eJyzk2FgyIHiBCQ2DBdjEQNhByD2BeJqKM5DYsNwMRYxEPaH6jWVZWgAYZBeWVlUXAyRx8Ck6JXFo7dXhqGhFs0/IPWH0fzZCxWH6QWyG2qAetH9A1KDHgY1mHoxMLJeXPIwvfEy2PXmE6F3K5q/cqHidUTorcLhL1wYn38JYZDeGKjeLhzpDh+IweFmWDwRoxeXuwajXgDMWlNu
+   eAHNkUsKAkEMRPsg08dwK15AvICgB/CzcOePXgsexxN4MaskBWVmGHHnQEg6qZdOeqZdKZuwtcXKHQZyrM1gc9gpbGexcmQVu18gT3ZSS6ORrfXTyKLWs19Y9vQezt670i64Q3tyH+qflmMNundeLDTtDDbvQza/AXSZ7e3JvmLps9m9ZRVaacTuU97rfGeeH/DalX4b+Wt4MfJ+7xEa31d7SZu9s7n27Ux2GTPd4H1mxvxPY5/YPDPnZ++xT+zQjP/KvgDMWlNu
   </data>
  </layer>
- <layer name="Tile Layer 3" width="15" height="16">
+ <layer id="2" name="Tile Layer 3" width="15" height="16">
   <data encoding="base64" compression="zlib">
-   eJxjYKAMfOVkYPjGSZ5eJS4GBmUu4tWbyZJnD6V67WSxs7EBfTkGBgM5/GpYgfJsQMyOps4MyDcnoJcHKM8LxHxo6iyAfEsCenEBe6A+BzL1IgMpoBmSVDCHGqBcmIGhX4KBYYIEcXGCDLqBercD9e2QIC5O0MF9oL4HEqTpwQYkpQirAQDT8g83
+   eAFjYKAMfOVkYPgGxOQAJS4GBmUgJhaYyRKrElMdJXrtkOxFZmPawsCgL8fAYADE+AArUJ4NiNnR1JkB+eZoYujm8ADleYGYD02dBZBviSaGrhcX3x6oz4FMvchmSgHNkKSCOchmkssuF2Zg6JdgYJgAxMTECbI93UC924H6dgAxMXGCrBfEvg/U9wCIKQWSUoRNAADT8g83
   </data>
  </layer>
- <layer name="Tile Layer 2" width="15" height="16">
+ <layer id="3" name="Tile Layer 2" width="15" height="16">
   <data encoding="base64" compression="zlib">
-   eJxjYBgcwFCOfL3HBHGa2eDFTb65xICJEtjFNwkzMGwWxq93Jw69x4D6jhPQ+xCH3oEE0sA4lKEgHkcB6QAATagIbw==
+   eAFjYBgcwFCOfHccE8SuF2hmgxc3djlqiU6UwG7SJmEGhs1AjA/sxKH3GFDfcQJ6H+LQi88+WstJA+NQhoJ4pLX7hqP5AE2oCG8=
   </data>
  </layer>
- <layer name="Above Player" width="15" height="16">
+ <layer id="4" name="Above Player" width="15" height="16">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFowABROQYGETlBtoVo4BYAACtKABm
+   eAFjYBgFoyGACAEROQYGUSAeBUMjBACtKABm
   </data>
  </layer>
- <layer name="Above Player" width="15" height="16">
+ <layer id="5" name="Above Player" width="15" height="16">
   <data encoding="base64" compression="zlib">
-   eJxjYBj8IFVkoF0wcoCwHAODkNxAu2IUEAsAHroA2w==
+   eAFjYBj8IFVk8LtxuLhQWI6BQQiIR8HQCAEAHroA2w==
   </data>
  </layer>
- <objectgroup color="#ffff00" name="Events">
+ <objectgroup color="#ffff00" id="6" name="Events">
   <object id="17" name="Go downstairs" type="event" x="64" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport wayfarer_inn1.tmx,3,2,0.3"/>
-    <property name="act2" value="player_face left"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
+    <property name="act10" value="transition_teleport wayfarer_inn1.tmx,3,2,0.3"/>
+    <property name="act20" value="player_face left"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
    </properties>
   </object>
   <object id="23" name="Go to the other downstairs" type="event" x="160" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport wayfarer_inn1.tmx,11,3,0.3"/>
-    <property name="act2" value="player_face right"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing right"/>
+    <property name="act10" value="transition_teleport wayfarer_inn1.tmx,11,3,0.3"/>
+    <property name="act20" value="player_face right"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
   <object id="31" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music music_cathedral_theme"/>
-    <property name="cond1" value="not music_playing music_cathedral_theme"/>
+    <property name="act10" value="play_music music_cathedral_theme"/>
+    <property name="cond10" value="not music_playing music_cathedral_theme"/>
    </properties>
   </object>
   <object id="32" name="Player Spawn" type="event" x="80" y="32" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ff0000" name="Collisions">
+ <objectgroup color="#ff0000" id="7" name="Collisions">
   <object id="2" type="collision" x="0" y="0" width="16" height="256"/>
   <object id="3" type="collision" x="16" y="256" width="96" height="16"/>
   <object id="4" type="collision" x="32" y="176" width="48" height="48"/>


### PR DESCRIPTION
We are now using `natsort` for event action/condition sorting, which is more natural in daily use compared to ASCII sorting.  Using the "renumber_events.py" script, i've cleaned up the events and normalized them ordering each item (action/condition/behav) by tens (10, 20, 30, etc).

Part of the process imported the maps into tiled and saved them, so the map versions and some data may vary slightly.