### PR TITLE
Refactor to use tuxemon.compat.Rect where possible

### DIFF
--- a/tuxemon/core/animation.py
+++ b/tuxemon/core/animation.py
@@ -12,6 +12,8 @@ import pygame
 
 __all__ = ('Task', 'Animation', 'remove_animations_of')
 
+from tuxemon.compat import Rect
+
 logger = logging.getLogger(__name__)
 
 ANIMATION_NOT_STARTED = 0
@@ -497,7 +499,7 @@ class Animation(pygame.sprite.Sprite):
         self.targets = list()
         for target in self._targets:
             props = dict()
-            if isinstance(target, pygame.Rect):
+            if isinstance(target, Rect):
                 self._round_values = True
             for name, value in self.props.items():
                 initial = self._get_value(target, name)

--- a/tuxemon/core/menu/input.py
+++ b/tuxemon/core/menu/input.py
@@ -9,6 +9,7 @@ from functools import partial
 
 import pygame
 
+from tuxemon.compat import Rect
 from tuxemon.core import tools
 from tuxemon.core.menu.interface import MenuItem
 from tuxemon.core.menu.menu import Menu
@@ -41,14 +42,14 @@ class InputMenu(Menu):
         # area where the input will be shown
         self.text_area = TextArea(self.font, self.font_color, (96, 96, 96))
         self.text_area.animated = False
-        self.text_area.rect = pygame.Rect(tools.scale_sequence([90, 30, 80, 100]))
+        self.text_area.rect = Rect(tools.scale_sequence([90, 30, 80, 100]))
         self.text_area.text = self.input_string
         self.sprites.add(self.text_area)
 
         # prompt
         self.prompt = TextArea(self.font, self.font_color, (96, 96, 96))
         self.prompt.animated = False
-        self.prompt.rect = pygame.Rect(tools.scale_sequence([50, 20, 80, 100]))
+        self.prompt.rect = Rect(tools.scale_sequence([50, 20, 80, 100]))
         self.sprites.add(self.prompt)
 
         self.prompt.text = kwargs.get("prompt", "")

--- a/tuxemon/core/menu/menu.py
+++ b/tuxemon/core/menu/menu.py
@@ -400,7 +400,7 @@ class Menu(state.State):
         If no borders are present, a copy of the menu rect will be returned
 
         :returns: Rect representing space inside borders, if any
-        :rtype: pygame.Rect
+        :rtype: Rect
         """
         return self.window.calc_inner_rect(self.rect)
 
@@ -599,7 +599,7 @@ class Menu(state.State):
     def calc_menu_items_rect(self):
         """ Calculate the area inside the internal rect where items are listed
 
-        :rtype: pygame.Rect
+        :rtype: Rect
         """
         # WARNING: hardcoded values related to menu arrow size
         #          if menu arrow image changes, this should be adjusted
@@ -618,7 +618,7 @@ class Menu(state.State):
 
         The rect represents the size of the menu after all items are added.
 
-        :rtype: pygame.Rect
+        :rtype: Rect
         """
         original = self.rect.copy()    # store the original rect
         self.refresh_layout()          # arrange the menu

--- a/tuxemon/core/npc.py
+++ b/tuxemon/core/npc.py
@@ -39,6 +39,7 @@ from math import hypot
 
 import pygame
 
+from tuxemon.compat import Rect
 from tuxemon.core import monster, pyganim
 from tuxemon.core.db import db
 from tuxemon.core.entity import Entity
@@ -153,7 +154,7 @@ class NPC(Entity):
         self.sprite = {}  # Moving animation frames
         self.moveConductor = pyganim.PygConductor()
         self.load_sprites()
-        self.rect = pygame.Rect(self.tile_pos, (self.playerWidth, self.playerHeight))  # Collision rect
+        self.rect = Rect(self.tile_pos, (self.playerWidth, self.playerHeight))  # Collision rect
 
     def get_state(self, game):
         """Prepares a dictionary of the npc to be saved to a file

--- a/tuxemon/core/pyganim.py
+++ b/tuxemon/core/pyganim.py
@@ -53,6 +53,8 @@ import time
 import pygame
 
 # setting up constants
+from tuxemon.compat import Rect
+
 PLAYING = 'playing'
 PAUSED = 'paused'
 STOPPED = 'stopped'
@@ -355,11 +357,11 @@ class PygAnimation(object):
         return (maxWidth, maxHeight)
 
     def get_rect(self):
-        # Returns a pygame.Rect object for this animation object.
+        # Returns a Rect object for this animation object.
         # The top and left will be set to 0, 0, and the width and height
         # will be set to what is returned by getMaxSize().
         maxWidth, maxHeight = self.getMaxSize()
-        return pygame.Rect(0, 0, maxWidth, maxHeight)
+        return Rect(0, 0, maxWidth, maxHeight)
 
     def anchor(self, anchorPoint=NORTHWEST):
         # If the Surface objects are of different sizes, align them all to a

--- a/tuxemon/core/sprite.py
+++ b/tuxemon/core/sprite.py
@@ -35,6 +35,7 @@ import pygame
 from pygame.transform import rotozoom
 from pygame.transform import scale
 
+from tuxemon.compat import Rect
 from tuxemon.core.pyganim import PygAnimation
 from tuxemon.core.platform.const import buttons
 
@@ -165,7 +166,7 @@ class SpriteGroup(pygame.sprite.LayeredUpdates):
     Variations from standard group:
     * SpriteGroup.add no longer accepts a sequence, use SpriteGroup.extend
     """
-    _init_rect = pygame.Rect(0, 0, 0, 0)
+    _init_rect = Rect(0, 0, 0, 0)
 
     def __init__(self, *args, **kwargs):
         self._spritelayers = dict()
@@ -249,7 +250,7 @@ class SpriteGroup(pygame.sprite.LayeredUpdates):
         if not sprites:
             return self.rect
         elif len(sprites) == 1:
-            return pygame.Rect(sprites[0].rect)
+            return Rect(sprites[0].rect)
         else:
             return sprites[0].rect.unionall([s.rect for s in sprites[1:]])
 
@@ -258,7 +259,7 @@ class RelativeGroup(SpriteGroup):
     """
     Drawing operations are relative to the group's rect
     """
-    rect = pygame.Rect(0, 0, 0, 0)
+    rect = Rect(0, 0, 0, 0)
 
     def __init__(self, **kwargs):
         self.parent = kwargs.get('parent')
@@ -279,7 +280,7 @@ class RelativeGroup(SpriteGroup):
         try:
             self.rect = self.parent()
         except TypeError:
-            self.rect = pygame.Rect(self.parent.rect)
+            self.rect = Rect(self.parent.rect)
 
     def draw(self, surface):
         self.update_rect_from_parent()

--- a/tuxemon/core/state.py
+++ b/tuxemon/core/state.py
@@ -38,6 +38,7 @@ from importlib import import_module
 
 import pygame
 
+from tuxemon.compat import Rect
 from tuxemon.constants import paths
 from tuxemon.core import prepare, graphics
 from tuxemon.core import tools
@@ -69,7 +70,7 @@ class State(object):
     """
     __metaclass__ = ABCMeta
 
-    rect = pygame.Rect((0, 0), prepare.SCREEN_SIZE)
+    rect = Rect((0, 0), prepare.SCREEN_SIZE)
     transparent = False   # ignore all background/borders
     force_draw = False    # draw even if completely under another state
 
@@ -95,7 +96,7 @@ class State(object):
     def load_sprite(self, filename, **kwargs):
         """ Load a sprite and add it to this state
 
-        kwargs can be any value used by pygame Rect, or layer
+        kwargs can be any value used by Rect, or layer
 
         :param filename: filename, relative to the resources folder
         :type filename: String

--- a/tuxemon/core/states/combat/combat.py
+++ b/tuxemon/core/states/combat/combat.py
@@ -40,6 +40,7 @@ from itertools import chain
 
 import pygame
 
+from tuxemon.compat import Rect
 from tuxemon.core import audio, state, tools, graphics
 from tuxemon.core.combat import check_status, fainted, get_awake_monsters, defeated
 from tuxemon.core.locale import T
@@ -159,7 +160,7 @@ class CombatState(CombatAnimations):
         :returns: None
         """
         for monster, hud in self.hud.items():
-            rect = pygame.Rect(0, 0, tools.scale(70), tools.scale(8))
+            rect = Rect(0, 0, tools.scale(70), tools.scale(8))
             rect.right = hud.image.get_width() - tools.scale(8)
             rect.top += tools.scale(12)
             self._hp_bars[monster].draw(hud.image, rect)
@@ -171,7 +172,7 @@ class CombatState(CombatAnimations):
         """
         for monster, hud in self.hud.items():
             if hud.player:
-                rect = pygame.Rect(0, 0, tools.scale(70), tools.scale(6))
+                rect = Rect(0, 0, tools.scale(70), tools.scale(6))
                 rect.right = hud.image.get_width() - tools.scale(8)
                 rect.top += tools.scale(31)
                 self._exp_bars[monster].draw(hud.image, rect)
@@ -513,7 +514,7 @@ class CombatState(CombatAnimations):
         """
         # make the border and area at the bottom of the screen for messages
         x, y, w, h = self.game.screen.get_rect()
-        rect = pygame.Rect(0, 0, w, h // 4)
+        rect = Rect(0, 0, w, h // 4)
         rect.bottomright = w, h
         border = graphics.load_and_scale(self.borders_filename)
         self.dialog_box = GraphicBox(border, None, self.background_color)
@@ -536,7 +537,7 @@ class CombatState(CombatAnimations):
         message = T.format('combat_monster_choice', {"name": monster.name})
         self.alert(message)
         x, y, w, h = self.game.screen.get_rect()
-        rect = pygame.Rect(0, 0, w // 2.5, h // 4)
+        rect = Rect(0, 0, w // 2.5, h // 4)
         rect.bottomright = w, h
 
         state = self.game.push_state("MainCombatMenuState", columns=2)

--- a/tuxemon/core/states/combat/combat_animations.py
+++ b/tuxemon/core/states/combat/combat_animations.py
@@ -13,6 +13,7 @@ from functools import partial
 
 import pygame
 
+from tuxemon.compat import Rect
 from tuxemon.core import audio, graphics, tools
 from tuxemon.core.locale import T
 from tuxemon.core.menu.interface import HpBar, ExpBar
@@ -33,7 +34,7 @@ def toggle_visible(sprite):
 
 
 def scale_area(area):
-    return pygame.Rect(tools.scale_sequence(area))
+    return Rect(tools.scale_sequence(area))
 
 
 class CombatAnimations(Menu):
@@ -69,7 +70,7 @@ class CombatAnimations(Menu):
         layout.append(opponent)
         # end config =========================================
 
-        # convert the list/tuple of coordinates to pygame Rects
+        # convert the list/tuple of coordinates to Rects
         for position in layout:
             for key, value in position.items():
                 position[key] = list(map(scale_area, value))
@@ -290,7 +291,7 @@ class CombatAnimations(Menu):
     def get_side(self, rect):
         """ [WIP] get 'side' of screen rect is in
 
-        :type rect: pygame.Rect
+        :type rect: Rect
         :return: basestring
         """
         return "left" if rect.centerx < scale(100) else "right"
@@ -315,7 +316,7 @@ class CombatAnimations(Menu):
     def build_hud(self, home, monster):
         """
 
-        :type home: pygame.Rect
+        :type home: Rect
         :type monster: core.monster.Monster
         :return:
         """
@@ -352,7 +353,7 @@ class CombatAnimations(Menu):
         """ Party HUD is the arrow thing with balls.  Yes, that one.
 
         :param player: the player
-        :type home: pygame.Rect
+        :type home: Rect
         :param slots: Number of slots
         :return:
         """
@@ -406,7 +407,7 @@ class CombatAnimations(Menu):
         This function updates the balls to reflect how many Tuxemon have fainted.
 
         :param player: the player
-        :type home: pygame.Rect
+        :type home: Rect
         :param slots: Number of slots
         :return:
         """

--- a/tuxemon/core/states/monster/__init__.py
+++ b/tuxemon/core/states/monster/__init__.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 
 import pygame
 
+from tuxemon.compat import Rect
 from tuxemon.core import prepare, graphics
 from tuxemon.core import tools
 from tuxemon.core.menu.interface import HpBar, ExpBar, MenuItem
@@ -27,7 +28,7 @@ class MonsterMenuState(Menu):
 
         # make a text area to show messages
         self.text_area = TextArea(self.font, self.font_color, (96, 96, 96))
-        self.text_area.rect = pygame.Rect(tools.scale_sequence([20, 80, 80, 100]))
+        self.text_area.rect = Rect(tools.scale_sequence([20, 80, 80, 100]))
         self.sprites.add(self.text_area, layer=100)
 
         # Set up the border images used for the monster slots
@@ -68,7 +69,7 @@ class MonsterMenuState(Menu):
         left = width // 2.25
         top = height // 12
         width /= 2
-        return pygame.Rect(left, top, width, height - top * 2)
+        return Rect(left, top, width, height - top * 2)
 
     def initialize_items(self):
         # position the monster portrait
@@ -90,7 +91,7 @@ class MonsterMenuState(Menu):
 
         # make 6 slots
         for i in range(self.game.player1.party_limit):
-            rect = pygame.Rect(0, 0, width, height)
+            rect = Rect(0, 0, width, height)
             surface = pygame.Surface(rect.size, pygame.SRCALPHA)
             item = MenuItem(surface, None, None, None)
             yield item

--- a/tuxemon/core/states/persistance/save_menu.py
+++ b/tuxemon/core/states/persistance/save_menu.py
@@ -9,6 +9,7 @@ from base64 import b64decode
 
 import pygame
 
+from tuxemon.compat import Rect
 from tuxemon.core import prepare
 from tuxemon.core import save
 from tuxemon.core.locale import T
@@ -32,7 +33,7 @@ class SaveMenuState(PopUpMenu):
     def initialize_items(self):
         empty_image = None
         rect = self.game.screen.get_rect()
-        slot_rect = pygame.Rect(0, 0, rect.width * 0.80, rect.height // 6)
+        slot_rect = Rect(0, 0, rect.width * 0.80, rect.height // 6)
         for i in range(self.number_of_slots):
             # Check to see if a save exists for the current slot
             if os.path.exists(prepare.SAVE_PATH + str(i + 1) + ".save"):

--- a/tuxemon/core/states/world/world_menus.py
+++ b/tuxemon/core/states/world/world_menus.py
@@ -8,6 +8,7 @@ from functools import partial
 
 import pygame
 
+from tuxemon.compat import Rect
 from tuxemon.core import prepare
 from tuxemon.core.locale import T
 from tuxemon.core.menu.interface import MenuItem
@@ -160,7 +161,7 @@ class WorldMenuState(Menu):
         self.shrink_to_items = False   # force menu to expand
         self.menu_items.expand = True  # force menu to expand
         self.refresh_layout()          # rearrange items
-        self.rect = pygame.Rect(right, 0, width, height)  # set new rect
+        self.rect = Rect(right, 0, width, height)  # set new rect
 
         # animate the menu sliding in
         ani = self.animate(self.rect, x=right - width, duration=.50)

--- a/tuxemon/core/states/world/worldstate.py
+++ b/tuxemon/core/states/world/worldstate.py
@@ -38,6 +38,7 @@ import logging
 import pygame
 from six.moves import map as imap
 
+from tuxemon.compat import Rect
 from tuxemon.core import prepare, state, networking
 from tuxemon.core.db import db
 from tuxemon.core.map import PathfindNode, Map, dirs2, pairs
@@ -772,20 +773,20 @@ class WorldState(state.State):
             entity.move(time_delta, self)
 
     def _collision_box_to_pgrect(self, box):
-        """Returns a pygame.Rect (in screen-coords) version of a collision box (in world-coords).
+        """Returns a Rect (in screen-coords) version of a collision box (in world-coords).
         """
 
         # For readability
         x, y = self.get_pos_from_tilepos(box)
         tw, th = self.tile_size
 
-        return pygame.Rect(x, y, tw, th)
+        return Rect(x, y, tw, th)
 
     def _npc_to_pgrect(self, npc):
-        """Returns a pygame.Rect (in screen-coords) version of an NPC's bounding box.
+        """Returns a Rect (in screen-coords) version of an NPC's bounding box.
         """
         pos = self.get_pos_from_tilepos(npc.tile_pos)
-        return pygame.Rect(pos, self.tile_size)
+        return Rect(pos, self.tile_size)
 
     ####################################################
     #                Debug Drawing                     #

--- a/tuxemon/core/tools.py
+++ b/tuxemon/core/tools.py
@@ -78,7 +78,7 @@ def new_scaled_rect(*args, **kwargs):
 def scale_rect(rect, factor=prepare.SCALE):
     """ Scale a rect.  Returns a new object.
 
-    :param rect: pygame Rect
+    :param rect: Rect
     :param factor: int
     :rtype: tuxemon.compat.rect.Rect
     """

--- a/tuxemon/core/ui/controller.py
+++ b/tuxemon/core/ui/controller.py
@@ -37,6 +37,7 @@ import logging
 
 import pygame
 
+from tuxemon.compat import Rect
 from tuxemon.core import graphics
 from tuxemon.core import screen
 
@@ -65,19 +66,19 @@ class Controller(object):
 
         # Create the collision rectangle objects for the dpad so we can see if we're pressing a button
         self.dpad["rect"] = {}
-        self.dpad["rect"]["up"] = pygame.Rect(self.dpad["position"][0] + (self.dpad["surface"].get_width() /3),
+        self.dpad["rect"]["up"] = Rect(self.dpad["position"][0] + (self.dpad["surface"].get_width() /3),
             self.dpad["position"][1],                      # Rectangle position_y
             self.dpad["surface"].get_width() /3,           # Rectangle size_x
             self.dpad["surface"].get_height() /2)          # Rectangle size_y
-        self.dpad["rect"]["down"] = pygame.Rect(self.dpad["position"][0] + (self.dpad["surface"].get_width() /3),
+        self.dpad["rect"]["down"] = Rect(self.dpad["position"][0] + (self.dpad["surface"].get_width() /3),
             self.dpad["position"][1] + (self.dpad["surface"].get_height() /2),
             self.dpad["surface"].get_width() /3,
             self.dpad["surface"].get_height() /2)
-        self.dpad["rect"]["left"] = pygame.Rect(self.dpad["position"][0],
+        self.dpad["rect"]["left"] = Rect(self.dpad["position"][0],
             self.dpad["position"][1] + (self.dpad["surface"].get_height() /3),
             self.dpad["surface"].get_width() /2,
             self.dpad["surface"].get_height() /3)
-        self.dpad["rect"]["right"] = pygame.Rect(self.dpad["position"][0] + (self.dpad["surface"].get_width() /2),
+        self.dpad["rect"]["right"] = Rect(self.dpad["position"][0] + (self.dpad["surface"].get_width() /2),
             self.dpad["position"][1] + (self.dpad["surface"].get_height() /3),
             self.dpad["surface"].get_width() /2,
             self.dpad["surface"].get_height() /3)
@@ -87,7 +88,7 @@ class Controller(object):
         self.a_button["surface"] = graphics.load_and_scale("gfx/a-button.png")
         self.a_button["position"] = (prepare.SCREEN_SIZE[0] - int( self.a_button["surface"].get_width() * 1.0 ),
             (self.dpad["position"][1] + (self.dpad["surface"].get_height() / 2) - (self.a_button["surface"].get_height() / 2)))
-        self.a_button["rect"] = pygame.Rect(
+        self.a_button["rect"] = Rect(
             self.a_button["position"][0], self.a_button["position"][1],
             self.a_button["surface"].get_width(),
             self.a_button["surface"].get_height())
@@ -96,7 +97,7 @@ class Controller(object):
         self.b_button["surface"] = graphics.load_and_scale("gfx/b-button.png")
         self.b_button["position"] = (prepare.SCREEN_SIZE[0] - int( self.b_button["surface"].get_width() * 2.1 ),
             (self.dpad["position"][1] + (self.dpad["surface"].get_height() / 2) - (self.b_button["surface"].get_height() / 2)))
-        self.b_button["rect"] = pygame.Rect(
+        self.b_button["rect"] = Rect(
             self.b_button["position"][0],
             self.b_button["position"][1],
             self.b_button["surface"].get_width(),

--- a/tuxemon/core/ui/draw.py
+++ b/tuxemon/core/ui/draw.py
@@ -9,6 +9,7 @@ from itertools import product
 
 import pygame
 
+from tuxemon.compat import Rect
 from tuxemon.core import prepare
 from tuxemon.core.sprite import Sprite
 
@@ -74,7 +75,7 @@ class GraphicBox(Sprite):
                        for x, y in product(range(0, iw, tw), range(0, ih, th))]
 
     def update_image(self):
-        rect = pygame.Rect((0, 0), self._rect.size)
+        rect = Rect((0, 0), self._rect.size)
         surface = pygame.Surface(rect.size, pygame.SRCALPHA)
         self._original_image = surface
         self._image = surface

--- a/tuxemon/core/ui/text.py
+++ b/tuxemon/core/ui/text.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 
 import pygame
 
+from tuxemon.compat import Rect
 from tuxemon.core.sprite import Sprite
 from tuxemon.core.ui import draw
 
@@ -18,7 +19,7 @@ class TextArea(Sprite):
 
     def __init__(self, font, font_color, bg=(192, 192, 192)):
         super(TextArea, self).__init__()
-        self.rect = pygame.Rect(0, 0, 0, 0)
+        self.rect = Rect(0, 0, 0, 0)
         self.drawing_text = False
         self.font = font
         self.font_color = font_color


### PR DESCRIPTION
Where possible, use tuxemon.compat.Rect instead of pygame

This is a step of several towards reducing the amount of pygame code in the core engine to support a totally headless game server.