### PR TITLE
Issue #573 - Grey font color on moves

### DIFF
--- a/tuxemon/core/menu/menu.py
+++ b/tuxemon/core/menu/menu.py
@@ -48,6 +48,7 @@ class Menu(state.State):
     draw_borders = True
     background = None                 # Image used to draw the background
     background_color = 248, 248, 248  # The window's background color
+    unavailable_color = 220, 220, 220 # Font color when the action is unavailable
     background_filename = None        # File to load for image background
     menu_select_sound_filename = "sound_menu_select"
     font_filename = prepare.fetch("font", "PressStart2P.ttf")
@@ -251,14 +252,18 @@ class Menu(state.State):
         """
         self.menu_select_sound = audio.load_sound(self.menu_select_sound_filename)
 
-    def shadow_text(self, text, bg=(192, 192, 192)):
+    def shadow_text(self, text, bg=(192, 192, 192), fg=None):
         """ Draw shadowed text
 
         :param text: Text to draw
         :param bg:
         :returns:
         """
-        top = self.font.render(text, 1, self.font_color)
+        color = fg
+        if not color:
+            color = self.font_color
+
+        top = self.font.render(text, 1, color)
         shadow = self.font.render(text, 1, bg)
 
         offset = layout((0.5, 0.5))

--- a/tuxemon/core/states/combat/combat_menus.py
+++ b/tuxemon/core/states/combat/combat_menus.py
@@ -147,7 +147,10 @@ class MainCombatMenuState(PopUpMenu):
                 if tech.next_use <= 0:
                     image = self.shadow_text(tech.name)
                 else:
+                    tmp = self.font_color
+                    self.font_color = (220, 220, 220)
                     image = self.shadow_text("%s -%s" % (tech.name, tech.next_use))
+                    self.font_color = tmp
                 item = MenuItem(image, None, None, tech)
                 menu.add(item)
 

--- a/tuxemon/core/states/combat/combat_menus.py
+++ b/tuxemon/core/states/combat/combat_menus.py
@@ -147,10 +147,7 @@ class MainCombatMenuState(PopUpMenu):
                 if tech.next_use <= 0:
                     image = self.shadow_text(tech.name)
                 else:
-                    tmp = self.font_color
-                    self.font_color = (220, 220, 220)
-                    image = self.shadow_text("%s -%s" % (tech.name, tech.next_use))
-                    self.font_color = tmp
+                    image = self.shadow_text("%s %d" % (tech.name, abs(tech.next_use)), fg=self.unavailable_color)
                 item = MenuItem(image, None, None, tech)
                 menu.add(item)
 


### PR DESCRIPTION
Fixes #573 

Since shadow_text uses self.font_color to draw text,  
I put the font_color is a temporary variable, change to grey,
then put back the font_color.

I would personally made font_color as an optional parameter,
with self.font_color as default.