### PR TITLE
Fix capture devices catching trainer monsters

### DIFF
--- a/mods/tuxemon/db/item/capture_device.json
+++ b/mods/tuxemon/db/item/capture_device.json
@@ -6,6 +6,9 @@
   "effects": [
     "capture 100"
   ],
+  "conditions": [
+    "is_wild_monster target"
+  ],
   "sort": "utility",
   "sprite": "gfx/items/capture_device.png",
   "target": {

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -1897,4 +1897,4 @@ msgstr "@*!^: 0H... @ n3wc0m3r! H0vv p1d y0v g3t he7e? <NONE> h3llen\"T $33N %^&
 "TH S D ES N T EX ST Y U AR  C NNE  ED TO TH  V ID YO  M ST LEA E N W"
 
 msgid "cannot_use_item_monster"
-msgstr "This item cannot be used on this monster"
+msgstr "This item cannot be used on this monster."

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -1895,3 +1895,6 @@ msgid "37707_villager_female_missing"
 msgstr "@*!^: 0H... @ n3wc0m3r! H0vv p1d y0v g3t he7e? <NONE> h3llen\"T $33N %^&one new 1n... ()h, never n3ver m3V3t N3W37 MIIIIIIIIND\n"
 "@*!^: WElcoME! W3lcome t0... 0H N/A: We never g0t ar0und to gi^ing 0ur town {<1} We never g00000000 {<2} W3 neVer Bu1lt 0uR t0wN\n"
 "TH S D ES N T EX ST Y U AR  C NNE  ED TO TH  V ID YO  M ST LEA E N W"
+
+msgid "cannot_use_item_monster"
+msgstr "This item cannot be used on this monster"

--- a/tuxemon/core/event/actions/random_encounter.py
+++ b/tuxemon/core/event/actions/random_encounter.py
@@ -135,7 +135,10 @@ def _create_monster_npc(encounter):
 
     # Create an NPC object which will be this monster's "trainer"
     npc = NPC("maple_girl")
-    npc.monsters.append(current_monster)
+    npc.add_monster(current_monster)
+    # NOTE: random battles are implemented as trainer battles.
+    #       this is a hack. remove this once trainer/random battlers are fixed
+    current_monster.owner = None
     npc.party_limit = 0
 
     # Set the NPC object's AI model.

--- a/tuxemon/core/item/conditions/is_wild_monster.py
+++ b/tuxemon/core/item/conditions/is_wild_monster.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+# Tuxemon
+# Copyright (c) 2014-2017 William Edwards <shadowapex@gmail.com>,
+#                         Benjamin Bean <superman2k5@gmail.com>
+#
+# This file is part of Tuxemon
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Contributor(s):
+#
+# Leif Theden <leif.theden@gmail.com>
+#
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from tuxemon.core.item.itemcondition import ItemCondition
+
+
+class IsWildMonsterCondition(ItemCondition):
+    """ True if not owned by a trainer
+    """
+    name = "is_wild_monster"
+    valid_parameters = []
+
+    def test(self, target):
+        return target.owner is None

--- a/tuxemon/core/item/item.py
+++ b/tuxemon/core/item/item.py
@@ -190,9 +190,9 @@ class Item(object):
         ret = list()
 
         for line in raw:
-            space_split = line.split()
-            args = "".join(space_split[1:]).split(",")
-            name = space_split[0]
+            words = line.split()
+            args = "".join(words[1:]).split(",")
+            name = words[0]
             context = args[0]
             params = args[1:]
             try:

--- a/tuxemon/core/item/item.py
+++ b/tuxemon/core/item/item.py
@@ -38,7 +38,7 @@ from __future__ import unicode_literals
 import logging
 import pprint
 
-from tuxemon.core import tools, prepare, graphics
+from tuxemon.core import prepare, graphics
 from tuxemon.core.db import db, process_targets
 from tuxemon.core.locale import T
 
@@ -190,15 +190,18 @@ class Item(object):
         ret = list()
 
         for line in raw:
-            name = line.split()[0]
-            params = line.split()[1].split(",")
+            space_split = line.split()
+            args = "".join(space_split[1:]).split(",")
+            name = space_split[0]
+            context = args[0]
+            params = args[1:]
             try:
                 condition = Item.conditions[name]
             except KeyError:
                 error = 'Error: ItemCondition "{}" not implemented'.format(name)
                 logger.error(error)
             else:
-                ret.append(condition(params[0], self.game, self.user, params[1:]))
+                ret.append(condition(context, self.game, self.user, params))
 
         return ret
 

--- a/tuxemon/core/monster.py
+++ b/tuxemon/core/monster.py
@@ -50,7 +50,7 @@ SIMPLE_PERSISTANCE_ATTRIBUTES = (
     'slug',
     'status',
     'total_experience',
-    'flairs',
+    'flairs'
 )
 
 SHAPES = {

--- a/tuxemon/core/monster.py
+++ b/tuxemon/core/monster.py
@@ -50,7 +50,7 @@ SIMPLE_PERSISTANCE_ATTRIBUTES = (
     'slug',
     'status',
     'total_experience',
-    'flairs'
+    'flairs',
 )
 
 SHAPES = {
@@ -217,6 +217,7 @@ class Monster(object):
         self.battle_cry = ""    # a slug for a sound file, used primarly when they enter battle
         self.faint_cry = ""     # a slug for a sound file, used when the monster faints
         self.ai = None
+        self.owner = None       # set to NPC instance if they own it
 
         # The multiplier for experience
         self.experience_required_modifier = 1

--- a/tuxemon/core/states/combat/combat_menus.py
+++ b/tuxemon/core/states/combat/combat_menus.py
@@ -119,8 +119,15 @@ class MainCombatMenuState(PopUpMenu):
             state.on_menu_selection = partial(enqueue_item, item)
 
         def enqueue_item(item, menu_item):
-            # enqueue the item
             target = menu_item.game_object
+            # is the item valid to use?
+            if not item.validate(target):
+                msg = T.format('item_no_available_target', {'name': item.name})
+                tools.open_dialog(self.game, [msg])
+                return
+
+
+            # enqueue the item
             combat_state = self.game.get_state_name("CombatState")
             # TODO: don't hardcode to player0
             combat_state.enqueue_action(combat_state.players[0], item, target)

--- a/tuxemon/core/states/combat/combat_menus.py
+++ b/tuxemon/core/states/combat/combat_menus.py
@@ -122,10 +122,9 @@ class MainCombatMenuState(PopUpMenu):
             target = menu_item.game_object
             # is the item valid to use?
             if not item.validate(target):
-                msg = T.format('item_no_available_target', {'name': item.name})
+                msg = T.format('cannot_use_item_monster', {'name': item.name})
                 tools.open_dialog(self.game, [msg])
                 return
-
 
             # enqueue the item
             combat_state = self.game.get_state_name("CombatState")

--- a/tuxemon/core/states/items/__init__.py
+++ b/tuxemon/core/states/items/__init__.py
@@ -94,16 +94,10 @@ class ItemMenuState(Menu):
             monster = menu_item.game_object
 
             # item must be used before state is popped.
-            # don't try to combine with "if result..." condition below
             result = item.use(player, monster)
             self.game.pop_state()  # pop the monster screen
             self.game.pop_state()  # pop the item screen
-
-            msg_type = 'use_success' if result['success'] else 'use_failure'
-            template = getattr(item, msg_type)
-            if template:
-                message = T.translate(template)
-                tools.open_dialog(self.game, [message])
+            tools.show_item_result_as_dialog(self.game, item, result)
 
         def confirm():
             self.game.pop_state()  # close the confirm dialog

--- a/tuxemon/core/tools.py
+++ b/tuxemon/core/tools.py
@@ -42,6 +42,7 @@ from six.moves import zip_longest
 
 from tuxemon.compat.rect import Rect
 from tuxemon.core import prepare
+from tuxemon.core.locale import T
 
 logger = logging.getLogger(__name__)
 
@@ -229,3 +230,11 @@ def cast_values(parameters, valid_parameters):
         logger.error("expected: {}".format(valid_parameters))
         logger.error("got: {}".format(parameters))
         raise
+
+
+def show_item_result_as_dialog(game, item, result):
+    msg_type = 'use_success' if result['success'] else 'use_failure'
+    template = getattr(item, msg_type)
+    if template:
+        message = T.translate(template)
+        open_dialog(game, [message])


### PR DESCRIPTION
Fixes 674

Attempting to use the capture device on an owned (not wild) monster will result in a dialog saying "this item cannot be used on this monster".  It is generic now because we cannot set per-item error messages at the moment.

* "owner" attribute on monsters
* Owner is set when monster is added to npc/player, removed when they are released (possible?)
* Implement new condition to check for owner
* Allow combat menus to check for item conditions
* Allow item conditions to have parameter-less conditions