### PR TITLE
Adjust movement speed of mother NPC

### DIFF
--- a/mods/tuxemon/maps/player_house_downstairs.tmx
+++ b/mods/tuxemon/maps/player_house_downstairs.tmx
@@ -89,7 +89,7 @@
    <properties>
     <property name="act10" value="create_npc npc_mom,9,4,,stand"/>
     <property name="act20" value="npc_face npc_mom,left"/>
-    <property name="act40" value="npc_wander npc_mom"/>
+    <property name="act40" value="npc_wander npc_mom,3.0"/>
     <property name="cond10" value="not npc_exists npc_mom"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/player_house_downstairs.tmx
+++ b/mods/tuxemon/maps/player_house_downstairs.tmx
@@ -89,7 +89,6 @@
    <properties>
     <property name="act10" value="create_npc npc_mom,9,4,,stand"/>
     <property name="act20" value="npc_face npc_mom,left"/>
-    <property name="act30" value="npc_speed npc_mom, 0.2"/>
     <property name="act40" value="npc_wander npc_mom"/>
     <property name="cond10" value="not npc_exists npc_mom"/>
    </properties>


### PR DESCRIPTION
Hi! This pull request is rather trivial, so it's more of my way of saying hello to the community for the first time!

I have replaced the mother NPC's movement speed of 0.2 for wandering frequency of 3. I think the person who set the movement speed to less than 1 was intending to set the wandering frequency instead, as moving an NPC at a speed less than 1 makes the NPC look like it's glitchy / gliding. 

This is related in topic to to #651 