### PR TITLE
WIP Battle check

### DIFF
--- a/tuxemon/core/event/actions/start_battle.py
+++ b/tuxemon/core/event/actions/start_battle.py
@@ -88,13 +88,12 @@ class StartBattleAction(EventAction):
         logger.debug("Starting battle!")
         self.game.push_state("CombatState", players=(player, npc), combat_type="trainer",
                              graphics=env['battle_graphics'])
+        npc.battled_already = True
 
         # Start some music!
         filename = env['battle_music']
         self.game.event_engine.execute_action("play_music", [filename])
 
     def update(self):
-        # Check if the CombatState no longer exists (hence combat is over)
         if self.game.get_state_name("CombatState") is None:
-            npc.battled_already = True 
             self.stop()

--- a/tuxemon/core/npc.py
+++ b/tuxemon/core/npc.py
@@ -122,8 +122,6 @@ class NPC(Entity):
         self.ai = None  # Whether or not this player has AI associated with it
         self.speed = 10  # To determine combat order (not related to movement!)
         self.moves = []  # list of techniques
-        self.battled_already = False # For actual non-playable NPCs only: tracks whether protagonist already fought them
-        # (The implication for now is that a protagonist can only battle an NPC once)
 
         # pathfinding and waypoint related
         self.pathfinding = None

--- a/tuxemon/core/npc.py
+++ b/tuxemon/core/npc.py
@@ -122,6 +122,8 @@ class NPC(Entity):
         self.ai = None  # Whether or not this player has AI associated with it
         self.speed = 10  # To determine combat order (not related to movement!)
         self.moves = []  # list of techniques
+        self.battled_already = False # For actual non-playable NPCs only: tracks whether protagonist already fought them
+        # (The implication for now is that a protagonist can only battle an NPC once)
 
         # pathfinding and waypoint related
         self.pathfinding = None

--- a/tuxemon/core/npc.py
+++ b/tuxemon/core/npc.py
@@ -167,6 +167,7 @@ class NPC(Entity):
 
         """
         return {
+            'battled_already' : self.battled_already,
             'current_map': game.get_map_name(),
             'facing': self.facing,
             'game_variables': self.game_variables,
@@ -191,7 +192,7 @@ class NPC(Entity):
         :returns: None
 
         """
-
+        self.battled_already = save_data.get('battled_already', False)
         self.facing = save_data.get('facing', 'down')
         self.game_variables = save_data['game_variables']
         self.inventory = decode_inventory(game, self, save_data)

--- a/tuxemon/core/npc.py
+++ b/tuxemon/core/npc.py
@@ -167,7 +167,6 @@ class NPC(Entity):
 
         """
         return {
-            'battled_already' : self.battled_already,
             'current_map': game.get_map_name(),
             'facing': self.facing,
             'game_variables': self.game_variables,
@@ -192,7 +191,6 @@ class NPC(Entity):
         :returns: None
 
         """
-        self.battled_already = save_data.get('battled_already', False)
         self.facing = save_data.get('facing', 'down')
         self.game_variables = save_data['game_variables']
         self.inventory = decode_inventory(game, self, save_data)

--- a/tuxemon/core/player.py
+++ b/tuxemon/core/player.py
@@ -48,4 +48,17 @@ class Player(NPC):
         self.isplayer = True
 
         # Game variables for use with events
-        self.game_variables = {}
+        self.game_variables = {
+        	'battle_history' : {} # Maps the names of NPCs the Player has battled to the outcome of their battle
+        						  #    any NPC name not present in the dictionary implies the Player has never 
+        						  #    battled them before
+        }
+
+    def set_state(self, game, save_data):
+    	super(Player, self).set_state(game, save_data)
+
+    	# Add 'battle_history' as a game variable if it wasn't saved as one
+    	# this line was added 03/29/2020 so as not to break saves from older versions of the codebase
+    	# feel free to remove this if case in the future
+    	if 'battle_history' not in self.game_variables:
+    		self.game_variables['battle_history'] = {}

--- a/tuxemon/core/player.py
+++ b/tuxemon/core/player.py
@@ -47,18 +47,7 @@ class Player(NPC):
         super(Player, self).__init__(npc_slug)
         self.isplayer = True
 
-        # Game variables for use with events
-        self.game_variables = {
-        	'battle_history' : {} # Maps the names of NPCs the Player has battled to the outcome of their battle
-        						  #    any NPC name not present in the dictionary implies the Player has never 
-        						  #    battled them before
-        }
-
-    def set_state(self, game, save_data):
-    	super(Player, self).set_state(game, save_data)
-
-    	# Add 'battle_history' as a game variable if it wasn't saved as one
-    	# this line was added 03/29/2020 so as not to break saves from older versions of the codebase
-    	# feel free to remove this if case in the future
-    	if 'battle_history' not in self.game_variables:
-    		self.game_variables['battle_history'] = {}
+        # Game variables for use with events:
+        self.game_variables['battle_history'] = {} # Maps the slugs of NPCs the Player has battled to the outcome of their battle
+        						  				   #    any NPC slug not present in the dictionary implies the Player has never 
+        						  				   #    battled them before

--- a/tuxemon/core/save_upgrader.py
+++ b/tuxemon/core/save_upgrader.py
@@ -49,8 +49,9 @@ Other changes:
     - Increment the value of SAVE_VERSION
     - Amend the `upgrade_save` function as necessary
 """
+from tuxemon.core.player import Player
 
-SAVE_VERSION = 1
+SAVE_VERSION = 2
 MAP_RENAMES = {
     # 0: {'before1.tmx': 'after1.tmx', 'before2.tmx': 'after2.tmx'},
 }
@@ -62,8 +63,17 @@ def upgrade_save(save_data):
         _update_current_map(i, save_data)
         if i == 0:
             _remove_slug_prefixes(save_data)
+        if i == 1:
+            _add_battle_history(save_data)
     return save_data
 
+def _add_battle_history(save_data):
+    """
+    'battle_history' is a dictionary added to the class tuxemon.core.player.Player
+    """
+    if 'battle_history' not in save_data['game_variables']:
+        # If 'battle_history' not present, use the default value for a new Player
+        save_data['game_variables']['battle_history'] = Player("").game_variables['battle_history']
 
 def _update_current_map(version, save_data):
     if version in MAP_RENAMES:

--- a/tuxemon/core/states/combat/combat.py
+++ b/tuxemon/core/states/combat/combat.py
@@ -127,7 +127,7 @@ class CombatState(CombatAnimations):
 
         super(CombatState, self).startup(**kwargs)
         self.is_trainer_battle = kwargs.get('combat_type') == "trainer"
-        self.players = list(self.players)
+        self.players = list(self.players) # A list of tuxemon.core.npc.NPC objects; the humans in the battle
         self.graphics = kwargs.get('graphics')
         self.show_combat_dialog()
         self.transition_phase("begin")
@@ -320,12 +320,24 @@ class CombatState(CombatAnimations):
             # This assumes that player[0] is the human playing in single player
             self.players[0].set_party_status()
             if self.remaining_players[0] == self.players[0]:
-                self.players[0].game_variables['battle_last_result'] = 'won'
+                battle_result = 'won'
                 self.alert(T.translate('combat_victory'))
             else:
-                self.players[0].game_variables['battle_last_result'] = 'lost'
+                battle_result = 'lost'
                 self.players[0].game_variables['battle_lost_faint'] = 'true'
                 self.alert(T.translate('combat_defeat'))
+
+            # Record the result of this battle as the most recent battle result of the player
+            self.players[0].game_variables['battle_last_result'] = battle_result
+
+            if self.is_trainer_battle:
+                # Assumes self.players[0] represents the protagonist (a tuxemon.core.player.Player object)
+                # Assumes self.players[1] represents the AI NPC antagonist (a tuxemon.core.npc.NPC object)
+                # Assumes these are the only elements in self.players
+                # If this is a trainer battle, record whether the protagonist
+                # won or lost against this particular NPC
+                antagonist_name = self.players[1].name 
+                self.players[0].game_variables['battle_history'][antagonist_name] = battle_result
 
             # after 3 seconds, push a state that blocks until enter is pressed
             # after the state is popped, the combat state will clean up and close


### PR DESCRIPTION
To resolve issue #574

This PR prevents a trainer battle from being started if the protagonist has already battled this trainer NPC. It persists across loading and saving, as well as when leaving and returning to a given `.tmx` map.

Please note it does not include a feature to "check if you lost that would send you directly to the last Tuxemon Center you visited. That way, your Tuxemon can heal" per @Qiangong2 from the discussion on issue #574. We'll have to open another issue to implement that feature. We should note that for that feature, the game variable `'battle_last_result'` actually already exists and would help with that issue.

This PR does establish a new game variable  `'battle_history'`, which is a dictionary that maps npc's names to the outcome of the battle with the player (no key implies a battle hasn't happened yet). Hopefully this variable will help for future improvements to the game where we want the npc to have different dialogues post-battle depending on whether the player won or lost.

Please squash commits when merging this PR. Thank you