### PR TITLE
Fix the building of the translations on install.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,23 @@
 #!/usr/bin/env python
 
-from setuptools import setup
 import fnmatch
 import os
 
-#build the translations
-from tuxemon.core.components.locale import T
+from setuptools import setup
+from setuptools.command.install import install
+
+
+def build_translations():
+    from tuxemon.core.locale import T
+
+    T.collect_languages()
+
+
+class InstallAndBuildTranslations(install):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        build_translations()
+
 
 
 # Find all the python modules
@@ -16,7 +28,7 @@ for root, dirnames, filenames in os.walk('tuxemon'):
         matches.append(os.path.join(root, filename))
 
 for match in matches:
-    match = match.replace(os.sep+"__init__.py", "")
+    match = match.replace(os.sep + "__init__.py", "")
     match = match.replace(os.sep, ".")
     modules.append(match)
 
@@ -58,5 +70,6 @@ setup(name='tuxemon',
           "Programming Language :: Python :: 3.6",
           "Topic :: Games/Entertainment",
           "Topic :: Games/Entertainment :: Role-Playing",
-      ]
+      ],
+      cmdclass={'install': InstallAndBuildTranslations}
       )


### PR DESCRIPTION
I think this should fix  #535. At the very least, it works, unless the current setup.py, and it builds the *.mo files for me in Windows after the dependencies are installed.