### PR TITLE
Fixes syntax warning upon launch using Python 3.8

### DIFF
--- a/tuxemon/core/menu/menu.py
+++ b/tuxemon/core/menu/menu.py
@@ -475,7 +475,7 @@ class Menu(state.State):
             # TODO: generalized widget system
             if self.touch_aware and valid_change:
                 mouse_pos = event.value
-                assert mouse_pos is not 0
+                assert mouse_pos != 0
 
                 try:
                     self.menu_items.update_rect_from_parent()


### PR DESCRIPTION
Since Python 3.8 produces syntax warnings when using is/is not to compare against literals,  SyntaxWarning: "is not" with a literal. Did you mean "!="?
  assert mouse_pos is not 0
is printed upon launch.
Instead == or != should be used.