### PR TITLE
Use Unicode arrows and musical note.

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -1514,7 +1514,7 @@ msgstr "Get the scoop at the Scoop Store!"
 
 msgid "Cotton_Town_Sign\n"
 msgstr "Welcome to Cotton Town: A Growing Force\n"
-"^ Cotton Town --- Route 1 v\n"
+"↑ Cotton Town --- Route 1 ↓\n"
 
 msgid "column1"
 msgstr "A rare and ancient column. This used to be a temple."
@@ -1524,7 +1524,7 @@ msgstr "A rare and ancient column. Other ruins from the same culture can be foun
 
 msgid "cityparksign\n"
 msgstr "Welcome to City Park: A Taste of the Wild\n"
-"^ City Park --- Route 2 v\n"
+"↑ City Park --- Route 2 ↓\n"
 
 msgid "route2speech"
 msgstr "EEK!!!"
@@ -1605,8 +1605,8 @@ msgid "yesmaam"
 msgstr "Yes Ma'am"
 
 msgid "firsts"
-msgstr "Watch me whip\n"
-"Watch me nae nae"
+msgstr "♪ Watch me whip ♪\n"
+"♪ Watch me nae nae ♪"
 
 msgid "nopenotyet"
 msgstr "Sorry, someone got injured on the route. It's closed right now."

--- a/tuxemon/core/menu/input.py
+++ b/tuxemon/core/menu/input.py
@@ -69,7 +69,7 @@ class InputMenu(Menu):
             yield MenuItem(self.shadow_text(char), None, None, partial(self.add_input_char, char))
 
         # backspace key
-        yield MenuItem(self.shadow_text("<="), None, None, self.backspace)
+        yield MenuItem(self.shadow_text("←"), None, None, self.backspace)
 
         # button to confirm the input and close the dialog
         yield MenuItem(self.shadow_text("END"), None, None, self.confirm)


### PR DESCRIPTION
Currently the font allows the use of proper arrow characters and the musical note symbol, so I think it is preferable to use them instead of ugly workarounds such as <=, ^ or v.