### PR TITLE
Add config option to recompile translations.

### DIFF
--- a/tuxemon/core/config.py
+++ b/tuxemon/core/config.py
@@ -89,6 +89,7 @@ class TuxemonConfig(object):
         self.net_controller_enabled = cfg.getboolean("game", "net_controller_enabled")
         self.locale = cfg.get("game", "locale")
         self.dev_tools = cfg.getboolean("game", "dev_tools")
+        self.recompile_translations = cfg.getboolean("game", "recompile_translations")
         
         # [gameplay]
         self.items_consumed_on_failure = cfg.getboolean("gameplay", "items_consumed_on_failure")
@@ -155,6 +156,7 @@ def get_defaults():
             ("net_controller_enabled", False),
             ("locale", "en_US"),
             ("dev_tools", False),
+            ("recompile_translations", False),
         ))),
         ("gameplay", OrderedDict((
             ("items_consumed_on_failure", True),

--- a/tuxemon/core/locale.py
+++ b/tuxemon/core/locale.py
@@ -58,7 +58,7 @@ class TranslatorPo(object):
         self.translate = None
         self.languages = []
 
-    def collect_languages(self):
+    def collect_languages(self, recompile_translations=False):
         """Collect languages/locales with available translation files."""
         self.languages = []
 
@@ -68,10 +68,10 @@ class TranslatorPo(object):
             if os.path.isdir(ld_full_path):
                 self.languages.append(ld)
 
-        self.build_translations()
+        self.build_translations(recompile_translations)
         self.load_locale(prepare.CONFIG.locale)
 
-    def build_translations(self):
+    def build_translations(self, recompile_translations=False):
         """Create MO files for existing PO translation files."""
 
         for ld in self.languages:
@@ -79,7 +79,8 @@ class TranslatorPo(object):
             outfile = os.path.join(os.path.dirname(infile), "base.mo")
 
             # build only complete translations
-            if os.path.exists(infile) and not os.path.exists(outfile):
+            if os.path.exists(infile) and (
+                    not os.path.exists(outfile) or recompile_translations):
                 with io.open(infile, "r", encoding="UTF8") as po_file:
                     catalog = read_po(po_file)
                 with io.open(outfile, "wb") as mo_file:

--- a/tuxemon/core/prepare.py
+++ b/tuxemon/core/prepare.py
@@ -128,7 +128,7 @@ def pygame_init():
 
     # Configure locale
     from tuxemon.core.locale import T
-    T.collect_languages()
+    T.collect_languages(CONFIG.recompile_translations)
 
     # Configure databases
     from tuxemon.core.db import db


### PR DESCRIPTION
The new option recompile_translations, if True, recompiles automatically the translations when running the executable. This is very useful for translators, as it is no longer necessary to manually remove the *.mo files. Closes #661 and closes #708. 