### PR TITLE
Fixing opponent battle tuxemon

### DIFF
--- a/tuxemon/core/states/combat/combat.py
+++ b/tuxemon/core/states/combat/combat.py
@@ -162,7 +162,7 @@ class CombatState(CombatAnimations):
         self._layout = dict()  # player => home areas on screen
         self._animation_in_progress = False  # if true, delay phase change
         self._round = 0
-
+        
         super(CombatState, self).startup(**kwargs)
         self.is_trainer_battle = kwargs.get('combat_type') == "trainer"
         self.players = list(self.players)
@@ -189,9 +189,9 @@ class CombatState(CombatAnimations):
 
     def draw(self, surface):
         """ Draw combat state
-        
-        :param pygame.surface.Surface surface: 
-        :rtype: None 
+
+        :param pygame.surface.Surface surface:
+        :rtype: None
         """
         super(CombatState, self).draw(surface)
         self.draw_hp_bars()

--- a/tuxemon/core/states/combat/combat.py
+++ b/tuxemon/core/states/combat/combat.py
@@ -162,7 +162,7 @@ class CombatState(CombatAnimations):
         self._layout = dict()  # player => home areas on screen
         self._animation_in_progress = False  # if true, delay phase change
         self._round = 0
-        
+
         super(CombatState, self).startup(**kwargs)
         self.is_trainer_battle = kwargs.get('combat_type') == "trainer"
         self.players = list(self.players)

--- a/tuxemon/core/states/combat/combat_animations.py
+++ b/tuxemon/core/states/combat/combat_animations.py
@@ -492,10 +492,9 @@ class CombatAnimations(Menu):
                                              centerx=back_island.rect.centerx)
             self._monster_sprite_map[right_monster] = enemy
             self.monsters_in_play[opponent].append(right_monster)
+            self.build_hud(self._layout[opponent]['hud'][0], right_monster)
 
         self.sprites.add(enemy)
-        self.build_hud(self._layout[opponent]['hud'][0], right_monster)
-
 
         if self.is_trainer_battle:
             self.alert(T.format('combat_trainer_appeared', {"name": opponent.name.upper()}))


### PR DESCRIPTION
Fixes the following issues from #729 :
> 
> * [X]  First enemy txmn name card comes in with trainer
> * [X]  First enemy txmn name card comes in _again_ after released
> * [X]  First enemy txmn name card is still visible after defeat
> * [X]  First enemy txmn name card HP is filled after defeat
> * [ ]  The final TXMN capdev icon is not greyed out after defeat
> * [ ]  Various UI elements are duplicated (maybe they are created per monster?)
> * [ ]  The monster name is lower case is messages, maybe it is using the slug?
> 
> When all are fixed, this issue may be closed.

