### PR TITLE
Makes final capdev icon grey out after defeat

### DIFF
--- a/tuxemon/core/states/combat/combat.py
+++ b/tuxemon/core/states/combat/combat.py
@@ -162,7 +162,7 @@ class CombatState(CombatAnimations):
         self._layout = dict()  # player => home areas on screen
         self._animation_in_progress = False  # if true, delay phase change
         self._round = 0
-
+        
         super(CombatState, self).startup(**kwargs)
         self.is_trainer_battle = kwargs.get('combat_type') == "trainer"
         self.players = list(self.players)
@@ -189,9 +189,9 @@ class CombatState(CombatAnimations):
 
     def draw(self, surface):
         """ Draw combat state
-        
-        :param pygame.surface.Surface surface: 
-        :rtype: None 
+
+        :param pygame.surface.Surface surface:
+        :rtype: None
         """
         super(CombatState, self).draw(surface)
         self.draw_hp_bars()

--- a/tuxemon/core/states/combat/combat.py
+++ b/tuxemon/core/states/combat/combat.py
@@ -162,7 +162,7 @@ class CombatState(CombatAnimations):
         self._layout = dict()  # player => home areas on screen
         self._animation_in_progress = False  # if true, delay phase change
         self._round = 0
-        
+
         super(CombatState, self).startup(**kwargs)
         self.is_trainer_battle = kwargs.get('combat_type') == "trainer"
         self.players = list(self.players)

--- a/tuxemon/core/states/combat/combat_animations.py
+++ b/tuxemon/core/states/combat/combat_animations.py
@@ -186,9 +186,7 @@ class CombatAnimations(Menu):
         if call_sound:
             self.task(call_sound.play, delay)
 
-        # update tuxemon balls to reflect fainted tuxemon
-        #for player, layout in self._layout.items():
-        #    self.animate_update_party_hud(player, layout['party'][0])
+
 
     def animate_sprite_spin(self, sprite):
         """
@@ -232,6 +230,8 @@ class CombatAnimations(Menu):
                 monsters.remove(monster)
             except ValueError:
                 pass
+
+        # update tuxemon balls to reflect fainted tuxemon
         for player, layout in self._layout.items():
             self.animate_update_party_hud(player, layout['party'][0])
 

--- a/tuxemon/core/states/combat/combat_animations.py
+++ b/tuxemon/core/states/combat/combat_animations.py
@@ -187,8 +187,8 @@ class CombatAnimations(Menu):
             self.task(call_sound.play, delay)
 
         # update tuxemon balls to reflect fainted tuxemon
-        for player, layout in self._layout.items():
-            self.animate_update_party_hud(player, layout['party'][0])
+        #for player, layout in self._layout.items():
+        #    self.animate_update_party_hud(player, layout['party'][0])
 
     def animate_sprite_spin(self, sprite):
         """
@@ -232,6 +232,8 @@ class CombatAnimations(Menu):
                 monsters.remove(monster)
             except ValueError:
                 pass
+        for player, layout in self._layout.items():
+            self.animate_update_party_hud(player, layout['party'][0])
 
     def animate_sprite_take_damage(self, sprite):
         """

--- a/tuxemon/core/states/combat/combat_animations.py
+++ b/tuxemon/core/states/combat/combat_animations.py
@@ -492,10 +492,9 @@ class CombatAnimations(Menu):
                                              centerx=back_island.rect.centerx)
             self._monster_sprite_map[right_monster] = enemy
             self.monsters_in_play[opponent].append(right_monster)
+            self.build_hud(self._layout[opponent]['hud'][0], right_monster)
 
         self.sprites.add(enemy)
-        self.build_hud(self._layout[opponent]['hud'][0], right_monster)
-
 
         if self.is_trainer_battle:
             self.alert(T.format('combat_trainer_appeared', {"name": opponent.name.upper()}))


### PR DESCRIPTION
#729
> * [X]  The final TXMN capdev icon is not greyed out after defeat

This updates the capdevs after each tuxemon faints instead of when they are released into the battle. 