### PR TITLE
Confirmation box when saving

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -265,6 +265,12 @@ msgstr "Saved!"
 msgid "save_failure"
 msgstr "There was a problem saving!"
 
+msgid "save_overwrite"
+msgstr "Yes, overwrite this save."
+
+msgid "save_keep"
+msgstr "No, keep this save."
+
 msgid "slot"
 msgstr "Slot"
 

--- a/mods/tuxemon/l18n/fr_FR/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/fr_FR/LC_MESSAGES/base.po
@@ -192,6 +192,12 @@ msgstr "Sauvegardé !"
 msgid "save_failure"
 msgstr "Il y a eu un problème lors de la sauvegarde !"
 
+msgid "save_overwrite"
+msgstr "Oui, écraser cette sauvegarde."
+
+msgid "save_keep"
+msgstr "Non, conserver cette sauvegarde."
+
 msgid "slot"
 msgstr "Emplacement"
 

--- a/tuxemon/core/states/persistance/save_menu.py
+++ b/tuxemon/core/states/persistance/save_menu.py
@@ -89,7 +89,7 @@ class SaveMenuState(PopUpMenu):
 
         return slot_image
 
-    def on_menu_selection(self, menuitem):
+    def save(self):
         logger.info("Saving!")
         try:
             save_data = save.get_save_data(
@@ -108,5 +108,33 @@ class SaveMenuState(PopUpMenu):
         else:
             open_dialog(local_session, [T.translate('save_success')])
 
-        self.client.pop_state(self)
+
+    def on_menu_selection(self, menuitem):
+        def positive_answer():
+            self.client.pop_state() # close confirmation menu
+            self.client.pop_state() # close save menu
+
+            self.save()
+
+        def negative_answer():
+            self.client.pop_state() # close confirmation menu
+
+        def ask_confirmation():
+            # open menu to confirm the save
+            menu = self.client.push_state("Menu")
+            menu.shrink_to_items = True
+
+            # add choices
+            yes = MenuItem(self.shadow_text(T.translate('save_overwrite')), None, None, positive_answer)
+            no = MenuItem(self.shadow_text(T.translate('save_keep')), None, None, negative_answer)
+
+            menu.add(yes)
+            menu.add(no)
+
+        save_data = save.load(self.selected_index + 1)
+        if save_data:
+            ask_confirmation()
+        else:
+            self.client.pop_state() # close save menu
+            self.save()
 


### PR DESCRIPTION
When overwriting a save, confirmation box will pop up:

![tuxemon_save](https://user-images.githubusercontent.com/32700018/80974384-f17fbe80-8e20-11ea-938c-329c363d5ca8.png)

Only if the slot is arleady used

Closes #775