### PR TITLE
Key bindings in config now override defaults (Tuxemon#767)

### DIFF
--- a/tuxemon/core/config.py
+++ b/tuxemon/core/config.py
@@ -53,20 +53,15 @@ class TuxemonConfig(object):
     """
 
     def __init__(self, config_path=None):
-        import os.path
-        
         # load default config
-        cfg = configparser.ConfigParser()
+        cfg = generate_default_config()
+        self.cfg = cfg
 
         # update with customized values
-        if os.path.isfile(config_path):
+        if config_path:
             temp = configparser.ConfigParser()
             temp.read(config_path)
             populate_config(cfg, temp._sections)
-        else:
-            populate_config(cfg, get_defaults())
-
-        self.cfg = cfg
 
         # [display]
         resolution_x = cfg.getint("display", "resolution_x")
@@ -133,17 +128,19 @@ def get_custom_pygame_keyboard_controls(cfg):
 
     #custom_controls = PygameKeyboardInput.default_input_map.copy()
     custom_controls = {None: events.UNICODE}
-    for key, value in cfg.items("controls"):
-        # pygame.locals uses all caps for constants except for letters
-        key = key.lower() if len(key) == 1 else key.upper()
-        value = value.upper()
-        pygame_value = getattr(pygame.locals, "K_" + key, None)
-        button_value = getattr(buttons, value, None)
-        event_value = getattr(events, value, None)
-        if pygame_value is not None and button_value is not None:
-            custom_controls[pygame_value] = button_value
-        elif pygame_value is not None and event_value is not None:
-            custom_controls[pygame_value] = event_value
+    for key, values in cfg.items("controls"):
+        key = key.upper()   
+        button_value = getattr(buttons, key, None)
+        event_value = getattr(events, key, None)
+        for each in values.split(", "):
+            # pygame.locals uses all caps for constants except for letters
+            each = each.lower() if len(each) == 1 else each.upper()
+            print(each)
+            pygame_value = getattr(pygame.locals, "K_"+each, None)
+            if pygame_value is not None and button_value is not None:
+                custom_controls[pygame_value] = button_value
+            elif pygame_value is not None and event_value is not None:
+                custom_controls[pygame_value] = event_value
 
     return custom_controls
 
@@ -203,10 +200,9 @@ def get_defaults():
             ("down", "down"),
             ("left", "left"),
             ("right", "right"),
-            ("return", "a"),
-            ("rshift", "b"),
-            ("lshift", "b"),
-            ("escape", "back"),
+            ("a", "return"),
+            ("b", "rshift, lshift"),
+            ("back", "escape"),
             ("backspace", "backspace")
         ))),
     ))

--- a/tuxemon/core/config.py
+++ b/tuxemon/core/config.py
@@ -53,15 +53,20 @@ class TuxemonConfig(object):
     """
 
     def __init__(self, config_path=None):
+        import os.path
+        
         # load default config
-        cfg = generate_default_config()
-        self.cfg = cfg
+        cfg = configparser.ConfigParser()
 
         # update with customized values
-        if config_path:
+        if os.path.isfile(config_path):
             temp = configparser.ConfigParser()
             temp.read(config_path)
             populate_config(cfg, temp._sections)
+        else:
+            populate_config(cfg, get_defaults())
+
+        self.cfg = cfg
 
         # [display]
         resolution_x = cfg.getint("display", "resolution_x")
@@ -126,7 +131,8 @@ def get_custom_pygame_keyboard_controls(cfg):
     import pygame.locals
     from tuxemon.core.platform.platform_pygame.events import PygameKeyboardInput
 
-    custom_controls = PygameKeyboardInput.default_input_map.copy()
+    #custom_controls = PygameKeyboardInput.default_input_map.copy()
+    custom_controls = {None: events.UNICODE}
     for key, value in cfg.items("controls"):
         # pygame.locals uses all caps for constants except for letters
         key = key.lower() if len(key) == 1 else key.upper()

--- a/tuxemon/core/config.py
+++ b/tuxemon/core/config.py
@@ -126,7 +126,6 @@ def get_custom_pygame_keyboard_controls(cfg):
     import pygame.locals
     from tuxemon.core.platform.platform_pygame.events import PygameKeyboardInput
 
-    #custom_controls = PygameKeyboardInput.default_input_map.copy()
     custom_controls = {None: events.UNICODE}
     for key, values in cfg.items("controls"):
         key = key.upper()   

--- a/tuxemon/core/config.py
+++ b/tuxemon/core/config.py
@@ -135,7 +135,6 @@ def get_custom_pygame_keyboard_controls(cfg):
         for each in values.split(", "):
             # pygame.locals uses all caps for constants except for letters
             each = each.lower() if len(each) == 1 else each.upper()
-            print(each)
             pygame_value = getattr(pygame.locals, "K_"+each, None)
             if pygame_value is not None and button_value is not None:
                 custom_controls[pygame_value] = button_value


### PR DESCRIPTION
This fix reverses the key/value pairs of the `controls` section of the config. Now the key is the pygame internal action, and the value is a comma separated list of strings for your keyboard buttons. Since the keys in the config section never get deleted or modified, you can modify the controls without `generate_default_config()` always adding back the default controls.