### PR TITLE
Issue #792 - Added check for sfx attribute before using it

### DIFF
--- a/tuxemon/core/item/item.py
+++ b/tuxemon/core/item/item.py
@@ -78,6 +78,7 @@ class Item(object):
         self.description = "None"
         self.images = []
         self.type = None
+        self.sfx = None
         self.sprite = ""  # The path to the sprite to load.
         self.surface = None  # The pygame.Surface object of the item.
         self.surface_size_original = (0, 0)  # The original size of the image before scaling.

--- a/tuxemon/core/technique.py
+++ b/tuxemon/core/technique.py
@@ -71,6 +71,7 @@ class Technique(object):
         self.carrier = carrier
         self.category = "attack"
         self.effect = []
+        self.icon = None
         self.images = []
         self.is_area = False
         self.is_fast = False
@@ -81,12 +82,16 @@ class Technique(object):
         self.power = 1
         self.range = None
         self.recharge_length = 0
+        self.sfx = None
+        self.sort = None
         self.slug = slug
+        self.target = list()
         self.type1 = "aether"
         self.type2 = None
         self.use_item = None
         self.use_success = None
         self.use_failure = None
+        self.use_tech = None
 
         # If a slug of the technique was provided, autoload it.
         if slug:


### PR DESCRIPTION
Closes #792 

The game won't crash anymore when using items that don't have an sfx file associated but once they are initialized with one, they should start working with this code.