### PR TITLE
add the taba town greeter

### DIFF
--- a/mods/tuxemon/db/npc/npc_taba_greeter.json
+++ b/mods/tuxemon/db/npc/npc_taba_greeter.json
@@ -1,0 +1,6 @@
+{
+    "slug": "npc_taba_greeter",
+    "sprite_name": "tuxemartemployee",
+    "combat_front": "red_front.png",
+    "combat_back": "red_back.png"
+}

--- a/mods/tuxemon/db/npc/taba_greeter.json
+++ b/mods/tuxemon/db/npc/taba_greeter.json
@@ -1,5 +1,5 @@
 {
-    "slug": "npc_taba_greeter",
+    "slug": "taba_greeter",
     "sprite_name": "tuxemartemployee",
     "combat_front": "red_front.png",
     "combat_back": "red_back.png"

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -1956,3 +1956,15 @@ msgstr "@*!^: 0H... @ n3wc0m3r! H0vv p1d y0v g3t he7e? <NONE> h3llen\"T $33N %^&
 
 msgid "cannot_use_item_monster"
 msgstr "This item cannot be used on this monster."
+
+msgid "taba_greeting1"
+msgstr "Greeter Jaime: Hey there ${{name}}! Heard you got a Tuxemon, congrats! If you wanna grow your party, you'll need Tuxeballs."
+
+msgid "taba_greeting2a"
+msgstr "The shop is doing a promo, here's some to get you started. You use them to capture Tuxemon. It's easier if they're weakend first though!"
+
+msgid "taba_greeting2b"
+msgstr "Ah! I see you've already got some. You've got a good head on your shoulders ${{name}}, I'm sure you'll be a champ in no time."
+
+msgid "gotfivetuxeballs"
+msgstr "You got 5 Tuxeballs!"

--- a/mods/tuxemon/maps/taba_town.tmx
+++ b/mods/tuxemon/maps/taba_town.tmx
@@ -656,19 +656,19 @@
   </object>
   <object id="132" name="martgreeter" type="event" x="336" y="208" width="16" height="16">
    <properties>
-    <property name="act10" value="create_npc npc_taba_greeter,29,12,,stand"/>
-    <property name="act20" value="npc_face npc_taba_greeter,down"/>
-    <property name="cond1" value="not npc_exists npc_taba_greeter"/>
+    <property name="act10" value="create_npc taba_greeter,29,12,,stand"/>
+    <property name="act20" value="npc_face taba_greeter,down"/>
+    <property name="cond1" value="not npc_exists taba_greeter"/>
    </properties>
   </object>
   <object id="133" name="greeter_greets" type="event" x="480" y="192" width="16" height="16">
    <properties>
-    <property name="act10" value="npc_face npc_taba_greeter,player"/>
+    <property name="act10" value="npc_face taba_greeter,player"/>
     <property name="act20" value="translated_dialog taba_greeting1"/>
     <property name="act25" value="translated_dialog taba_greeting2a"/>
     <property name="act30" value="add_item capture_device,5"/>
     <property name="act40" value="translated_dialog gotfivetuxeballs"/>
-    <property name="act60" value="npc_face npc_taba_greeter,down"/>
+    <property name="act60" value="npc_face taba_greeter,down"/>
     <property name="act70" value="set_variable greeter_greets:yes"/>
     <property name="cond10" value="not has_item player,capture_device"/>
     <property name="cond20" value="is party_size greater_than,0"/>
@@ -678,10 +678,10 @@
   </object>
   <object id="134" name="greeter_greets2" type="event" x="480" y="192" width="16" height="16">
    <properties>
-    <property name="act10" value="npc_face npc_taba_greeter,player"/>
+    <property name="act10" value="npc_face taba_greeter,player"/>
     <property name="act20" value="translated_dialog taba_greeting1"/>
     <property name="act30" value="translated_dialog taba_greeting2b"/>
-    <property name="act60" value="npc_face npc_taba_greeter,down"/>
+    <property name="act60" value="npc_face taba_greeter,down"/>
     <property name="act70" value="set_variable greeter_greets:yes"/>
     <property name="cond10" value="is has_item player,capture_device"/>
     <property name="cond20" value="is party_size greater_than,0"/>

--- a/mods/tuxemon/maps/taba_town.tmx
+++ b/mods/tuxemon/maps/taba_town.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.3.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="64" height="60" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="132">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="64" height="60" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="136">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -652,6 +652,52 @@
     <property name="act2" value="player_resume"/>
     <property name="act3" value="set_variable comeinside:done"/>
     <property name="cond1" value="is variable_set comeinside:yes"/>
+   </properties>
+  </object>
+  <object id="132" name="martgreeter" type="event" x="336" y="208" width="16" height="16">
+   <properties>
+    <property name="act10" value="create_npc npc_taba_greeter,29,12,,stand"/>
+    <property name="act20" value="npc_face npc_taba_greeter,down"/>
+    <property name="cond1" value="not npc_exists npc_taba_greeter"/>
+   </properties>
+  </object>
+  <object id="133" name="greeter_greets" type="event" x="480" y="192" width="16" height="16">
+   <properties>
+    <property name="act10" value="npc_face npc_taba_greeter,player"/>
+    <property name="act20" value="translated_dialog taba_greeting1"/>
+    <property name="act25" value="translated_dialog taba_greeting2a"/>
+    <property name="act30" value="add_item capture_device,5"/>
+    <property name="act40" value="translated_dialog gotfivetuxeballs"/>
+    <property name="act60" value="npc_face npc_taba_greeter,down"/>
+    <property name="act70" value="set_variable greeter_greets:yes"/>
+    <property name="cond10" value="not has_item player,capture_device"/>
+    <property name="cond20" value="is party_size greater_than,0"/>
+    <property name="cond30" value="is player_at"/>
+    <property name="cond40" value="not variable_set greeter_greets:yes"/>
+   </properties>
+  </object>
+  <object id="134" name="greeter_greets2" type="event" x="480" y="192" width="16" height="16">
+   <properties>
+    <property name="act10" value="npc_face npc_taba_greeter,player"/>
+    <property name="act20" value="translated_dialog taba_greeting1"/>
+    <property name="act30" value="translated_dialog taba_greeting2b"/>
+    <property name="act60" value="npc_face npc_taba_greeter,down"/>
+    <property name="act70" value="set_variable greeter_greets:yes"/>
+    <property name="cond10" value="is has_item player,capture_device"/>
+    <property name="cond20" value="is party_size greater_than,0"/>
+    <property name="cond30" value="is player_at"/>
+    <property name="cond40" value="not variable_set greeter_greets:yes"/>
+   </properties>
+  </object>
+  <object id="135" name="secret_tuxeball" type="event" x="625" y="240.5" width="16" height="16">
+   <properties>
+    <property name="act10" value="set_variable secret_ball:found"/>
+    <property name="act20" value="add_item capture_device,5"/>
+    <property name="act25" value="translated_dialog gotfivetuxeballs"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
+    <property name="cond30" value="not variable_set secret_ball:found"/>
+    <property name="cond40" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
  </objectgroup>

--- a/tuxemon/core/event/actions/add_item.py
+++ b/tuxemon/core/event/actions/add_item.py
@@ -29,9 +29,12 @@ class AddItemAction(EventAction):
     """
     name = "add_item"
     valid_parameters = [
-        (str, "item_slug")
+        (str, "item_slug"),
+        ((int, None), "quantity")
     ]
 
     def start(self):
         player = self.session.player
-        player.alter_item_quantity(self.session, self.parameters.item_slug, 1)
+        if self.parameters.quantity is None:
+            self.parameters.quantity = 1
+        player.alter_item_quantity(self.session, self.parameters.item_slug, self.parameters.quantity)

--- a/tuxemon/core/event/conditions/party_size.py
+++ b/tuxemon/core/event/conditions/party_size.py
@@ -51,7 +51,7 @@ class PartySizeCondition(EventCondition):
 
         **Examples:**
 
-        >>> condition.__dict__
+        >>> EventCondition.__dict__
         {
             "type": "party_size",
             "parameters": [
@@ -96,4 +96,3 @@ class PartySizeCondition(EventCondition):
         else:
             raise Exception("Party size check parameters are incorrect.")
 
-        return False


### PR DESCRIPTION
Adds a new npc, Greeter Jaime, who is a greeter standing outside the Taba Town Tuxemart.
This npc, and the corresponding dialog scripts, are meant to showcase the functioning of the has_item condition.
Once you have at least one monster in your party and step in front of the door to the mart, Jaime will talk to you.
The event diverges here; if you have capture devices in your inventory already he'll note this and wish you well.
If you don't, he'll tell you the shop is having a promotion right now and give you 5.
He won't greet you again after that.

I've also added a secret cache of 5 tuxeballs. If you follow the southern side of the fence just below the mart to the east and "activate" the tree at the end you'll get 5 tuxeballs. This makes it easier to test this particular event, in the case you are already outside of the mart.

I put a little effort into this so it's good enough to just be left in the game, in my opinion.
Oh, while I was at it, I updated add_item to accept an optional quantity parameter.