### PR TITLE
Add Visual Studio Code launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Tuxemon",
+            "type": "python",
+            "request": "launch",
+            "program": "tuxemon.py",
+            "console": "integratedTerminal"
+        }
+    ]
+}


### PR DESCRIPTION
This allows people to easily launch the integrated debugger from within VS Code (and set breakpoints etc)