### PR TITLE
Feature/add monster to npc

### DIFF
--- a/tuxemon/core/event/actions/add_monster.py
+++ b/tuxemon/core/event/actions/add_monster.py
@@ -24,11 +24,12 @@ from tuxemon.core.event.eventaction import EventAction
 from tuxemon.core.event import get_npc
 
 class AddMonsterAction(EventAction):
-    """Adds a monster to the current player's party if there is room.
+    """Adds a monster to the specified trainer's party if there is room.
+    If no is trainer specified it defaults to the current player.
 
     The action parameter must contain a monster slug to look up in the monster database.
 
-    Valid Parameters: monster_slug, level
+    Valid Parameters: monster_slug, level(, trainer_slug)
     """
     name = "add_monster"
     valid_parameters = [
@@ -41,7 +42,6 @@ class AddMonsterAction(EventAction):
 
         monster_slug, monster_level, trainer_slug = self.parameters
 
-        trainer = {}
         if trainer_slug is None:
             trainer = self.session.player
         else:

--- a/tuxemon/core/event/actions/add_monster.py
+++ b/tuxemon/core/event/actions/add_monster.py
@@ -23,6 +23,7 @@ from tuxemon.core import monster
 from tuxemon.core.event.eventaction import EventAction
 from tuxemon.core.event import get_npc
 
+
 class AddMonsterAction(EventAction):
     """Adds a monster to the specified trainer's party if there is room.
     If no is trainer specified it defaults to the current player.
@@ -45,7 +46,7 @@ class AddMonsterAction(EventAction):
         if trainer_slug is None:
             trainer = self.session.player
         else:
-            trainer = get_npc(trainer_slug)
+            trainer = get_npc(self.session, trainer_slug)
 
         current_monster = monster.Monster()
         current_monster.load_from_db(monster_slug)

--- a/tuxemon/core/event/actions/add_monster.py
+++ b/tuxemon/core/event/actions/add_monster.py
@@ -23,6 +23,7 @@ from tuxemon.core import monster
 from tuxemon.core.event.eventaction import EventAction
 from tuxemon.core.event import get_npc
 
+
 class AddMonsterAction(EventAction):
     """Adds a monster to the current player's party if there is room.
 
@@ -44,7 +45,7 @@ class AddMonsterAction(EventAction):
         if trainer_slug is None:
             trainer = self.session.player
         else:
-            trainer = get_npc(trainer_slug)
+            trainer = get_npc(self.session, trainer_slug)
 
         current_monster = monster.Monster()
         current_monster.load_from_db(monster_slug)

--- a/tuxemon/core/event/actions/add_monster.py
+++ b/tuxemon/core/event/actions/add_monster.py
@@ -41,7 +41,6 @@ class AddMonsterAction(EventAction):
 
         monster_slug, monster_level, trainer_slug = self.parameters
 
-        trainer = {}
         if trainer_slug is None:
             trainer = self.session.player
         else:

--- a/tuxemon/core/event/actions/add_monster.py
+++ b/tuxemon/core/event/actions/add_monster.py
@@ -21,7 +21,7 @@
 
 from tuxemon.core import monster
 from tuxemon.core.event.eventaction import EventAction
-
+from tuxemon.core.event import get_npc
 
 class AddMonsterAction(EventAction):
     """Adds a monster to the current player's party if there is room.
@@ -33,15 +33,23 @@ class AddMonsterAction(EventAction):
     name = "add_monster"
     valid_parameters = [
         (str, "monster_slug"),
-        (int, "monster_level")
+        (int, "monster_level"),
+        ((str, None), "trainer_slug")
     ]
 
     def start(self):
-        monster_slug, monster_level = self.parameters
+
+        monster_slug, monster_level, trainer_slug = self.parameters
+
+        trainer = {}
+        if trainer_slug is None:
+            trainer = self.session.player
+        else:
+            trainer = get_npc(trainer_slug)
 
         current_monster = monster.Monster()
         current_monster.load_from_db(monster_slug)
         current_monster.set_level(monster_level)
         current_monster.current_hp = current_monster.hp
 
-        self.session.player.add_monster(current_monster)
+        trainer.add_monster(current_monster)

--- a/tuxemon/core/event/actions/remove_monster.py
+++ b/tuxemon/core/event/actions/remove_monster.py
@@ -20,22 +20,30 @@
 #
 
 from tuxemon.core.event.eventaction import EventAction
+from tuxemon.core.event import get_npc
 
 
 class RemoveMonsterAction(EventAction):
-    """Removes a monster to the current player's party if the monster is there.
+    """Removes a monster from the current player's party if the monster is there.
 
     Valid Parameters: monster_slug
     """
     name = "remove_monster"
     valid_parameters = [
-        (str, "monster_slug")
+        (str, "monster_slug"),
+        ((str, None), "trainer_slug")
     ]
 
     def start(self):
         monster_slug = self.parameters.monster_slug
+        trainer_slug = self.parameters.trainer
+
+        if trainer_slug is None:
+            trainer = self.session.player
+        else:
+            trainer = get_npc(trainer_slug)
 
         # TODO: will give unpredictable result with multiple copies of the same monster
-        monster = self.session.player.find_monster(monster_slug)
+        monster = trainer.find_monster(monster_slug)
         if monster:
-            self.session.player.remove_monster(monster)
+            trainer.remove_monster(monster)

--- a/tuxemon/core/event/actions/remove_monster.py
+++ b/tuxemon/core/event/actions/remove_monster.py
@@ -21,22 +21,33 @@
 import uuid
 
 from tuxemon.core.event.eventaction import EventAction
+from tuxemon.core.event import get_npc
 
 
 class RemoveMonsterAction(EventAction):
-    """Removes a monster from the current player's party if the monster is there.
+    """Removes a monster from the given trainer's party if the monster is there.
+    Monster is determined by instance_id, which must be passed in a game variable.
+    If no trainer slug is passed it defaults to the current player.
 
     Valid Parameters: instance_id
     """
     name = "remove_monster"
     valid_parameters = [
-        (str, "instance_id")
+        (str, "instance_id"),
+        ((str, None), "trainer_slug")
     ]
 
     def start(self):
         iid = self.session.player.game_variables[self.parameters.instance_id]
         instance_id = uuid.UUID(iid)
+        trainer_slug = self.parameters.trainer
 
-        monster = self.session.player.find_monster_by_id(instance_id)
+        if trainer_slug is None:
+            trainer = self.session.player
+        else:
+            trainer = get_npc(trainer_slug)
+
+        monster = trainer.find_monster_by_id(instance_id)
         if monster is not None:
             self.session.player.remove_monster(monster)
+


### PR DESCRIPTION
adds optional trainer slug parameter to <add/remove>_monster. Defaults to player (to preserve existing functionality).
This allows a script to alter an npc's party, but only for the current session. Changes are not preserved in the save.