### PR TITLE
Introduce Catch resistance mechanic

### DIFF
--- a/mods/tuxemon/db/monster/aardart.json
+++ b/mods/tuxemon/db/monster/aardart.json
@@ -21,5 +21,7 @@
         "Earth"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/aardorn.json
+++ b/mods/tuxemon/db/monster/aardorn.json
@@ -21,5 +21,7 @@
         "Earth"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/abesnaki.json
+++ b/mods/tuxemon/db/monster/abesnaki.json
@@ -21,5 +21,7 @@
         "Fire"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/agnidon.json
+++ b/mods/tuxemon/db/monster/agnidon.json
@@ -21,5 +21,7 @@
         "Fire"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/agnigon.json
+++ b/mods/tuxemon/db/monster/agnigon.json
@@ -21,5 +21,7 @@
         "Fire"
     ],
     "weight": 25,
-    "catch_rate": 45.0
+    "catch_rate": 45.0,
+    "lower_catch_resistance": 0.85,
+    "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/agnite.json
+++ b/mods/tuxemon/db/monster/agnite.json
@@ -21,5 +21,7 @@
         "Fire"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/allagon.json
+++ b/mods/tuxemon/db/monster/allagon.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 3.0
+    "catch_rate": 3.0,
+    "lower_catch_resistance": 0.8,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/angrito.json
+++ b/mods/tuxemon/db/monster/angrito.json
@@ -22,5 +22,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/anoleaf.json
+++ b/mods/tuxemon/db/monster/anoleaf.json
@@ -21,5 +21,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/anu.json
+++ b/mods/tuxemon/db/monster/anu.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/araignee.json
+++ b/mods/tuxemon/db/monster/araignee.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/arthrobolt.json
+++ b/mods/tuxemon/db/monster/arthrobolt.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 45.0
+    "catch_rate": 45.0,
+    "lower_catch_resistance": 0.85,
+    "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/av8r.json
+++ b/mods/tuxemon/db/monster/av8r.json
@@ -25,5 +25,7 @@
         "combat_call": "sound_av8r",
         "faint_call": "sound_av8r_faint"
     },
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/axylightl.json
+++ b/mods/tuxemon/db/monster/axylightl.json
@@ -21,5 +21,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/bamboon.json
+++ b/mods/tuxemon/db/monster/bamboon.json
@@ -21,5 +21,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/bigfin.json
+++ b/mods/tuxemon/db/monster/bigfin.json
@@ -21,5 +21,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 45.0
+    "catch_rate": 45.0,
+    "lower_catch_resistance": 0.85,
+    "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/birb_robo.json
+++ b/mods/tuxemon/db/monster/birb_robo.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 100,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/birdling.json
+++ b/mods/tuxemon/db/monster/birdling.json
@@ -21,5 +21,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/bolt.json
+++ b/mods/tuxemon/db/monster/bolt.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/botbot.json
+++ b/mods/tuxemon/db/monster/botbot.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/budaye.json
+++ b/mods/tuxemon/db/monster/budaye.json
@@ -21,5 +21,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/bugnin.json
+++ b/mods/tuxemon/db/monster/bugnin.json
@@ -22,5 +22,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 3.0
+    "catch_rate": 3.0,
+    "lower_catch_resistance": 0.8,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/bursa.json
+++ b/mods/tuxemon/db/monster/bursa.json
@@ -21,5 +21,7 @@
         "Fire"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/cairfrey.json
+++ b/mods/tuxemon/db/monster/cairfrey.json
@@ -21,5 +21,7 @@
         "Earth"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/capiti.json
+++ b/mods/tuxemon/db/monster/capiti.json
@@ -21,5 +21,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/cardiling.json
+++ b/mods/tuxemon/db/monster/cardiling.json
@@ -21,5 +21,7 @@
         "Fire"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/cardinale.json
+++ b/mods/tuxemon/db/monster/cardinale.json
@@ -21,5 +21,7 @@
         "Fire"
     ],
     "weight": 25,
-    "catch_rate": 45.0
+    "catch_rate": 45.0,
+    "lower_catch_resistance": 0.85,
+    "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/cardiwing.json
+++ b/mods/tuxemon/db/monster/cardiwing.json
@@ -21,5 +21,7 @@
         "Fire"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/cataspike.json
+++ b/mods/tuxemon/db/monster/cataspike.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/cateye.json
+++ b/mods/tuxemon/db/monster/cateye.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/chenipode.json
+++ b/mods/tuxemon/db/monster/chenipode.json
@@ -21,5 +21,7 @@
         "Earth"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/chillimp.json
+++ b/mods/tuxemon/db/monster/chillimp.json
@@ -22,5 +22,7 @@
         "Earth"
     ],
     "weight": 25,
-    "catch_rate": 45.0
+    "catch_rate": 45.0,
+    "lower_catch_resistance": 0.85,
+    "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/chloragon.json
+++ b/mods/tuxemon/db/monster/chloragon.json
@@ -21,5 +21,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/chrome_robo.json
+++ b/mods/tuxemon/db/monster/chrome_robo.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 100,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/chromeye.json
+++ b/mods/tuxemon/db/monster/chromeye.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/cochini.json
+++ b/mods/tuxemon/db/monster/cochini.json
@@ -21,5 +21,7 @@
         "Earth"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/coleorus.json
+++ b/mods/tuxemon/db/monster/coleorus.json
@@ -22,5 +22,7 @@
         "Earth"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/conifrost.json
+++ b/mods/tuxemon/db/monster/conifrost.json
@@ -22,5 +22,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/conileaf.json
+++ b/mods/tuxemon/db/monster/conileaf.json
@@ -21,5 +21,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/corvix.json
+++ b/mods/tuxemon/db/monster/corvix.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 45.0
+    "catch_rate": 45.0,
+    "lower_catch_resistance": 0.85,
+    "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/cowpignon.json
+++ b/mods/tuxemon/db/monster/cowpignon.json
@@ -22,5 +22,7 @@
         "Earth"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/criniotherme.json
+++ b/mods/tuxemon/db/monster/criniotherme.json
@@ -21,5 +21,7 @@
         "Fire"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/d0llf1n.json
+++ b/mods/tuxemon/db/monster/d0llf1n.json
@@ -22,5 +22,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/dandicub.json
+++ b/mods/tuxemon/db/monster/dandicub.json
@@ -21,5 +21,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/dandylion.json
+++ b/mods/tuxemon/db/monster/dandylion.json
@@ -21,5 +21,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/dark_robo.json
+++ b/mods/tuxemon/db/monster/dark_robo.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 100,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/dinoflop.json
+++ b/mods/tuxemon/db/monster/dinoflop.json
@@ -21,5 +21,7 @@
         "Earth"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/djinnbo.json
+++ b/mods/tuxemon/db/monster/djinnbo.json
@@ -21,5 +21,7 @@
         "Fire"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/dollfin.json
+++ b/mods/tuxemon/db/monster/dollfin.json
@@ -21,5 +21,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/dracune.json
+++ b/mods/tuxemon/db/monster/dracune.json
@@ -21,5 +21,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/dragarbor.json
+++ b/mods/tuxemon/db/monster/dragarbor.json
@@ -21,5 +21,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 45.0
+    "catch_rate": 45.0,
+    "lower_catch_resistance": 0.85,
+    "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/drokoro.json
+++ b/mods/tuxemon/db/monster/drokoro.json
@@ -21,5 +21,7 @@
         "Fire"
     ],
     "weight": 25,
-    "catch_rate": 3.0
+    "catch_rate": 3.0,
+    "lower_catch_resistance": 0.8,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/dune_pincher.json
+++ b/mods/tuxemon/db/monster/dune_pincher.json
@@ -21,5 +21,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/eaglace.json
+++ b/mods/tuxemon/db/monster/eaglace.json
@@ -21,5 +21,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 45.0
+    "catch_rate": 45.0,
+    "lower_catch_resistance": 0.85,
+    "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/elofly.json
+++ b/mods/tuxemon/db/monster/elofly.json
@@ -21,5 +21,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/elostorm.json
+++ b/mods/tuxemon/db/monster/elostorm.json
@@ -21,5 +21,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 45.0
+    "catch_rate": 45.0,
+    "lower_catch_resistance": 0.85,
+    "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/elowind.json
+++ b/mods/tuxemon/db/monster/elowind.json
@@ -21,5 +21,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/embazook.json
+++ b/mods/tuxemon/db/monster/embazook.json
@@ -22,5 +22,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/embra.json
+++ b/mods/tuxemon/db/monster/embra.json
@@ -21,5 +21,7 @@
         "Fire"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/enduros.json
+++ b/mods/tuxemon/db/monster/enduros.json
@@ -21,5 +21,7 @@
         "Earth"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/eruptibus.json
+++ b/mods/tuxemon/db/monster/eruptibus.json
@@ -21,5 +21,7 @@
         "Fire"
     ],
     "weight": 25,
-    "catch_rate": 45.0
+    "catch_rate": 45.0,
+    "lower_catch_resistance": 0.85,
+    "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/exapode.json
+++ b/mods/tuxemon/db/monster/exapode.json
@@ -21,5 +21,7 @@
         "Earth"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/eyenemy.json
+++ b/mods/tuxemon/db/monster/eyenemy.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/eyesore.json
+++ b/mods/tuxemon/db/monster/eyesore.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/f7u1t3ra.json
+++ b/mods/tuxemon/db/monster/f7u1t3ra.json
@@ -22,5 +22,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/fancair.json
+++ b/mods/tuxemon/db/monster/fancair.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/flacono.json
+++ b/mods/tuxemon/db/monster/flacono.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/flambear.json
+++ b/mods/tuxemon/db/monster/flambear.json
@@ -21,5 +21,7 @@
         "Fire"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/fluoresfin.json
+++ b/mods/tuxemon/db/monster/fluoresfin.json
@@ -21,5 +21,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/fluttaflap.json
+++ b/mods/tuxemon/db/monster/fluttaflap.json
@@ -21,5 +21,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/foofle.json
+++ b/mods/tuxemon/db/monster/foofle.json
@@ -21,5 +21,7 @@
         "Earth"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/forturtle.json
+++ b/mods/tuxemon/db/monster/forturtle.json
@@ -21,5 +21,7 @@
         "Earth"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/foxfire.json
+++ b/mods/tuxemon/db/monster/foxfire.json
@@ -21,5 +21,7 @@
         "Fire"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/frondly.json
+++ b/mods/tuxemon/db/monster/frondly.json
@@ -21,5 +21,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 3.0
+    "catch_rate": 3.0,
+    "lower_catch_resistance": 0.8,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/fruitera.json
+++ b/mods/tuxemon/db/monster/fruitera.json
@@ -21,5 +21,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/galnec.json
+++ b/mods/tuxemon/db/monster/galnec.json
@@ -21,5 +21,7 @@
         "Earth"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/gectile.json
+++ b/mods/tuxemon/db/monster/gectile.json
@@ -21,5 +21,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/ghosteeth.json
+++ b/mods/tuxemon/db/monster/ghosteeth.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/grimachin.json
+++ b/mods/tuxemon/db/monster/grimachin.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/grinflare.json
+++ b/mods/tuxemon/db/monster/grinflare.json
@@ -22,5 +22,7 @@
         "Fire"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/grintot.json
+++ b/mods/tuxemon/db/monster/grintot.json
@@ -21,5 +21,7 @@
         "Earth"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/grintrock.json
+++ b/mods/tuxemon/db/monster/grintrock.json
@@ -22,5 +22,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/hampotamos.json
+++ b/mods/tuxemon/db/monster/hampotamos.json
@@ -21,5 +21,7 @@
         "Earth"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/happito.json
+++ b/mods/tuxemon/db/monster/happito.json
@@ -22,5 +22,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/hatchling.json
+++ b/mods/tuxemon/db/monster/hatchling.json
@@ -21,5 +21,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/heronquak.json
+++ b/mods/tuxemon/db/monster/heronquak.json
@@ -21,5 +21,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/hydrone.json
+++ b/mods/tuxemon/db/monster/hydrone.json
@@ -22,5 +22,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/ignibus.json
+++ b/mods/tuxemon/db/monster/ignibus.json
@@ -21,5 +21,7 @@
         "Fire"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/incandesfin.json
+++ b/mods/tuxemon/db/monster/incandesfin.json
@@ -21,5 +21,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/jemuar.json
+++ b/mods/tuxemon/db/monster/jemuar.json
@@ -21,5 +21,7 @@
         "Earth"
     ],
     "weight": 25,
-    "catch_rate": 45.0
+    "catch_rate": 45.0,
+    "lower_catch_resistance": 0.85,
+    "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/k9.json
+++ b/mods/tuxemon/db/monster/k9.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/katacoon.json
+++ b/mods/tuxemon/db/monster/katacoon.json
@@ -22,5 +22,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/katapill.json
+++ b/mods/tuxemon/db/monster/katapill.json
@@ -22,5 +22,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/komodraw.json
+++ b/mods/tuxemon/db/monster/komodraw.json
@@ -21,5 +21,7 @@
         "Fire"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/l3gk0.json
+++ b/mods/tuxemon/db/monster/l3gk0.json
@@ -22,5 +22,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/lambert.json
+++ b/mods/tuxemon/db/monster/lambert.json
@@ -21,5 +21,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/lapinou.json
+++ b/mods/tuxemon/db/monster/lapinou.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/legko.json
+++ b/mods/tuxemon/db/monster/legko.json
@@ -21,5 +21,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/lightmare.json
+++ b/mods/tuxemon/db/monster/lightmare.json
@@ -21,5 +21,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 45.0
+    "catch_rate": 45.0,
+    "lower_catch_resistance": 0.85,
+    "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/manosting.json
+++ b/mods/tuxemon/db/monster/manosting.json
@@ -21,5 +21,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/masknake.json
+++ b/mods/tuxemon/db/monster/masknake.json
@@ -21,5 +21,7 @@
         "Fire"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/memnomnom.json
+++ b/mods/tuxemon/db/monster/memnomnom.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/miaownolith.json
+++ b/mods/tuxemon/db/monster/miaownolith.json
@@ -22,5 +22,7 @@
         "Earth"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/mk01_alpha.json
+++ b/mods/tuxemon/db/monster/mk01_alpha.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 100,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/mk01_beta.json
+++ b/mods/tuxemon/db/monster/mk01_beta.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 100,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/moloch.json
+++ b/mods/tuxemon/db/monster/moloch.json
@@ -21,5 +21,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 45.0
+    "catch_rate": 45.0,
+    "lower_catch_resistance": 0.85,
+    "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/mrmoswitch.json
+++ b/mods/tuxemon/db/monster/mrmoswitch.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/narcileaf.json
+++ b/mods/tuxemon/db/monster/narcileaf.json
@@ -21,5 +21,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/neutrito.json
+++ b/mods/tuxemon/db/monster/neutrito.json
@@ -22,5 +22,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/noctalo.json
+++ b/mods/tuxemon/db/monster/noctalo.json
@@ -21,5 +21,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/noctula.json
+++ b/mods/tuxemon/db/monster/noctula.json
@@ -21,5 +21,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/nostray.json
+++ b/mods/tuxemon/db/monster/nostray.json
@@ -21,5 +21,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/nudiflot_female.json
+++ b/mods/tuxemon/db/monster/nudiflot_female.json
@@ -21,5 +21,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/nudiflot_male.json
+++ b/mods/tuxemon/db/monster/nudiflot_male.json
@@ -21,5 +21,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/nudikill.json
+++ b/mods/tuxemon/db/monster/nudikill.json
@@ -21,5 +21,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/nudimind.json
+++ b/mods/tuxemon/db/monster/nudimind.json
@@ -21,5 +21,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/nut.json
+++ b/mods/tuxemon/db/monster/nut.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/ouroboutlet.json
+++ b/mods/tuxemon/db/monster/ouroboutlet.json
@@ -22,5 +22,7 @@
         "Fire"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/pairagrim.json
+++ b/mods/tuxemon/db/monster/pairagrim.json
@@ -25,5 +25,7 @@
         "wood"
     ],
     "weight": 10,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/pairagrin.json
+++ b/mods/tuxemon/db/monster/pairagrin.json
@@ -21,5 +21,7 @@
         "wood"
     ],
     "weight": 4,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/pharfan.json
+++ b/mods/tuxemon/db/monster/pharfan.json
@@ -21,5 +21,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/picc.json
+++ b/mods/tuxemon/db/monster/picc.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/pigabyte.json
+++ b/mods/tuxemon/db/monster/pigabyte.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/pipis.json
+++ b/mods/tuxemon/db/monster/pipis.json
@@ -21,5 +21,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/poinchin.json
+++ b/mods/tuxemon/db/monster/poinchin.json
@@ -21,5 +21,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/polyrock.json
+++ b/mods/tuxemon/db/monster/polyrock.json
@@ -21,5 +21,7 @@
         "Earth"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/possessun.json
+++ b/mods/tuxemon/db/monster/possessun.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/propellercat.json
+++ b/mods/tuxemon/db/monster/propellercat.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/prophetoise.json
+++ b/mods/tuxemon/db/monster/prophetoise.json
@@ -21,5 +21,7 @@
         "Fire"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/puparmor.json
+++ b/mods/tuxemon/db/monster/puparmor.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/pyraminx.json
+++ b/mods/tuxemon/db/monster/pyraminx.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 45.0
+    "catch_rate": 45.0,
+    "lower_catch_resistance": 0.85,
+    "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/pythwire.json
+++ b/mods/tuxemon/db/monster/pythwire.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/r0ck1tt3n.json
+++ b/mods/tuxemon/db/monster/r0ck1tt3n.json
@@ -22,5 +22,7 @@
         "Earth"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/rabbitosaur.json
+++ b/mods/tuxemon/db/monster/rabbitosaur.json
@@ -21,5 +21,7 @@
         "Earth"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/rhincus.json
+++ b/mods/tuxemon/db/monster/rhincus.json
@@ -21,5 +21,7 @@
         "Earth"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/rockat.json
+++ b/mods/tuxemon/db/monster/rockat.json
@@ -21,5 +21,7 @@
         "Earth"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/rockitten.json
+++ b/mods/tuxemon/db/monster/rockitten.json
@@ -21,5 +21,7 @@
         "Earth"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/ruption.json
+++ b/mods/tuxemon/db/monster/ruption.json
@@ -21,5 +21,7 @@
         "Fire"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/sadito.json
+++ b/mods/tuxemon/db/monster/sadito.json
@@ -22,5 +22,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/sampsack.json
+++ b/mods/tuxemon/db/monster/sampsack.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/sampsage.json
+++ b/mods/tuxemon/db/monster/sampsage.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 45.0
+    "catch_rate": 45.0,
+    "lower_catch_resistance": 0.85,
+    "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/sapragon.json
+++ b/mods/tuxemon/db/monster/sapragon.json
@@ -21,5 +21,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/sapsnap.json
+++ b/mods/tuxemon/db/monster/sapsnap.json
@@ -21,5 +21,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/saurchin.json
+++ b/mods/tuxemon/db/monster/saurchin.json
@@ -21,5 +21,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/sclairus.json
+++ b/mods/tuxemon/db/monster/sclairus.json
@@ -21,5 +21,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/seirein.json
+++ b/mods/tuxemon/db/monster/seirein.json
@@ -22,5 +22,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 45.0
+    "catch_rate": 45.0,
+    "lower_catch_resistance": 0.85,
+    "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/shammer.json
+++ b/mods/tuxemon/db/monster/shammer.json
@@ -21,5 +21,7 @@
         "Earth"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/sharpfin.json
+++ b/mods/tuxemon/db/monster/sharpfin.json
@@ -22,5 +22,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 45.0
+    "catch_rate": 45.0,
+    "lower_catch_resistance": 0.85,
+    "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/shybulb.json
+++ b/mods/tuxemon/db/monster/shybulb.json
@@ -21,5 +21,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/skwib.json
+++ b/mods/tuxemon/db/monster/skwib.json
@@ -21,5 +21,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/sludgehog.json
+++ b/mods/tuxemon/db/monster/sludgehog.json
@@ -21,5 +21,7 @@
         "Earth"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/snarlon.json
+++ b/mods/tuxemon/db/monster/snarlon.json
@@ -21,5 +21,7 @@
         "Earth"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/sockeserp.json
+++ b/mods/tuxemon/db/monster/sockeserp.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 45.0
+    "catch_rate": 45.0,
+    "lower_catch_resistance": 0.85,
+    "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/spighter.json
+++ b/mods/tuxemon/db/monster/spighter.json
@@ -21,5 +21,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/squabbit.json
+++ b/mods/tuxemon/db/monster/squabbit.json
@@ -21,5 +21,7 @@
         "Earth"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/strella.json
+++ b/mods/tuxemon/db/monster/strella.json
@@ -21,5 +21,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/sumchon.json
+++ b/mods/tuxemon/db/monster/sumchon.json
@@ -22,5 +22,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/tigrock.json
+++ b/mods/tuxemon/db/monster/tigrock.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/tikoal.json
+++ b/mods/tuxemon/db/monster/tikoal.json
@@ -22,5 +22,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/tikorch.json
+++ b/mods/tuxemon/db/monster/tikorch.json
@@ -22,5 +22,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/toufigel.json
+++ b/mods/tuxemon/db/monster/toufigel.json
@@ -22,5 +22,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/tourbidi.json
+++ b/mods/tuxemon/db/monster/tourbidi.json
@@ -21,5 +21,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/trapsnap.json
+++ b/mods/tuxemon/db/monster/trapsnap.json
@@ -21,5 +21,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/tumblebee.json
+++ b/mods/tuxemon/db/monster/tumblebee.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/tumbleworm.json
+++ b/mods/tuxemon/db/monster/tumbleworm.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/tweesher.json
+++ b/mods/tuxemon/db/monster/tweesher.json
@@ -21,5 +21,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/vamporm.json
+++ b/mods/tuxemon/db/monster/vamporm.json
@@ -21,5 +21,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/velocitile.json
+++ b/mods/tuxemon/db/monster/velocitile.json
@@ -21,5 +21,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 45.0
+    "catch_rate": 45.0,
+    "lower_catch_resistance": 0.85,
+    "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/vivicinder.json
+++ b/mods/tuxemon/db/monster/vivicinder.json
@@ -21,5 +21,7 @@
         "Fire"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/vivipere.json
+++ b/mods/tuxemon/db/monster/vivipere.json
@@ -21,5 +21,7 @@
         "Earth"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/viviphyta.json
+++ b/mods/tuxemon/db/monster/viviphyta.json
@@ -21,5 +21,7 @@
         "Wood"
     ],
     "weight": 25,
-    "catch_rate": 45.0
+    "catch_rate": 45.0,
+    "lower_catch_resistance": 0.85,
+    "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/viviteel.json
+++ b/mods/tuxemon/db/monster/viviteel.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 170.0
+    "catch_rate": 170.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/vivitrans.json
+++ b/mods/tuxemon/db/monster/vivitrans.json
@@ -22,5 +22,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/vivitron.json
+++ b/mods/tuxemon/db/monster/vivitron.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 45.0
+    "catch_rate": 45.0,
+    "lower_catch_resistance": 0.85,
+    "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/volcoli.json
+++ b/mods/tuxemon/db/monster/volcoli.json
@@ -21,5 +21,7 @@
         "Fire"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/weavifly.json
+++ b/mods/tuxemon/db/monster/weavifly.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 85.0
+    "catch_rate": 85.0,
+    "lower_catch_resistance": 0.9,
+    "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/windeye.json
+++ b/mods/tuxemon/db/monster/windeye.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/wrougon.json
+++ b/mods/tuxemon/db/monster/wrougon.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 45.0
+    "catch_rate": 45.0,
+    "lower_catch_resistance": 0.85,
+    "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/xeon.json
+++ b/mods/tuxemon/db/monster/xeon.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 100,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/xeon_2.json
+++ b/mods/tuxemon/db/monster/xeon_2.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 100,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/yiinaang.json
+++ b/mods/tuxemon/db/monster/yiinaang.json
@@ -22,5 +22,7 @@
         "Water"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/zunna.json
+++ b/mods/tuxemon/db/monster/zunna.json
@@ -21,5 +21,7 @@
         "Metal"
     ],
     "weight": 25,
-    "catch_rate": 120.0
+    "catch_rate": 120.0,
+    "lower_catch_resistance": 0.95,
+    "upper_catch_resistance": 1.05
 }

--- a/tuxemon/config.py
+++ b/tuxemon/config.py
@@ -92,6 +92,8 @@ class TuxemonConfig:
         self.default_monster_storage_box = cfg.get("gameplay", "default_monster_storage_box")
         self.default_item_storage_box = cfg.get("gameplay", "default_item_storage_box")
         self.default_monster_catch_rate = cfg.get("gameplay", "default_monster_catch_rate")
+        self.default_upper_monster_catch_resistance = cfg.get("gameplay", "default_upper_monster_catch_resistance")
+        self.default_lower_monster_catch_resistance = cfg.get("gameplay", "default_lower_monster_catch_resistance")
 
         # [player]
         self.player_animation_speed = cfg.getfloat("player", "animation_speed")
@@ -202,6 +204,8 @@ def get_defaults():
                         ("default_monster_storage_box", "Kennel"),
                         ("default_item_storage_box", "Locker"),
                         ("default_monster_catch_rate", 125),
+                        ("default_upper_monster_catch_resistance", 1),
+                        ("default_lower_monster_catch_resistance", 1),
                     )
                 ),
             ),

--- a/tuxemon/item/effects/capture.py
+++ b/tuxemon/item/effects/capture.py
@@ -73,7 +73,10 @@ class CaptureEffect(ItemEffect):
             (3 * target.hp - 2 * target.current_hp) * target.catch_rate * item_power * status_modifier / (3 * target.hp)
         )
         shake_check = shake_constant / (sqrt(sqrt(max_catch_rate / catch_check)) * 8)
-
+        #Catch_resistance is calculated 
+        catch_resistance = random.randrange(target.lower_catch_resistance, target.upper_catch_resistance)
+        #Catch_resistance is applied
+        shake_check = shake_check * catch_resistance
         # Debug section
         logger.debug("--- Capture Variables ---")
         logger.debug(

--- a/tuxemon/item/effects/capture.py
+++ b/tuxemon/item/effects/capture.py
@@ -73,10 +73,13 @@ class CaptureEffect(ItemEffect):
             (3 * target.hp - 2 * target.current_hp) * target.catch_rate * item_power * status_modifier / (3 * target.hp)
         )
         shake_check = shake_constant / (sqrt(sqrt(max_catch_rate / catch_check)) * 8)
-        #Catch_resistance is calculated 
-        catch_resistance = random.randrange(target.lower_catch_resistance, target.upper_catch_resistance)
-        #Catch_resistance is applied
+        # Catch_resistance is a randomly generated number between the lower and upper catch_resistance of a tuxemon.
+        # This value is used to slightly increase or decrease the chance of a tuxemon being caught. The value changes
+        # Every time a new caprute device is thrown.
+        catch_resistance = random.uniform(target.lower_catch_resistance, target.upper_catch_resistance)
+        # Catch_resistance is applied to the shake_check
         shake_check = shake_check * catch_resistance
+        
         # Debug section
         logger.debug("--- Capture Variables ---")
         logger.debug(

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -231,6 +231,10 @@ class Monster:
         # This is based on the pokemon calculation and can be found at https://bulbapedia.bulbagarden.net/wiki/List_of_Pok%C3%A9mon_by_catch_rate
         self.catch_rate = TuxemonConfig().default_monster_catch_rate
 
+        # Document how the catch resistance 
+        self.upper_catch_resistance = TuxemonConfig().default_upper_monster_catch_resistance
+        self.lower_catch_Resistance = TuxemonConfig().default_lower_monster_catch_resistance
+        
         # The tuxemon's state is used for various animations, etc. For example
         # a tuxemon's state might be "attacking" or "fainting" so we know when
         # to play the animations for those states.
@@ -297,6 +301,8 @@ class Monster:
 
         self.weight = results["weight"]
         self.catch_rate = results.get("catch_rate", TuxemonConfig().default_monster_catch_rate)
+        self.upper_catch_resistance = results.get("upper_catch_resistance",TuxemonConfig().default_upper_monster_catch_resistance)
+        self.upper_lower_resistance = results.get("lower_catch_resistance",TuxemonConfig().default_lower_monster_catch_resistance)
 
         # Look up the moves that this monster can learn AND LEARN THEM.
         moveset = results.get("moveset")

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -231,7 +231,8 @@ class Monster:
         # This is based on the pokemon calculation and can be found at https://bulbapedia.bulbagarden.net/wiki/List_of_Pok%C3%A9mon_by_catch_rate
         self.catch_rate = TuxemonConfig().default_monster_catch_rate
 
-        # Document how the catch resistance 
+        # The catch_resistance value is calculated during the capture. The upper and lower catch_resistance
+        # set the span on which the catch_resistance will be. For more imformation check capture.py 
         self.upper_catch_resistance = TuxemonConfig().default_upper_monster_catch_resistance
         self.lower_catch_Resistance = TuxemonConfig().default_lower_monster_catch_resistance
         
@@ -302,7 +303,7 @@ class Monster:
         self.weight = results["weight"]
         self.catch_rate = results.get("catch_rate", TuxemonConfig().default_monster_catch_rate)
         self.upper_catch_resistance = results.get("upper_catch_resistance",TuxemonConfig().default_upper_monster_catch_resistance)
-        self.upper_lower_resistance = results.get("lower_catch_resistance",TuxemonConfig().default_lower_monster_catch_resistance)
+        self.lower_catch_resistance = results.get("lower_catch_resistance",TuxemonConfig().default_lower_monster_catch_resistance)
 
         # Look up the moves that this monster can learn AND LEARN THEM.
         moveset = results.get("moveset")


### PR DESCRIPTION
Fix issue (#801)

This PR aims to:
*  Introduce catch resistance mechanic for the capture system
*  Add variety to the capture system, making it more interesting and complex

### Catch_resistance 
The concept behind the catch_resistance as discussed in issue( #801 ), is to have a multiplier for the catch probability of a Tuxemon, in order to increase or decrease the chances of a Tuxemon being caught. Since the catch_rate was introduced recently, I propose that the catch resistance should not be a single value for every Tuxemon, but rather a randomly generated number within a defined span. The span is defined by the upper_catch_resistance and lower_catch resistance that have been assigned to each Tuxemon following this model:
- Evolution 1 - lower_catch resistance = 0.95 , upper_catch_resistance = 1.25
- Evolution 2 - lower_catch resistance = 0.9 , upper_catch_resistance = 1.15
- Evolution 3 - lower_catch resistance = 0.85 , upper_catch_resistance = 1.1
- Super Rare - lower_catch resistance = 0.8 , upper_catch_resistance = 1.05

For Tuxemon that their evolution/rarity was not defined, the values 0.95 and 1.05 were given.
This way for example a evolution 1 type Tuxemon will have more chances of being caught giving the players a head start in the game. 

### Calculation

The catch_resistance is calculated every time a capture device is used, and is a randomly generated number in the span of lower_catch resistance, upper_catch_resistance. This value is then multiplied by the already predefined probability to give us the final rate.
  
## Note

For the introduction of the new values in the Tuxemon DB the script modify_json.py was used.