### PR TITLE
Disable access to the multiplayer menu via the „not implemeted” dialog

### DIFF
--- a/tuxemon/states/pc/__init__.py
+++ b/tuxemon/states/pc/__init__.py
@@ -48,6 +48,8 @@ def add_menu_items(state, items):
 
         state.build_item(label, callback)
 
+def not_implemented_dialog():
+            open_dialog(local_session, [T.translate("not_implemented")])
 
 class PCState(PopUpMenu):
     """The state responsible in game settings."""
@@ -65,7 +67,7 @@ class PCState(PopUpMenu):
             (
                 ("menu_monsters", change_state("MonsterMenuState")),
                 ("menu_items", change_state("ItemMenuState")),
-                ("menu_multiplayer", change_state("MultiplayerMenu")),
+                ("menu_multiplayer", not_implemented_dialog), #change_state("MultiplayerMenu")),
                 ("log_off", self.client.pop_state),
             ),
         )


### PR DESCRIPTION
Fixes the issue #570