### PR TITLE
Refactor actions parameters

### DIFF
--- a/tuxemon/event/actions/add_item.py
+++ b/tuxemon/event/actions/add_item.py
@@ -36,7 +36,6 @@ class AddItemAction(EventAction):
     """
 
     name = "add_item"
-    valid_parameters = [(str, "item_slug"), ((int, None), "quantity")]
     _param_factory = AddItemActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/add_item.py
+++ b/tuxemon/event/actions/add_item.py
@@ -21,7 +21,7 @@
 
 from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
-from typing import Union, NamedTuple
+from typing import Union, NamedTuple, final
 
 
 class AddItemActionParameters(NamedTuple):
@@ -29,16 +29,19 @@ class AddItemActionParameters(NamedTuple):
     quantity: Union[int, None]
 
 
-class AddItemAction(EventAction):
-    """Adds an item to the current player's inventory.
+@final
+class AddItemAction(EventAction[AddItemActionParameters]):
+    """
+    Adds an item to the current player's inventory.
 
-    The action parameter must contain an item name to look up in the item database.
+    The action parameter must contain an item name to look up in the item
+    database.
     """
 
     name = "add_item"
     param_class = AddItemActionParameters
 
-    def start(self):
+    def start(self) -> None:
         player = self.session.player
         if self.parameters.quantity is None:
             quantity = 1

--- a/tuxemon/event/actions/add_item.py
+++ b/tuxemon/event/actions/add_item.py
@@ -19,7 +19,14 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
+from typing import Union, NamedTuple
+
+
+class AddItemActionParameters(NamedTuple):
+    item_slug: str
+    quantity: Union[int, None]
 
 
 class AddItemAction(EventAction):
@@ -30,6 +37,7 @@ class AddItemAction(EventAction):
 
     name = "add_item"
     valid_parameters = [(str, "item_slug"), ((int, None), "quantity")]
+    _param_factory = AddItemActionParameters
 
     def start(self):
         player = self.session.player

--- a/tuxemon/event/actions/add_item.py
+++ b/tuxemon/event/actions/add_item.py
@@ -36,7 +36,7 @@ class AddItemAction(EventAction):
     """
 
     name = "add_item"
-    _param_factory = AddItemActionParameters
+    param_class = AddItemActionParameters
 
     def start(self):
         player = self.session.player

--- a/tuxemon/event/actions/add_monster.py
+++ b/tuxemon/event/actions/add_monster.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 from tuxemon import monster
 from tuxemon.event.eventaction import EventAction
 from tuxemon.event import get_npc
-from typing import Union, NamedTuple
+from typing import Union, NamedTuple, final
 
 
 class AddMonsterActionParameters(NamedTuple):
@@ -32,11 +32,13 @@ class AddMonsterActionParameters(NamedTuple):
     trainer_slug: Union[str, None]
 
 
-class AddMonsterAction(EventAction):
+@final
+class AddMonsterAction(EventAction[AddMonsterActionParameters]):
     """Adds a monster to the specified trainer's party if there is room.
     If no is trainer specified it defaults to the current player.
 
-    The action parameter must contain a monster slug to look up in the monster database.
+    The action parameter must contain a monster slug to look up in the monster
+    database.
 
     Valid Parameters: monster_slug, level(, trainer_slug)
     """
@@ -44,7 +46,7 @@ class AddMonsterAction(EventAction):
     name = "add_monster"
     param_class = AddMonsterActionParameters
 
-    def start(self):
+    def start(self) -> None:
 
         monster_slug, monster_level, trainer_slug = self.parameters
 

--- a/tuxemon/event/actions/add_monster.py
+++ b/tuxemon/event/actions/add_monster.py
@@ -42,7 +42,7 @@ class AddMonsterAction(EventAction):
     """
 
     name = "add_monster"
-    _param_factory = AddMonsterActionParameters
+    param_class = AddMonsterActionParameters
 
     def start(self):
 

--- a/tuxemon/event/actions/add_monster.py
+++ b/tuxemon/event/actions/add_monster.py
@@ -42,7 +42,6 @@ class AddMonsterAction(EventAction):
     """
 
     name = "add_monster"
-    valid_parameters = [(str, "monster_slug"), (int, "monster_level"), ((str, None), "trainer_slug")]
     _param_factory = AddMonsterActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/add_monster.py
+++ b/tuxemon/event/actions/add_monster.py
@@ -19,9 +19,17 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon import monster
 from tuxemon.event.eventaction import EventAction
 from tuxemon.event import get_npc
+from typing import Union, NamedTuple
+
+
+class AddMonsterActionParameters(NamedTuple):
+    monster_slug: str
+    monster_level: int
+    trainer_slug: Union[str, None]
 
 
 class AddMonsterAction(EventAction):
@@ -35,6 +43,7 @@ class AddMonsterAction(EventAction):
 
     name = "add_monster"
     valid_parameters = [(str, "monster_slug"), (int, "monster_level"), ((str, None), "trainer_slug")]
+    _param_factory = AddMonsterActionParameters
 
     def start(self):
 

--- a/tuxemon/event/actions/call_event.py
+++ b/tuxemon/event/actions/call_event.py
@@ -21,14 +21,15 @@
 
 from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class CallEventActionParameters(NamedTuple):
     event_id: int
 
 
-class CallEventAction(EventAction):
+@final
+class CallEventAction(EventAction[CallEventActionParameters]):
     """Executes the specified event's actions by id.
 
     Valid Parameters: event_id
@@ -37,7 +38,7 @@ class CallEventAction(EventAction):
     name = "call_event"
     param_class = CallEventActionParameters
 
-    def start(self):
+    def start(self) -> None:
         event_engine = self.session.client.event_engine
         events = self.session.client.events
 

--- a/tuxemon/event/actions/call_event.py
+++ b/tuxemon/event/actions/call_event.py
@@ -35,7 +35,7 @@ class CallEventAction(EventAction):
     """
 
     name = "call_event"
-    _param_factory = CallEventActionParameters
+    param_class = CallEventActionParameters
 
     def start(self):
         event_engine = self.session.client.event_engine

--- a/tuxemon/event/actions/call_event.py
+++ b/tuxemon/event/actions/call_event.py
@@ -19,7 +19,13 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
+
+
+class CallEventActionParameters(NamedTuple):
+    event_id: int
 
 
 class CallEventAction(EventAction):
@@ -30,6 +36,7 @@ class CallEventAction(EventAction):
 
     name = "call_event"
     valid_parameters = [(int, "event_id")]
+    _param_factory = CallEventActionParameters
 
     def start(self):
         event_engine = self.session.client.event_engine

--- a/tuxemon/event/actions/call_event.py
+++ b/tuxemon/event/actions/call_event.py
@@ -35,7 +35,6 @@ class CallEventAction(EventAction):
     """
 
     name = "call_event"
-    valid_parameters = [(int, "event_id")]
     _param_factory = CallEventActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/change_state.py
+++ b/tuxemon/event/actions/change_state.py
@@ -19,7 +19,13 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
+
+
+class ChangeStateActionParameters(NamedTuple):
+    state_name: str
 
 
 class ChangeStateAction(EventAction):
@@ -32,6 +38,7 @@ class ChangeStateAction(EventAction):
 
     name = "change_state"
     valid_parameters = [(str, "state_name")]
+    _param_factory = ChangeStateActionParameters
 
     def start(self):
         # Don't override previous state if we are still in the state.

--- a/tuxemon/event/actions/change_state.py
+++ b/tuxemon/event/actions/change_state.py
@@ -21,14 +21,15 @@
 
 from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class ChangeStateActionParameters(NamedTuple):
     state_name: str
 
 
-class ChangeStateAction(EventAction):
+@final
+class ChangeStateAction(EventAction[ChangeStateActionParameters]):
     """Changes to the specified state.
 
     Valid Parameters: state_name
@@ -39,7 +40,7 @@ class ChangeStateAction(EventAction):
     name = "change_state"
     param_class = ChangeStateActionParameters
 
-    def start(self):
+    def start(self) -> None:
         # Don't override previous state if we are still in the state.
         if self.session.client.state_name != self.parameters.state_name:
             self.session.client.push_state(self.parameters.state_name)

--- a/tuxemon/event/actions/change_state.py
+++ b/tuxemon/event/actions/change_state.py
@@ -37,7 +37,6 @@ class ChangeStateAction(EventAction):
     """
 
     name = "change_state"
-    valid_parameters = [(str, "state_name")]
     _param_factory = ChangeStateActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/change_state.py
+++ b/tuxemon/event/actions/change_state.py
@@ -37,7 +37,7 @@ class ChangeStateAction(EventAction):
     """
 
     name = "change_state"
-    _param_factory = ChangeStateActionParameters
+    param_class = ChangeStateActionParameters
 
     def start(self):
         # Don't override previous state if we are still in the state.

--- a/tuxemon/event/actions/clear_variable.py
+++ b/tuxemon/event/actions/clear_variable.py
@@ -42,7 +42,7 @@ class ClearVariableAction(EventAction):
     """
 
     name = "clear_variable"
-    _param_factory = ClearVariableActionParameters
+    param_class = ClearVariableActionParameters
 
     def start(self):
         player = self.session.player

--- a/tuxemon/event/actions/clear_variable.py
+++ b/tuxemon/event/actions/clear_variable.py
@@ -25,7 +25,7 @@
 from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
 import logging
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +35,8 @@ class ClearVariableActionParameters(NamedTuple):
 
 
 # noinspection PyAttributeOutsideInit
-class ClearVariableAction(EventAction):
+@final
+class ClearVariableAction(EventAction[ClearVariableActionParameters]):
     """Clears the value of var from the game.
 
     Valid Parameters: string variable_name
@@ -44,7 +45,7 @@ class ClearVariableAction(EventAction):
     name = "clear_variable"
     param_class = ClearVariableActionParameters
 
-    def start(self):
+    def start(self) -> None:
         player = self.session.player
         key = self.parameters.variable
         player.game_variables.pop(key, None)

--- a/tuxemon/event/actions/clear_variable.py
+++ b/tuxemon/event/actions/clear_variable.py
@@ -22,10 +22,16 @@
 #
 # Adam Chevalier <chevalierAdam2@gmail.com>
 
+from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
 import logging
+from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
+
+
+class ClearVariableActionParameters(NamedTuple):
+    variable: str
 
 
 # noinspection PyAttributeOutsideInit
@@ -37,6 +43,7 @@ class ClearVariableAction(EventAction):
 
     name = "clear_variable"
     valid_parameters = [(str, "variable")]
+    _param_factory = ClearVariableActionParameters
 
     def start(self):
         player = self.session.player

--- a/tuxemon/event/actions/clear_variable.py
+++ b/tuxemon/event/actions/clear_variable.py
@@ -42,7 +42,6 @@ class ClearVariableAction(EventAction):
     """
 
     name = "clear_variable"
-    valid_parameters = [(str, "variable")]
     _param_factory = ClearVariableActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/copy_variable.py
+++ b/tuxemon/event/actions/copy_variable.py
@@ -22,10 +22,17 @@
 #
 # Adam Chevalier <chevalierAdam2@gmail.com>
 
+from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
 import logging
+from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
+
+
+class CopyVariableActionParameters(NamedTuple):
+    var1: str
+    var2: str
 
 
 # noinspection PyAttributeOutsideInit
@@ -38,6 +45,7 @@ class CopyVariableAction(EventAction):
 
     name = "copy_variable"
     valid_parameters = [(str, "var1"), (str, "var2")]
+    _param_factory = CopyVariableActionParameters
 
     def start(self):
         player = self.session.player

--- a/tuxemon/event/actions/copy_variable.py
+++ b/tuxemon/event/actions/copy_variable.py
@@ -44,7 +44,7 @@ class CopyVariableAction(EventAction):
     """
 
     name = "copy_variable"
-    _param_factory = CopyVariableActionParameters
+    param_class = CopyVariableActionParameters
 
     def start(self):
         player = self.session.player

--- a/tuxemon/event/actions/copy_variable.py
+++ b/tuxemon/event/actions/copy_variable.py
@@ -25,7 +25,7 @@
 from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
 import logging
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +36,8 @@ class CopyVariableActionParameters(NamedTuple):
 
 
 # noinspection PyAttributeOutsideInit
-class CopyVariableAction(EventAction):
+@final
+class CopyVariableAction(EventAction[CopyVariableActionParameters]):
     """Copies the value of var2 into var1,
     (e.g. var1 = var 2)
 
@@ -46,7 +47,7 @@ class CopyVariableAction(EventAction):
     name = "copy_variable"
     param_class = CopyVariableActionParameters
 
-    def start(self):
+    def start(self) -> None:
         player = self.session.player
         first = self.parameters.var1
         second = self.parameters.var2

--- a/tuxemon/event/actions/copy_variable.py
+++ b/tuxemon/event/actions/copy_variable.py
@@ -44,7 +44,6 @@ class CopyVariableAction(EventAction):
     """
 
     name = "copy_variable"
-    valid_parameters = [(str, "var1"), (str, "var2")]
     _param_factory = CopyVariableActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/create_npc.py
+++ b/tuxemon/event/actions/create_npc.py
@@ -45,13 +45,6 @@ class CreateNpcAction(EventAction):
     """
 
     name = "create_npc"
-    valid_parameters = [
-        (str, "npc_slug"),
-        (int, "tile_pos_x"),
-        (int, "tile_pos_y"),
-        (str, "animations"),
-        (str, "behavior"),
-    ]
     _param_factory = CreateNpcActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/create_npc.py
+++ b/tuxemon/event/actions/create_npc.py
@@ -18,15 +18,24 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-
+from __future__ import annotations
 import logging
 
 import tuxemon.npc
 from tuxemon import ai
 from tuxemon.db import db
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
+
+
+class CreateNpcActionParameters(NamedTuple):
+    npc_slug: str
+    tile_pos_x: int
+    tile_pos_y: int
+    animations: str
+    behavior: str
 
 
 class CreateNpcAction(EventAction):
@@ -43,6 +52,7 @@ class CreateNpcAction(EventAction):
         (str, "animations"),
         (str, "behavior"),
     ]
+    _param_factory = CreateNpcActionParameters
 
     def start(self):
         # Get a copy of the world state.

--- a/tuxemon/event/actions/create_npc.py
+++ b/tuxemon/event/actions/create_npc.py
@@ -45,7 +45,7 @@ class CreateNpcAction(EventAction):
     """
 
     name = "create_npc"
-    _param_factory = CreateNpcActionParameters
+    param_class = CreateNpcActionParameters
 
     def start(self):
         # Get a copy of the world state.

--- a/tuxemon/event/actions/create_npc.py
+++ b/tuxemon/event/actions/create_npc.py
@@ -25,7 +25,7 @@ import tuxemon.npc
 from tuxemon import ai
 from tuxemon.db import db
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 logger = logging.getLogger(__name__)
 
@@ -38,16 +38,17 @@ class CreateNpcActionParameters(NamedTuple):
     behavior: str
 
 
-class CreateNpcAction(EventAction):
+@final
+class CreateNpcAction(EventAction[CreateNpcActionParameters]):
     """Creates an NPC object and adds it to the game's current list of NPC's.
 
-    Valid Parameters: slug, tile_pos_x, tile_pos_y, animations, behavior
+    Valid Parameters: slug, tile_pos_x, tile_pos_y, animations, behavior.
     """
 
     name = "create_npc"
     param_class = CreateNpcActionParameters
 
-    def start(self):
+    def start(self) -> None:
         # Get a copy of the world state.
         world = self.session.client.get_state_by_name("WorldState")
         if not world:

--- a/tuxemon/event/actions/delayed_teleport.py
+++ b/tuxemon/event/actions/delayed_teleport.py
@@ -37,7 +37,7 @@ class DelayedTeleportAction(EventAction):
     """
 
     name = "delayed_teleport"
-    _param_factory = DelayedTeleportActionParameters
+    param_class = DelayedTeleportActionParameters
 
     def start(self):
         # Get the world object from the session

--- a/tuxemon/event/actions/delayed_teleport.py
+++ b/tuxemon/event/actions/delayed_teleport.py
@@ -21,7 +21,7 @@
 
 from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class DelayedTeleportActionParameters(NamedTuple):
@@ -30,16 +30,20 @@ class DelayedTeleportActionParameters(NamedTuple):
     position_y: int
 
 
-class DelayedTeleportAction(EventAction):
-    """Set teleport information.  Teleport will be triggered during screen transition
+@final
+class DelayedTeleportAction(EventAction[DelayedTeleportActionParameters]):
+    """
+    Set teleport information.
 
-    Only use this if followed by a transition
+    Teleport will be triggered during screen transition.
+
+    Only use this if followed by a transition.
     """
 
     name = "delayed_teleport"
     param_class = DelayedTeleportActionParameters
 
-    def start(self):
+    def start(self) -> None:
         # Get the world object from the session
         world = self.session.client.get_state_by_name("WorldState")
 

--- a/tuxemon/event/actions/delayed_teleport.py
+++ b/tuxemon/event/actions/delayed_teleport.py
@@ -19,7 +19,15 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
+
+
+class DelayedTeleportActionParameters(NamedTuple):
+    map_name: str
+    position_x: int
+    position_y: int
 
 
 class DelayedTeleportAction(EventAction):
@@ -30,6 +38,7 @@ class DelayedTeleportAction(EventAction):
 
     name = "delayed_teleport"
     valid_parameters = [(str, "map_name"), (int, "position_x"), (int, "position_y")]
+    _param_factory = DelayedTeleportActionParameters
 
     def start(self):
         # Get the world object from the session

--- a/tuxemon/event/actions/delayed_teleport.py
+++ b/tuxemon/event/actions/delayed_teleport.py
@@ -37,7 +37,6 @@ class DelayedTeleportAction(EventAction):
     """
 
     name = "delayed_teleport"
-    valid_parameters = [(str, "map_name"), (int, "position_x"), (int, "position_y")]
     _param_factory = DelayedTeleportActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/dialog.py
+++ b/tuxemon/event/actions/dialog.py
@@ -19,14 +19,21 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 import logging
 
 from tuxemon.locale import replace_text
 from tuxemon.event.eventaction import EventAction
 from tuxemon.tools import open_dialog
 from tuxemon.graphics import get_avatar
+from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
+
+
+class DialogActionParameters(NamedTuple):
+    text: str
+    avatar: str
 
 
 class DialogAction(EventAction):
@@ -41,6 +48,7 @@ class DialogAction(EventAction):
 
     name = "dialog"
     valid_parameters = [(str, "text"), (str, "avatar")]
+    _param_factory = DialogActionParameters
 
     def start(self):
         text = replace_text(self.session, self.parameters.text)

--- a/tuxemon/event/actions/dialog.py
+++ b/tuxemon/event/actions/dialog.py
@@ -47,7 +47,6 @@ class DialogAction(EventAction):
     """
 
     name = "dialog"
-    valid_parameters = [(str, "text"), (str, "avatar")]
     _param_factory = DialogActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/dialog.py
+++ b/tuxemon/event/actions/dialog.py
@@ -47,7 +47,7 @@ class DialogAction(EventAction):
     """
 
     name = "dialog"
-    _param_factory = DialogActionParameters
+    param_class = DialogActionParameters
 
     def start(self):
         text = replace_text(self.session, self.parameters.text)

--- a/tuxemon/event/actions/dialog.py
+++ b/tuxemon/event/actions/dialog.py
@@ -26,7 +26,7 @@ from tuxemon.locale import replace_text
 from tuxemon.event.eventaction import EventAction
 from tuxemon.tools import open_dialog
 from tuxemon.graphics import get_avatar
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 logger = logging.getLogger(__name__)
 
@@ -36,12 +36,14 @@ class DialogActionParameters(NamedTuple):
     avatar: str
 
 
-class DialogAction(EventAction):
+@final
+class DialogAction(EventAction[DialogActionParameters]):
     """Opens a single dialog and waits until it is closed.
 
     Valid Parameters: text_to_display
 
-    You may also use special variables in dialog events. Here is a list of available variables:
+    You may also use special variables in dialog events.
+    Here is a list of available variables:
 
     * ${{name}} - The current player's name.
     """
@@ -49,15 +51,15 @@ class DialogAction(EventAction):
     name = "dialog"
     param_class = DialogActionParameters
 
-    def start(self):
+    def start(self) -> None:
         text = replace_text(self.session, self.parameters.text)
         avatar = get_avatar(self.session, self.parameters.avatar)
         self.open_dialog(text, avatar)
 
-    def update(self):
+    def update(self) -> None:
         if self.session.client.get_state_by_name("DialogState") is None:
             self.stop()
 
-    def open_dialog(self, initial_text, avatar):
+    def open_dialog(self, initial_text, avatar) -> None:
         logger.info("Opening dialog window")
         open_dialog(self.session, [initial_text], avatar)

--- a/tuxemon/event/actions/dialog_chain.py
+++ b/tuxemon/event/actions/dialog_chain.py
@@ -49,7 +49,7 @@ class DialogChainAction(EventAction):
     """
 
     name = "dialog_chain"
-    _param_factory = DialogChainActionParameters
+    param_class = DialogChainActionParameters
 
     def start(self):
         # hack to allow unescaped commas in the dialog string

--- a/tuxemon/event/actions/dialog_chain.py
+++ b/tuxemon/event/actions/dialog_chain.py
@@ -19,14 +19,21 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 import logging
 
 from tuxemon.locale import replace_text
 from tuxemon.event.eventaction import EventAction
 from tuxemon.tools import open_dialog
 from tuxemon.graphics import get_avatar
+from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
+
+
+class DialogChainActionParameters(NamedTuple):
+    text: str
+    avatar: str
 
 
 class DialogChainAction(EventAction):
@@ -43,6 +50,7 @@ class DialogChainAction(EventAction):
 
     name = "dialog_chain"
     valid_parameters = [(str, "text"), (str, "avatar")]
+    _param_factory = DialogChainActionParameters
 
     def start(self):
         # hack to allow unescaped commas in the dialog string

--- a/tuxemon/event/actions/dialog_chain.py
+++ b/tuxemon/event/actions/dialog_chain.py
@@ -26,7 +26,7 @@ from tuxemon.locale import replace_text
 from tuxemon.event.eventaction import EventAction
 from tuxemon.tools import open_dialog
 from tuxemon.graphics import get_avatar
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 logger = logging.getLogger(__name__)
 
@@ -36,13 +36,18 @@ class DialogChainActionParameters(NamedTuple):
     avatar: str
 
 
-class DialogChainAction(EventAction):
-    """Opens a dialog and waits.  Other dialog chains will add text to the dialog
-        without closing it.  Dialog chains must be ended with the ${{end}} keyword.
+@final
+class DialogChainAction(EventAction[DialogChainActionParameters]):
+    """
+    Opens a dialog and waits.
+
+    Other dialog chains will add text to the dialog
+    without closing it. Dialog chains must be ended with the ${{end}} keyword.
 
     Valid Parameters: text_to_display
 
-    You may also use special variables in dialog events. Here is a list of available variables:
+    You may also use special variables in dialog events. Here is a list of
+    available variables:
 
     * ${{name}} - The current player's name.
     * ${{end}} - Ends the dialog chain.
@@ -51,7 +56,7 @@ class DialogChainAction(EventAction):
     name = "dialog_chain"
     param_class = DialogChainActionParameters
 
-    def start(self):
+    def start(self) -> None:
         # hack to allow unescaped commas in the dialog string
         text = ", ".join(self.raw_parameters)
         text = replace_text(self.session, text)
@@ -71,7 +76,7 @@ class DialogChainAction(EventAction):
                 avatar = get_avatar(self.session, self.parameters.avatar)
                 self.open_dialog(text, avatar)
 
-    def update(self):
+    def update(self) -> None:
         # hack to allow unescaped commas in the dialog string
         text = ", ".join(self.raw_parameters)
         if text == "${{end}}":

--- a/tuxemon/event/actions/dialog_chain.py
+++ b/tuxemon/event/actions/dialog_chain.py
@@ -49,7 +49,6 @@ class DialogChainAction(EventAction):
     """
 
     name = "dialog_chain"
-    valid_parameters = [(str, "text"), (str, "avatar")]
     _param_factory = DialogChainActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/dialog_choice.py
+++ b/tuxemon/event/actions/dialog_choice.py
@@ -41,7 +41,7 @@ class DialogChoiceAction(EventAction):
     """
 
     name = "dialog_choice"
-    _param_factory = DialogChoiceActionParameters
+    param_class = DialogChoiceActionParameters
 
     def start(self):
         def set_variable(var_value):

--- a/tuxemon/event/actions/dialog_choice.py
+++ b/tuxemon/event/actions/dialog_choice.py
@@ -24,7 +24,9 @@ from functools import partial
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.locale import replace_text
-from typing import NamedTuple
+from tuxemon.session import Session
+from tuxemon.state import State
+from typing import NamedTuple, final, Tuple, Callable, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +36,8 @@ class DialogChoiceActionParameters(NamedTuple):
     variable: str
 
 
-class DialogChoiceAction(EventAction):
+@final
+class DialogChoiceAction(EventAction[DialogChoiceActionParameters]):
     """Asks the player to make a choice.
 
     Valid Parameters: choice1:choice2, var_key
@@ -43,8 +46,8 @@ class DialogChoiceAction(EventAction):
     name = "dialog_choice"
     param_class = DialogChoiceActionParameters
 
-    def start(self):
-        def set_variable(var_value):
+    def start(self) -> None:
+        def set_variable(var_value: str) -> None:
             player.game_variables[self.parameters.variable] = var_value
             self.session.client.pop_state()
 
@@ -61,10 +64,14 @@ class DialogChoiceAction(EventAction):
 
         self.open_choice_dialog(self.session, var_menu)
 
-    def update(self):
+    def update(self) -> None:
         if self.session.client.get_state_by_name("ChoiceState") is None:
             self.stop()
 
-    def open_choice_dialog(self, session, menu):
+    def open_choice_dialog(
+        self,
+        session: Session,
+        menu: Sequence[Tuple[str, str, Callable[[], None]]],
+    ) -> State:
         logger.info("Opening choice window")
         return session.client.push_state("ChoiceState", menu=menu)

--- a/tuxemon/event/actions/dialog_choice.py
+++ b/tuxemon/event/actions/dialog_choice.py
@@ -41,7 +41,6 @@ class DialogChoiceAction(EventAction):
     """
 
     name = "dialog_choice"
-    valid_parameters = [(str, "choices"), (str, "variable")]
     _param_factory = DialogChoiceActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/dialog_choice.py
+++ b/tuxemon/event/actions/dialog_choice.py
@@ -18,14 +18,20 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-
+from __future__ import annotations
 import logging
 from functools import partial
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.locale import replace_text
+from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
+
+
+class DialogChoiceActionParameters(NamedTuple):
+    choices: str
+    variable: str
 
 
 class DialogChoiceAction(EventAction):
@@ -36,6 +42,7 @@ class DialogChoiceAction(EventAction):
 
     name = "dialog_choice"
     valid_parameters = [(str, "choices"), (str, "variable")]
+    _param_factory = DialogChoiceActionParameters
 
     def start(self):
         def set_variable(var_value):

--- a/tuxemon/event/actions/evolve_monsters.py
+++ b/tuxemon/event/actions/evolve_monsters.py
@@ -22,14 +22,15 @@
 from __future__ import annotations
 from tuxemon import monster
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class EvolveMonstersActionParameters(NamedTuple):
     path: str
 
 
-class EvolveMonstersAction(EventAction):
+@final
+class EvolveMonstersAction(EventAction[EvolveMonstersActionParameters]):
     """Evolves all monsters in the player's party for the specified evolutionary path.
 
     Valid Parameters: path
@@ -38,7 +39,7 @@ class EvolveMonstersAction(EventAction):
     name = "evolve_monsters"
     param_class = EvolveMonstersActionParameters
 
-    def start(self):
+    def start(self) -> None:
         player = self.session.player
         for slot, current_monster in enumerate(player.monsters):
             new_slug = current_monster.get_evolution(self.parameters.path)

--- a/tuxemon/event/actions/evolve_monsters.py
+++ b/tuxemon/event/actions/evolve_monsters.py
@@ -19,8 +19,14 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon import monster
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
+
+
+class EvolveMonstersActionParameters(NamedTuple):
+    path: str
 
 
 class EvolveMonstersAction(EventAction):
@@ -31,6 +37,7 @@ class EvolveMonstersAction(EventAction):
 
     name = "evolve_monsters"
     valid_parameters = [(str, "path")]
+    _param_factory = EvolveMonstersActionParameters
 
     def start(self):
         player = self.session.player

--- a/tuxemon/event/actions/evolve_monsters.py
+++ b/tuxemon/event/actions/evolve_monsters.py
@@ -36,7 +36,7 @@ class EvolveMonstersAction(EventAction):
     """
 
     name = "evolve_monsters"
-    _param_factory = EvolveMonstersActionParameters
+    param_class = EvolveMonstersActionParameters
 
     def start(self):
         player = self.session.player

--- a/tuxemon/event/actions/evolve_monsters.py
+++ b/tuxemon/event/actions/evolve_monsters.py
@@ -36,7 +36,6 @@ class EvolveMonstersAction(EventAction):
     """
 
     name = "evolve_monsters"
-    valid_parameters = [(str, "path")]
     _param_factory = EvolveMonstersActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/fadeout_music.py
+++ b/tuxemon/event/actions/fadeout_music.py
@@ -40,7 +40,6 @@ class FadeoutMusicAction(EventAction):
     """
 
     name = "fadeout_music"
-    valid_parameters = [(int, "duration")]
     _param_factory = FadeoutMusicActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/fadeout_music.py
+++ b/tuxemon/event/actions/fadeout_music.py
@@ -19,12 +19,18 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 import logging
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.platform import mixer
+from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
+
+
+class FadeoutMusicActionParameters(NamedTuple):
+    duration: int
 
 
 class FadeoutMusicAction(EventAction):
@@ -35,6 +41,7 @@ class FadeoutMusicAction(EventAction):
 
     name = "fadeout_music"
     valid_parameters = [(int, "duration")]
+    _param_factory = FadeoutMusicActionParameters
 
     def start(self):
         time = self.parameters.duration

--- a/tuxemon/event/actions/fadeout_music.py
+++ b/tuxemon/event/actions/fadeout_music.py
@@ -40,7 +40,7 @@ class FadeoutMusicAction(EventAction):
     """
 
     name = "fadeout_music"
-    _param_factory = FadeoutMusicActionParameters
+    param_class = FadeoutMusicActionParameters
 
     def start(self):
         time = self.parameters.duration

--- a/tuxemon/event/actions/fadeout_music.py
+++ b/tuxemon/event/actions/fadeout_music.py
@@ -24,7 +24,7 @@ import logging
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.platform import mixer
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 logger = logging.getLogger(__name__)
 
@@ -33,8 +33,10 @@ class FadeoutMusicActionParameters(NamedTuple):
     duration: int
 
 
-class FadeoutMusicAction(EventAction):
-    """Fades out the music over a set amount of time in milliseconds
+@final
+class FadeoutMusicAction(EventAction[FadeoutMusicActionParameters]):
+    """
+    Fades out the music over a set amount of time in milliseconds.
 
     Valid Parameters: time_milliseconds
     """
@@ -42,7 +44,7 @@ class FadeoutMusicAction(EventAction):
     name = "fadeout_music"
     param_class = FadeoutMusicActionParameters
 
-    def start(self):
+    def start(self) -> None:
         time = self.parameters.duration
         mixer.music.fadeout(time)
         if self.session.client.current_music["song"]:

--- a/tuxemon/event/actions/get_player_monster.py
+++ b/tuxemon/event/actions/get_player_monster.py
@@ -22,10 +22,16 @@
 #
 # Adam Chevalier <chevalierAdam2@gmail.com>
 
+from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
 import logging
+from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
+
+
+class GetPlayerMonsterActionParameters(NamedTuple):
+    variable_name: str
 
 
 # noinspection PyAttributeOutsideInit
@@ -38,6 +44,7 @@ class GetPlayerMonsterAction(EventAction):
 
     name = "get_player_monster"
     valid_parameters = [(str, "variable_name")]
+    _param_factory = GetPlayerMonsterActionParameters
 
     def set_var(self, menu_item):
         self.player.game_variables[self.variable] = menu_item.game_object.instance_id.hex

--- a/tuxemon/event/actions/get_player_monster.py
+++ b/tuxemon/event/actions/get_player_monster.py
@@ -25,7 +25,7 @@
 from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
 import logging
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +35,8 @@ class GetPlayerMonsterActionParameters(NamedTuple):
 
 
 # noinspection PyAttributeOutsideInit
-class GetPlayerMonsterAction(EventAction):
+@final
+class GetPlayerMonsterAction(EventAction[GetPlayerMonsterActionParameters]):
     """Sets the given key in the player.game_variables dictionary
     to the instance_id of the monster the player selects via monster menu.
 
@@ -45,11 +46,11 @@ class GetPlayerMonsterAction(EventAction):
     name = "get_player_monster"
     param_class = GetPlayerMonsterActionParameters
 
-    def set_var(self, menu_item):
+    def set_var(self, menu_item) -> None:
         self.player.game_variables[self.variable] = menu_item.game_object.instance_id.hex
         self.session.client.pop_state()
 
-    def start(self):
+    def start(self) -> None:
         self.player = self.session.player
         self.variable = self.parameters.variable_name
 
@@ -57,6 +58,6 @@ class GetPlayerMonsterAction(EventAction):
         menu = self.session.client.push_state("MonsterMenuState")
         menu.on_menu_selection = self.set_var
 
-    def update(self):
+    def update(self) -> None:
         if self.session.client.get_state_by_name("MonsterMenuState") is None:
             self.stop()

--- a/tuxemon/event/actions/get_player_monster.py
+++ b/tuxemon/event/actions/get_player_monster.py
@@ -43,7 +43,7 @@ class GetPlayerMonsterAction(EventAction):
     """
 
     name = "get_player_monster"
-    _param_factory = GetPlayerMonsterActionParameters
+    param_class = GetPlayerMonsterActionParameters
 
     def set_var(self, menu_item):
         self.player.game_variables[self.variable] = menu_item.game_object.instance_id.hex

--- a/tuxemon/event/actions/get_player_monster.py
+++ b/tuxemon/event/actions/get_player_monster.py
@@ -43,7 +43,6 @@ class GetPlayerMonsterAction(EventAction):
     """
 
     name = "get_player_monster"
-    valid_parameters = [(str, "variable_name")]
     _param_factory = GetPlayerMonsterActionParameters
 
     def set_var(self, menu_item):

--- a/tuxemon/event/actions/modify_npc_attribute.py
+++ b/tuxemon/event/actions/modify_npc_attribute.py
@@ -43,7 +43,6 @@ class ModifyNpcAttributeAction(EventAction):
     """
 
     name = "modify_npc_attribute"
-    valid_parameters = [(str, "npc_slug"), (str, "name"), (float, "value")]
     _param_factory = ModifyNpcAttributeActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/modify_npc_attribute.py
+++ b/tuxemon/event/actions/modify_npc_attribute.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 from tuxemon.event import get_npc
 from tuxemon.event.actions.common import CommonAction
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class ModifyNpcAttributeActionParameters(NamedTuple):
@@ -32,7 +32,10 @@ class ModifyNpcAttributeActionParameters(NamedTuple):
     value: float
 
 
-class ModifyNpcAttributeAction(EventAction):
+@final
+class ModifyNpcAttributeAction(
+    EventAction[ModifyNpcAttributeActionParameters],
+):
     """Modifies the given attribute of the npc by modifier. By default
     this is achieved via addition, but prepending a '%' will cause it to be
     multiplied by the attribute.
@@ -45,7 +48,7 @@ class ModifyNpcAttributeAction(EventAction):
     name = "modify_npc_attribute"
     param_class = ModifyNpcAttributeActionParameters
 
-    def start(self):
+    def start(self) -> None:
         npc = get_npc(self.session, self.parameters[0])
         attribute = self.parameters[1]
         modifier = self.parameters[2]

--- a/tuxemon/event/actions/modify_npc_attribute.py
+++ b/tuxemon/event/actions/modify_npc_attribute.py
@@ -43,7 +43,7 @@ class ModifyNpcAttributeAction(EventAction):
     """
 
     name = "modify_npc_attribute"
-    _param_factory = ModifyNpcAttributeActionParameters
+    param_class = ModifyNpcAttributeActionParameters
 
     def start(self):
         npc = get_npc(self.session, self.parameters[0])

--- a/tuxemon/event/actions/modify_npc_attribute.py
+++ b/tuxemon/event/actions/modify_npc_attribute.py
@@ -19,9 +19,17 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon.event import get_npc
 from tuxemon.event.actions.common import CommonAction
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
+
+
+class ModifyNpcAttributeActionParameters(NamedTuple):
+    npc_slug: str
+    name: str
+    value: float
 
 
 class ModifyNpcAttributeAction(EventAction):
@@ -36,6 +44,7 @@ class ModifyNpcAttributeAction(EventAction):
 
     name = "modify_npc_attribute"
     valid_parameters = [(str, "npc_slug"), (str, "name"), (float, "value")]
+    _param_factory = ModifyNpcAttributeActionParameters
 
     def start(self):
         npc = get_npc(self.session, self.parameters[0])

--- a/tuxemon/event/actions/modify_player_attribute.py
+++ b/tuxemon/event/actions/modify_player_attribute.py
@@ -41,7 +41,7 @@ class ModifyPlayerAttributeAction(EventAction):
     """
 
     name = "modify_player_attribute"
-    _param_factory = ModifyPlayerAttributeActionParameters
+    param_class = ModifyPlayerAttributeActionParameters
 
     def start(self):
         attribute = self.parameters[0]

--- a/tuxemon/event/actions/modify_player_attribute.py
+++ b/tuxemon/event/actions/modify_player_attribute.py
@@ -22,7 +22,7 @@
 from __future__ import annotations
 from tuxemon.event.actions.common import CommonAction
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class ModifyPlayerAttributeActionParameters(NamedTuple):
@@ -30,7 +30,10 @@ class ModifyPlayerAttributeActionParameters(NamedTuple):
     value: float
 
 
-class ModifyPlayerAttributeAction(EventAction):
+@final
+class ModifyPlayerAttributeAction(
+    EventAction[ModifyPlayerAttributeActionParameters],
+):
     """Modifies the given attribute of the player character by modifier. By default
     this is achieved via addition, but prepending a '%' will cause it to be
     multiplied by the attribute.
@@ -43,7 +46,7 @@ class ModifyPlayerAttributeAction(EventAction):
     name = "modify_player_attribute"
     param_class = ModifyPlayerAttributeActionParameters
 
-    def start(self):
+    def start(self) -> None:
         attribute = self.parameters[0]
         modifier = self.parameters[1]
         CommonAction.modify_character_attribute(self.session.player, attribute, modifier)

--- a/tuxemon/event/actions/modify_player_attribute.py
+++ b/tuxemon/event/actions/modify_player_attribute.py
@@ -19,8 +19,15 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon.event.actions.common import CommonAction
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
+
+
+class ModifyPlayerAttributeActionParameters(NamedTuple):
+    name: str
+    value: float
 
 
 class ModifyPlayerAttributeAction(EventAction):
@@ -35,6 +42,7 @@ class ModifyPlayerAttributeAction(EventAction):
 
     name = "modify_player_attribute"
     valid_parameters = [(str, "name"), (float, "value")]
+    _param_factory = ModifyPlayerAttributeActionParameters
 
     def start(self):
         attribute = self.parameters[0]

--- a/tuxemon/event/actions/modify_player_attribute.py
+++ b/tuxemon/event/actions/modify_player_attribute.py
@@ -41,7 +41,6 @@ class ModifyPlayerAttributeAction(EventAction):
     """
 
     name = "modify_player_attribute"
-    valid_parameters = [(str, "name"), (float, "value")]
     _param_factory = ModifyPlayerAttributeActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/npc_face.py
+++ b/tuxemon/event/actions/npc_face.py
@@ -19,9 +19,16 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.map import get_direction, dirs2
+from typing import NamedTuple
+
+
+class NpcFaceActionParameters(NamedTuple):
+    npc_slug: str
+    direction: str
 
 
 class NpcFaceAction(EventAction):
@@ -34,6 +41,7 @@ class NpcFaceAction(EventAction):
 
     name = "npc_face"
     valid_parameters = [(str, "npc_slug"), (str, "direction")]
+    _param_factory = NpcFaceActionParameters
 
     def start(self):
         npc = get_npc(self.session, self.parameters.npc_slug)

--- a/tuxemon/event/actions/npc_face.py
+++ b/tuxemon/event/actions/npc_face.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.map import get_direction, dirs2
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class NpcFaceActionParameters(NamedTuple):
@@ -31,7 +31,8 @@ class NpcFaceActionParameters(NamedTuple):
     direction: str
 
 
-class NpcFaceAction(EventAction):
+@final
+class NpcFaceAction(EventAction[NpcFaceActionParameters]):
     """Makes the NPC face a certain direction.
 
     Valid Parameters: npc_slug, direction
@@ -42,7 +43,7 @@ class NpcFaceAction(EventAction):
     name = "npc_face"
     param_class = NpcFaceActionParameters
 
-    def start(self):
+    def start(self) -> None:
         npc = get_npc(self.session, self.parameters.npc_slug)
         direction = self.parameters.direction
         if direction not in dirs2:

--- a/tuxemon/event/actions/npc_face.py
+++ b/tuxemon/event/actions/npc_face.py
@@ -40,7 +40,7 @@ class NpcFaceAction(EventAction):
     """
 
     name = "npc_face"
-    _param_factory = NpcFaceActionParameters
+    param_class = NpcFaceActionParameters
 
     def start(self):
         npc = get_npc(self.session, self.parameters.npc_slug)

--- a/tuxemon/event/actions/npc_face.py
+++ b/tuxemon/event/actions/npc_face.py
@@ -40,7 +40,6 @@ class NpcFaceAction(EventAction):
     """
 
     name = "npc_face"
-    valid_parameters = [(str, "npc_slug"), (str, "direction")]
     _param_factory = NpcFaceActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/npc_move.py
+++ b/tuxemon/event/actions/npc_move.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.map import dirs2
-from typing import NamedTuple
+from typing import NamedTuple, final, Sequence
 
 
 def simple_path(origin, direction, tiles):
@@ -33,7 +33,10 @@ def simple_path(origin, direction, tiles):
         yield tuple(int(i) for i in origin)
 
 
-def parse_path_parameters(origin, move_list):
+def parse_path_parameters(
+    origin,
+    move_list: Sequence[str],
+):
     for move in move_list:
         try:
             direction, tiles = move.strip().split()
@@ -48,7 +51,8 @@ class NpcMoveActionParameters(NamedTuple):
     pass
 
 
-class NpcMoveAction(EventAction):
+@final
+class NpcMoveAction(EventAction[NpcMoveActionParameters]):
     """Relative tile movement for NPC
 
     This action blocks until the destination is reached.
@@ -69,7 +73,7 @@ class NpcMoveAction(EventAction):
 
     # parameter checking not supported due to undefined number of parameters
 
-    def start(self):
+    def start(self) -> None:
         npc_slug = self.raw_parameters[0]
         self.npc = get_npc(self.session, npc_slug)
 
@@ -81,7 +85,7 @@ class NpcMoveAction(EventAction):
         self.npc.path = path
         self.npc.next_waypoint()
 
-    def update(self):
+    def update(self) -> None:
         if self.npc is None:
             self.stop()
             return

--- a/tuxemon/event/actions/npc_move.py
+++ b/tuxemon/event/actions/npc_move.py
@@ -65,7 +65,7 @@ class NpcMoveAction(EventAction):
     """
 
     name = "npc_move"
-    _param_factory = NpcMoveActionParameters
+    param_class = NpcMoveActionParameters
 
     # parameter checking not supported due to undefined number of parameters
 

--- a/tuxemon/event/actions/npc_move.py
+++ b/tuxemon/event/actions/npc_move.py
@@ -19,9 +19,11 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.map import dirs2
+from typing import NamedTuple
 
 
 def simple_path(origin, direction, tiles):
@@ -42,6 +44,10 @@ def parse_path_parameters(origin, move_list):
         origin = point
 
 
+class NpcMoveActionParameters(NamedTuple):
+    pass
+
+
 class NpcMoveAction(EventAction):
     """Relative tile movement for NPC
 
@@ -59,6 +65,7 @@ class NpcMoveAction(EventAction):
     """
 
     name = "npc_move"
+    _param_factory = NpcMoveActionParameters
 
     # parameter checking not supported due to undefined number of parameters
 

--- a/tuxemon/event/actions/npc_run.py
+++ b/tuxemon/event/actions/npc_run.py
@@ -35,9 +35,6 @@ class NpcRun(EventAction):
     """
 
     name = "npc_run"
-    valid_parameters = [
-        (str, "npc_slug"),
-    ]
     _param_factory = NpcRunActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/npc_run.py
+++ b/tuxemon/event/actions/npc_run.py
@@ -18,9 +18,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-
+from __future__ import annotations
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
+
+
+class NpcRunActionParameters(NamedTuple):
+    npc_slug: str
 
 
 class NpcRun(EventAction):
@@ -33,6 +38,7 @@ class NpcRun(EventAction):
     valid_parameters = [
         (str, "npc_slug"),
     ]
+    _param_factory = NpcRunActionParameters
 
     def start(self):
         npc = get_npc(self.session, self.parameters.npc_slug)

--- a/tuxemon/event/actions/npc_run.py
+++ b/tuxemon/event/actions/npc_run.py
@@ -21,14 +21,15 @@
 from __future__ import annotations
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class NpcRunActionParameters(NamedTuple):
     npc_slug: str
 
 
-class NpcRun(EventAction):
+@final
+class NpcRun(EventAction[NpcRunActionParameters]):
     """Sets the NPC movement speed to the global run speed
 
     Valid Parameters: npc_slug
@@ -37,6 +38,6 @@ class NpcRun(EventAction):
     name = "npc_run"
     param_class = NpcRunActionParameters
 
-    def start(self):
+    def start(self) -> None:
         npc = get_npc(self.session, self.parameters.npc_slug)
         npc.moverate = self.session.client.config.player_runrate

--- a/tuxemon/event/actions/npc_run.py
+++ b/tuxemon/event/actions/npc_run.py
@@ -35,7 +35,7 @@ class NpcRun(EventAction):
     """
 
     name = "npc_run"
-    _param_factory = NpcRunActionParameters
+    param_class = NpcRunActionParameters
 
     def start(self):
         npc = get_npc(self.session, self.parameters.npc_slug)

--- a/tuxemon/event/actions/npc_speed.py
+++ b/tuxemon/event/actions/npc_speed.py
@@ -37,10 +37,6 @@ class NpcSpeed(EventAction):
     """
 
     name = "npc_speed"
-    valid_parameters = [
-        (str, "npc_slug"),
-        (float, "speed"),
-    ]
     _param_factory = NpcSpeedActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/npc_speed.py
+++ b/tuxemon/event/actions/npc_speed.py
@@ -37,7 +37,7 @@ class NpcSpeed(EventAction):
     """
 
     name = "npc_speed"
-    _param_factory = NpcSpeedActionParameters
+    param_class = NpcSpeedActionParameters
 
     def start(self):
         npc = get_npc(self.session, self.parameters.npc_slug)

--- a/tuxemon/event/actions/npc_speed.py
+++ b/tuxemon/event/actions/npc_speed.py
@@ -22,7 +22,7 @@
 from __future__ import annotations
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class NpcSpeedActionParameters(NamedTuple):
@@ -30,7 +30,8 @@ class NpcSpeedActionParameters(NamedTuple):
     speed: float
 
 
-class NpcSpeed(EventAction):
+@final
+class NpcSpeed(EventAction[NpcSpeedActionParameters]):
     """Sets the NPC movement speed to a custom value
 
     Valid Parameters: npc_slug
@@ -39,7 +40,7 @@ class NpcSpeed(EventAction):
     name = "npc_speed"
     param_class = NpcSpeedActionParameters
 
-    def start(self):
+    def start(self) -> None:
         npc = get_npc(self.session, self.parameters.npc_slug)
         npc.moverate = self.parameters.speed
         assert 0 < npc.moverate < 20  # just set some sane limit to avoid losing sprites

--- a/tuxemon/event/actions/npc_speed.py
+++ b/tuxemon/event/actions/npc_speed.py
@@ -19,8 +19,15 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
+
+
+class NpcSpeedActionParameters(NamedTuple):
+    npc_slug: str
+    speed: float
 
 
 class NpcSpeed(EventAction):
@@ -34,6 +41,7 @@ class NpcSpeed(EventAction):
         (str, "npc_slug"),
         (float, "speed"),
     ]
+    _param_factory = NpcSpeedActionParameters
 
     def start(self):
         npc = get_npc(self.session, self.parameters.npc_slug)

--- a/tuxemon/event/actions/npc_walk.py
+++ b/tuxemon/event/actions/npc_walk.py
@@ -19,8 +19,14 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
+
+
+class NpcWalkActionParameters(NamedTuple):
+    npc_slug: str
 
 
 class NpcWalk(EventAction):
@@ -33,6 +39,7 @@ class NpcWalk(EventAction):
     valid_parameters = [
         (str, "npc_slug"),
     ]
+    _param_factory = NpcWalkActionParameters
 
     def start(self):
         npc = get_npc(self.session, self.parameters.npc_slug)

--- a/tuxemon/event/actions/npc_walk.py
+++ b/tuxemon/event/actions/npc_walk.py
@@ -36,9 +36,6 @@ class NpcWalk(EventAction):
     """
 
     name = "npc_walk"
-    valid_parameters = [
-        (str, "npc_slug"),
-    ]
     _param_factory = NpcWalkActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/npc_walk.py
+++ b/tuxemon/event/actions/npc_walk.py
@@ -36,7 +36,7 @@ class NpcWalk(EventAction):
     """
 
     name = "npc_walk"
-    _param_factory = NpcWalkActionParameters
+    param_class = NpcWalkActionParameters
 
     def start(self):
         npc = get_npc(self.session, self.parameters.npc_slug)

--- a/tuxemon/event/actions/npc_walk.py
+++ b/tuxemon/event/actions/npc_walk.py
@@ -22,14 +22,15 @@
 from __future__ import annotations
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class NpcWalkActionParameters(NamedTuple):
     npc_slug: str
 
 
-class NpcWalk(EventAction):
+@final
+class NpcWalk(EventAction[NpcWalkActionParameters]):
     """Sets the NPC movement speed to the global walk speed
 
     Valid Parameters: npc_slug
@@ -38,6 +39,6 @@ class NpcWalk(EventAction):
     name = "npc_walk"
     param_class = NpcWalkActionParameters
 
-    def start(self):
+    def start(self) -> None:
         npc = get_npc(self.session, self.parameters.npc_slug)
         npc.moverate = self.session.client.config.player_walkrate

--- a/tuxemon/event/actions/npc_wander.py
+++ b/tuxemon/event/actions/npc_wander.py
@@ -24,7 +24,7 @@ import random
 
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class NpcWanderActionParameters(NamedTuple):
@@ -32,7 +32,8 @@ class NpcWanderActionParameters(NamedTuple):
     frequency: float
 
 
-class NpcWanderAction(EventAction):
+@final
+class NpcWanderAction(EventAction[NpcWanderActionParameters]):
     """Makes an NPC wander around the map
 
     Valid Parameters: npc_slug, frequency
@@ -41,11 +42,11 @@ class NpcWanderAction(EventAction):
     name = "npc_wander"
     param_class = NpcWanderActionParameters
 
-    def start(self):
+    def start(self) -> None:
         npc = get_npc(self.session, self.parameters.npc_slug)
         world = self.session.client.get_state_by_name("WorldState")
 
-        def move():
+        def move() -> None:
             # Don't interrupt existing movement
             if npc.moving or npc.path:
                 return
@@ -63,7 +64,7 @@ class NpcWanderAction(EventAction):
                 npc.path = [random.choice(exits)]
                 npc.next_waypoint()
 
-        def schedule():
+        def schedule() -> None:
             # The timer is randomized between 0.5 and 1.0 of the frequency parameter
             # Frequency can be set to 0 to indicate that we want to stop wandering
             world.remove_animations_of(schedule)

--- a/tuxemon/event/actions/npc_wander.py
+++ b/tuxemon/event/actions/npc_wander.py
@@ -39,7 +39,6 @@ class NpcWanderAction(EventAction):
     """
 
     name = "npc_wander"
-    valid_parameters = [(str, "npc_slug"), (float, "frequency")]
     _param_factory = NpcWanderActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/npc_wander.py
+++ b/tuxemon/event/actions/npc_wander.py
@@ -19,10 +19,17 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 import random
 
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
+
+
+class NpcWanderActionParameters(NamedTuple):
+    npc_slug: str
+    frequency: float
 
 
 class NpcWanderAction(EventAction):
@@ -33,6 +40,7 @@ class NpcWanderAction(EventAction):
 
     name = "npc_wander"
     valid_parameters = [(str, "npc_slug"), (float, "frequency")]
+    _param_factory = NpcWanderActionParameters
 
     def start(self):
         npc = get_npc(self.session, self.parameters.npc_slug)

--- a/tuxemon/event/actions/npc_wander.py
+++ b/tuxemon/event/actions/npc_wander.py
@@ -39,7 +39,7 @@ class NpcWanderAction(EventAction):
     """
 
     name = "npc_wander"
-    _param_factory = NpcWanderActionParameters
+    param_class = NpcWanderActionParameters
 
     def start(self):
         npc = get_npc(self.session, self.parameters.npc_slug)

--- a/tuxemon/event/actions/open_shop.py
+++ b/tuxemon/event/actions/open_shop.py
@@ -31,7 +31,7 @@ class OpenShopActionParameters(NamedTuple):
 
 class OpenShopAction(EventAction):
     name = "open_shop"
-    _param_factory = OpenShopActionParameters
+    param_class = OpenShopActionParameters
 
     def start(self):
         npc = get_npc(self.session, self.parameters.npc_slug)

--- a/tuxemon/event/actions/open_shop.py
+++ b/tuxemon/event/actions/open_shop.py
@@ -19,8 +19,14 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
+
+
+class OpenShopActionParameters(NamedTuple):
+    npc_slug: str
 
 
 class OpenShopAction(EventAction):
@@ -28,6 +34,7 @@ class OpenShopAction(EventAction):
     valid_parameters = [
         (str, "npc_slug"),
     ]
+    _param_factory = OpenShopActionParameters
 
     def start(self):
         npc = get_npc(self.session, self.parameters.npc_slug)

--- a/tuxemon/event/actions/open_shop.py
+++ b/tuxemon/event/actions/open_shop.py
@@ -31,9 +31,6 @@ class OpenShopActionParameters(NamedTuple):
 
 class OpenShopAction(EventAction):
     name = "open_shop"
-    valid_parameters = [
-        (str, "npc_slug"),
-    ]
     _param_factory = OpenShopActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/open_shop.py
+++ b/tuxemon/event/actions/open_shop.py
@@ -22,21 +22,22 @@
 from __future__ import annotations
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class OpenShopActionParameters(NamedTuple):
     npc_slug: str
 
 
-class OpenShopAction(EventAction):
+@final
+class OpenShopAction(EventAction[OpenShopActionParameters]):
     name = "open_shop"
     param_class = OpenShopActionParameters
 
-    def start(self):
+    def start(self) -> None:
         npc = get_npc(self.session, self.parameters.npc_slug)
 
-        def buy_menu():
+        def buy_menu() -> None:
             self.session.client.pop_state()
             self.session.client.push_state(
                 "ShopMenuState",
@@ -44,7 +45,7 @@ class OpenShopAction(EventAction):
                 seller=npc,
             )
 
-        def sell_menu():
+        def sell_menu() -> None:
             self.session.client.pop_state()
             self.session.client.push_state(
                 "ShopMenuState",
@@ -57,4 +58,8 @@ class OpenShopAction(EventAction):
             ("Sell", "Sell", sell_menu),
         ]
 
-        return self.session.client.push_state("ChoiceState", menu=var_menu, escape_key_exits=True)
+        self.session.client.push_state(
+            "ChoiceState",
+            menu=var_menu,
+            escape_key_exits=True,
+        )

--- a/tuxemon/event/actions/pathfind.py
+++ b/tuxemon/event/actions/pathfind.py
@@ -40,7 +40,6 @@ class PathfindAction(EventAction):
     """
 
     name = "pathfind"
-    valid_parameters = [(str, "npc_slug"), (int, "tile_pos_x"), (int, "tile_pos_y")]
     _param_factory = PathfindActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/pathfind.py
+++ b/tuxemon/event/actions/pathfind.py
@@ -22,7 +22,7 @@
 from __future__ import annotations
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class PathfindActionParameters(NamedTuple):
@@ -31,7 +31,8 @@ class PathfindActionParameters(NamedTuple):
     tile_pos_y: int
 
 
-class PathfindAction(EventAction):
+@final
+class PathfindAction(EventAction[PathfindActionParameters]):
     """Pathfind the player / npc to the given location
 
     This action blocks until the destination is reached.
@@ -42,10 +43,10 @@ class PathfindAction(EventAction):
     name = "pathfind"
     param_class = PathfindActionParameters
 
-    def start(self):
+    def start(self) -> None:
         self.npc = get_npc(self.session, self.parameters.npc_slug)
         self.npc.pathfind((self.parameters.tile_pos_x, self.parameters.tile_pos_y))
 
-    def update(self):
+    def update(self) -> None:
         if not self.npc.moving and not self.npc.path:
             self.stop()

--- a/tuxemon/event/actions/pathfind.py
+++ b/tuxemon/event/actions/pathfind.py
@@ -19,8 +19,16 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
+
+
+class PathfindActionParameters(NamedTuple):
+    npc_slug: str
+    tile_pos_x: int
+    tile_pos_y: int
 
 
 class PathfindAction(EventAction):
@@ -33,6 +41,7 @@ class PathfindAction(EventAction):
 
     name = "pathfind"
     valid_parameters = [(str, "npc_slug"), (int, "tile_pos_x"), (int, "tile_pos_y")]
+    _param_factory = PathfindActionParameters
 
     def start(self):
         self.npc = get_npc(self.session, self.parameters.npc_slug)

--- a/tuxemon/event/actions/pathfind.py
+++ b/tuxemon/event/actions/pathfind.py
@@ -40,7 +40,7 @@ class PathfindAction(EventAction):
     """
 
     name = "pathfind"
-    _param_factory = PathfindActionParameters
+    param_class = PathfindActionParameters
 
     def start(self):
         self.npc = get_npc(self.session, self.parameters.npc_slug)

--- a/tuxemon/event/actions/pause_music.py
+++ b/tuxemon/event/actions/pause_music.py
@@ -40,7 +40,6 @@ class PauseMusicAction(EventAction):
     """
 
     name = "pause_music"
-    valid_parameters = []
     _param_factory = PauseMusicActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/pause_music.py
+++ b/tuxemon/event/actions/pause_music.py
@@ -19,12 +19,18 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 import logging
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.platform import mixer
+from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
+
+
+class PauseMusicActionParameters(NamedTuple):
+    pass
 
 
 class PauseMusicAction(EventAction):
@@ -35,6 +41,7 @@ class PauseMusicAction(EventAction):
 
     name = "pause_music"
     valid_parameters = []
+    _param_factory = PauseMusicActionParameters
 
     def start(self):
         mixer.music.pause()

--- a/tuxemon/event/actions/pause_music.py
+++ b/tuxemon/event/actions/pause_music.py
@@ -24,7 +24,7 @@ import logging
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.platform import mixer
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +33,8 @@ class PauseMusicActionParameters(NamedTuple):
     pass
 
 
-class PauseMusicAction(EventAction):
+@final
+class PauseMusicAction(EventAction[PauseMusicActionParameters]):
     """Pauses the current music playback
 
     Valid Parameters: None
@@ -42,7 +43,7 @@ class PauseMusicAction(EventAction):
     name = "pause_music"
     param_class = PauseMusicActionParameters
 
-    def start(self):
+    def start(self) -> None:
         mixer.music.pause()
         if self.session.client.current_music["song"]:
             self.session.client.current_music["status"] = "paused"

--- a/tuxemon/event/actions/pause_music.py
+++ b/tuxemon/event/actions/pause_music.py
@@ -40,7 +40,7 @@ class PauseMusicAction(EventAction):
     """
 
     name = "pause_music"
-    _param_factory = PauseMusicActionParameters
+    param_class = PauseMusicActionParameters
 
     def start(self):
         mixer.music.pause()

--- a/tuxemon/event/actions/play_map_animation.py
+++ b/tuxemon/event/actions/play_map_animation.py
@@ -19,13 +19,23 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 import logging
 
 from tuxemon import prepare
 from tuxemon.event.eventaction import EventAction
 from tuxemon.graphics import load_animation_from_frames
+from typing import NamedTuple, Union
 
 logger = logging.getLogger(__name__)
+
+
+class PlayMapAnimationActionParameters(NamedTuple):
+    animation_name: str
+    duration: float
+    loop: str
+    tile_pos_x: Union[int, str]
+    tile_pos_y: Union[int, None]
 
 
 class PlayMapAnimationAction(EventAction):
@@ -50,6 +60,7 @@ class PlayMapAnimationAction(EventAction):
         ((int, str), "tile_pos_x"),
         ((int, None), "tile_pos_y"),
     ]
+    _param_factory = PlayMapAnimationActionParameters
 
     def start(self):
         # ('play_animation', 'grass,1.5,noloop,player', '1', 6)

--- a/tuxemon/event/actions/play_map_animation.py
+++ b/tuxemon/event/actions/play_map_animation.py
@@ -53,13 +53,6 @@ class PlayMapAnimationAction(EventAction):
     """
 
     name = "play_map_animation"
-    valid_parameters = [
-        (str, "animation_name"),
-        (float, "duration"),
-        (str, "loop"),
-        ((int, str), "tile_pos_x"),
-        ((int, None), "tile_pos_y"),
-    ]
     _param_factory = PlayMapAnimationActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/play_map_animation.py
+++ b/tuxemon/event/actions/play_map_animation.py
@@ -25,7 +25,7 @@ import logging
 from tuxemon import prepare
 from tuxemon.event.eventaction import EventAction
 from tuxemon.graphics import load_animation_from_frames
-from typing import NamedTuple, Union
+from typing import NamedTuple, Union, final
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +38,8 @@ class PlayMapAnimationActionParameters(NamedTuple):
     tile_pos_y: Union[int, None]
 
 
-class PlayMapAnimationAction(EventAction):
+@final
+class PlayMapAnimationAction(EventAction[PlayMapAnimationActionParameters]):
     """Plays a map animation at a given position in the world map.
 
     Valid Parameters: animation_name, duration, loop, tile_pos_x, tile_pos_y
@@ -55,7 +56,7 @@ class PlayMapAnimationAction(EventAction):
     name = "play_map_animation"
     param_class = PlayMapAnimationActionParameters
 
-    def start(self):
+    def start(self) -> None:
         # ('play_animation', 'grass,1.5,noloop,player', '1', 6)
         # "position" can be either a (x, y) tile coordinate or "player"
         animation_name = self.parameters.animation_name

--- a/tuxemon/event/actions/play_map_animation.py
+++ b/tuxemon/event/actions/play_map_animation.py
@@ -53,7 +53,7 @@ class PlayMapAnimationAction(EventAction):
     """
 
     name = "play_map_animation"
-    _param_factory = PlayMapAnimationActionParameters
+    param_class = PlayMapAnimationActionParameters
 
     def start(self):
         # ('play_animation', 'grass,1.5,noloop,player', '1', 6)

--- a/tuxemon/event/actions/play_music.py
+++ b/tuxemon/event/actions/play_music.py
@@ -42,9 +42,6 @@ class PlayMusicAction(EventAction):
     """
 
     name = "play_music"
-    valid_parameters = [
-        (str, "filename"),
-    ]
     _param_factory = PlayMusicActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/play_music.py
+++ b/tuxemon/event/actions/play_music.py
@@ -42,7 +42,7 @@ class PlayMusicAction(EventAction):
     """
 
     name = "play_music"
-    _param_factory = PlayMusicActionParameters
+    param_class = PlayMusicActionParameters
 
     def start(self):
         filename = self.parameters.filename

--- a/tuxemon/event/actions/play_music.py
+++ b/tuxemon/event/actions/play_music.py
@@ -26,7 +26,7 @@ from tuxemon import prepare
 from tuxemon.db import db
 from tuxemon.event.eventaction import EventAction
 from tuxemon.platform import mixer
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +35,8 @@ class PlayMusicActionParameters(NamedTuple):
     filename: str
 
 
-class PlayMusicAction(EventAction):
+@final
+class PlayMusicAction(EventAction[PlayMusicActionParameters]):
     """Plays a music file from "resources/music/"
 
     Valid Parameters: filename
@@ -44,7 +45,7 @@ class PlayMusicAction(EventAction):
     name = "play_music"
     param_class = PlayMusicActionParameters
 
-    def start(self):
+    def start(self) -> None:
         filename = self.parameters.filename
 
         try:

--- a/tuxemon/event/actions/play_music.py
+++ b/tuxemon/event/actions/play_music.py
@@ -19,14 +19,20 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 import logging
 
 from tuxemon import prepare
 from tuxemon.db import db
 from tuxemon.event.eventaction import EventAction
 from tuxemon.platform import mixer
+from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
+
+
+class PlayMusicActionParameters(NamedTuple):
+    filename: str
 
 
 class PlayMusicAction(EventAction):
@@ -39,6 +45,7 @@ class PlayMusicAction(EventAction):
     valid_parameters = [
         (str, "filename"),
     ]
+    _param_factory = PlayMusicActionParameters
 
     def start(self):
         filename = self.parameters.filename

--- a/tuxemon/event/actions/play_sound.py
+++ b/tuxemon/event/actions/play_sound.py
@@ -36,7 +36,7 @@ class PlaySoundAction(EventAction):
     """
 
     name = "play_sound"
-    _param_factory = PlaySoundActionParameters
+    param_class = PlaySoundActionParameters
 
     def start(self):
         filename = self.parameters.filename

--- a/tuxemon/event/actions/play_sound.py
+++ b/tuxemon/event/actions/play_sound.py
@@ -22,14 +22,15 @@
 from __future__ import annotations
 from tuxemon import audio
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class PlaySoundActionParameters(NamedTuple):
     filename: str
 
 
-class PlaySoundAction(EventAction):
+@final
+class PlaySoundAction(EventAction[PlaySoundActionParameters]):
     """Plays a sound from "resources/sounds/"
 
     Valid Parameters: filename
@@ -38,7 +39,7 @@ class PlaySoundAction(EventAction):
     name = "play_sound"
     param_class = PlaySoundActionParameters
 
-    def start(self):
+    def start(self) -> None:
         filename = self.parameters.filename
         sound = audio.load_sound(filename)
         sound.play()

--- a/tuxemon/event/actions/play_sound.py
+++ b/tuxemon/event/actions/play_sound.py
@@ -36,9 +36,6 @@ class PlaySoundAction(EventAction):
     """
 
     name = "play_sound"
-    valid_parameters = [
-        (str, "filename"),
-    ]
     _param_factory = PlaySoundActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/play_sound.py
+++ b/tuxemon/event/actions/play_sound.py
@@ -19,8 +19,14 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon import audio
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
+
+
+class PlaySoundActionParameters(NamedTuple):
+    filename: str
 
 
 class PlaySoundAction(EventAction):
@@ -33,6 +39,7 @@ class PlaySoundAction(EventAction):
     valid_parameters = [
         (str, "filename"),
     ]
+    _param_factory = PlaySoundActionParameters
 
     def start(self):
         filename = self.parameters.filename

--- a/tuxemon/event/actions/player_face.py
+++ b/tuxemon/event/actions/player_face.py
@@ -39,7 +39,7 @@ class PlayerFaceAction(EventAction):
     """
 
     name = "player_face"
-    _param_factory = PlayerFaceActionParameters
+    param_class = PlayerFaceActionParameters
 
     def start(self):
         # Get the parameters to determine what direction the player will face.

--- a/tuxemon/event/actions/player_face.py
+++ b/tuxemon/event/actions/player_face.py
@@ -23,14 +23,15 @@ from __future__ import annotations
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.map import dirs2, get_direction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class PlayerFaceActionParameters(NamedTuple):
     direction: str
 
 
-class PlayerFaceAction(EventAction):
+@final
+class PlayerFaceAction(EventAction[PlayerFaceActionParameters]):
     """Makes the player face a certain direction.
 
     Valid Parameters: direction
@@ -41,7 +42,7 @@ class PlayerFaceAction(EventAction):
     name = "player_face"
     param_class = PlayerFaceActionParameters
 
-    def start(self):
+    def start(self) -> None:
         # Get the parameters to determine what direction the player will face.
         direction = self.parameters.direction
         if direction not in dirs2:

--- a/tuxemon/event/actions/player_face.py
+++ b/tuxemon/event/actions/player_face.py
@@ -39,9 +39,6 @@ class PlayerFaceAction(EventAction):
     """
 
     name = "player_face"
-    valid_parameters = [
-        (str, "direction"),
-    ]
     _param_factory = PlayerFaceActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/player_face.py
+++ b/tuxemon/event/actions/player_face.py
@@ -19,9 +19,15 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.map import dirs2, get_direction
+from typing import NamedTuple
+
+
+class PlayerFaceActionParameters(NamedTuple):
+    direction: str
 
 
 class PlayerFaceAction(EventAction):
@@ -36,6 +42,7 @@ class PlayerFaceAction(EventAction):
     valid_parameters = [
         (str, "direction"),
     ]
+    _param_factory = PlayerFaceActionParameters
 
     def start(self):
         # Get the parameters to determine what direction the player will face.

--- a/tuxemon/event/actions/player_resume.py
+++ b/tuxemon/event/actions/player_resume.py
@@ -19,7 +19,13 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
+
+
+class PlayerResumeActionParameters(NamedTuple):
+    pass
 
 
 class PlayerResumeAction(EventAction):
@@ -30,6 +36,7 @@ class PlayerResumeAction(EventAction):
 
     name = "player_resume"
     valid_parameters = []
+    _param_factory = PlayerResumeActionParameters
 
     def start(self):
         # Get a copy of the world state.

--- a/tuxemon/event/actions/player_resume.py
+++ b/tuxemon/event/actions/player_resume.py
@@ -35,7 +35,7 @@ class PlayerResumeAction(EventAction):
     """
 
     name = "player_resume"
-    _param_factory = PlayerResumeActionParameters
+    param_class = PlayerResumeActionParameters
 
     def start(self):
         # Get a copy of the world state.

--- a/tuxemon/event/actions/player_resume.py
+++ b/tuxemon/event/actions/player_resume.py
@@ -21,14 +21,15 @@
 
 from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class PlayerResumeActionParameters(NamedTuple):
     pass
 
 
-class PlayerResumeAction(EventAction):
+@final
+class PlayerResumeAction(EventAction[PlayerResumeActionParameters]):
     """Makes the player resume movement.
 
     Valid Parameters: None
@@ -37,7 +38,7 @@ class PlayerResumeAction(EventAction):
     name = "player_resume"
     param_class = PlayerResumeActionParameters
 
-    def start(self):
+    def start(self) -> None:
         # Get a copy of the world state.
         world = self.session.client.get_state_by_name("WorldState")
         if not world:

--- a/tuxemon/event/actions/player_resume.py
+++ b/tuxemon/event/actions/player_resume.py
@@ -35,7 +35,6 @@ class PlayerResumeAction(EventAction):
     """
 
     name = "player_resume"
-    valid_parameters = []
     _param_factory = PlayerResumeActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/player_stop.py
+++ b/tuxemon/event/actions/player_stop.py
@@ -35,7 +35,6 @@ class PlayerStopAction(EventAction):
     """
 
     name = "player_stop"
-    valid_parameters = []
     _param_factory = PlayerStopActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/player_stop.py
+++ b/tuxemon/event/actions/player_stop.py
@@ -35,7 +35,7 @@ class PlayerStopAction(EventAction):
     """
 
     name = "player_stop"
-    _param_factory = PlayerStopActionParameters
+    param_class = PlayerStopActionParameters
 
     def start(self):
         # Get a copy of the world state.

--- a/tuxemon/event/actions/player_stop.py
+++ b/tuxemon/event/actions/player_stop.py
@@ -21,14 +21,15 @@
 
 from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class PlayerStopActionParameters(NamedTuple):
     pass
 
 
-class PlayerStopAction(EventAction):
+@final
+class PlayerStopAction(EventAction[PlayerStopActionParameters]):
     """Makes the player stop moving.
 
     Valid Parameters: None
@@ -37,7 +38,7 @@ class PlayerStopAction(EventAction):
     name = "player_stop"
     param_class = PlayerStopActionParameters
 
-    def start(self):
+    def start(self) -> None:
         # Get a copy of the world state.
         world = self.session.client.get_state_by_name("WorldState")
         if not world:

--- a/tuxemon/event/actions/player_stop.py
+++ b/tuxemon/event/actions/player_stop.py
@@ -19,7 +19,13 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
+
+
+class PlayerStopActionParameters(NamedTuple):
+    pass
 
 
 class PlayerStopAction(EventAction):
@@ -30,6 +36,7 @@ class PlayerStopAction(EventAction):
 
     name = "player_stop"
     valid_parameters = []
+    _param_factory = PlayerStopActionParameters
 
     def start(self):
         # Get a copy of the world state.

--- a/tuxemon/event/actions/quit.py
+++ b/tuxemon/event/actions/quit.py
@@ -19,7 +19,13 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
+
+
+class QuitActionParameters(NamedTuple):
+    pass
 
 
 class QuitAction(EventAction):
@@ -27,6 +33,7 @@ class QuitAction(EventAction):
 
     name = "quit"
     valid_parameters = []
+    _param_factory = QuitActionParameters
 
     def start(self):
         # TODO: API

--- a/tuxemon/event/actions/quit.py
+++ b/tuxemon/event/actions/quit.py
@@ -32,7 +32,6 @@ class QuitAction(EventAction):
     """Completely quit the game"""
 
     name = "quit"
-    valid_parameters = []
     _param_factory = QuitActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/quit.py
+++ b/tuxemon/event/actions/quit.py
@@ -21,20 +21,21 @@
 
 from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class QuitActionParameters(NamedTuple):
     pass
 
 
-class QuitAction(EventAction):
+@final
+class QuitAction(EventAction[QuitActionParameters]):
     """Completely quit the game"""
 
     name = "quit"
     param_class = QuitActionParameters
 
-    def start(self):
+    def start(self) -> None:
         # TODO: API
         self.session.client._wants_to_exit = True
         self.session.client.exit = True

--- a/tuxemon/event/actions/quit.py
+++ b/tuxemon/event/actions/quit.py
@@ -32,7 +32,7 @@ class QuitAction(EventAction):
     """Completely quit the game"""
 
     name = "quit"
-    _param_factory = QuitActionParameters
+    param_class = QuitActionParameters
 
     def start(self):
         # TODO: API

--- a/tuxemon/event/actions/random_encounter.py
+++ b/tuxemon/event/actions/random_encounter.py
@@ -50,7 +50,7 @@ class RandomEncounterAction(EventAction):
     """
 
     name = "random_encounter"
-    _param_factory = RandomEncounterActionParameters
+    param_class = RandomEncounterActionParameters
 
     def start(self):
         player = self.session.player

--- a/tuxemon/event/actions/random_encounter.py
+++ b/tuxemon/event/actions/random_encounter.py
@@ -19,6 +19,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 import logging
 import random
 
@@ -27,8 +28,14 @@ from tuxemon.combat import check_battle_legal
 from tuxemon.db import db
 from tuxemon.event.eventaction import EventAction
 from tuxemon.npc import NPC
+from typing import NamedTuple, Union
 
 logger = logging.getLogger(__name__)
+
+
+class RandomEncounterActionParameters(NamedTuple):
+    encounter_slug: str
+    total_prob: Union[float, None]
 
 
 class RandomEncounterAction(EventAction):
@@ -47,6 +54,7 @@ class RandomEncounterAction(EventAction):
         (str, "encounter_slug"),
         ((float, None), "total_prob"),
     ]
+    _param_factory = RandomEncounterActionParameters
 
     def start(self):
         player = self.session.player

--- a/tuxemon/event/actions/random_encounter.py
+++ b/tuxemon/event/actions/random_encounter.py
@@ -28,7 +28,7 @@ from tuxemon.combat import check_battle_legal
 from tuxemon.db import db
 from tuxemon.event.eventaction import EventAction
 from tuxemon.npc import NPC
-from typing import NamedTuple, Union
+from typing import NamedTuple, Union, final
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +38,8 @@ class RandomEncounterActionParameters(NamedTuple):
     total_prob: Union[float, None]
 
 
-class RandomEncounterAction(EventAction):
+@final
+class RandomEncounterAction(EventAction[RandomEncounterActionParameters]):
     """Randomly starts a battle with a monster defined in the "encounter" table in the
     "monster.db" database. The chance that this will start a battle depends on the
     "encounter_rate" specified in the database. The "encounter_rate" number is the chance
@@ -52,7 +53,7 @@ class RandomEncounterAction(EventAction):
     name = "random_encounter"
     param_class = RandomEncounterActionParameters
 
-    def start(self):
+    def start(self) -> None:
         player = self.session.player
 
         # Don't start a battle if we don't even have monsters in our party yet.
@@ -99,7 +100,7 @@ class RandomEncounterAction(EventAction):
             self.stop()
 
 
-def _choose_encounter(encounters, total_prob):
+def _choose_encounter(encounters, total_prob: Union[float, None]):
     total = 0
     roll = random.random() * 100
     if total_prob is not None:

--- a/tuxemon/event/actions/random_encounter.py
+++ b/tuxemon/event/actions/random_encounter.py
@@ -50,10 +50,6 @@ class RandomEncounterAction(EventAction):
     """
 
     name = "random_encounter"
-    valid_parameters = [
-        (str, "encounter_slug"),
-        ((float, None), "total_prob"),
-    ]
     _param_factory = RandomEncounterActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/remove_monster.py
+++ b/tuxemon/event/actions/remove_monster.py
@@ -40,7 +40,7 @@ class RemoveMonsterAction(EventAction):
     """
 
     name = "remove_monster"
-    _param_factory = RemoveMonsterActionParameters
+    param_class = RemoveMonsterActionParameters
 
     def start(self):
         iid = self.session.player.game_variables[self.parameters.instance_id]

--- a/tuxemon/event/actions/remove_monster.py
+++ b/tuxemon/event/actions/remove_monster.py
@@ -40,7 +40,6 @@ class RemoveMonsterAction(EventAction):
     """
 
     name = "remove_monster"
-    valid_parameters = [(str, "instance_id"), ((str, None), "trainer_slug")]
     _param_factory = RemoveMonsterActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/remove_monster.py
+++ b/tuxemon/event/actions/remove_monster.py
@@ -18,10 +18,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import annotations
 import uuid
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.event import get_npc
+from typing import Union, NamedTuple
+
+
+class RemoveMonsterActionParameters(NamedTuple):
+    instance_id: str
+    trainer_slug: Union[str, None]
 
 
 class RemoveMonsterAction(EventAction):
@@ -34,6 +41,7 @@ class RemoveMonsterAction(EventAction):
 
     name = "remove_monster"
     valid_parameters = [(str, "instance_id"), ((str, None), "trainer_slug")]
+    _param_factory = RemoveMonsterActionParameters
 
     def start(self):
         iid = self.session.player.game_variables[self.parameters.instance_id]

--- a/tuxemon/event/actions/remove_monster.py
+++ b/tuxemon/event/actions/remove_monster.py
@@ -23,7 +23,7 @@ import uuid
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.event import get_npc
-from typing import Union, NamedTuple
+from typing import Union, NamedTuple, final
 
 
 class RemoveMonsterActionParameters(NamedTuple):
@@ -31,7 +31,8 @@ class RemoveMonsterActionParameters(NamedTuple):
     trainer_slug: Union[str, None]
 
 
-class RemoveMonsterAction(EventAction):
+@final
+class RemoveMonsterAction(EventAction[RemoveMonsterActionParameters]):
     """Removes a monster from the given trainer's party if the monster is there.
     Monster is determined by instance_id, which must be passed in a game variable.
     If no trainer slug is passed it defaults to the current player.
@@ -42,7 +43,7 @@ class RemoveMonsterAction(EventAction):
     name = "remove_monster"
     param_class = RemoveMonsterActionParameters
 
-    def start(self):
+    def start(self) -> None:
         iid = self.session.player.game_variables[self.parameters.instance_id]
         instance_id = uuid.UUID(iid)
         trainer_slug = self.parameters.trainer

--- a/tuxemon/event/actions/remove_npc.py
+++ b/tuxemon/event/actions/remove_npc.py
@@ -19,7 +19,13 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
+
+
+class RemoveNpcActionParameters(NamedTuple):
+    npc_slug: str
 
 
 class RemoveNpcAction(EventAction):
@@ -30,6 +36,7 @@ class RemoveNpcAction(EventAction):
 
     name = "remove_npc"
     valid_parameters = [(str, "npc_slug")]
+    _param_factory = RemoveNpcActionParameters
 
     def start(self):
         # Get a copy of the world state.

--- a/tuxemon/event/actions/remove_npc.py
+++ b/tuxemon/event/actions/remove_npc.py
@@ -35,7 +35,6 @@ class RemoveNpcAction(EventAction):
     """
 
     name = "remove_npc"
-    valid_parameters = [(str, "npc_slug")]
     _param_factory = RemoveNpcActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/remove_npc.py
+++ b/tuxemon/event/actions/remove_npc.py
@@ -21,14 +21,15 @@
 
 from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class RemoveNpcActionParameters(NamedTuple):
     npc_slug: str
 
 
-class RemoveNpcAction(EventAction):
+@final
+class RemoveNpcAction(EventAction[RemoveNpcActionParameters]):
     """Removes an NPC object from the list of NPCs.
 
     Valid Parameters: slug
@@ -37,7 +38,7 @@ class RemoveNpcAction(EventAction):
     name = "remove_npc"
     param_class = RemoveNpcActionParameters
 
-    def start(self):
+    def start(self) -> None:
         # Get a copy of the world state.
         world = self.session.client.get_state_by_name("WorldState")
         if not world:

--- a/tuxemon/event/actions/remove_npc.py
+++ b/tuxemon/event/actions/remove_npc.py
@@ -35,7 +35,7 @@ class RemoveNpcAction(EventAction):
     """
 
     name = "remove_npc"
-    _param_factory = RemoveNpcActionParameters
+    param_class = RemoveNpcActionParameters
 
     def start(self):
         # Get a copy of the world state.

--- a/tuxemon/event/actions/rename_monster.py
+++ b/tuxemon/event/actions/rename_monster.py
@@ -40,7 +40,6 @@ class RenameMonsterAction(EventAction):
     """
 
     name = "rename_monster"
-    valid_parameters = []
     _param_factory = RenameMonsterActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/rename_monster.py
+++ b/tuxemon/event/actions/rename_monster.py
@@ -40,7 +40,7 @@ class RenameMonsterAction(EventAction):
     """
 
     name = "rename_monster"
-    _param_factory = RenameMonsterActionParameters
+    param_class = RenameMonsterActionParameters
 
     def start(self):
         # Get a copy of the world state.

--- a/tuxemon/event/actions/rename_monster.py
+++ b/tuxemon/event/actions/rename_monster.py
@@ -26,14 +26,15 @@
 from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
 from tuxemon.locale import T
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class RenameMonsterActionParameters(NamedTuple):
     pass
 
 
-class RenameMonsterAction(EventAction):
+@final
+class RenameMonsterAction(EventAction[RenameMonsterActionParameters]):
     """Opens the monster menu and text input screens to rename a selected monster.
 
     Valid Parameters: None
@@ -42,7 +43,7 @@ class RenameMonsterAction(EventAction):
     name = "rename_monster"
     param_class = RenameMonsterActionParameters
 
-    def start(self):
+    def start(self) -> None:
         # Get a copy of the world state.
         world = self.session.client.get_state_by_name("WorldState")
         if world is None:
@@ -52,14 +53,14 @@ class RenameMonsterAction(EventAction):
         menu = self.session.client.push_state("MonsterMenuState")
         menu.on_menu_selection = self.prompt_for_name
 
-    def update(self):
+    def update(self) -> None:
         if (
             self.session.client.get_state_by_name("MonsterMenuState") is None
             and self.session.client.get_state_by_name("InputMenu") is None
         ):
             self.stop()
 
-    def set_monster_name(self, name):
+    def set_monster_name(self, name: str) -> None:
         self.monster.name = name
         self.session.client.get_state_by_name("MonsterMenuState").refresh_menu_items()
 

--- a/tuxemon/event/actions/rename_monster.py
+++ b/tuxemon/event/actions/rename_monster.py
@@ -23,9 +23,14 @@
 # Adam Chevalier <chevalierAdam2@gmail.com>
 #
 
-
+from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
 from tuxemon.locale import T
+from typing import NamedTuple
+
+
+class RenameMonsterActionParameters(NamedTuple):
+    pass
 
 
 class RenameMonsterAction(EventAction):
@@ -36,6 +41,7 @@ class RenameMonsterAction(EventAction):
 
     name = "rename_monster"
     valid_parameters = []
+    _param_factory = RenameMonsterActionParameters
 
     def start(self):
         # Get a copy of the world state.

--- a/tuxemon/event/actions/rename_player.py
+++ b/tuxemon/event/actions/rename_player.py
@@ -40,7 +40,7 @@ class RenamePlayerAction(EventAction):
     """
 
     name = "rename_player"
-    _param_factory = RenamePlayerActionParameters
+    param_class = RenamePlayerActionParameters
 
     def set_player_name(self, name):
         self.session.player.name = name

--- a/tuxemon/event/actions/rename_player.py
+++ b/tuxemon/event/actions/rename_player.py
@@ -26,14 +26,15 @@
 from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
 from tuxemon.locale import T
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class RenamePlayerActionParameters(NamedTuple):
     pass
 
 
-class RenamePlayerAction(EventAction):
+@final
+class RenamePlayerAction(EventAction[RenamePlayerActionParameters]):
     """Opens the text input screen to rename the player.
 
     Valid Parameters: None
@@ -42,10 +43,10 @@ class RenamePlayerAction(EventAction):
     name = "rename_player"
     param_class = RenamePlayerActionParameters
 
-    def set_player_name(self, name):
+    def set_player_name(self, name: str) -> None:
         self.session.player.name = name
 
-    def start(self):
+    def start(self) -> None:
         self.session.client.push_state(
             state_name="InputMenu",
             prompt=T.translate("input_name"),
@@ -54,6 +55,6 @@ class RenamePlayerAction(EventAction):
             initial=self.session.player.name,
         )
 
-    def update(self):
+    def update(self) -> None:
         if self.session.client.get_state_by_name("InputMenu") is None:
             self.stop()

--- a/tuxemon/event/actions/rename_player.py
+++ b/tuxemon/event/actions/rename_player.py
@@ -40,7 +40,6 @@ class RenamePlayerAction(EventAction):
     """
 
     name = "rename_player"
-    valid_parameters = []
     _param_factory = RenamePlayerActionParameters
 
     def set_player_name(self, name):

--- a/tuxemon/event/actions/rename_player.py
+++ b/tuxemon/event/actions/rename_player.py
@@ -23,9 +23,14 @@
 # Adam Chevalier <chevalierAdam2@gmail.com>
 #
 
-
+from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
 from tuxemon.locale import T
+from typing import NamedTuple
+
+
+class RenamePlayerActionParameters(NamedTuple):
+    pass
 
 
 class RenamePlayerAction(EventAction):
@@ -36,6 +41,7 @@ class RenamePlayerAction(EventAction):
 
     name = "rename_player"
     valid_parameters = []
+    _param_factory = RenamePlayerActionParameters
 
     def set_player_name(self, name):
         self.session.player.name = name

--- a/tuxemon/event/actions/rumble.py
+++ b/tuxemon/event/actions/rumble.py
@@ -19,7 +19,14 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
+
+
+class RumbleActionParameters(NamedTuple):
+    duration: float
+    power: int
 
 
 class RumbleAction(EventAction):
@@ -33,6 +40,7 @@ class RumbleAction(EventAction):
 
     name = "rumble"
     valid_parameters = [(float, "duration"), (int, "power")]
+    _param_factory = RumbleActionParameters
 
     def start(self):
         duration = float(self.parameters[0])

--- a/tuxemon/event/actions/rumble.py
+++ b/tuxemon/event/actions/rumble.py
@@ -21,7 +21,7 @@
 
 from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class RumbleActionParameters(NamedTuple):
@@ -29,7 +29,8 @@ class RumbleActionParameters(NamedTuple):
     power: int
 
 
-class RumbleAction(EventAction):
+@final
+class RumbleAction(EventAction[RumbleActionParameters]):
     """Rumbles available controllers with rumble support
 
     Valid Parameters: duration,power
@@ -41,7 +42,7 @@ class RumbleAction(EventAction):
     name = "rumble"
     param_class = RumbleActionParameters
 
-    def start(self):
+    def start(self) -> None:
         duration = float(self.parameters[0])
         power = int(self.parameters[1])
 

--- a/tuxemon/event/actions/rumble.py
+++ b/tuxemon/event/actions/rumble.py
@@ -39,7 +39,6 @@ class RumbleAction(EventAction):
     """
 
     name = "rumble"
-    valid_parameters = [(float, "duration"), (int, "power")]
     _param_factory = RumbleActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/rumble.py
+++ b/tuxemon/event/actions/rumble.py
@@ -39,7 +39,7 @@ class RumbleAction(EventAction):
     """
 
     name = "rumble"
-    _param_factory = RumbleActionParameters
+    param_class = RumbleActionParameters
 
     def start(self):
         duration = float(self.parameters[0])

--- a/tuxemon/event/actions/screen_transition.py
+++ b/tuxemon/event/actions/screen_transition.py
@@ -35,7 +35,7 @@ class ScreenTransitionAction(EventAction):
     """
 
     name = "screen_transition"
-    _param_factory = ScreenTransitionActionParameters
+    param_class = ScreenTransitionActionParameters
 
     def start(self):
         pass

--- a/tuxemon/event/actions/screen_transition.py
+++ b/tuxemon/event/actions/screen_transition.py
@@ -21,14 +21,15 @@
 
 from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class ScreenTransitionActionParameters(NamedTuple):
     transition_time: float
 
 
-class ScreenTransitionAction(EventAction):
+@final
+class ScreenTransitionAction(EventAction[ScreenTransitionActionParameters]):
     """Initiates a screen transition
 
     Valid Parameters: transition_time_in_seconds
@@ -37,10 +38,10 @@ class ScreenTransitionAction(EventAction):
     name = "screen_transition"
     param_class = ScreenTransitionActionParameters
 
-    def start(self):
+    def start(self) -> None:
         pass
 
-    def update(self):
+    def update(self) -> None:
         world = self.session.client.get_state_by_name("WorldState")
 
         if world is not None:

--- a/tuxemon/event/actions/screen_transition.py
+++ b/tuxemon/event/actions/screen_transition.py
@@ -19,7 +19,13 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
+
+
+class ScreenTransitionActionParameters(NamedTuple):
+    transition_time: float
 
 
 class ScreenTransitionAction(EventAction):
@@ -30,6 +36,7 @@ class ScreenTransitionAction(EventAction):
 
     name = "screen_transition"
     valid_parameters = [(float, "transition_time")]
+    _param_factory = ScreenTransitionActionParameters
 
     def start(self):
         pass

--- a/tuxemon/event/actions/screen_transition.py
+++ b/tuxemon/event/actions/screen_transition.py
@@ -35,7 +35,6 @@ class ScreenTransitionAction(EventAction):
     """
 
     name = "screen_transition"
-    valid_parameters = [(float, "transition_time")]
     _param_factory = ScreenTransitionActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/set_inventory.py
+++ b/tuxemon/event/actions/set_inventory.py
@@ -36,10 +36,6 @@ class SetInventoryAction(EventAction):
     """Overwrites the inventory of the npc or player."""
 
     name = "set_inventory"
-    valid_parameters = [
-        (str, "npc_slug"),
-        ((str, None), "inventory_slug"),
-    ]
     _param_factory = SetInventoryActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/set_inventory.py
+++ b/tuxemon/event/actions/set_inventory.py
@@ -24,7 +24,7 @@ from tuxemon.db import db
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.item.item import decode_inventory
-from typing import NamedTuple, Union
+from typing import NamedTuple, Union, final
 
 
 class SetInventoryActionParameters(NamedTuple):
@@ -32,13 +32,14 @@ class SetInventoryActionParameters(NamedTuple):
     inventory_slug: Union[str, None]
 
 
-class SetInventoryAction(EventAction):
+@final
+class SetInventoryAction(EventAction[SetInventoryActionParameters]):
     """Overwrites the inventory of the npc or player."""
 
     name = "set_inventory"
     param_class = SetInventoryActionParameters
 
-    def start(self):
+    def start(self) -> None:
         npc = get_npc(self.session, self.parameters.npc_slug)
         if self.parameters.inventory_slug == "None":
             npc.inventory = {}

--- a/tuxemon/event/actions/set_inventory.py
+++ b/tuxemon/event/actions/set_inventory.py
@@ -19,10 +19,17 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon.db import db
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.item.item import decode_inventory
+from typing import NamedTuple, Union
+
+
+class SetInventoryActionParameters(NamedTuple):
+    npc_slug: str
+    inventory_slug: Union[str, None]
 
 
 class SetInventoryAction(EventAction):
@@ -33,6 +40,7 @@ class SetInventoryAction(EventAction):
         (str, "npc_slug"),
         ((str, None), "inventory_slug"),
     ]
+    _param_factory = SetInventoryActionParameters
 
     def start(self):
         npc = get_npc(self.session, self.parameters.npc_slug)

--- a/tuxemon/event/actions/set_inventory.py
+++ b/tuxemon/event/actions/set_inventory.py
@@ -36,7 +36,7 @@ class SetInventoryAction(EventAction):
     """Overwrites the inventory of the npc or player."""
 
     name = "set_inventory"
-    _param_factory = SetInventoryActionParameters
+    param_class = SetInventoryActionParameters
 
     def start(self):
         npc = get_npc(self.session, self.parameters.npc_slug)

--- a/tuxemon/event/actions/set_monster_flair.py
+++ b/tuxemon/event/actions/set_monster_flair.py
@@ -37,11 +37,6 @@ class SetMonsterFlairAction(EventAction):
     """
 
     name = "set_monster_flair"
-    valid_parameters = [
-        (int, "slot"),
-        (str, "category"),
-        (str, "name"),
-    ]
     _param_factory = SetMonsterFlairActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/set_monster_flair.py
+++ b/tuxemon/event/actions/set_monster_flair.py
@@ -37,7 +37,7 @@ class SetMonsterFlairAction(EventAction):
     """
 
     name = "set_monster_flair"
-    _param_factory = SetMonsterFlairActionParameters
+    param_class = SetMonsterFlairActionParameters
 
     def start(self):
         monster = session.player.monsters[self.parameters.slot]

--- a/tuxemon/event/actions/set_monster_flair.py
+++ b/tuxemon/event/actions/set_monster_flair.py
@@ -19,7 +19,15 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple, Union
+
+
+class SetMonsterFlairActionParameters(NamedTuple):
+    slot: int
+    category: str
+    name: str
 
 
 class SetMonsterFlairAction(EventAction):
@@ -34,6 +42,7 @@ class SetMonsterFlairAction(EventAction):
         (str, "category"),
         (str, "name"),
     ]
+    _param_factory = SetMonsterFlairActionParameters
 
     def start(self):
         monster = session.player.monsters[self.parameters.slot]

--- a/tuxemon/event/actions/set_monster_flair.py
+++ b/tuxemon/event/actions/set_monster_flair.py
@@ -21,7 +21,7 @@
 
 from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple, Union
+from typing import NamedTuple, Union, final
 
 
 class SetMonsterFlairActionParameters(NamedTuple):
@@ -30,7 +30,8 @@ class SetMonsterFlairActionParameters(NamedTuple):
     name: str
 
 
-class SetMonsterFlairAction(EventAction):
+@final
+class SetMonsterFlairAction(EventAction[SetMonsterFlairActionParameters]):
     """Sets a monster's flair to the given value
 
     Valid Parameters: slot, name, value
@@ -39,7 +40,7 @@ class SetMonsterFlairAction(EventAction):
     name = "set_monster_flair"
     param_class = SetMonsterFlairActionParameters
 
-    def start(self):
+    def start(self) -> None:
         monster = session.player.monsters[self.parameters.slot]
         if self.parameters.category in monster.flairs:
             monster.flairs[self.parameters.category] = Flair(self.parameters.category, self.parameters.name)

--- a/tuxemon/event/actions/set_monster_health.py
+++ b/tuxemon/event/actions/set_monster_health.py
@@ -44,7 +44,6 @@ class SetMonsterHealthAction(EventAction):
     """
 
     name = "set_monster_health"
-    valid_parameters = [(int, "slot"), (float, "health")]
     _param_factory = SetMonsterHealthActionParameters
 
     @staticmethod

--- a/tuxemon/event/actions/set_monster_health.py
+++ b/tuxemon/event/actions/set_monster_health.py
@@ -19,11 +19,18 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 import logging
 
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
+
+
+class SetMonsterHealthActionParameters(NamedTuple):
+    slot: int
+    health: float
 
 
 class SetMonsterHealthAction(EventAction):
@@ -38,6 +45,7 @@ class SetMonsterHealthAction(EventAction):
 
     name = "set_monster_health"
     valid_parameters = [(int, "slot"), (float, "health")]
+    _param_factory = SetMonsterHealthActionParameters
 
     @staticmethod
     def set_health(monster, value):

--- a/tuxemon/event/actions/set_monster_health.py
+++ b/tuxemon/event/actions/set_monster_health.py
@@ -44,7 +44,7 @@ class SetMonsterHealthAction(EventAction):
     """
 
     name = "set_monster_health"
-    _param_factory = SetMonsterHealthActionParameters
+    param_class = SetMonsterHealthActionParameters
 
     @staticmethod
     def set_health(monster, value):

--- a/tuxemon/event/actions/set_monster_health.py
+++ b/tuxemon/event/actions/set_monster_health.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import logging
 
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +33,8 @@ class SetMonsterHealthActionParameters(NamedTuple):
     health: float
 
 
-class SetMonsterHealthAction(EventAction):
+@final
+class SetMonsterHealthAction(EventAction[SetMonsterHealthActionParameters]):
     """Changes the hp of a monster in the current player's party. The action parameters
     may contain a monster slot and the amount of health. If no slot is specified,
     all monsters are healed. If no health is specified, the hp is maxed out.
@@ -57,7 +58,7 @@ class SetMonsterHealthAction(EventAction):
 
             monster.current_hp = int(monster.hp * value)
 
-    def start(self):
+    def start(self) -> None:
         if not self.session.player.monsters:
             return
 

--- a/tuxemon/event/actions/set_monster_level.py
+++ b/tuxemon/event/actions/set_monster_level.py
@@ -19,7 +19,14 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
+
+
+class SetMonsterLevelActionParameters(NamedTuple):
+    slot: int
+    level: int
 
 
 class SetMonsterLevelAction(EventAction):
@@ -32,6 +39,7 @@ class SetMonsterLevelAction(EventAction):
 
     name = "set_monster_level"
     valid_parameters = [(int, "slot"), (int, "level")]
+    _param_factory = SetMonsterLevelActionParameters
 
     def start(self):
         if not self.session.player.monsters > 0:

--- a/tuxemon/event/actions/set_monster_level.py
+++ b/tuxemon/event/actions/set_monster_level.py
@@ -38,7 +38,6 @@ class SetMonsterLevelAction(EventAction):
     """
 
     name = "set_monster_level"
-    valid_parameters = [(int, "slot"), (int, "level")]
     _param_factory = SetMonsterLevelActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/set_monster_level.py
+++ b/tuxemon/event/actions/set_monster_level.py
@@ -21,7 +21,7 @@
 
 from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class SetMonsterLevelActionParameters(NamedTuple):
@@ -29,7 +29,8 @@ class SetMonsterLevelActionParameters(NamedTuple):
     level: int
 
 
-class SetMonsterLevelAction(EventAction):
+@final
+class SetMonsterLevelAction(EventAction[SetMonsterLevelActionParameters]):
     """Changes the level of a monster in the current player's party. The action parameters
     may contain a monster slot and the amount by which to level. If no slot is specified,
     all monsters are leveled. If no level is specified, the level is reverted to 1.
@@ -40,7 +41,7 @@ class SetMonsterLevelAction(EventAction):
     name = "set_monster_level"
     param_class = SetMonsterLevelActionParameters
 
-    def start(self):
+    def start(self) -> None:
         if not self.session.player.monsters > 0:
             return
 

--- a/tuxemon/event/actions/set_monster_level.py
+++ b/tuxemon/event/actions/set_monster_level.py
@@ -38,7 +38,7 @@ class SetMonsterLevelAction(EventAction):
     """
 
     name = "set_monster_level"
-    _param_factory = SetMonsterLevelActionParameters
+    param_class = SetMonsterLevelActionParameters
 
     def start(self):
         if not self.session.player.monsters > 0:

--- a/tuxemon/event/actions/set_monster_status.py
+++ b/tuxemon/event/actions/set_monster_status.py
@@ -43,7 +43,7 @@ class SetMonsterStatusAction(EventAction):
     """
 
     name = "set_monster_status"
-    _param_factory = SetMonsterStatusActionParameters
+    param_class = SetMonsterStatusActionParameters
 
     @staticmethod
     def set_status(monster, value):

--- a/tuxemon/event/actions/set_monster_status.py
+++ b/tuxemon/event/actions/set_monster_status.py
@@ -24,7 +24,7 @@ import logging
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.technique import Technique
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +34,8 @@ class SetMonsterStatusActionParameters(NamedTuple):
     status: str
 
 
-class SetMonsterStatusAction(EventAction):
+@final
+class SetMonsterStatusAction(EventAction[SetMonsterStatusActionParameters]):
     """Changes the status of a monster in the current player's party. The action parameters
     may contain a monster slot and the new status to be appended. If no slot is specified,
     all monsters are modified. If no status is specified, the status is cleared.
@@ -55,7 +56,7 @@ class SetMonsterStatusAction(EventAction):
             status = Technique(value)
             monster.apply_status(status)
 
-    def start(self):
+    def start(self) -> None:
         if not self.session.player.monsters:
             return
 

--- a/tuxemon/event/actions/set_monster_status.py
+++ b/tuxemon/event/actions/set_monster_status.py
@@ -43,7 +43,6 @@ class SetMonsterStatusAction(EventAction):
     """
 
     name = "set_monster_status"
-    valid_parameters = [(int, "slot"), (str, "status")]
     _param_factory = SetMonsterStatusActionParameters
 
     @staticmethod

--- a/tuxemon/event/actions/set_monster_status.py
+++ b/tuxemon/event/actions/set_monster_status.py
@@ -19,12 +19,19 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 import logging
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.technique import Technique
+from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
+
+
+class SetMonsterStatusActionParameters(NamedTuple):
+    slot: int
+    status: str
 
 
 class SetMonsterStatusAction(EventAction):
@@ -37,6 +44,7 @@ class SetMonsterStatusAction(EventAction):
 
     name = "set_monster_status"
     valid_parameters = [(int, "slot"), (str, "status")]
+    _param_factory = SetMonsterStatusActionParameters
 
     @staticmethod
     def set_status(monster, value):

--- a/tuxemon/event/actions/set_npc_attribute.py
+++ b/tuxemon/event/actions/set_npc_attribute.py
@@ -19,9 +19,17 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon.event import get_npc
 from tuxemon.event.actions.common import CommonAction
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
+
+
+class SetNpcAttributeActionParameters(NamedTuple):
+    npc_slug: str
+    name: str
+    value: str
 
 
 class SetNpcAttributeAction(EventAction):
@@ -32,6 +40,7 @@ class SetNpcAttributeAction(EventAction):
 
     name = "set_npc_attribute"
     valid_parameters = [(str, "npc_slug"), (str, "name"), (str, "value")]
+    _param_factory = SetNpcAttributeActionParameters
 
     def start(self):
         npc = get_npc(self.session, self.parameters[0])

--- a/tuxemon/event/actions/set_npc_attribute.py
+++ b/tuxemon/event/actions/set_npc_attribute.py
@@ -39,7 +39,6 @@ class SetNpcAttributeAction(EventAction):
     """
 
     name = "set_npc_attribute"
-    valid_parameters = [(str, "npc_slug"), (str, "name"), (str, "value")]
     _param_factory = SetNpcAttributeActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/set_npc_attribute.py
+++ b/tuxemon/event/actions/set_npc_attribute.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 from tuxemon.event import get_npc
 from tuxemon.event.actions.common import CommonAction
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class SetNpcAttributeActionParameters(NamedTuple):
@@ -32,7 +32,8 @@ class SetNpcAttributeActionParameters(NamedTuple):
     value: str
 
 
-class SetNpcAttributeAction(EventAction):
+@final
+class SetNpcAttributeAction(EventAction[SetNpcAttributeActionParameters]):
     """Sets the given attribute of the npc to the given value.
 
     Valid Parameters: slug, attribute, value
@@ -41,7 +42,7 @@ class SetNpcAttributeAction(EventAction):
     name = "set_npc_attribute"
     param_class = SetNpcAttributeActionParameters
 
-    def start(self):
+    def start(self) -> None:
         npc = get_npc(self.session, self.parameters[0])
         attribute = self.parameters[1]
         value = self.parameters[2]

--- a/tuxemon/event/actions/set_npc_attribute.py
+++ b/tuxemon/event/actions/set_npc_attribute.py
@@ -39,7 +39,7 @@ class SetNpcAttributeAction(EventAction):
     """
 
     name = "set_npc_attribute"
-    _param_factory = SetNpcAttributeActionParameters
+    param_class = SetNpcAttributeActionParameters
 
     def start(self):
         npc = get_npc(self.session, self.parameters[0])

--- a/tuxemon/event/actions/set_player_attribute.py
+++ b/tuxemon/event/actions/set_player_attribute.py
@@ -38,7 +38,6 @@ class SetPlayerAttributeAction(EventAction):
     """
 
     name = "set_player_attribute"
-    valid_parameters = [(str, "npc_slug"), (str, "name"), (str, "value")]
     _param_factory = SetPlayerAttributeActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/set_player_attribute.py
+++ b/tuxemon/event/actions/set_player_attribute.py
@@ -38,7 +38,7 @@ class SetPlayerAttributeAction(EventAction):
     """
 
     name = "set_player_attribute"
-    _param_factory = SetPlayerAttributeActionParameters
+    param_class = SetPlayerAttributeActionParameters
 
     def start(self):
         attribute = self.parameters[0]

--- a/tuxemon/event/actions/set_player_attribute.py
+++ b/tuxemon/event/actions/set_player_attribute.py
@@ -22,7 +22,7 @@
 from __future__ import annotations
 from tuxemon.event.actions.common import CommonAction
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class SetPlayerAttributeActionParameters(NamedTuple):
@@ -31,7 +31,8 @@ class SetPlayerAttributeActionParameters(NamedTuple):
     value: str
 
 
-class SetPlayerAttributeAction(EventAction):
+@final
+class SetPlayerAttributeAction(EventAction[SetPlayerAttributeActionParameters]):
     """Sets the given attribute of the player character to the given value.
 
     Valid Parameters: attribute, value
@@ -40,7 +41,7 @@ class SetPlayerAttributeAction(EventAction):
     name = "set_player_attribute"
     param_class = SetPlayerAttributeActionParameters
 
-    def start(self):
+    def start(self) -> None:
         attribute = self.parameters[0]
         value = self.parameters[1]
         CommonAction.set_character_attribute(self.session.player, attribute, value)

--- a/tuxemon/event/actions/set_player_attribute.py
+++ b/tuxemon/event/actions/set_player_attribute.py
@@ -19,8 +19,16 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon.event.actions.common import CommonAction
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
+
+
+class SetPlayerAttributeActionParameters(NamedTuple):
+    npc_slug: str
+    name: str
+    value: str
 
 
 class SetPlayerAttributeAction(EventAction):
@@ -31,6 +39,7 @@ class SetPlayerAttributeAction(EventAction):
 
     name = "set_player_attribute"
     valid_parameters = [(str, "npc_slug"), (str, "name"), (str, "value")]
+    _param_factory = SetPlayerAttributeActionParameters
 
     def start(self):
         attribute = self.parameters[0]

--- a/tuxemon/event/actions/set_variable.py
+++ b/tuxemon/event/actions/set_variable.py
@@ -35,7 +35,7 @@ class SetVariableAction(EventAction):
     """
 
     name = "set_variable"
-    _param_factory = SetVariableActionParameters
+    param_class = SetVariableActionParameters
 
     def start(self):
         player = self.session.player

--- a/tuxemon/event/actions/set_variable.py
+++ b/tuxemon/event/actions/set_variable.py
@@ -19,7 +19,13 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
+
+
+class SetVariableActionParameters(NamedTuple):
+    var_list: str
 
 
 class SetVariableAction(EventAction):
@@ -30,6 +36,7 @@ class SetVariableAction(EventAction):
 
     name = "set_variable"
     valid_parameters = [(str, "var_list")]
+    _param_factory = SetVariableActionParameters
 
     def start(self):
         player = self.session.player

--- a/tuxemon/event/actions/set_variable.py
+++ b/tuxemon/event/actions/set_variable.py
@@ -35,7 +35,6 @@ class SetVariableAction(EventAction):
     """
 
     name = "set_variable"
-    valid_parameters = [(str, "var_list")]
     _param_factory = SetVariableActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/set_variable.py
+++ b/tuxemon/event/actions/set_variable.py
@@ -21,14 +21,15 @@
 
 from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class SetVariableActionParameters(NamedTuple):
     var_list: str
 
 
-class SetVariableAction(EventAction):
+@final
+class SetVariableAction(EventAction[SetVariableActionParameters]):
     """Sets the key in the player.game_variables dictionary.
 
     Valid Parameters: variable_name:value
@@ -37,7 +38,7 @@ class SetVariableAction(EventAction):
     name = "set_variable"
     param_class = SetVariableActionParameters
 
-    def start(self):
+    def start(self) -> None:
         player = self.session.player
 
         # Split the variable into a key: value pair

--- a/tuxemon/event/actions/spawn_monster.py
+++ b/tuxemon/event/actions/spawn_monster.py
@@ -53,7 +53,6 @@ class SpawnMonsterAction(EventAction):
     """
 
     name = "spawn_monster"
-    valid_parameters = [(str, "npc_slug"), (str, "breeding_mother"), (str, "breeding_father")]
     _param_factory = SpawnMonsterActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/spawn_monster.py
+++ b/tuxemon/event/actions/spawn_monster.py
@@ -53,7 +53,7 @@ class SpawnMonsterAction(EventAction):
     """
 
     name = "spawn_monster"
-    _param_factory = SpawnMonsterActionParameters
+    param_class = SpawnMonsterActionParameters
 
     def start(self):
         npc_slug, breeding_mother, breeding_father = self.parameters

--- a/tuxemon/event/actions/spawn_monster.py
+++ b/tuxemon/event/actions/spawn_monster.py
@@ -29,7 +29,7 @@ from tuxemon.event.eventaction import EventAction
 from tuxemon.tools import open_dialog
 from tuxemon.graphics import get_avatar
 import logging
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +41,8 @@ class SpawnMonsterActionParameters(NamedTuple):
 
 
 # noinspection PyAttributeOutsideInit
-class SpawnMonsterAction(EventAction):
+@final
+class SpawnMonsterAction(EventAction[SpawnMonsterActionParameters]):
     """Adds a new monster, created by breeding the two
     given mons (identified by instance_id, stored in a
     variable) and adds it to the given character's party
@@ -55,7 +56,7 @@ class SpawnMonsterAction(EventAction):
     name = "spawn_monster"
     param_class = SpawnMonsterActionParameters
 
-    def start(self):
+    def start(self) -> None:
         npc_slug, breeding_mother, breeding_father = self.parameters
         world = self.session.client.get_state_by_name("WorldState")
         if not world:
@@ -102,7 +103,7 @@ class SpawnMonsterAction(EventAction):
             avatar,
         )
 
-    def update(self):
+    def update(self) -> None:
         if self.session.client.get_state_by_name("DialogState") is None:
             self.stop()
 

--- a/tuxemon/event/actions/spawn_monster.py
+++ b/tuxemon/event/actions/spawn_monster.py
@@ -21,6 +21,7 @@
 # Contributor(s):
 #
 # Adam Chevalier <chevalierAdam2@gmail.com>
+from __future__ import annotations
 import uuid
 
 from tuxemon.locale import process_translate_text
@@ -28,8 +29,15 @@ from tuxemon.event.eventaction import EventAction
 from tuxemon.tools import open_dialog
 from tuxemon.graphics import get_avatar
 import logging
+from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
+
+
+class SpawnMonsterActionParameters(NamedTuple):
+    npc_slug: str
+    breeding_mother: str
+    breeding_father: str
 
 
 # noinspection PyAttributeOutsideInit
@@ -46,6 +54,7 @@ class SpawnMonsterAction(EventAction):
 
     name = "spawn_monster"
     valid_parameters = [(str, "npc_slug"), (str, "breeding_mother"), (str, "breeding_father")]
+    _param_factory = SpawnMonsterActionParameters
 
     def start(self):
         npc_slug, breeding_mother, breeding_father = self.parameters

--- a/tuxemon/event/actions/start_battle.py
+++ b/tuxemon/event/actions/start_battle.py
@@ -19,13 +19,19 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 import logging
 
 from tuxemon.combat import check_battle_legal
 from tuxemon.db import db
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
+
+
+class StartBattleActionParameters(NamedTuple):
+    npc_slug: str
 
 
 class StartBattleAction(EventAction):
@@ -37,6 +43,7 @@ class StartBattleAction(EventAction):
 
     name = "start_battle"
     valid_parameters = [(str, "npc_slug")]
+    _param_factory = StartBattleActionParameters
 
     def start(self):
         player = self.session.player

--- a/tuxemon/event/actions/start_battle.py
+++ b/tuxemon/event/actions/start_battle.py
@@ -25,7 +25,7 @@ import logging
 from tuxemon.combat import check_battle_legal
 from tuxemon.db import db
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +34,8 @@ class StartBattleActionParameters(NamedTuple):
     npc_slug: str
 
 
-class StartBattleAction(EventAction):
+@final
+class StartBattleAction(EventAction[StartBattleActionParameters]):
     """Start a battle and switch to the combat module. The parameters must
     contain an NPC slug in the NPC database.
 
@@ -44,7 +45,7 @@ class StartBattleAction(EventAction):
     name = "start_battle"
     param_class = StartBattleActionParameters
 
-    def start(self):
+    def start(self) -> None:
         player = self.session.player
 
         # Don't start a battle if we don't even have monsters in our party yet.
@@ -76,6 +77,6 @@ class StartBattleAction(EventAction):
         filename = env["battle_music"]
         self.session.client.event_engine.execute_action("play_music", [filename])
 
-    def update(self):
+    def update(self) -> None:
         if self.session.client.get_state_by_name("CombatState") is None:
             self.stop()

--- a/tuxemon/event/actions/start_battle.py
+++ b/tuxemon/event/actions/start_battle.py
@@ -42,7 +42,6 @@ class StartBattleAction(EventAction):
     """
 
     name = "start_battle"
-    valid_parameters = [(str, "npc_slug")]
     _param_factory = StartBattleActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/start_battle.py
+++ b/tuxemon/event/actions/start_battle.py
@@ -42,7 +42,7 @@ class StartBattleAction(EventAction):
     """
 
     name = "start_battle"
-    _param_factory = StartBattleActionParameters
+    param_class = StartBattleActionParameters
 
     def start(self):
         player = self.session.player

--- a/tuxemon/event/actions/start_cinema_mode.py
+++ b/tuxemon/event/actions/start_cinema_mode.py
@@ -32,7 +32,6 @@ class StartCinemaModeAction(EventAction):
     """Starts cinema mode by animating moving black bars to narrow the aspect ratio."""
 
     name = "start_cinema_mode"
-    valid_parameters = []
     _param_factory = StartCinemaModeActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/start_cinema_mode.py
+++ b/tuxemon/event/actions/start_cinema_mode.py
@@ -21,20 +21,21 @@
 
 from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class StartCinemaModeActionParameters(NamedTuple):
     pass
 
 
-class StartCinemaModeAction(EventAction):
+@final
+class StartCinemaModeAction(EventAction[StartCinemaModeActionParameters]):
     """Starts cinema mode by animating moving black bars to narrow the aspect ratio."""
 
     name = "start_cinema_mode"
     param_class = StartCinemaModeActionParameters
 
-    def start(self):
+    def start(self) -> None:
         world = self.session.client.current_state
 
         if world.cinema_state == "off":

--- a/tuxemon/event/actions/start_cinema_mode.py
+++ b/tuxemon/event/actions/start_cinema_mode.py
@@ -19,7 +19,13 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
+
+
+class StartCinemaModeActionParameters(NamedTuple):
+    pass
 
 
 class StartCinemaModeAction(EventAction):
@@ -27,6 +33,7 @@ class StartCinemaModeAction(EventAction):
 
     name = "start_cinema_mode"
     valid_parameters = []
+    _param_factory = StartCinemaModeActionParameters
 
     def start(self):
         world = self.session.client.current_state

--- a/tuxemon/event/actions/start_cinema_mode.py
+++ b/tuxemon/event/actions/start_cinema_mode.py
@@ -32,7 +32,7 @@ class StartCinemaModeAction(EventAction):
     """Starts cinema mode by animating moving black bars to narrow the aspect ratio."""
 
     name = "start_cinema_mode"
-    _param_factory = StartCinemaModeActionParameters
+    param_class = StartCinemaModeActionParameters
 
     def start(self):
         world = self.session.client.current_state

--- a/tuxemon/event/actions/stop_cinema_mode.py
+++ b/tuxemon/event/actions/stop_cinema_mode.py
@@ -36,7 +36,7 @@ class StopCinemaModeAction(EventAction):
     """Stops cinema mode by animating moving black bars to back to the normal aspect ratio."""
 
     name = "stop_cinema_mode"
-    _param_factory = StopCinemaModeActionParameters
+    param_class = StopCinemaModeActionParameters
 
     def start(self):
         world = self.session.client.current_state

--- a/tuxemon/event/actions/stop_cinema_mode.py
+++ b/tuxemon/event/actions/stop_cinema_mode.py
@@ -36,7 +36,6 @@ class StopCinemaModeAction(EventAction):
     """Stops cinema mode by animating moving black bars to back to the normal aspect ratio."""
 
     name = "stop_cinema_mode"
-    valid_parameters = []
     _param_factory = StopCinemaModeActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/stop_cinema_mode.py
+++ b/tuxemon/event/actions/stop_cinema_mode.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import logging
 
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 logger = logging.getLogger(__name__)
 
@@ -32,13 +32,14 @@ class StopCinemaModeActionParameters(NamedTuple):
     pass
 
 
-class StopCinemaModeAction(EventAction):
+@final
+class StopCinemaModeAction(EventAction[StopCinemaModeActionParameters]):
     """Stops cinema mode by animating moving black bars to back to the normal aspect ratio."""
 
     name = "stop_cinema_mode"
     param_class = StopCinemaModeActionParameters
 
-    def start(self):
+    def start(self) -> None:
         world = self.session.client.current_state
         if world.cinema_state == "on":
             logger.info("Turning off cinema mode")

--- a/tuxemon/event/actions/stop_cinema_mode.py
+++ b/tuxemon/event/actions/stop_cinema_mode.py
@@ -19,11 +19,17 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 import logging
 
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
+
+
+class StopCinemaModeActionParameters(NamedTuple):
+    pass
 
 
 class StopCinemaModeAction(EventAction):
@@ -31,6 +37,7 @@ class StopCinemaModeAction(EventAction):
 
     name = "stop_cinema_mode"
     valid_parameters = []
+    _param_factory = StopCinemaModeActionParameters
 
     def start(self):
         world = self.session.client.current_state

--- a/tuxemon/event/actions/store_monster.py
+++ b/tuxemon/event/actions/store_monster.py
@@ -45,7 +45,6 @@ class StoreMonsterAction(EventAction):
     """
 
     name = "store_monster"
-    valid_parameters = [(str, "monster_id"), (str, "box")]
     _param_factory = StoreMonsterActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/store_monster.py
+++ b/tuxemon/event/actions/store_monster.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
 import logging
 import uuid
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +37,8 @@ class StoreMonsterActionParameters(NamedTuple):
 
 
 # noinspection PyAttributeOutsideInit
-class StoreMonsterAction(EventAction):
+@final
+class StoreMonsterAction(EventAction[StoreMonsterActionParameters]):
     """Save the player's monster with the given instance_id to
     the named storage box, removing it from the player party.
 
@@ -47,7 +48,7 @@ class StoreMonsterAction(EventAction):
     name = "store_monster"
     param_class = StoreMonsterActionParameters
 
-    def start(self):
+    def start(self) -> None:
         player = self.session.player
         instance_id = uuid.UUID(player.game_variables[self.parameters.monster_id])
         box = self.parameters.box

--- a/tuxemon/event/actions/store_monster.py
+++ b/tuxemon/event/actions/store_monster.py
@@ -45,7 +45,7 @@ class StoreMonsterAction(EventAction):
     """
 
     name = "store_monster"
-    _param_factory = StoreMonsterActionParameters
+    param_class = StoreMonsterActionParameters
 
     def start(self):
         player = self.session.player

--- a/tuxemon/event/actions/store_monster.py
+++ b/tuxemon/event/actions/store_monster.py
@@ -22,11 +22,18 @@
 #
 # Adam Chevalier <chevalierAdam2@gmail.com>
 
+from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
 import logging
 import uuid
+from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
+
+
+class StoreMonsterActionParameters(NamedTuple):
+    monster_id: str
+    box: str
 
 
 # noinspection PyAttributeOutsideInit
@@ -39,6 +46,7 @@ class StoreMonsterAction(EventAction):
 
     name = "store_monster"
     valid_parameters = [(str, "monster_id"), (str, "box")]
+    _param_factory = StoreMonsterActionParameters
 
     def start(self):
         player = self.session.player

--- a/tuxemon/event/actions/teleport.py
+++ b/tuxemon/event/actions/teleport.py
@@ -38,7 +38,7 @@ class TeleportAction(EventAction):
     """
 
     name = "teleport"
-    _param_factory = TeleportActionParameters
+    param_class = TeleportActionParameters
 
     def start(self):
         player = self.session.player

--- a/tuxemon/event/actions/teleport.py
+++ b/tuxemon/event/actions/teleport.py
@@ -38,7 +38,6 @@ class TeleportAction(EventAction):
     """
 
     name = "teleport"
-    valid_parameters = [(str, "map_name"), (int, "x"), (int, "y")]
     _param_factory = TeleportActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/teleport.py
+++ b/tuxemon/event/actions/teleport.py
@@ -22,7 +22,7 @@
 from __future__ import annotations
 from tuxemon import prepare
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class TeleportActionParameters(NamedTuple):
@@ -31,7 +31,8 @@ class TeleportActionParameters(NamedTuple):
     y: int
 
 
-class TeleportAction(EventAction):
+@final
+class TeleportAction(EventAction[TeleportActionParameters]):
     """Teleport the player to a particular map and tile coordinates
 
     Valid Parameters: map_name, coordinate_x, coordinate_y
@@ -40,7 +41,7 @@ class TeleportAction(EventAction):
     name = "teleport"
     param_class = TeleportActionParameters
 
-    def start(self):
+    def start(self) -> None:
         player = self.session.player
         world = self.session.client.get_state_by_name("WorldState")
         map_name = self.parameters.map_name

--- a/tuxemon/event/actions/teleport.py
+++ b/tuxemon/event/actions/teleport.py
@@ -19,8 +19,16 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon import prepare
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
+
+
+class TeleportActionParameters(NamedTuple):
+    map_name: str
+    x: int
+    y: int
 
 
 class TeleportAction(EventAction):
@@ -31,6 +39,7 @@ class TeleportAction(EventAction):
 
     name = "teleport"
     valid_parameters = [(str, "map_name"), (int, "x"), (int, "y")]
+    _param_factory = TeleportActionParameters
 
     def start(self):
         player = self.session.player

--- a/tuxemon/event/actions/teleport_faint.py
+++ b/tuxemon/event/actions/teleport_faint.py
@@ -21,18 +21,19 @@
 
 from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class TeleportFaintActionParameters(NamedTuple):
     pass
 
 
-class TeleportFaintAction(EventAction):
+@final
+class TeleportFaintAction(EventAction[TeleportFaintActionParameters]):
     name = "teleport_faint"
     param_class = TeleportFaintActionParameters
 
-    def start(self):
+    def start(self) -> None:
         player = self.session.player
 
         # Start with the default value, override if game variable exists

--- a/tuxemon/event/actions/teleport_faint.py
+++ b/tuxemon/event/actions/teleport_faint.py
@@ -19,11 +19,18 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
+
+
+class TeleportFaintActionParameters(NamedTuple):
+    pass
 
 
 class TeleportFaintAction(EventAction):
     name = "teleport_faint"
+    _param_factory = TeleportFaintActionParameters
 
     def start(self):
         player = self.session.player

--- a/tuxemon/event/actions/teleport_faint.py
+++ b/tuxemon/event/actions/teleport_faint.py
@@ -30,7 +30,7 @@ class TeleportFaintActionParameters(NamedTuple):
 
 class TeleportFaintAction(EventAction):
     name = "teleport_faint"
-    _param_factory = TeleportFaintActionParameters
+    param_class = TeleportFaintActionParameters
 
     def start(self):
         player = self.session.player

--- a/tuxemon/event/actions/transition_teleport.py
+++ b/tuxemon/event/actions/transition_teleport.py
@@ -21,7 +21,7 @@
 
 from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class TransitionTeleportActionParameters(NamedTuple):
@@ -31,7 +31,8 @@ class TransitionTeleportActionParameters(NamedTuple):
     transition_time: float
 
 
-class TransitionTeleportAction(EventAction):
+@final
+class TransitionTeleportAction(EventAction[TransitionTeleportActionParameters]):
     """Combines the "teleport" and "screen_transition" actions to perform a teleport with a
     screen transition. Useful for allowing the player to go to different maps.
 
@@ -41,13 +42,13 @@ class TransitionTeleportAction(EventAction):
     name = "transition_teleport"
     param_class = TransitionTeleportActionParameters
 
-    def start(self):
+    def start(self) -> None:
         # Start the screen transition
         params = [self.parameters.transition_time]
         self.transition = self.session.client.event_engine.get_action("screen_transition", params)
         self.transition.start()
 
-    def update(self):
+    def update(self) -> None:
         if not self.transition.done:
             self.transition.update()
         if self.transition.done:

--- a/tuxemon/event/actions/transition_teleport.py
+++ b/tuxemon/event/actions/transition_teleport.py
@@ -39,12 +39,6 @@ class TransitionTeleportAction(EventAction):
     """
 
     name = "transition_teleport"
-    valid_parameters = [
-        (str, "map_name"),
-        (int, "x"),
-        (int, "y"),
-        (float, "transition_time"),
-    ]
     _param_factory = TransitionTeleportActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/transition_teleport.py
+++ b/tuxemon/event/actions/transition_teleport.py
@@ -19,7 +19,16 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
+
+
+class TransitionTeleportActionParameters(NamedTuple):
+    map_name: str
+    x: int
+    y: int
+    transition_time: float
 
 
 class TransitionTeleportAction(EventAction):
@@ -36,6 +45,7 @@ class TransitionTeleportAction(EventAction):
         (int, "y"),
         (float, "transition_time"),
     ]
+    _param_factory = TransitionTeleportActionParameters
 
     def start(self):
         # Start the screen transition

--- a/tuxemon/event/actions/transition_teleport.py
+++ b/tuxemon/event/actions/transition_teleport.py
@@ -39,7 +39,7 @@ class TransitionTeleportAction(EventAction):
     """
 
     name = "transition_teleport"
-    _param_factory = TransitionTeleportActionParameters
+    param_class = TransitionTeleportActionParameters
 
     def start(self):
         # Start the screen transition

--- a/tuxemon/event/actions/translated_dialog.py
+++ b/tuxemon/event/actions/translated_dialog.py
@@ -26,7 +26,7 @@ from tuxemon.locale import process_translate_text
 from tuxemon.event.eventaction import EventAction
 from tuxemon.tools import open_dialog
 from tuxemon.graphics import get_avatar
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +35,8 @@ class TranslatedDialogActionParameters(NamedTuple):
     pass
 
 
-class TranslatedDialogAction(EventAction):
+@final
+class TranslatedDialogAction(EventAction[TranslatedDialogActionParameters]):
     """Opens a dialog window with translated text according to the passed translation key. Parameters
     passed to the translation string will also be checked if a translation key exists.
 
@@ -54,7 +55,7 @@ class TranslatedDialogAction(EventAction):
     name = "translated_dialog"
     param_class = TranslatedDialogActionParameters
 
-    def start(self):
+    def start(self) -> None:
         key = self.raw_parameters[0]
         replace = []
         avatar = None
@@ -73,7 +74,7 @@ class TranslatedDialogAction(EventAction):
             avatar,
         )
 
-    def update(self):
+    def update(self) -> None:
         if self.session.client.get_state_by_name("DialogState") is None:
             self.stop()
 

--- a/tuxemon/event/actions/translated_dialog.py
+++ b/tuxemon/event/actions/translated_dialog.py
@@ -52,7 +52,7 @@ class TranslatedDialogAction(EventAction):
     """
 
     name = "translated_dialog"
-    _param_factory = TranslatedDialogActionParameters
+    param_class = TranslatedDialogActionParameters
 
     def start(self):
         key = self.raw_parameters[0]

--- a/tuxemon/event/actions/translated_dialog.py
+++ b/tuxemon/event/actions/translated_dialog.py
@@ -19,14 +19,20 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 import logging
 
 from tuxemon.locale import process_translate_text
 from tuxemon.event.eventaction import EventAction
 from tuxemon.tools import open_dialog
 from tuxemon.graphics import get_avatar
+from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
+
+
+class TranslatedDialogActionParameters(NamedTuple):
+    pass
 
 
 class TranslatedDialogAction(EventAction):
@@ -46,6 +52,7 @@ class TranslatedDialogAction(EventAction):
     """
 
     name = "translated_dialog"
+    _param_factory = TranslatedDialogActionParameters
 
     def start(self):
         key = self.raw_parameters[0]

--- a/tuxemon/event/actions/translated_dialog_chain.py
+++ b/tuxemon/event/actions/translated_dialog_chain.py
@@ -52,7 +52,7 @@ class TranslatedDialogChainAction(EventAction):
     """
 
     name = "translated_dialog_chain"
-    _param_factory = TranslatedDialogChainActionParameters
+    param_class = TranslatedDialogChainActionParameters
 
     def start(self):
         key = self.raw_parameters[0]

--- a/tuxemon/event/actions/translated_dialog_chain.py
+++ b/tuxemon/event/actions/translated_dialog_chain.py
@@ -19,14 +19,20 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 import logging
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.graphics import get_avatar
 from tuxemon.locale import process_translate_text
 from tuxemon.tools import open_dialog
+from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
+
+
+class TranslatedDialogChainActionParameters(NamedTuple):
+    pass
 
 
 class TranslatedDialogChainAction(EventAction):
@@ -46,6 +52,7 @@ class TranslatedDialogChainAction(EventAction):
     """
 
     name = "translated_dialog_chain"
+    _param_factory = TranslatedDialogChainActionParameters
 
     def start(self):
         key = self.raw_parameters[0]

--- a/tuxemon/event/actions/translated_dialog_chain.py
+++ b/tuxemon/event/actions/translated_dialog_chain.py
@@ -26,7 +26,7 @@ from tuxemon.event.eventaction import EventAction
 from tuxemon.graphics import get_avatar
 from tuxemon.locale import process_translate_text
 from tuxemon.tools import open_dialog
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +35,8 @@ class TranslatedDialogChainActionParameters(NamedTuple):
     pass
 
 
-class TranslatedDialogChainAction(EventAction):
+@final
+class TranslatedDialogChainAction(EventAction[TranslatedDialogChainActionParameters]):
     """Opens a chain of dialogs in order. Dialog chain must be ended with the ${{end}} keyword.
 
     Valid Parameters: text_to_display
@@ -54,7 +55,7 @@ class TranslatedDialogChainAction(EventAction):
     name = "translated_dialog_chain"
     param_class = TranslatedDialogChainActionParameters
 
-    def start(self):
+    def start(self) -> None:
         key = self.raw_parameters[0]
         replace = []
         avatar = None
@@ -82,7 +83,7 @@ class TranslatedDialogChainAction(EventAction):
         else:
             self.open_dialog(pages, avatar)
 
-    def update(self):
+    def update(self) -> None:
         key = self.raw_parameters[0]
         if key == "${{end}}":
             if self.session.client.get_state_by_name("DialogState") is None:

--- a/tuxemon/event/actions/translated_dialog_choice.py
+++ b/tuxemon/event/actions/translated_dialog_choice.py
@@ -26,7 +26,7 @@ from functools import partial
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.locale import T, replace_text
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +36,8 @@ class TranslatedDialogChoiceActionParameters(NamedTuple):
     variable: str
 
 
-class TranslatedDialogChoiceAction(EventAction):
+@final
+class TranslatedDialogChoiceAction(EventAction[TranslatedDialogChoiceActionParameters]):
     """Asks the player to make a choice.
 
     Valid Parameters: choice1:choice2,var_key
@@ -46,7 +47,7 @@ class TranslatedDialogChoiceAction(EventAction):
 
     param_class = TranslatedDialogChoiceActionParameters
 
-    def start(self):
+    def start(self) -> None:
         def set_variable(var_value):
             player.game_variables[self.parameters.variable] = var_value
             self.session.client.pop_state()
@@ -65,7 +66,7 @@ class TranslatedDialogChoiceAction(EventAction):
 
         self.open_choice_dialog(self.session, var_menu)
 
-    def update(self):
+    def update(self) -> None:
         if self.session.client.get_state_by_name("ChoiceState") is None:
             self.stop()
 

--- a/tuxemon/event/actions/translated_dialog_choice.py
+++ b/tuxemon/event/actions/translated_dialog_choice.py
@@ -44,7 +44,7 @@ class TranslatedDialogChoiceAction(EventAction):
 
     name = "translated_dialog_choice"
 
-    _param_factory = TranslatedDialogChoiceActionParameters
+    param_class = TranslatedDialogChoiceActionParameters
 
     def start(self):
         def set_variable(var_value):

--- a/tuxemon/event/actions/translated_dialog_choice.py
+++ b/tuxemon/event/actions/translated_dialog_choice.py
@@ -44,7 +44,6 @@ class TranslatedDialogChoiceAction(EventAction):
 
     name = "translated_dialog_choice"
 
-    valid_parameters = [(str, "choices"), (str, "variable")]
     _param_factory = TranslatedDialogChoiceActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/translated_dialog_choice.py
+++ b/tuxemon/event/actions/translated_dialog_choice.py
@@ -19,14 +19,21 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 import logging
 from functools import partial
 
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.locale import T, replace_text
+from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
+
+
+class TranslatedDialogChoiceActionParameters(NamedTuple):
+    choices: str
+    variable: str
 
 
 class TranslatedDialogChoiceAction(EventAction):
@@ -38,6 +45,7 @@ class TranslatedDialogChoiceAction(EventAction):
     name = "translated_dialog_choice"
 
     valid_parameters = [(str, "choices"), (str, "variable")]
+    _param_factory = TranslatedDialogChoiceActionParameters
 
     def start(self):
         def set_variable(var_value):

--- a/tuxemon/event/actions/update_inventory.py
+++ b/tuxemon/event/actions/update_inventory.py
@@ -24,7 +24,7 @@ from tuxemon.db import db
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.item.item import decode_inventory
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class UpdateInventoryActionParameters(NamedTuple):
@@ -32,7 +32,8 @@ class UpdateInventoryActionParameters(NamedTuple):
     inventory_slug: str
 
 
-class UpdateInventoryAction(EventAction):
+@final
+class UpdateInventoryAction(EventAction[UpdateInventoryActionParameters]):
     """Updates the inventory of the npc or player. Overwrites the quantity of an item if it's already present,
     but leaves other items alone.
     """
@@ -40,7 +41,7 @@ class UpdateInventoryAction(EventAction):
     name = "update_inventory"
     param_class = UpdateInventoryActionParameters
 
-    def start(self):
+    def start(self) -> None:
         npc = get_npc(self.session, self.parameters.npc_slug)
         if self.parameters.inventory_slug is None:
             return

--- a/tuxemon/event/actions/update_inventory.py
+++ b/tuxemon/event/actions/update_inventory.py
@@ -19,10 +19,17 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon.db import db
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.item.item import decode_inventory
+from typing import NamedTuple
+
+
+class UpdateInventoryActionParameters(NamedTuple):
+    npc_slug: str
+    inventory_slug: str
 
 
 class UpdateInventoryAction(EventAction):
@@ -35,6 +42,7 @@ class UpdateInventoryAction(EventAction):
         (str, "npc_slug"),
         (str, "inventory_slug"),
     ]
+    _param_factory = UpdateInventoryActionParameters
 
     def start(self):
         npc = get_npc(self.session, self.parameters.npc_slug)

--- a/tuxemon/event/actions/update_inventory.py
+++ b/tuxemon/event/actions/update_inventory.py
@@ -38,10 +38,6 @@ class UpdateInventoryAction(EventAction):
     """
 
     name = "update_inventory"
-    valid_parameters = [
-        (str, "npc_slug"),
-        (str, "inventory_slug"),
-    ]
     _param_factory = UpdateInventoryActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/update_inventory.py
+++ b/tuxemon/event/actions/update_inventory.py
@@ -38,7 +38,7 @@ class UpdateInventoryAction(EventAction):
     """
 
     name = "update_inventory"
-    _param_factory = UpdateInventoryActionParameters
+    param_class = UpdateInventoryActionParameters
 
     def start(self):
         npc = get_npc(self.session, self.parameters.npc_slug)

--- a/tuxemon/event/actions/variable_math.py
+++ b/tuxemon/event/actions/variable_math.py
@@ -45,7 +45,6 @@ class VariableMathAction(EventAction):
     """
 
     name = "variable_math"
-    valid_parameters = [(str, "var1"), (str, "operation"), (str, "var2"), ((str, None), "result")]
     _param_factory = VariableMathActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/variable_math.py
+++ b/tuxemon/event/actions/variable_math.py
@@ -24,7 +24,7 @@ import logging
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.tools import number_or_variable
-from typing import Union, NamedTuple
+from typing import Union, NamedTuple, final
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +36,8 @@ class VariableMathActionParameters(NamedTuple):
     result: Union[str, None]
 
 
-class VariableMathAction(EventAction):
+@final
+class VariableMathAction(EventAction[VariableMathActionParameters]):
     """Performs a mathematical operation on the key in the player.game_variables dictionary.
     Optionally accepts a fourth parameter to store the result, otherwise it is stored in
     variable1.
@@ -47,7 +48,7 @@ class VariableMathAction(EventAction):
     name = "variable_math"
     param_class = VariableMathActionParameters
 
-    def start(self):
+    def start(self) -> None:
         player = self.session.player
 
         # Read the parameters

--- a/tuxemon/event/actions/variable_math.py
+++ b/tuxemon/event/actions/variable_math.py
@@ -19,12 +19,21 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 import logging
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.tools import number_or_variable
+from typing import Union, NamedTuple
 
 logger = logging.getLogger(__name__)
+
+
+class VariableMathActionParameters(NamedTuple):
+    var1: str
+    operation: str
+    var2: str
+    result: Union[str, None]
 
 
 class VariableMathAction(EventAction):
@@ -37,6 +46,7 @@ class VariableMathAction(EventAction):
 
     name = "variable_math"
     valid_parameters = [(str, "var1"), (str, "operation"), (str, "var2"), ((str, None), "result")]
+    _param_factory = VariableMathActionParameters
 
     def start(self):
         player = self.session.player

--- a/tuxemon/event/actions/variable_math.py
+++ b/tuxemon/event/actions/variable_math.py
@@ -45,7 +45,7 @@ class VariableMathAction(EventAction):
     """
 
     name = "variable_math"
-    _param_factory = VariableMathActionParameters
+    param_class = VariableMathActionParameters
 
     def start(self):
         player = self.session.player

--- a/tuxemon/event/actions/wait.py
+++ b/tuxemon/event/actions/wait.py
@@ -19,9 +19,15 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 import time
 
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
+
+
+class WaitActionParameters(NamedTuple):
+    seconds: float
 
 
 class WaitAction(EventAction):
@@ -34,6 +40,7 @@ class WaitAction(EventAction):
 
     name = "wait"
     valid_parameters = [(float, "seconds")]
+    _param_factory = WaitActionParameters
 
     # TODO: use event loop time, not wall clock
     def start(self):

--- a/tuxemon/event/actions/wait.py
+++ b/tuxemon/event/actions/wait.py
@@ -39,7 +39,6 @@ class WaitAction(EventAction):
     """
 
     name = "wait"
-    valid_parameters = [(float, "seconds")]
     _param_factory = WaitActionParameters
 
     # TODO: use event loop time, not wall clock

--- a/tuxemon/event/actions/wait.py
+++ b/tuxemon/event/actions/wait.py
@@ -23,14 +23,15 @@ from __future__ import annotations
 import time
 
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class WaitActionParameters(NamedTuple):
     seconds: float
 
 
-class WaitAction(EventAction):
+@final
+class WaitAction(EventAction[WaitActionParameters]):
     """Blocks event chain for some time
 
     Valid Parameters: duration
@@ -42,9 +43,9 @@ class WaitAction(EventAction):
     param_class = WaitActionParameters
 
     # TODO: use event loop time, not wall clock
-    def start(self):
+    def start(self) -> None:
         self.finish_time = time.time() + self.parameters.seconds
 
-    def update(self):
+    def update(self) -> None:
         if time.time() >= self.finish_time:
             self.stop()

--- a/tuxemon/event/actions/wait.py
+++ b/tuxemon/event/actions/wait.py
@@ -39,7 +39,7 @@ class WaitAction(EventAction):
     """
 
     name = "wait"
-    _param_factory = WaitActionParameters
+    param_class = WaitActionParameters
 
     # TODO: use event loop time, not wall clock
     def start(self):

--- a/tuxemon/event/actions/wait_for_secs.py
+++ b/tuxemon/event/actions/wait_for_secs.py
@@ -21,14 +21,15 @@
 
 from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 
 class WaitForSecsActionParameters(NamedTuple):
     seconds: float
 
 
-class WaitForSecsAction(EventAction):
+@final
+class WaitForSecsAction(EventAction[WaitForSecsActionParameters]):
     """Pauses the event engine for n number of seconds.
 
     Valid Parameters: duration
@@ -39,7 +40,7 @@ class WaitForSecsAction(EventAction):
     name = "wait_for_secs"
     param_class = WaitForSecsActionParameters
 
-    def start(self):
+    def start(self) -> None:
         secs = self.parameters.seconds
         self.session.client.event_engine.state = "waiting"
         self.session.client.event_engine.wait = secs

--- a/tuxemon/event/actions/wait_for_secs.py
+++ b/tuxemon/event/actions/wait_for_secs.py
@@ -37,7 +37,6 @@ class WaitForSecsAction(EventAction):
     """
 
     name = "wait_for_secs"
-    valid_parameters = [(float, "seconds")]
     _param_factory = WaitForSecsActionParameters
 
     def start(self):

--- a/tuxemon/event/actions/wait_for_secs.py
+++ b/tuxemon/event/actions/wait_for_secs.py
@@ -37,7 +37,7 @@ class WaitForSecsAction(EventAction):
     """
 
     name = "wait_for_secs"
-    _param_factory = WaitForSecsActionParameters
+    param_class = WaitForSecsActionParameters
 
     def start(self):
         secs = self.parameters.seconds

--- a/tuxemon/event/actions/wait_for_secs.py
+++ b/tuxemon/event/actions/wait_for_secs.py
@@ -19,7 +19,13 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple
+
+
+class WaitForSecsActionParameters(NamedTuple):
+    seconds: float
 
 
 class WaitForSecsAction(EventAction):
@@ -32,6 +38,7 @@ class WaitForSecsAction(EventAction):
 
     name = "wait_for_secs"
     valid_parameters = [(float, "seconds")]
+    _param_factory = WaitForSecsActionParameters
 
     def start(self):
         secs = self.parameters.seconds

--- a/tuxemon/event/actions/withdraw_monster.py
+++ b/tuxemon/event/actions/withdraw_monster.py
@@ -22,11 +22,18 @@
 #
 # Adam Chevalier <chevalierAdam2@gmail.com>
 
+from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
 import logging
 import uuid
+from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
+
+
+class WithdrawMonsterActionParameters(NamedTuple):
+    trainer: str
+    monster_id: str
 
 
 class WithdrawMonsterAction(EventAction):
@@ -40,6 +47,7 @@ class WithdrawMonsterAction(EventAction):
 
     name = "withdraw_monster"
     valid_parameters = [(str, "trainer"), (str, "monster_id")]
+    _param_factory = WithdrawMonsterActionParameters
 
     def start(self):
         trainer, monster_id = self.parameters

--- a/tuxemon/event/actions/withdraw_monster.py
+++ b/tuxemon/event/actions/withdraw_monster.py
@@ -46,7 +46,7 @@ class WithdrawMonsterAction(EventAction):
     """
 
     name = "withdraw_monster"
-    _param_factory = WithdrawMonsterActionParameters
+    param_class = WithdrawMonsterActionParameters
 
     def start(self):
         trainer, monster_id = self.parameters

--- a/tuxemon/event/actions/withdraw_monster.py
+++ b/tuxemon/event/actions/withdraw_monster.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
 import logging
 import uuid
-from typing import NamedTuple
+from typing import NamedTuple, final
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +36,8 @@ class WithdrawMonsterActionParameters(NamedTuple):
     monster_id: str
 
 
-class WithdrawMonsterAction(EventAction):
+@final
+class WithdrawMonsterAction(EventAction[WithdrawMonsterActionParameters]):
     """
     Pulls a monster from the given trainer's storage (identified by slug and instance_id respectively)
     and puts it in their party. Note: If the trainer's party is already full then the monster will be
@@ -48,7 +49,7 @@ class WithdrawMonsterAction(EventAction):
     name = "withdraw_monster"
     param_class = WithdrawMonsterActionParameters
 
-    def start(self):
+    def start(self) -> None:
         trainer, monster_id = self.parameters
         world = self.session.client.get_state_by_name("WorldState")
         if not world:

--- a/tuxemon/event/actions/withdraw_monster.py
+++ b/tuxemon/event/actions/withdraw_monster.py
@@ -46,7 +46,6 @@ class WithdrawMonsterAction(EventAction):
     """
 
     name = "withdraw_monster"
-    valid_parameters = [(str, "trainer"), (str, "monster_id")]
     _param_factory = WithdrawMonsterActionParameters
 
     def start(self):

--- a/tuxemon/event/eventaction.py
+++ b/tuxemon/event/eventaction.py
@@ -23,15 +23,20 @@
 # Leif Theden <leif.theden@gmail.com>
 #
 
+from __future__ import annotations
 import logging
 from collections import namedtuple
 
-from tuxemon.tools import cast_values
-from typing import Optional, Type, Sequence, Any, Tuple
+from tuxemon.tools import cast_values, ValidParameterTypes
+from typing import Optional, Type, Sequence, Any, Tuple, NamedTuple, Union
 from types import TracebackType
 from tuxemon.session import Session
 
 logger = logging.getLogger(__name__)
+
+
+class EventActionParameters(NamedTuple):
+    pass
 
 
 class EventAction:
@@ -100,8 +105,8 @@ class EventAction:
     """
 
     name = "GenericAction"
-    valid_parameters: Sequence[Tuple[Type[Any], str]] = list()
-    _param_factory = None
+    valid_parameters: Sequence[Tuple[ValidParameterTypes, str]] = list()
+    _param_factory: Type[Any] = EventActionParameters
 
     def __init__(
         self,
@@ -114,7 +119,7 @@ class EventAction:
         # TODO: METACLASS
         # make a namedtuple class that will generate the parameters
         # the patching of the class attribute should only happen once
-        if self.__class__._param_factory is None:
+        if self.__class__._param_factory is EventActionParameters:
             self.__class__._param_factory = namedtuple("parameters", [i[1] for i in self.valid_parameters])
 
         # if you need the parameters before they are processed, use this

--- a/tuxemon/event/eventaction.py
+++ b/tuxemon/event/eventaction.py
@@ -105,7 +105,7 @@ class EventAction:
     """
 
     name = "GenericAction"
-    _param_factory: Type[NamedTupleProtocol] = EventActionParameters
+    param_class: Type[NamedTupleProtocol] = EventActionParameters
  
     def __init__(
         self,
@@ -120,17 +120,17 @@ class EventAction:
 
         # parse parameters
         try:
-            if self._param_factory._fields:
+            if self.param_class._fields:
 
                 # cast the parameters to the correct type, as defined in cls.valid_parameters
-                self.parameters = cast_parameters_to_namedtuple(parameters, self._param_factory)
+                self.parameters = cast_parameters_to_namedtuple(parameters, self.param_class)
             else:
                 self.parameters = parameters
 
         except:
             logger.error(f"error while parsing for {self.name}")
             logger.error(f"cannot parse parameters: {parameters}")
-            logger.error(self._param_factory)
+            logger.error(self.param_class)
             logger.error("please check the parameters and verify they are correct")
             self.parameters = None
 

--- a/tuxemon/event/eventaction.py
+++ b/tuxemon/event/eventaction.py
@@ -116,12 +116,6 @@ class EventAction:
 
         self.session = session
 
-        # TODO: METACLASS
-        # make a namedtuple class that will generate the parameters
-        # the patching of the class attribute should only happen once
-        if self.__class__._param_factory is EventActionParameters:
-            self.__class__._param_factory = namedtuple("parameters", [i[1] for i in self.valid_parameters])
-
         # if you need the parameters before they are processed, use this
         self.raw_parameters = parameters
 

--- a/tuxemon/event/eventaction.py
+++ b/tuxemon/event/eventaction.py
@@ -105,7 +105,6 @@ class EventAction:
     """
 
     name = "GenericAction"
-    valid_parameters: Sequence[Tuple[ValidParameterTypes, str]] = list()
     _param_factory: Type[NamedTupleProtocol] = EventActionParameters
  
     def __init__(
@@ -121,7 +120,7 @@ class EventAction:
 
         # parse parameters
         try:
-            if self.valid_parameters:
+            if self._param_factory._fields:
 
                 # cast the parameters to the correct type, as defined in cls.valid_parameters
                 self.parameters = cast_parameters_to_namedtuple(parameters, self._param_factory)
@@ -131,7 +130,7 @@ class EventAction:
         except:
             logger.error(f"error while parsing for {self.name}")
             logger.error(f"cannot parse parameters: {parameters}")
-            logger.error(self.valid_parameters)
+            logger.error(self._param_factory)
             logger.error("please check the parameters and verify they are correct")
             self.parameters = None
 

--- a/tuxemon/event/eventaction.py
+++ b/tuxemon/event/eventaction.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 import logging
 from collections import namedtuple
 
-from tuxemon.tools import cast_values, ValidParameterTypes
+from tuxemon.tools import cast_parameters_to_namedtuple, ValidParameterTypes, NamedTupleProtocol
 from typing import Optional, Type, Sequence, Any, Tuple, NamedTuple, Union
 from types import TracebackType
 from tuxemon.session import Session
@@ -106,8 +106,8 @@ class EventAction:
 
     name = "GenericAction"
     valid_parameters: Sequence[Tuple[ValidParameterTypes, str]] = list()
-    _param_factory: Type[Any] = EventActionParameters
-
+    _param_factory: Type[NamedTupleProtocol] = EventActionParameters
+ 
     def __init__(
         self,
         session: Session,
@@ -124,8 +124,7 @@ class EventAction:
             if self.valid_parameters:
 
                 # cast the parameters to the correct type, as defined in cls.valid_parameters
-                values = cast_values(parameters, self.valid_parameters)
-                self.parameters = self._param_factory(*values)
+                self.parameters = cast_parameters_to_namedtuple(parameters, self._param_factory)
             else:
                 self.parameters = parameters
 

--- a/tuxemon/tools.py
+++ b/tuxemon/tools.py
@@ -25,6 +25,9 @@
 # Leif Theden <leif.theden@gmail.com>
 #
 #
+from __future__ import annotations
+from typing import Sequence, Any, Type, Tuple, Union, Optional
+
 """
 
 Do not import platform-specific libraries such as pygame.
@@ -44,6 +47,12 @@ from tuxemon import prepare
 from tuxemon.locale import T
 
 logger = logging.getLogger(__name__)
+
+ValidParameterSingleType = Optional[Type[Any]]
+ValidParameterTypes = Union[
+    ValidParameterSingleType,
+    Sequence[ValidParameterSingleType],
+]
 
 
 def get_cell_coordinates(rect, point, size):
@@ -188,7 +197,10 @@ def number_or_variable(session, value):
             raise ValueError
 
 
-def cast_values(parameters, valid_parameters):
+def cast_values(
+    parameters: Sequence[Any],
+    valid_parameters: Sequence[Tuple[ValidParameterTypes, str]],
+) -> Sequence[Any]:
     """Change all the string values to the expected type
 
     This will also check and enforce the correct parameters for actions
@@ -199,7 +211,9 @@ def cast_values(parameters, valid_parameters):
     """
 
     # TODO: stability/testing
-    def cast(i):
+    def cast(
+        i: Tuple[Tuple[ValidParameterTypes, str], Any],
+    ) -> Any:
         ve = False
         t, v = i
         try:


### PR DESCRIPTION
Refactor the actions.

Improvements:
* The parameters are now specified creating a NamedTuple, instead of using a list as a class argument.
* The casting of the arguments is now done extracting the information from the NamedTuple.
* Mypy can now typecheck the parameters, as the NamedTuple is known at import time.
* The class `EventAction` is now abstract, as well as the `start` method and the `param_class` attribute. If one of those is not defined in a `final` subclass, Mypy would warn about it (otherwise it will fail at runtime).

Caveats:
* Uses `Protocol`, `get_origin` and `get_args`, that are only available in Python 3.8 or above. I could make it to work in previous versions using the module `typing_extensions` if that is necessary.
* The namedtuple used for the parameters has to be passed twice to the action, one as a generic parameter (for typechecking) and one as a class attribute (for constructing it). This is because currently there is no portable way to recover the class from the typing information (see https://github.com/python/typing/issues/629).
* The plugin subsystem logs warnings like `ERROR - found incomplete actions: AddItemActionParameters`. This is because it assumes that the only classes available in the module are the intended ones. This limitation is easy to fix (just pass the intended superclass to the loading routine, and check the classes against it. It also will allow to typecheck the return type), and will be addressed later.