### PR TITLE
Typing plugins

### DIFF
--- a/tuxemon/event/eventaction.py
+++ b/tuxemon/event/eventaction.py
@@ -29,7 +29,7 @@ from collections import namedtuple
 
 from tuxemon.tools import cast_parameters_to_namedtuple, NamedTupleProtocol
 from typing import Optional, Type, Sequence, Any, Tuple, NamedTuple, Union,\
-    TypeVar, Generic
+    TypeVar, Generic, ClassVar
 from types import TracebackType
 from tuxemon.session import Session
 from abc import ABC, abstractmethod
@@ -105,7 +105,8 @@ class EventAction(ABC, Generic[ParameterClass]):
 
     """
 
-    name = "GenericAction"
+    name: ClassVar[str] = "GenericAction"
+    param_class: ClassVar[Type[ParameterClass]]
 
     def __init__(
         self,
@@ -138,11 +139,6 @@ class EventAction(ABC, Generic[ParameterClass]):
             self.parameters = None
 
         self._done = False
-
-    @property
-    @abstractmethod
-    def param_class(self) -> Type[ParameterClass]:
-        raise NotImplementedError
 
     def __enter__(self) -> None:
         """

--- a/tuxemon/event/eventcondition.py
+++ b/tuxemon/event/eventcondition.py
@@ -27,11 +27,11 @@
 from __future__ import annotations
 from tuxemon.session import Session
 from tuxemon.event import MapCondition
-from typing import Mapping, Any
+from typing import Mapping, Any, ClassVar
 
 
 class EventCondition:
-    name = "GenericCondition"
+    name: ClassVar[str] = "GenericCondition"
 
     def __init__(self) -> None:
         pass

--- a/tuxemon/event/eventengine.py
+++ b/tuxemon/event/eventengine.py
@@ -78,7 +78,7 @@ class RunningEvent:
         self.map_event = map_event
         self.context: Dict[str, Any] = dict()
         self.action_index = 0
-        self.current_action: Optional[EventAction] = None
+        self.current_action: Optional[EventAction[Any]] = None
         self.current_map_action = None
 
     def get_next_action(self) -> Optional[MapAction]:
@@ -159,7 +159,7 @@ class EventEngine:
         self,
         name: str,
         parameters: Optional[Sequence[Any]] = None,
-    ) -> Optional[EventAction]:
+    ) -> Optional[EventAction[Any]]:
         """
         Get an action that is loaded into the engine.
 

--- a/tuxemon/event/eventengine.py
+++ b/tuxemon/event/eventengine.py
@@ -125,8 +125,6 @@ class EventEngine:
     def __init__(self, session: Session) -> None:
         self.session = session
 
-        self.conditions: Mapping[str, Type[EventCondition]] = dict()
-        self.actions: Mapping[str, Type[EventAction]] = dict()
         self.running_events: Dict[int, RunningEvent] = dict()
         self.name = "Event"
         self.current_map = None
@@ -137,8 +135,17 @@ class EventEngine:
         # debug
         self.partial_events: List[Sequence[Tuple[bool, MapCondition]]] = list()
 
-        self.conditions = plugin.load_plugins(paths.CONDITIONS_PATH, "conditions")
-        self.actions = plugin.load_plugins(paths.ACTIONS_PATH, "actions")
+        self.conditions = plugin.load_plugins(
+            paths.CONDITIONS_PATH,
+            "conditions",
+            interface=EventCondition,
+        )
+
+        self.actions = plugin.load_plugins(
+            paths.ACTIONS_PATH,
+            "actions",
+            interface=EventAction,
+        )
 
     def reset(self) -> None:
         """Clear out running events.  Use when changing maps."""

--- a/tuxemon/event/eventengine.py
+++ b/tuxemon/event/eventengine.py
@@ -141,6 +141,10 @@ class EventEngine:
             interface=EventCondition,
         )
 
+        # Mypy fails to typecheck here because
+        # https://github.com/python/mypy/issues/4717
+        # The workarounds are ugly, so we will wait
+        # for that to be fixed.
         self.actions = plugin.load_plugins(
             paths.ACTIONS_PATH,
             "actions",

--- a/tuxemon/plugin.py
+++ b/tuxemon/plugin.py
@@ -37,7 +37,7 @@ import sys
 from typing import (
     Mapping, Sequence, Any, Optional, List, Iterable,
     Protocol, Tuple, Type, TypeVar, Generic, overload, Union,
-    ClassVar, Callable, runtime_checkable
+    ClassVar, runtime_checkable
 )
 from types import ModuleType
 
@@ -56,13 +56,15 @@ class PluginObject(Protocol):
     name: ClassVar[str]
 
 
-Interface = TypeVar("Interface", bound=Type[PluginObject])
+T = TypeVar("T")
+InterfaceValue = TypeVar("InterfaceValue", bound=PluginObject)
+Interface = Type[InterfaceValue]
 
 
-class Plugin(Generic[Interface]):
+class Plugin(Generic[T]):
     __slots__ = ("name", "plugin_object")
 
-    def __init__(self, name: str, module: Interface) -> None:
+    def __init__(self, name: str, module: T) -> None:
         self.name = name
         self.plugin_object = module
 
@@ -122,8 +124,8 @@ class PluginManager:
 
     def getAllPlugins(
         self,
-        interface: Interface,
-    ) -> Sequence[Plugin[Interface]]:
+        interface: Type[InterfaceValue],
+    ) -> Sequence[Plugin[Type[InterfaceValue]]]:
         imported_modules = []
         for module in self.modules:
             logger.debug("Searching module: " + str(module))
@@ -148,8 +150,8 @@ class PluginManager:
     def _getClassesFromModule(
         self,
         module: ModuleType,
-        interface: Interface,
-    ) -> Iterable[Tuple[str, Interface]]:
+        interface: Type[InterfaceValue],
+    ) -> Iterable[Tuple[str, Type[InterfaceValue]]]:
 
         # This is required because of
         # https://github.com/python/typing/issues/822
@@ -211,8 +213,8 @@ def get_available_methods(
 
 def get_available_classes(
     plugin_manager: PluginManager,
-    interface: Interface,
-) -> Sequence[Interface]:
+    interface: Type[InterfaceValue],
+) -> Sequence[Type[InterfaceValue]]:
     """Gets the available methods in a dictionary of plugins.
 
     :param plugin_manager: A dictionary of modules.
@@ -243,8 +245,8 @@ def load_plugins(
     path: str,
     category: str = "plugins",
     *,
-    interface: Interface
-) -> Mapping[str, Interface]:
+    interface: Type[InterfaceValue]
+) -> Mapping[str, Type[InterfaceValue]]:
     pass
 
 
@@ -252,8 +254,8 @@ def load_plugins(
     path: str,
     category: str = "plugins",
     *,
-    interface: Union[Interface, Type[PluginObject]] = PluginObject
-) -> Mapping[str, Union[Interface, Type[PluginObject]]]:
+    interface: Union[Type[InterfaceValue], Type[PluginObject]] = PluginObject
+) -> Mapping[str, Union[Type[InterfaceValue], Type[PluginObject]]]:
     """Load classes using plugin system
 
     :param str path: where plugins are stored


### PR DESCRIPTION
Typing the plugins module.

It adds a new optional parameter `interface` to the `plugin.load_plugins` function that serves two purposes:
* It restricts the loaded classes to those that conform to a particular superclass or runtime checkable protocol. Thus, auxiliary classes, such as action parameters, can be used in plugin files without errors.
* It tells Mypy that the returned classes conform to that interface, so the code that uses them can typecheck.

In the road several limitations of Mypy have been found. Some have been worked around and the others will (hopefully) be solved by the Mypy/Python team in the future.