### PR TITLE
Allow the translation of the input alphabet.

### DIFF
--- a/mods/tuxemon/l18n/de_DE/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/de_DE/LC_MESSAGES/base.po
@@ -240,6 +240,13 @@ msgid "run"
 msgstr "Flucht"
 
 ## MENU TRANSLATIONS ##
+
+msgid "menu_alphabet"
+msgstr "AÄBCDEFGHIJKLMNOÖPQRS\0TUÜVWXYZaäbcdefghijklmnoöpqrsßtuüvwxyz1234567890.-!\0\0"
+
+msgid "menu_alphabet_n_columns"
+msgstr "15"
+
 # Monster Menu notifications
 msgid "monster_menu_info"
 msgstr "Info"

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -578,6 +578,13 @@ msgid "wing_tip"
 msgstr "Wing Tip"
 
 ## MENU TRANSLATIONS ##
+
+msgid "menu_alphabet"
+msgstr "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890.-!"
+
+msgid "menu_alphabet_n_columns"
+msgstr "13"
+
 # Monster Menu notifications
 msgid "monster_menu_info"
 msgstr "Info"

--- a/mods/tuxemon/l18n/eo/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/eo/LC_MESSAGES/base.po
@@ -240,6 +240,13 @@ msgid "run"
 msgstr "Run"
 
 ## MENU TRANSLATIONS ##
+
+msgid "menu_alphabet"
+msgstr "ABCĈDEFGĜHĤIJĴKLMNOPRSŜTUŬVZabcĉdefgĝhĥijĵklmnoprsŝtuŭvz1234567890.-!\0"
+
+msgid "menu_alphabet_n_columns"
+msgstr "14"
+
 # Monster Menu notifications
 msgid "monster_menu_info"
 msgstr "Informoj"

--- a/mods/tuxemon/l18n/es_ES/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/es_ES/LC_MESSAGES/base.po
@@ -566,6 +566,13 @@ msgid "wing_tip"
 msgstr "Punta de Ala"
 
 ## MENU TRANSLATIONS ##
+
+msgid "menu_alphabet"
+msgstr "ABCDEFGHIJKLMNÑOPQRSTUVWXYZ\0abcdefghijklmnñopqrstuvwxyz\01234567890.-¡!"
+
+msgid "menu_alphabet_n_columns"
+msgstr "14"
+
 # Monster Menu notifications
 msgid "monster_menu_info"
 msgstr "Información"

--- a/tuxemon/menu/input.py
+++ b/tuxemon/menu/input.py
@@ -2,6 +2,7 @@ from functools import partial
 
 from tuxemon.compat import Rect
 from tuxemon import tools
+from tuxemon.locale import T
 from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.menu import Menu
 from tuxemon.platform.const import events
@@ -11,9 +12,6 @@ from tuxemon.ui.text import TextArea
 class InputMenu(Menu):
     background = None
     draw_borders = False
-
-    chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890.-!"
-    alphabet_length = 26
 
     def startup(self, *items, **kwargs):
         """
@@ -29,6 +27,8 @@ class InputMenu(Menu):
         """
         super().startup(*items, **kwargs)
         self.input_string = kwargs.get("initial", "")
+        self.chars = T.translate("menu_alphabet").replace(r"\0", "\0")
+        self.n_columns = int(T.translate("menu_alphabet_n_columns"))
 
         # area where the input will be shown
         self.text_area = TextArea(self.font, self.font_color, (96, 96, 96))
@@ -55,11 +55,16 @@ class InputMenu(Menu):
         return rect
 
     def initialize_items(self):
-        self.menu_items.columns = self.alphabet_length // 2
+        self.menu_items.columns = self.n_columns
 
         # add the keys
         for char in self.chars:
-            yield MenuItem(self.shadow_text(char), None, None, partial(self.add_input_char, char))
+            if char == "\0":
+                empty = MenuItem(self.shadow_text(" "), None, None, None)
+                empty.enabled = False
+                yield empty
+            else:
+                yield MenuItem(self.shadow_text(char), None, None, partial(self.add_input_char, char))
 
         # backspace key
         yield MenuItem(self.shadow_text("←"), None, None, self.backspace)


### PR DESCRIPTION
The "\0" character represent an empty space, often necessary to align letters (for example in German, where the uppercase ß is not available).

Example alphabets are provided for English, Spanish, German and Esperanto.