### PR TITLE
Add world file for the default campaign + minor alignment fixes

### DIFF
--- a/mods/tuxemon/maps/citypark.tmx
+++ b/mods/tuxemon/maps/citypark.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="123">
+<map version="1.5" tiledversion="1.7.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="124">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -338,7 +338,7 @@
     <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
-  <object id="88" name="Teleport to Leather Town" type="event" x="624" y="160" width="16" height="16">
+  <object id="88" name="Teleport to Leather Town" type="event" x="624" y="176" width="16" height="16">
    <properties>
     <property name="act10" value="transition_teleport leather_town.tmx,0,31,0.3"/>
     <property name="act20" value="player_face right"/>
@@ -346,7 +346,7 @@
     <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
-  <object id="89" name="Teleport to Leather Town" type="event" x="624" y="176" width="16" height="16">
+  <object id="89" name="Teleport to Leather Town" type="event" x="624" y="192" width="16" height="16">
    <properties>
     <property name="act10" value="transition_teleport leather_town.tmx,0,32,0.3"/>
     <property name="act20" value="player_face right"/>
@@ -354,7 +354,7 @@
     <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
-  <object id="90" name="Teleport to Leather Town" type="event" x="624" y="192" width="16" height="16">
+  <object id="90" name="Teleport to Leather Town" type="event" x="624" y="208" width="16" height="16">
    <properties>
     <property name="act10" value="transition_teleport leather_town.tmx,0,33,0.3"/>
     <property name="act20" value="player_face right"/>
@@ -472,6 +472,14 @@
     <property name="act40" value="set_variable omnichannelhere:here"/>
     <property name="act50" value="player_face left"/>
     <property name="cond10" value="is variable_set iamsecret:ohno"/>
+   </properties>
+  </object>
+  <object id="123" name="Teleport to Leather Town" type="event" x="624" y="160" width="16" height="16">
+   <properties>
+    <property name="act10" value="transition_teleport leather_town.tmx,0,30,0.3"/>
+    <property name="act20" value="player_face right"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing right"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/flower_city.tmx
+++ b/mods/tuxemon/maps/flower_city.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="206">
+<map version="1.5" tiledversion="1.7.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="206">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -181,7 +181,7 @@
   </object>
   <object id="195" name="Teleport to Side Route A" type="event" x="176" y="0" width="16" height="16">
    <properties>
-    <property name="act10" value="transition_teleport routea.tmx,12,39,0.3"/>
+    <property name="act10" value="transition_teleport routea.tmx,11,39,0.3"/>
     <property name="act20" value="player_face up"/>
     <property name="cond10" value="is player_at"/>
     <property name="cond20" value="is player_facing up"/>
@@ -189,7 +189,7 @@
   </object>
   <object id="196" name="Teleport to Side Route A" type="event" x="192" y="0" width="16" height="16">
    <properties>
-    <property name="act10" value="transition_teleport routea.tmx,13,39,0.3"/>
+    <property name="act10" value="transition_teleport routea.tmx,12,39,0.3"/>
     <property name="act20" value="player_face up"/>
     <property name="cond10" value="is player_at"/>
     <property name="cond20" value="is player_facing up"/>

--- a/mods/tuxemon/maps/leather_town.tmx
+++ b/mods/tuxemon/maps/leather_town.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.5" tiledversion="1.7.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="93">
+<map version="1.5" tiledversion="1.7.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="94">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -123,7 +123,7 @@
  <objectgroup color="#ffff00" id="6" name="Event">
   <object id="75" name="Teleport to City Park" type="event" x="0" y="512" width="16" height="16">
    <properties>
-    <property name="act10" value="transition_teleport citypark.tmx,39,11,0.3"/>
+    <property name="act10" value="transition_teleport citypark.tmx,39,12,0.3"/>
     <property name="act20" value="player_face left"/>
     <property name="cond10" value="is player_at"/>
     <property name="cond20" value="is player_facing left"/>
@@ -131,7 +131,7 @@
   </object>
   <object id="76" name="Teleport to City Park" type="event" x="0" y="496" width="16" height="16">
    <properties>
-    <property name="act10" value="transition_teleport citypark.tmx,39,10,0.3"/>
+    <property name="act10" value="transition_teleport citypark.tmx,39,11,0.3"/>
     <property name="act20" value="player_face left"/>
     <property name="cond10" value="is player_at"/>
     <property name="cond20" value="is player_facing left"/>
@@ -139,7 +139,7 @@
   </object>
   <object id="77" name="Teleport to City Park" type="event" x="0" y="528" width="16" height="16">
    <properties>
-    <property name="act10" value="transition_teleport citypark.tmx,39,12,0.3"/>
+    <property name="act10" value="transition_teleport citypark.tmx,39,13,0.3"/>
     <property name="act20" value="player_face left"/>
     <property name="cond10" value="is player_at"/>
     <property name="cond20" value="is player_facing left"/>
@@ -217,5 +217,13 @@
    </properties>
   </object>
   <object id="92" name="Player Spawn" type="event" x="32" y="528" width="16" height="16"/>
+  <object id="93" name="Teleport to City Park" type="event" x="0" y="480" width="16" height="16">
+   <properties>
+    <property name="act10" value="transition_teleport citypark.tmx,39,10,0.3"/>
+    <property name="act20" value="player_face left"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
+   </properties>
+  </object>
  </objectgroup>
 </map>

--- a/mods/tuxemon/maps/leather_town.tmx
+++ b/mods/tuxemon/maps/leather_town.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="93">
+<map version="1.5" tiledversion="1.7.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="93">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -39,7 +39,7 @@
  </layer>
  <layer id="3" name="Layer 3" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAG110lwFFUcx/HHkkAAE0mAoECC4AKlSZDNi5KdLaC4gEu0OFmKmckGSoJKIIHypCcPolDKgQSy6AnPHtyr5OC+nYQkZCMs7lql378z//JVV/fM62TmX/WZN93T6febf2+TnGxjrg+pdKoxZShHBSpRMiUm0Wer2GZZljHL4a3VmcYMsXIYOso2BWQbzzXmsqNrbBchTxT1aEAjtBJ9toN8W8lW45NvN/my+HwWdJR9Sr78PGMKGdtnxEZ5r8t1vI8ginosYttj5Hkdb+A4TkAr0WeSz7W0h3a+bk8+WW4iUzP2Yl8834fk+Qgf4xN8ilq+/1PMn+izp0Pk0x5qvvdnGvMBtHc67idTC1pxIJ5vKWO66ggZjkJL842ybswnn/eYy/FNZ75eMvT55NN+Zcw2JhO67D3mmu+nacacxwX0YwB2DbJ8EUMYxgjClJ5/ct1Wxq8PyVREtuJ4Pr/rWraV/uVM576EuchFHuyax/J8LEA+FsJb52fx/dCPAQxCS88/7dObzPkWTkLXyXWdy3KxRwnLdzPfPdiAUpTBrnKWK1CJKlTDW7Ppwxxch2zkQMvun9zTTjFnJ7og+dq4diVf0Lm2h/meQR0iiMKuepYb0IgmNMNba8izFuuwHndBS/uXRxbJ0cPYiz5Ivq4k+XQ/kxlryfM4nsBrHNvdVj7tn16/ksl7L7b7d4Xz+yqu4Wf8gl/hV3IvdKkO8hzBUbxHvpesfNo/O5/fvViPbwHHpxBLcROWYTkmUz3k6UUf3sY70PLrX6J7cQ1ZtmE77sV92IF0lV//9LrVUe91kqGFLK04gOfxAl5EOmox92dv/+Q5oc8KfdbZ+VKZYwnzF6DQek7Y+69ivbd/8pzQZ4U+69KVr5r5N2JTQL4I6+3+lXJ/8fv9p88K+7sN8VtlGCMYxRhSXa+ST/tXxH1F7sX6jOiw3ss6eVbYtYB7Sj4W4gbcCL96lDkei6tlDFvaP/k7uRdLSU45xomqkjxVqMZGbIJfHSZTe1xHknwr478Lz7GjJ3l/O7R/um+5NjSnrJNlv2okTxOasRf74FdnyNQd15Mk3xbyXGInqoZl7Z+O3r55l/0ypGqdXz7tn46TnUu++0TLL5/2TceJ7lv+bhSSb1wWHEv+n9Tyy6d901G3lfEUz4VOdOE0zqAbQTXGB2Hzyf+TWns43yLIRhR10L7pqNvK+DlZvsCX+Apf4xtIfcv4Hb7HD/gRE8kX21vwq/ZNR3vLf5jTZBgzBVMxDdMhlcGYiRmYiSyEybeLa/lhPJLkmta+6RibPfZ6B3MWoRglWIU7IbWacQ3WYh3WI0y+g+Rqw6Ek+bRvOsZm///1M96eczSH88X1/HPNp33TUZLZ15QsS8m8rlyu30761oXTE+iffU39F46XEch15SKH7VJVdt+S7fMCv1H6MYBBXIRdv/GM+x1/4E/8BalLbDeOy7iCq3CtoPPO7+/nMl8u8jAP82HXzVzvt+BW3IYVkFrEdouxBAUohEv9neTYe/exgf2WogzlqIBd95PnATyIh7ATUpvZbgu2ogbb4ForuH+vhMtxrmO/EURRjwbYdZA8bTiEw2iH1LNs9xz2owWtcK2dZNuFMMfZdd+p2K6dbB2O/UvFfGH34e2fy3EOO4d3ez2ndH3QsqzX/um2kznO+t2Cxpf5Lf4KtCeaK2hZ12u2oP26rtfvFjSeJdu70J7o/EHLul7y/Qu/RXRK
+   eAG110lwVEUcx/FmSSCAiSRAUCBBcIHSJMjmRcnOFlBcwCVanCzFzGQDJUElkEB50pMHUSjlQAJZ9IRnD+5VcnDfTkISshEWd63S79+Zf9n16r2ZfsnMv+ozPf2m8/o3/bZJTrYx14dUOtWYMpSjApUomRKT6LNVjFmWZcxyeGt1pjFDbByGtjKmgGzjucZcdnSNcRHyRFGPBjRCK9FnO8i3lWw1Pvl2ky+Lz2dBW9mn5MvPM6aQtn1GrJX32q/jfQRR1GMRY4+R53W8geM4Aa1En0k+19I1tPN1e/JJv4lMzdiLffF8H5LnI3yMT/Apavn+TzF/os+eDpFP11DzvT/TmA+ga6ftfjK1oBUH4vmW0qarjpDhKLQ03yjbxnzyeY+5HN905uslQ59PPl2vjNnGZEL73mOu+X6aZsx5XEA/BmDXIP2LGMIwRhCm9PyT67Yyfn1IpiKyFcfz+V3XMlbWL2c69yXMRS7yYNc8+vOxAPlYCG+dn8X3Qz8GMAgtPf90nd5kzrdwErpNrutc+sUeJfTvZr57sAGlKINd5fQrUIkqVMNbs1mHObgO2ciBlr1+ck87xZyd6ILka+PalXxB59oe5nsGdYggCrvq6TegEU1ohrfWkGct1mE97oKWrl8eWSRHD20v+iD5upLk0/1Mpq0lz+N4Aq9xbHdb+XT99PqVTN57sb1+Vzi/r+IafsYv+BV+JfdCl+ogzxEcxXvke8nKp+tn5/O7F+vxLeD4FGIpbsIyLMdkqoc8vejD23gHWn7rl+heXEOWbdiOe3EfdiBd5bd+et1qq/c6ydBCllYcwPN4AS8iHbWY+7N3/eQ5oc8KfdbZ+VKZYwnzF6DQek7Y+69iu3f95Dmhzwp91qUrXzXzb8SmgHwRttvrV8r9xe/3nz4r7O82xG+VYYxgFGNIdb1KPl2/Iu4rci/WZ0SH9V62ybPCrgXcU/KxEDfgRvjVo8zxWFwtbdjS9ZO/k3uxlOSUY5yoKslThWpsxCb41WEytcd1JMm3Mv678Bw7epL3t0PXT3PKtaE5ZT7p+1UjeZrQjL3YB786Q6buuJ4k+baQ5xI7UTX0NZfm9K6bt++XIVXb/PJpLs052bnku0+0/PJpLs050X3L341C8o1Lx7Hk/0ktv3yaS3PqWGlP8VzoRBdO4wy6EVRjfBA2n/w/qbWH8y2CbERRB82lOXWstJ+T5Qt8ia/wNb6B1Le03+F7/IAfMZF8sb0Fv2ouzWmP/Ic5TYYxUzAV0zAdUhm0mZiBmchCmHy7uJYfxiNJrmnNpTljs8de72DOIhSjBKtwJ6RW067BWqzDeoTJd5BcbTiUJJ/m0pyx2f9//Yy35xzN4XxxPf9c82kuzSnJ7GtK+lIyryuX67eTdevCacf1+y9E/MW+pnT7CG/kunKRw7hUla6fy/4u8BulHwMYxEXY9RvPuN/xB/7EX5C6xLhxXMYVXIVr2cc12d/MZb5c5GEe5sOum7neb8GtuA0rILWIcYuxBAUohEv9neTYe/exgf2WogzlqIBd95PnATyIh7ATUpsZtwVbUYNtcK0V3L9XwuU417HfCKKoRwPsOkieNhzCYbRD6lnGPYf9aEErXGsn2XYhzHF23XcqxrWTrcNx/VIxX9h9eNfP5TiHncM7Xs8p3R7Ul+26fjp2MsdZv1tQ+zK/xV+BronmCurrds0WtF/X7frdgtqzZHsXuiY6f1Bft0u+fwG0n3RK
   </data>
  </layer>
  <layer id="4" name="Above Player" width="40" height="40">
@@ -48,7 +48,7 @@
   </data>
  </layer>
  <objectgroup color="#ff0000" id="5" name="Collisions">
-  <object id="1" type="collision" x="0" y="336" width="32" height="160"/>
+  <object id="1" type="collision" x="0" y="320" width="32" height="160"/>
   <object id="2" type="collision" x="272" y="608" width="192" height="32"/>
   <object id="3" type="collision" x="80" y="400" width="96" height="48"/>
   <object id="4" type="collision" x="192" y="400" width="80" height="48"/>

--- a/mods/tuxemon/maps/normal.world
+++ b/mods/tuxemon/maps/normal.world
@@ -1,0 +1,125 @@
+{
+    "maps": [
+        {
+            "fileName": "route1.tmx",
+            "height": 672,
+            "width": 944,
+            "x": -16,
+            "y": 0
+        },
+        {
+            "fileName": "taba_town.tmx",
+            "height": 960,
+            "width": 1024,
+            "x": 928,
+            "y": 0
+        },
+        {
+            "fileName": "route1_sanglorian.tmx",
+            "height": 320,
+            "width": 640,
+            "x": 112,
+            "y": -320
+        },
+        {
+            "fileName": "cotton_town.tmx",
+            "height": 640,
+            "width": 640,
+            "x": 112,
+            "y": -960
+        },
+        {
+            "fileName": "dryadsgrove.tmx",
+            "height": 320,
+            "width": 640,
+            "x": 752,
+            "y": -960
+        },
+        {
+            "fileName": "route2.tmx",
+            "height": 320,
+            "width": 640,
+            "x": -528,
+            "y": -640
+        },
+        {
+            "fileName": "citypark.tmx",
+            "height": 640,
+            "width": 640,
+            "x": -528,
+            "y": -1280
+        },
+        {
+            "fileName": "leather_town.tmx",
+            "height": 640,
+            "width": 640,
+            "x": 112,
+            "y": -1600
+        },
+        {
+            "fileName": "route3.tmx",
+            "height": 640,
+            "width": 640,
+            "x": 112,
+            "y": -2240
+        },
+        {
+            "fileName": "route4.tmx",
+            "height": 640,
+            "width": 320,
+            "x": 432,
+            "y": -2880
+        },
+        {
+            "fileName": "flower_city.tmx",
+            "height": 640,
+            "width": 640,
+            "x": 752,
+            "y": -2896
+        },
+        {
+            "fileName": "route5.tmx",
+            "height": 320,
+            "width": 640,
+            "x": 1392,
+            "y": -2896
+        },
+        {
+            "fileName": "routea.tmx",
+            "height": 640,
+            "width": 320,
+            "x": 752,
+            "y": -3536
+        },
+        {
+            "fileName": "timber_town.tmx",
+            "height": 640,
+            "width": 640,
+            "x": 2032,
+            "y": -3216
+        },
+        {
+            "fileName": "tunnel.tmx",
+            "height": 640,
+            "width": 320,
+            "x": 2352,
+            "y": -3856
+        },
+        {
+            "fileName": "route6.tmx",
+            "height": 320,
+            "width": 640,
+            "x": 1712,
+            "y": -3856
+        },
+        {
+            "fileName": "candy_town.tmx",
+            "height": 640,
+            "width": 640,
+            "x": 1712,
+            "y": -4496
+        }
+    ],
+    "onlyShowAdjacentMaps": false,
+    "type": "world"
+}

--- a/mods/tuxemon/maps/routea.tmx
+++ b/mods/tuxemon/maps/routea.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="56">
+<map version="1.5" tiledversion="1.7.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="57">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -25,7 +25,7 @@
  </layer>
  <layer id="2" name="Layer 2" width="20" height="40">
   <data encoding="base64" compression="zlib">
-   eAHFlrlOA0EMhqcAEjp4AyooOarQcwoJ6Dh6oKKEgioEeqDjGRA9yRvQcvQk78H1/2H/YFkzZDZCYMnZGY/97YztzW4I/yfvIyF8QBvQM6fnmJeVjUoIm9CbSOxtxHYxFMJlQq9gnwRrqgTvDjHNhLZgHxsOYRzK/Z3gcFZj++vHq4E1D334JR7zrZrYvXE8yP7IU03IoIj7F7wX5Lyd0A7sFO3va/b96/e3jDxXoNWEjsJOyeXRdxoxM4U2qyG0oJrPwj4HVQ/S34rfH9e24L9daBusDlTzHdh3oepBy+I4xqO9jpiYnsLegKoH6WtFvJo1RsaHqANV51T/eVfycJyepPzE03puPXT/3g2KgXhaz+V5Tmourl9X/rx90HkZXj3jJmV4Gbhk/+XEWp/Y/0vsfWBjNF5BP1tRD/n/P8tbQ4yeKfqv431B5XuNcWLQz/aOzZ948tUzxd44LpTvIfJsv/TjaV05iV1XzZnFvsZ9YvvzvAXELhpdMizmUXnhOMbT/bieI8oLfT1PZ/McWxNbG/op3xx7nj2bPRdzcGTqwvqwNhTlh2PPo01i+0wx3L/kvhhojdMUT2fQ+RVjeeJq7SeeamJ5b0Vfs6dVU973FcrvrRRPvmLxSr7tadVUdvV57LzyJYd9K253A4kf+cR4DNG6zWMC1TXLP8VTrPJo+0jPCvtpD477hR7g2o8nrr9OeEMxt7xH1OkpQ+03N7/Jbcwz5mWF36USO5aN109tus6W
+   eAHFlrFSFEEQhidAODN8AyIMRaIjF8SySslEcyEihIDoOMyVjGegzOXewFQl9+49FPh/2A+7pma83SsLu6pvZ3q6v53p7r3dlP6fXM6ndCUdSo8z/aB5V3m9kNKW9KwQ+7lg+ziX0qeKnsi+LNbjDrwvijmv6Ej2xQcpPZJ6f4c6XNTS/qbx+mKtSb/9I57zTU3i3jyeZX/mURMzLHDvg/dTOR9XdCK7hf3dzv785vt7rjwvSHsVfSi7pS3Pvk8Us9LoeS+lkZT5U9lXpfSg/aPk+/PaG/lvNzoWayJl/lb2d1J6MLI8LvFsHyimpEeyD6X0oH2jwOtHY2G8pzpYOSf9l7uap+PcSc0PHutt68H9727QDOCx3paXc2pzuPk6+cvts8678AYtbtKF1wJX7b82sdGn9P9Seh/EGMab6uco9FD+/xd5LxXDM2X/V3pfWP1ecxwM+8XeifmDhy/PlHvjoFG/h8yL/TKNxzo5KV1fhDPDPtV9SvvLec8Uux50I7CcR/LicYnH/bzeRsiLfXMeZ8s5sSaxNvYj3x7nvHi2eC7nYD/UxfVxbSzkx+OcZxsS+4wY7x/52gxY87TG4wycn5jIg8va33jUJPJ+N33tnqamvu8vqb+3ajx8YflqfuxpaoqdPi+dF19z3LdwbzZQ+cGnxHMI6zGPFdSNGf8aj1jyGPuIZ8X99F6OO43u6jqNBze/LuWGZh5531WnH1M0fm/zPR5jLhTfRfxNisQxNq7XSqrORg==
   </data>
  </layer>
  <layer id="3" name="Layer 3" width="20" height="40">
@@ -41,7 +41,7 @@
  <objectgroup color="#ffff00" id="5" name="Events">
   <object id="44" name="Teleport to Flower City" type="event" x="192" y="624" width="16" height="16">
    <properties>
-    <property name="act10" value="transition_teleport flower_city.tmx,11,0,0.3"/>
+    <property name="act10" value="transition_teleport flower_city.tmx,12,0,0.3"/>
     <property name="act20" value="player_face down"/>
     <property name="cond10" value="is player_at"/>
     <property name="cond20" value="is player_facing down"/>
@@ -77,7 +77,15 @@
     <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
-  <object id="55" name="Player Spawn" type="event" x="208" y="608" width="16" height="16"/>
+  <object id="55" name="Player Spawn" type="event" x="176" y="608" width="16" height="16"/>
+  <object id="56" name="Teleport to Flower City" type="event" x="176" y="624" width="16" height="16">
+   <properties>
+    <property name="act10" value="transition_teleport flower_city.tmx,11,0,0.3"/>
+    <property name="act20" value="player_face down"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing down"/>
+   </properties>
+  </object>
  </objectgroup>
  <objectgroup color="#ff0000" id="6" name="Collisions">
   <object id="2" type="collision" x="128" y="208" width="32" height="80"/>
@@ -94,10 +102,10 @@
   <object id="14" type="collision" x="224" y="16" width="80" height="16"/>
   <object id="16" type="collision" x="288" y="32" width="16" height="592"/>
   <object id="17" type="collision" x="16" y="48" width="16" height="576"/>
-  <object id="18" type="collision" x="32" y="608" width="160" height="16"/>
-  <object id="19" type="collision" x="224" y="608" width="64" height="16"/>
-  <object id="20" type="collision" x="176" y="624" width="16" height="16"/>
-  <object id="21" type="collision" x="224" y="624" width="16" height="16"/>
+  <object id="18" type="collision" x="32" y="608" width="144" height="16"/>
+  <object id="19" type="collision" x="208" y="608" width="80" height="16"/>
+  <object id="20" type="collision" x="160" y="624" width="16" height="16"/>
+  <object id="21" type="collision" x="208" y="624" width="16" height="16"/>
   <object id="22" type="collision" x="32" y="48" width="160" height="16"/>
   <object id="23" type="collision" x="48" y="64" width="128" height="112"/>
   <object id="24" type="collision" x="64" y="16" width="96" height="32"/>


### PR DESCRIPTION
This PR adds a world file, and changes alignments in leather_town — citypark and flower_city — routea

﻿- Add world file
- Change alignment of the trees in leather_town.tmx
- Move teleport events between leather_town and citypark
- Fix alignment of the routea
