### PR TITLE
Remove duplicate play music event (spyder_leather_town.tmx)

### DIFF
--- a/mods/tuxemon/maps/spyder_leather_town.tmx
+++ b/mods/tuxemon/maps/spyder_leather_town.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.4" tiledversion="1.4.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="303">
+<map version="1.5" tiledversion="1.7.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="303">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -152,12 +152,6 @@
     <property name="act2" value="player_face right"/>
     <property name="cond1" value="is player_at"/>
     <property name="cond2" value="is player_facing right"/>
-   </properties>
-  </object>
-  <object id="178" name="Play Music" type="event" x="640" y="32" width="16" height="16" rotation="180">
-   <properties>
-    <property name="act1" value="play_music JRPG_town_loop.ogg"/>
-    <property name="cond1" value="not music_playing JRPG_town_loop.ogg"/>
    </properties>
   </object>
   <object id="179" name="Teleport to Route 3" type="event" x="160" y="16" width="16" height="16" rotation="180">


### PR DESCRIPTION
Fixes #971. 

The errors were most likely caused by the `duplicate tuxemon.event.play_music` events, plus their associated conditions (not `music_playing music_town_theme`).

Music now appears to play normally.