### PR TITLE
Fix #970, bug allowing you to move 1 tile outside of map bounds

### DIFF
--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -716,8 +716,8 @@ class WorldState(state.State):
 
             # We only need to check the perimeter,
             # as there is no way to get further out of bounds
-            if not (self.invalid_x[0] <= neighbor[0] <= self.invalid_x[1]) or not (
-                self.invalid_y[0] <= neighbor[1] <= self.invalid_y[1]
+            if not (self.invalid_x[0] < neighbor[0] < self.invalid_x[1]) or not (
+                self.invalid_y[0] < neighbor[1] < self.invalid_y[1]
             ):
                 continue
 


### PR DESCRIPTION
Fix off-by-one error in the get_exits function. 

We only want to add neighbour tile as an exit if it is inbetween the invalid x/y coordinates. 

Can be tested using CLI:
teleport 0 3 spyder_leather_house1.tmx
Before this commit, you can walk outside the map in right/left/down directions by 1 tile, after the commit you stop at the walls as expected. 