### PR TITLE
Specify map_name at WorldState startup time.

### DIFF
--- a/tuxemon/main.py
+++ b/tuxemon/main.py
@@ -87,9 +87,8 @@ def main(
 
     # TODO: rename this to "debug map" or something
     if config.skip_titlescreen:
-        state = client.push_state("WorldState")
         map_name = prepare.fetch("maps", prepare.CONFIG.starting_map)
-        state.change_map(map_name)
+        state = client.push_state("WorldState", map_name=map_name)
 
     # block of code useful for testing
     if config.collision_map:

--- a/tuxemon/states/persistance/load_menu.py
+++ b/tuxemon/states/persistance/load_menu.py
@@ -1,6 +1,6 @@
 import logging
 
-from tuxemon import save
+from tuxemon import save, prepare
 from .save_menu import SaveMenuState
 from tuxemon.session import local_session
 
@@ -32,7 +32,11 @@ class LoadMenuState(SaveMenuState):
                 self.client.pop_state(self)
                 self.client.pop_state(old_world)
 
-            self.client.push_state("WorldState")
+            map_path = prepare.fetch("maps", save_data["current_map"])
+            self.client.push_state(
+                "WorldState",
+                map_name=map_path,
+            )
 
             # teleport the player to the correct position using an event engine action
             tele_x, tele_y = save_data["tile_pos"]

--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -89,7 +89,7 @@ class WorldState(state.State):
         buttons.BACK: intentions.WORLD_MENU,
     }
 
-    def startup(self, **kwargs: Any) -> None:
+    def startup(self, *, map_name: Optional[str] = None, **kwargs: Any) -> None:
         # Provide access to the screen surface
         self.screen = self.client.screen
         self.screen_rect = self.screen.get_rect()
@@ -110,7 +110,7 @@ class WorldState(state.State):
         #                              Map                                   #
         ######################################################################
 
-        self.current_map: Optional[TuxemonMap] = None
+        self.current_map: TuxemonMap
 
         ######################################################################
         #                            Transitions                             #
@@ -164,6 +164,11 @@ class WorldState(state.State):
         self.cinema_bottom["on_position"] = [0, self.resolution[1] - self.cinema_bottom["surface"].get_height()]
 
         self.map_animations = dict()
+
+        if map_name:
+            self.change_map(map_name)
+        else:
+            raise ValueError("You must pass the map name to load")
 
     def resume(self) -> None:
         """Called after returning focus to this state"""


### PR DESCRIPTION
This guarantees that `current_map` always have a valid value.