### PR TITLE
Fix in remove_monster - trainer is not a parameter

### DIFF
--- a/tuxemon/event/actions/remove_monster.py
+++ b/tuxemon/event/actions/remove_monster.py
@@ -46,7 +46,7 @@ class RemoveMonsterAction(EventAction[RemoveMonsterActionParameters]):
     def start(self) -> None:
         iid = self.session.player.game_variables[self.parameters.instance_id]
         instance_id = uuid.UUID(iid)
-        trainer_slug = self.parameters.trainer
+        trainer_slug = self.parameters.trainer_slug
 
         if trainer_slug is None:
             trainer = self.session.player


### PR DESCRIPTION
I haven't created an issue for this, just a small fix - error message is as follows when correctly using the remove_monster action:
'RemoveMonsterActionParameters has no variable trainer'
Crashes on the following line:
     trainer_slug = self.parameters.trainer

To test it, I created the following events:

1:
act1 get_player_monster var1
act2 set_variable xoxo:yes
cond1 not variable_set xoxo:yes

2:
remove_monster var1
cond1 variable_set xoxo:yes

This will crash with error 'RemoveMonsterActionParameters has no variable trainer'
Once fixed it correctly removes the chosen tuxemon