### PR TITLE
Fix typing errors in set monster level action

### DIFF
--- a/tests/tuxemon/test_monster.py
+++ b/tests/tuxemon/test_monster.py
@@ -1,0 +1,31 @@
+import unittest
+from unittest import skip
+from unittest.mock import Mock
+
+from tuxemon.monster import Monster, MAX_LEVEL
+
+
+class MonsterTestBase(unittest.TestCase):
+    pass
+
+
+class SetLevel(MonsterTestBase):
+    def setUp(self):
+        self.mon = Monster()
+        self.mon.name = "agnite"
+        self.mon.set_level(2)
+
+    def test_set_level(self):
+        mon = self.mon
+        mon.set_level(5)
+        self.assertEqual(mon.level, 5)
+
+    def test_set_level_clamps_max(self):
+        mon = self.mon
+        mon.set_level(10000)
+        self.assertEqual(mon.level, MAX_LEVEL)
+
+    def test_set_level_clamps_to_1(self):
+        mon = self.mon
+        mon.set_level(-100)
+        self.assertEqual(mon.level, 1)

--- a/tuxemon/event/actions/set_monster_level.py
+++ b/tuxemon/event/actions/set_monster_level.py
@@ -26,14 +26,21 @@ from typing import NamedTuple, final, Union
 
 class SetMonsterLevelActionParameters(NamedTuple):
     slot: Union[int, None]
-    level: Union[int, None]
+    level: int
 
 
 @final
 class SetMonsterLevelAction(EventAction[SetMonsterLevelActionParameters]):
     """Changes the level of a monster in the current player's party. The action parameters
     may contain a monster slot and the amount by which to level. If no slot is specified,
-    all monsters are leveled. If no level is specified, the level is reverted to 1.
+    all monsters are leveled. The level parameter can be negative, which decreases
+    the monster's level.
+
+    Examples:
+    set_player_monster 0,5 # Increases the monster in the first slot's level by 5
+    set_player_monster ,1  # Increases all player's monsters by 1 level
+    set_player_monster 4,-100 # Decreases the monster in the fifth slot's level
+                # by 100 levels
 
     Valid Parameters: slot, level
     """
@@ -53,13 +60,7 @@ class SetMonsterLevelAction(EventAction[SetMonsterLevelActionParameters]):
                 return
 
             monster = self.session.player.monsters[int(monster_slot)]
-            if monster_level:
-                monster.level = max(1, monster.level + int(monster_level))
-            else:
-                monster.level = 1
+            monster.level = max(1, monster.level + int(monster_level))
         else:
             for monster in self.session.player.monsters:
-                if monster_level:
-                    monster.level = max(1, monster.level + int(monster_level))
-                else:
-                    monster.level = 1
+                monster.level = max(1, monster.level + int(monster_level))

--- a/tuxemon/event/actions/set_monster_level.py
+++ b/tuxemon/event/actions/set_monster_level.py
@@ -21,12 +21,12 @@
 
 from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple, final
+from typing import NamedTuple, final, Union
 
 
 class SetMonsterLevelActionParameters(NamedTuple):
-    slot: int
-    level: int
+    slot: Union[int, None]
+    level: Union[int, None]
 
 
 @final
@@ -42,7 +42,7 @@ class SetMonsterLevelAction(EventAction[SetMonsterLevelActionParameters]):
     param_class = SetMonsterLevelActionParameters
 
     def start(self) -> None:
-        if not self.session.player.monsters > 0:
+        if not len(self.session.player.monsters) > 0:
             return
 
         monster_slot = self.parameters[0]

--- a/tuxemon/event/actions/set_monster_level.py
+++ b/tuxemon/event/actions/set_monster_level.py
@@ -42,7 +42,7 @@ class SetMonsterLevelAction(EventAction[SetMonsterLevelActionParameters]):
     param_class = SetMonsterLevelActionParameters
 
     def start(self) -> None:
-        if not len(self.session.player.monsters) > 0:
+        if not self.session.player.monsters:
             return
 
         monster_slot = self.parameters[0]

--- a/tuxemon/event/actions/set_monster_level.py
+++ b/tuxemon/event/actions/set_monster_level.py
@@ -34,13 +34,13 @@ class SetMonsterLevelAction(EventAction[SetMonsterLevelActionParameters]):
     """Changes the level of a monster in the current player's party. The action parameters
     may contain a monster slot and the amount by which to level. If no slot is specified,
     all monsters are leveled. The level parameter can be negative, which decreases
-    the monster's level.
+    the monster's level. The new level never goes below 1 or above MAX_LEVEL.
 
     Examples:
     set_player_monster 0,5 # Increases the monster in the first slot's level by 5
     set_player_monster ,1  # Increases all player's monsters by 1 level
     set_player_monster 4,-100 # Decreases the monster in the fifth slot's level
-                # by 100 levels
+                # by 100 levels, but sets it to 1 if the new level is 0 or negative.
 
     Valid Parameters: slot, level
     """
@@ -60,7 +60,7 @@ class SetMonsterLevelAction(EventAction[SetMonsterLevelActionParameters]):
                 return
 
             monster = self.session.player.monsters[int(monster_slot)]
-            monster.level = max(1, monster.level + int(monster_level))
+            monster.set_level(monster.level + int(monster_level))
         else:
             for monster in self.session.player.monsters:
-                monster.level = max(1, monster.level + int(monster_level))
+                monster.set_level(monster.level + int(monster_level))

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -460,6 +460,7 @@ class Monster:
 
         Sets the Monster's level to the specified arbitrary level,
         and modifies experience accordingly.
+        Does not let level go above MAX_LEVEL or below 1.
 
         Parameters:
             level: The level to set the monster to.
@@ -469,6 +470,10 @@ class Monster:
         >>> bulbatux.set_level(20)
 
         """
+        if level > MAX_LEVEL:
+            level = MAX_LEVEL
+        elif level < 1:
+            level = 1
         self.level = level
         self.total_experience = self.experience_required()
         self.set_stats()


### PR DESCRIPTION
Firstly, we need to add a len() around the player.monsters list, as you can't compare a list and 0 and it was giving an error when the action was used. 
(I guess you could replace it with:
`if not self.session.player.monsters:`
I can change it if that's more Python-y? )

Secondly, add typing around the params, as you're allowed to pass None for both params, eg the action:
set_player_monster ,
Will set all player's monsters to level 1. 
Previously this was giving errors if you tried to pass None as a param. 
