### PR TITLE
Add default image and rect  to Sprite objects.

### DIFF
--- a/tuxemon/graphics.py
+++ b/tuxemon/graphics.py
@@ -173,8 +173,7 @@ def load_sprite(
         Loaded sprite.
 
     """
-    sprite = Sprite()
-    sprite.image = load_and_scale(filename)
+    sprite = Sprite(image=load_and_scale(filename))
     sprite.rect = sprite.image.get_rect(**rect_kwargs)
     return sprite
 

--- a/tuxemon/states/items/__init__.py
+++ b/tuxemon/states/items/__init__.py
@@ -58,7 +58,6 @@ class ItemMenuState(Menu[Item]):
         # its also animated to pop out of the backpack
         self.item_center = self.rect.width * 0.164, self.rect.height * 0.13
         self.item_sprite = Sprite()
-        self.item_sprite.image = None
         self.sprites.add(self.item_sprite)
 
         # do not move this line
@@ -221,7 +220,6 @@ class ShopMenuState(Menu[Item]):
         # this sprite is used to display the item
         self.item_center = self.rect.width * 0.164, self.rect.height * 0.13
         self.item_sprite = Sprite()
-        self.item_sprite.image = None
         self.sprites.add(self.item_sprite)
 
         # do not move this line

--- a/tuxemon/ui/draw.py
+++ b/tuxemon/ui/draw.py
@@ -56,19 +56,9 @@ class GraphicBox(Sprite):
         self._fill_tiles = fill_tiles
         self._tiles: List[pygame.surface.Surface] = []
         self._tile_size = 0, 0
-        self._rect: Optional[pygame.rect.Rect] = None
+
         if border:
             self._set_border(border)
-
-    @property
-    def rect(self) -> Optional[Rect]:
-        return self._rect
-
-    @rect.setter
-    def rect(self, rect: Optional[Rect]) -> None:
-        if not rect == self._rect:
-            self._rect = rect
-            self._needs_update = True
 
     def calc_inner_rect(self, rect: Rect) -> Rect:
         if self._tiles:

--- a/tuxemon/ui/text.py
+++ b/tuxemon/ui/text.py
@@ -29,7 +29,6 @@ class TextArea(Sprite):
         self.font_bg = bg
         self._rendered_text = None
         self._text_rect = None
-        self._image = None
         self._text = ""
 
     def __iter__(self) -> TextArea:
@@ -56,7 +55,7 @@ class TextArea(Sprite):
         if self.animated:
             try:
                 dest, scrap = next(self._iter)
-                self._image.blit(scrap, dest)
+                self.image.blit(scrap, dest)
             except StopIteration:
                 self.drawing_text = False
                 raise


### PR DESCRIPTION
The sprite objects now have a default image and rect.

This removes tons of stupid errors when accessing these attributes (as
previously they could be `None`).