### PR TITLE
Always return a state in get_state_by_name

### DIFF
--- a/tuxemon/client.py
+++ b/tuxemon/client.py
@@ -464,9 +464,6 @@ class LocalPygameClient:
 
         """
         world = self.get_state_by_name(WorldState)
-        if not world:
-            return
-
         world.npcs = {}
         world.npcs_off_map = {}
         for client in registry:
@@ -498,9 +495,6 @@ class LocalPygameClient:
 
         """
         world = self.get_state_by_name(WorldState)
-        if not world:
-            return None
-
         return world.current_map.filename
 
     def get_map_name(self) -> Optional[str]:
@@ -523,20 +517,20 @@ class LocalPygameClient:
     """
 
     @overload
-    def get_state_by_name(self, state_name: str) -> Optional[State]:
+    def get_state_by_name(self, state_name: str) -> State:
         pass
 
     @overload
     def get_state_by_name(
         self,
         state_name: Type[StateType],
-    ) -> Optional[StateType]:
+    ) -> StateType:
         pass
 
     def get_state_by_name(
         self,
         state_name: Union[str, Type[State]],
-    ) -> Optional[State]:
+    ) -> State:
         """
         Query the state stack for a state by the name supplied.
         """

--- a/tuxemon/event/__init__.py
+++ b/tuxemon/event/__init__.py
@@ -86,9 +86,6 @@ def get_npc(session: Session, slug: str) -> Optional[NPC]:
 
     # Loop through the NPC list and see if the slug matches any in the list
     world = session.client.get_state_by_name(WorldState)
-    if world is None:
-        logger.error("Cannot search for NPC if world doesn't exist: " + slug)
-        return None
 
     # logger.error("Unable to find NPC: " + slug)
     return world.get_entity(slug)

--- a/tuxemon/event/actions/create_npc.py
+++ b/tuxemon/event/actions/create_npc.py
@@ -64,8 +64,6 @@ class CreateNpcAction(EventAction[CreateNpcActionParameters]):
     def start(self) -> None:
         # Get a copy of the world state.
         world = self.session.client.get_state_by_name(WorldState)
-        if not world:
-            return
 
         # Get the npc's parameters from the action
         slug = self.parameters.npc_slug

--- a/tuxemon/event/actions/delayed_teleport.py
+++ b/tuxemon/event/actions/delayed_teleport.py
@@ -58,8 +58,6 @@ class DelayedTeleportAction(EventAction[DelayedTeleportActionParameters]):
     def start(self) -> None:
         # Get the world object from the session
         world = self.session.client.get_state_by_name(WorldState)
-        if not world:
-            return
 
         # give up if there is a teleport in progress
         if world.delayed_teleport:

--- a/tuxemon/event/actions/dialog.py
+++ b/tuxemon/event/actions/dialog.py
@@ -70,7 +70,9 @@ class DialogAction(EventAction[DialogActionParameters]):
         self.open_dialog(text, avatar)
 
     def update(self) -> None:
-        if self.session.client.get_state_by_name(DialogState) is None:
+        try:
+            self.session.client.get_state_by_name(DialogState)
+        except ValueError:
             self.stop()
 
     def open_dialog(self, initial_text: str, avatar: Optional[Sprite]) -> None:

--- a/tuxemon/event/actions/dialog_chain.py
+++ b/tuxemon/event/actions/dialog_chain.py
@@ -78,12 +78,11 @@ class DialogChainAction(EventAction[DialogChainActionParameters]):
             self.stop()
 
             # is a dialog already open?
-            dialog = self.session.client.get_state_by_name(DialogState)
-
-            if dialog:
+            try:
+                dialog = self.session.client.get_state_by_name(DialogState)
                 # yes, so just add text to it
                 dialog.text_queue.append(text)
-            else:
+            except ValueError:
                 # no, so create new dialog with this line
                 avatar = get_avatar(self.session, self.parameters.avatar)
                 self.open_dialog(text, avatar)
@@ -92,7 +91,9 @@ class DialogChainAction(EventAction[DialogChainActionParameters]):
         # hack to allow unescaped commas in the dialog string
         text = ", ".join(self.raw_parameters)
         if text == "${{end}}":
-            if self.session.client.get_state_by_name(DialogState) is None:
+            try:
+                self.session.client.get_state_by_name(DialogState)
+            except ValueError:
                 self.stop()
 
     def open_dialog(self, initial_text: str, avatar: Optional[Sprite]) -> None:

--- a/tuxemon/event/actions/dialog_choice.py
+++ b/tuxemon/event/actions/dialog_choice.py
@@ -75,7 +75,9 @@ class DialogChoiceAction(EventAction[DialogChoiceActionParameters]):
         self.open_choice_dialog(self.session, var_menu)
 
     def update(self) -> None:
-        if self.session.client.get_state_by_name(ChoiceState) is None:
+        try:
+            self.session.client.get_state_by_name(ChoiceState)
+        except ValueError:
             self.stop()
 
     def open_choice_dialog(

--- a/tuxemon/event/actions/get_player_monster.py
+++ b/tuxemon/event/actions/get_player_monster.py
@@ -70,5 +70,7 @@ class GetPlayerMonsterAction(EventAction[GetPlayerMonsterActionParameters]):
         menu.on_menu_selection = self.set_var
 
     def update(self) -> None:
-        if self.session.client.get_state_by_name(MonsterMenuState) is None:
+        try:
+            self.session.client.get_state_by_name(MonsterMenuState)
+        except ValueError:
             self.stop()

--- a/tuxemon/event/actions/npc_wander.py
+++ b/tuxemon/event/actions/npc_wander.py
@@ -55,10 +55,7 @@ class NpcWanderAction(EventAction[NpcWanderActionParameters]):
 
     def start(self) -> None:
         npc = get_npc(self.session, self.parameters.npc_slug)
-        maybe_world = self.session.client.get_state_by_name(WorldState)
-        assert maybe_world
-
-        world = maybe_world
+        world = self.session.client.get_state_by_name(WorldState)
 
         def move(world: WorldState, npc: NPC) -> None:
             # Don't interrupt existing movement

--- a/tuxemon/event/actions/play_map_animation.py
+++ b/tuxemon/event/actions/play_map_animation.py
@@ -83,10 +83,6 @@ class PlayMapAnimationAction(EventAction[PlayMapAnimationActionParameters]):
         # If it has, play the animation using the animation's conductor.
         world_state = self.session.client.get_state_by_name(WorldState)
 
-        if world_state is None:
-            logger.error("Cannot run MapAnimation outside of world state")
-            raise RuntimeError
-
         # Determine the tile position where to draw the animation.
         # TODO: unify npc/player sprites and map animations
         if self.parameters[3] == "player":

--- a/tuxemon/event/actions/player_face.py
+++ b/tuxemon/event/actions/player_face.py
@@ -64,8 +64,6 @@ class PlayerFaceAction(EventAction[PlayerFaceActionParameters]):
         # If we're doing a transition, only change the player's facing when
         # we've reached the apex of the transition.
         world_state = self.session.client.get_state_by_name(WorldState)
-        if world_state is None:
-            return
 
         if world_state.in_transition:
             world_state.delayed_facing = direction

--- a/tuxemon/event/actions/player_resume.py
+++ b/tuxemon/event/actions/player_resume.py
@@ -47,7 +47,5 @@ class PlayerResumeAction(EventAction[PlayerResumeActionParameters]):
     def start(self) -> None:
         # Get a copy of the world state.
         world = self.session.client.get_state_by_name(WorldState)
-        if not world:
-            return
 
         world.menu_blocking = False

--- a/tuxemon/event/actions/player_stop.py
+++ b/tuxemon/event/actions/player_stop.py
@@ -47,7 +47,4 @@ class PlayerStopAction(EventAction[PlayerStopActionParameters]):
     def start(self) -> None:
         # Get a copy of the world state.
         world = self.session.client.get_state_by_name(WorldState)
-        if not world:
-            return
-
         world.stop_player()

--- a/tuxemon/event/actions/random_encounter.py
+++ b/tuxemon/event/actions/random_encounter.py
@@ -103,8 +103,6 @@ class RandomEncounterAction(EventAction[RandomEncounterActionParameters]):
 
             # stop the player
             world = self.session.client.get_state_by_name(WorldState)
-            if world is None:
-                return
             world.lock_controls()
             world.stop_player()
 
@@ -119,7 +117,9 @@ class RandomEncounterAction(EventAction[RandomEncounterActionParameters]):
             )
 
     def update(self) -> None:
-        if self.session.client.get_state_by_name(CombatState) is None:
+        try:
+            self.session.client.get_state_by_name(CombatState)
+        except ValueError:
             self.stop()
 
 

--- a/tuxemon/event/actions/remove_npc.py
+++ b/tuxemon/event/actions/remove_npc.py
@@ -50,8 +50,6 @@ class RemoveNpcAction(EventAction[RemoveNpcActionParameters]):
     def start(self) -> None:
         # Get a copy of the world state.
         world = self.session.client.get_state_by_name(WorldState)
-        if not world:
-            return
 
         # Get the npc's parameters from the action
         world.remove_entity(self.parameters.npc_slug)

--- a/tuxemon/event/actions/rename_monster.py
+++ b/tuxemon/event/actions/rename_monster.py
@@ -54,26 +54,33 @@ class RenameMonsterAction(EventAction[RenameMonsterActionParameters]):
 
     def start(self) -> None:
         # Get a copy of the world state.
-        world = self.session.client.get_state_by_name(WorldState)
-        if world is None:
-            return
+        self.session.client.get_state_by_name(WorldState)
 
         # pull up the monster menu so we know which one we are renaming
         menu = self.session.client.push_state("MonsterMenuState")
         menu.on_menu_selection = self.prompt_for_name
 
     def update(self) -> None:
-        if (
-            self.session.client.get_state_by_name(MonsterMenuState) is None
-            and self.session.client.get_state_by_name(InputMenu) is None
-        ):
-            self.stop()
+
+        missing_monster_menu = False
+
+        try:
+            self.session.client.get_state_by_name(MonsterMenuState)
+        except ValueError:
+            missing_monster_menu = True
+
+        try:
+            self.session.client.get_state_by_name(InputMenu)
+        except ValueError:
+            if missing_monster_menu:
+                self.stop()
 
     def set_monster_name(self, name: str) -> None:
         self.monster.name = name
-        monster_menu_state = self.session.client.get_state_by_name(MonsterMenuState)
-        if monster_menu_state:
-            monster_menu_state.refresh_menu_items()
+        monster_menu_state = self.session.client.get_state_by_name(
+            MonsterMenuState,
+        )
+        monster_menu_state.refresh_menu_items()
 
     def prompt_for_name(self, menu_item: MenuItem) -> None:
         self.monster = menu_item.game_object

--- a/tuxemon/event/actions/rename_player.py
+++ b/tuxemon/event/actions/rename_player.py
@@ -62,5 +62,7 @@ class RenamePlayerAction(EventAction[RenamePlayerActionParameters]):
         )
 
     def update(self) -> None:
-        if self.session.client.get_state_by_name(InputMenu) is None:
+        try:
+            self.session.client.get_state_by_name(InputMenu)
+        except ValueError:
             self.stop()

--- a/tuxemon/event/actions/screen_transition.py
+++ b/tuxemon/event/actions/screen_transition.py
@@ -53,7 +53,6 @@ class ScreenTransitionAction(EventAction[ScreenTransitionActionParameters]):
     def update(self) -> None:
         world = self.session.client.get_state_by_name(WorldState)
 
-        if world is not None:
-            if not world.in_transition:
-                world.fade_and_teleport(self.parameters.transition_time)
-                self.stop()
+        if not world.in_transition:
+            world.fade_and_teleport(self.parameters.transition_time)
+            self.stop()

--- a/tuxemon/event/actions/spawn_monster.py
+++ b/tuxemon/event/actions/spawn_monster.py
@@ -74,8 +74,6 @@ class SpawnMonsterAction(EventAction[SpawnMonsterActionParameters]):
     def start(self) -> None:
         npc_slug, breeding_mother, breeding_father = self.parameters
         world = self.session.client.get_state_by_name(WorldState)
-        if not world:
-            return
 
         npc_slug = npc_slug.replace("player", "npc_red")
         trainer = world.get_entity(npc_slug)
@@ -119,7 +117,9 @@ class SpawnMonsterAction(EventAction[SpawnMonsterActionParameters]):
         )
 
     def update(self) -> None:
-        if self.session.client.get_state_by_name(DialogState) is None:
+        try:
+            self.session.client.get_state_by_name(DialogState)
+        except ValueError:
             self.stop()
 
     def open_dialog(

--- a/tuxemon/event/actions/start_battle.py
+++ b/tuxemon/event/actions/start_battle.py
@@ -63,8 +63,6 @@ class StartBattleAction(EventAction[StartBattleActionParameters]):
             return
 
         world = self.session.client.get_state_by_name(WorldState)
-        if not world:
-            return
 
         npc = world.get_entity(self.parameters.npc_slug)
         assert npc
@@ -94,5 +92,7 @@ class StartBattleAction(EventAction[StartBattleActionParameters]):
         )
 
     def update(self) -> None:
-        if self.session.client.get_state_by_name(CombatState) is None:
+        try:
+            self.session.client.get_state_by_name(CombatState)
+        except ValueError:
             self.stop()

--- a/tuxemon/event/actions/teleport.py
+++ b/tuxemon/event/actions/teleport.py
@@ -55,8 +55,6 @@ class TeleportAction(EventAction[TeleportActionParameters]):
     def start(self) -> None:
         player = self.session.player
         world = self.session.client.get_state_by_name(WorldState)
-        if not world:
-            return
 
         map_name = self.parameters.map_name
 

--- a/tuxemon/event/actions/translated_dialog.py
+++ b/tuxemon/event/actions/translated_dialog.py
@@ -93,7 +93,9 @@ class TranslatedDialogAction(EventAction[TranslatedDialogActionParameters]):
         )
 
     def update(self) -> None:
-        if self.session.client.get_state_by_name(DialogState) is None:
+        try:
+            self.session.client.get_state_by_name(DialogState)
+        except ValueError:
             self.stop()
 
     def open_dialog(

--- a/tuxemon/event/actions/translated_dialog_chain.py
+++ b/tuxemon/event/actions/translated_dialog_chain.py
@@ -95,16 +95,18 @@ class TranslatedDialogChainAction(
             replace,
         )
 
-        dialog = self.session.client.get_state_by_name(DialogState)
-        if dialog:
+        try:
+            dialog = self.session.client.get_state_by_name(DialogState)
             dialog.text_queue += pages
-        else:
+        except ValueError:
             self.open_dialog(pages, avatar)
 
     def update(self) -> None:
         key = self.raw_parameters[0]
         if key == "${{end}}":
-            if self.session.client.get_state_by_name(DialogState) is None:
+            try:
+                self.session.client.get_state_by_name(DialogState)
+            except ValueError:
                 self.stop()
 
     def open_dialog(

--- a/tuxemon/event/actions/translated_dialog_choice.py
+++ b/tuxemon/event/actions/translated_dialog_choice.py
@@ -83,7 +83,9 @@ class TranslatedDialogChoiceAction(
         self.open_choice_dialog(self.session, var_menu)
 
     def update(self) -> None:
-        if self.session.client.get_state_by_name(ChoiceState) is None:
+        try:
+            self.session.client.get_state_by_name(ChoiceState)
+        except ValueError:
             self.stop()
 
     def open_choice_dialog(

--- a/tuxemon/event/actions/withdraw_monster.py
+++ b/tuxemon/event/actions/withdraw_monster.py
@@ -63,8 +63,6 @@ class WithdrawMonsterAction(EventAction[WithdrawMonsterActionParameters]):
     def start(self) -> None:
         trainer, monster_id = self.parameters
         world = self.session.client.get_state_by_name(WorldState)
-        if not world:
-            return
 
         trainer = trainer.replace("player", "npc_red")
         npc = world.get_entity(trainer)

--- a/tuxemon/event/conditions/npc_exists.py
+++ b/tuxemon/event/conditions/npc_exists.py
@@ -54,7 +54,5 @@ class NPCExistsCondition(EventCondition):
 
         """
         world = session.client.get_state_by_name(WorldState)
-        if not world:
-            return False
 
         return get_npc(session, condition.parameters[0]) is not None

--- a/tuxemon/graphics.py
+++ b/tuxemon/graphics.py
@@ -463,7 +463,6 @@ def capture_screenshot(game: LocalPygameClient) -> pygame.surface.Surface:
 
     screenshot = pygame.Surface(game.screen.get_size())
     world = game.get_state_by_name(WorldState)
-    assert world
     world.draw(screenshot)
     return screenshot
 

--- a/tuxemon/networking.py
+++ b/tuxemon/networking.py
@@ -512,8 +512,6 @@ class TuxemonClient:
 
             if event_data["type"] == "NOTIFY_CLIENT_INTERACTION":
                 world = self.game.get_state_by_name("WorldState")
-                if not world:
-                    return
                 world.handle_interaction(event_data, self.client.registry)
                 del self.client.event_notifies[euuid]
 
@@ -874,8 +872,6 @@ def update_client(sprite, char_dict, game):
     return
 
     world = game.get_state_by_name("WorldState")
-    if not world:
-        return
 
     for item in char_dict:
         sprite.__dict__[item] = char_dict[item]

--- a/tuxemon/save.py
+++ b/tuxemon/save.py
@@ -82,7 +82,6 @@ def capture_screenshot(client: LocalPygameClient) -> pygame.surface.Surface:
     """
     screenshot = pygame.Surface(client.screen.get_size())
     world = client.get_state_by_name(WorldState)
-    assert world
     world.draw(screenshot)
     return screenshot
 

--- a/tuxemon/state.py
+++ b/tuxemon/state.py
@@ -617,20 +617,20 @@ class StateManager:
         return self._state_stack[:]
 
     @overload
-    def get_state_by_name(self, state_name: str) -> Optional[State]:
+    def get_state_by_name(self, state_name: str) -> State:
         pass
 
     @overload
     def get_state_by_name(
         self,
         state_name: Type[StateType],
-    ) -> Optional[StateType]:
+    ) -> StateType:
         pass
 
     def get_state_by_name(
         self,
         state_name: Union[str, Type[State]],
-    ) -> Optional[State]:
+    ) -> State:
         """
         Query the state stack for a state by the name supplied.
 
@@ -648,4 +648,4 @@ class StateManager:
             ):
                 return state
 
-        return None
+        raise ValueError(f"Missing state {state_name}")

--- a/tuxemon/states/combat/combat_menus.py
+++ b/tuxemon/states/combat/combat_menus.py
@@ -71,9 +71,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
         """
         # TODO: only works for player0
         self.client.pop_state(self)
-        maybe_combat_state = self.client.get_state_by_name(CombatState)
-        assert maybe_combat_state
-        combat_state = maybe_combat_state
+        combat_state = self.client.get_state_by_name(CombatState)
 
         if combat_state.is_trainer_battle:
 
@@ -105,7 +103,6 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                 tools.open_dialog(local_session, [T.format("combat_fainted", {"name": monster.name})])
                 return
             combat_state = self.client.get_state_by_name(CombatState)
-            assert combat_state
             swap = Technique("swap")
             swap.combat_state = combat_state
             player = local_session.player
@@ -136,7 +133,6 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
             self.client.pop_state()  # close the item menu
             # TODO: don't hardcode to player0
             combat_state = self.client.get_state_by_name(CombatState)
-            assert combat_state
             state = self.client.push_state(
                 "CombatTargetMenuState",
                 player=combat_state.players[0],
@@ -155,7 +151,6 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
 
             # enqueue the item
             combat_state = self.client.get_state_by_name(CombatState)
-            assert combat_state
             # TODO: don't hardcode to player0
             combat_state.enqueue_action(combat_state.players[0], item, target)
 
@@ -201,7 +196,6 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                 return
 
             combat_state = self.client.get_state_by_name(CombatState)
-            assert combat_state
             state = self.client.push_state(
                 "CombatTargetMenuState",
                 player=combat_state.players[0],
@@ -217,7 +211,6 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
             # enqueue the technique
             target = menu_item.game_object
             combat_state = self.client.get_state_by_name(CombatState)
-            assert combat_state
             combat_state.enqueue_action(self.monster, technique, target)
 
             # close all the open menus
@@ -268,7 +261,6 @@ class CombatTargetMenuState(Menu[Monster]):
     def initialize_items(self) -> Generator[MenuItem[Monster], None, None]:
         # get a ref to the combat state
         combat_state = self.client.get_state_by_name(CombatState)
-        assert combat_state
 
         # TODO: trainer targeting
         # TODO: cleanup how monster sprites and whatnot are managed

--- a/tuxemon/states/persistance/load_menu.py
+++ b/tuxemon/states/persistance/load_menu.py
@@ -6,6 +6,7 @@ from .save_menu import SaveMenuState
 from tuxemon.session import local_session
 from typing import Any, Optional
 from tuxemon.menu.interface import MenuItem
+from tuxemon.states.world.worldstate import WorldState
 
 logger = logging.getLogger(__name__)
 
@@ -27,15 +28,15 @@ class LoadMenuState(SaveMenuState):
             # order to build a Session
             local_session.player.set_state(local_session, save_data)
 
-            old_world = self.client.get_state_by_name("WorldState")
-            if old_world is None:
-                # when game is loaded from the start menu
-                self.client.pop_state()  # close this menu
-                self.client.pop_state()  # close the start menu
-            else:
+            try:
+                old_world = self.client.get_state_by_name(WorldState)
                 # when game is loaded from world menu
                 self.client.pop_state(self)
                 self.client.pop_state(old_world)
+            except ValueError:
+                # when game is loaded from the start menu
+                self.client.pop_state()  # close this menu
+                self.client.pop_state()  # close the start menu
 
             map_path = prepare.fetch("maps", save_data["current_map"])
             self.client.push_state(


### PR DESCRIPTION
Make `get_state_by_name` always return a state. This removes the need for some asserts.

In case the state is not present an exception will be raised.