### PR TITLE
Typing improvements

### DIFF
--- a/tuxemon/compat/rect.py
+++ b/tuxemon/compat/rect.py
@@ -5,7 +5,7 @@ from typing import (
     Union,
     Tuple,
     Sequence,
-    TypeVar,
+    TypeVar, cast,
 )
 from abc import abstractmethod
 
@@ -239,11 +239,13 @@ class Rect(ReadOnlyRect):
             self._y = arg.y
             self._w = arg.w
             self._h = arg.h
-        elif isinstance(arg, list) or isinstance(arg, tuple):
+        elif isinstance(arg, (list, tuple)):
             if len(arg) == 2:
+                arg = cast(Tuple[Tuple[int, int], Tuple[int, int]], arg)
                 self._x, self._y = arg[0]
                 self._w, self._h = arg[1]
             elif len(arg) == 4:
+                arg = cast(Tuple[int, int, int, int], arg)
                 self._x, self._y, self._w, self._h = arg
         else:
             self._x, self._y, self._w, self._h = arg

--- a/tuxemon/graphics.py
+++ b/tuxemon/graphics.py
@@ -181,7 +181,6 @@ def load_sprite(
 def load_animated_sprite(
     filenames: Iterable[str],
     delay: float,
-    **rect_kwargs: Any,
 ) -> Sprite:
     """
     Load a set of images and return an animated sprite.
@@ -195,7 +194,6 @@ def load_animated_sprite(
     Parameters:
         filenames: Filenames to load.
         delay: Frame interval; time between each frame.
-        rect_kwargs: Parameters for ``get_rect``.
 
     Returns:
         Loaded animated sprite.
@@ -209,10 +207,7 @@ def load_animated_sprite(
 
     tech = SurfaceAnimation(anim, True)
     tech.play()
-    sprite = Sprite()
-    sprite.image = tech
-    sprite.rect = sprite.image.get_rect(**rect_kwargs)
-    return sprite
+    return Sprite(animation=tech)
 
 
 def scale_surface(

--- a/tuxemon/map.py
+++ b/tuxemon/map.py
@@ -33,7 +33,7 @@ import logging
 from itertools import product
 from math import pi, atan2
 from typing import Optional, Literal, Generator, Tuple, TypeVar, Mapping,\
-    Sequence, List, Set, TypedDict
+    Sequence, List, Set, TypedDict, Union
 
 import pyscroll
 
@@ -113,8 +113,8 @@ def translate_short_path(
 
 
 def get_direction(
-    base: Tuple[int, int],
-    target: Tuple[int, int],
+    base: Union[Vector2, Tuple[int, int]],
+    target: Union[Vector2, Tuple[int, int]],
 ) -> Direction:
     y_offset = base[1] - target[1]
     x_offset = base[0] - target[0]

--- a/tuxemon/menu/menu.py
+++ b/tuxemon/menu/menu.py
@@ -23,6 +23,139 @@ logger = logging.getLogger(__name__)
 MenuState = Literal["closed", "opening", "normal", "disabled", "closing"]
 
 
+def determine_cursor_movement(
+    sprite_list: VisualSpriteList[MenuItem[Any]],
+    index: int,
+    event: PlayerInput,
+) -> int:
+    """
+    Given an event, determine a new selected item offset.
+
+    You must pass the currently selected object.
+    The return value will be the newly selected object index.
+
+    Parameters:
+        sprite_list: The sprite list in which to move.
+        index: Index of the item in the list.
+        event: Player event that may cause to select another menu item.
+
+    Returns:
+        New menu item offset
+
+    """
+    if sprite_list.orientation == "horizontal":
+        return _determine_cursor_movement_horizontal(sprite_list, index, event)
+    else:
+        raise RuntimeError
+
+def _determine_cursor_movement_horizontal(
+    sprite_list: VisualSpriteList[MenuItem[Any]],
+    index: int,
+    event: PlayerInput,
+) -> int:
+    """Given an event, determine a new selected item offset
+
+    You must pass the currently selected object.
+    The return value will be the newly selected object index.
+
+    This is for menus that are laid out horizontally first:
+       [1] [2] [3]
+       [4] [5]
+
+    Works pretty well for most menus, but large grids may require
+    handling them differently.
+
+    Parameters:
+        sprite_list: The sprite list in which to move.
+        index: Index of the item in the list.
+        event: Player event that may cause to select another menu item.
+
+    Returns:
+        New menu item offset
+
+    """
+    # sanity check:
+    # if there are 0 or 1 enabled items, then ignore movement
+    enabled = len([i for i in sprite_list if i.enabled])
+    if enabled < 2:
+        return index
+
+    if event.pressed:
+
+        # in order to accommodate disabled menu items,
+        # the mod incrementer will loop until a suitable
+        # index is found...one that is not disabled.
+        items = len(sprite_list)
+        mod = 0
+
+        # horizontal movement: left and right will inc/dec mod by one
+        if sprite_list.columns > 1:
+            if event.button == buttons.LEFT:
+                mod -= 1
+
+            elif event.button == buttons.RIGHT:
+                mod += 1
+
+        # vertical movement: up/down will inc/dec the mod by adjusted
+        # value of number of items in a column
+        rows, remainder = divmod(items, sprite_list.columns)
+        row, col = divmod(index, sprite_list.columns)
+
+        # down key pressed
+        if event.button == buttons.DOWN:
+            if remainder:
+                if row == rows:
+                    mod += remainder
+
+                elif col < remainder:
+                    mod += sprite_list.columns
+                else:
+                    if row == rows - 1:
+                        mod += sprite_list.columns + remainder
+                    else:
+                        mod += sprite_list.columns
+
+            else:
+                mod = sprite_list.columns
+
+        # up key pressed
+        elif event.button == buttons.UP:
+            if remainder:
+                if row == 0:
+                    if col < remainder:
+                        mod -= remainder
+                    else:
+                        mod += sprite_list.columns * (rows - 1)
+                else:
+                    mod -= sprite_list.columns
+
+            else:
+                mod -= sprite_list.columns
+
+        original_index = index
+        seeking_index = True
+        # seeking_index once false, will exit the loop
+        while seeking_index and mod:
+            index += mod
+
+            # wrap the cursor position
+            if index < 0:
+                index = items - abs(index)
+            if index >= items:
+                index -= items
+
+            # while looking for a suitable index, we've looked over all choices
+            # just raise an error for now, instead of infinite looping
+            # TODO: some graceful way to handle situations where cannot find an
+            # index
+            if index == original_index:
+                raise RuntimeError
+
+            seeking_index = not sprite_list.sprites()[index].enabled
+
+    return index
+
+
 def layout_func(scale: float) -> Callable[[Sequence[float]], Sequence[float]]:
     def func(area: Sequence[float]) -> Sequence[float]:
         return [scale * i for i in area]
@@ -521,7 +654,8 @@ class Menu(Generic[T], state.State):
         ):
             handled_event = True
             if valid_change:
-                index = self.menu_items.determine_cursor_movement(
+                index = determine_cursor_movement(
+                    self.menu_items,
                     self.selected_index,
                     event,
                 )

--- a/tuxemon/prepare.py
+++ b/tuxemon/prepare.py
@@ -83,7 +83,7 @@ with open(paths.USER_CONFIG_PATH, "w") as fp:
 SCREEN_SIZE = CONFIG.resolution
 
 # Set the native tile size so we know how much to scale our maps
-TILE_SIZE = [16, 16]  # 1 tile = 16 pixels
+TILE_SIZE = (16, 16)  # 1 tile = 16 pixels
 
 # Set the status icon size so we know how much to scale our menu icons
 ICON_SIZE = [7, 7]
@@ -101,12 +101,10 @@ NATIVE_RESOLUTION = [240, 160]
 # If scaling is enabled, scale the tiles based on the resolution
 if CONFIG.large_gui:
     SCALE = 2
-    TILE_SIZE[0] *= SCALE
-    TILE_SIZE[1] *= SCALE
+    TILE_SIZE = (TILE_SIZE[0] * SCALE, TILE_SIZE[1] * SCALE)
 elif CONFIG.scaling:
     SCALE = int(SCREEN_SIZE[0] / NATIVE_RESOLUTION[0])
-    TILE_SIZE[0] *= SCALE
-    TILE_SIZE[1] *= SCALE
+    TILE_SIZE = (TILE_SIZE[0] * SCALE, TILE_SIZE[1] * SCALE)
 else:
     SCALE = 1
 

--- a/tuxemon/sprite.py
+++ b/tuxemon/sprite.py
@@ -128,14 +128,12 @@ class Sprite(pygame.sprite.DirtySprite):
         # should always be a cached copy
         if self.animation is not None:
             return self.animation.get_current_frame()
-        elif self._image is None:
-            return dummy_image
 
         if self._needs_update:
             self.update_image()
             self._needs_update = False
             self._needs_rescale = False
-        return self._image
+        return self._image if self._image else dummy_image
 
     @image.setter
     def image(self, image: Optional[pygame.surface.Surface]) -> None:

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -137,10 +137,7 @@ class TechniqueAnimationCache:
             image = graphics.load_and_scale(fn)
             images.append((image, frame_time))
         tech = SurfaceAnimation(images, False)
-        sprite = Sprite()
-        sprite.image = tech
-        sprite.rect = tech.get_rect()
-        return sprite
+        return Sprite(animation=tech)
 
 
 class WaitForInputState(state.State):
@@ -948,7 +945,7 @@ class CombatState(CombatAnimations):
         tech_sprite = self._technique_cache.get(technique)
         if result["success"] and target_sprite and tech_sprite:
             tech_sprite.rect.center = target_sprite.rect.center
-            self.task(tech_sprite.image.play, hit_delay)
+            self.task(tech_sprite.animation.play, hit_delay)
             self.task(
                 partial(self.sprites.add, tech_sprite, layer=50),
                 hit_delay,

--- a/tuxemon/states/combat/combat_animations.py
+++ b/tuxemon/states/combat/combat_animations.py
@@ -512,7 +512,7 @@ class CombatAnimations(ABC, Menu[None]):
                 duration=1.5,
                 delay=2.2 + index * 0.2,
             )
-            capdev.draw(animate)
+            capdev.animate_capture(animate)
 
     def animate_update_party_hud(self, player: NPC, home: Rect) -> None:
         """

--- a/tuxemon/states/combat/combat_animations.py
+++ b/tuxemon/states/combat/combat_animations.py
@@ -147,8 +147,8 @@ class CombatAnimations(ABC, Menu[None]):
         :type monster: tuxemon.monster.Monster
         :return:
         """
-        feet = list(self._layout[npc]["home"][0].center)
-        feet[1] += tools.scale(11)
+        feet_list = list(self._layout[npc]["home"][0].center)
+        feet = (feet_list[0], feet_list[1] + tools.scale(11))
 
         capdev = self.load_sprite("gfx/items/capture_device.png")
         graphics.scale_sprite(capdev, 0.4)
@@ -156,7 +156,11 @@ class CombatAnimations(ABC, Menu[None]):
 
         # animate the capdev falling
         fall_time = 0.7
-        animate = partial(self.animate, duration=fall_time, transition="out_quad")
+        animate = partial(
+            self.animate,
+            duration=fall_time,
+            transition="out_quad",
+        )
         animate(capdev.rect, bottom=feet[1], transition="in_back")
         animate(capdev, rotation=720, initial=0)
 
@@ -189,7 +193,8 @@ class CombatAnimations(ABC, Menu[None]):
         self.sprites.add(monster_sprite)
         self._monster_sprite_map[monster] = monster_sprite
 
-        # position monster_sprite off screen and set animation to move it back to final spot
+        # position monster_sprite off screen and set animation to move it
+        # back to final spot
         monster_sprite.rect.top = self.client.screen.get_height()
         self.animate(
             monster_sprite.rect,
@@ -208,9 +213,7 @@ class CombatAnimations(ABC, Menu[None]):
 
         delay = 1.3
         tech = SurfaceAnimation(images, False)
-        sprite = Sprite()
-        sprite.image = tech
-        sprite.rect = tech.get_rect()
+        sprite = Sprite(animation=tech)
         sprite.rect.midbottom = feet
         self.task(tech.play, delay)
         self.task(partial(self.sprites.add, sprite), delay)
@@ -633,7 +636,7 @@ class CombatAnimations(ABC, Menu[None]):
             monster: The monster to capture.
 
         """
-        monster_sprite = self._monster_sprite_map.get(monster, None)
+        monster_sprite = self._monster_sprite_map[monster]
         capdev = self.load_sprite("gfx/items/capture_device.png")
         animate = partial(self.animate, capdev.rect, transition="in_quad", duration=1.0)
         graphics.scale_sprite(capdev, 0.4)
@@ -657,9 +660,7 @@ class CombatAnimations(ABC, Menu[None]):
             images.append((image, 0.07))
 
         tech = SurfaceAnimation(images, False)
-        sprite = Sprite()
-        sprite.image = tech
-        sprite.rect = tech.get_rect()
+        sprite = Sprite(animation=tech)
         self.task(tech.play, 1.0)
         self.task(partial(self.sprites.add, sprite), 1.0)
         sprite.rect.midbottom = monster_sprite.rect.midbottom

--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -150,6 +150,9 @@ class WorldState(state.State):
         # middle of a transition. For example, fading to black, then
         # teleporting the player, and fading back in again.
         self.delayed_teleport = False
+        self.delayed_mapname = ""
+        self.delayed_x = 0
+        self.delayed_y = 0
 
         # The delayed facing variable used to change the player's facing in
         # the middle of a transition.
@@ -655,7 +658,7 @@ class WorldState(state.State):
         self,
         dest: Tuple[int, int],
         queue: List[PathfindNode],
-        known_nodes: Set[PathfindNode],
+        known_nodes: Set[Tuple[int, int]],
     ) -> Optional[PathfindNode]:
         """
         Breadth first search algorithm.
@@ -677,7 +680,10 @@ class WorldState(state.State):
             if node.get_value() == dest:
                 return node
             else:
-                for adj_pos in self.get_exits(node.get_value(), collision_map, known_nodes):
+                for adj_pos in self.get_exits(
+                    node.get_value(),
+                    collision_map, known_nodes,
+                ):
                     new_node = PathfindNode(adj_pos, node)
                     known_nodes.add(new_node.get_value())
                     queue.append(new_node)

--- a/tuxemon/surfanim.py
+++ b/tuxemon/surfanim.py
@@ -148,6 +148,10 @@ class SurfaceAnimation:
 
     def get_frame(self, frame_num: int) -> pygame.surface.Surface:
         """Return the pygame.Surface object of the frame_num-th frame."""
+        from tuxemon.sprite import dummy_image
+        if frame_num >= len(self._images):
+            return dummy_image
+
         return self._images[frame_num]
 
     def get_current_frame(self) -> pygame.surface.Surface:

--- a/tuxemon/surfanim.py
+++ b/tuxemon/surfanim.py
@@ -126,26 +126,6 @@ class SurfaceAnimation:
             itertools.accumulate(self._durations),
         )
 
-    def blit(
-        self,
-        dest_surface: pygame.surface.Surface,
-        dest: pygame.rect.Rect,
-    ) -> None:
-        """
-        Draw the appropriate frame of the animation to the destination Surface.
-
-        Note:
-            If the visibility attribute is False, then nothing will be drawn.
-
-        Parameters:
-            dest_surface: The Surface object to draw the frame to.
-            dest: The position to draw the frame.
-
-        """
-        if not self.visibility or self.state == STOPPED:
-            return
-        dest_surface.blit(self.get_current_frame(), dest)
-
     def get_frame(self, frame_num: int) -> pygame.surface.Surface:
         """Return the pygame.Surface object of the frame_num-th frame."""
         from tuxemon.sprite import dummy_image

--- a/tuxemon/ui/draw.py
+++ b/tuxemon/ui/draw.py
@@ -79,9 +79,8 @@ class GraphicBox(Sprite):
     def update_image(self) -> None:
         rect = Rect((0, 0), self._rect.size)
         surface = pygame.Surface(rect.size, pygame.SRCALPHA)
-        self._original_image = surface
-        self._image = surface
         self._draw(surface, rect)
+        self.image = surface
 
     def _draw(
         self,


### PR DESCRIPTION
Sprites now have a `animation` attribute separated from the `image` attribute.
The `image` attribute returns the current animation frame (or a dummy 0-size one if the animation has finished) in the case that the sprite is animated. Thus, there is no need to know about animations outside the sprite class (and thus the Group classes need no special knowledge, and the `blit` method could be removed).

I also moved two methods outside of `VisualSpriteList` to the place where they were used.

Additional small type fixes.