### PR TITLE
Fix groups

### DIFF
--- a/tuxemon/menu/menu.py
+++ b/tuxemon/menu/menu.py
@@ -9,7 +9,8 @@ from tuxemon import audio, prepare, state, tools, graphics
 from tuxemon.menu.interface import MenuCursor, MenuItem
 from tuxemon.platform.const import intentions
 from tuxemon.platform.const import buttons
-from tuxemon.sprite import RelativeGroup, VisualSpriteList, SpriteGroup
+from tuxemon.sprite import RelativeGroup, VisualSpriteList, SpriteGroup,\
+    MenuSpriteGroup
 from tuxemon.ui.draw import GraphicBox
 from tuxemon.ui.text import TextArea
 from typing import Any, Callable, Optional, Literal, Dict, Sequence, Tuple,\
@@ -95,7 +96,7 @@ class Menu(Generic[T], state.State):
 
         """
         # contains the selectable elements of the menu
-        self.menu_items: VisualSpriteList[MenuItem[T]] = VisualSpriteList(
+        self.menu_items: MenuSpriteGroup[MenuItem[T]] = VisualSpriteList(
             parent=self.calc_menu_items_rect,
         )
         self.menu_items.columns = self.columns

--- a/tuxemon/menu/menu.py
+++ b/tuxemon/menu/menu.py
@@ -237,8 +237,7 @@ class Menu(Generic[T], state.State):
                 if item.enabled:
                     item.enabled = self.is_valid_entry(item.game_object)
 
-            if hasattr(self.menu_items, "arrange_menu_items"):
-                self.menu_items.arrange_menu_items()
+            self.menu_items.arrange_menu_items()
             for index, item in enumerate(self.menu_items):
                 # TODO: avoid introspection of the items to implement
                 # different behavior

--- a/tuxemon/menu/menu.py
+++ b/tuxemon/menu/menu.py
@@ -23,139 +23,6 @@ logger = logging.getLogger(__name__)
 MenuState = Literal["closed", "opening", "normal", "disabled", "closing"]
 
 
-def determine_cursor_movement(
-    sprite_list: VisualSpriteList[MenuItem[Any]],
-    index: int,
-    event: PlayerInput,
-) -> int:
-    """
-    Given an event, determine a new selected item offset.
-
-    You must pass the currently selected object.
-    The return value will be the newly selected object index.
-
-    Parameters:
-        sprite_list: The sprite list in which to move.
-        index: Index of the item in the list.
-        event: Player event that may cause to select another menu item.
-
-    Returns:
-        New menu item offset
-
-    """
-    if sprite_list.orientation == "horizontal":
-        return _determine_cursor_movement_horizontal(sprite_list, index, event)
-    else:
-        raise RuntimeError
-
-def _determine_cursor_movement_horizontal(
-    sprite_list: VisualSpriteList[MenuItem[Any]],
-    index: int,
-    event: PlayerInput,
-) -> int:
-    """Given an event, determine a new selected item offset
-
-    You must pass the currently selected object.
-    The return value will be the newly selected object index.
-
-    This is for menus that are laid out horizontally first:
-       [1] [2] [3]
-       [4] [5]
-
-    Works pretty well for most menus, but large grids may require
-    handling them differently.
-
-    Parameters:
-        sprite_list: The sprite list in which to move.
-        index: Index of the item in the list.
-        event: Player event that may cause to select another menu item.
-
-    Returns:
-        New menu item offset
-
-    """
-    # sanity check:
-    # if there are 0 or 1 enabled items, then ignore movement
-    enabled = len([i for i in sprite_list if i.enabled])
-    if enabled < 2:
-        return index
-
-    if event.pressed:
-
-        # in order to accommodate disabled menu items,
-        # the mod incrementer will loop until a suitable
-        # index is found...one that is not disabled.
-        items = len(sprite_list)
-        mod = 0
-
-        # horizontal movement: left and right will inc/dec mod by one
-        if sprite_list.columns > 1:
-            if event.button == buttons.LEFT:
-                mod -= 1
-
-            elif event.button == buttons.RIGHT:
-                mod += 1
-
-        # vertical movement: up/down will inc/dec the mod by adjusted
-        # value of number of items in a column
-        rows, remainder = divmod(items, sprite_list.columns)
-        row, col = divmod(index, sprite_list.columns)
-
-        # down key pressed
-        if event.button == buttons.DOWN:
-            if remainder:
-                if row == rows:
-                    mod += remainder
-
-                elif col < remainder:
-                    mod += sprite_list.columns
-                else:
-                    if row == rows - 1:
-                        mod += sprite_list.columns + remainder
-                    else:
-                        mod += sprite_list.columns
-
-            else:
-                mod = sprite_list.columns
-
-        # up key pressed
-        elif event.button == buttons.UP:
-            if remainder:
-                if row == 0:
-                    if col < remainder:
-                        mod -= remainder
-                    else:
-                        mod += sprite_list.columns * (rows - 1)
-                else:
-                    mod -= sprite_list.columns
-
-            else:
-                mod -= sprite_list.columns
-
-        original_index = index
-        seeking_index = True
-        # seeking_index once false, will exit the loop
-        while seeking_index and mod:
-            index += mod
-
-            # wrap the cursor position
-            if index < 0:
-                index = items - abs(index)
-            if index >= items:
-                index -= items
-
-            # while looking for a suitable index, we've looked over all choices
-            # just raise an error for now, instead of infinite looping
-            # TODO: some graceful way to handle situations where cannot find an
-            # index
-            if index == original_index:
-                raise RuntimeError
-
-            seeking_index = not sprite_list.sprites()[index].enabled
-
-    return index
-
-
 def layout_func(scale: float) -> Callable[[Sequence[float]], Sequence[float]]:
     def func(area: Sequence[float]) -> Sequence[float]:
         return [scale * i for i in area]
@@ -654,8 +521,7 @@ class Menu(Generic[T], state.State):
         ):
             handled_event = True
             if valid_change:
-                index = determine_cursor_movement(
-                    self.menu_items,
+                index = self.menu_items.determine_cursor_movement(
                     self.selected_index,
                     event,
                 )

--- a/tuxemon/sprite.py
+++ b/tuxemon/sprite.py
@@ -366,6 +366,11 @@ class MenuSpriteGroup(SpriteGroup[_MenuElement]):
         buttons.UP: -1,
         buttons.DOWN: 1,
     }
+    expand = False  # Used in subclasses only
+
+    def arrange_menu_items(self) -> None:
+        """Iterate through menu items and position them in the menu."""
+        pass
 
     def _allowed_input(self) -> Container[int]:
         """Returns allowed buttons."""


### PR DESCRIPTION
Simplifies a lot of group-related code:
- `draw` code that only has a few changes w.r.t. Pygame has been simplified
- `determine_cursor_movement` has been simplified, especially for the bidimensional movement case. Now up/down movement is done moving to a top-bottom indexing, increasing or decreasing that index, and going back to left-right indexing.

`MenuSpriteGroup` now takes into account disabled `MenuItem`'s.