### PR TITLE
Fix dialogue appearing before random encounters finish #964

### DIFF
--- a/tuxemon/client.py
+++ b/tuxemon/client.py
@@ -542,6 +542,15 @@ class LocalPygameClient:
         """
         return self.state_manager.get_state_by_name(state_name)
 
+    def get_queued_state_by_name(
+        self,
+        state_name: str,
+    ) -> Tuple[str, Mapping[str, Any]]:
+        """
+        Query the state stack for a state by the name supplied.
+        """
+        return self.state_manager.get_queued_state_by_name(state_name)
+
     def queue_state(self, state_name: str, **kwargs: Any) -> None:
         """Queue a state"""
         self.state_manager.queue_state(state_name, **kwargs)

--- a/tuxemon/event/actions/random_encounter.py
+++ b/tuxemon/event/actions/random_encounter.py
@@ -118,10 +118,14 @@ class RandomEncounterAction(EventAction[RandomEncounterActionParameters]):
             )
 
     def update(self) -> None:
+        # If state is not queued, AND state is not active, then stop.
         try:
-            self.session.client.get_state_by_name(CombatState)
+            self.session.client.get_queued_state_by_name("CombatState")
         except ValueError:
-            self.stop()
+            try:
+                self.session.client.get_state_by_name(CombatState)
+            except ValueError:
+                self.stop()
 
 
 def _choose_encounter(

--- a/tuxemon/state.py
+++ b/tuxemon/state.py
@@ -664,6 +664,17 @@ class StateManager:
         """
         return self._state_stack[:]
 
+    @property
+    def queued_states(self) -> Sequence[Tuple[str, Mapping[str, Any]]]:
+        """
+        Sequence of states that are queued.
+
+        Returns:
+            List of queued states
+
+        """
+        return self._state_queue[:]
+
     @overload
     def get_state_by_name(self, state_name: str) -> State:
         pass
@@ -697,3 +708,23 @@ class StateManager:
                 return state
 
         raise ValueError(f"Missing state {state_name}")
+
+    def get_queued_state_by_name(
+        self,
+        state_name: str,
+    ) -> Tuple[str, Mapping[str, Any]]:
+        """
+        Query the queued state stack for a state by the name supplied.
+
+        Parameters:
+            state_name: Name of a state.
+
+        Returns:
+            State with that name, if one exist. ``None`` otherwise.
+
+        """
+        for queued_state in self._state_queue:
+            if queued_state[0] == state_name:
+                return queued_state
+
+        raise ValueError(f"Missing queued state {state_name}")


### PR DESCRIPTION
Prepare for some dodgy code... In particular, the types are probably all wrong! However, I've tested and it works. 

This fixes #964, which happens in the Spyder mod, and my mod too - so I think it deserves a fix even the solution isn't that nice. But better suggestions are welcome. 

I've made a .tmx file that reproduces the bug at the bottom of this post. Basically:
If you have a random encounter action, and then some dialogue, the dialogue plays DURING the battle, not waiting until afterwards. 
Then, the game usually crashes in a horrible way. 

The problem is that the random_encounter action waits until the CombatState is not active in the stack, and returns after that. 
However, instead of pushing the CombatState onto the stack, it queues it up for eg. a few seconds while it shows the FlashTransition state. 
So on the first call to update() to see if CombatState is active in the stack, it's NOT active, (because it's in the queued stack), so random_encounter stops itself and the other actions start playing.

This PR adds the ability to query the queued stack just like the active stack, and changes the random_encounter action to make sure the CombatState is not in the queued stack AND not in the active stack before letting other actions run. 

Comments and suggestions are welcome, it seems like a difficult change for what seems like a simple bug. 

[test_dialogue_after_battle.zip](https://github.com/Tuxemon/Tuxemon/files/7573487/test_dialogue_after_battle.zip)