### PR TITLE
Start menu fix (issue #1077)

### DIFF
--- a/tuxemon/states/start/__init__.py
+++ b/tuxemon/states/start/__init__.py
@@ -103,6 +103,7 @@ class StartState(PopUpMenu[StartGameObj]):
                 callback=set_player_name,
                 escape_key_exits=True,
             )
+            self.client.pop_state(self)
             self.client.push_state(FadeInTransition)
 
         def exit_game() -> None:

--- a/tuxemon/states/start/__init__.py
+++ b/tuxemon/states/start/__init__.py
@@ -94,6 +94,7 @@ class StartState(PopUpMenu[StartGameObj]):
             self.client.push_state("WorldState", map_name=map_name)
             self.client.push_state(FadeInTransition)
             local_session.player.name = text
+            self.client.pop_state(self)
 
         def new_game() -> None:
             # load the starting map
@@ -103,7 +104,6 @@ class StartState(PopUpMenu[StartGameObj]):
                 callback=set_player_name,
                 escape_key_exits=True,
             )
-            self.client.pop_state(self)
             self.client.push_state(FadeInTransition)
 
         def exit_game() -> None:


### PR DESCRIPTION
Adds one line to erase the start menu as soon as the player name is read.