### PR TITLE
Initial draft of monster journal, proof of concept

### DIFF
--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -376,6 +376,21 @@ class JSONDatabase:
 
         return filename
 
+    def lookup_entire_table(self, table: str) -> Dict[str, Any]:
+        """
+        Returns an entire table from the database.
+
+        Useful if you need to loop through ALL items in a table.
+
+        Parameters:
+            table: The name of the table to return, like "monster" or "items".
+
+        Returns:
+            An entire table, exactly how it's represented in the DB.
+
+        """
+        return self.database[table]
+
 
 def set_defaults(results: Dict[str, Any], table: str) -> Mapping[str, Any]:
     if table == "monster":

--- a/tuxemon/states/world/world_menus.py
+++ b/tuxemon/states/world/world_menus.py
@@ -77,7 +77,7 @@ class WorldMenuState(Menu[WorldMenuGameObj]):
 
         # Main Menu - Allows users to open the main menu in game.
         menu_items_map = (
-            ("menu_journal", not_implemented_dialog),
+            ("menu_journal", self.open_journal_menu),
             ("menu_monster", self.open_monster_menu),
             ("menu_bag", change_state("ItemMenuState")),
             ("menu_player", not_implemented_dialog),
@@ -159,6 +159,12 @@ class WorldMenuState(Menu[WorldMenuGameObj]):
         monster_menu = self.client.replace_state("MonsterMenuState")
         monster_menu.on_menu_selection = handle_selection
         monster_menu.on_menu_selection_change = monster_menu_hook
+
+    def open_journal_menu(self) -> None:
+        from tuxemon.states.monster import JournalMenuState
+
+        context = dict()  # dict passed around to hold info between menus/callbacks
+        monster_menu = self.client.replace_state("JournalMenuState")
 
     def animate_open(self) -> Animation:
         """


### PR DESCRIPTION
This PR adds a new screen, which shows the (translated) name, (translated) description, and front sprite of all monsters. 

It's accessible from the Main Menu, by choosing 'Journal'.  
Using the up and down buttons moves you up and down in the list, and using left and right buttons lets you skip a screen forward or back. 
Clicking on a tuxemon doesn't do anything at the moment - in the future it should maybe open another screen that shows more details of the Tuxemon. 
A lot of the tuxemon names, descriptions, and ID numbers are actually missing, despite being in the wiki - I'll raise an issue seperately saying these need to be scraped/updated from the wiki. (The ID number at the minute is just the number they appear in, there's no order to the tuxemon appearing) 

This PR contains a bit of weird code in places - usually marked with 'TODO' comments. 
It doesn't need to be merged as is - maybe some bits are OK, or some bits can inspire someone on how to do it better - either way is fine, I'm not in a rush to get the functionality merged. 

The screen looks like this:
![monster_journal2](https://user-images.githubusercontent.com/89098769/145694535-8d23ecba-8675-42c3-bc5f-84bbb80970fb.png)


The PR also contains code to fix this issue, ie. not being able to show more than 11 items in one list:
![too_many_items](https://user-images.githubusercontent.com/89098769/145694539-8f301bbb-e1ab-4a0c-8e95-1454ee13b040.png)

It does this by over-riding process_events, on_change_selection, and initialize_items. These 3 functions are probably the hackiest part of the PR, the rest was mostly copied from the Bag state. 
