### PR TITLE
Switch reference to IRC with Matrix in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ External links
 
 * Official website: [tuxemon.org](https://www.tuxemon.org)
 * Official forum: [forum.tuxemon.org](https://forum.tuxemon.org/)
-* IRC: [#tuxemon](ircs://chat.freenode.net/#tuxemon) on freenode ([webchat](https://webchat.freenode.net/?channels=%23tuxemon))
+* Matrix: [Tuxemon](https://matrix.to/#/!ktrcrHpgkDOGCQOlxX:matrix.org)
 * Discord: [Tuxemon](https://discord.gg/3ZffZwz)
 * Reddit: [/r/Tuxemon](https://www.reddit.com/r/tuxemon)
 * YouTube: [Tuxemon](https://www.youtube.com/channel/UC6BJ6H7dB2Dpb8wzcYhDU3w)


### PR DESCRIPTION
Switches out reference to the (dead) IRC channel in the README.md to the Tuxemon Matrix server. Links to the main Tuxemon Matrix space, which contains the nested Tuxemon Discord Bridge Space.