### PR TITLE
Fixes crash in worldstate.py

### DIFF
--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -509,6 +509,7 @@ class WorldState(state.State):
 
             # project to pixel/screen coords
             c = self.get_pos_from_tilepos(c)
+            r = Rect(c, s.get_size())
 
             # TODO: better handling of tall sprites
             # handle tall sprites


### PR DESCRIPTION
Should fix: #1097

 As explained by @vnmabus:

"The variable r should be initialized even if the if is not entered."

As the crash was only very occasional, this may have to be play tested. Just load the Spyder campaign, walk around the first few maps for a while and see if it crashes still.