### PR TITLE
Add print action. Closes #1100

### DIFF
--- a/docs/handcrafted/action_list.rst
+++ b/docs/handcrafted/action_list.rst
@@ -28,6 +28,7 @@
 .. autoscriptinfoclass:: tuxemon.event.actions.player_face.PlayerFaceAction 
 .. autoscriptinfoclass:: tuxemon.event.actions.player_resume.PlayerResumeAction 
 .. autoscriptinfoclass:: tuxemon.event.actions.player_stop.PlayerStopAction 
+.. autoscriptinfoclass:: tuxemon.event.actions.print.PrintAction 
 .. autoscriptinfoclass:: tuxemon.event.actions.quit.QuitAction 
 .. autoscriptinfoclass:: tuxemon.event.actions.random_encounter.RandomEncounterAction 
 .. autoscriptinfoclass:: tuxemon.event.actions.remove_monster.RemoveMonsterAction 

--- a/tuxemon/event/actions/print.py
+++ b/tuxemon/event/actions/print.py
@@ -1,0 +1,65 @@
+#
+# Tuxemon
+# Copyright (c) 2014-2017 William Edwards <shadowapex@gmail.com>,
+#                         Benjamin Bean <superman2k5@gmail.com>
+#
+# This file is part of Tuxemon
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import annotations
+import logging
+
+from tuxemon.event.eventaction import EventAction
+from typing import NamedTuple, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class PrintActionParameters(NamedTuple):
+    variable: Optional[str]
+
+
+class PrintAction(EventAction[PrintActionParameters]):
+    """
+    Print the current value of a game variable.
+
+    If no variables are specified, print out values of all game variables.
+
+    Script usage:
+        .. code-block::
+
+            print
+            print <variable>
+
+        Script parameters:
+            variable: Optional, prints out the value of this variable.
+
+    """
+
+    name = "print"
+    param_class = PrintActionParameters
+
+    def start(self) -> None:
+        player = self.session.player
+
+        variable = self.parameters.variable
+        if variable and variable > "":
+            if variable in player.game_variables:
+                print(f"{variable}: {player.game_variables[variable]}")
+            else:
+                print(f"'{variable}' has not been set yet by map actions.")
+        else:
+            print(player.game_variables)

--- a/tuxemon/event/actions/print.py
+++ b/tuxemon/event/actions/print.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import logging
 
 from tuxemon.event.eventaction import EventAction
-from typing import NamedTuple, Optional
+from typing import NamedTuple, Optional, final
 
 logger = logging.getLogger(__name__)
 
@@ -32,11 +32,12 @@ class PrintActionParameters(NamedTuple):
     variable: Optional[str]
 
 
+@final
 class PrintAction(EventAction[PrintActionParameters]):
     """
-    Print the current value of a game variable.
+    Print the current value of a game variable to the console.
 
-    If no variables are specified, print out values of all game variables.
+    If no variable is specified, print out values of all game variables.
 
     Script usage:
         .. code-block::
@@ -56,7 +57,7 @@ class PrintAction(EventAction[PrintActionParameters]):
         player = self.session.player
 
         variable = self.parameters.variable
-        if variable and variable > "":
+        if variable:
             if variable in player.game_variables:
                 print(f"{variable}: {player.game_variables[variable]}")
             else:


### PR DESCRIPTION
This adds a print action, callable from map events. See #1100 for details

The following map tests printing a bunch of variables, some that exist, some that don't:
[test_print_action.zip](https://github.com/Tuxemon/Tuxemon/files/7835012/test_print_action.zip)
