### PR TITLE
Fix crash if moving cursor when only 1 item in your bag. Closes #1088

### DIFF
--- a/tuxemon/sprite.py
+++ b/tuxemon/sprite.py
@@ -408,9 +408,6 @@ class MenuSpriteGroup(SpriteGroup[_MenuElement]):
             while seeking_index:
                 index = self._advance_input(index, event.button)
 
-                if index == original_index:
-                    raise RuntimeError
-
                 seeking_index = not self.sprites()[index].enabled
 
         return index


### PR DESCRIPTION
A quick fix to fix #1088 - see that issue for details on how to replicate, and discussion on how to fix it. 