### PR TITLE
Add actions to lock and unlock controls.

### DIFF
--- a/tuxemon/event/actions/lock_controls.py
+++ b/tuxemon/event/actions/lock_controls.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import NamedTuple, final
+from tuxemon.event.eventaction import EventAction
+from tuxemon.states.sink import SinkState
+
+
+class LockControlsActionParameters(NamedTuple):
+    pass
+
+
+@final
+class LockControlsAction(
+    EventAction[LockControlsActionParameters],
+):
+    """
+    Lock player controls
+
+    Script usage:
+        .. code-block::
+
+            lock_controls
+
+    """
+
+    name = "lock_controls"
+
+    param_class = LockControlsActionParameters
+
+    def start(self) -> None:
+        self.session.client.push_state(SinkState)

--- a/tuxemon/event/actions/unlock_controls.py
+++ b/tuxemon/event/actions/unlock_controls.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import NamedTuple, final
+from tuxemon.event.eventaction import EventAction
+from tuxemon.states.sink import SinkState
+
+
+class UnlockControlsActionParameters(NamedTuple):
+    pass
+
+
+@final
+class UnlockControlsAction(
+    EventAction[UnlockControlsActionParameters],
+):
+    """
+    Unlock player controls
+
+    Script usage:
+        .. code-block::
+
+            unlock_controls
+
+    """
+
+    name = "unlock_controls"
+
+    param_class = UnlockControlsActionParameters
+
+    def start(self) -> None:
+        sink_state = self.session.client.get_state_by_name(SinkState)
+
+        if sink_state:
+            self.session.client.remove_state(sink_state)

--- a/tuxemon/states/sink/__init__.py
+++ b/tuxemon/states/sink/__init__.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from tuxemon.state import State
+from tuxemon.platform.events import PlayerInput
+from typing import Optional
+
+
+class SinkState(State):
+    """State blocking input to lower states in the stack."""
+
+    transparent = True
+
+    def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
+        return None


### PR DESCRIPTION
This is done by creating a state that discards events going to lower
states in the stack. This allows the user to still interact with dialogs
created after the controls have been locked.

I have tested this adding the actions manually to the initial
taba_town.tmx cutscene.

Closes #1110. This is an alternative to #840 that is more general, as it
will even work with states that are not the WorldState (for example,
minigames).