### PR TITLE
Fixes game crash on route 3 (issue #868)

### DIFF
--- a/mods/tuxemon/maps/dryadsgrove.tmx
+++ b/mods/tuxemon/maps/dryadsgrove.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="40">
+<map version="1.5" tiledversion="1.7.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="40">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -12,28 +12,25 @@
  <tileset firstgid="1889" name="Cave_Tiles_by_George_" tilewidth="16" tileheight="16" tilecount="154" columns="14">
   <image source="../gfx/tilesets/Cave_Tiles_by_George_.png" width="224" height="181"/>
  </tileset>
- <tileset firstgid="2043" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="1000" columns="40">
-  <image source="../gfx/tilesets/Cave_Tiles_by_ArMM1998_(Tuxemon_Style).png" width="640" height="400"/>
+ <tileset firstgid="2043" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="160" columns="16">
+  <image source="../gfx/tilesets/Cave_Tiles_by_ArMM1998_(Tuxemon_Style).png" width="256" height="160"/>
  </tileset>
- <tileset firstgid="3043" name="Terrain_by_George" tilewidth="16" tileheight="16" tilecount="360" columns="15">
+ <tileset firstgid="2203" name="Terrain_by_George" tilewidth="16" tileheight="16" tilecount="360" columns="15">
   <image source="../gfx/tilesets/Terrain_by_George.png" width="240" height="384"/>
  </tileset>
- <tileset firstgid="3403" name="Fancy_House" tilewidth="16" tileheight="16" tilecount="20" columns="5">
-  <image source="../gfx/tilesets/Fancy_House.png" width="80" height="72"/>
- </tileset>
- <tileset firstgid="3423" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
+ <tileset firstgid="2563" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>
  </tileset>
- <tileset firstgid="5023" name="Truck-red-all" tilewidth="16" tileheight="16" tilecount="36" columns="6">
+ <tileset firstgid="4163" name="Truck-red-all" tilewidth="16" tileheight="16" tilecount="36" columns="6">
   <image source="../gfx/tilesets/Truck-red-all.png" width="96" height="96"/>
  </tileset>
- <tileset firstgid="5059" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
+ <tileset firstgid="4199" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
   <image source="../gfx/tilesets/boxfont.png" width="208" height="192"/>
  </tileset>
- <tileset firstgid="5215" name="Interiors 2 by Redshrike" tilewidth="16" tileheight="16" tilecount="28" columns="7">
+ <tileset firstgid="4355" name="Interiors 2 by Redshrike" tilewidth="16" tileheight="16" tilecount="28" columns="7">
   <image source="../gfx/tilesets/Interiors 2 by Redshrike.PNG" width="112" height="64"/>
  </tileset>
- <tileset firstgid="5243" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
+ <tileset firstgid="4383" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>
   <tile id="839">
    <animation>
@@ -59,17 +56,17 @@
  </layer>
  <layer id="2" name="Tile Layer 2" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHFlslNBFEMRFtwZbkSCSSDIBNyQATBEs2QA+SBC/GkJ6vdM+LSX/rjrVyuMT0tDjfL8lk357XsW9297NX5slzX9Xz86Dv8ad3L3pa2u7qej2+dH6XVN9pznIvvQy0515ynRg5rHnz0YNFpbvhs8eGe8B2XmLPVAwY9WPKx9GNdw3+ov8MpJxzTpX+ak92xP2PNl/zUT8+WNZd58KmvcWR37A98cPSQw6Z2f+Legs0xFzzkqP8C20ffm8v0w+da98H2PDF1uBzbB49lb8RYeoi3LDPBEH+dLct3XR/z4oM3zr6fv47tsfuO+Rf1DFyuPAfmtD/x+fkLJj3cqWfiPdbX+Y79/vOcT/ubZpG39dzkTzn9N/ZeTbn99P2lzuyOJbaGyZ94jIfPuuyn3vdnbWtc5Cac68zH0gOGvDXZT31tf/St2WkG+d7TtUy46OrawsU78Kne052rzyL2jO6DiXXN8alz0sM7EJ3JbR24PXvLNxc4OFxb860Jncbl/7B+zM28YJzvPf+N0YRO7PPfe/+x9L2UT34vi05svq/fneT3sj8/Nx3M
+   eAHFlttNxFAMRCP45fFFAxQBRUAJCJpYCkFUAXVBH3gQRzqy4uyKn1zprl/j8azJRhxuluW1bs5D2ce6e9mr82W5ruv5+NF3+NO6l70rbfd1PR/fOj9Lq2+05zgX34dacq45T40c1jz46MGi09zw2eLDPeE7LjFnqwcMerDkY+nHuob/XH+HU044pkv/NCe7Y3/Gmi/5qZ+eLWsu8+BTX+PI7tgf+ODoIYdN7enEvQWbYy54yFH/BbaPvjeX6YfPte6D7Xli6nA5tg8ey96IsfQQb1lmgiH+OluW77o+5sUHb5x9P38d22P3HfMv6hm4XHkOzGl/4vPzF0x6uFPPxHusr/Md+/3nOZ/2N80ib+u5yZ9y+m/so5py++n7S53ZHUtsDZM/8RgPn3XZT73vz9rWuMhNONeZj6UHDHlrsp/62v7oW7PTDPK9p2uZcNHVtYWLd+Btvac7V59F7BndBxPrmuNT56SHdyA6k9s6cHv2lm8ucHC4tuZbEzqNy/9h/ZibecE433v+G6MJndi3v/f+S+l7L5/8Xhad2HxfvzvJ72V/AAum0yY=
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAGrk2BgqAfiwQ7qBpk7Ye6B0YM9/Aaj+0BhNxp+gzFmRoabQGlvFJAfAqP5l/ywA+kcDT/Kw28otF0o8yVtdA+VeheXO0HiAwlwuWsg3TQU7QYAGnsP3g==
+   eAFTEmVgUAbiwQ6UBpk7Ye6B0YM9/Aaj+0BhNxp+gzFmRoabQGlvFJAfAqP5l/ywA+kcDT/Kw28otF0o8yVtdA+VeheXO0HiAwlwuWsg3TQU7QYAONUF2Q==
   </data>
  </layer>
  <layer id="4" name="Above Player" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAFjYBgFoyEwGgJDLQTqJBgY6oF4FFAWAqPhSFn4jeoeDYHREMAfAqNlDP7wIUYWVxjCxOlNE+PmUTWEQwAA2D0WWA==
+   eAFjYBgFoyEwGgJDLQSURBkYlIF4FFAWAqPhSFn4jeoeDYHREMAfAqNlDP7wIUYWVxjCxOlNE+PmUTWEQwAAJGsIPg==
   </data>
  </layer>
  <objectgroup color="#ff0000" id="5" name="Collisions">

--- a/mods/tuxemon/maps/route3.tmx
+++ b/mods/tuxemon/maps/route3.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="178">
+<map version="1.5" tiledversion="1.7.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="178">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -12,27 +12,25 @@
  <tileset firstgid="1889" name="Cave_Tiles_by_George_" tilewidth="16" tileheight="16" tilecount="154" columns="14">
   <image source="../gfx/tilesets/Cave_Tiles_by_George_.png" width="224" height="181"/>
  </tileset>
- <tileset firstgid="2043" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="1000" columns="40">
-  <image source="../gfx/tilesets/Cave_Tiles_by_ArMM1998_(Tuxemon_Style).png" width="640" height="400"/>
+ <tileset firstgid="2043" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="160" columns="16">
+  <image source="../gfx/tilesets/Cave_Tiles_by_ArMM1998_(Tuxemon_Style).png" width="256" height="160"/>
  </tileset>
- <tileset firstgid="3043" name="Terrain_by_George" tilewidth="16" tileheight="16" tilecount="360" columns="15">
+ <tileset firstgid="2203" name="Terrain_by_George" tilewidth="16" tileheight="16" tilecount="360" columns="15">
   <image source="../gfx/tilesets/Terrain_by_George.png" width="240" height="384"/>
  </tileset>
- <tileset firstgid="3403" name="Fancy_House" tilewidth="16" tileheight="16" tilecount="20" columns="5">
-  <image source="../gfx/tilesets/Fancy_House.png" width="80" height="72"/>
- </tileset>
- <tileset firstgid="3423" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
+ <tileset firstgid="2563" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>
  </tileset>
- <tileset firstgid="5023" name="Truck-red-all" tilewidth="16" tileheight="16" tilecount="36" columns="6">
+ <tileset firstgid="4163" name="Truck-red-all" tilewidth="16" tileheight="16" tilecount="36" columns="6">
   <image source="../gfx/tilesets/Truck-red-all.png" width="96" height="96"/>
  </tileset>
- <tileset firstgid="5059" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
+ <tileset firstgid="4199" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
   <image source="../gfx/tilesets/boxfont.png" width="208" height="192"/>
  </tileset>
- <tileset firstgid="5215" name="Interiors 2 by Redshrike" tilewidth="16" tileheight="16" tilecount="28" columns="7">
+ <tileset firstgid="4355" name="Interiors 2 by Redshrike" tilewidth="16" tileheight="16" tilecount="28" columns="7">
   <image source="../gfx/tilesets/Interiors 2 by Redshrike.PNG" width="112" height="64"/>
  </tileset>
+ <tileset firstgid="4383" source="../gfx/tilesets/core_buildings.tsx"/>
  <layer id="1" name="Layer 1" width="40" height="40">
   <data encoding="base64" compression="zlib">
    eAHtl0tOxEAMBecwHJiLDLABrkfeokTJanemMx9mwaLVjv38XDFBiPPpdHrbzvt2zk8YPyOT9/XPd933s7q/z+0b/Vo8/LzoXfnWj/BlzpGT9/rezst2Lp1rHe8XD7wSc5KDizrPsxst9yof3vTD093Ro3Vs/WqeXu8rcc6IbzSfHF65zeG4auoMa2vM99rxVT1c5Otz5eQ5ek566Kc+8+F3aGV/+OPrHdWZeTaTOa2teTz5Ro/w2R8OfDOPuPL5vXhXvHhGY778vKmjx3uUtyZxtPhGTw931TtPjRw+Mz5mpoc+fOjv8qm7Dz23++KJL3l0/v7YH5qjfGbDi5xvuGCJ1vrUzUcdzS34zIM/PDM+auZjf/ZEZ+a9mH505iKHb254rSNXv7/w4oEmHuQuieGjn7l4JE+t40Nb9wcf9fRfwmTNKp9neG7iR/GZmd1xh4/6X/KFgQMTu4P10XyZx0zYcpN7Rr4w3YLPHqsxu0ofveRmfNFQT9+9fz9W+XgX+m7Nh2+3K+9nFuNzCR/amZ9/Jui7G+3Mj95/vt+/ZdlJdsZucne7RNPtLz7eP96dH3l8fVcm1/Zi81kLm+eSi66L7UEvfLmZ5//NHLs/MXr//5F8vPGnp2NyHi0eZjNHF7s/8Yivm+d8F9s/74cu798xOe9+4vR6f3hS53a+i9HmvpYvM+Jzb77MyKx6eJduf3t8qfsb9PMonuXiU8+1fLw3jKP5zPAdPVp6XU8th9w1+8Nj5WY2jKNe18yXuOrr91frtZ/f+VG+9u49Z/bIx/nXTePnI/HH5jHjPuJp7h+2j19D
@@ -40,22 +38,22 @@
  </layer>
  <layer id="2" name="Layer 2" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHtWEtS1UAUbZWBinkZOHEP8GAhkBf8ggquw2W4hOcCeEzUgTpQV+DQKlegI4YOOceXWxy60p1OkxeKKm7Vye3b93dyO5CAc879Af6KxvK/+PursmP96Lt3y7n7gGmLN3vVOtbPfFeldwrndoEKmAE1QLGzWlrjX382LffA5zHwBHgKPAModmZLK/26jtBZTzxAvObRNnkOPi+AfeAAeAlQcue3vUzvdZ0iWvNom7wCn9fAIXAEvAEo/vz0/jifLYHOq2ZyT5kiPsQvVErnR245fUO1dZ/jWAAbQNk4Kmi9Z13b2ev89N6aEoMpzo78iJQ+jPclJc/PSbVtVpyL9tmYuPkd4Hfh5lpL421f82xvFbqOFPX56hx9fv8idVJcBYImDcqUhJYY5cdn1+qpvkxtPm9Ebm3ld9zUOoFWbMPOkQpJfN6MI+v7CPG2+WxK43WsZy2oJYbLzdveRsQkx7aa3FPuC9ghWPncOVl+Xx3jbvfEezDhrEszRtYfHjr3EfgEqEzVwHpMjr+k92fw+gJ8FX4F/Pr8WfjY58y+38DrO/BD+PmzC/E7vWuecXUqv3FZnXe74Xc+C67mPZ+Tm/ldnJ9aKe+gtvmdoshV/H5R7rZu40ffdeS31uObwO4/ph/h/xRd0ja/d0hKmd/bruID+Nv48RurHqB2qEQBxySCUhJ9fmNwa3vfC6ULZ+fzSzlXrdVnzbl1cWM95VDB1u8/9TF2SPFnEartc9A83xeqkbOvfWL5yuE93oeap75YjRxfhaQtwL7bTev5sa5xsG/XIfnlfCdqf+XHNUX9xn3pufzVZhCrxP7HwAI4AXwOKfwK5E0SUSKuj/j8+PeP9tKfed9ncRrT1TtUw2r5mrV1fl31c/17uYmJeWfVPYdJ
+   eAHtWLtu1FAQvaAUkMTrQCj4h7z+ABL6zVICBaQgfAMdEhLUfAIdVTbi9R1QUgKhgYqSknNYj/ZkZF9f33gdIWWk47njuXPmeOzETkII4SfwSzyW/8yfX1Qc68fc1UshLAPmbb/Fi/TP161bCC+wfglov3n2fFZvoecd8B74AHwEaHavZtHwx89Vy6/Q8w34DpwAPwCazXAWpR9XsHW/I1axX+sYm5U3QlgDrgHXgXWAlju/nVl5p+MWdmsdY7Nb0HMb2AX2gDsAzc9Pr4/z2RbovCYs7mgxfU1UOj9qy+nbxK3nCwRTYAMoq8QYXq9Z13bvdX46+4qiN8fZUR+R0of7vaXU+ZrU2GbFuWifT8vh9RvgGaBcut/Oa52dW4SfREi9Xp2j1/cnwpOSKrBpVKFMKajZo/r47Bqf+rNw83kjcrlV31HFdQyv2EGcY2MU8XkzjeT3aNJt89mUxitY79dgInu43LzsTkRCaqzj5DnVPkXcBKPPnZPVd/Ux7XZNvAYzzrq0YGB/by2E+8ADQG1LA6yH1PhFej+ErkfAgegrkNfnz7YPfZ/Z9zF0HQJPRJ+fXZO+gyuWGdan6htW1bzbhb75LLja7ficXMzv9Pw0SnkH1c3vN0jO4/eLard1nT7m/kd9Sx2+Cez6Y/4m/k/RZnXze4WilPk9bSPvIV+nj99Ykx64mygKJEYRlFLo9Q2hre59L5JO3TuvL+W+KleXNefWpo18qmGMWL//NMe9fZqfRRO316B1PtfEkXNe+8TqVcMe3odap7kYR05ujKJtwL7bzev9I69psG/XPvXlfCdqf9XHNU3zpn2WOfvRZhBjYv8jYAocA15Dir4CdaNElNjXxbw+/v2jvfRn3udsn+5p693EYVzek1vn18afm7+bW5hY9xdzP4jg
   </data>
  </layer>
  <layer id="3" name="Layer 3" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHNmLluFEEQhhsSjgAJjOE5ACGeggBxhWRkBAgLIfEQgJCIDURLakQGpFwPgo1AXA9A/TDfqLZcPdO7O0JbUrm6ju7655+envGWsl+OHCjlqOm6yq4B21tDcOAa42/WYX/xn68BXOBcpr3HzBi7zHrM0RrgAue9w2TXw4IrohH2KTiI69b8qXp9MH7fB/04Mec1rPRWv3dJT+U/mf4I+tv8DGPrPWCP1bgl/rPr+8ssAmZxJmw+R80ziz93cxQfw7Z7iNmlsMfAmfH3NKzPbDCLswyb6lRTy7GO7K2TZfum6Q1TH2cMTvwh+916blrBKdPTQ4UDuYsht9dx9rmzES/8aVrGYViunO8CF2Ki4vv1KyX7wl+S+zy2N1hkCJ/flzwb3B9w0gefdWvW163CX3yO494DJ/jw6U8cH0tdDX+M1/jLntc4N/PpDz58LDizuVlsanxZDx8DZ+3eHrfiJ52eMLsovvsbpdjZMSezY3PuoDPEn7Btudk7Nq7h03mndwbvOZ4PTbfzrZeItU90A+V1TQj84Xv70jmXbXzWtIZPpbVz2860XjxWgh6zz8Od7IxiZz0+cScB3zkbL3NGg9Vz5DGRVy+4k81kCJ/qF8H4eqOUN6ZvTaMIU21PwmGcI38Mn2qEUe+7RbWVezhUL4l/jjN8V63GLndlGbousMOdbCYZPtVNhTHrqRjvdrhr2X93bJ7OP0QYrzXqonwL37adVRI4/OfN//X8KbMzny7x7A7p3uWZ7wMjA/hTGRz6fcf0iE8c3jblfbJFodmI3aX+7odWrlV3vZsMdy37z/fLxkP4svqWGNzV9t8ZW+RKy0JWI27h1e/Toemen71KITWVdBHGuwMa8b+y2hYutZ88P7Xfoaix8l70renf730iGcQ9KnzicoxD4ZOO8ZPl+RZpwRj3gPC1cChsM9PIj+JeYp4cGPlewmaY2QP+XtfuccYHPeEUf8z67yV+H6j9LqC1hPNSp/oWi6L+NT5UW8MXOY3reh9eMx593aJjYci4XQQbPYUx/n9GbhU7xO0q604596t9i34L36PLcAimVeb6NVhn86B9S5pGIR/jNV9nwzLi+zx0OHz8cRfPevg6378W9zV+3FL/wOHzcx+5OOv8ASSR91k=
+   eAHNmEtuE0EQhhtYAGGDEYElV+AhxJbHOhIhAbYk4QKIiGsAQmLN1myDOBMJgjNQfzLfqFypnoc9Qi6pXF2P7vr9T0/P2KWcl6sXStkwXVc5NmAnawgOXH38zRvs3//zdwAXOJdp7zEzxi6zHnO0BrjAefcK2fWw4IpohH0KDuK6NX+qXi+M3+2gOxNzXsNKb/V7nvRUftd0L+hb8zOMQ68Be6zGLfH9pu+BWQTM4kzYfI6apxZ/5uYo3oft+DKzS2GPgTPj70lYn9lgFmcZNtWpppZjHdnZrHzbML1k6uOMwYnfZd9Yz00ruGV6u6uwI7cVcicNZ78aG/HCn6ZlHIblysMm8CgmKr5fv1JyLvw7uc59e4NFuvD5fcm9wfUBJ33wWbdmfd0q/MX7OO49cIIPn/7E8bHU1fDHeI2/7H6NczOf/uDDx4Izm5vFpsaX9fAxcNau7cyKvzZ6w+xYfHeul2Jnx4JsXVtwO50u/rTsoZt9ZOMaPp13embwnOP+0HQ731qJWNtEM1Be3wmBP3xvfzhnx8b3TWv4VFo7t+1Ma8VjJegx+zzcyc4pdtbjE3cS8D2w8TJnNFg9Rx4TefWCO9lMuvCpfgzGPbtm+6YH7trRU5hqexIOqfW2D59qhVHPu7E6lHs4VC+Jv48zfC+t5uZp5WofXd8L7HAnm0mGT3VTYcx6KsazHe6G7L/3Nk/nHyKMrwbqWL6F77GdVRI4PPMWPz1/yhwtpouODX92h3Trcs+3gZ4B/KkMDv2+Y3rEJw7fmYLpkEKzEbtLne6HoVyr7nUzGe6G7D/fLxt34cvqh8Tgrrb/7tkiu0MWshpxC69+n3ZN9/ycVAqpqaSLMH7o0Ij/p9UO4VL7yfNT+x+KGitvRe+a/vneJpJB3KPCJy77OBQ+aR8/WZ53kSEY4x4QviEcCtvcNPKjuJeYJwdG3pewGWb2gL/WtWuc8UFPOMXvs/59if8Hav8LaC3h3G5U72JR1L/Gh2pr+CKncV3vw2vGo68bOxaGjNsx2OgpjPH3GblVbBe3q6w75dw/9i76N7yPLsMhmFaZ69dgnc2L9i5pGoV8jNd8nQ3LiO/zyeHw8S9NPOvh63z/WtzX+PGQ+o8On5/72cVZ5x9snMLb
   </data>
  </layer>
  <layer id="4" name="Above Player" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHt0LEJACAMBECHcD879x/BKpBCsFFicTaCCe9zrTkECBAgQIAAAQIE7giMfifnVcpM/U5dT/NXHSM3d4233Gk3j72q+8dOVRb+JUCAAAECBAgQIECgXmABf6YDtQ==
+   eAHt0DEKgDAMBdCAm5t4ZD14XQoZpJkkDi9QOvxCfl+EqQSuM+J+jiFAgAABAgQIEFgLbMc670731K/qWuVf/yV3nbtyp7d8vuu6/9ipy8JeAgQIECBAgAABAgT6BQYdJAHq
   </data>
  </layer>
  <layer id="5" name="Above Player" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHt0LENgEAMBEFTA/0XAQRASRBQA5fQAu9gXjp96NVUeQQIECBAgAABAgQIdBFY5qo127KOb0/XkZ1N+zqaaSJAgMAogSuH7+z7R3W4S4AAgS4Cz9SlRMdfAi+y8QlG
+   eAHt0LENgEAMBEHTAc0BAdC/IKAGLqEF3sG8dPrQq6nyCBAgQIAAAQIECBDoIrDMVWu2ZR3fnq4jO5v2dTTTRIAAgVECVw7f2feP6nCXAAECXQSeqUuJjr8EXqSYBww=
   </data>
  </layer>
  <objectgroup color="#ff0000" id="6" name="Collisions" visible="0">


### PR DESCRIPTION
This will fix the crash on route 3 (caused by the Wayfair Inn tiles being moved to core_buildings.tsx.

Closes #868

@Qiangong2 has indicated he will eventually continue the campaign, but for now this will at least make sure it doesn't crash (since it is still the default campaign and reachable by players).

**EDIT:** @ultidonki pointed out this crash also occurs on dryadsgrove.tmx. Added fix for this map.