### PR TITLE
Fix NPC appearing on map after random encounter

### DIFF
--- a/mods/tuxemon/db/npc/random_encounter_dummy.json
+++ b/mods/tuxemon/db/npc/random_encounter_dummy.json
@@ -1,0 +1,6 @@
+{
+    "slug": "random_encounter_dummy",
+    "sprite_name": "girl1",
+    "combat_front": "femaletrainer_front.png",
+    "combat_back": "maple_back.png"
+}

--- a/tuxemon/event/actions/random_encounter.py
+++ b/tuxemon/event/actions/random_encounter.py
@@ -84,8 +84,8 @@ class RandomEncounterAction(EventAction[RandomEncounterActionParameters]):
         if encounter:
             logger.info("Starting random encounter!")
 
-            world = self.session.client.get_state_by_name(WorldState)
-            npc = _create_monster_npc(encounter, world=world)
+            self.world = self.session.client.get_state_by_name(WorldState)
+            npc = _create_monster_npc(encounter, world=self.world)
 
             # Lookup the environment
             env_slug = "grass"
@@ -104,8 +104,8 @@ class RandomEncounterAction(EventAction[RandomEncounterActionParameters]):
             )
 
             # stop the player
-            world.lock_controls()
-            world.stop_player()
+            self.world.lock_controls()
+            self.world.stop_player()
 
             # flash the screen
             self.session.client.push_state(FlashTransition)
@@ -123,6 +123,9 @@ class RandomEncounterAction(EventAction[RandomEncounterActionParameters]):
         except ValueError:
             self.stop()
 
+    def cleanup(self) -> None:
+        npc = None
+        self.world.remove_entity("random_encounter_dummy")
 
 def _choose_encounter(
     encounters: Sequence[JSONEncounterItem],
@@ -168,7 +171,7 @@ def _create_monster_npc(
     current_monster.current_hp = current_monster.hp
 
     # Create an NPC object which will be this monster's "trainer"
-    npc = NPC("maple_girl", world=world)
+    npc = NPC("random_encounter_dummy", world=world)
     npc.add_monster(current_monster)
     # NOTE: random battles are implemented as trainer battles.
     #       this is a hack. remove this once trainer/random battlers are fixed


### PR DESCRIPTION
This fixes an NPC appearing on the worldstate map after a random encounter, as discussed in Matrix.

This map shows the problem (and can be used to check the problem is fixed): Just enter the grass to start a random encounter, and after the battle the NPC will be in the top-left square of the map. 
[random_npc.zip](https://github.com/Tuxemon/Tuxemon/files/7989664/random_npc.zip)

During random_encounter, an NPC is created as part of the combat state, but not shown during the battle. But recently they started appearing in the top-left corner of the map after the battle was over. This might be because of some updates in the UI, which made NPC's always have a world now, but I haven't checked the root cause, it was suggested to just remove the NPC after the battle which I've done in this PR, and it seems to work. 

Instead of using an NPC called 'maple_girl', I've changed it to an NPC called 'random_encounter_dummy', because if someone used maple_girl on the map, it could've caused problems maybe if we now removed it? There's still a problem of relying on a file in /mods/ which might be removed by a mod creator when they start a new mod, but hopefully the name will make them think twice. For now I'll just leave it like that. 