### PR TITLE
Fix random_encounter crash when walking in grass

### DIFF
--- a/tuxemon/event/actions/random_encounter.py
+++ b/tuxemon/event/actions/random_encounter.py
@@ -70,6 +70,7 @@ class RandomEncounterAction(EventAction[RandomEncounterActionParameters]):
 
     def start(self) -> None:
         player = self.session.player
+        self.world = None
 
         # Don't start a battle if we don't even have monsters in our party yet.
         if not check_battle_legal(player):
@@ -125,7 +126,8 @@ class RandomEncounterAction(EventAction[RandomEncounterActionParameters]):
 
     def cleanup(self) -> None:
         npc = None
-        self.world.remove_entity("random_encounter_dummy")
+        if self.world:
+            self.world.remove_entity("random_encounter_dummy")
 
 def _choose_encounter(
     encounters: Sequence[JSONEncounterItem],


### PR DESCRIPTION
This fixes a bug I introduced where walking in grass instantly crashes the game. (Oops!)

Although I had tested my commit #1114 on a test map, it had 100% probability of starting an encounter, so this bug never triggered. 

If you don't have any tuxemon, or you step on grass and a battle doesn't start, the game crashes because self.world isn't initialized. So I've added here some initialization, and a check to see if it exists before removing the NPC. (We need to remove the NPC in #1114 because it appears in the top-left corner of the worldstate after the battle, and is rendered and you collide with them)

You can test by walking around on route1.tmx, it should not crash the game. 
Then, add a tuxemon, eg. `action add_monster rockitten,100` from the command-line, and walk around until a battle starts. That should also not crash the game! 