### PR TITLE
Fix npc_move bug

### DIFF
--- a/tuxemon/event/actions/npc_move.py
+++ b/tuxemon/event/actions/npc_move.py
@@ -35,7 +35,7 @@ def simple_path(
     origin_vec = Vector2(origin)
     for _ in range(tiles):
         origin_vec += dirs2[direction]
-        yield (int(origin_vec[0]), int(origin_vec[0]))
+        yield (int(origin_vec[0]), int(origin_vec[1]))
 
 
 def parse_path_parameters(


### PR DESCRIPTION
The NPC Move action was broken, this fixes it. 

I've created a test map displaying the error - this was copied and pasted from the professor's lab, which is where I noticed the problem.

Before the bugfix, nobody moves. 
(Because the path to follow is [4,4],[5,5],[5,5], instead of [4,5],[5,5],[5,6],[5,7]... etc.)
After the bugfix, the 3 characters at the top leave the map one-by-one. 

[test_npc_move.zip](https://github.com/Tuxemon/Tuxemon/files/8053414/test_npc_move.zip)
