### PR TITLE
Fix bug in store_monster creating boxes with blank names

### DIFF
--- a/tuxemon/event/actions/store_monster.py
+++ b/tuxemon/event/actions/store_monster.py
@@ -24,6 +24,7 @@
 
 from __future__ import annotations
 from tuxemon.event.eventaction import EventAction
+from tuxemon.prepare import CONFIG
 import logging
 import uuid
 from typing import NamedTuple, final
@@ -71,6 +72,8 @@ class StoreMonsterAction(EventAction[StoreMonsterActionParameters]):
                 f"No monster found with instance_id {instance_id}",
             )
 
+        if not box:
+            box = CONFIG.default_monster_storage_box
         if box not in player.monster_boxes.keys():
             player.monster_boxes[box] = list()
 


### PR DESCRIPTION
If you don't pass a second parameter to store_monster, it creates a box called None (not the string, the actual None value) and stores the tuxemon in there.
```
get_player_monster temp
store_monster temp
```
Result: `monster_boxes = {None: [monster]}`

If you pass a 2nd parameter to store_monster, but it's a blank string, it creates a box with the empty string, "", and stores the tuxemon in there.
```
get_player_monster temp
store_monster temp,
```
(^ Notice the comma at the end of the 'store_monster' command, which wasn't on the first one)
Result: `monster_boxes = {'': [monster]}`

This PR fixes both bugs by using the default config box name if the box param is left blank. 