### PR TITLE
Add menu to choose between default, and spyder campaign

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -693,6 +693,13 @@ msgstr "Press a key to set your new input key"
 msgid "options_new_input_key1"
 msgstr "Restart your game for changes to take effect!"
 
+# Default mod names on selection menu
+msgid "default_campaign"
+msgstr "Tuxemon"
+
+msgid "spyder_campaign"
+msgstr "Spyder and the Cathedral"
+
 # Multiplayer notifications
 msgid "multiplayer_accept"
 msgstr "Accept"


### PR DESCRIPTION
This PR adds a menu, after selecting 'New Game', that allows you to choose between the default and spyder campaign mods.

In the future, we should probably build the menu dynamically depending on what mod manifest files are found in /mods/*, but for now this menu allows you to choose either of the default campaigns without using the command-line, or modifying tuxemon.cfg

If you don't pass any command-line params to change the map, this is what you see:
![mod_chooser](https://user-images.githubusercontent.com/89098769/153719817-cae4eb4d-7b57-44be-a58c-e890cb31b2e2.png)

If you pass a -s for a custom starting map, or change the default starting map in tuxemon.cfg, you see an extra menu option, 'START':
I wanted to be able to skip the mod menu if you already had passed in a different map to start from, but I couldn't do it. 
Instead, selecting 'START' loads the map you passed in:
![mod_chooser_2](https://user-images.githubusercontent.com/89098769/153719843-15c1f85b-7d08-4ee3-9cd6-f1533e7236a0.png)

This should preserve all functionality the screen used to have - for example, if you click cancel on the Name Input screen, you'll go back to this menu, added in #1045. 