### PR TITLE
Give both campaigns names & align names in new game menu

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -694,11 +694,11 @@ msgid "options_new_input_key1"
 msgstr "Restart your game for changes to take effect!"
 
 # Default mod names on selection menu
-msgid "default_campaign"
-msgstr "Tuxemon"
+msgid "xero_campaign"
+msgstr "Tuxemon: Xero"
 
 msgid "spyder_campaign"
-msgstr "Spyder and the Cathedral"
+msgstr "Tuxemon: Spyder and the Cathedral"
 
 # Multiplayer notifications
 msgid "multiplayer_accept"

--- a/tuxemon/states/start/__init__.py
+++ b/tuxemon/states/start/__init__.py
@@ -158,17 +158,18 @@ class ModChooserMenuState(PopUpMenu[StartGameObj]):
         # If a different map has been passed as a parameter, show as an option:
         if prepare.CONFIG.starting_map != "player_house_bedroom.tmx":
             menu_items_map = menu_items_map + (
-                ("start", new_game_callback(prepare.CONFIG.starting_map)),
+                (str(prepare.CONFIG.starting_map), new_game_callback(prepare.CONFIG.starting_map)),
             )
 
         menu_items_map = menu_items_map + (
-            ("default_campaign", new_game_callback("player_house_bedroom.tmx")),
             ("spyder_campaign", new_game_callback("spyder_bedroom.tmx")),
+            ("xero_campaign", new_game_callback("player_house_bedroom.tmx")),
             ("cancel", self.close),
         )
 
         for key, callback in menu_items_map:
             label = T.translate(key).upper()
+            label = label.center(32)
             image = self.shadow_text(label)
             item = MenuItem(image, label, None, callback)
             self.add(item)


### PR DESCRIPTION
1. Changes default campaign to 'Tuxemon: Xero' from 'Tuxemon'. 
2. Adds 'Tuxemon' prefix to the 'Spyder and Cathedral' campaign for consistency. 
3. Changes the custom map start button to the name of the non-standard map set in tuxemon.cfg (by default this option is hidden until the default starting map is changed in the config file).
4. Centres the campaign names and puts the longest one on top for better readability.
