### PR TITLE
Add trainer line of sight battles in spyder route 2

### DIFF
--- a/mods/tuxemon/maps/spyder_route2.tmx
+++ b/mods/tuxemon/maps/spyder_route2.tmx
@@ -1,30 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.4" tiledversion="1.4.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="2" nextobjectid="188">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="2" nextobjectid="202">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>
  </tileset>
- <tileset firstgid="449" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="1000" columns="40">
-  <image source="../gfx/tilesets/Cave_Tiles_by_ArMM1998_(Tuxemon_Style).png" width="640" height="400"/>
+ <tileset firstgid="449" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="160" columns="16">
+  <image source="../gfx/tilesets/Cave_Tiles_by_ArMM1998_(Tuxemon_Style).png" width="256" height="160"/>
  </tileset>
- <tileset firstgid="1449" name="Set_Pieces_by_Kelvin_Shadewing" tilewidth="16" tileheight="16" tilecount="1440" columns="45">
+ <tileset firstgid="609" name="Set_Pieces_by_Kelvin_Shadewing" tilewidth="16" tileheight="16" tilecount="1440" columns="45">
   <image source="../gfx/tilesets/Set_Pieces_by_Kelvin_Shadewing.png" width="720" height="512"/>
  </tileset>
- <tileset firstgid="2889" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
+ <tileset firstgid="2049" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>
  </tileset>
- <tileset firstgid="4489" name="Outdoor_Tiles_-_City_and_Country_-_by_ArMM1998" tilewidth="16" tileheight="16" tilecount="1440" columns="40">
-  <image source="../gfx/tilesets/Outdoor_Tiles_-_City_and_Country_-_by_ArMM1998.png" width="640" height="576"/>
- </tileset>
- <tileset firstgid="5929" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
+ <tileset firstgid="3649" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
   <image source="../gfx/tilesets/boxfont.png" width="208" height="192"/>
  </tileset>
- <tileset firstgid="6085" name="Interiors 2 by Redshrike" tilewidth="16" tileheight="16" tilecount="28" columns="7">
+ <tileset firstgid="3805" name="Interiors 2 by Redshrike" tilewidth="16" tileheight="16" tilecount="28" columns="7">
   <image source="../gfx/tilesets/Interiors 2 by Redshrike.PNG" width="112" height="64"/>
  </tileset>
- <tileset firstgid="6113" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
+ <tileset firstgid="3833" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>
   <tile id="839">
    <animation>
@@ -43,7 +40,7 @@
    </animation>
   </tile>
  </tileset>
- <tileset firstgid="7425" name="My_tuxemon_sheet_OLD" tilewidth="16" tileheight="16" tilecount="104" columns="8">
+ <tileset firstgid="5145" name="My_tuxemon_sheet_OLD" tilewidth="16" tileheight="16" tilecount="104" columns="8">
   <image source="../gfx/tilesets/My_tuxemon_sheet.png" width="128" height="208"/>
  </tileset>
  <layer id="1" name="Layer 1" width="40" height="20">
@@ -53,22 +50,22 @@
  </layer>
  <layer id="2" name="Layer 2" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHtlU0KwjAQhbMU/D2AgktBRTeCS5duqlfqiTyjb6RTn0PSTmoVBAOD08nL5OtrakP4j192YAJ4jab7mIZQQvcSY1w3reE5aB/7cK2PfDQPpbCtIyyoBcy5xtalyhcdwLeLsGknzLlGAdXIpcwTiX9X8F2qGBpW+FJ6O6qHNyzw3ldbb/GPNdbLHD7u0zWHT40jh2+MTninvjpy+PR5fhJQzp/tL+eHh3g05UKVd+HLXWPPXwSjLgknx6aeiSf7RShniPisryr+afhW+FRH4jpT7lv9VIl/Gs/q+9mSmFaUpzqnnrt6p+cwpbN98T8ZLlXYOb0egOvkYBM974t3tB7qnZ5D1tUikwjb1dRyLmPfTd6X+di/R96y0bts2l4YU+8a87F/khfaIPGb65ueAf31fKOZz/qXwOqt3Hb/shF7YP3rDaSnRncvxjbO
+   eAHtVbsOwjAMzM5rgA9gYEACxMrIyNKWkZFP6RfxjZxRXQ4raR1eEhKWrDrOxblcnTaEv/2yAmOQV+86xySEGrgHH2HctYbngL3tw7l3xItpqIXbKsIFuYA5l21cqHxQAX7bCDethDmXFUANXcg8kOhXgV/Z+MBwhS61t6JqeMEC77n6aot+jLFa5vDjOs/G0KnTcviNUAl36quWw0/f5ycJSv/Z+tI/bKLRhBNN/Ay/3DW2/yI02pTwZF+3M/HgMAv1Eh6f9WVFP3XfCh/qSLzOFPtW31Gin/o9+3q0I057ilOVU+9dtdM+TOFsXXwnQ9m4ndPxHLxODm6C531xR1tT7bQPGdeCTCDcKpPLGcb+m7wv82P9JO77R73KTc8hHFN3jfmxfrdYCySeubppD+iz7/yyLfOz+iVovS1dOCqxBlY/x/KvQq5T5zlE
   </data>
  </layer>
  <layer id="3" name="Layer 3" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHFlV1Ow0AMhANv5ac9CCBuACdoews4DX/HKA9I8FQkLlROgSfkU0fWZpNKQVhyvesZeyfOKt01TfMdvhuIAbc2xJsanx01zUn4UETfEG9q/Pm4aV7C/8rOo/E8+aI7TNirOTzhvIdtaPucUB9nEC87LR4uYiMcTBrdrmPDe/B8Xr9H4iMnJ96fRr9V52ddb+ljfl2qN0jjGPua7VlvsdQZnOsRDWJL2zqcd3ylZFhpft7/l7X/3eyX1dVDoI+dP/Uw0SBYOqRN/RXBlM/z4xkCao09kXwt0p/5iXub7jYcYejjjKWSYetwv3/gPEdLih/y7PviPAA59108nV2ymj7OI3o9OaJjQ+tc4/PLtWP05Tl5D9XrPEzfgpqhzWukj2+I5rqwBs53jni4+Pn+0cKfTzn6gRPJ86zsFbNJBxp5fuezpk53w+8feUXXRx3ReaxLmHLZdKZsGb4quL479BJ3aH7g1BCjtGjgxExCX86z97ra/NDFfNmrvs/yPJiF8/2uLQy4674/6CNyrlHbZdaV95lf2usd+v9EiZNz0rUJRx/nZh73L+N5r7qb9O31XodoRBNRffrmJyy/L98LH2vSONZcm2pK81A+/x8pd6jdV+aqXv68pbU4tfkJ/29jfj/O46H3
+   eAG1lltOw0AMRQMfSLzahQBiB7AC6GbYBrAO+ECCL1hSWQU+bY9imUnSSq0lxzP2tX3HGVKWXdf9hi4nbIRXMoXbd/z0qOvOQqes/KZw+45/RuMvmx/AXkbNWdH5pg+x96TiiPsevo+77id0X2IP7XWj8FX4iBuDY5bb2Pgesr+uDz1b+p2HPm70AkcI/JzfyjHygOM28nTSoz5iSQ/7ZisH0HBbhPqOb3CGtOaX669R/fOtX46uniP6stHXAaQcCMMDbtTHGsNf5+cZIrQS91r9Y9b6zg/sfbnbYojJzx4POEMWofn+GfccK1A89LsfsrMIoN53cPRuyRg/+2lzvj5tjk2ta06eX83dhl+dU65BPv0UvgVjIjesf0vw8xvCXOepQMZnDDgVfL1/lsjnw2c941r9ntVvEf4q8JCj5zc/W/O4G/n+6cdmfjm31Re8GH6D4Ii2sPREHkIfG8p3x1pgp+Zn3BxtpP4TOYnBVpFf9bs3l/3Y/OTlfN23elq7zsNZGMfmuzZPAc6GyE9r33W0f1Zedd8jh1e8w/w7MYzsI/B6C5WffXvEeuX9q/G6B31Xvr251i4c5aSlztD8iNX3lffEtxU4biuZGzmteeCvv0f4dpWp/yfzeVtr+o3Nb1c+h8A7vz+MraW2
   </data>
  </layer>
  <layer id="4" name="Above Player" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAFjYBj6QIprcPvBfZC7D1/oHRXHJzvwcmcGsfvu8DMwXB7E7qNX7BGb/ukVXoO9vKBXvAw2e9KZBpuLEO6ZAHTbxEHsvh1At+0E4r5B6Ma0QegmRMyOskZDYDQEBioEAGyfCk8=
+   eAFjYBj64BLb4PbD/0HuPnyhd5cPn+zAyz0ZxO6bwsPA8HoQu49esUds+qdXeA328oJe8TJqz/AJgR1MDAw7gXgUjIbAaAiMhsBQCQEA0HAKPw==
   </data>
  </layer>
  <layer id="1" name="Above Player" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAFjYBgFoyGAOwSOiuOWGwwyZwaZ+0bDazCkilE3jIbAaAiMhsBoCIyGwGgIDOYQAAAawwN/
+   eAFjYBgFoyGAOwTu8uGWGwwyTwaZ+0bDazCkilE3jIbAaAiMhsBoCIyGwGgIDOYQAABTJQO7
   </data>
  </layer>
  <objectgroup color="#ff0000" id="5" name="Collisions">
@@ -532,52 +529,59 @@
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
-  <object id="158" name="Create Roddick" type="event" x="192" y="32" width="16" height="16">
+  <object id="158" name="Create Roddick" type="event" x="80" y="48" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_route2_roddick,5,3"/>
     <property name="cond2" value="not npc_exists spyder_route2_roddick"/>
    </properties>
   </object>
-  <object id="159" name="Create Marion&#10;" type="event" x="208" y="32" width="16" height="16">
+  <object id="159" name="Create Marion&#10;" type="event" x="352" y="144" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_route2_marion,22,9"/>
     <property name="cond2" value="not npc_exists spyder_route2_marion"/>
    </properties>
   </object>
-  <object id="160" name="Create Graf" type="event" x="224" y="32" width="16" height="16">
+  <object id="160" name="Create Graf" type="event" x="464" y="48" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_route2_graf,29,3"/>
     <property name="cond2" value="not npc_exists spyder_route2_graf"/>
    </properties>
   </object>
-  <object id="161" name="Talk roddick&#10;" type="event" x="192" y="48" width="16" height="16">
+  <object id="161" name="Talk roddick&#10;" type="event" x="80" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route2_roddick1"/>
-    <property name="act2" value="start_battle spyder_route2_roddick"/>
-    <property name="act3" value="translated_dialog spyder_route2_roddick2"/>
-    <property name="act4" value="set_variable route2roddick:yes"/>
+    <property name="act10" value="translated_dialog spyder_route2_roddick1"/>
+    <property name="act12" value="set_variable spyder_roddick_fought:yes"/>
+    <property name="act20" value="start_battle spyder_route2_roddick"/>
+    <property name="act31" value="set_variable after_spyder_roddick:yes"/>
+    <property name="act40" value="set_variable route2roddick:yes"/>
     <property name="behav1" value="talk spyder_route2_roddick"/>
     <property name="cond1" value="not variable_set route2roddick:yes"/>
+    <property name="cond2" value="not variable_set spyder_roddick_fought:yes"/>
+    <property name="cond3" value="not variable_set spyder_roddick_won:yes"/>
    </properties>
   </object>
-  <object id="162" name="Talk marion&#10;" type="event" x="208" y="48" width="16" height="16">
+  <object id="162" name="Talk marion&#10;" type="event" x="352" y="128" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_route2_marion1"/>
+    <property name="act12" value="set_variable spyder_marion_fought:yes"/>
     <property name="act2" value="start_battle spyder_route2_marion"/>
-    <property name="act3" value="translated_dialog spyder_route2_marion2"/>
-    <property name="act4" value="set_variable route2marion:yes"/>
+    <property name="act30" value="set_variable after_spyder_marion:yes"/>
     <property name="behav1" value="talk spyder_route2_marion"/>
     <property name="cond1" value="not variable_set route2marion:yes"/>
+    <property name="cond2" value="not variable_set spyder_marion_fought:yes"/>
+    <property name="cond3" value="not variable_set spyder_marion_won:yes"/>
    </properties>
   </object>
-  <object id="163" name="Talk graf&#10;" type="event" x="224" y="48" width="16" height="16">
+  <object id="163" name="Talk graf&#10;" type="event" x="464" y="32" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_route2_graf1"/>
-    <property name="act2" value="start_battle spyder_route2_graf"/>
-    <property name="act3" value="translated_dialog spyder_route2_graf2"/>
-    <property name="act4" value="set_variable route2graf:yes"/>
+    <property name="act12" value="set_variable spyder_graf_fought:yes"/>
+    <property name="act20" value="start_battle spyder_route2_graf"/>
+    <property name="act30" value="set_variable after_spyder_graf:yes"/>
     <property name="behav1" value="talk spyder_route2_graf"/>
-    <property name="cond1" value="not variable_set route2graf:yes"/>
+    <property name="cond2" value="not variable_set spyder_graf_fought:yes"/>
+    <property name="cond3" value="not variable_set spyder_graf_won:yes"/>
+    <property name="cond4" value="not variable_set route2graf:yes"/>
    </properties>
   </object>
   <object id="164" name="Route Music" type="event" x="0" y="0" width="16" height="16">
@@ -598,6 +602,141 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set environment:grass"/>
+   </properties>
+  </object>
+  <object id="188" name="BATTLE roddick" type="event" x="80" y="64" width="16" height="48">
+   <properties>
+    <property name="act10" value="translated_dialog spyder_route2_roddick1"/>
+    <property name="act12" value="set_variable spyder_roddick_fought:yes"/>
+    <property name="act20" value="start_battle spyder_route2_roddick"/>
+    <property name="act31" value="set_variable after_spyder_roddick:yes"/>
+    <property name="act40" value="set_variable route2roddick:yes"/>
+    <property name="cond1" value="is player_at"/>
+    <property name="cond2" value="not variable_set spyder_roddick_fought:yes"/>
+    <property name="cond3" value="not variable_set spyder_roddick_won:yes"/>
+    <property name="cond4" value="not variable_set route2roddick:yes"/>
+   </properties>
+  </object>
+  <object id="189" name="Win roddick" type="event" x="32" y="64" width="16" height="16">
+   <properties>
+    <property name="act3" value="translated_dialog spyder_route2_roddick2"/>
+    <property name="act40" value="set_variable spyder_roddick_won:yes"/>
+    <property name="cond1" value="is variable_set battle_last_result:won"/>
+    <property name="cond2" value="not variable_set spyder_roddick_won:yes"/>
+    <property name="cond3" value="is variable_set after_spyder_roddick:yes"/>
+   </properties>
+  </object>
+  <object id="190" name="Lose roddick" type="event" x="32" y="48" width="16" height="16">
+   <properties>
+    <property name="act30" value="set_variable spyder_roddick_lose:yes"/>
+    <property name="act40" value="set_monster_health ,"/>
+    <property name="act41" value="set_monster_status ,"/>
+    <property name="act42" value="teleport_faint"/>
+    <property name="cond1" value="is variable_set battle_last_result:lost"/>
+    <property name="cond2" value="is variable_set spyder_roddick_fought:yes"/>
+    <property name="cond3" value="is variable_set after_spyder_roddick:yes"/>
+    <property name="cond4" value="not variable_set spyder_roddick_lose:yes"/>
+   </properties>
+  </object>
+  <object id="191" name="BATTLE_INIT roddick" type="event" x="64" y="48" width="48" height="64">
+   <properties>
+    <property name="act1" value="set_variable spyder_roddick_fought:no"/>
+    <property name="act20" value="set_variable spyder_roddick_lose:no"/>
+    <property name="act21" value="set_variable after_spyder_roddick:no"/>
+    <property name="cond1" value="not player_at"/>
+    <property name="cond2" value="not variable_set spyder_roddick_fought:no"/>
+   </properties>
+  </object>
+  <object id="193" name="BATTLE marion" type="event" x="352" y="160" width="16" height="48">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route2_marion1"/>
+    <property name="act12" value="set_variable spyder_marion_fought:yes"/>
+    <property name="act20" value="start_battle spyder_route2_marion"/>
+    <property name="act30" value="set_variable after_spyder_marion:yes"/>
+    <property name="cond1" value="is player_at"/>
+    <property name="cond2" value="not variable_set spyder_marion_fought:yes"/>
+    <property name="cond3" value="not variable_set spyder_marion_won:yes"/>
+    <property name="cond4" value="not variable_set route2marion:yes"/>
+   </properties>
+  </object>
+  <object id="194" name="Win marion" type="event" x="416" y="144" width="16" height="16">
+   <properties>
+    <property name="act40" value="set_variable spyder_marion_won:yes"/>
+    <property name="act50" value="translated_dialog spyder_route2_marion2"/>
+    <property name="act51" value="set_variable route2marion:yes"/>
+    <property name="cond1" value="is variable_set battle_last_result:won"/>
+    <property name="cond2" value="not variable_set spyder_marion_won:yes"/>
+    <property name="cond3" value="is variable_set after_spyder_marion:yes"/>
+   </properties>
+  </object>
+  <object id="195" name="Lose marion" type="event" x="416" y="192" width="16" height="16">
+   <properties>
+    <property name="act30" value="set_variable spyder_marion_lose:yes"/>
+    <property name="act40" value="set_monster_health ,"/>
+    <property name="act41" value="set_monster_status ,"/>
+    <property name="act42" value="teleport_faint"/>
+    <property name="cond1" value="is variable_set battle_last_result:lost"/>
+    <property name="cond2" value="is variable_set spyder_marion_fought:yes"/>
+    <property name="cond3" value="is variable_set after_spyder_marion:yes"/>
+    <property name="cond4" value="not variable_set spyder_marion_lose:yes"/>
+   </properties>
+  </object>
+  <object id="196" name="BATTLE_INIT marion" type="event" x="336" y="128" width="48" height="80">
+   <properties>
+    <property name="act1" value="set_variable spyder_marion_fought:no"/>
+    <property name="act20" value="set_variable spyder_marion_lose:no"/>
+    <property name="act21" value="set_variable after_spyder_marion:no"/>
+    <property name="cond1" value="not player_at"/>
+    <property name="cond2" value="not variable_set spyder_marion_fought:no"/>
+   </properties>
+  </object>
+  <object id="197" name="BATTLE graf" type="event" x="464" y="64" width="16" height="48">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route2_graf1"/>
+    <property name="act12" value="set_variable spyder_graf_fought:yes"/>
+    <property name="act20" value="start_battle spyder_route2_graf"/>
+    <property name="act30" value="set_variable after_spyder_graf:yes"/>
+    <property name="cond1" value="is player_at"/>
+    <property name="cond2" value="not variable_set spyder_graf_fought:yes"/>
+    <property name="cond3" value="not variable_set spyder_graf_won:yes"/>
+    <property name="cond4" value="not variable_set route2graf:yes"/>
+   </properties>
+  </object>
+  <object id="198" name="Win graf" type="event" x="416" y="32" width="16" height="16">
+   <properties>
+    <property name="act40" value="set_variable spyder_graf_won:yes"/>
+    <property name="act50" value="translated_dialog spyder_route2_graf2"/>
+    <property name="act51" value="set_variable route2graf:yes"/>
+    <property name="cond1" value="is variable_set battle_last_result:won"/>
+    <property name="cond2" value="not variable_set spyder_graf_won:yes"/>
+    <property name="cond3" value="is variable_set after_spyder_graf:yes"/>
+   </properties>
+  </object>
+  <object id="199" name="Lose graf" type="event" x="416" y="48" width="16" height="16">
+   <properties>
+    <property name="act30" value="set_variable spyder_graf_lose:yes"/>
+    <property name="act40" value="set_monster_health ,"/>
+    <property name="act41" value="set_monster_status ,"/>
+    <property name="act42" value="teleport_faint"/>
+    <property name="cond1" value="is variable_set battle_last_result:lost"/>
+    <property name="cond2" value="is variable_set spyder_graf_fought:yes"/>
+    <property name="cond3" value="is variable_set after_spyder_graf:yes"/>
+    <property name="cond4" value="not variable_set spyder_graf_lose:yes"/>
+   </properties>
+  </object>
+  <object id="200" name="BATTLE_INIT graf" type="event" x="448" y="32" width="48" height="80">
+   <properties>
+    <property name="act1" value="set_variable spyder_graf_fought:no"/>
+    <property name="act20" value="set_variable spyder_graf_lose:no"/>
+    <property name="act21" value="set_variable after_spyder_graf:no"/>
+    <property name="cond1" value="not player_at"/>
+    <property name="cond2" value="not variable_set spyder_graf_fought:no"/>
+   </properties>
+  </object>
+  <object id="201" name="Set Checkpoint" type="event" x="64" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_variable teleport_faint:spyder_cotton_town.tmx 20 27"/>
+    <property name="cond1" value="not variable_set teleport_faint:spyder_cotton_town.tmx 20 27"/>
    </properties>
   </object>
  </objectgroup>


### PR DESCRIPTION
_Note: This is definitely a hacky, and slightly unmaintainable way of getting the battles working automatically... 
It requires 5 new event actions to get all the win/lose/automatic battle events to work.
Eventually, I'd like to create some actions to automate these instead, but for now this seems the best way to do it., but feel free to reject the PR if you think it would be better to create some actions to help instead - Otherwise I'll start adding this to every route/dungeon in the spyder campaign_  

New features:
- If you walk in front of one of the 3 trainers in Spyder's route 2, a battle will now start automatically. 
(Previously, you would need to talk to them)

- Also, if you lose, you will be teleported to the previous town (Spyder's Cotton Town) by using the teleport_faint action, and all your tuxemon will be healed. 
If you talk or walk in front of the trainer again, you will need to battle them again, repeating until you win. 

- If you win, you can't battle them again, or talk to them, just like it worked previously. 
(Previously, winning did nothing, you would stay in the same place with all your monsters defeated)

(If you lose during a random battle in the grass, or during the Billie battle that automatically starts on this map, you're not teleported back anywhere - I'll fix/test this in a future PR) 

(I've also fixed some messed-up tiles on this map, where rocks were appearing as stairs or roofs of houses, which is why some of the tilset stuff has been updated in the diff)