### PR TITLE
Fix item revive action

### DIFF
--- a/mods/tuxemon/db/item/revive.json
+++ b/mods/tuxemon/db/item/revive.json
@@ -4,10 +4,12 @@
   "use_success": "generic_success",
   "use_failure": "generic_failure",
   "effects": [
+    "revive",
     "heal 20"
   ],
   "conditions": [
-    "current_hp target,==,0"
+    "current_hp target,==,0",
+    "status target,status_faint"
   ],
   "sort": "food",
   "sprite": "gfx/items/revive.png",

--- a/tuxemon/item/conditions/status.py
+++ b/tuxemon/item/conditions/status.py
@@ -24,10 +24,12 @@
 #
 
 from __future__ import annotations
+import logging
 from tuxemon.item.itemcondition import ItemCondition
 from typing import NamedTuple
 from tuxemon.monster import Monster
 
+logger = logging.getLogger(__name__)
 
 class StatusConditionParameters(NamedTuple):
     expected: str
@@ -45,4 +47,5 @@ class StatusCondition(ItemCondition[StatusConditionParameters]):
     param_class = StatusConditionParameters
 
     def test(self, target: Monster) -> bool:
-        return self.parameters.expected in target.status
+        return self.parameters.expected in \
+            [x.slug for x in target.status if hasattr(x, "slug")]

--- a/tuxemon/item/effects/revive.py
+++ b/tuxemon/item/effects/revive.py
@@ -1,0 +1,55 @@
+#
+# Tuxemon
+# Copyright (c) 2014-2017 William Edwards <shadowapex@gmail.com>,
+#                         Benjamin Bean <superman2k5@gmail.com>
+#
+# This file is part of Tuxemon
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Contributor(s):
+#
+# William Edwards <shadowapex@gmail.com>
+# Leif Theden <leif.theden@gmail.com>
+# Andy Mender <andymenderunix@gmail.com>
+# Adam Chevalier <chevalieradam2@gmail.com>
+#
+
+from __future__ import annotations
+from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
+from typing import NamedTuple, Union
+from tuxemon.monster import Monster
+
+
+class ReviveEffectResult(ItemEffectResult):
+    pass
+
+
+class ReviveEffectParameters(NamedTuple):
+    pass
+
+
+class ReviveEffect(ItemEffect[ReviveEffectParameters]):
+    """
+    Revives the target tuxemon, and sets HP to 1.
+    """
+
+    name = "revive"
+    param_class = ReviveEffectParameters
+
+    def apply(self, target: Monster) -> ReviveEffectResult(ItemEffectResult):
+        target.status = []
+        target.current_hp = 1
+
+        return {"success": True}

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -170,7 +170,10 @@ class Item:
 
         for line in raw:
             name = line.split()[0]
-            params = line.split()[1].split(",")
+            if len(line.split()) > 1:
+                params = line.split()[1].split(",")
+            else:
+                params = None
             try:
                 effect = Item.effects_classes[name]
             except KeyError:


### PR DESCRIPTION
When using the 'Revive' item, it was healing your monster by 20 HP, but not removing the status_faint status. 

This PR also fixes another 2 related bugs, needed to get it working:
- If you create a 'revive' item effect with no parameters, it was causing an error when parsing because it always expects at least 1 parameter in tuxemon/item/item.py , so that's been fixed. 
- Checking for statuses inside item conditions stopped working - because a status used to be a string, but now it's a Technique(string) - so, there's a change in tuxemon/item/conditions/status.py to fix that - It used to expect a string to be inside monster.status, but instead there's a Technique('status_faint'), so it has to check the technique's slug matches the string. 

To test it:
- Give yourself some revive items, and some tuxemon:
```
add_item revive,5
add_monster eyenemy,1
```
- Start a battle:
``` 
create_npc spyder_route2_graf
start_battle spyder_route2_graf
```
- Let your tuxemon be defeated.
- Go into Bag -> Revive, use the item on the tuxemon. 
- Start the battle again, and your tuxemon should be alive 
(Before the PR, the tuxemon would immediately die on entering the battle as it still has the status_faint status applied. After this PR, it should stay alive in the new battle.)