### PR TITLE
Always add black background even if skipping title screen

### DIFF
--- a/tuxemon/main.py
+++ b/tuxemon/main.py
@@ -75,8 +75,8 @@ def main(
     # since menus do not clean up dirty areas, the blank,
     # "Background state" will do that.  The alternative is creating
     # a system for states to clean up their dirty screen areas.
+    client.push_state(BackgroundState)
     if not config.skip_titlescreen:
-        client.push_state(BackgroundState)
         client.push_state(StartState)
 
     if load_slot:


### PR DESCRIPTION
The black background state should always be shown, even if you skip the title screen.

Otherwise, when on an indoor map, opening the menu leaves the menu still visible on any black areas, as it's not being re-drawn properly. 