### PR TITLE
Add trainer battles if static NPC sees player

### DIFF
--- a/mods/tuxemon/maps/spyder_candy_town.tmx
+++ b/mods/tuxemon/maps/spyder_candy_town.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.5" tiledversion="1.7.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="421">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="421">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -395,7 +395,7 @@
   </object>
   <object id="414" name="Teleport to Greenwash" type="event" x="480" y="336" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport spyder_greenwash.tmx,4,7,0.3"/>
+    <property name="act1" value="transition_teleport spyder_greenwash_greenhouse.tmx,25,15,0.3"/>
     <property name="act2" value="player_face up"/>
     <property name="cond1" value="is player_at"/>
     <property name="cond2" value="is player_facing up"/>

--- a/mods/tuxemon/maps/spyder_citypark.tmx
+++ b/mods/tuxemon/maps/spyder_citypark.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.4" tiledversion="1.4.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="274">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="275">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -321,14 +321,14 @@
     <property name="cond1" value="not variable_set citypark_frances:yes"/>
    </properties>
   </object>
-  <object id="230" name="Create Bobette" type="event" x="240" y="256" width="16" height="16">
+  <object id="230" name="Create Bobette" type="event" x="256" y="272" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_citypark_bobette,16,17"/>
     <property name="act2" value="npc_face spyder_citypark_bobette,left"/>
     <property name="cond2" value="not npc_exists spyder_citypark_bobette"/>
    </properties>
   </object>
-  <object id="231" name="Talk Bobette" type="event" x="240" y="272" width="16" height="16">
+  <object id="231" name="Talk Bobette" type="event" x="256" y="256" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_citypark_bobette1"/>
     <property name="act2" value="start_battle spyder_citypark_bobette"/>
@@ -541,6 +541,16 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set environment:grass"/>
+   </properties>
+  </object>
+  <object id="274" name="Talk Bobette" type="event" x="208" y="272" width="48" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_citypark_bobette1"/>
+    <property name="act2" value="start_battle spyder_citypark_bobette"/>
+    <property name="act3" value="translated_dialog spyder_citypark_bobette2"/>
+    <property name="act4" value="set_variable citypark_bobette:yes"/>
+    <property name="cond1" value="not variable_set citypark_bobette:yes"/>
+    <property name="cond2" value="is player_at"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_dragonscave.tmx
+++ b/mods/tuxemon/maps/spyder_dragonscave.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.5" tiledversion="1.7.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="92">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="102">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -145,14 +145,14 @@
     <property name="cond1" value="not variable_set dragonscavelessa:yes"/>
    </properties>
   </object>
-  <object id="65" name="Create Cailin" type="event" x="112" y="432" width="16" height="16">
+  <object id="65" name="Create Cailin" type="event" x="112" y="416" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_dragonscave_cailin,7,26"/>
     <property name="act2" value="npc_face spyder_dragonscave_cailin,right"/>
     <property name="cond1" value="not npc_exists spyder_dragonscave_cailin"/>
    </properties>
   </object>
-  <object id="66" name="Talk Cailin" type="event" x="112" y="416" width="16" height="16">
+  <object id="66" name="Talk Cailin" type="event" x="112" y="432" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_dragonscave_cailin1"/>
     <property name="act3" value="start_battle spyder_dragonscave_cailin"/>
@@ -169,7 +169,7 @@
     <property name="cond1" value="not npc_exists spyder_dragonscave_griffin"/>
    </properties>
   </object>
-  <object id="68" name="Talk Griffin" type="event" x="112" y="592" width="16" height="16">
+  <object id="68" name="Talk Griffin" type="event" x="96" y="608" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_dragonscave_griffin1"/>
     <property name="act3" value="start_battle spyder_dragonscave_griffin"/>
@@ -186,7 +186,7 @@
     <property name="cond1" value="not npc_exists spyder_dragonscave_daenny"/>
    </properties>
   </object>
-  <object id="70" name="Talk Daenny" type="event" x="192" y="480" width="16" height="16">
+  <object id="70" name="Talk Daenny" type="event" x="176" y="496" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_dragonscave_daenny1"/>
     <property name="act3" value="start_battle spyder_dragonscave_daenny"/>
@@ -293,7 +293,7 @@
     <property name="cond2" value="not variable_set dragonscavetru:yes"/>
    </properties>
   </object>
-  <object id="83" name="Talk Tru" type="event" x="240" y="144" width="16" height="16">
+  <object id="83" name="Talk Tru" type="event" x="224" y="160" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_dragonscave_tru1"/>
     <property name="act3" value="start_battle spyder_dragonscave_tru"/>
@@ -344,6 +344,108 @@
    <properties>
     <property name="act1" value="set_variable environment:cave"/>
     <property name="cond1" value="not variable_set environment:cave"/>
+   </properties>
+  </object>
+  <object id="92" name="Talk Tomas" type="event" x="240" y="528" width="48" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_dragonscave_tomas1"/>
+    <property name="act3" value="start_battle spyder_dragonscave_tomas"/>
+    <property name="act4" value="translated_dialog spyder_dragonscave_tomas2"/>
+    <property name="act6" value="set_variable dragonscavetomas:yes"/>
+    <property name="cond1" value="not variable_set dragonscavetomas:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="93" name="Talk Daenny" type="event" x="192" y="432" width="16" height="64">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_dragonscave_daenny1"/>
+    <property name="act3" value="start_battle spyder_dragonscave_daenny"/>
+    <property name="act4" value="translated_dialog spyder_dragonscave_daenny2"/>
+    <property name="act6" value="set_variable dragonscavedaenny:yes"/>
+    <property name="cond1" value="not variable_set dragonscavedaenny:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="94" name="Talk Cailin" type="event" x="128" y="416" width="32" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_dragonscave_cailin1"/>
+    <property name="act3" value="start_battle spyder_dragonscave_cailin"/>
+    <property name="act4" value="translated_dialog spyder_dragonscave_cailin2"/>
+    <property name="act6" value="set_variable dragonscavecailin:yes"/>
+    <property name="cond1" value="not variable_set dragonscavecailin:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="95" name="Talk Lessa" type="event" x="256" y="336" width="16" height="48">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_dragonscave_lessa1"/>
+    <property name="act3" value="start_battle spyder_dragonscave_lessa"/>
+    <property name="act4" value="translated_dialog spyder_dragonscave_lessa2"/>
+    <property name="act6" value="set_variable dragonscavelessa:yes"/>
+    <property name="cond1" value="not variable_set dragonscavelessa:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="96" name="Talk Griffin" type="event" x="112" y="528" width="16" height="80">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_dragonscave_griffin1"/>
+    <property name="act3" value="start_battle spyder_dragonscave_griffin"/>
+    <property name="act4" value="translated_dialog spyder_dragonscave_griffin2"/>
+    <property name="act6" value="set_variable dragonscavegriffin:yes"/>
+    <property name="cond1" value="not variable_set dragonscavegriffin:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="97" name="Talk Benden" type="event" x="80" y="240" width="16" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_dragonscave_benden1"/>
+    <property name="act3" value="start_battle spyder_dragonscave_benden"/>
+    <property name="act4" value="translated_dialog spyder_dragonscave_benden2"/>
+    <property name="act5" value="set_monster_health ,"/>
+    <property name="act7" value="set_monster_status ,"/>
+    <property name="act8" value="set_variable dragonscavebenden:yes"/>
+    <property name="cond1" value="not variable_set dragonscavebenden:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="98" name="Talk Ray" type="event" x="288" y="144" width="16" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_dragonscave_ray1"/>
+    <property name="act3" value="start_battle spyder_dragonscave_ray"/>
+    <property name="act4" value="translated_dialog spyder_dragonscave_ray2"/>
+    <property name="act6" value="set_variable dragonscaveray:yes"/>
+    <property name="cond1" value="not variable_set dragonscaveray:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="99" name="Talk Tru" type="event" x="240" y="112" width="16" height="48">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_dragonscave_tru1"/>
+    <property name="act3" value="start_battle spyder_dragonscave_tru"/>
+    <property name="act4" value="translated_dialog spyder_dragonscave_tru2"/>
+    <property name="act6" value="set_variable dragonscavetru:yes"/>
+    <property name="cond1" value="not variable_set dragonscavetru:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="100" name="Talk Lucille" type="event" x="208" y="128" width="16" height="32">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_dragonscave_lucille1"/>
+    <property name="act3" value="start_battle spyder_dragonscave_lucille"/>
+    <property name="act4" value="translated_dialog spyder_dragonscave_lucille2"/>
+    <property name="act6" value="set_variable dragonscavelucille:yes"/>
+    <property name="cond1" value="not variable_set dragonscavelucille:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="101" name="Talk Mal" type="event" x="176" y="144" width="32" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_dragonscave_mal1"/>
+    <property name="act3" value="start_battle spyder_dragonscave_mal"/>
+    <property name="act4" value="translated_dialog spyder_dragonscave_mal2"/>
+    <property name="act6" value="set_variable dragonscavemal:yes"/>
+    <property name="cond1" value="not variable_set dragonscavemal:yes"/>
+    <property name="cond2" value="is player_at"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_dryadsgrove.tmx
+++ b/mods/tuxemon/maps/spyder_dryadsgrove.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.5" tiledversion="1.7.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="220">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="223">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -613,7 +613,7 @@
     <property name="cond2" value="is player_moved"/>
    </properties>
   </object>
-  <object id="208" name="Create Aquemini" type="event" x="544" y="256" width="16" height="16">
+  <object id="208" name="Create Aquemini" type="event" x="544" y="240" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_dryadsgrove_aquemini,34,15"/>
     <property name="act2" value="npc_face spyder_dryadsgrove_aquemini,up"/>
@@ -621,7 +621,7 @@
     <property name="cond2" value="not variable_set dryadsgroveaquemini:yes"/>
    </properties>
   </object>
-  <object id="209" name="Talk Aquemini" type="event" x="544" y="240" width="16" height="16">
+  <object id="209" name="Talk Aquemini" type="event" x="528" y="240" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_dryadsgrove_aquemini1"/>
     <property name="act3" value="start_battle spyder_dryadsgrove_aquemini"/>
@@ -698,6 +698,36 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set environment:grass"/>
+   </properties>
+  </object>
+  <object id="220" name="Talk Aquemini" type="event" x="544" y="192" width="16" height="48">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_dryadsgrove_aquemini1"/>
+    <property name="act3" value="start_battle spyder_dryadsgrove_aquemini"/>
+    <property name="act4" value="translated_dialog spyder_dryadsgrove_aquemini2"/>
+    <property name="act6" value="set_variable dryadsgroveaquemini:yes"/>
+    <property name="cond1" value="not variable_set dryadsgroveaquemini:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="221" name="Talk Ignatia" type="event" x="400" y="128" width="48" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_dryadsgrove_ignatia1"/>
+    <property name="act3" value="start_battle spyder_dryadsgrove_ignatia"/>
+    <property name="act4" value="translated_dialog spyder_dryadsgrove_ignatia2"/>
+    <property name="act6" value="set_variable dryadsgroveignatia:yes"/>
+    <property name="cond1" value="not variable_set dryadsgroveignatia:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="222" name="Talk Petra" type="event" x="240" y="96" width="16" height="32">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_dryadsgrove_petra1"/>
+    <property name="act3" value="start_battle spyder_dryadsgrove_petra"/>
+    <property name="act4" value="translated_dialog spyder_dryadsgrove_petra2"/>
+    <property name="act6" value="set_variable dryadsgrovepetra:yes"/>
+    <property name="cond1" value="not variable_set dryadsgrovepetra:yes"/>
+    <property name="cond2" value="is player_at"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_greenwash.tmx
+++ b/mods/tuxemon/maps/spyder_greenwash.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.5" tiledversion="1.7.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="16" height="32" tilewidth="16" tileheight="16" infinite="0" nextlayerid="11" nextobjectid="75">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="16" height="32" tilewidth="16" tileheight="16" infinite="0" nextlayerid="11" nextobjectid="79">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -105,7 +105,7 @@
   </object>
   <object id="46" name="Teleport to Greenhouse" type="event" x="240" y="304" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport spyder_greenwash_greenhouse.tmx,0,39,0.3"/>
+    <property name="act1" value="transition_teleport spyder_greenwash_greenhouse.tmx,1,7,0.3"/>
     <property name="act2" value="player_face right"/>
     <property name="cond1" value="is player_at"/>
     <property name="cond2" value="is player_facing right"/>
@@ -113,7 +113,7 @@
   </object>
   <object id="51" name="Teleport to Greenhouse" type="event" x="240" y="320" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport spyder_greenwash_greenhouse.tmx,0,40,0.3"/>
+    <property name="act1" value="transition_teleport spyder_greenwash_greenhouse.tmx,1,8,0.3"/>
     <property name="act2" value="player_face right"/>
     <property name="cond1" value="is player_at"/>
     <property name="cond2" value="is player_facing right"/>
@@ -130,7 +130,7 @@
   </object>
   <object id="68" name="Teleport to Level 2" type="event" x="16" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport spyder_greenwash_level2.tmx,0,40,0.3"/>
+    <property name="act1" value="transition_teleport spyder_greenwash_level2.tmx,13,5,0.3"/>
     <property name="act2" value="player_face left"/>
     <property name="cond1" value="is player_at"/>
     <property name="cond2" value="is player_facing left"/>
@@ -188,6 +188,42 @@
     <property name="act6" value="set_variable greenwashlouis:yes"/>
     <property name="behav1" value="talk spyder_greenwash_louis"/>
     <property name="cond1" value="not variable_set greenwashlouis:yes"/>
+   </properties>
+  </object>
+  <object id="75" name="Talk Chip" type="event" x="80" y="224" width="16" height="48">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_greenwash_chip1"/>
+    <property name="act3" value="start_battle spyder_greenwash_chip"/>
+    <property name="act4" value="translated_dialog spyder_greenwash_chip2"/>
+    <property name="act6" value="set_variable greenwashchip:yes"/>
+    <property name="cond1" value="not variable_set greenwashchip:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="76" name="Talk Louis" type="event" x="96" y="64" width="16" height="32">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_greenwash_louis1"/>
+    <property name="act3" value="start_battle spyder_greenwash_louis"/>
+    <property name="act4" value="translated_dialog spyder_greenwash_louis2"/>
+    <property name="act6" value="set_variable greenwashlouis:yes"/>
+    <property name="cond1" value="not variable_set greenwashlouis:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="77" name="Talk Clarence" type="event" x="208" y="48" width="16" height="48">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_greenwash_clarence1"/>
+    <property name="act3" value="start_battle spyder_greenwash_clarence"/>
+    <property name="act4" value="translated_dialog spyder_greenwash_clarence2"/>
+    <property name="act6" value="set_variable greenwashclarence:yes"/>
+    <property name="cond1" value="not variable_set greenwashclarence:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="78" name="Move Right" type="event" x="144" y="464" width="16" height="16">
+   <properties>
+    <property name="act1" value="npc_move player,right"/>
+    <property name="cond1" value="is player_at"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_greenwash_greenhouse.tmx
+++ b/mods/tuxemon/maps/spyder_greenwash_greenhouse.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.5" tiledversion="1.7.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="32" height="16" tilewidth="16" tileheight="16" infinite="0" nextlayerid="12" nextobjectid="89">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="32" height="16" tilewidth="16" tileheight="16" infinite="0" nextlayerid="12" nextobjectid="90">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -95,7 +95,7 @@
  <objectgroup color="#ffff00" id="4" name="Events">
   <object id="46" name="Teleport to Candy Town" type="event" x="384" y="240" width="48" height="16">
    <properties>
-    <property name="act1" value="transition_teleport spyder_candy_town.tmx,3,20,0.3"/>
+    <property name="act1" value="transition_teleport spyder_candy_town.tmx,30,22,0.3"/>
     <property name="act2" value="player_face down"/>
     <property name="cond1" value="is player_at"/>
     <property name="cond2" value="is player_facing down"/>
@@ -103,7 +103,7 @@
   </object>
   <object id="52" name="Teleport to Next Level" type="event" x="0" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport spyder_greenwash.tmx,15,23,0.3"/>
+    <property name="act1" value="transition_teleport spyder_greenwash.tmx,14,19,0.3"/>
     <property name="act2" value="player_face left"/>
     <property name="cond1" value="is player_at"/>
     <property name="cond2" value="is player_facing left"/>
@@ -111,7 +111,7 @@
   </object>
   <object id="53" name="Teleport to Next Level" type="event" x="0" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport spyder_greenwash.tmx,15,24,0.3"/>
+    <property name="act1" value="transition_teleport spyder_greenwash.tmx,14,20,0.3"/>
     <property name="act2" value="player_face left"/>
     <property name="cond1" value="is player_at"/>
     <property name="cond2" value="is player_facing left"/>
@@ -253,6 +253,16 @@
     <property name="act6" value="set_variable greenwashgregor:yes"/>
     <property name="behav1" value="talk spyder_greenwash_gregor"/>
     <property name="cond1" value="not variable_set greenwashgregor:yes"/>
+   </properties>
+  </object>
+  <object id="89" name="Talk Gregor" type="event" x="368" y="48" width="16" height="32">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_greenwash_gregor1"/>
+    <property name="act3" value="start_battle spyder_greenwash_gregor"/>
+    <property name="act4" value="translated_dialog spyder_greenwash_gregor2"/>
+    <property name="act6" value="set_variable greenwashgregor:yes"/>
+    <property name="cond1" value="not variable_set greenwashgregor:yes"/>
+    <property name="cond2" value="is player_at"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_greenwash_level2.tmx
+++ b/mods/tuxemon/maps/spyder_greenwash_level2.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.5" tiledversion="1.7.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="16" height="32" tilewidth="16" tileheight="16" infinite="0" nextlayerid="13" nextobjectid="92">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="16" height="32" tilewidth="16" tileheight="16" infinite="0" nextlayerid="13" nextobjectid="105">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -65,6 +65,16 @@
   <object id="76" type="collision-line" x="240" y="96">
    <polyline points="0,0 -16,0"/>
   </object>
+  <object id="95" type="collision" x="96" y="32" width="32" height="80"/>
+  <object id="96" type="collision" x="128" y="80" width="32" height="16"/>
+  <object id="97" type="collision" x="16" y="144" width="192" height="48"/>
+  <object id="98" type="collision" x="48" y="224" width="160" height="48"/>
+  <object id="99" type="collision" x="48" y="304" width="80" height="48"/>
+  <object id="100" type="collision" x="96" y="368" width="112" height="48"/>
+  <object id="101" type="collision" x="96" y="416" width="32" height="96"/>
+  <object id="102" type="collision" x="96" y="352" width="32" height="16"/>
+  <object id="103" type="collision" x="48" y="272" width="32" height="32"/>
+  <object id="104" type="collision" x="32" y="32" width="64" height="32"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="4" name="Events">
   <object id="51" name="Fall to Lower Floor" type="event" x="16" y="432" width="16" height="16">
@@ -133,7 +143,7 @@
     <property name="cond1" value="not variable_set greenwashaissa:yes"/>
    </properties>
   </object>
-  <object id="88" name="Create Moreau" type="event" x="144" y="480" width="16" height="16">
+  <object id="88" name="Create Moreau" type="event" x="128" y="480" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_greenwash_moreau,8,30"/>
     <property name="act2" value="npc_face spyder_greenwash_moreau,down"/>
@@ -141,7 +151,7 @@
     <property name="cond2" value="not variable_set greenwash_moreau:yes"/>
    </properties>
   </object>
-  <object id="89" name="Talk Moreau" type="event" x="128" y="480" width="16" height="16">
+  <object id="89" name="Talk Moreau" type="event" x="128" y="464" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_greenwash_moreau1"/>
     <property name="act3" value="start_battle spyder_greenwash_moreau"/>
@@ -167,6 +177,36 @@
     <property name="act6" value="set_variable greenwashdippel:yes"/>
     <property name="behav1" value="talk spyder_greenwash_dippel"/>
     <property name="cond1" value="not variable_set greenwashdippel:yes"/>
+   </properties>
+  </object>
+  <object id="92" name="Talk Aissa" type="event" x="176" y="48" width="16" height="48">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_greenwash_aissa1"/>
+    <property name="act3" value="start_battle spyder_greenwash_aissa"/>
+    <property name="act4" value="translated_dialog spyder_greenwash_aissa2"/>
+    <property name="act6" value="set_variable greenwashaissa:yes"/>
+    <property name="cond1" value="not variable_set greenwashaissa:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="93" name="Talk Dippel" type="event" x="160" y="304" width="48" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_greenwash_dippel1"/>
+    <property name="act3" value="start_battle spyder_greenwash_dippel"/>
+    <property name="act4" value="translated_dialog spyder_greenwash_dippel2"/>
+    <property name="act6" value="set_variable greenwashdippel:yes"/>
+    <property name="cond1" value="not variable_set greenwashdippel:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="94" name="Talk Moreau" type="event" x="128" y="496" width="16" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_greenwash_moreau1"/>
+    <property name="act3" value="start_battle spyder_greenwash_moreau"/>
+    <property name="act4" value="translated_dialog spyder_greenwash_moreau2"/>
+    <property name="act6" value="set_variable greenwashmoreau:yes"/>
+    <property name="cond1" value="not variable_set greenwashmoreau:yes"/>
+    <property name="cond2" value="is player_at"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_nimrod_bottom.tmx
+++ b/mods/tuxemon/maps/spyder_nimrod_bottom.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.4" tiledversion="1.4.2" orientation="orthogonal" renderorder="right-down" width="18" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="53">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" width="18" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="56">
  <tileset firstgid="1" name="factory" tilewidth="16" tileheight="16" tilecount="32" columns="8">
   <image source="../gfx/tilesets/factory.png" width="128" height="64"/>
  </tileset>
@@ -69,7 +69,7 @@
     <property name="cond1" value="not npc_exists spyder_enforcer_rookie"/>
    </properties>
   </object>
-  <object id="35" name="Talk Dirk" type="event" x="32" y="176" width="16" height="16">
+  <object id="35" name="Talk Dirk" type="event" x="48" y="304" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_nimrod_dirk1"/>
     <property name="behav1" value="talk spyder_enforcer_rookie"/>
@@ -89,13 +89,14 @@
     <property name="behav1" value="talk spyder_soldier"/>
    </properties>
   </object>
-  <object id="40" name="Create Rebel" type="event" x="208" y="240" width="16" height="16">
+  <object id="40" name="Create Rebel" type="event" x="192" y="240" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_nimrod_rebel,12,15"/>
+    <property name="act2" value="npc_face spyder_nimrod_rebel,right"/>
     <property name="cond1" value="not npc_exists spyder_nimrod_rebel"/>
    </properties>
   </object>
-  <object id="41" name="Talk Rebel" type="event" x="192" y="240" width="16" height="16">
+  <object id="41" name="Talk Rebel" type="event" x="192" y="256" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_nimrod_rebel1"/>
     <property name="act3" value="start_battle spyder_nimrod_rebel"/>
@@ -105,13 +106,13 @@
     <property name="cond1" value="not variable_set nimrodrebel:yes"/>
    </properties>
   </object>
-  <object id="42" name="Create Bowie" type="event" x="32" y="240" width="16" height="16">
+  <object id="42" name="Create Bowie" type="event" x="16" y="240" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_nimrod_bowie,1,15"/>
     <property name="cond1" value="not npc_exists spyder_nimrod_bowie"/>
    </properties>
   </object>
-  <object id="43" name="Talk Bowie" type="event" x="16" y="240" width="16" height="16">
+  <object id="43" name="Talk Bowie" type="event" x="48" y="240" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_nimrod_bowie1"/>
     <property name="act3" value="start_battle spyder_nimrod_bowie"/>
@@ -128,7 +129,7 @@
     <property name="cond1" value="not npc_exists spyder_nimrod_tru"/>
    </properties>
   </object>
-  <object id="45" name="Talk Tru" type="event" x="32" y="288" width="16" height="16">
+  <object id="45" name="Talk Tru" type="event" x="16" y="304" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_nimrod_tru1"/>
     <property name="act3" value="start_battle spyder_nimrod_tru"/>
@@ -153,6 +154,39 @@
    <properties>
     <property name="act1" value="set_variable environment:snow"/>
     <property name="cond1" value="not variable_set environment:snow"/>
+   </properties>
+  </object>
+  <object id="53" name="Talk Rebel" type="event" x="208" y="240" width="32" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_nimrod_rebel1"/>
+    <property name="act3" value="start_battle spyder_nimrod_rebel"/>
+    <property name="act4" value="translated_dialog spyder_nimrod_rebel2"/>
+    <property name="act6" value="set_variable nimrodrebel:yes"/>
+    <property name="cond1" value="not variable_set nimrodrebel:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="54" name="Talk Tru" type="event" x="32" y="288" width="32" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_nimrod_tru1"/>
+    <property name="act3" value="start_battle spyder_nimrod_tru"/>
+    <property name="act4" value="translated_dialog spyder_nimrod_tru2"/>
+    <property name="act5" value="pathfind spyder_enforcer_rookie,5,17"/>
+    <property name="act6" value="set_variable nimrodtru:yes"/>
+    <property name="act7" value="pathfind spyder_soldier,0,17"/>
+    <property name="act8" value="remove_npc spyder_soldier"/>
+    <property name="cond1" value="not variable_set nimrodtru:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="55" name="Talk Bowie" type="event" x="16" y="256" width="16" height="32">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_nimrod_bowie1"/>
+    <property name="act3" value="start_battle spyder_nimrod_bowie"/>
+    <property name="act4" value="translated_dialog spyder_nimrod_bowie2"/>
+    <property name="act6" value="set_variable nimrodbowie:yes"/>
+    <property name="cond1" value="not variable_set nimrodbowie:yes"/>
+    <property name="cond2" value="is player_at"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_nimrod_middle.tmx
+++ b/mods/tuxemon/maps/spyder_nimrod_middle.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.4" tiledversion="1.4.2" orientation="orthogonal" renderorder="right-down" width="18" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="37">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" width="18" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="44">
  <tileset firstgid="1" name="factory" tilewidth="16" tileheight="16" tilecount="32" columns="8">
   <image source="../gfx/tilesets/factory.png" width="128" height="64"/>
  </tileset>
@@ -30,8 +30,8 @@
  <tileset firstgid="3336" name="Cave_Tiles_by_George_" tilewidth="16" tileheight="16" tilecount="154" columns="14">
   <image source="../gfx/tilesets/Cave_Tiles_by_George_.png" width="224" height="181"/>
  </tileset>
- <tileset firstgid="3490" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="1000" columns="40">
-  <image source="../gfx/tilesets/Cave_Tiles_by_ArMM1998_(Tuxemon_Style).png" width="640" height="400"/>
+ <tileset firstgid="3490" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="160" columns="16">
+  <image source="../gfx/tilesets/Cave_Tiles_by_ArMM1998_(Tuxemon_Style).png" width="256" height="160"/>
  </tileset>
  <layer id="1" name="Tile Layer 1" width="18" height="20">
   <data encoding="base64" compression="zlib">
@@ -40,7 +40,7 @@
  </layer>
  <layer id="2" name="Tile Layer 3" width="18" height="20">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFQxV4MWGn8amhlTkXGBkYLpKILzHi998oGFrAiW+gXTD8AACSlA7F
+   eJxjYBgFQxV4MWGn8amhlTkXGBkYLpKILzHi998oGFrgEe9Au2D4AQBl0A9k
   </data>
  </layer>
  <layer id="3" name="Tile Layer 4" width="18" height="20">
@@ -61,8 +61,8 @@
   <object id="11" type="collision-line" x="32" y="272">
    <polyline points="0,0 0,32"/>
   </object>
-  <object id="12" type="collision-line" x="256" y="288">
-   <polyline points="0,0 0,32"/>
+  <object id="12" type="collision-line" x="256" y="304">
+   <polyline points="0,0 0,16"/>
   </object>
   <object id="15" type="collision" x="240" y="160" width="48" height="16"/>
   <object id="28" type="collision-line" x="32" y="288">
@@ -121,7 +121,7 @@
     <property name="cond1" value="not npc_exists spyder_nimrod_honour"/>
    </properties>
   </object>
-  <object id="17" name="Talk Honour" type="event" x="224" y="64" width="16" height="16">
+  <object id="17" name="Talk Honour" type="event" x="256" y="64" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_nimrod_honour1"/>
     <property name="act3" value="start_battle spyder_nimrod_honour"/>
@@ -184,15 +184,15 @@
     <property name="cond1" value="not variable_set nimrodbirbrobo_middle:yes"/>
    </properties>
   </object>
-  <object id="24" name="Create Xeon" type="event" x="160" y="224" width="16" height="16">
+  <object id="24" name="Create Xeon" type="event" x="160" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc spyder_nimrod_xeon,10,14"/>
+    <property name="act1" value="create_npc spyder_nimrod_xeon,10,15"/>
     <property name="act2" value="npc_face spyder_nimrod_xeon,up"/>
     <property name="cond1" value="not npc_exists spyder_nimrod_xeon"/>
     <property name="cond2" value="not variable_set nimrodxeon_middle:yes"/>
    </properties>
   </object>
-  <object id="25" name="Talk Xeon" type="event" x="176" y="224" width="16" height="16">
+  <object id="25" name="Talk Xeon" type="event" x="176" y="240" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_nimrod_xeon1"/>
     <property name="act3" value="start_battle spyder_nimrod_xeon"/>
@@ -206,6 +206,7 @@
   <object id="26" name="Create Argon" type="event" x="208" y="144" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_nimrod_argon,13,9"/>
+    <property name="act2" value="npc_face spyder_nimrod_argon,right"/>
     <property name="cond1" value="not npc_exists spyder_nimrod_argon"/>
    </properties>
   </object>
@@ -226,7 +227,7 @@
     <property name="cond1" value="not npc_exists spyder_nimrod_archer"/>
    </properties>
   </object>
-  <object id="30" name="Talk Archer" type="event" x="48" y="192" width="16" height="16">
+  <object id="30" name="Talk Archer" type="event" x="32" y="208" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_nimrod_archer1"/>
     <property name="act3" value="start_battle spyder_nimrod_archer"/>
@@ -240,6 +241,79 @@
    <properties>
     <property name="act1" value="set_variable environment:snow"/>
     <property name="cond1" value="not variable_set environment:snow"/>
+   </properties>
+  </object>
+  <object id="37" name="Talk Argon" type="event" x="224" y="144" width="16" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_nimrod_argon1"/>
+    <property name="act3" value="start_battle spyder_nimrod_argon"/>
+    <property name="act4" value="translated_dialog spyder_nimrod_argon2"/>
+    <property name="act6" value="set_variable nimrodargon:yes"/>
+    <property name="cond1" value="not variable_set nimrodargon:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="38" name="Talk Honour" type="event" x="192" y="64" width="48" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_nimrod_honour1"/>
+    <property name="act3" value="start_battle spyder_nimrod_honour"/>
+    <property name="act4" value="translated_dialog spyder_nimrod_honour2"/>
+    <property name="act6" value="set_variable nimrodhonour:yes"/>
+    <property name="cond1" value="not variable_set nimrodhonour:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="39" name="Talk Birb Robo" type="event" x="192" y="192" width="16" height="64">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_nimrod_birbrobo1"/>
+    <property name="act3" value="start_battle spyder_nimrod_birbrobo"/>
+    <property name="act4" value="translated_dialog spyder_nimrod_birbrobo2"/>
+    <property name="act6" value="set_variable nimrodbirbrobo_middle:yes"/>
+    <property name="act7" value="remove_npc spyder_nimrod_birbrobo"/>
+    <property name="cond1" value="not variable_set nimrodbirbrobo_middle:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="40" name="Talk Xeon" type="event" x="160" y="176" width="16" height="64">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_nimrod_xeon1"/>
+    <property name="act3" value="start_battle spyder_nimrod_xeon"/>
+    <property name="act4" value="translated_dialog spyder_nimrod_xeon2"/>
+    <property name="act6" value="set_variable nimrodxeon_middle:yes"/>
+    <property name="act7" value="remove_npc spyder_nimrod_xeon"/>
+    <property name="cond1" value="not variable_set nimrodxeon_middle:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="41" name="Talk Chrome Robo" type="event" x="144" y="192" width="16" height="64">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_nimrod_chromerobo1"/>
+    <property name="act3" value="start_battle spyder_nimrod_chromerobo"/>
+    <property name="act4" value="translated_dialog spyder_nimrod_chromerobo2"/>
+    <property name="act6" value="set_variable nimrodchromerobo_middle:yes"/>
+    <property name="act7" value="remove_npc spyder_nimrod_chromerobo"/>
+    <property name="cond1" value="not variable_set nimrodchromerobo_middle:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="42" name="Talk Archer" type="event" x="64" y="208" width="16" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_nimrod_archer1"/>
+    <property name="act3" value="start_battle spyder_nimrod_archer"/>
+    <property name="act4" value="translated_dialog spyder_nimrod_archer2"/>
+    <property name="act6" value="set_variable nimrodarcher:yes"/>
+    <property name="cond1" value="not variable_set nimrodarcher:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="43" name="Talk Antimony" type="event" x="64" y="192" width="16" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_nimrod_antimony1"/>
+    <property name="act3" value="start_battle spyder_nimrod_antimony"/>
+    <property name="act4" value="translated_dialog spyder_nimrod_antimony2"/>
+    <property name="act6" value="set_variable nimrodantimony:yes"/>
+    <property name="cond1" value="not variable_set nimrodantimony:yes"/>
+    <property name="cond2" value="is player_at"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_nimrod_top.tmx
+++ b/mods/tuxemon/maps/spyder_nimrod_top.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.4" tiledversion="1.4.2" orientation="orthogonal" renderorder="right-down" width="18" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="40">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" width="18" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="43">
  <tileset firstgid="1" name="factory" tilewidth="16" tileheight="16" tilecount="32" columns="8">
   <image source="../gfx/tilesets/factory.png" width="128" height="64"/>
  </tileset>
@@ -21,8 +21,8 @@
  <tileset firstgid="1401" name="Set_Pieces_by_Kelvin_Shadewing" tilewidth="16" tileheight="16" tilecount="1440" columns="45">
   <image source="../gfx/tilesets/Set_Pieces_by_Kelvin_Shadewing.png" width="720" height="512"/>
  </tileset>
- <tileset firstgid="2841" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="1000" columns="40">
-  <image source="../gfx/tilesets/Cave_Tiles_by_ArMM1998_(Tuxemon_Style).png" width="640" height="400"/>
+ <tileset firstgid="2841" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="160" columns="16">
+  <image source="../gfx/tilesets/Cave_Tiles_by_ArMM1998_(Tuxemon_Style).png" width="256" height="160"/>
  </tileset>
  <layer id="1" name="Tile Layer 1" width="18" height="20">
   <data encoding="base64" compression="zlib">
@@ -31,7 +31,7 @@
  </layer>
  <layer id="2" name="Tile Layer 2" width="18" height="20">
   <data encoding="base64" compression="zlib">
-   eJxjYBg6QAaIRZCwLAl6RZDY3Ghy0iSYw42DTYo5O7mpYw413AMLU1EKzUHXQ0tzRLCoQQfCDKhpBd2P5IJaRgaGOiCuB2JVJvLNOQvUfw6IzwOxLwXmjILhDQCSYQel
+   eJxjYBg6QAaIRZCwLAl6RZDY3Ghy0iSYw42DTYo5kdzUMYca7oGFqSiF5qDroaU5IljUoANhBtS0gu5HckEtIwNDHRDXA7EqE/nmnAXqPwfE54HYlwJzRsHwBgAB0gdF
   </data>
  </layer>
  <layer id="3" name="Tile Layer 4" width="18" height="20">
@@ -58,13 +58,13 @@
     <property name="cond2" value="is player_facing up"/>
    </properties>
   </object>
-  <object id="14" name="Create Berke" type="event" x="144" y="256" width="16" height="16">
+  <object id="14" name="Create Berke" type="event" x="144" y="240" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_scientist,9,15"/>
     <property name="cond1" value="not npc_exists spyder_scientist"/>
    </properties>
   </object>
-  <object id="15" name="Talk Berke" type="event" x="144" y="240" width="16" height="16">
+  <object id="15" name="Talk Berke" type="event" x="128" y="240" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_nimrod_berke1"/>
     <property name="behav1" value="talk spyder_scientist"/>
@@ -77,13 +77,14 @@
     <property name="cond1" value="is player_at"/>
    </properties>
   </object>
-  <object id="30" name="Create Maverick" type="event" x="144" y="128" width="16" height="16">
+  <object id="30" name="Create Maverick" type="event" x="128" y="128" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_nimrod_maverick,8,8"/>
+    <property name="act2" value="npc_face spyder_nimrod_maverick,right"/>
     <property name="cond1" value="not npc_exists spyder_nimrod_maverick"/>
    </properties>
   </object>
-  <object id="31" name="Talk Maverick" type="event" x="128" y="128" width="16" height="16">
+  <object id="31" name="Talk Maverick" type="event" x="128" y="144" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_nimrod_maverick1"/>
     <property name="act3" value="start_battle spyder_nimrod_maverick"/>
@@ -93,13 +94,14 @@
     <property name="cond1" value="not variable_set nimrodmaverick:yes"/>
    </properties>
   </object>
-  <object id="32" name="Create Justice" type="event" x="240" y="256" width="16" height="16">
+  <object id="32" name="Create Justice" type="event" x="224" y="256" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_nimrod_justice,14,16"/>
+    <property name="act2" value="npc_face spyder_nimrod_justice,right"/>
     <property name="cond1" value="not npc_exists spyder_nimrod_justice"/>
    </properties>
   </object>
-  <object id="33" name="Talk Justice" type="event" x="224" y="256" width="16" height="16">
+  <object id="33" name="Talk Justice" type="event" x="224" y="272" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_nimrod_justice1"/>
     <property name="act3" value="start_battle spyder_nimrod_justice"/>
@@ -109,13 +111,13 @@
     <property name="cond1" value="not variable_set nimrodjustice:yes"/>
    </properties>
   </object>
-  <object id="34" name="Create Zircon" type="event" x="192" y="160" width="16" height="16">
+  <object id="34" name="Create Zircon" type="event" x="176" y="160" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_nimrod_zircon,11,10"/>
     <property name="cond1" value="not npc_exists spyder_nimrod_zircon"/>
    </properties>
   </object>
-  <object id="35" name="Talk Zircon" type="event" x="176" y="160" width="16" height="16">
+  <object id="35" name="Talk Zircon" type="event" x="176" y="144" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_nimrod_zircon1"/>
     <property name="act3" value="start_battle spyder_nimrod_zircon"/>
@@ -129,6 +131,36 @@
    <properties>
     <property name="act1" value="set_variable environment:snow"/>
     <property name="cond1" value="not variable_set environment:snow"/>
+   </properties>
+  </object>
+  <object id="40" name="Talk Justice" type="event" x="240" y="256" width="48" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_nimrod_justice1"/>
+    <property name="act3" value="start_battle spyder_nimrod_justice"/>
+    <property name="act4" value="translated_dialog spyder_nimrod_justice2"/>
+    <property name="act6" value="set_variable nimrodjustice:yes"/>
+    <property name="cond1" value="not variable_set nimrodjustice:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="41" name="Talk Zircon" type="event" x="176" y="176" width="16" height="32">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_nimrod_zircon1"/>
+    <property name="act3" value="start_battle spyder_nimrod_zircon"/>
+    <property name="act4" value="translated_dialog spyder_nimrod_zircon2"/>
+    <property name="act6" value="set_variable nimrodzircon:yes"/>
+    <property name="cond1" value="not variable_set nimrodzircon:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="42" name="Talk Maverick" type="event" x="144" y="128" width="32" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_nimrod_maverick1"/>
+    <property name="act3" value="start_battle spyder_nimrod_maverick"/>
+    <property name="act4" value="translated_dialog spyder_nimrod_maverick2"/>
+    <property name="act6" value="set_variable nimrodmaverick:yes"/>
+    <property name="cond1" value="not variable_set nimrodmaverick:yes"/>
+    <property name="cond2" value="is player_at"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_omnichannel1.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel1.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.4" tiledversion="1.4.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="14" height="21" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="30">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="14" height="21" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="30">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -25,22 +25,22 @@
   <image source="../gfx/tilesets/Terrain_by_KelvinShadewing.png" width="304" height="240"/>
  </tileset>
  <tileset firstgid="3145" name="Interior_Walls_by_George" tilewidth="16" tileheight="16" tilecount="0" columns="15"/>
- <tileset firstgid="3145" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="1000" columns="40">
-  <image source="../gfx/tilesets/Cave_Tiles_by_ArMM1998_(Tuxemon_Style).png" width="640" height="400"/>
+ <tileset firstgid="3145" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="160" columns="16">
+  <image source="../gfx/tilesets/Cave_Tiles_by_ArMM1998_(Tuxemon_Style).png" width="256" height="160"/>
  </tileset>
- <tileset firstgid="4145" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
+ <tileset firstgid="3305" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
   <image source="../gfx/tilesets/boxfont.png" width="208" height="192"/>
  </tileset>
- <tileset firstgid="4301" name="Office_interiors_16x16" tilewidth="16" tileheight="16" tilecount="528" columns="22">
+ <tileset firstgid="3461" name="Office_interiors_16x16" tilewidth="16" tileheight="16" tilecount="528" columns="22">
   <image source="../gfx/tilesets/Office_interiors_16x16.png" width="352" height="384"/>
  </tileset>
- <tileset firstgid="4829" name="Office_interiors_shadowless_16x16" tilewidth="16" tileheight="16" tilecount="528" columns="22">
+ <tileset firstgid="3989" name="Office_interiors_shadowless_16x16" tilewidth="16" tileheight="16" tilecount="528" columns="22">
   <image source="../gfx/tilesets/Office_interiors_shadowless_16x16.png" width="352" height="384"/>
  </tileset>
- <tileset firstgid="5357" name="Interiors_16x16" tilewidth="16" tileheight="16" tilecount="2592" columns="16">
+ <tileset firstgid="4517" name="Interiors_16x16" tilewidth="16" tileheight="16" tilecount="2592" columns="16">
   <image source="../gfx/tilesets/Interiors_16x16.png" width="256" height="2592"/>
  </tileset>
- <tileset firstgid="7949" name="Tilesets_16x16" tilewidth="16" tileheight="16" tilecount="1760" columns="40">
+ <tileset firstgid="7109" name="Tilesets_16x16" tilewidth="16" tileheight="16" tilecount="1760" columns="40">
   <image source="../gfx/tilesets/Tilesets_16x16.png" width="640" height="704"/>
  </tileset>
  <layer id="1" name="Tile Layer 1" width="14" height="21">
@@ -55,7 +55,7 @@
  </layer>
  <layer id="5" name="Tile Layer 3" width="14" height="21">
   <data encoding="base64" compression="zlib">
-   eAFjYMAO7okyMNwHYlLBO6Ce91j0LRMh1SSI+j1k6rtEQF8C0I0FSO4MQGLjc2kuUF0DEOdBcT6R+vCZOSo3tEJgsKXloRV6xLkWAH9VDM8=
+   eAFjYMAOpgkxMEwHYlLBMqCe5Vj0xQmSahJEfQmZ+roI6JMAulEDyZ0cSGx8LlUFqrMAYjUoVidSHz4zR+WGVggMtrQ8tEKPONcCALudB4k=
   </data>
  </layer>
  <objectgroup color="#ff0000" id="3" name="Collision">

--- a/mods/tuxemon/maps/spyder_omnichannel3.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel3.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.4" tiledversion="1.4.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="14" height="21" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="35">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="14" height="21" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="38">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -25,37 +25,37 @@
   <image source="../gfx/tilesets/Terrain_by_KelvinShadewing.png" width="304" height="240"/>
  </tileset>
  <tileset firstgid="3145" name="Interior_Walls_by_George" tilewidth="16" tileheight="16" tilecount="0" columns="15"/>
- <tileset firstgid="3145" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="1000" columns="40">
-  <image source="../gfx/tilesets/Cave_Tiles_by_ArMM1998_(Tuxemon_Style).png" width="640" height="400"/>
+ <tileset firstgid="3145" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="160" columns="16">
+  <image source="../gfx/tilesets/Cave_Tiles_by_ArMM1998_(Tuxemon_Style).png" width="256" height="160"/>
  </tileset>
- <tileset firstgid="4145" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
+ <tileset firstgid="3305" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
   <image source="../gfx/tilesets/boxfont.png" width="208" height="192"/>
  </tileset>
- <tileset firstgid="4301" name="Office_interiors_shadowless_16x16" tilewidth="16" tileheight="16" tilecount="528" columns="22">
+ <tileset firstgid="3461" name="Office_interiors_shadowless_16x16" tilewidth="16" tileheight="16" tilecount="528" columns="22">
   <image source="../gfx/tilesets/Office_interiors_shadowless_16x16.png" width="352" height="384"/>
  </tileset>
- <tileset firstgid="4829" name="Office_interiors_16x16" tilewidth="16" tileheight="16" tilecount="528" columns="22">
+ <tileset firstgid="3989" name="Office_interiors_16x16" tilewidth="16" tileheight="16" tilecount="528" columns="22">
   <image source="../gfx/tilesets/Office_interiors_16x16.png" width="352" height="384"/>
  </tileset>
- <tileset firstgid="5357" name="Interiors_16x16" tilewidth="16" tileheight="16" tilecount="2592" columns="16">
+ <tileset firstgid="4517" name="Interiors_16x16" tilewidth="16" tileheight="16" tilecount="2592" columns="16">
   <image source="../gfx/tilesets/Interiors_16x16.png" width="256" height="2592"/>
  </tileset>
- <tileset firstgid="7949" name="Tilesets_16x16" tilewidth="16" tileheight="16" tilecount="1760" columns="40">
+ <tileset firstgid="7109" name="Tilesets_16x16" tilewidth="16" tileheight="16" tilecount="1760" columns="40">
   <image source="../gfx/tilesets/Tilesets_16x16.png" width="640" height="704"/>
  </tileset>
  <layer id="1" name="Tile Layer 1" width="14" height="21">
   <data encoding="base64" compression="zlib">
-   eAGzl2dgcIBiRyQ2SAyZj8x2AsqlA3EmEGdAMTHsLKDafiCeAMQ7ScCTgGq3A/EOEvSAzB8ofbDwBNHo/kSWg7Fh7oSFJYhG14csB2PD9KGrReZjCzN66wOlF1D8IbsLnY3NnaD0Qo4+evtvoOwbzvkIABhr4rI=
+   eAH7Ls3A8AOKfyKxQWLIfGT2L6CcvAwDgyIQK0AxMWwloFp3IPYA4kISsBdQbT4QF5CgB2T+QOmDhSeIRvcnshyMDXMnLCxBNLo+ZDkYG6YPXS0yH1uY0VsfKL2A4g/ZXehsbO4EpRdy9NHbfwNl33DORwCwvaN5
   </data>
  </layer>
  <layer id="2" name="Tile Layer 2" width="14" height="21">
   <data encoding="base64" compression="zlib">
-   eAG1kksOAVEQRWsqRgwY2on2G9gCY3QzkjBC24LvXiQ2I7ESt9LvJuXpT1q4ye16v1PVXa9FfqtJXWQKz4xDjCM4Txvsb+GdcYzxHs7TEfsn78wF86u3lpfjn3vdlkgPVgWInRQnu+/POc4tHBciRikmsaqKrGHq7LiDi1z3o8/d3flbAefneX7JMU/Zepbr10QGsIpj9rtREWnCFNe13gjM2HEcs99tMIHhuK73kCb227/boTufdQ/k/LtdZvRT86vIJbPP58O8p/5zml/ZIs5mst9ahrO1y3C2tnIv4dMvgg==
+   eAG1UjkOwkAMnBYhQFBAQSCBipqrhJLzL0jAX5D4KGfBWFlLZsmhIBhpYq+9Yyd2gN8iqAEdsmsY0o/ILAyZH5Fjwwn9KZmFJfMr786G560Xy6rxz9ytDdxJwYX2msA4+/7sBUCfFIS0UQLjLHAoA0dSsXa6hbMa962v27v7uxydX+f8pU7rFO1ndY8K8CQF6uu8myWgRSo0Lv3qVaBBCtTXec+omRudxmUPSdB5+7uFu5+2B9X5ux2kzFPqC1QXnz6fJ/Oe8s9JfdHm6Wwl+61FdLZ3EZ3tLboXSO0sZw==
   </data>
  </layer>
  <layer id="5" name="Tile Layer 3" width="14" height="21">
   <data encoding="base64" compression="zlib">
-   eAFjYEAF0oIMDDJA7CfEwOAPxAFIOBDIDgJibMAQqMcIiEcBZgg8k4eIvQDSv4Fh9IdAOGUC1WUAsbkCRB+IFgSGuxAQg+SigXQMjngA6UDWpw5UpwFVWwiki/DoiwfaAwIw/RAeYbJdAaKGVH0wk+mlL45Md8LcB6Nh7iaWJlYfKG7PCjAwnANiEIDFB4gNSju2wLhzANLYwGOgnidQfbD4AKkD2R0M1AdKT6QAkN2ZeNIKLrOQ7calhhhxADqCG4Y=
+   eAFjYEAFl3kZGK4AMRs/AwM7EHMgYU4gmwuIsYGXQD2vgHgUYIbAPBmI2AIgvZmPgWELEOMDikB1CkD8HqoPRJ8E6jkFxCA5YWAciOCIB5C5yPruA/U8gNqnCdSjhUefuCzEVTD9+NyILGdPpj6YGaTaR64+MTLdCXMfjIbZTyxNrD5Q3LYC81AbNB/B4gNkDyjtfAXG4w9p7LbOBuqZA9UHiw+QSpDd3MA4B6UnUgDIbkU8aQWXWch241JDjDgABJchvA==
   </data>
  </layer>
  <objectgroup color="#ff0000" id="4" name="Collision">
@@ -114,14 +114,14 @@
    </properties>
   </object>
   <object id="8" name="Player Spawn" type="event" x="32" y="176" width="16" height="16"/>
-  <object id="9" name="Create Carnegie" type="event" x="160" y="144" width="16" height="16">
+  <object id="9" name="Create Carnegie" type="event" x="160" y="128" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_omnichannel_carnegie,10,8"/>
     <property name="cond1" value="not npc_exists spyder_omnichannel_carnegie"/>
     <property name="cond2" value="not variable_set omnichannelcarnegie:yes"/>
    </properties>
   </object>
-  <object id="10" name="Talk Carnegie" type="event" x="160" y="128" width="16" height="16">
+  <object id="10" name="Talk Carnegie" type="event" x="144" y="128" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_omnichannel_carnegie1"/>
     <property name="act3" value="start_battle spyder_omnichannel_carnegie"/>
@@ -131,14 +131,14 @@
     <property name="cond1" value="not variable_set omnichannelcarnegie:yes"/>
    </properties>
   </object>
-  <object id="11" name="Create Byrne" type="event" x="192" y="304" width="16" height="16">
+  <object id="11" name="Create Byrne" type="event" x="192" y="288" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_omnichannel_byrne,12,18"/>
     <property name="cond1" value="not npc_exists spyder_omnichannel_byrne"/>
     <property name="cond2" value="not variable_set omnichannelbyrne:yes"/>
    </properties>
   </object>
-  <object id="12" name="Talk Byrne" type="event" x="192" y="288" width="16" height="16">
+  <object id="12" name="Talk Byrne" type="event" x="176" y="288" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_omnichannel_byrne1"/>
     <property name="act3" value="start_battle spyder_omnichannel_byrne"/>
@@ -148,14 +148,14 @@
     <property name="cond1" value="not variable_set omnichannelbyrne:yes"/>
    </properties>
   </object>
-  <object id="13" name="Create Strauss" type="event" x="48" y="48" width="16" height="16">
+  <object id="13" name="Create Strauss" type="event" x="48" y="32" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_omnichannel_strauss,3,2"/>
     <property name="cond1" value="not npc_exists spyder_omnichannel_strauss"/>
     <property name="cond2" value="not variable_set omnichannelstrauss:yes"/>
    </properties>
   </object>
-  <object id="14" name="Talk Strauss" type="event" x="48" y="32" width="16" height="16">
+  <object id="14" name="Talk Strauss" type="event" x="32" y="32" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_omnichannel_strauss1"/>
     <property name="act3" value="start_battle spyder_omnichannel_strauss"/>
@@ -169,6 +169,36 @@
    <properties>
     <property name="act1" value="set_variable environment:snow"/>
     <property name="cond1" value="not variable_set environment:snow"/>
+   </properties>
+  </object>
+  <object id="35" name="Talk Strauss" type="event" x="48" y="48" width="16" height="48">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_omnichannel_strauss1"/>
+    <property name="act3" value="start_battle spyder_omnichannel_strauss"/>
+    <property name="act4" value="translated_dialog spyder_omnichannel_strauss2"/>
+    <property name="act6" value="set_variable omnichannelstrauss:yes"/>
+    <property name="cond1" value="not variable_set omnichannelstrauss:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="36" name="Talk Carnegie" type="event" x="160" y="144" width="16" height="48">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_omnichannel_carnegie1"/>
+    <property name="act3" value="start_battle spyder_omnichannel_carnegie"/>
+    <property name="act4" value="translated_dialog spyder_omnichannel_carnegie2"/>
+    <property name="act6" value="set_variable omnichannelcarnegie:yes"/>
+    <property name="cond1" value="not variable_set omnichannelcarnegie:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="37" name="Talk Byrne" type="event" x="192" y="304" width="16" height="32">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_omnichannel_byrne1"/>
+    <property name="act3" value="start_battle spyder_omnichannel_byrne"/>
+    <property name="act4" value="translated_dialog spyder_omnichannel_byrne2"/>
+    <property name="act6" value="set_variable omnichannelbyrne:yes"/>
+    <property name="cond1" value="not variable_set omnichannelbyrne:yes"/>
+    <property name="cond2" value="is player_at"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_omnichannel4.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel4.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.5" tiledversion="1.7.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="14" height="21" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="24">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="14" height="21" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="24">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -105,7 +105,7 @@
     <property name="cond1" value="is player_at"/>
    </properties>
   </object>
-  <object id="20" name="Teleport to Omnichannel 3" type="event" x="192" y="16" width="16" height="16">
+  <object id="20" name="Teleport to Radio Tower" type="event" x="192" y="16" width="16" height="16">
    <properties>
     <property name="act1" value="transition_teleport spyder_radiotower.tmx,3,17,0.3"/>
     <property name="act2" value="player_face up"/>

--- a/mods/tuxemon/maps/spyder_route2.tmx
+++ b/mods/tuxemon/maps/spyder_route2.tmx
@@ -1,30 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.4" tiledversion="1.4.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="2" nextobjectid="188">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="2" nextobjectid="191">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>
  </tileset>
- <tileset firstgid="449" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="1000" columns="40">
-  <image source="../gfx/tilesets/Cave_Tiles_by_ArMM1998_(Tuxemon_Style).png" width="640" height="400"/>
+ <tileset firstgid="449" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="160" columns="16">
+  <image source="../gfx/tilesets/Cave_Tiles_by_ArMM1998_(Tuxemon_Style).png" width="256" height="160"/>
  </tileset>
- <tileset firstgid="1449" name="Set_Pieces_by_Kelvin_Shadewing" tilewidth="16" tileheight="16" tilecount="1440" columns="45">
+ <tileset firstgid="698" name="Set_Pieces_by_Kelvin_Shadewing" tilewidth="16" tileheight="16" tilecount="1440" columns="45">
   <image source="../gfx/tilesets/Set_Pieces_by_Kelvin_Shadewing.png" width="720" height="512"/>
  </tileset>
- <tileset firstgid="2889" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
+ <tileset firstgid="2138" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>
  </tileset>
- <tileset firstgid="4489" name="Outdoor_Tiles_-_City_and_Country_-_by_ArMM1998" tilewidth="16" tileheight="16" tilecount="1440" columns="40">
+ <tileset firstgid="3738" name="Outdoor_Tiles_-_City_and_Country_-_by_ArMM1998" tilewidth="16" tileheight="16" tilecount="1440" columns="40">
   <image source="../gfx/tilesets/Outdoor_Tiles_-_City_and_Country_-_by_ArMM1998.png" width="640" height="576"/>
  </tileset>
- <tileset firstgid="5929" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
+ <tileset firstgid="5178" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
   <image source="../gfx/tilesets/boxfont.png" width="208" height="192"/>
  </tileset>
- <tileset firstgid="6085" name="Interiors 2 by Redshrike" tilewidth="16" tileheight="16" tilecount="28" columns="7">
+ <tileset firstgid="5334" name="Interiors 2 by Redshrike" tilewidth="16" tileheight="16" tilecount="28" columns="7">
   <image source="../gfx/tilesets/Interiors 2 by Redshrike.PNG" width="112" height="64"/>
  </tileset>
- <tileset firstgid="6113" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
+ <tileset firstgid="5362" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>
   <tile id="839">
    <animation>
@@ -43,7 +43,7 @@
    </animation>
   </tile>
  </tileset>
- <tileset firstgid="7425" name="My_tuxemon_sheet_OLD" tilewidth="16" tileheight="16" tilecount="104" columns="8">
+ <tileset firstgid="6674" name="My_tuxemon_sheet_OLD" tilewidth="16" tileheight="16" tilecount="104" columns="8">
   <image source="../gfx/tilesets/My_tuxemon_sheet.png" width="128" height="208"/>
  </tileset>
  <layer id="1" name="Layer 1" width="40" height="20">
@@ -53,22 +53,22 @@
  </layer>
  <layer id="2" name="Layer 2" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHtlU0KwjAQhbMU/D2AgktBRTeCS5duqlfqiTyjb6RTn0PSTmoVBAOD08nL5OtrakP4j192YAJ4jab7mIZQQvcSY1w3reE5aB/7cK2PfDQPpbCtIyyoBcy5xtalyhcdwLeLsGknzLlGAdXIpcwTiX9X8F2qGBpW+FJ6O6qHNyzw3ldbb/GPNdbLHD7u0zWHT40jh2+MTninvjpy+PR5fhJQzp/tL+eHh3g05UKVd+HLXWPPXwSjLgknx6aeiSf7RShniPisryr+afhW+FRH4jpT7lv9VIl/Gs/q+9mSmFaUpzqnnrt6p+cwpbN98T8ZLlXYOb0egOvkYBM974t3tB7qnZ5D1tUikwjb1dRyLmPfTd6X+di/R96y0bts2l4YU+8a87F/khfaIPGb65ueAf31fKOZz/qXwOqt3Hb/shF7YP3rDaSnRncvxjbO
+   eAHtVbsOwjAMzM5rBomBGRBiZGRBYmgRI3/TL+IbOaO6HFbSOlCQkLBk1XEuzuXqtCH87ZcVGIO8ets5JiFUwD35COO2NTwH7H0fzvURz6ehEm7LCBfkAuZctnah8kEH8NtEuGklzLmsAGroQuaBRL8T+JW1DwxX6FJ5K6qGVyzwnqurtujHGKtlDj+u82oMnVoth98IlXCnvmo5/PR9fpKg9J+tL/3DJhpNOFHHr/DLXWP7L0KjSQlP9lUzEw/2s1At4PFZX1b0U/et8KGOxOtCsW/1AyX6qT+y70db4rSjOFU59d5VO+3DFM7WxXcylLXbOR1Pwevs4CZ43hd3tDHVTvuQcQ3IBMLtZHI5w9h/k/dlfqyfxF3/qHe56TmEY+quMT/WT+JCCySeubppD+iz6/yyLfOz+iVo9ZbuOr9sxBpY/Xoj0lOhG7b8ORo=
   </data>
  </layer>
  <layer id="3" name="Layer 3" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHFlV1Ow0AMhANv5ac9CCBuACdoews4DX/HKA9I8FQkLlROgSfkU0fWZpNKQVhyvesZeyfOKt01TfMdvhuIAbc2xJsanx01zUn4UETfEG9q/Pm4aV7C/8rOo/E8+aI7TNirOTzhvIdtaPucUB9nEC87LR4uYiMcTBrdrmPDe/B8Xr9H4iMnJ96fRr9V52ddb+ljfl2qN0jjGPua7VlvsdQZnOsRDWJL2zqcd3ylZFhpft7/l7X/3eyX1dVDoI+dP/Uw0SBYOqRN/RXBlM/z4xkCao09kXwt0p/5iXub7jYcYejjjKWSYetwv3/gPEdLih/y7PviPAA59108nV2ymj7OI3o9OaJjQ+tc4/PLtWP05Tl5D9XrPEzfgpqhzWukj2+I5rqwBs53jni4+Pn+0cKfTzn6gRPJ86zsFbNJBxp5fuezpk53w+8feUXXRx3ReaxLmHLZdKZsGb4quL479BJ3aH7g1BCjtGjgxExCX86z97ra/NDFfNmrvs/yPJiF8/2uLQy4674/6CNyrlHbZdaV95lf2usd+v9EiZNz0rUJRx/nZh73L+N5r7qb9O31XodoRBNRffrmJyy/L98LH2vSONZcm2pK81A+/x8pd6jdV+aqXv68pbU4tfkJ/29jfj/O46H3
+   eAG1lktOA0EMRAcWQfySLdwABIiTJDkZcI6wQIJ7cJBwANjiCv2YktXziTSx5Lhtl93VntZMtk3TfIVuB2ykdzKEmzp/etQ0Z6FDFn5DuKnzV8dNcx16KLmMxvOki7KZcq+m4JTnOdwEt9sJ+bEH9r5wcXMXjvLkxNHlMRyeg8fz+j0CHzk4sX8e/VZFL0pv8WN+JdRpxHGMfM5a1FsstQf7uoWD0OK2DuUZPygYUpuf9/9Dtb+bdtm7eorsc9GXDiQclBYPcVN/WXKK5/lxhkjtBB9LvM/Sn/kJ+xPvBhcwisGPPZYFuA7r94885yiw/7njd9l5JKTcd+G0d036+MED6/XEsJ4bWucan1+uHcMvz8l7qF77IXoX9AncvEb8eIdorgtr4HjHCIcKn+8fLfx8itGPPJY4Z8WXzSIecOT8jmdNne6G3z/iss6POqzjWNdyimXRnpJl6Kqieu/QS9ih+ZGnBhulVSGPzSD45Ti+1/XND17MF1/1XZLnwSwc73dtYYlZ+bbCD8u+Bt0tM6/sZ3zN1zP070QNk2PitQmFH/tmHPcv57Ovuu/07vVe+3CEE1Z9uuanXH5e7is/VsRxrDg31dTmoXj+Him2r5wM/F/z89bW2q9vfvvyOQSe+f0CvTehaA==
   </data>
  </layer>
  <layer id="4" name="Above Player" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAFjYBj6QIprcPvBfZC7D1/oHRXHJzvwcmcGsfvu8DMwXB7E7qNX7BGb/ukVXoO9vKBXvAw2e9KZBpuLEO6ZAHTbxEHsvh1At+0E4r5B6Ma0QegmRMyOskZDYDQEBioEAGyfCk8=
+   eAFjYBj6QJt9cPshYpC7D1/oXRPBJzvwcncHsfve8jAwPBnE7qNX7BGb/ukVXoO9vKBXvAw2e9iZBpuLEO6RALpNchC7TwPoNk0gFhuEbmQbhG5CxOwoazQERkNgoEIAADkoB5M=
   </data>
  </layer>
  <layer id="1" name="Above Player" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAFjYBgFoyGAOwSOiuOWGwwyZwaZ+0bDazCkilE3jIbAaAiMhsBoCIyGwGgIDOYQAAAawwN/
+   eAFjYBgFoyGAOwSuieCWGwwydweZ+0bDazCkilE3jIbAaAiMhsBoCIyGwGgIDOYQAAAtLQO3
   </data>
  </layer>
  <objectgroup color="#ff0000" id="5" name="Collisions">
@@ -598,6 +598,36 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set environment:grass"/>
+   </properties>
+  </object>
+  <object id="188" name="Talk roddick&#10;" type="event" x="80" y="64" width="16" height="48">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route2_roddick1"/>
+    <property name="act2" value="start_battle spyder_route2_roddick"/>
+    <property name="act3" value="translated_dialog spyder_route2_roddick2"/>
+    <property name="act4" value="set_variable route2roddick:yes"/>
+    <property name="cond1" value="not variable_set route2roddick:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="189" name="Talk marion&#10;" type="event" x="352" y="160" width="16" height="48">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route2_marion1"/>
+    <property name="act2" value="start_battle spyder_route2_marion"/>
+    <property name="act3" value="translated_dialog spyder_route2_marion2"/>
+    <property name="act4" value="set_variable route2marion:yes"/>
+    <property name="cond1" value="not variable_set route2marion:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="190" name="Talk graf&#10;" type="event" x="464" y="64" width="16" height="48">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route2_graf1"/>
+    <property name="act2" value="start_battle spyder_route2_graf"/>
+    <property name="act3" value="translated_dialog spyder_route2_graf2"/>
+    <property name="act4" value="set_variable route2graf:yes"/>
+    <property name="cond1" value="not variable_set route2graf:yes"/>
+    <property name="cond2" value="is player_at"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_route3_trainer.tmx
+++ b/mods/tuxemon/maps/spyder_route3_trainer.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="685">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="-1" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="688">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -41,27 +41,27 @@
  </tileset>
  <layer id="1" name="Layer 1" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHtllGO1EAMRPcwHJQjcJEFfoDrkSftk0old9LZQTBC+9Gyu1wuV3cSzby+vHz+dqyvx3p9wvwZPeV9ffh77P25c38/j/fzR7yj7O+s7N2du8v7dHj59eaHOe9d+W7t5O/xd8dnc7lvsFxixL7j9pd9mdubGPkOvuK0VurhE2/pDyw5q9xn2/rpI/PkgU+6cuxrf+JTb/uWq0/rV732XfHU9f5896czTJr0ixO7z31GePaAdy5XnBntLzW8E/ndL060Zo/zjeL2TLgacnb9TVo9LzXl69uaePeynzj+H/D7sF+uOuDWxHJ28hNP7llOzb6cs+tv6tUT0Zw5zhLLeavcnqyDTf6a457ocra6Gc3l2A++yu3JOhhr9/vQW2roQX01wa0l/yzPmr19f+JG5tlHNKeenOTp1bo9zWncvX35u+z30Rru6XXpTR048sTkNK6HCc8a9V1/zEpv6qSXnve3/Oll5W/lY4Wr1+dJfWq796de9zvfqCZ78sTVAD/Ls/aoP7XSh76MepX7p/yljtpE86xP/sAmbvad5dRYq++DWp/9jj/7WwP8zHfW7vpbaaemub7oWfVNuP323bm/SU+dq5hzV3nrs/8f/eVd+RzzTrJunvVVDjdr7M/uT+3dqNeJn3NXOX3W1Nrx5++y/yOyh1wtIzPao3PTQ+fuk6uO/6+YJ2a88odvvREf8ZcenU/UX2LmO/7geO5H/TFXrfTADPbeRdb6mU7PWs1/6U/PnKGXZ3sGf3iYlu+fzwDOCuM81j23e6N4vn9qZ83nKwanedTQVZsoP6N1+eqscHjpL7X6PWvN5HbNuc252tOXXuHj78uxvCf2q/xKv+srnQnvXvfe39Rz5nWX//3tDnb5/dzw8Bunqn9w
+   eJztmMENwyAMRRkmg3aELpK0F5L1mksk9+vb2JBQqvZgNaJgP75jEzGndHvstuw2D/g8Csef7/N8625ZjK9By4FYUb5pt03EqbUefBFOnHusl4Y+LT5cu8HamnFtjhUnEz7mjz1nJZ6HCbWSYxZfiUk+s9yWGNdgDMk3JV1jba1kLeXaw2fpNxEfWp5QQ+kb53l0auWL5lv68eaRjWP9WnzafnF+VDPWc6J8bK38xVqpqQPWUxkfzkE+q0bO5ovUB+NjnDV8ml/Uz3rXsUewPs1yHuWzzjemu9bDruI7/Hn5UDvcp9ZrevCx3KKGo/HJ+Kz3jcCnvYc9+Nj5EOHDPlZzlpT4RtfP61tj1vpOT77sNG9Of4EvF+b04ovamXzHmIfPe5dg5T3Cx3LRwrekd8YWPsnI+FhuvPcKst+08LFxyce0/RY+WQvs+2AUvk0x7TyJ1u9Z+rF9W3n2amnxScP3zMoJ/mf1Q8s0/e7JVwfReJF7SM3H1ffPzxP8vACnqn9w
   </data>
  </layer>
  <layer id="2" name="Layer 2" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHlmD1uFEEQhduIAAyzS4JwApgY25wAsA9gr0NAwjYScAESEvBwA25BZPsopFzBRIQk/LwnzRPPpZ7Z+dn1Gljpqbqru6q+qZ4dz/o0pfIrdLpAm6pP5KD76lIqlyHapZVUJujXrVT+hH5Avq59s7bii3nll70HtlXoLnQHug1p7SLYLfBsQo+hR9BDiFxvbi6OTmdOghfgOYD2oT3oOSSy67g/dypdg/W5/NMs45SvrdWZc/8H8JTQIfQeegcpz7rlfoCxz7VnmmXctD1x3fsX13zuPH35JuCLPd7I+LzP3r+mM9uurn0Mex86horK59cxizGvwxmV03skX7TsHdmoNvtjfNs562iv+qYeyX+4nFY/QZ8h+RhXt197ZmGdT33I8cRaE7uuuDbLeY6va/4xWEeVioHc30N8Fz7nEA+tvidD7sWm3OrXWtUDr+1jchxlRC6K92O8d5V7mmWfToKYk/UUqzpNVt+JHcRFdWFbu/SnLutPMvmY358vTbXF0oVB1z3Esq+KX7cxfc9upPIp9ATSnvO0Y/DwnlJN3n+FzQ/AtQ/tGd8XW1fcPGxkUw3v4WtwvYJeGp/2zdv6uXot53P/vMdbV85WuGh8Z+lS+l/4NsO5xD70nf/L/YvP/r49aor7G/r3LfOsXdTzJfZySP9W8D+GmG/I/HJ4V2CuIXxDWBj7NnNuMSf5Pmb2+fmOsT5qUJGJj3X6zifI7e9WyuN8dT3W3vg+If+sbGTk+9+29WQaHznmzegM3jvW9jXO6z4xrm5fH78zsI7/vfK1ptznyUcOvYNGPp6/3vNlN8I90XQdfdacIfbB15g7rreptzvw/cEZYn2unUDH0BEU13N86n1urY/P+fhdHJn426QrnzOMLZfnzY0L7PVYjZ1PPrfOF/lzddznv708Z25cl7tLjlzeNr7dmt60idWe3/g3TNQ=
+   eJzlmD9OwzAUxl3EUNoCXVC7AGXuvxMA7QGgHQGJtkjABVhYoOEG3IKJcBRWrlAmxi78+SJi6dXYsePETYFP+mQSHPvHs+O8x4Qx7xWeZNiyULL7KznmFeCgzVVxD/6sMO8Dfq983+e/d9VyPtV9rh2w1eBteAverP7sk6W64OnA+/AevBvyXW1kx0TX+gw8I3gID+BTEr8S+hyGLsL02tRFFn896FrfgceDx/AtfEP4mmTsNn5uWszVtnhGfIdUSoOvJ4lpSxNnGr+oNTsIn1lHW4d9eNWC0fTvkO0Fk5i0QzbfMoamonuhJMSIa1xgtQf4GabPqfq74uNxkPGI6jlkopLxxVWwF9dCJ92LU+H5OHyUg7qewl6MGpv3aSj60L6PEnO2UoK9GMTpSbAfjs/7+GQulU3OHhM1lmb7ys5E8Qw0+Va5fFdlitp/J2XmHcNH5WzyF/4N4NcN4f0bgWsIDwjfy5ziJ7Jx0RhegusCPs8gfqocwuW3Kkrd/Oz1ovGJ+i98nby+j43+cvzEs9+FfkP83ixz53koSfyqkpo+iZYl+yXL9b02mCPgu9esrypnTCtXjpJJ7aaro8V8Im2JjGL+a1Lnu2aMyv9M/w8xr/o3mId+rxaRL2h5DiryyfL/luOcP8762sSpnzB/0PHROs+EL+38n/KJ9W/dgo9Kd36anKW6d4Dy6er3qNpfJ9XYccawVT+FOb4A+DdM1A==
   </data>
  </layer>
  <layer id="3" name="Layer 3" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHNmEFuFDEQRRtYEMKGQZAswxUShLImrLMICbAISCThAogIsZwbAELKHWAL4kwwiJyB+hp/6atS5bGhR6GlGtvlsuv5293TM8Nw+dfqlWF6w+zySWKC2TBMf5rFvcv1fil5P1fyU78xOZmXJVap9Z5Vk4ucPWOXHftuZZiSi5zROtm3bB7Mj/wRAzkjhlpfFB/5Hq8Mw56zfWuPcbXql60dbAdmR85eWftvGZGLXD36RYw7xvHIzF/H5gMjde1lrXFdmwz3Vs0mZj6vb4PjJOBDHPqoaxbzMhir+mEez/Pj+vyZOSslYnDtVp5l84j4c93GrZndNXsY8ESjvH6/HEs0Rn08H+rL6ttlXQ9KmcXBD+1Qts7POIyDsa3r0/s3Ome9fMjD+ZmPJfpgbDOOfraxRl56zqL7tpcP8/r8zFvjIE+t3LHz5e/nHj7OTR62xyrH4qN+rVy7Ny++B23cuuhbxHfbzs5ZsYmVUX7sodcvyhWNjXx6f+C7xD/rdH+/CtOp1TPGXv08lz27p/Tp/eHZEJPxoe+b8KLNy+sHv+ZkHEpq+8L287nZYbCvGq/1dct/vzDg+bdltl/aiIv48E5b0w9nLWI9Ma5js6NGPmUDC5/PuscRH2Ij/eCPLuTB91OvUTfO2cPn9asx+DzM11PesfU9McOYTD/ct+jH5fXblr55xHifyoZZMz7NqPpt2jOhlw85nzYadUN+PP/eiBat56+Xj2dJ18x67Rms2iE+41P9EPesUQtqpppgvF7KcGrznhV7baVqhzERH86hP386/7/WlW/RXBEfxnj9dB72sdS+rK576jXKxhyYTptmUX9NP/axhN7RHOqDZt9dHPK/rVjGhnkXacN+sC3i4z3p+bK903WhjvcL/95NbTRWOdiP70L1azzr1E75anvHcSj5+zl6r9A41GtazYwz+y9M7wfuabR3+h7G38XR+xhZevioZ6TllrHvFYu4kIc68fcwy5puPhc18n6/jt422WosLXNSo5bYnhi8v/ayeY3O7X/g3//xf8FrV+3/BzPoAnbP36MXY8eYg/8Pfyps5GOOD4mf/S0lc7TEIobrYgnfR+FAm9f7xM9+lDqP+rN6Fq/+PwY+bSo=
+   eJzNmMFOAjEQhiseQLyIUTzqK6gxnNWzBxH1oCYCvoDRGI+8gRoT34G9YnwmxegzOA1bHYeZabu7iH8yISm7nW//ttOmxkxf1RnTm4OYNoekoTG9NzMdviTN21fyO/+K5HR5E9RfkrFvx/Ufx/m28sPlOLnv/Ms5kAgMmn9FeNusGLNP4qCSp8cfhfonfbtla0G0SVzkYLR5ssxNjnEHGHYZjk7KmNVPjWu2ZtaqEDUIXz+Woyvk7iA/pWfOmXbsH8fzWh61D8u/+fcyrqMVeK8OsQyxHegj9e+9HJc7Zt030ue2Aud5TP+4NknztumZZ7F8iRmvjT4O+h7us+NZt3n8c/lCOELErecYPqdJ7XlF8cXua3vz48+uLoy3+fgWIZ7SqAn5ufHjcoUKr48WU+sw3wAxXSuMec8FUCu/3/XVYYnP6llg4OYfzonlvD2D31OIkwivbW3eRHwbEAeIiePrG/3Maucax9oFrg5EO5APszk++zvw8FnFrF+3P8XGJskdw0f90xhonixagj4OPXz4bET9axTAEMKm8WFh/9Yr8Xw251FgYDZb/64yzL9YPm0v0GpwaH2h8+84wg/qCRWtwY71kngn8eXZ/0NEPdIU6h/3X8weg8eUeiSpBc+tZ6h/3JnLl8t69kKes/lvlJDYrHze0POqxubWJOWTxo6qyZxpOf+4+tgP4HPeYT5t7Cgbd+bhpHml+T0gXNLYcfcMEhvHofFpc9GeSfbTkDyT7hk032gu7R4pj2LGUNOkaqJ2xyCJevQJXB//7I4Qq14yveXSiC+kpoSoiD7c/fBjiT+H3QvtWXKEirtDfijxfdwJ7Vx/sfm19i8GPm0q
   </data>
  </layer>
  <layer id="4" name="Above Player" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHt0DkKwCAQAMCt01mkDuRo8pS8Kk+PnRY2EsRmBGFZ3YOJcEYLPOvoCfr3CmypVOw5PvI9q1x5nRNdjV3uRm7OdqYSIECAAAECvQJLire3xn8CBAgQIECAAAECBAgQ+CfwAQMUAjg=
+   eJztzisKgFAQhtHJtglmwUdxKa7KpXubIBoMegXPgYE/TPgieNrS1i7gqMt992UP5ca8/n/bdNIyf6gPALinyVhrNwAAAPzNBgMUAjg=
   </data>
  </layer>
  <layer id="5" name="Above Player" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHt1jEKgDAMheEnbk56OOt1cl0dPINZCumiHYRA+QuhtAkk/aZKLAQQQAABBBBAAAEE+gXmTdZf/U/lV8+YXxLmiz3jLPX1xyorHrtHvcva46xZM9AXAQQQQKAVuCQ7PereZjkhgAACYwncU/6feCxRXvMm8AAugQ3p
+   eJzt1DEKgDAMheEnbp3q4bTXyXXr4BnsIpRSxKWNw/9ByJAhjwyRAAAAgO/WTfa3nfU8OOSrd/aypig7Su1xfraWx30AAO9OyXKpp3vnAYCRroU/h3luLoEN6Q==
   </data>
  </layer>
  <objectgroup color="#ff0000" id="6" name="Collisions">
@@ -398,6 +398,7 @@
   </object>
   <object id="590" name="Shaft Plot Revealed" type="event" x="64" y="96" width="64" height="16">
    <properties>
+    <property name="act1" value="stop_player"/>
     <property name="act11" value="lock_controls"/>
     <property name="act14" value="remove_npc spyder_route3_zoolander"/>
     <property name="act15" value="create_npc spyder_route3_zoolander,6,11"/>
@@ -418,7 +419,7 @@
     <property name="cond2" value="not variable_set shaftscheme:yes"/>
    </properties>
   </object>
-  <object id="592" name="Make Zoolander" type="event" x="80" y="320" width="16" height="16">
+  <object id="592" name="Make Zoolander" type="event" x="48" y="336" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_route3_zoolander,5,20"/>
     <property name="cond1" value="not npc_exists spyder_route3_zoolander"/>
@@ -436,7 +437,7 @@
     <property name="cond1" value="not variable_set zoolanderdefeat:yes"/>
    </properties>
   </object>
-  <object id="594" name="Make Rookie" type="event" x="16" y="32" width="16" height="16">
+  <object id="594" name="Make Rookie" type="event" x="48" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_route3_qqq,1,2"/>
     <property name="cond1" value="not npc_exists spyder_route3_qqq"/>
@@ -462,12 +463,12 @@
     <property name="cond1" value="not npc_exists spyder_route3_weaver"/>
    </properties>
   </object>
-  <object id="597" name="Enforcer Talk" type="event" x="256" y="128" width="16" height="16">
+  <object id="597" name="Enforcer Talk" type="event" x="352" y="128" width="16" height="16">
    <properties>
+    <property name="act12" value="set_variable spyder_weaver_fought:yes"/>
     <property name="act2" value="translated_dialog spyder_route3_weaver1"/>
-    <property name="act3" value="start_battle spyder_route3_weaver"/>
-    <property name="act4" value="translated_dialog spyder_route3_weaver2"/>
-    <property name="act6" value="set_variable route3weaver:yes"/>
+    <property name="act20" value="start_battle spyder_route3_weaver"/>
+    <property name="act30" value="set_variable after_spyder_weaver:yes"/>
     <property name="behav1" value="talk spyder_route3_weaver"/>
     <property name="cond1" value="not variable_set route3weaver:yes"/>
    </properties>
@@ -748,57 +749,47 @@
     <property name="cond1" value="not variable_set environment:sand"/>
    </properties>
   </object>
-  <object id="679" name="Enforcer Talk" type="event" x="272" y="144" width="16" height="16">
+  <object id="684" name="BATTLE_INIT " type="event" x="256" y="128" width="32" height="48">
    <properties>
-    <property name="act2" value="translated_dialog spyder_route3_weaver1"/>
-    <property name="act3" value="start_battle spyder_route3_weaver"/>
-    <property name="act4" value="translated_dialog spyder_route3_weaver2"/>
-    <property name="act6" value="set_variable route3weaver:yes"/>
-    <property name="cond1" value="not variable_set route3weaver:yes"/>
-    <property name="cond2" value="is player_at"/>
+    <property name="act1" value="set_variable spyder_weaver_fought:no"/>
+    <property name="act20" value="set_variable spyder_weaver_lose:no"/>
+    <property name="act21" value="set_variable after_spyder_weaver:no"/>
+    <property name="cond1" value="not player_at"/>
+    <property name="cond2" value="not variable_set spyder_weaver_fought:no"/>
    </properties>
   </object>
-  <object id="680" name="Talk Twig" type="event" x="384" y="240" width="32" height="16">
+  <object id="685" name="BATTLE marion" type="event" x="272" y="144" width="16" height="16">
    <properties>
-    <property name="act2" value="translated_dialog spyder_route3_twig1"/>
-    <property name="act3" value="start_battle spyder_route3_twig"/>
-    <property name="act4" value="translated_dialog spyder_route3_twig2"/>
-    <property name="act6" value="set_variable route3twig:yes"/>
-    <property name="cond1" value="not variable_set route3twig:yes"/>
-    <property name="cond2" value="is player_at"/>
+    <property name="act1" value="translated_dialog spyder_route3_weaver1"/>
+    <property name="act12" value="set_variable spyder_weaver_fought:yes"/>
+    <property name="act20" value="start_battle spyder_route3_weaver"/>
+    <property name="act30" value="set_variable after_spyder_weaver:yes"/>
+    <property name="cond1" value="is player_at"/>
+    <property name="cond2" value="not variable_set spyder_weaver_fought:yes"/>
+    <property name="cond3" value="not variable_set spyder_weaver_won:yes"/>
+    <property name="cond4" value="not variable_set route3weaver:yes"/>
    </properties>
   </object>
-  <object id="681" name="Talk Wanda" type="event" x="512" y="288" width="16" height="16">
+  <object id="686" name="Lose marion" type="event" x="320" y="128" width="16" height="16">
    <properties>
-    <property name="act2" value="translated_dialog spyder_route3_wanda1"/>
-    <property name="act3" value="start_battle spyder_route3_wanda"/>
-    <property name="act4" value="translated_dialog spyder_route3_wanda2"/>
-    <property name="act5" value="add_item fishing_rod"/>
-    <property name="act6" value="set_variable route3wanda:yes"/>
-    <property name="cond1" value="not variable_set route3wanda:yes"/>
-    <property name="cond2" value="is player_at"/>
+    <property name="act30" value="set_variable spyder_weaver_lose:yes"/>
+    <property name="act40" value="set_monster_health ,"/>
+    <property name="act41" value="set_monster_status ,"/>
+    <property name="act42" value="teleport_faint"/>
+    <property name="cond1" value="is variable_set battle_last_result:lost"/>
+    <property name="cond2" value="is variable_set spyder_weaver_fought:yes"/>
+    <property name="cond3" value="is variable_set after_spyder_weaver:yes"/>
+    <property name="cond4" value="not variable_set spyder_weaver_lose:yes"/>
    </properties>
   </object>
-  <object id="682" name="Novak Talk" type="event" x="192" y="480" width="16" height="32">
+  <object id="687" name="Win marion" type="event" x="336" y="128" width="16" height="16">
    <properties>
-    <property name="act2" value="translated_dialog spyder_route3_novak1"/>
-    <property name="act3" value="start_battle spyder_route3_novak"/>
-    <property name="act4" value="translated_dialog spyder_route3_novak2"/>
-    <property name="act6" value="set_variable route3novak:yes"/>
-    <property name="cond1" value="not variable_set route3novak:yes"/>
-    <property name="cond2" value="is player_at"/>
-   </properties>
-  </object>
-  <object id="684" name="Rookie Talk" type="event" x="16" y="48" width="16" height="16">
-   <properties>
-    <property name="act2" value="translated_dialog spyder_route3_qqq1"/>
-    <property name="act3" value="start_battle spyder_route3_qqq"/>
-    <property name="act4" value="translated_dialog spyder_route3_qqq2"/>
-    <property name="act6" value="set_variable ambushedbyqqq:yes"/>
-    <property name="act7" value="pathfind spyder_route3_qqq,0,2"/>
-    <property name="act8" value="remove_npc spyder_route3_qqq"/>
-    <property name="cond1" value="not variable_set ambushedbyqqq:yes"/>
-    <property name="cond2" value="is player_at"/>
+    <property name="act40" value="set_variable spyder_weaver_won:yes"/>
+    <property name="act50" value="translated_dialog spyder_route3_weaver2"/>
+    <property name="act51" value="set_variable route2weaver:yes"/>
+    <property name="cond1" value="is variable_set battle_last_result:won"/>
+    <property name="cond2" value="not variable_set spyder_weaver_won:yes"/>
+    <property name="cond3" value="is variable_set after_spyder_weaver:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_route4.tmx
+++ b/mods/tuxemon/maps/spyder_route4.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.4" tiledversion="1.4.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="82">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="86">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -93,13 +93,14 @@
     <property name="cond2" value="is player_facing right"/>
    </properties>
   </object>
-  <object id="47" name="Create Marshall" type="event" x="48" y="464" width="16" height="16">
+  <object id="47" name="Create Marshall" type="event" x="32" y="464" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_route4_marshall,2,29"/>
+    <property name="act2" value="npc_face spyder_route4_marshall,right"/>
     <property name="cond1" value="not npc_exists spyder_route4_marshall"/>
    </properties>
   </object>
-  <object id="48" name="Talk Marshall" type="event" x="32" y="464" width="16" height="16">
+  <object id="48" name="Talk Marshall" type="event" x="32" y="480" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_route4_marshall1"/>
     <property name="act3" value="start_battle spyder_route4_marshall"/>
@@ -294,13 +295,13 @@
     <property name="cond1" value="not variable_set route4roger:yes"/>
    </properties>
   </object>
-  <object id="72" name="Create Wulf" type="event" x="48" y="192" width="16" height="16">
+  <object id="72" name="Create Wulf" type="event" x="32" y="192" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_route4_wulf,2,12"/>
     <property name="cond1" value="not npc_exists spyder_route4_wulf"/>
    </properties>
   </object>
-  <object id="73" name="Talk Wulf" type="event" x="32" y="192" width="16" height="16">
+  <object id="73" name="Talk Wulf" type="event" x="32" y="176" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_route4_wulf1"/>
     <property name="act3" value="start_battle spyder_route4_wulf"/>
@@ -343,10 +344,11 @@
     <property name="cond1" value="not variable_set route4rosamund:yes"/>
    </properties>
   </object>
-  <object id="78" name="Create Roger" type="event" x="48" y="320" width="16" height="16">
+  <object id="78" name="Create Beck" type="event" x="48" y="320" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc spyder_route4_roger,12,20"/>
-    <property name="cond1" value="not npc_exists spyder_route4_roger"/>
+    <property name="act1" value="create_npc spyder_route4_beck,3,20"/>
+    <property name="act2" value="npc_face spyder_route4_beck,right"/>
+    <property name="cond1" value="not npc_exists spyder_route4_beck"/>
    </properties>
   </object>
   <object id="79" name="Talk Beck" type="event" x="32" y="320" width="16" height="16">
@@ -363,6 +365,46 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set environment:grass"/>
+   </properties>
+  </object>
+  <object id="82" name="Talk Marshall" type="event" x="48" y="464" width="48" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_route4_marshall1"/>
+    <property name="act3" value="start_battle spyder_route4_marshall"/>
+    <property name="act4" value="translated_dialog spyder_route4_marshall2"/>
+    <property name="act6" value="set_variable route4marshall:yes"/>
+    <property name="cond1" value="not variable_set route4marshall:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="83" name="Talk Beck" type="event" x="64" y="320" width="32" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_route4_beck1"/>
+    <property name="act3" value="start_battle spyder_route4_beck"/>
+    <property name="act4" value="translated_dialog spyder_route4_beck2"/>
+    <property name="act6" value="set_variable route4beck:yes"/>
+    <property name="cond1" value="not variable_set route4beck:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="84" name="Talk Wulf" type="event" x="32" y="208" width="16" height="48">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_route4_wulf1"/>
+    <property name="act3" value="start_battle spyder_route4_wulf"/>
+    <property name="act4" value="translated_dialog spyder_route4_wulf2"/>
+    <property name="act6" value="set_variable route4wulf:yes"/>
+    <property name="cond1" value="not variable_set route4wulf:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="85" name="Talk Rosamund" type="event" x="192" y="496" width="16" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_route4_rosamund1"/>
+    <property name="act3" value="start_battle spyder_route4_rosamund"/>
+    <property name="act4" value="translated_dialog spyder_route4_rosamund2"/>
+    <property name="act6" value="set_variable route4rosamund:yes"/>
+    <property name="cond1" value="not variable_set route4rosamund:yes"/>
+    <property name="cond2" value="is player_at"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_route5.tmx
+++ b/mods/tuxemon/maps/spyder_route5.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.5" tiledversion="1.7.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="62">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="66">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -249,14 +249,14 @@
     <property name="behav1" value="talk spyder_granny"/>
    </properties>
   </object>
-  <object id="47" name="Create Sara" type="event" x="384" y="128" width="16" height="16">
+  <object id="47" name="Create Sara" type="event" x="368" y="128" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_route5_sara,23,8"/>
     <property name="act2" value="npc_face spyder_route5_sara,right"/>
     <property name="cond1" value="not npc_exists spyder_route5_sara"/>
    </properties>
   </object>
-  <object id="48" name="Talk Sara" type="event" x="368" y="128" width="16" height="16">
+  <object id="48" name="Talk Sara" type="event" x="352" y="128" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_route5_sara1"/>
     <property name="act3" value="start_battle spyder_route5_sara"/>
@@ -293,7 +293,7 @@
     <property name="cond1" value="not npc_exists spyder_route5_edith"/>
    </properties>
   </object>
-  <object id="54" name="Talk Edith" type="event" x="304" y="240" width="16" height="16">
+  <object id="54" name="Talk Edith" type="event" x="320" y="224" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_route5_edith1"/>
     <property name="act3" value="start_battle spyder_route5_edith"/>
@@ -326,7 +326,7 @@
     <property name="cond1" value="not npc_exists spyder_route5_cleo"/>
    </properties>
   </object>
-  <object id="58" name="Talk Cleo" type="event" x="320" y="96" width="16" height="16">
+  <object id="58" name="Talk Cleo" type="event" x="336" y="80" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_route5_cleo1"/>
     <property name="act3" value="start_battle spyder_route5_cleo"/>
@@ -342,7 +342,7 @@
     <property name="cond1" value="not npc_exists spyder_route5_tryphaena"/>
    </properties>
   </object>
-  <object id="60" name="Talk Tryphaena" type="event" x="288" y="96" width="16" height="16">
+  <object id="60" name="Talk Tryphaena" type="event" x="272" y="80" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_route5_tryphaena1"/>
     <property name="act3" value="start_battle spyder_route5_tryphaena"/>
@@ -356,6 +356,46 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set environment:grass"/>
+   </properties>
+  </object>
+  <object id="62" name="Talk Sara" type="event" x="384" y="128" width="16" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_route5_sara1"/>
+    <property name="act3" value="start_battle spyder_route5_sara"/>
+    <property name="act4" value="translated_dialog spyder_route5_sara2"/>
+    <property name="act6" value="set_variable route5sara:yes"/>
+    <property name="cond1" value="not variable_set route5sara:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="63" name="Talk Cleo" type="event" x="320" y="96" width="16" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_route5_cleo1"/>
+    <property name="act3" value="start_battle spyder_route5_cleo"/>
+    <property name="act4" value="translated_dialog spyder_route5_cleo2"/>
+    <property name="act6" value="set_variable route5cleo:yes"/>
+    <property name="cond1" value="not variable_set route5cleo:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="64" name="Talk Tryphaena" type="event" x="288" y="96" width="16" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_route5_tryphaena1"/>
+    <property name="act3" value="start_battle spyder_route5_tryphaena"/>
+    <property name="act4" value="translated_dialog spyder_route5_tryphaena2"/>
+    <property name="act6" value="set_variable route5tryphaena:yes"/>
+    <property name="cond1" value="not variable_set route5tryphaena:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="65" name="Talk Edith" type="event" x="304" y="240" width="16" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_route5_edith1"/>
+    <property name="act3" value="start_battle spyder_route5_edith"/>
+    <property name="act4" value="translated_dialog spyder_route5_edith2"/>
+    <property name="act6" value="set_variable route5edith:yes"/>
+    <property name="cond1" value="not variable_set route5edith:yes"/>
+    <property name="cond2" value="is player_at"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_route6.tmx
+++ b/mods/tuxemon/maps/spyder_route6.tmx
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.4" tiledversion="1.4.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="5" nextobjectid="213">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="5" nextobjectid="218">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>
  </tileset>
- <tileset firstgid="449" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="1000" columns="40">
-  <image source="../gfx/tilesets/Cave_Tiles_by_ArMM1998_(Tuxemon_Style).png" width="640" height="400"/>
+ <tileset firstgid="449" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="160" columns="16">
+  <image source="../gfx/tilesets/Cave_Tiles_by_ArMM1998_(Tuxemon_Style).png" width="256" height="160"/>
  </tileset>
- <tileset firstgid="1449" name="Outdoor_Tiles_-_City_and_Country_-_by_ArMM1998" tilewidth="16" tileheight="16" tilecount="1440" columns="40">
+ <tileset firstgid="695" name="Outdoor_Tiles_-_City_and_Country_-_by_ArMM1998" tilewidth="16" tileheight="16" tilecount="1440" columns="40">
   <image source="../gfx/tilesets/Outdoor_Tiles_-_City_and_Country_-_by_ArMM1998.png" width="640" height="576"/>
  </tileset>
- <tileset firstgid="2889" name="Car,_Black_by_Isaiah658" tilewidth="16" tileheight="16" tilecount="36" columns="6">
+ <tileset firstgid="2135" name="Car,_Black_by_Isaiah658" tilewidth="16" tileheight="16" tilecount="36" columns="6">
   <image source="../gfx/tilesets/Car,_Black_by_Isaiah658.png" width="96" height="96"/>
  </tileset>
- <tileset firstgid="2925" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
+ <tileset firstgid="2171" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
   <image source="../gfx/tilesets/boxfont.png" width="208" height="192"/>
  </tileset>
- <tileset firstgid="3081" name="Vegetation_and_Outdoor_Fittings_by_George" tilewidth="16" tileheight="16" tilecount="60" columns="15">
+ <tileset firstgid="2327" name="Vegetation_and_Outdoor_Fittings_by_George" tilewidth="16" tileheight="16" tilecount="60" columns="15">
   <image source="../gfx/tilesets/Vegetation_and_Outdoor_Fittings_by_George.png" width="240" height="64"/>
  </tileset>
  <layer id="1" name="Tile Layer 1" width="40" height="20">
@@ -28,7 +28,7 @@
  </layer>
  <layer id="2" name="Obstacles" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHNlb1twzAUhJkUBpKhsk7W4CRx6nRpMoKdVezC8Qh5V3zAw+GJEiuZAHF8P0eeTpR9aa1dY14eFF+eWnuN+ajovoWNuwzXQey+7SIuDnUdxOgE99LHuegA0QnSV2F8Rz14fQ0r7vtz61Xec+gA0Ql6f47jO+rB62uYObNrdIDoBD8PrR9jfsRkb3rxTfmv8JE6a+og9RlEB/ht5N/QdY55SvroxTfpQZPoxNRB23pTiBegkyp93qMYTRmvC/ez4i/l8AL0vq36xMvaFOObo2qj8RPfDn4tIfwZfXBmsbrj+LWEnHGPe/cX85buH7UtyDse9Y48cP9G+1B72/jbpX7eLdwKR/rcv4qvnD+Hx5mX7yH+0Z/7WI/0wQPhOPpzeJz7pY8Y/+gnn3GkDx6ITp4b9LzH+Tytve4x+6p3dMfhgejkuUHPe6xz8vC6x+ybOdUaHojOWWRvvVtNYnxa20/99MDNOWronEXthTZQOXxa20+99Gitof9acuA/B3gmjw==
+   eAHNlUtOAzEQRB1YRHAQzunzIILEXYA7JAfIKqB0LZ7UKvkzXk1Gssr9qZ6aGk9yLqVcYp0fFF8OpbzGelR038LGXS7XQey+7SIubuo6iNEJ7qWP+6IDRCdIXwvjO6rBqzNscY9PpbbynkMHiE7Q+3Mc31ENXp1h5qzu0QGiE/x8LvUU6yMWs+nFN+Xfw0fq7KmD1FcQHeCXkX9D10+s76SPXnyTHjSJTkwdtNGbQrwAndTS5z2K0ZTx0jmfLX4vhxeg923VJ17WphjfHFUbXW/x7eBXD+Gv6IOziq0zjl895B7/ce7+Yt3S+aO2BXnHo96RB+7faA61a/ymsJ8h73bUN9Ln/vXm+HN4nHn5HOIf/bmP/UgfPBCOoz+Hx7lf+ojxj37yGUf64IHo5LlBz3uc76e91z1mrnpHZxweiE6eG/S8x7pPvrzuMXMzp7WHB6JzFZmtd6tFjE+zeeqnB27OUUPnKmoW2kDl8Gk2T730aK9L/7XkwDtDvSfi
   </data>
  </layer>
  <objectgroup color="#ffff00" id="3" name="Events">
@@ -277,14 +277,14 @@
     <property name="cond1" value="not variable_set route6blair:yes"/>
    </properties>
   </object>
-  <object id="199" name="Create Maxwell" type="event" x="160" y="96" width="16" height="16">
+  <object id="199" name="Create Maxwell" type="event" x="160" y="80" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_route6_maxwell,10,5"/>
     <property name="act2" value="npc_face spyder_route6_maxwell,left"/>
     <property name="cond1" value="not npc_exists spyder_route6_maxwell"/>
    </properties>
   </object>
-  <object id="200" name="Talk Maxwell" type="event" x="160" y="80" width="16" height="16">
+  <object id="200" name="Talk Maxwell" type="event" x="160" y="96" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_route6_maxwell1"/>
     <property name="act3" value="start_battle spyder_route6_maxwell"/>
@@ -301,7 +301,7 @@
     <property name="cond1" value="not npc_exists spyder_route6_orion"/>
    </properties>
   </object>
-  <object id="202" name="Talk Orion" type="event" x="336" y="80" width="16" height="16">
+  <object id="202" name="Talk Orion" type="event" x="352" y="96" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_route6_orion1"/>
     <property name="act3" value="start_battle spyder_route6_orion"/>
@@ -311,14 +311,14 @@
     <property name="cond1" value="not variable_set route6orion:yes"/>
    </properties>
   </object>
-  <object id="203" name="Create Mungo" type="event" x="528" y="48" width="16" height="16">
+  <object id="203" name="Create Mungo" type="event" x="512" y="48" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_route6_mungo,32,3"/>
     <property name="act2" value="npc_face spyder_route6_mungo,left"/>
     <property name="cond1" value="not npc_exists spyder_route6_mungo"/>
    </properties>
   </object>
-  <object id="204" name="Talk Mungo" type="event" x="512" y="48" width="16" height="16">
+  <object id="204" name="Talk Mungo" type="event" x="528" y="64" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_route6_mungo1"/>
     <property name="act3" value="start_battle spyder_route6_mungo"/>
@@ -328,14 +328,14 @@
     <property name="cond1" value="not variable_set route6mungo:yes"/>
    </properties>
   </object>
-  <object id="205" name="Create Rigel" type="event" x="464" y="256" width="16" height="16">
+  <object id="205" name="Create Rigel" type="event" x="448" y="256" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_route6_rigel,28,16"/>
     <property name="cond1" value="not npc_exists spyder_route6_rigel"/>
     <property name="cond2" value="not variable_set route6rigel:yes"/>
    </properties>
   </object>
-  <object id="206" name="Talk Rigel" type="event" x="448" y="256" width="16" height="16">
+  <object id="206" name="Talk Rigel" type="event" x="448" y="240" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_route6_rigel1"/>
     <property name="act3" value="start_battle spyder_route6_rigel"/>
@@ -347,17 +347,18 @@
   </object>
   <object id="207" name="Create Gunner" type="event" x="480" y="272" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc spyder_route6_gunner,30,18"/>
+    <property name="act1" value="create_npc spyder_route6_gunner,30,17"/>
     <property name="act2" value="npc_face spyder_route6_gunner,up"/>
     <property name="cond1" value="not npc_exists spyder_route6_gunner"/>
    </properties>
   </object>
-  <object id="208" name="Talk Gunner" type="event" x="480" y="288" width="16" height="16">
+  <object id="208" name="Talk Gunner" type="event" x="464" y="272" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_route6_gunner1"/>
     <property name="act3" value="start_battle spyder_route6_gunner"/>
     <property name="act4" value="translated_dialog spyder_route6_gunner2"/>
     <property name="act6" value="set_variable route6gunner:yes"/>
+    <property name="act90" value="pathfind spyder_route6_gunner,28,17"/>
     <property name="behav1" value="talk spyder_route6_gunner"/>
     <property name="cond1" value="not variable_set route6gunner:yes"/>
    </properties>
@@ -382,6 +383,56 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set environment:grass"/>
+   </properties>
+  </object>
+  <object id="213" name="Talk Maxwell" type="event" x="96" y="80" width="64" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_route6_maxwell1"/>
+    <property name="act3" value="start_battle spyder_route6_maxwell"/>
+    <property name="act4" value="translated_dialog spyder_route6_maxwell2"/>
+    <property name="act6" value="set_variable route6maxwell:yes"/>
+    <property name="cond1" value="not variable_set route6maxwell:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="214" name="Talk Orion" type="event" x="336" y="48" width="16" height="48">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_route6_orion1"/>
+    <property name="act3" value="start_battle spyder_route6_orion"/>
+    <property name="act4" value="translated_dialog spyder_route6_orion2"/>
+    <property name="act6" value="set_variable route6orion:yes"/>
+    <property name="cond1" value="not variable_set route6orion:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="215" name="Talk Richard" type="event" x="432" y="176" width="64" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_route6_richard1"/>
+    <property name="act3" value="start_battle spyder_route6_richard"/>
+    <property name="act4" value="translated_dialog spyder_route6_richard2"/>
+    <property name="act6" value="set_variable route6richard:yes"/>
+    <property name="cond1" value="not variable_set route6richard:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="216" name="Talk Blair" type="event" x="496" y="144" width="64" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_route6_blair1"/>
+    <property name="act3" value="start_battle spyder_route6_blair"/>
+    <property name="act4" value="translated_dialog spyder_route6_blair2"/>
+    <property name="act6" value="set_variable route6blair:yes"/>
+    <property name="cond1" value="not variable_set route6blair:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="217" name="Talk Mungo" type="event" x="464" y="48" width="48" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_route6_mungo1"/>
+    <property name="act3" value="start_battle spyder_route6_mungo"/>
+    <property name="act4" value="translated_dialog spyder_route6_mungo2"/>
+    <property name="act6" value="set_variable route6mungo:yes"/>
+    <property name="cond1" value="not variable_set route6mungo:yes"/>
+    <property name="cond2" value="is player_at"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_routec.tmx
+++ b/mods/tuxemon/maps/spyder_routec.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.4" tiledversion="1.4.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="222">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="227">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -217,7 +217,7 @@
     <property name="cond1" value="not npc_exists spyder_searoutec_rutherford"/>
    </properties>
   </object>
-  <object id="212" name="Talk Rutherford" type="event" x="544" y="176" width="16" height="16">
+  <object id="212" name="Talk Rutherford" type="event" x="528" y="192" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_searoutec_rutherford1"/>
     <property name="act3" value="start_battle spyder_searoutec_rutherford"/>
@@ -279,6 +279,56 @@
    <properties>
     <property name="act1" value="set_variable environment:water"/>
     <property name="cond1" value="not variable_set environment:water"/>
+   </properties>
+  </object>
+  <object id="222" name="Talk Rutherford" type="event" x="544" y="144" width="16" height="48">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_searoutec_rutherford1"/>
+    <property name="act3" value="start_battle spyder_searoutec_rutherford"/>
+    <property name="act4" value="translated_dialog spyder_searoutec_rutherford2"/>
+    <property name="act6" value="set_variable searoutecrutherford:yes"/>
+    <property name="cond1" value="not variable_set searoutecrutherford:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="223" name="Talk Gil" type="event" x="384" y="256" width="16" height="32">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_searoutec_gil1"/>
+    <property name="act3" value="start_battle spyder_searoutec_gil"/>
+    <property name="act4" value="translated_dialog spyder_searoutec_gil2"/>
+    <property name="act6" value="set_variable searoutecgil:yes"/>
+    <property name="cond1" value="not variable_set searoutecgil:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="224" name="Talk Carstair" type="event" x="384" y="96" width="16" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_searoutec_carstair1"/>
+    <property name="act3" value="start_battle spyder_searoutec_carstair"/>
+    <property name="act4" value="translated_dialog spyder_searoutec_carstair2"/>
+    <property name="act6" value="set_variable searouteccarstair:yes"/>
+    <property name="cond1" value="not variable_set searouteccarstair:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="225" name="Talk Wade" type="event" x="224" y="192" width="16" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_searoutec_wade1"/>
+    <property name="act3" value="start_battle spyder_searoutec_wade"/>
+    <property name="act4" value="translated_dialog spyder_searoutec_wade2"/>
+    <property name="act6" value="set_variable searoutecwade:yes"/>
+    <property name="cond1" value="not variable_set searoutecwade:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="226" name="Talk Sandy" type="event" x="80" y="240" width="16" height="48">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_searoutec_sandy1"/>
+    <property name="act3" value="start_battle spyder_searoutec_sandy"/>
+    <property name="act4" value="translated_dialog spyder_searoutec_sandy2"/>
+    <property name="act6" value="set_variable searoutecsandy:yes"/>
+    <property name="cond1" value="not variable_set searoutecsandy:yes"/>
+    <property name="cond2" value="is player_at"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_scoop1.tmx
+++ b/mods/tuxemon/maps/spyder_scoop1.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.5" tiledversion="1.7.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="21" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="65">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="21" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="70">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -272,14 +272,14 @@
     <property name="cond1" value="not variable_set scooprubid:yes"/>
    </properties>
   </object>
-  <object id="53" name="Create Berys" type="event" x="320" y="64" width="16" height="16">
+  <object id="53" name="Create Berys" type="event" x="304" y="64" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_scoop_berys,19,4"/>
     <property name="act2" value="npc_face spyder_scoop_berys,left"/>
     <property name="cond1" value="not npc_exists spyder_scoop_berys"/>
    </properties>
   </object>
-  <object id="54" name="Talk Berys" type="event" x="304" y="64" width="16" height="16">
+  <object id="54" name="Talk Berys" type="event" x="304" y="80" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_scoop_berys1"/>
     <property name="act3" value="start_battle spyder_scoop_berys"/>
@@ -332,6 +332,56 @@
     <property name="act1" value="create_npc spyder_scoop_landrace,10,9"/>
     <property name="cond1" value="not npc_exists spyder_scoop_landrace"/>
     <property name="cond2" value="not variable_set scooplandrace:yes"/>
+   </properties>
+  </object>
+  <object id="65" name="Talk Lanth" type="event" x="0" y="80" width="16" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_scoop_lanth1"/>
+    <property name="act3" value="start_battle spyder_scoop_lanth"/>
+    <property name="act4" value="translated_dialog spyder_scoop_lanth2"/>
+    <property name="act6" value="set_variable scooplanth:yes"/>
+    <property name="cond1" value="not variable_set scooplanth:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="66" name="Talk Berys" type="event" x="272" y="64" width="32" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_scoop_berys1"/>
+    <property name="act3" value="start_battle spyder_scoop_berys"/>
+    <property name="act4" value="translated_dialog spyder_scoop_berys2"/>
+    <property name="act6" value="set_variable scoopberys:yes"/>
+    <property name="cond1" value="not variable_set scoopberys:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="67" name="Talk Turner" type="event" x="16" y="160" width="16" height="48">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_scoop_turner1"/>
+    <property name="act3" value="start_battle spyder_scoop_turner"/>
+    <property name="act4" value="translated_dialog spyder_scoop_turner2"/>
+    <property name="act6" value="set_variable scoopturner:yes"/>
+    <property name="cond1" value="not variable_set scoopturner:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="68" name="Talk Paine" type="event" x="96" y="64" width="16" height="32">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_scoop_paine1"/>
+    <property name="act3" value="start_battle spyder_scoop_paine"/>
+    <property name="act4" value="translated_dialog spyder_scoop_paine2"/>
+    <property name="act6" value="set_variable scooppaine:yes"/>
+    <property name="cond1" value="not variable_set scooppaine:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="69" name="Talk Rubid" type="event" x="192" y="160" width="16" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_scoop_rubid1"/>
+    <property name="act3" value="start_battle spyder_scoop_rubid"/>
+    <property name="act4" value="translated_dialog spyder_scoop_rubid2"/>
+    <property name="act6" value="set_variable scooprubid:yes"/>
+    <property name="cond1" value="not variable_set scooprubid:yes"/>
+    <property name="cond2" value="is player_at"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_scoop3.tmx
+++ b/mods/tuxemon/maps/spyder_scoop3.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.5" tiledversion="1.7.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="12" height="12" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="26">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="12" height="12" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="29">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -161,7 +161,7 @@
     <property name="cond1" value="not variable_set scooptaggart:yes"/>
    </properties>
   </object>
-  <object id="22" name="Create Donald" type="event" x="176" y="160" width="16" height="16">
+  <object id="22" name="Create Donald" type="event" x="176" y="128" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_scoop_donald,11,9"/>
     <property name="cond1" value="not npc_exists spyder_scoop_donald"/>
@@ -181,6 +181,36 @@
    <properties>
     <property name="act1" value="set_variable environment:snow"/>
     <property name="cond1" value="not variable_set environment:snow"/>
+   </properties>
+  </object>
+  <object id="26" name="Talk Alyssa" type="event" x="64" y="160" width="16" height="32">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_scoop_alyssa1"/>
+    <property name="act3" value="start_battle spyder_scoop_alyssa"/>
+    <property name="act4" value="translated_dialog spyder_scoop_alyssa2"/>
+    <property name="act6" value="set_variable scoopalyssa:yes"/>
+    <property name="cond1" value="not variable_set scoopalyssa:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="27" name="Talk Taggart" type="event" x="96" y="144" width="16" height="32">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_scoop_taggart1"/>
+    <property name="act3" value="start_battle spyder_scoop_taggart"/>
+    <property name="act4" value="translated_dialog spyder_scoop_taggart2"/>
+    <property name="act6" value="set_variable scooptaggart:yes"/>
+    <property name="cond1" value="not variable_set scooptaggart:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="28" name="Talk Donald" type="event" x="176" y="160" width="16" height="32">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_scoop_donald1"/>
+    <property name="act3" value="start_battle spyder_scoop_donald"/>
+    <property name="act4" value="translated_dialog spyder_scoop_donald2"/>
+    <property name="act6" value="set_variable scoopdonald:yes"/>
+    <property name="cond1" value="not variable_set scoopdonald:yes"/>
+    <property name="cond2" value="is player_at"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_scoop4.tmx
+++ b/mods/tuxemon/maps/spyder_scoop4.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.5" tiledversion="1.7.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="12" height="22" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="55">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="12" height="22" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="58">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -148,7 +148,7 @@
     <property name="cond2" value="not variable_set scooporba:yes"/>
    </properties>
   </object>
-  <object id="31" name="Talk Orba" type="event" x="16" y="192" width="16" height="16">
+  <object id="31" name="Talk Orba" type="event" x="48" y="192" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_scoop_orba1"/>
     <property name="act3" value="start_battle spyder_scoop_orba"/>
@@ -349,6 +349,36 @@
    <properties>
     <property name="act1" value="set_variable environment:snow"/>
     <property name="cond1" value="not variable_set environment:snow"/>
+   </properties>
+  </object>
+  <object id="55" name="Talk Orba" type="event" x="0" y="192" width="32" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_scoop_orba1"/>
+    <property name="act3" value="start_battle spyder_scoop_orba"/>
+    <property name="act4" value="translated_dialog spyder_scoop_orba2"/>
+    <property name="act6" value="set_variable scooporba:yes"/>
+    <property name="cond1" value="not variable_set scooporba:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="56" name="Talk Arachne" type="event" x="128" y="128" width="32" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_scoop_arachne1"/>
+    <property name="act3" value="start_battle spyder_scoop_arachne"/>
+    <property name="act4" value="translated_dialog spyder_scoop_arachne2"/>
+    <property name="act6" value="set_variable scooparachne:yes"/>
+    <property name="cond1" value="not variable_set scooparachne:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="57" name="Talk Weaver" type="event" x="112" y="112" width="16" height="32">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_scoop_weaver1"/>
+    <property name="act3" value="start_battle spyder_scoop_weaver"/>
+    <property name="act4" value="translated_dialog spyder_scoop_weaver2"/>
+    <property name="act6" value="set_variable scoopweaver:yes"/>
+    <property name="cond1" value="not variable_set scoopweaver:yes"/>
+    <property name="cond2" value="is player_at"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_tunnel.tmx
+++ b/mods/tuxemon/maps/spyder_tunnel.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.4" tiledversion="1.4.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="341">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="342">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -9,19 +9,19 @@
  <tileset firstgid="449" name="Waterfall_by_George" tilewidth="16" tileheight="16" tilecount="90" columns="9">
   <image source="../gfx/tilesets/Waterfall_by_George.png" width="144" height="160"/>
  </tileset>
- <tileset firstgid="539" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="1000" columns="40">
-  <image source="../gfx/tilesets/Cave_Tiles_by_ArMM1998_(Tuxemon_Style).png" width="640" height="400"/>
+ <tileset firstgid="539" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="160" columns="16">
+  <image source="../gfx/tilesets/Cave_Tiles_by_ArMM1998_(Tuxemon_Style).png" width="256" height="160"/>
  </tileset>
- <tileset firstgid="1539" name="Outdoor_Tiles_-_City_and_Country_-_by_ArMM1998" tilewidth="16" tileheight="16" tilecount="1440" columns="40">
+ <tileset firstgid="908" name="Outdoor_Tiles_-_City_and_Country_-_by_ArMM1998" tilewidth="16" tileheight="16" tilecount="1440" columns="40">
   <image source="../gfx/tilesets/Outdoor_Tiles_-_City_and_Country_-_by_ArMM1998.png" width="640" height="576"/>
  </tileset>
- <tileset firstgid="2979" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="1000" columns="40">
-  <image source="../gfx/tilesets/Cave_Tiles_by_ArMM1998_(Tuxemon_Style).png" width="640" height="400"/>
+ <tileset firstgid="2348" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="160" columns="16">
+  <image source="../gfx/tilesets/Cave_Tiles_by_ArMM1998_(Tuxemon_Style).png" width="256" height="160"/>
  </tileset>
- <tileset firstgid="3979" name="Cave_Tiles_by_George_" tilewidth="16" tileheight="16" tilecount="154" columns="14">
+ <tileset firstgid="2508" name="Cave_Tiles_by_George_" tilewidth="16" tileheight="16" tilecount="154" columns="14">
   <image source="../gfx/tilesets/Cave_Tiles_by_George_.png" width="224" height="181"/>
  </tileset>
- <tileset firstgid="4133" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
+ <tileset firstgid="2662" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
   <image source="../gfx/tilesets/boxfont.png" width="208" height="192"/>
  </tileset>
  <layer id="1" name="Lowest Level" width="20" height="40">
@@ -31,12 +31,12 @@
  </layer>
  <layer id="2" name="Obstacles" width="20" height="40">
   <data encoding="base64" compression="zlib">
-   eAG1llFOAzEMRAN8AS2V4BiAOEnbK+0Hh+AU/eAGHAe4BB7YJ0aR06QtRLLsje3JxHa7W8rvepxNNJ4njFn780cp03sI2kPBQePzfO3589VZmS5D0OTMcZM/u70IDptZ1qHdh/06G6vw34TcN+KIH9XBf+rFRg32xkQNS9Twe/0FXtSwRA2beJ/n0bOQn4hSTuV3d1Gm2xDHYybQ+KQzfteNGqm36ikzgXa8Q+rHXeGFdryMn/vdBg9eaI/xM7Zxl95dPTez6zNaMwO3DEN71M35aT/Dow/ytxZ1G+HX46YzRvjx21835se5jvATr90AluPuq9/IPR1L9r76PQQ3/X8hywGuNT/N4CYkm8Me3+fIq/nBP5ubHp5ya36n4v0nv1Xcn9pn7xD1p9cT55fVjPuje5hevxE84e7DrPnt4k7KWYRuzY38rV63+BHf4oxf2L5qfviIPxRP+XwfeC5427h3/VtRTfBzfqYzPMX5PnnqiWZrGcJerT3Pe+j7dU7Nk36s4px6hokF782+E8Alhmf6oZzs20K1Ao8caeZp3bivcrJvC+VmePBCK85XnaPzOXsbtmbbBZ8wsjqA17uHc8hs3nPgwf8lqX2WX+/xnqvx6PuxmhpRF/p+rP4CcZPZQw==
+   eAG1lt1NAzEQhA1vQEIKAUQlSWiBFqCBE1BPHugKqmAH7hMjax07CViyds+7O579Se5K+V13s4rEco8yS3/+LGX6iI10V3CQ2DxeZ/58eVami9hIYma/yZ9dXwSHzbzXId2G/j4rq7Bfx75p+OE/KoP/1PONGuz1iRqWqOH3+gu8qGGJGjbxns/L9BT7x6OUU/m9BtZLhcdMILlLMuN31aiRequeMhNIxzukfuQKL6TjZfzc7jp48EK6j9+xjVx6uXpsptd3tGYGbhmGzqib89N5hkcfZG8t6jbCr8dNd4zw47e/bsyPcx3hJ167ASzH3Ve/kTwdS/q++t0GN/1/sZcDXGt+msFN7GwOe3zfIq7mB/9sbnp4iq35nYr3n/xWkT+1z94h6k+vJ84vqxn5I3uYXr8RPOHuw6z57SInxSxCtuZG9lavW/zwb3HGLmxfNT9s+B+Kp3i+DzwWvG3kXf9WVBPs3J/JDE9+fk6ceqLZWsbmrJYe5z308zqm5kk/VnFPPcP4gvdo73Vw8eGZfigm+7ZQrcAjRpJ5WjfyVUz2baHYDA9eSPn5qmN0P3dvQ9ds+8YmjKwO4PXycA6ZznsOPPg/JLXP4usz3nM1Hn0/VlIj6kLfj5VfYUrYFw==
   </data>
  </layer>
  <layer id="3" name="Obstacles 2" width="20" height="40">
   <data encoding="base64" compression="zlib">
-   eAHtVdsNwjAMDJQ/HmUH+APUSaAr8Q0LwBLMAHswABJL1JZq6Wo1aR5VVSQqWXGofT4fjWPM7z2FMWdkfYD9e9J8h3Hif6bNmDY8xJQ837UNzzdX4nLqaVXbDvpbkH+EvcR3rZqTxMf22YWnNZZ6trWse9J5sfy4DmOeyOZkrBv7Mdppzozrg3PNmt+ZxonZXwIx14HxMZzGkONz7ofk+VIzZsjafdR6joh/TudNZuGS/NT+CsBImS/Cow3vnqAfzxeZW33wQ577WssUHeWsYd+MG4N5A524b57VwjcWU/J5RY68D9VTn+NUPOaAjw1P34OY4/IFL+W+w9qCF6qbjWNJ/6/rHs4ocWZLDvj9QbFsG7JtQJ4rFPG+rsD/O28FKkbOQ1Q=
+   eAHtVdsNwjAMDI8/Hh0C/gB1EihsABswAhPxAeuwAUtgS7V0tZo0cRBqJSpZcVr7cr40jnPDe0rnbsh6B/PXqPkN48S/jpsxbXiIKXmxYxtebK7EFVTTsrYN1Dcnfw9zie8aNSeJt9bZhac1lvV8Y1XXpPOs/HgdxjyQzchYN/Yt2mnOjBuD81T/mcaxzB+JmLfEeAunPuTEnPtf8rwMXPdzj/gXdN6kFy7Iz93HEjBy+ovwaMM7ZejH/UX61jf4Ic9trWWOjnLWsG7GtWAeQSeum3u18LViSj6PyJHnqXrqc5yLxxzw8eHpexBzQr7g5dx3uLbgperm41jR/obu4QklTn3JCe/vFMu2Ilsn5IVCEe8dCvx/i1bgA32xQAk=
   </data>
  </layer>
  <objectgroup color="#ffff00" id="4" name="Events">
@@ -158,6 +158,16 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set environment:grass"/>
+   </properties>
+  </object>
+  <object id="341" name="Talk Greta" type="event" x="208" y="576" width="16" height="32">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_tunnelb_greta1"/>
+    <property name="act3" value="start_battle spyder_tunnelb_greta"/>
+    <property name="act4" value="translated_dialog spyder_tunnelb_greta2"/>
+    <property name="act6" value="set_variable tunnelbgreta:yes"/>
+    <property name="cond1" value="not variable_set tunnelbgreta:yes"/>
+    <property name="cond2" value="is player_at"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_tunnel_below.tmx
+++ b/mods/tuxemon/maps/spyder_tunnel_below.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.5" tiledversion="1.7.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="50">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="53">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -89,7 +89,7 @@
   <object id="36" type="collision" x="288" y="176" width="16" height="208"/>
   <object id="37" type="collision" x="256" y="304" width="32" height="80"/>
  </objectgroup>
- <objectgroup color="#ffff00" id="6" name="Events" visible="0">
+ <objectgroup color="#ffff00" id="6" name="Events">
   <object id="38" name="Teleport to Aboveground" type="event" x="112" y="32" width="16" height="16">
    <properties>
     <property name="act1" value="transition_teleport spyder_tunnel.tmx,12,3,0.3"/>
@@ -138,14 +138,14 @@
     <property name="cond1" value="not variable_set tunnelbberyll:yes"/>
    </properties>
   </object>
-  <object id="45" name="Create Lute" type="event" x="176" y="592" width="16" height="16">
+  <object id="45" name="Create Lute" type="event" x="128" y="592" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_tunnelb_lute,8,37"/>
     <property name="act2" value="npc_face spyder_tunnelb_lute,up"/>
     <property name="cond1" value="not npc_exists spyder_tunnelb_lute"/>
    </properties>
   </object>
-  <object id="46" name="Talk Lute" type="event" x="176" y="576" width="16" height="16">
+  <object id="46" name="Talk Lute" type="event" x="112" y="592" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_tunnelb_lute1"/>
     <property name="act3" value="start_battle spyder_tunnelb_lute"/>
@@ -162,7 +162,7 @@
     <property name="cond1" value="not npc_exists spyder_tunnelb_meitner"/>
    </properties>
   </object>
-  <object id="48" name="Talk Meitner" type="event" x="256" y="272" width="16" height="16">
+  <object id="48" name="Talk Meitner" type="event" x="272" y="288" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_tunnelb_meitner1"/>
     <property name="act3" value="start_battle spyder_tunnelb_meitner"/>
@@ -176,6 +176,36 @@
    <properties>
     <property name="act1" value="set_variable environment:cave"/>
     <property name="cond1" value="not variable_set environment:cave"/>
+   </properties>
+  </object>
+  <object id="50" name="Talk Meitner" type="event" x="256" y="240" width="16" height="48">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_tunnelb_meitner1"/>
+    <property name="act3" value="start_battle spyder_tunnelb_meitner"/>
+    <property name="act4" value="translated_dialog spyder_tunnelb_meitner2"/>
+    <property name="act6" value="set_variable tunnelbmeitner:yes"/>
+    <property name="cond1" value="not variable_set tunnelbmeitner:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="51" name="Talk Lute" type="event" x="128" y="576" width="16" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_tunnelb_lute1"/>
+    <property name="act3" value="start_battle spyder_tunnelb_lute"/>
+    <property name="act4" value="translated_dialog spyder_tunnelb_lute2"/>
+    <property name="act6" value="set_variable tunnelblute:yes"/>
+    <property name="cond1" value="not variable_set tunnelblute:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="52" name="Talk Beryll" type="event" x="144" y="512" width="16" height="32">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_tunnelb_beryll1"/>
+    <property name="act3" value="start_battle spyder_tunnelb_beryll"/>
+    <property name="act4" value="translated_dialog spyder_tunnelb_beryll2"/>
+    <property name="act6" value="set_variable tunnelbberyll:yes"/>
+    <property name="cond1" value="not variable_set tunnelbberyll:yes"/>
+    <property name="cond2" value="is player_at"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
+++ b/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.4" tiledversion="1.4.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="16" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="71">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="16" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="73">
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>
  </tileset>
@@ -21,63 +21,63 @@
  <tileset firstgid="4926" name="Stairs" tilewidth="16" tileheight="16" tilecount="24" columns="8">
   <image source="../gfx/tilesets/stairs.png" width="128" height="48"/>
  </tileset>
- <tileset firstgid="4950" name="Plants" tilewidth="16" tileheight="16" tilecount="16" columns="4">
-  <image source="../gfx/tilesets/plants.png" width="64" height="64"/>
+ <tileset firstgid="4950" name="Plants" tilewidth="16" tileheight="16" tilecount="2" columns="1">
+  <image source="../gfx/tilesets/plants.png" width="16" height="32"/>
  </tileset>
- <tileset firstgid="4966" name="Outdoor_Tiles_-_City_and_Country_-_by_Kelvin_Shadewing" tilewidth="16" tileheight="16" tilecount="500" columns="20">
+ <tileset firstgid="4952" name="Outdoor_Tiles_-_City_and_Country_-_by_Kelvin_Shadewing" tilewidth="16" tileheight="16" tilecount="500" columns="20">
   <image source="../gfx/tilesets/Outdoor_Tiles_-_City_and_Country_-_by_Kelvin_Shadewing.png" width="320" height="400"/>
  </tileset>
- <tileset firstgid="5466" name="Objects_by_ArMM1998" tilewidth="16" tileheight="16" tilecount="660" columns="33">
+ <tileset firstgid="5452" name="Objects_by_ArMM1998" tilewidth="16" tileheight="16" tilecount="660" columns="33">
   <image source="../gfx/tilesets/Objects_by_ArMM1998.png" width="528" height="320"/>
  </tileset>
- <tileset firstgid="6126" name="Kitchen" tilewidth="16" tileheight="16" tilecount="16" columns="4">
+ <tileset firstgid="6112" name="Kitchen" tilewidth="16" tileheight="16" tilecount="16" columns="4">
   <image source="../gfx/tilesets/kitchen.png" width="64" height="64"/>
  </tileset>
- <tileset firstgid="6142" name="Interior_Tiles_by_Mike_Bramson" tilewidth="16" tileheight="16" tilecount="88" columns="11">
+ <tileset firstgid="6128" name="Interior_Tiles_by_Mike_Bramson" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/Interior_Tiles_by_Mike_Bramson.png" width="176" height="128"/>
  </tileset>
- <tileset firstgid="6230" name="Interior_Tiles_by_ArMM1998" tilewidth="16" tileheight="16" tilecount="1000" columns="40">
+ <tileset firstgid="6216" name="Interior_Tiles_by_ArMM1998" tilewidth="16" tileheight="16" tilecount="1000" columns="40">
   <image source="../gfx/tilesets/Interior_Tiles_by_ArMM1998.png" width="640" height="400"/>
  </tileset>
- <tileset firstgid="7230" name="Interior_Walls_by_George" tilewidth="16" tileheight="16" tilecount="210" columns="15">
+ <tileset firstgid="7216" name="Interior_Walls_by_George" tilewidth="16" tileheight="16" tilecount="210" columns="15">
   <image source="../gfx/tilesets/Interior_Walls_by_George.png" width="240" height="224"/>
  </tileset>
- <tileset firstgid="7440" name="Interior_Floors_by_George" tilewidth="16" tileheight="16" tilecount="54" columns="9">
+ <tileset firstgid="7426" name="Interior_Floors_by_George" tilewidth="16" tileheight="16" tilecount="54" columns="9">
   <image source="../gfx/tilesets/Interior_Floors_by_George.png" width="144" height="96"/>
  </tileset>
- <tileset firstgid="7494" name="Furniture" tilewidth="16" tileheight="16" tilecount="72" columns="12">
+ <tileset firstgid="7480" name="Furniture" tilewidth="16" tileheight="16" tilecount="72" columns="12">
   <image source="../gfx/tilesets/furniture.png" width="192" height="96"/>
  </tileset>
- <tileset firstgid="7566" name="Electronics" tilewidth="16" tileheight="16" tilecount="16" columns="4">
+ <tileset firstgid="7552" name="Electronics" tilewidth="16" tileheight="16" tilecount="16" columns="4">
   <image source="../gfx/tilesets/electronics.png" width="64" height="64"/>
  </tileset>
- <tileset firstgid="7582" name="items" tilewidth="16" tileheight="16" tilecount="100" columns="10">
-  <image source="../gfx/tilesets/items.png" width="160" height="160"/>
+ <tileset firstgid="7568" name="items" tilewidth="16" tileheight="16" tilecount="6" columns="3">
+  <image source="../gfx/tilesets/items.png" width="48" height="32"/>
  </tileset>
- <tileset firstgid="7682" name="Interiors by Redshrike" tilewidth="16" tileheight="16" tilecount="84" columns="7">
+ <tileset firstgid="7574" name="Interiors by Redshrike" tilewidth="16" tileheight="16" tilecount="84" columns="7">
   <image source="../gfx/tilesets/Interiors by Redshrike.png" width="112" height="192"/>
  </tileset>
- <tileset firstgid="7766" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
+ <tileset firstgid="7658" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
   <image source="../gfx/tilesets/boxfont.png" width="208" height="192"/>
  </tileset>
  <layer id="1" name="Tile Layer 1" width="15" height="16">
   <data encoding="base64" compression="zlib">
-   eAHFkjsKAkEQROcYBu4RDE3FwFQMTEVNzERT8Yexnsf7WQX9YFyGcTIbiurt7urP7k6GKc0CSbaXvxXMYBd56sxTYS4sA9Ze5B8FMzhFnjrzQrC2675xV2ysGLAWH0Y7GqSUgzxc03ruU725D+buWyH3Uoydz/K5Dz4UYuTYOb/X74tna/H7nGs3UWetzbWt2re03Akr9ujP4zmfW7r32rgz/VrZc1fRu/SN/N/VDG1pZ/euGdrSrv/Srn/s/AGnIk3m
+   eAHFkjsKAkEQROcGpgaKoakYmIqBqaiJmWgq/g6g4G28plXQD8ZlGCezoaje7q7+7O5kkNIskGR7+VvBDHaRp848FebCMmDtRf5RMINT5KkzLwRre8Nv3BUbKwasxYfRjvop5SAP17Se+1Bv7oO5+1bIPRVj57N87oMPhRg5ds7v9fvi2Vr8LufaTdRZa3Ntq/YtLXfCir2683jO55buvTbuTL9W9txV9C59I/93NUNb2tm9a4a2tOu/tOsfO38AsUlC9g==
   </data>
  </layer>
  <layer id="2" name="Tile Layer 4" width="15" height="16">
   <data encoding="base64" compression="zlib">
-   eAGVjz0OwjAMhX0EEANQ2g6UiQHY+BkQRWKlCG4AKxIbDF16BSQOwBnYuAqXYOACPKuxGqWpCJZe49rvix0ioqNfCL+VsW4TJZAeKVhRFFLGvXczd2SN/OTvGdzFYIsuUV+xH7B3cDfF4k5rBAGRrhD/ZuDOn/HwyhZbrewieoE9Ye61VXS5NsPcPWoHaG7s4Ks9efcUeiq2hrwOxfDzyVoZLE/xUJN3y9Q2vB6UoLeBttAOMkN/l+TCMi/qIDeD3yUhuSsrnH52MSMy1LPMZUZ21XnXXHZ19bNvgD2GmkYVe9nuHMM70TT9g13AG2taOrBfYmMnVQ==
+   eAGVjzsKAjEQhgctfYJvUVA7tVMPoHfQVrDTYhtPIAgewDPYCbZ2nkAsBAtL8XUN/8EMG7JZjAPfZnYyXzIhIhpXfPAbGv0S0QDo4cEV9lVa8N6t8O2YZ74rf6fwZobr7xIdlPuEu4a3Ui7OtEYKdZ20pQ9n/oxNOdhiqwW7iI5wJ7hjWfR3uXZCbYjaCJyNGZLqn2f3wFa5EeRRcFEr51dgxg41ebfsxVCLgzt4gBd4AzP0d0kuLvtCwuLyuyQkd3XF09cs7sgZ5C33siOz6r5rLrO69nNfDXPUNRohc9nObKK3pdH+w+2gt6vRc3A/GHYqeg==
   </data>
  </layer>
  <layer id="3" name="Tile Layer 5" width="15" height="16">
   <data encoding="base64" compression="zlib">
-   eAFjYKAcuElSbsZINyFDFBICp0kIy4cSQz/UmOQYGJiBmAWIqQn0geYZQM2cBAynySSElRlQnzlU7y6gvt0k6EX2wyOgvsck6JWUQtZNHBsAsXcJgw==
+   eAFjYKAcWEhSbsZINyFKFBICe0kIy8sSQz/UpskyMEwH4hlATE1wGGjeEaiZLcBwaiUhrE4B9Z2G6l0D1LeWBL3IfrgC1HeVBL3cUsi6iWMDANwHDO4=
   </data>
  </layer>
  <layer id="4" name="Above Player" width="15" height="16">
   <data encoding="base64" compression="zlib">
-   eAFjYBgF9A4BYTl62zhq33ANAQB0LgAy
+   eAFjYBgF9A6B5bL0tnHUvuEaAgDF4gDF
   </data>
  </layer>
  <objectgroup color="#ff0000" id="5" name="Collisions">
@@ -271,7 +271,7 @@
     <property name="cond1" value="not npc_exists spyder_wayfarer1_victor"/>
    </properties>
   </object>
-  <object id="62" name="Talk Victor" type="event" x="192" y="32" width="16" height="16">
+  <object id="62" name="Talk Victor" type="event" x="208" y="48" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_wayfarer1_victor1"/>
     <property name="act3" value="start_battle spyder_wayfarer1_victor"/>
@@ -287,7 +287,7 @@
     <property name="cond1" value="not npc_exists spyder_wayfarer1_morningstar"/>
    </properties>
   </object>
-  <object id="64" name="Talk Morningstar" type="event" x="32" y="48" width="16" height="16">
+  <object id="64" name="Talk Morningstar" type="event" x="16" y="32" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog spyder_wayfarer1_morningstar1"/>
     <property name="act3" value="start_battle spyder_wayfarer1_morningstar"/>
@@ -295,6 +295,26 @@
     <property name="act6" value="set_variable wayfarer1morningstar:yes"/>
     <property name="behav1" value="talk spyder_wayfarer1_morningstar"/>
     <property name="cond1" value="not variable_set wayfarer1morningstar:yes"/>
+   </properties>
+  </object>
+  <object id="71" name="Talk Morningstar" type="event" x="32" y="48" width="16" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_wayfarer1_morningstar1"/>
+    <property name="act3" value="start_battle spyder_wayfarer1_morningstar"/>
+    <property name="act4" value="translated_dialog spyder_wayfarer1_morningstar2"/>
+    <property name="act6" value="set_variable wayfarer1morningstar:yes"/>
+    <property name="cond1" value="not variable_set wayfarer1morningstar:yes"/>
+    <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="72" name="Talk Victor" type="event" x="176" y="32" width="32" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_wayfarer1_victor1"/>
+    <property name="act3" value="start_battle spyder_wayfarer1_victor"/>
+    <property name="act4" value="translated_dialog spyder_wayfarer1_victor2"/>
+    <property name="act6" value="set_variable wayfarer1victor:yes"/>
+    <property name="cond1" value="not variable_set wayfarer1victor:yes"/>
+    <property name="cond2" value="is player_at"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_wayfarer_inn2.tmx
+++ b/mods/tuxemon/maps/spyder_wayfarer_inn2.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.4" tiledversion="1.4.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="16" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="49">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="16" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="50">
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>
  </tileset>
@@ -21,68 +21,68 @@
  <tileset firstgid="4926" name="Stairs" tilewidth="16" tileheight="16" tilecount="24" columns="8">
   <image source="../gfx/tilesets/stairs.png" width="128" height="48"/>
  </tileset>
- <tileset firstgid="4950" name="Plants" tilewidth="16" tileheight="16" tilecount="16" columns="4">
-  <image source="../gfx/tilesets/plants.png" width="64" height="64"/>
+ <tileset firstgid="4950" name="Plants" tilewidth="16" tileheight="16" tilecount="2" columns="1">
+  <image source="../gfx/tilesets/plants.png" width="16" height="32"/>
  </tileset>
- <tileset firstgid="4966" name="Outdoor_Tiles_-_City_and_Country_-_by_Kelvin_Shadewing" tilewidth="16" tileheight="16" tilecount="500" columns="20">
+ <tileset firstgid="4952" name="Outdoor_Tiles_-_City_and_Country_-_by_Kelvin_Shadewing" tilewidth="16" tileheight="16" tilecount="500" columns="20">
   <image source="../gfx/tilesets/Outdoor_Tiles_-_City_and_Country_-_by_Kelvin_Shadewing.png" width="320" height="400"/>
  </tileset>
- <tileset firstgid="5466" name="Objects_by_ArMM1998" tilewidth="16" tileheight="16" tilecount="660" columns="33">
+ <tileset firstgid="5452" name="Objects_by_ArMM1998" tilewidth="16" tileheight="16" tilecount="660" columns="33">
   <image source="../gfx/tilesets/Objects_by_ArMM1998.png" width="528" height="320"/>
  </tileset>
- <tileset firstgid="6126" name="Kitchen" tilewidth="16" tileheight="16" tilecount="16" columns="4">
+ <tileset firstgid="6112" name="Kitchen" tilewidth="16" tileheight="16" tilecount="16" columns="4">
   <image source="../gfx/tilesets/kitchen.png" width="64" height="64"/>
  </tileset>
- <tileset firstgid="6142" name="Interior_Tiles_by_Mike_Bramson" tilewidth="16" tileheight="16" tilecount="88" columns="11">
+ <tileset firstgid="6128" name="Interior_Tiles_by_Mike_Bramson" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/Interior_Tiles_by_Mike_Bramson.png" width="176" height="128"/>
  </tileset>
- <tileset firstgid="6230" name="Interior_Tiles_by_ArMM1998" tilewidth="16" tileheight="16" tilecount="1000" columns="40">
+ <tileset firstgid="6216" name="Interior_Tiles_by_ArMM1998" tilewidth="16" tileheight="16" tilecount="1000" columns="40">
   <image source="../gfx/tilesets/Interior_Tiles_by_ArMM1998.png" width="640" height="400"/>
  </tileset>
- <tileset firstgid="7230" name="Interior_Walls_by_George" tilewidth="16" tileheight="16" tilecount="210" columns="15">
+ <tileset firstgid="7216" name="Interior_Walls_by_George" tilewidth="16" tileheight="16" tilecount="210" columns="15">
   <image source="../gfx/tilesets/Interior_Walls_by_George.png" width="240" height="224"/>
  </tileset>
- <tileset firstgid="7440" name="Interior_Floors_by_George" tilewidth="16" tileheight="16" tilecount="54" columns="9">
+ <tileset firstgid="7426" name="Interior_Floors_by_George" tilewidth="16" tileheight="16" tilecount="54" columns="9">
   <image source="../gfx/tilesets/Interior_Floors_by_George.png" width="144" height="96"/>
  </tileset>
- <tileset firstgid="7494" name="Furniture" tilewidth="16" tileheight="16" tilecount="72" columns="12">
+ <tileset firstgid="7480" name="Furniture" tilewidth="16" tileheight="16" tilecount="72" columns="12">
   <image source="../gfx/tilesets/furniture.png" width="192" height="96"/>
  </tileset>
- <tileset firstgid="7566" name="Electronics" tilewidth="16" tileheight="16" tilecount="16" columns="4">
+ <tileset firstgid="7552" name="Electronics" tilewidth="16" tileheight="16" tilecount="16" columns="4">
   <image source="../gfx/tilesets/electronics.png" width="64" height="64"/>
  </tileset>
- <tileset firstgid="7582" name="items" tilewidth="16" tileheight="16" tilecount="100" columns="10">
-  <image source="../gfx/tilesets/items.png" width="160" height="160"/>
+ <tileset firstgid="7568" name="items" tilewidth="16" tileheight="16" tilecount="6" columns="3">
+  <image source="../gfx/tilesets/items.png" width="48" height="32"/>
  </tileset>
- <tileset firstgid="7682" name="Interiors by Redshrike" tilewidth="16" tileheight="16" tilecount="84" columns="7">
+ <tileset firstgid="7574" name="Interiors by Redshrike" tilewidth="16" tileheight="16" tilecount="84" columns="7">
   <image source="../gfx/tilesets/Interiors by Redshrike.png" width="112" height="192"/>
  </tileset>
- <tileset firstgid="7766" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
+ <tileset firstgid="7658" name="boxfont" tilewidth="16" tileheight="16" tilecount="156" columns="13">
   <image source="../gfx/tilesets/boxfont.png" width="208" height="192"/>
  </tileset>
  <layer id="1" name="Tile Layer 1" width="15" height="16">
   <data encoding="base64" compression="zlib">
-   eAHNkUsKAkEMRPsg08dwK15AvICgB/CzcOePXgsexxN4MaskBWVmGHHnQEg6qZdOeqZdKZuwtcXKHQZyrM1gc9gpbGexcmQVu18gT3ZSS6ORrfXTyKLWs19Y9vQezt670i64Q3tyH+qflmMNundeLDTtDDbvQza/AXSZ7e3JvmLps9m9ZRVaacTuU97rfGeeH/DalX4b+Wt4MfJ+7xEa31d7SZu9s7n27Ux2GTPd4H1mxvxPY5/YPDPnZ++xT+zQjP/KvgDMWlNu
+   eAHNkcsNwkAMRLcDGkjOXBENIBpAggKAHLjxKwCJ7YYK6I8Z5JEGJwriRiTLXnue197MmlK2YRuLlTsM5FibwxawU9jeYuXIKna/RJ7stC2VRnbSfhpZ1Hr2C8ue3sPZe1PqBXdoT+5D/dNyrEH3zouFpp7B5n3I5jeALrO9PdlXLH02u7esQyuN2C7lvc535vkBr13pd5G/hhcj7/ceofF9tZe02Tuba9/OZFcx0w3eZ2bM/zT2ic0zc372HvvEDs34r+wLGRFIOA==
   </data>
  </layer>
  <layer id="2" name="Tile Layer 3" width="15" height="16">
   <data encoding="base64" compression="zlib">
-   eAFjYKAMfOVkYPgGxOQAJS4GBmUgJhaYyRKrElMdJXrtkOxFZmPawsCgL8fAYADE+AArUJ4NiNnR1JkB+eZoYujm8ADleYGYj4A6dH34+PZAsxyoYJ4U0AxJKpiDz63EypULMzD0SzAwTABiYuIE2dxuoN7tQH07gJiYOEHWC2LfB+p7AMSUAkkpwiYAAIDjDoo=
+   eAFjYKAMfOVkYPgGxOQAJS4GBmUgJhZoyBKrElMdJXoNkOxFZmPawsBwGKj2CJJ6bGpmAuVnAfFsNHWngPzTaGLo+hcA5RcC8SIC6tD14eNfBpp1hQrmrQOasZYK5uBzK7FymcIMDI0SDAxNQExMnCCbWwvUuxKobxUQExMnyHpB7ItAfZeAmFLALUXYBACw6Bgq
   </data>
  </layer>
  <layer id="3" name="Tile Layer 2" width="15" height="16">
   <data encoding="base64" compression="zlib">
-   eAFjYBgcwFCOfHccE8SuF2hmgxc3djlqiU6UwG7SJmEGhs1AjA/sxKH3GFDfcQJ6H+LQi88+WstJA+NQhoJ4pLX7hqP5AE2oCG8=
+   eAFjYBgc4Kgs+e44JohdL9DMBi9u7HLUEm2WwG7SEmEGhqVAjA+sxqF3B1DfTgJ6L+PQi88+WsutB8bhBgrikdbuG47mAwCaAApZ
   </data>
  </layer>
  <layer id="4" name="Above Player" width="15" height="16">
   <data encoding="base64" compression="zlib">
-   eAFjYBgFoyGACAEROQYGUSAeBUMjBACtKABm
+   eAFjYBgFoyGACIEVsgwMK4F4FAyNEAAAmxwBjA==
   </data>
  </layer>
  <layer id="5" name="Above Player" width="15" height="16">
   <data encoding="base64" compression="zlib">
-   eAFjYBj8IFVk8LtxoF1oIcfAYAnElAJhoBlCVDCHUneM6icuBABxyQGI
+   eAFjYBj8IFxk8LtxoF14RpaB4SwQUwqWA81YRgVzKHXHqH7iQgAAdNkDxg==
   </data>
  </layer>
  <objectgroup color="#ff0000" id="7" name="Collisions">
@@ -166,7 +166,7 @@
   </object>
   <object id="39" name="Create Bravo" type="event" x="208" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc spyder_wayfarer1_bravo,33,2"/>
+    <property name="act1" value="create_npc spyder_wayfarer1_bravo,13,2"/>
     <property name="cond1" value="not npc_exists spyder_wayfarer1_bravo"/>
    </properties>
   </object>
@@ -214,6 +214,16 @@
    <properties>
     <property name="act1" value="set_variable environment:snow"/>
     <property name="cond1" value="not variable_set environment:snow"/>
+   </properties>
+  </object>
+  <object id="49" name="Talk Bravo" type="event" x="208" y="48" width="16" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_wayfarer1_bravo1"/>
+    <property name="act3" value="start_battle spyder_wayfarer1_bravo"/>
+    <property name="act4" value="translated_dialog spyder_wayfarer1_bravo2"/>
+    <property name="act6" value="set_variable wayfarer1bravo:yes"/>
+    <property name="cond1" value="not variable_set wayfarer1bravo:yes"/>
+    <property name="cond2" value="is player_at"/>
    </properties>
   </object>
  </objectgroup>


### PR DESCRIPTION
@Sanglorian , do you want to make sure you don't have any changes you need to make before this gets merged, as it will be hard to merge our changes if you do? Do you have any changes in the Greenwash dungeon that haven't been pushed yet, for example? (This PR changes almost every map in the spyder campaign)

This PR adds trainer battles for static NPCs in the Spyder campaign, so if you walk 1-4 spaces in front of an NPC, the battle will trigger without you having to talk to them. NPCs that are set to 'wander' using npc_wander aren't affected, you still need to talk to them. 

This PR also contains a bunch of bug fixes I found when going through the spyder campaign, too:
- Some NPC's were spawning in the wrong place, or weren't appearing because there was a syntax error
- Fixed a bug in Nimrod's middle floor, where you can't get past the stairs when you walk onto that map for the first time. 
- The dragonbirth animation on route 3 wasn't appearing because of a syntax error (The animation now crashes when it plays but I'll fix that in another PR)
- The guard blocking the path on route 6, before Candy Town, now pathfinds out of the way after talking to him, so you no longer need to walk through the river to get to Candy Town
- Lots of doors were broken in Greenwash, I've fixed them all
- I added the one-way tile in Greenwash that pushes you back if you try to go in the opposite way to the arrow
- Added collisions to spyder_greenwash_level2.tmx 