### PR TITLE
Add player_defeated condition

### DIFF
--- a/docs/handcrafted/condition_list.rst
+++ b/docs/handcrafted/condition_list.rst
@@ -13,6 +13,7 @@
 .. autoscriptinfoclass:: tuxemon.event.conditions.npc_facing.NPCFacingCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.party_size.PartySizeCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.player_at.PlayerAtCondition
+.. autoscriptinfoclass:: tuxemon.event.conditions.player_defeated.PlayerDefeatedCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.player_facing_npc.PlayerFacingNPCCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.player_facing_tile.PlayerFacingTileCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.player_facing.PlayerFacingCondition

--- a/tuxemon/event/conditions/player_defeated.py
+++ b/tuxemon/event/conditions/player_defeated.py
@@ -1,0 +1,62 @@
+#
+# Tuxemon
+# Copyright (c) 2014-2017 William Edwards <shadowapex@gmail.com>,
+#                         Benjamin Bean <superman2k5@gmail.com>
+#
+# This file is part of Tuxemon
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import annotations
+from tuxemon.event.eventcondition import EventCondition
+from tuxemon.session import Session
+from tuxemon.event import MapCondition
+
+class PlayerDefeatedCondition(EventCondition):
+    """
+    Check to see the player has at least one tuxemon, and all tuxemon in their
+    party are defeated.
+
+    Script usage:
+        .. code-block::
+
+            is player_defeated
+
+    """
+
+    name = "player_defeated"
+
+    def test(self, session: Session, condition: MapCondition) -> bool:
+        """
+        Check to see the player has at least one tuxemon, and all tuxemon in their
+        party are defeated.
+
+        Parameters:
+            session: The session object
+            condition: The map condition object.
+
+        Returns:
+            Whether the player has at least one tuxemon in their party and if
+            all their tuxemon are defeated.
+
+        """
+        player = session.player
+
+        if player.monsters:
+            for mon in player.monsters:
+                if not "status_faint" in (s.slug for s in mon.status):
+                    return False
+
+            return True
+        return False


### PR DESCRIPTION
This condition checks if the player is defeated, ie. has at least one tuxemon in their party, and all their tuxemon are defeated. 

The typical usage would be to teleport to the nearest health center if defeated:
`act1 teleport_faint
cond1 is player_defeated`

But modders could also do story events if the player was defeated, too. 

The python that does the check could maybe be easier to read/use. Happy to change it if needed. 