### PR TITLE
Added default box to monster_boxes

### DIFF
--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -175,7 +175,7 @@ class NPC(Entity[NPCState]):
         # Variables for long-term item and monster storage
         # Keeping these seperate so other code can safely
         # assume that all values are lists
-        self.monster_boxes: Dict[str, List[Monster]] = {}
+        self.monster_boxes: Dict[str, List[Monster]] = {CONFIG.default_monster_storage_box: []}
         self.item_boxes: Dict[str, Mapping[str, InventoryItem]] = {}
 
         # combat related


### PR DESCRIPTION
Fixes: https://github.com/Tuxemon/Tuxemon/issues/1101

I'm not entirely sure if this is the optimal solution, but this is what happens if you insert
```python
print(self.monster_boxes[CONFIG.default_monster_storage_box])
``` 
at the end of `add_monster()` in `npc.py`
```
PS C:\Users\novia\Documents\GitHub\Tuxemon> python run_tuxemon.py
pygame 2.1.3.dev4 (SDL 2.0.20, Python 3.9.0)
Hello from the pygame community. https://www.pygame.org/contribute.html
pygame-menu 4.2.8
Enabling logging of all modules.
2022-05-13 02:51:46,471 - tuxemon.rumble - ERROR - No rumble backends available.
> action add_monster agnite,1
2022-05-13 02:51:57,967 - tuxemon.technique - ERROR - Cannot find animation frames for: darkfire
[]
> action add_monster agnite,1
2022-05-13 02:51:58,246 - tuxemon.technique - ERROR - Cannot find animation frames for: darkfire
[]
> action add_monster agnite,1
2022-05-13 02:51:58,512 - tuxemon.technique - ERROR - Cannot find animation frames for: darkfire
[]
> action add_monster agnite,1
2022-05-13 02:51:58,754 - tuxemon.technique - ERROR - Cannot find animation frames for: darkfire
[]
> action add_monster agnite,1
2022-05-13 02:51:59,006 - tuxemon.technique - ERROR - Cannot find animation frames for: darkfire
[]
> action add_monster agnite,1
2022-05-13 02:51:59,248 - tuxemon.technique - ERROR - Cannot find animation frames for: darkfire
[]
> action add_monster agnite,1
2022-05-13 02:51:59,520 - tuxemon.technique - ERROR - Cannot find animation frames for: darkfire
[<tuxemon.monster.Monster object at 0x000002038471A7C0>]
> action add_monster agnite,1
2022-05-13 02:51:59,750 - tuxemon.technique - ERROR - Cannot find animation frames for: darkfire
[<tuxemon.monster.Monster object at 0x000002038471A7C0>, <tuxemon.monster.Monster object at 0x0000020384759A30>]
> action add_monster agnite,1
2022-05-13 02:52:00,027 - tuxemon.technique - ERROR - Cannot find animation frames for: darkfire
[<tuxemon.monster.Monster object at 0x000002038471A7C0>, <tuxemon.monster.Monster object at 0x0000020384759A30>, <tuxemon.monster.Monster object at 0x00000203847B25B0>]
> action add_monster agnite,1
2022-05-13 02:52:00,309 - tuxemon.technique - ERROR - Cannot find animation frames for: darkfire
[<tuxemon.monster.Monster object at 0x000002038471A7C0>, <tuxemon.monster.Monster object at 0x0000020384759A30>, <tuxemon.monster.Monster object at 0x00000203847B25B0>, <tuxemon.monster.Monster object at 0x000002038436F5E0>]
> action add_monster agnite,1
2022-05-13 02:52:00,557 - tuxemon.technique - ERROR - Cannot find animation frames for: darkfire
[<tuxemon.monster.Monster object at 0x000002038471A7C0>, <tuxemon.monster.Monster object at 0x0000020384759A30>, <tuxemon.monster.Monster object at 0x00000203847B25B0>, <tuxemon.monster.Monster object at 0x000002038436F5E0>, <tuxemon.monster.Monster object at 0x0000020384391340>]
> action add_monster agnite,1
2022-05-13 02:52:00,808 - tuxemon.technique - ERROR - Cannot find animation frames for: darkfire
[<tuxemon.monster.Monster object at 0x000002038471A7C0>, <tuxemon.monster.Monster object at 0x0000020384759A30>, <tuxemon.monster.Monster object at 0x00000203847B25B0>, <tuxemon.monster.Monster object at 0x000002038436F5E0>, <tuxemon.monster.Monster object at 0x0000020384391340>, <tuxemon.monster.Monster object at 0x0000020384773730>]
```