### PR TITLE
Add/remove strange collisions in spyder route 3, fixes #1189

### DIFF
--- a/mods/tuxemon/maps/spyder_route3.tmx
+++ b/mods/tuxemon/maps/spyder_route3.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="685">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="686">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -85,7 +85,6 @@
   <object id="480" type="collision" x="528" y="0" width="32" height="80"/>
   <object id="481" type="collision" x="560" y="0" width="32" height="96"/>
   <object id="482" type="collision" x="592" y="0" width="32" height="32"/>
-  <object id="483" type="collision" x="512" y="64" width="16" height="16"/>
   <object id="484" type="collision" x="0" y="0" width="528" height="32"/>
   <object id="485" type="collision" x="32" y="240" width="144" height="16"/>
   <object id="486" type="collision" x="176" y="224" width="112" height="16"/>
@@ -302,6 +301,9 @@
   <object id="677" type="collision" x="96" y="80" width="32" height="16"/>
   <object id="678" type="collision-line" x="240" y="496">
    <polyline points="0,0 16,0"/>
+  </object>
+  <object id="685" type="collision-line" x="432" y="80">
+   <polyline points="0,0 0,16"/>
   </object>
  </objectgroup>
  <objectgroup color="#ffff00" id="7" name="Events">


### PR DESCRIPTION
Adds the missing collision mentioned in #1189, and removes a strange collision in the middle of the grass just above the boulder that I noticed, too. 