### PR TITLE
Add pydantic models for input validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,11 @@ schemas: tuxemon/db.py
 	PYTHONPATH=. python scripts/schema.py --generate
 
 # Validate all JSON data in db
+.PHONY: validate
 validate:
 	PYTHONPATH=. python scripts/schema.py --validate
+
+# Run the game
+.PHONY: run
+run:
+	python ./run_tuxemon.py

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+# Generate JSON schemas for all DB models
+.PHONY: schemas
+schemas: tuxemon/db.py
+	mkdir -p schemas
+	PYTHONPATH=. python scripts/schema.py --generate
+
+# Validate all JSON data in db
+validate:
+	PYTHONPATH=. python scripts/schema.py --validate

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ natsort
 PyYAML>=5.4.1
 prompt_toolkit
 pygame_menu>=4.2.8
+pydantic>=1.9.1

--- a/schemas/economy-schema.json
+++ b/schemas/economy-schema.json
@@ -1,0 +1,50 @@
+{
+  "title": "EconomyModel",
+  "type": "object",
+  "properties": {
+    "slug": {
+      "title": "Slug",
+      "description": "Slug uniquely identifying the economy",
+      "type": "string"
+    },
+    "items": {
+      "title": "Items",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/EconomyItemModel"
+      }
+    }
+  },
+  "required": [
+    "slug",
+    "items"
+  ],
+  "definitions": {
+    "EconomyItemModel": {
+      "title": "EconomyItemModel",
+      "type": "object",
+      "properties": {
+        "item_name": {
+          "title": "Item Name",
+          "description": "Name of the item",
+          "type": "string"
+        },
+        "price": {
+          "title": "Price",
+          "description": "Price of the item",
+          "default": 0,
+          "type": "integer"
+        },
+        "cost": {
+          "title": "Cost",
+          "description": "Cost of the item",
+          "default": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "item_name"
+      ]
+    }
+  }
+}

--- a/schemas/encounter-schema.json
+++ b/schemas/encounter-schema.json
@@ -1,0 +1,54 @@
+{
+  "title": "EncounterModel",
+  "type": "object",
+  "properties": {
+    "slug": {
+      "title": "Slug",
+      "description": "Slug to uniquely identify this encounter",
+      "type": "string"
+    },
+    "monsters": {
+      "title": "Monsters",
+      "description": "Monsters encounterable",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/EncounterItemModel"
+      }
+    }
+  },
+  "required": [
+    "slug"
+  ],
+  "definitions": {
+    "EncounterItemModel": {
+      "title": "EncounterItemModel",
+      "type": "object",
+      "properties": {
+        "monster": {
+          "title": "Monster",
+          "description": "Monster slug for this encounter",
+          "type": "string"
+        },
+        "encounter_rate": {
+          "title": "Encounter Rate",
+          "description": "Rate of this encounter",
+          "type": "number"
+        },
+        "level_range": {
+          "title": "Level Range",
+          "description": "Level range to encounter",
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        }
+      },
+      "required": [
+        "monster",
+        "encounter_rate",
+        "level_range"
+      ]
+    }
+  }
+}

--- a/schemas/environment-schema.json
+++ b/schemas/environment-schema.json
@@ -1,0 +1,46 @@
+{
+  "title": "EnvironmentModel",
+  "type": "object",
+  "properties": {
+    "slug": {
+      "title": "Slug",
+      "description": "Slug of the name of the environment",
+      "type": "string"
+    },
+    "battle_music": {
+      "title": "Battle Music",
+      "description": "Filename of the music to use for this environment",
+      "type": "string"
+    },
+    "battle_graphics": {
+      "$ref": "#/definitions/BattleGraphicsModel"
+    }
+  },
+  "required": [
+    "slug",
+    "battle_music",
+    "battle_graphics"
+  ],
+  "definitions": {
+    "BattleGraphicsModel": {
+      "title": "BattleGraphicsModel",
+      "type": "object",
+      "properties": {
+        "island_back": {
+          "title": "Island Back",
+          "description": "Sprite used for back combat",
+          "type": "string"
+        },
+        "island_front": {
+          "title": "Island Front",
+          "description": "Sprite used for front combat",
+          "type": "string"
+        }
+      },
+      "required": [
+        "island_back",
+        "island_front"
+      ]
+    }
+  }
+}

--- a/schemas/inventory-schema.json
+++ b/schemas/inventory-schema.json
@@ -1,0 +1,22 @@
+{
+  "title": "InventoryModel",
+  "type": "object",
+  "properties": {
+    "slug": {
+      "title": "Slug",
+      "description": "Slug uniquely identifying the inventory",
+      "type": "string"
+    },
+    "inventory": {
+      "title": "Inventory",
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer"
+      }
+    }
+  },
+  "required": [
+    "slug",
+    "inventory"
+  ]
+}

--- a/schemas/item-schema.json
+++ b/schemas/item-schema.json
@@ -1,0 +1,122 @@
+{
+  "title": "Item",
+  "type": "object",
+  "properties": {
+    "slug": {
+      "title": "Slug",
+      "description": "Slug to use",
+      "type": "string"
+    },
+    "use_item": {
+      "title": "Use Item",
+      "description": "Slug to determine which text is displayed when this item is used",
+      "type": "string"
+    },
+    "use_success": {
+      "title": "Use Success",
+      "description": "Slug to determine which text is displayed when this item is used successfully",
+      "default": "generic_success",
+      "type": "string"
+    },
+    "use_failure": {
+      "title": "Use Failure",
+      "description": "Slug to determine which text is displayed when this item failed to be used",
+      "default": "generic_failure",
+      "type": "string"
+    },
+    "sort": {
+      "description": "The kind of item this is.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ItemSort"
+        }
+      ]
+    },
+    "sprite": {
+      "title": "Sprite",
+      "description": "The sprite to use",
+      "type": "string"
+    },
+    "target": {
+      "title": "Target",
+      "description": "Target mapping of who to use the item on",
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer"
+      }
+    },
+    "type": {
+      "description": "The type of item this is",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ItemType"
+        }
+      ]
+    },
+    "usable_in": {
+      "description": "State(s) where this item can be used.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/State"
+      }
+    },
+    "conditions": {
+      "title": "Conditions",
+      "description": "Conditions that must be met",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "effects": {
+      "title": "Effects",
+      "description": "Effects this item will have",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "slug",
+    "use_item",
+    "sort",
+    "sprite",
+    "target",
+    "type",
+    "usable_in"
+  ],
+  "definitions": {
+    "ItemSort": {
+      "title": "ItemSort",
+      "description": "An enumeration.",
+      "enum": [
+        "food",
+        "potion",
+        "utility",
+        "quest"
+      ],
+      "type": "string"
+    },
+    "ItemType": {
+      "title": "ItemType",
+      "description": "An enumeration.",
+      "enum": [
+        "Consumable",
+        "KeyItem"
+      ],
+      "type": "string"
+    },
+    "State": {
+      "title": "State",
+      "description": "An enumeration.",
+      "enum": [
+        "MainCombatMenuState",
+        "WorldState",
+        ""
+      ]
+    }
+  }
+}

--- a/schemas/monster-schema.json
+++ b/schemas/monster-schema.json
@@ -1,0 +1,231 @@
+{
+  "title": "MonsterModel",
+  "type": "object",
+  "properties": {
+    "slug": {
+      "title": "Slug",
+      "description": "The slug of the monster",
+      "type": "string"
+    },
+    "category": {
+      "title": "Category",
+      "description": "The category of monster",
+      "type": "string"
+    },
+    "ai": {
+      "title": "Ai",
+      "description": "The AI to use for this monster",
+      "type": "string"
+    },
+    "weight": {
+      "title": "Weight",
+      "description": "The weight of the monster",
+      "type": "number"
+    },
+    "sprites": {
+      "$ref": "#/definitions/MonsterSpritesModel"
+    },
+    "shape": {
+      "title": "Shape",
+      "description": "The shape of the monster",
+      "default": "",
+      "type": "string"
+    },
+    "types": {
+      "title": "Types",
+      "description": "The type(s) of this monster",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "catch_rate": {
+      "title": "Catch Rate",
+      "description": "The catch rate of the monster",
+      "default": 0,
+      "type": "number"
+    },
+    "lower_catch_resistance": {
+      "title": "Lower Catch Resistance",
+      "description": "The lower catch resistance of the monster",
+      "default": 0,
+      "type": "number"
+    },
+    "upper_catch_resistance": {
+      "title": "Upper Catch Resistance",
+      "description": "The upper catch resistance of the monster",
+      "default": 0,
+      "type": "number"
+    },
+    "moveset": {
+      "title": "Moveset",
+      "description": "The moveset of this monster",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/MonsterMovesetItemModel"
+      }
+    },
+    "evolutions": {
+      "title": "Evolutions",
+      "description": "The evolutions this monster has",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/MonsterEvolutionItemModel"
+      }
+    },
+    "flairs": {
+      "title": "Flairs",
+      "description": "The flairs this monster has",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/MonsterFlairItemModel"
+      }
+    },
+    "sounds": {
+      "title": "Sounds",
+      "description": "The sounds this monster has",
+      "default": {
+        "combat_call": "sound_cry1",
+        "faint_call": "sound_faint1"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/MonsterSoundsModel"
+        }
+      ]
+    }
+  },
+  "required": [
+    "slug",
+    "category",
+    "ai",
+    "weight"
+  ],
+  "definitions": {
+    "MonsterSpritesModel": {
+      "title": "MonsterSpritesModel",
+      "type": "object",
+      "properties": {
+        "battle1": {
+          "title": "Battle1",
+          "description": "The battle1 sprite",
+          "type": "string"
+        },
+        "battle2": {
+          "title": "Battle2",
+          "description": "The battle2 sprite",
+          "type": "string"
+        },
+        "menu1": {
+          "title": "Menu1",
+          "description": "The menu1 sprite",
+          "type": "string"
+        },
+        "menu2": {
+          "title": "Menu2",
+          "description": "The menu2 sprite",
+          "type": "string"
+        }
+      },
+      "required": [
+        "battle1",
+        "battle2",
+        "menu1",
+        "menu2"
+      ]
+    },
+    "MonsterMovesetItemModel": {
+      "title": "MonsterMovesetItemModel",
+      "type": "object",
+      "properties": {
+        "level_learned": {
+          "title": "Level Learned",
+          "description": "Monster level in which this moveset is learned",
+          "type": "integer"
+        },
+        "technique": {
+          "title": "Technique",
+          "description": "Name of the technique for this moveset item",
+          "type": "string"
+        }
+      },
+      "required": [
+        "level_learned",
+        "technique"
+      ]
+    },
+    "MonsterEvolutionItemModel": {
+      "title": "MonsterEvolutionItemModel",
+      "type": "object",
+      "properties": {
+        "path": {
+          "title": "Path",
+          "description": "Path to evolution item",
+          "type": "string"
+        },
+        "at_level": {
+          "title": "At Level",
+          "description": "The level at which this item can be used for evolution",
+          "type": "integer"
+        },
+        "monster_slug": {
+          "title": "Monster Slug",
+          "description": "The monster slug that this evolution item applies to",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "at_level",
+        "monster_slug"
+      ]
+    },
+    "MonsterFlairItemModel": {
+      "title": "MonsterFlairItemModel",
+      "type": "object",
+      "properties": {
+        "category": {
+          "title": "Category",
+          "description": "The category of this flair item",
+          "type": "string"
+        },
+        "names": {
+          "title": "Names",
+          "description": "The names",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "category",
+        "names"
+      ]
+    },
+    "MonsterSoundsModel": {
+      "title": "MonsterSoundsModel",
+      "type": "object",
+      "properties": {
+        "combat_call": {
+          "title": "Combat Call",
+          "description": "The sound used when entering combat",
+          "type": "string"
+        },
+        "faint_call": {
+          "title": "Faint Call",
+          "description": "The sound used when the monster faints",
+          "type": "string"
+        }
+      },
+      "required": [
+        "combat_call",
+        "faint_call"
+      ]
+    }
+  }
+}

--- a/schemas/npc-schema.json
+++ b/schemas/npc-schema.json
@@ -1,0 +1,75 @@
+{
+  "title": "NpcModel",
+  "type": "object",
+  "properties": {
+    "slug": {
+      "title": "Slug",
+      "description": "Slug of the name of the NPC",
+      "type": "string"
+    },
+    "sprite_name": {
+      "title": "Sprite Name",
+      "description": "Name of the overworld sprite filename",
+      "type": "string"
+    },
+    "combat_front": {
+      "title": "Combat Front",
+      "description": "Name of the battle front sprite filename",
+      "type": "string"
+    },
+    "combat_back": {
+      "title": "Combat Back",
+      "description": "Name of the battle back sprite filename",
+      "type": "string"
+    },
+    "monsters": {
+      "title": "Monsters",
+      "description": "List of monsters in the NPCs party",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PartyMemberModel"
+      }
+    }
+  },
+  "required": [
+    "slug",
+    "sprite_name",
+    "combat_front",
+    "combat_back"
+  ],
+  "definitions": {
+    "PartyMemberModel": {
+      "title": "PartyMemberModel",
+      "type": "object",
+      "properties": {
+        "slug": {
+          "title": "Slug",
+          "description": "Slug of the monster",
+          "type": "string"
+        },
+        "level": {
+          "title": "Level",
+          "description": "Level of the monster",
+          "type": "integer"
+        },
+        "exp_give_mod": {
+          "title": "Exp Give Mod",
+          "description": "Modifier for experience this monster gives",
+          "type": "number"
+        },
+        "exp_req_mod": {
+          "title": "Exp Req Mod",
+          "description": "Experience required modifier",
+          "type": "number"
+        }
+      },
+      "required": [
+        "slug",
+        "level",
+        "exp_give_mod",
+        "exp_req_mod"
+      ]
+    }
+  }
+}

--- a/schemas/technique-schema.json
+++ b/schemas/technique-schema.json
@@ -137,7 +137,7 @@
     "userstatspeed": {
       "$ref": "#/definitions/StatModel"
     },
-    "usertathp": {
+    "userstathp": {
       "$ref": "#/definitions/StatModel"
     },
     "userstatarmour": {

--- a/schemas/technique-schema.json
+++ b/schemas/technique-schema.json
@@ -1,0 +1,209 @@
+{
+  "title": "TechniqueModel",
+  "type": "object",
+  "properties": {
+    "slug": {
+      "title": "Slug",
+      "description": "The slug of the technique",
+      "type": "string"
+    },
+    "sort": {
+      "title": "Sort",
+      "description": "The sort of technique this is",
+      "type": "string"
+    },
+    "category": {
+      "title": "Category",
+      "description": "The category of technique this is",
+      "type": "string"
+    },
+    "icon": {
+      "title": "Icon",
+      "description": "The icon to use for the technique",
+      "type": "string"
+    },
+    "effects": {
+      "title": "Effects",
+      "description": "Effects this technique uses",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "target": {
+      "title": "Target",
+      "description": "Target mapping of who this technique is used on",
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer"
+      }
+    },
+    "animation": {
+      "title": "Animation",
+      "description": "Animation to play for this technique",
+      "type": "string"
+    },
+    "sfx": {
+      "title": "Sfx",
+      "description": "Sound effect to play when this technique is used",
+      "type": "string"
+    },
+    "use_tech": {
+      "title": "Use Tech",
+      "description": "Slug of what string to display when technique is used",
+      "type": "string"
+    },
+    "use_success": {
+      "title": "Use Success",
+      "description": "Slug of what string to display when technique succeeds",
+      "type": "string"
+    },
+    "use_failure": {
+      "title": "Use Failure",
+      "description": "Slug of what string to display when technique fails",
+      "type": "string"
+    },
+    "types": {
+      "title": "Types",
+      "description": "Type(s) of the technique",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "power": {
+      "title": "Power",
+      "description": "Power of the technique",
+      "default": 0,
+      "type": "number"
+    },
+    "is_fast": {
+      "title": "Is Fast",
+      "description": "Whether or not this is a fast technique",
+      "default": false,
+      "type": "boolean"
+    },
+    "is_area": {
+      "title": "Is Area",
+      "description": "Whether or not this is an area of effect technique",
+      "default": false,
+      "type": "boolean"
+    },
+    "recharge": {
+      "title": "Recharge",
+      "description": "Recharge of this technique",
+      "default": 0,
+      "type": "integer"
+    },
+    "range": {
+      "description": "The attack range of this technique",
+      "default": "melee",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Range"
+        }
+      ]
+    },
+    "accuracy": {
+      "title": "Accuracy",
+      "description": "The accuracy of the technique",
+      "default": 0,
+      "type": "number"
+    },
+    "potency": {
+      "title": "Potency",
+      "description": "How potetent the technique is",
+      "type": "number"
+    },
+    "statspeed": {
+      "$ref": "#/definitions/StatModel"
+    },
+    "stathp": {
+      "$ref": "#/definitions/StatModel"
+    },
+    "statarmour": {
+      "$ref": "#/definitions/StatModel"
+    },
+    "statdodge": {
+      "$ref": "#/definitions/StatModel"
+    },
+    "statmelee": {
+      "$ref": "#/definitions/StatModel"
+    },
+    "statranged": {
+      "$ref": "#/definitions/StatModel"
+    },
+    "userstatspeed": {
+      "$ref": "#/definitions/StatModel"
+    },
+    "usertathp": {
+      "$ref": "#/definitions/StatModel"
+    },
+    "userstatarmour": {
+      "$ref": "#/definitions/StatModel"
+    },
+    "userstatdodge": {
+      "$ref": "#/definitions/StatModel"
+    },
+    "userstatmelee": {
+      "$ref": "#/definitions/StatModel"
+    },
+    "userstatranged": {
+      "$ref": "#/definitions/StatModel"
+    }
+  },
+  "required": [
+    "slug",
+    "sort",
+    "category",
+    "icon",
+    "effects",
+    "target",
+    "sfx"
+  ],
+  "definitions": {
+    "Range": {
+      "title": "Range",
+      "description": "An enumeration.",
+      "enum": [
+        "special",
+        "melee",
+        "ranged",
+        "touch",
+        "reach",
+        "reliable"
+      ],
+      "type": "string"
+    },
+    "StatModel": {
+      "title": "StatModel",
+      "type": "object",
+      "properties": {
+        "value": {
+          "title": "Value",
+          "description": "The value of the stat",
+          "type": "integer"
+        },
+        "max_deviation": {
+          "title": "Max Deviation",
+          "description": "The maximum deviation of the stat",
+          "type": "integer"
+        },
+        "operation": {
+          "title": "Operation",
+          "description": "The operation to be done to the stat",
+          "type": "string"
+        },
+        "overridetofull": {
+          "title": "Overridetofull",
+          "description": "Whether or not to override to full",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "operation"
+      ]
+    }
+  }
+}

--- a/scripts/schema.py
+++ b/scripts/schema.py
@@ -44,11 +44,17 @@ if __name__ == "__main__":
         print(f"Writing JSON schemas to '{args.output}'...")
         with open(os.path.join(args.output, "economy-schema.json"), "w") as f:
             f.write(EconomyModel.schema_json(indent=2))
-        with open(os.path.join(args.output, "encounter-schema.json"), "w") as f:
+        with open(
+            os.path.join(args.output, "encounter-schema.json"), "w"
+        ) as f:
             f.write(EncounterModel.schema_json(indent=2))
-        with open(os.path.join(args.output, "environment-schema.json"), "w") as f:
+        with open(
+            os.path.join(args.output, "environment-schema.json"), "w"
+        ) as f:
             f.write(EnvironmentModel.schema_json(indent=2))
-        with open(os.path.join(args.output, "inventory-schema.json"), "w") as f:
+        with open(
+            os.path.join(args.output, "inventory-schema.json"), "w"
+        ) as f:
             f.write(InventoryModel.schema_json(indent=2))
         with open(os.path.join(args.output, "item-schema.json"), "w") as f:
             f.write(ItemModel.schema_json(indent=2))
@@ -56,7 +62,9 @@ if __name__ == "__main__":
             f.write(MonsterModel.schema_json(indent=2))
         with open(os.path.join(args.output, "npc-schema.json"), "w") as f:
             f.write(NpcModel.schema_json(indent=2))
-        with open(os.path.join(args.output, "technique-schema.json"), "w") as f:
+        with open(
+            os.path.join(args.output, "technique-schema.json"), "w"
+        ) as f:
             f.write(TechniqueModel.schema_json(indent=2))
 
     if args.validate:

--- a/scripts/schema.py
+++ b/scripts/schema.py
@@ -1,0 +1,63 @@
+#!/usr/bin/python
+
+import os
+from argparse import ArgumentParser
+from tuxemon.db import (
+    db,
+    EconomyModel,
+    EncounterModel,
+    EnvironmentModel,
+    InventoryModel,
+    ItemModel,
+    MonsterModel,
+    NpcModel,
+    TechniqueModel,
+)
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument(
+        "-g",
+        "--generate",
+        dest="generate",
+        action="store_true",
+        default=False,
+        help="Generate JSON schemas",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        dest="output",
+        default="schemas",
+        help="Schema output directory",
+    )
+    parser.add_argument(
+        "--validate",
+        dest="validate",
+        action="store_true",
+        default=False,
+        help="Validate all JSON entries in db",
+    )
+    args = parser.parse_args()
+
+    if args.generate:
+        print(f"Writing JSON schemas to '{args.output}'...")
+        with open(os.path.join(args.output, "economy-schema.json"), "w") as f:
+            f.write(EconomyModel.schema_json(indent=2))
+        with open(os.path.join(args.output, "encounter-schema.json"), "w") as f:
+            f.write(EncounterModel.schema_json(indent=2))
+        with open(os.path.join(args.output, "environment-schema.json"), "w") as f:
+            f.write(EnvironmentModel.schema_json(indent=2))
+        with open(os.path.join(args.output, "inventory-schema.json"), "w") as f:
+            f.write(InventoryModel.schema_json(indent=2))
+        with open(os.path.join(args.output, "item-schema.json"), "w") as f:
+            f.write(ItemModel.schema_json(indent=2))
+        with open(os.path.join(args.output, "monster-schema.json"), "w") as f:
+            f.write(MonsterModel.schema_json(indent=2))
+        with open(os.path.join(args.output, "npc-schema.json"), "w") as f:
+            f.write(NpcModel.schema_json(indent=2))
+        with open(os.path.join(args.output, "technique-schema.json"), "w") as f:
+            f.write(TechniqueModel.schema_json(indent=2))
+
+    if args.validate:
+        db.load(validate=True)

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -255,6 +255,15 @@ class TechniqueModel(BaseModel):
     userstatmelee: Optional[StatModel] = Field(None)
     userstatranged: Optional[StatModel] = Field(None)
 
+    # Custom validation for range
+    @validator("range")
+    def range_validation(cls, v, values, **kwargs):
+        # Special indicates that we are not doing damage
+        if v == Range.special and "damage" in values["effects"]:
+            raise ValueError('"special" range cannot be used with effect "damage"')
+
+        return v
+
 
 class PartyMemberModel(BaseModel):
     slug: str = Field(..., description="Slug of the monster")

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -249,7 +249,7 @@ class TechniqueModel(BaseModel):
     statmelee: Optional[StatModel] = Field(None)
     statranged: Optional[StatModel] = Field(None)
     userstatspeed: Optional[StatModel] = Field(None)
-    usertathp: Optional[StatModel] = Field(None)
+    userstathp: Optional[StatModel] = Field(None)
     userstatarmour: Optional[StatModel] = Field(None)
     userstatdodge: Optional[StatModel] = Field(None)
     userstatmelee: Optional[StatModel] = Field(None)

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -34,7 +34,16 @@ import logging
 import os
 from enum import Enum
 from operator import itemgetter
-from typing import Any, Dict, Literal, Mapping, Optional, Sequence, TypedDict, overload
+from typing import (
+    Any,
+    Dict,
+    Literal,
+    Mapping,
+    Optional,
+    Sequence,
+    TypedDict,
+    overload,
+)
 
 from pydantic import BaseModel, Field, ValidationError, validator
 
@@ -83,13 +92,19 @@ class ItemModel(BaseModel):
     )
     sort: ItemSort = Field(..., description="The kind of item this is.")
     sprite: str = Field(..., description="The sprite to use")
-    target: Target = Field(..., description="Target mapping of who to use the item on")
+    target: Target = Field(
+        ..., description="Target mapping of who to use the item on"
+    )
     type: ItemType = Field(..., description="The type of item this is")
     usable_in: Sequence[State] = Field(
         ..., description="State(s) where this item can be used."
     )
-    conditions: Sequence[str] = Field([], description="Conditions that must be met")
-    effects: Sequence[str] = Field([], description="Effects this item will have")
+    conditions: Sequence[str] = Field(
+        [], description="Conditions that must be met"
+    )
+    effects: Sequence[str] = Field(
+        [], description="Effects this item will have"
+    )
 
     class Config:
         title = "Item"
@@ -113,7 +128,8 @@ class MonsterMovesetItemModel(BaseModel):
 class MonsterEvolutionItemModel(BaseModel):
     path: str = Field(..., description="Path to evolution item")
     at_level: int = Field(
-        ..., description="The level at which this item can be used for evolution"
+        ...,
+        description="The level at which this item can be used for evolution",
     )
     monster_slug: str = Field(
         ..., description="The monster slug that this evolution item applies to"
@@ -133,8 +149,12 @@ class MonsterSpritesModel(BaseModel):
 
 
 class MonsterSoundsModel(BaseModel):
-    combat_call: str = Field(..., description="The sound used when entering combat")
-    faint_call: str = Field(..., description="The sound used when the monster faints")
+    combat_call: str = Field(
+        ..., description="The sound used when entering combat"
+    )
+    faint_call: str = Field(
+        ..., description="The sound used when the monster faints"
+    )
 
 
 class MonsterModel(BaseModel):
@@ -164,7 +184,9 @@ class MonsterModel(BaseModel):
         [], description="The flairs this monster has"
     )
     sounds: MonsterSoundsModel = Field(
-        MonsterSoundsModel(combat_call="sound_cry1", faint_call="sound_faint1"),
+        MonsterSoundsModel(
+            combat_call="sound_cry1", faint_call="sound_faint1"
+        ),
         description="The sounds this monster has",
     )
 
@@ -191,7 +213,9 @@ class StatModel(BaseModel):
     max_deviation: Optional[int] = Field(
         None, description="The maximum deviation of the stat"
     )
-    operation: str = Field(..., description="The operation to be done to the stat")
+    operation: str = Field(
+        ..., description="The operation to be done to the stat"
+    )
     overridetofull: Optional[bool] = Field(
         None, description="Whether or not to override to full"
     )
@@ -211,7 +235,9 @@ class TechniqueModel(BaseModel):
     sort: str = Field(..., description="The sort of technique this is")
     category: str = Field(..., description="The category of technique this is")
     icon: str = Field(..., description="The icon to use for the technique")
-    effects: Sequence[str] = Field(..., description="Effects this technique uses")
+    effects: Sequence[str] = Field(
+        ..., description="Effects this technique uses"
+    )
     target: Target = Field(
         ..., description="Target mapping of who this technique is used on"
     )
@@ -224,24 +250,32 @@ class TechniqueModel(BaseModel):
 
     # Optional fields
     use_tech: str = Field(
-        None, description="Slug of what string to display when technique is used"
+        None,
+        description="Slug of what string to display when technique is used",
     )
     use_success: str = Field(
-        None, description="Slug of what string to display when technique succeeds"
+        None,
+        description="Slug of what string to display when technique succeeds",
     )
     use_failure: str = Field(
         None, description="Slug of what string to display when technique fails"
     )
     types: Sequence[str] = Field([], description="Type(s) of the technique")
     power: float = Field(0, description="Power of the technique")
-    is_fast: bool = Field(False, description="Whether or not this is a fast technique")
+    is_fast: bool = Field(
+        False, description="Whether or not this is a fast technique"
+    )
     is_area: bool = Field(
         False, description="Whether or not this is an area of effect technique"
     )
     recharge: int = Field(0, description="Recharge of this technique")
-    range: Range = Field("melee", description="The attack range of this technique")
+    range: Range = Field(
+        "melee", description="The attack range of this technique"
+    )
     accuracy: float = Field(0, description="The accuracy of the technique")
-    potency: Optional[float] = Field(None, description="How potetent the technique is")
+    potency: Optional[float] = Field(
+        None, description="How potetent the technique is"
+    )
     statspeed: Optional[StatModel] = Field(None)
     stathp: Optional[StatModel] = Field(None)
     statarmour: Optional[StatModel] = Field(None)
@@ -260,7 +294,9 @@ class TechniqueModel(BaseModel):
     def range_validation(cls, v, values, **kwargs):
         # Special indicates that we are not doing damage
         if v == Range.special and "damage" in values["effects"]:
-            raise ValueError('"special" range cannot be used with effect "damage"')
+            raise ValueError(
+                '"special" range cannot be used with effect "damage"'
+            )
 
         return v
 
@@ -276,11 +312,15 @@ class PartyMemberModel(BaseModel):
 
 class NpcModel(BaseModel):
     slug: str = Field(..., description="Slug of the name of the NPC")
-    sprite_name: str = Field(..., description="Name of the overworld sprite filename")
+    sprite_name: str = Field(
+        ..., description="Name of the overworld sprite filename"
+    )
     combat_front: str = Field(
         ..., description="Name of the battle front sprite filename"
     )
-    combat_back: str = Field(..., description="Name of the battle back sprite filename")
+    combat_back: str = Field(
+        ..., description="Name of the battle back sprite filename"
+    )
     monsters: Sequence[PartyMemberModel] = Field(
         [], description="List of monsters in the NPCs party"
     )
@@ -302,18 +342,24 @@ class EnvironmentModel(BaseModel):
 class EncounterItemModel(BaseModel):
     monster: str = Field(..., description="Monster slug for this encounter")
     encounter_rate: float = Field(..., description="Rate of this encounter")
-    level_range: Sequence[int] = Field(..., description="Level range to encounter")
+    level_range: Sequence[int] = Field(
+        ..., description="Level range to encounter"
+    )
 
 
 class EncounterModel(BaseModel):
-    slug: str = Field(..., description="Slug to uniquely identify this encounter")
+    slug: str = Field(
+        ..., description="Slug to uniquely identify this encounter"
+    )
     monsters: Sequence[EncounterItemModel] = Field(
         [], description="Monsters encounterable"
     )
 
 
 class InventoryModel(BaseModel):
-    slug: str = Field(..., description="Slug uniquely identifying the inventory")
+    slug: str = Field(
+        ..., description="Slug uniquely identifying the inventory"
+    )
     inventory: Mapping[str, Optional[int]] = Field(...)
 
 
@@ -458,7 +504,9 @@ class JSONDatabase:
         """
 
         if item["slug"] in self.database[table]:
-            logger.warning("Error: Item with slug %s was already loaded.", item)
+            logger.warning(
+                "Error: Item with slug %s was already loaded.", item
+            )
             return
 
         try:

--- a/tuxemon/event/actions/create_npc.py
+++ b/tuxemon/event/actions/create_npc.py
@@ -85,7 +85,7 @@ class CreateNpcAction(EventAction[CreateNpcActionParameters]):
                 slug,
             )
         else:
-            sprite = db.database["npc"][slug].get("sprite_name")
+            sprite = db.lookup(slug, "npc").sprite_name
 
         # Create a new NPC object
         npc = tuxemon.npc.NPC(slug, sprite_name=sprite, world=world)

--- a/tuxemon/event/actions/random_encounter.py
+++ b/tuxemon/event/actions/random_encounter.py
@@ -141,7 +141,9 @@ def _choose_encounter(
     total = 0.0
     roll = random.random() * 100
     if total_prob is not None:
-        current_total = sum(encounter["encounter_rate"] for encounter in encounters)
+        current_total = sum(
+            encounter["encounter_rate"] for encounter in encounters
+        )
         scale = float(total_prob) / current_total
     else:
         scale = 1

--- a/tuxemon/event/actions/random_encounter.py
+++ b/tuxemon/event/actions/random_encounter.py
@@ -77,7 +77,7 @@ class RandomEncounterAction(EventAction[RandomEncounterActionParameters]):
             return
 
         slug = self.parameters.encounter_slug
-        encounters = db.lookup(slug, table="encounter")["monsters"]
+        encounters = db.lookup(slug, table="encounter").dict()["monsters"]
         encounter = _choose_encounter(encounters, self.parameters.total_prob)
 
         # If a random encounter was successfully rolled, look up the monster
@@ -92,7 +92,7 @@ class RandomEncounterAction(EventAction[RandomEncounterActionParameters]):
             env_slug = "grass"
             if "environment" in player.game_variables:
                 env_slug = player.game_variables["environment"]
-            env = db.lookup(env_slug, table="environment")
+            env = db.lookup(env_slug, table="environment").dict()
 
             # Add our players and setup combat
             # "queueing" it will mean it starts after the top of the stack

--- a/tuxemon/event/actions/random_encounter.py
+++ b/tuxemon/event/actions/random_encounter.py
@@ -25,7 +25,7 @@ import random
 
 from tuxemon import ai, monster, prepare
 from tuxemon.combat import check_battle_legal
-from tuxemon.db import db, JSONEncounterItem
+from tuxemon.db import db, EncounterItemModel
 from tuxemon.event.eventaction import EventAction
 from tuxemon.npc import NPC
 from typing import NamedTuple, Union, final, Sequence, Optional
@@ -133,16 +133,15 @@ class RandomEncounterAction(EventAction[RandomEncounterActionParameters]):
         if self.world:
             self.world.remove_entity("random_encounter_dummy")
 
+
 def _choose_encounter(
-    encounters: Sequence[JSONEncounterItem],
+    encounters: Sequence[EncounterItemModel],
     total_prob: Optional[float],
-) -> Optional[JSONEncounterItem]:
+) -> Optional[EncounterItemModel]:
     total = 0.0
     roll = random.random() * 100
     if total_prob is not None:
-        current_total = sum(
-            encounter["encounter_rate"] for encounter in encounters
-        )
+        current_total = sum(encounter["encounter_rate"] for encounter in encounters)
         scale = float(total_prob) / current_total
     else:
         scale = 1
@@ -158,7 +157,7 @@ def _choose_encounter(
 
 
 def _create_monster_npc(
-    encounter: JSONEncounterItem,
+    encounter: EncounterItemModel,
     world: WorldState,
 ) -> NPC:
     current_monster = monster.Monster()

--- a/tuxemon/event/actions/set_inventory.py
+++ b/tuxemon/event/actions/set_inventory.py
@@ -58,9 +58,13 @@ class SetInventoryAction(EventAction[SetInventoryActionParameters]):
             npc.inventory = {}
             return
 
-        entry = db.lookup(
-            self.parameters.inventory_slug,
-            table="inventory",
-        ).get("inventory", {})
+        entry = (
+            db.lookup(
+                self.parameters.inventory_slug,
+                table="inventory",
+            )
+            .dict()
+            .get("inventory", {})
+        )
 
         npc.inventory = decode_inventory(self.session, npc, entry)

--- a/tuxemon/event/actions/start_battle.py
+++ b/tuxemon/event/actions/start_battle.py
@@ -59,7 +59,7 @@ class StartBattleAction(EventAction[StartBattleActionParameters]):
 
         # Don't start a battle if we don't even have monsters in our party yet.
         if not check_battle_legal(player):
-            logger.debug("battle is not legal, won't start")
+            logger.warning("battle is not legal, won't start")
             return
 
         world = self.session.client.get_state_by_name(WorldState)
@@ -67,16 +67,17 @@ class StartBattleAction(EventAction[StartBattleActionParameters]):
         npc = world.get_entity(self.parameters.npc_slug)
         assert npc
         if len(npc.monsters) == 0:
+            logger.warning("npc has no monsters, won't start")
             return
 
         # Lookup the environment
         env_slug = "grass"
         if "environment" in player.game_variables:
             env_slug = player.game_variables["environment"]
-        env = db.lookup(env_slug, table="environment")
+        env = db.lookup(env_slug, table="environment").dict()
 
         # Add our players and setup combat
-        logger.debug("Starting battle!")
+        logger.info("Starting battle!")
         self.session.client.push_state(
             CombatState,
             players=(player, npc),

--- a/tuxemon/event/actions/update_inventory.py
+++ b/tuxemon/event/actions/update_inventory.py
@@ -67,6 +67,8 @@ class UpdateInventoryAction(EventAction[UpdateInventoryActionParameters]):
                 db.lookup(
                     self.parameters.inventory_slug,
                     table="inventory",
-                ).get("inventory", {})
+                )
+                .dict()
+                .get("inventory", {}),
             )
         )

--- a/tuxemon/item/economy.py
+++ b/tuxemon/item/economy.py
@@ -101,7 +101,8 @@ class Economy:
 
         if not price:
             raise RuntimeError(
-                f"Price for item '{item_slug}' not found in " f"economy '{self.slug}'"
+                f"Price for item '{item_slug}' not found in "
+                f"economy '{self.slug}'"
             )
 
         return price
@@ -122,7 +123,8 @@ class Economy:
 
         if not cost:
             raise RuntimeError(
-                f"Cost for item '{item_slug}' not found in " f"economy '{self.slug}'"
+                f"Cost for item '{item_slug}' not found in "
+                f"economy '{self.slug}'"
             )
 
         return cost

--- a/tuxemon/item/economy.py
+++ b/tuxemon/item/economy.py
@@ -39,12 +39,9 @@ logger = logging.getLogger(__name__)
 
 class Economy:
     """An Economy holds a list of item names and their price/cost for this
-    economy. """
+    economy."""
 
-    def __init__(
-        self,
-        slug: Optional[str] = None
-    ) -> None:
+    def __init__(self, slug: Optional[str] = None) -> None:
 
         # Auto-load the economy from the economy database.
         if slug:
@@ -61,7 +58,7 @@ class Economy:
         """
 
         try:
-            results = db.lookup(slug, table="economy")
+            results = db.lookup(slug, table="economy").dict()
         except KeyError:
             raise RuntimeError(f"Failed to find economy with slug {slug}")
 
@@ -104,8 +101,7 @@ class Economy:
 
         if not price:
             raise RuntimeError(
-                f"Price for item '{item_slug}' not found in "
-                f"economy '{self.slug}'"
+                f"Price for item '{item_slug}' not found in " f"economy '{self.slug}'"
             )
 
         return price
@@ -126,8 +122,7 @@ class Economy:
 
         if not cost:
             raise RuntimeError(
-                f"Cost for item '{item_slug}' not found in "
-                f"economy '{self.slug}'"
+                f"Cost for item '{item_slug}' not found in " f"economy '{self.slug}'"
             )
 
         return cost

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -42,8 +42,17 @@ from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
 from tuxemon.item.itemcondition import ItemCondition
 from tuxemon.session import Session
 
-from typing import Mapping, Any, Type, Optional, Sequence, Dict, TYPE_CHECKING,\
-    ClassVar, TypedDict
+from typing import (
+    Mapping,
+    Any,
+    Type,
+    Optional,
+    Sequence,
+    Dict,
+    TYPE_CHECKING,
+    ClassVar,
+    TypedDict,
+)
 import pygame
 
 if TYPE_CHECKING:
@@ -83,8 +92,13 @@ class Item:
         self.type: Optional[str] = None
         self.sfx = None
         self.sprite = ""  # The path to the sprite to load.
-        self.surface: Optional[pygame.surface.Surface] = None  # The pygame.Surface object of the item.
-        self.surface_size_original = (0, 0)  # The original size of the image before scaling.
+        self.surface: Optional[
+            pygame.surface.Surface
+        ] = None  # The pygame.Surface object of the item.
+        self.surface_size_original = (
+            0,
+            0,
+        )  # The original size of the image before scaling.
 
         self.effects: Sequence[ItemEffect[Any]] = []
         self.conditions: Sequence[ItemCondition[Any]] = []
@@ -123,14 +137,16 @@ class Item:
         """
 
         try:
-            results = db.lookup(slug, table="item")
+            results = db.lookup(slug, table="item").dict()
         except KeyError:
             logger.error(msg=f"Failed to find item with slug {slug}")
             return
 
         self.slug = results["slug"]  # short English identifier
         self.name = T.translate(self.slug)  # translated name
-        self.description = T.translate(f"{self.slug}_description")  # will be locale string
+        self.description = T.translate(
+            f"{self.slug}_description"
+        )  # will be locale string
 
         # item use notifications (translated!)
         self.use_item = T.translate(results["use_item"])
@@ -280,7 +296,9 @@ class Item:
             meta_result.update(result)
 
         # If this is a consumable item, remove it from the player's inventory.
-        if (prepare.CONFIG.items_consumed_on_failure or meta_result["success"]) and self.type == "Consumable":
+        if (
+            prepare.CONFIG.items_consumed_on_failure or meta_result["success"]
+        ) and self.type == "Consumable":
             if user.inventory[self.slug]["quantity"] <= 1:
                 del user.inventory[self.slug]
             else:

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -576,7 +576,7 @@ class Monster:
         if len(self.flairs) > 0 or self.slug == "":
             return
 
-        results = db.lookup(self.slug, table="monster")
+        results = db.lookup(self.slug, table="monster").dict()
         flairs = results.get("flairs")
         if flairs:
             for flair in flairs:
@@ -606,7 +606,7 @@ class Monster:
         except OSError:
             pass
 
-        logger.debug(f"Could not find monster sprite {sprite}")
+        logger.error(f"Could not find monster sprite {sprite}")
         return MISSING_IMAGE
 
     def load_sprites(self) -> bool:

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -33,7 +33,7 @@ import random
 import uuid
 
 from tuxemon import ai, fusion, graphics
-from tuxemon.db import db, JSONMonsterMovesetItem, JSONMonsterEvolutionItem
+from tuxemon.db import db, MonsterMovesetItemModel, MonsterEvolutionItemModel
 from tuxemon.locale import T
 from tuxemon.technique import Technique
 from tuxemon.config import TuxemonConfig
@@ -201,7 +201,9 @@ class Monster:
         self.name = ""  # The display name of the Tuxemon
         self.category = ""
         self.description = ""
-        self.instance_id = uuid.uuid4()  # unique id for this specific, individual tuxemon
+        self.instance_id = (
+            uuid.uuid4()
+        )  # unique id for this specific, individual tuxemon
 
         self.armour = 0
         self.dodge = 0
@@ -213,10 +215,18 @@ class Monster:
         self.level = 0
 
         self.moves: List[Technique] = []  # list of technique objects. Used in combat.
-        self.moveset: List[JSONMonsterMovesetItem] = []  # list of possible technique objects.
-        self.evolutions: List[JSONMonsterEvolutionItem] = []  # list of possible evolution objects.
-        self.flairs: Dict[str, Flair] = {}  # dictionary of flairs, one is picked randomly.
-        self.battle_cry = ""  # slug for a sound file, used primarly when they enter battle
+        self.moveset: List[
+            MonsterMovesetItemModel
+        ] = []  # list of possible technique objects.
+        self.evolutions: List[
+            MonsterEvolutionItemModel
+        ] = []  # list of possible evolution objects.
+        self.flairs: Dict[
+            str, Flair
+        ] = {}  # dictionary of flairs, one is picked randomly.
+        self.battle_cry = (
+            ""  # slug for a sound file, used primarly when they enter battle
+        )
         self.faint_cry = ""  # slug for a sound file, used when the monster faints
         self.ai: Optional[ai.AI] = None
         self.owner: Optional[NPC] = None  # set to NPC instance if they own it
@@ -243,8 +253,12 @@ class Monster:
 
         # The catch_resistance value is calculated during the capture. The upper and lower catch_resistance
         # set the span on which the catch_resistance will be. For more imformation check capture.py
-        self.upper_catch_resistance = TuxemonConfig().default_upper_monster_catch_resistance
-        self.lower_catch_Resistance = TuxemonConfig().default_lower_monster_catch_resistance
+        self.upper_catch_resistance = (
+            TuxemonConfig().default_upper_monster_catch_resistance
+        )
+        self.lower_catch_Resistance = (
+            TuxemonConfig().default_lower_monster_catch_resistance
+        )
 
         # The tuxemon's state is used for various animations, etc. For example
         # a tuxemon's state might be "attacking" or "fainting" so we know when
@@ -286,7 +300,9 @@ class Monster:
 
         father_tech_count = len(father.moves)
         tech_to_replace = random.randrange(0, 2)
-        child.moves[tech_to_replace] = father.moves[random.randrange(0, father_tech_count - 1)]
+        child.moves[tech_to_replace] = father.moves[
+            random.randrange(0, father_tech_count - 1)
+        ]
 
         return child
 
@@ -302,15 +318,17 @@ class Monster:
         """
 
         # Look up the monster by name and set the attributes in this instance
-        results = db.lookup(slug, table="monster")
+        results = db.lookup(slug, table="monster").dict()
 
         if results is None:
             logger.error(f"monster {slug} is not found")
             raise RuntimeError
-        self.level = random.randint(2,5)
+        self.level = random.randint(2, 5)
         self.slug = results["slug"]  # short English identifier
         self.name = T.translate(results["slug"])  # translated name
-        self.description = T.translate("{}_description".format(results["slug"]))  # translated description
+        self.description = T.translate(
+            "{}_description".format(results["slug"])
+        )  # translated description
         self.category = T.translate(results["category"])  # translated category
         self.shape = results.get("shape", "landrace").lower()
         types = results.get("types")
@@ -355,8 +373,12 @@ class Monster:
         self.menu_sprite_2 = self.get_sprite_path(results["sprites"]["menu2"])
 
         # get sound slugs for this monster, defaulting to a generic type-based sound
-        self.combat_call = results.get("sounds", {}).get("combat_call", f"sound_{self.type1}_call")
-        self.faint_call = results.get("sounds", {}).get("faint_call", f"sound_{self.type1}_faint")
+        self.combat_call = results.get("sounds", {}).get(
+            "combat_call", f"sound_{self.type1}_call"
+        )
+        self.faint_call = results.get("sounds", {}).get(
+            "faint_call", f"sound_{self.type1}_faint"
+        )
 
         # Load the monster AI
         # TODO: clean up AI 'core' loading and what not
@@ -443,7 +465,9 @@ class Monster:
         Increases a Monster's level by one and increases stats accordingly.
 
         """
-        logger.info("Leveling %s from %i to %i!" % (self.name, self.level, self.level + 1))
+        logger.info(
+            "Leveling %s from %i to %i!" % (self.name, self.level, self.level + 1)
+        )
         # Increase Level and stats
         self.level += 1
         self.level = min(self.level, MAX_LEVEL)
@@ -452,7 +476,9 @@ class Monster:
         # Learn New Moves
         for move in self.moveset:
             if move["level_learned"] == self.level:
-                logger.info("{} learned technique {}!".format(self.name, move["technique"]))
+                logger.info(
+                    "{} learned technique {}!".format(self.name, move["technique"])
+                )
                 technique = Technique(move["technique"])
                 self.learn(technique)
 
@@ -491,7 +517,7 @@ class Monster:
             Required experience.
 
         """
-        return self.experience_required_modifier * (self.level + level_ofs)**3
+        return self.experience_required_modifier * (self.level + level_ofs) ** 3
 
     def get_evolution(self, path: str) -> Optional[str]:
         """
@@ -504,7 +530,9 @@ class Monster:
         for evolution in self.evolutions:
             if evolution["path"] == path:
                 level_over = 0 < evolution["at_level"] <= self.level
-                level_under = evolution["at_level"] < 0 and self.level <= -evolution["at_level"]
+                level_under = (
+                    evolution["at_level"] < 0 and self.level <= -evolution["at_level"]
+                )
                 if level_over or level_under:
                     return evolution["monster_slug"]
         return None
@@ -526,13 +554,17 @@ class Monster:
         elif sprite == "back":
             surface = graphics.load_sprite(self.back_battle_sprite, **kwargs)
         elif sprite == "menu":
-            surface = graphics.load_animated_sprite([self.menu_sprite_1, self.menu_sprite_2], 0.25, **kwargs)
+            surface = graphics.load_animated_sprite(
+                [self.menu_sprite_1, self.menu_sprite_2], 0.25, **kwargs
+            )
         else:
             raise ValueError(f"Cannot find sprite for: {sprite}")
 
         # Apply flairs to the monster sprite
         for flair in self.flairs.values():
-            flair_path = self.get_sprite_path(f"gfx/sprites/battle/{self.slug}-{sprite}-{flair.name}")
+            flair_path = self.get_sprite_path(
+                f"gfx/sprites/battle/{self.slug}-{sprite}-{flair.name}"
+            )
             if flair_path != MISSING_IMAGE:
                 flair_sprite = graphics.load_sprite(flair_path, **kwargs)
                 surface.image.blit(flair_sprite.image, (0, 0))
@@ -601,7 +633,11 @@ class Monster:
             Dictionary containing all the information about the monster.
 
         """
-        save_data = {attr: getattr(self, attr) for attr in SIMPLE_PERSISTANCE_ATTRIBUTES if getattr(self, attr)}
+        save_data = {
+            attr: getattr(self, attr)
+            for attr in SIMPLE_PERSISTANCE_ATTRIBUTES
+            if getattr(self, attr)
+        }
 
         save_data["instance_id"] = self.instance_id.hex
 

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -214,7 +214,9 @@ class Monster:
         self.hp = 0
         self.level = 0
 
-        self.moves: List[Technique] = []  # list of technique objects. Used in combat.
+        self.moves: List[
+            Technique
+        ] = []  # list of technique objects. Used in combat.
         self.moveset: List[
             MonsterMovesetItemModel
         ] = []  # list of possible technique objects.
@@ -227,7 +229,9 @@ class Monster:
         self.battle_cry = (
             ""  # slug for a sound file, used primarly when they enter battle
         )
-        self.faint_cry = ""  # slug for a sound file, used when the monster faints
+        self.faint_cry = (
+            ""  # slug for a sound file, used when the monster faints
+        )
         self.ai: Optional[ai.AI] = None
         self.owner: Optional[NPC] = None  # set to NPC instance if they own it
 
@@ -367,8 +371,12 @@ class Monster:
                 self.evolutions.append(evolution)
 
         # Look up the monster's sprite image paths
-        self.front_battle_sprite = self.get_sprite_path(results["sprites"]["battle1"])
-        self.back_battle_sprite = self.get_sprite_path(results["sprites"]["battle2"])
+        self.front_battle_sprite = self.get_sprite_path(
+            results["sprites"]["battle1"]
+        )
+        self.back_battle_sprite = self.get_sprite_path(
+            results["sprites"]["battle2"]
+        )
         self.menu_sprite_1 = self.get_sprite_path(results["sprites"]["menu1"])
         self.menu_sprite_2 = self.get_sprite_path(results["sprites"]["menu2"])
 
@@ -466,7 +474,8 @@ class Monster:
 
         """
         logger.info(
-            "Leveling %s from %i to %i!" % (self.name, self.level, self.level + 1)
+            "Leveling %s from %i to %i!"
+            % (self.name, self.level, self.level + 1)
         )
         # Increase Level and stats
         self.level += 1
@@ -477,7 +486,9 @@ class Monster:
         for move in self.moveset:
             if move["level_learned"] == self.level:
                 logger.info(
-                    "{} learned technique {}!".format(self.name, move["technique"])
+                    "{} learned technique {}!".format(
+                        self.name, move["technique"]
+                    )
                 )
                 technique = Technique(move["technique"])
                 self.learn(technique)
@@ -517,7 +528,9 @@ class Monster:
             Required experience.
 
         """
-        return self.experience_required_modifier * (self.level + level_ofs) ** 3
+        return (
+            self.experience_required_modifier * (self.level + level_ofs) ** 3
+        )
 
     def get_evolution(self, path: str) -> Optional[str]:
         """
@@ -531,7 +544,8 @@ class Monster:
             if evolution["path"] == path:
                 level_over = 0 < evolution["at_level"] <= self.level
                 level_under = (
-                    evolution["at_level"] < 0 and self.level <= -evolution["at_level"]
+                    evolution["at_level"] < 0
+                    and self.level <= -evolution["at_level"]
                 )
                 if level_over or level_under:
                     return evolution["monster_slug"]
@@ -620,7 +634,9 @@ class Monster:
         if len(self.sprites):
             return True
 
-        self.sprites["front"] = graphics.load_and_scale(self.front_battle_sprite)
+        self.sprites["front"] = graphics.load_and_scale(
+            self.front_battle_sprite
+        )
         self.sprites["back"] = graphics.load_and_scale(self.back_battle_sprite)
         self.sprites["menu"] = graphics.load_and_scale(self.menu_sprite_1)
         return False

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -169,7 +169,9 @@ class NPC(Entity[NPCState]):
         self.monsters: List[
             Monster
         ] = []  # This is a list of tuxemon the npc has. Do not modify directly
-        self.inventory: Dict[str, InventoryItem] = {}  # The Player's inventory.
+        self.inventory: Dict[
+            str, InventoryItem
+        ] = {}  # The Player's inventory.
         # Variables for long-term item and monster storage
         # Keeping these seperate so other code can safely
         # assume that all values are lists
@@ -203,7 +205,9 @@ class NPC(Entity[NPCState]):
         self.move_direction: Optional[
             Direction
         ] = None  # Set this value to move the npc (see below)
-        self.facing: Direction = "down"  # Set this value to change the facing direction
+        self.facing: Direction = (
+            "down"  # Set this value to change the facing direction
+        )
         self.moverate = CONFIG.player_walkrate  # walk by default
         self.ignore_collisions = False
 
@@ -275,13 +279,17 @@ class NPC(Entity[NPCState]):
         """
         self.facing = save_data.get("facing", "down")
         self.game_variables = save_data["game_variables"]
-        self.inventory = decode_inventory(session, self, save_data.get("inventory", {}))
+        self.inventory = decode_inventory(
+            session, self, save_data.get("inventory", {})
+        )
         self.monsters = decode_monsters(save_data.get("monsters"))
         self.name = save_data["player_name"]
         for monsterkey, monstervalue in save_data["monster_boxes"].items():
             self.monster_boxes[monsterkey] = decode_monsters(monstervalue)
         for itemkey, itemvalue in save_data["item_boxes"].items():
-            self.item_boxes[itemkey] = decode_inventory(session, self, itemvalue)
+            self.item_boxes[itemkey] = decode_inventory(
+                session, self, itemvalue
+            )
 
     def load_sprites(self) -> None:
         """Load sprite graphics."""
@@ -316,7 +324,9 @@ class NPC(Entity[NPCState]):
                 surface = load_and_scale(image)
                 frames.append((surface, frame_duration))
 
-            self.sprite[anim_type] = surfanim.SurfaceAnimation(frames, loop=True)
+            self.sprite[anim_type] = surfanim.SurfaceAnimation(
+                frames, loop=True
+            )
 
         # Have the animation objects managed by a SurfaceAnimationCollection.
         # With the SurfaceAnimationCollection, we can call play() and stop() on
@@ -379,7 +389,9 @@ class NPC(Entity[NPCState]):
 
     def check_continue(self) -> None:
         try:
-            direction_next = self.world.collision_map[self.tile_pos]["continue"]
+            direction_next = self.world.collision_map[self.tile_pos][
+                "continue"
+            ]
             self.move_one_tile(direction_next)
         except (KeyError, TypeError):
             pass
@@ -506,7 +518,9 @@ class NPC(Entity[NPCState]):
             direction: Direction where to move.
 
         """
-        self.path.append(vector2_to_tile_pos(Vector2(self.tile_pos) + dirs2[direction]))
+        self.path.append(
+            vector2_to_tile_pos(Vector2(self.tile_pos) + dirs2[direction])
+        )
 
     def valid_movement(self, tile: Tuple[int, int]) -> bool:
         """
@@ -522,7 +536,10 @@ class NPC(Entity[NPCState]):
             If the tile can me moved into.
 
         """
-        return tile in self.world.get_exits(self.tile_pos) or self.ignore_collisions
+        return (
+            tile in self.world.get_exits(self.tile_pos)
+            or self.ignore_collisions
+        )
 
     @property
     def move_destination(self) -> Optional[Tuple[int, int]]:
@@ -630,7 +647,9 @@ class NPC(Entity[NPCState]):
         """
         monster.owner = self
         if len(self.monsters) >= self.party_limit:
-            self.monster_boxes[CONFIG.default_monster_storage_box].append(monster)
+            self.monster_boxes[CONFIG.default_monster_storage_box].append(
+                monster
+            )
         else:
             self.monsters.append(monster)
             self.set_party_status()
@@ -663,9 +682,13 @@ class NPC(Entity[NPCState]):
             Monster found, or None.
 
         """
-        return next((m for m in self.monsters if m.instance_id == instance_id), None)
+        return next(
+            (m for m in self.monsters if m.instance_id == instance_id), None
+        )
 
-    def find_monster_in_storage(self, instance_id: uuid.UUID) -> Optional[Monster]:
+    def find_monster_in_storage(
+        self, instance_id: uuid.UUID
+    ) -> Optional[Monster]:
         """
         Finds a monster in the npc's storage boxes which has the given id.
 
@@ -678,7 +701,9 @@ class NPC(Entity[NPCState]):
         """
         monster = None
         for box in self.monster_boxes.values():
-            monster = next((m for m in box if m.instance_id == instance_id), None)
+            monster = next(
+                (m for m in box if m.instance_id == instance_id), None
+            )
             if monster is not None:
                 break
 
@@ -752,8 +777,12 @@ class NPC(Entity[NPCState]):
         npc_party = npc_details.get("monsters") or []
         for npc_monster_details in npc_party:
             monster = Monster(save_data=npc_monster_details)
-            monster.experience_give_modifier = npc_monster_details["exp_give_mod"]
-            monster.experience_required_modifier = npc_monster_details["exp_req_mod"]
+            monster.experience_give_modifier = npc_monster_details[
+                "exp_give_mod"
+            ]
+            monster.experience_required_modifier = npc_monster_details[
+                "exp_req_mod"
+            ]
             monster.set_level(monster.level)
             monster.current_hp = monster.hp
 

--- a/tuxemon/state.py
+++ b/tuxemon/state.py
@@ -305,10 +305,9 @@ class StateManager:
             changes.
 
     """
+
     def __init__(
-        self,
-        package: str,
-        on_state_change: Optional[Callable[[], None]] = None
+        self, package: str, on_state_change: Optional[Callable[[], None]] = None
     ) -> None:
         self.package = package
         # TODO: consider API for handling hooks
@@ -701,10 +700,7 @@ class StateManager:
 
         """
         for state in self.active_states:
-            if (
-                state.__class__.__name__ == state_name
-                or state.__class__ == state_name
-            ):
+            if state.__class__.__name__ == state_name or state.__class__ == state_name:
                 return state
 
         raise ValueError(f"Missing state {state_name}")

--- a/tuxemon/state.py
+++ b/tuxemon/state.py
@@ -307,7 +307,9 @@ class StateManager:
     """
 
     def __init__(
-        self, package: str, on_state_change: Optional[Callable[[], None]] = None
+        self,
+        package: str,
+        on_state_change: Optional[Callable[[], None]] = None,
     ) -> None:
         self.package = package
         # TODO: consider API for handling hooks
@@ -700,7 +702,10 @@ class StateManager:
 
         """
         for state in self.active_states:
-            if state.__class__.__name__ == state_name or state.__class__ == state_name:
+            if (
+                state.__class__.__name__ == state_name
+                or state.__class__ == state_name
+            ):
                 return state
 
         raise ValueError(f"Missing state {state_name}")

--- a/tuxemon/technique.py
+++ b/tuxemon/technique.py
@@ -40,6 +40,7 @@ from tuxemon.graphics import animation_frame_files
 from tuxemon.locale import T
 from typing import Optional, Sequence, TYPE_CHECKING, TypedDict, List, Tuple
 import operator
+
 if TYPE_CHECKING:
     from tuxemon.monster import Monster
 
@@ -86,6 +87,7 @@ class Technique:
             For example, monster that obtains life with lifeleech.
 
     """
+
     def __init__(
         self,
         slug: Optional[str] = None,
@@ -123,7 +125,6 @@ class Technique:
         self.use_tech = ""
         self.old_stats_data: List[Sequence[int]] = []
 
-
         # If a slug of the technique was provided, autoload it.
         if slug:
             self.load(slug)
@@ -137,7 +138,7 @@ class Technique:
             The slug of the technique to look up in the database.
         """
 
-        results = db.lookup(slug, table="technique")
+        results = db.lookup(slug, table="technique").dict()
         self.slug = results["slug"]  # a short English identifier
         self.name = T.translate(self.slug)  # locale-specific string
 
@@ -165,7 +166,6 @@ class Technique:
             self.type1 = self.type2 = None
 
         self.power = results.get("power", self.power)
-
 
         self.statspeed = results.get("statspeed")
         self.stathp = results.get("stathp")
@@ -224,10 +224,16 @@ class Technique:
 
     def keep_old_stats(self) -> Sequence[Sequence[int]]:
         mon = self.target
-        self.old_stats_data.append([
-            mon.speed, mon.hp, mon.armour,
-            mon.melee, mon.ranged, mon.dodge,
-        ])
+        self.old_stats_data.append(
+            [
+                mon.speed,
+                mon.hp,
+                mon.armour,
+                mon.melee,
+                mon.ranged,
+                mon.dodge,
+            ]
+        )
         return self.old_stats_data
 
     def use(self, user: Monster, target: Monster) -> TechniqueResult:
@@ -319,18 +325,22 @@ class Technique:
 
         """
         statsmaster = [
-            self.statspeed, self.stathp, self.statarmour,
-            self.statmelee, self.statranged, self.statdodge,
+            self.statspeed,
+            self.stathp,
+            self.statarmour,
+            self.statmelee,
+            self.statranged,
+            self.statdodge,
         ]
-        statslugs = ['speed', 'hp', 'armour', 'melee', 'ranged', 'dodge']
+        statslugs = ["speed", "hp", "armour", "melee", "ranged", "dodge"]
         newstatvalue = 0
         for stat, slugdata in zip(statsmaster, statslugs):
             if not stat:
                 continue
-            value = stat.get('value', 0)
-            max_deviation = stat.get('max_deviation', 0)
-            operation = stat.get('operation', '+')
-            override = stat.get('overridetofull', False)
+            value = stat.get("value", 0)
+            max_deviation = stat.get("max_deviation", 0)
+            operation = stat.get("operation", "+")
+            override = stat.get("overridetofull", False)
             basestatvalue = getattr(target, slugdata)
             if max_deviation:
                 value = random.randint(
@@ -347,7 +357,7 @@ class Technique:
                 }
                 newstatvalue = ops_dict[operation](basestatvalue, value)
                 setattr(target, slugdata, newstatvalue)
-            if slugdata == 'hp':
+            if slugdata == "hp":
                 if override:
                     target.current_hp = target.hp
                 newstatvalue = 1
@@ -355,9 +365,7 @@ class Technique:
             if newstatvalue <= 0:
                 newstatvalue = 1
                 setattr(target, slugdata, newstatvalue)
-        return {
-            "success": bool(newstatvalue)
-        }
+        return {"success": bool(newstatvalue)}
 
     def calculate_damage(
         self,
@@ -450,9 +458,7 @@ class Technique:
             Dict summarizing the result.
 
         """
-        already_applied = any(
-            t for t in target.status if t.slug == "status_lifeleech"
-        )
+        already_applied = any(t for t in target.status if t.slug == "status_lifeleech")
         success = not already_applied and self.potency >= random.random()
         tech = None
         if success:
@@ -508,9 +514,7 @@ class Technique:
         """
         # TODO: implement into the combat state, currently not used
 
-        already_fainted = any(
-            t for t in target.status if t.name == "status_faint"
-        )
+        already_fainted = any(t for t in target.status if t.name == "status_faint")
 
         if already_fainted:
             raise RuntimeError

--- a/tuxemon/technique.py
+++ b/tuxemon/technique.py
@@ -94,7 +94,9 @@ class Technique:
         carrier: Optional[Monster] = None,
         link: Optional[Monster] = None,
     ) -> None:
-        self._combat_counter = 0  # number of turns that this technique has been active
+        self._combat_counter = (
+            0  # number of turns that this technique has been active
+        )
         self._life_counter = 0
         self.accuracy = 0.0
         self.animation = ""
@@ -458,7 +460,9 @@ class Technique:
             Dict summarizing the result.
 
         """
-        already_applied = any(t for t in target.status if t.slug == "status_lifeleech")
+        already_applied = any(
+            t for t in target.status if t.slug == "status_lifeleech"
+        )
         success = not already_applied and self.potency >= random.random()
         tech = None
         if success:
@@ -514,7 +518,9 @@ class Technique:
         """
         # TODO: implement into the combat state, currently not used
 
-        already_fainted = any(t for t in target.status if t.name == "status_faint")
+        already_fainted = any(
+            t for t in target.status if t.name == "status_faint"
+        )
 
         if already_fainted:
             raise RuntimeError


### PR DESCRIPTION
This PR refactors `db.py` to use [pydantic](https://pydantic-docs.helpmanual.io/) data models to validate JSON defined in the db directory.

This gives us a few benefits:

* Validates whether or not some given JSON conforms to the correct schema.
* Can generate JSON schemas to allow auto-complete of JSON data in an editor.
* Allows us to use custom validation functions like ensuring sprites exist, translation slugs exist, etc.

I'll be continually improving the validation to provide more stronger validation to prevent crashes due to malformed data.