### PR TITLE
Shops: Make buying items cost money, and don't allow buying items unless you have enough money

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -607,6 +607,9 @@ msgstr "Move"
 msgid "monster_menu_release"
 msgstr "Release"
 
+msgid "shop_buy_free"
+msgstr "FREE!"
+
 #Release notifications
 msgid "cant_release"
 msgstr "Can't release only Tuxemon in party."

--- a/mods/tuxemon/maps/player_house_bedroom.yaml
+++ b/mods/tuxemon/maps/player_house_bedroom.yaml
@@ -9,11 +9,6 @@ events:
     width: 1
     x: 8
     y: 3
-  Player Spawn:
-    height: 1
-    width: 1
-    x: 4
-    y: 5
   Use Computer:
     actions:
     - change_state PCState
@@ -25,3 +20,20 @@ events:
     width: 1
     x: 4
     y: 3
+    type: "event"
+  Give Money:
+    actions:
+    - variable_math money,+,1000000
+    - set_variable xero_starting_money:yes
+    conditions:
+    - not variable_set xero_starting_money:yes
+    height: 1
+    width: 1
+    x: 2
+    y: 1
+    type: "event"
+  Player Spawn:
+    height: 1
+    width: 1
+    x: 4
+    y: 5

--- a/mods/tuxemon/maps/spyder_bedroom.tmx
+++ b/mods/tuxemon/maps/spyder_bedroom.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.5" tiledversion="1.7.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="11" height="9" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="28">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="11" height="9" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="29">
  <tileset firstgid="1" name="floors and walls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>
  </tileset>
@@ -67,6 +67,13 @@
     <property name="act1" value="translated_dialog spyder_papertown_restinbed"/>
     <property name="act2" value="set_monster_health ,"/>
     <property name="act3" value="set_monster_status ,"/>
+   </properties>
+  </object>
+  <object id="28" name="Give Starting Money" type="event" x="32" y="16" width="16" height="16">
+   <properties>
+    <property name="act30" value="variable_math money,+,1000000"/>
+    <property name="act40" value="set_variable spyder_starting_money:yes"/>
+    <property name="cond1" value="not variable_set spyder_starting_money:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/tuxemon/item/economy.py
+++ b/tuxemon/item/economy.py
@@ -100,7 +100,7 @@ class Economy:
         """
         price = self.lookup_item_field(item_slug, "price")
 
-        if not price:
+        if price is None:
             raise RuntimeError(
                 f"Price for item '{item_slug}' not found in "
                 f"economy '{self.slug}'"
@@ -122,7 +122,7 @@ class Economy:
         """
         cost = self.lookup_item_field(item_slug, "cost")
 
-        if not cost:
+        if cost is None:
             raise RuntimeError(
                 f"Cost for item '{item_slug}' not found in "
                 f"economy '{self.slug}'"

--- a/tuxemon/menu/quantity.py
+++ b/tuxemon/menu/quantity.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Callable, Generator, Optional
 
+from tuxemon.locale import T
 from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.menu import Menu
 from tuxemon.platform.const import buttons, intentions
@@ -114,6 +115,8 @@ class QuantityAndPriceMenu(QuantityMenu):
         price = (
             self.price if self.quantity == 0 else self.quantity * self.price
         )
+        if int(price) == 0:
+            price = T.translate("shop_buy_free")
 
         formatted_name = label_format(price, count_len=count_len)
         image = self.shadow_text(formatted_name, bg=(128, 128, 128))

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -909,7 +909,7 @@ class NPC(Entity[NPCState]):
 
         # Only players will have money in game_variables, so only update money
         # if it exists:
-        if self.game_variables.get("money"):
+        if self.game_variables.get("money") is not None:
             self.game_variables["money"] += qty * unit_price
 
     def buy_transaction(

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -848,8 +848,8 @@ class NPC(Entity[NPCState]):
         return success
 
     def can_buy_item(self, item_slug: str, qty: int, unit_price: int) -> bool:
-        current_money = self.game_variables["money"]
-        if current_money:
+        current_money = self.game_variables.get("money", None)
+        if current_money != None:
             return current_money >= qty * unit_price
         # If no 'money' variable, must be an NPC. Always allow buying:
         return True
@@ -875,9 +875,9 @@ class NPC(Entity[NPCState]):
 
         Raises an exception if there's not enough money to pay the price."""
 
-        # Only players will have game_variables, so only update money or raise
+        # Only players will have money in game_variables, so only update money or raise
         # exception if it exists:
-        if self.game_variables:
+        if self.game_variables.get("money", None):
             if not self.can_buy_item(item_slug, qty, unit_price):
                 raise Exception(
                     f"Tried to buy item with {self.game_variables['money']} coins "
@@ -907,9 +907,9 @@ class NPC(Entity[NPCState]):
                 f"Tried to sell item of qty {qty}, but not enough available."
             )
 
-        # Only players will have game_variables, so only update money
+        # Only players will have money in game_variables, so only update money
         # if it exists:
-        if self.game_variables:
+        if self.game_variables.get("money", None):
             self.game_variables["money"] += qty * unit_price
 
     def buy_transaction(

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -848,8 +848,8 @@ class NPC(Entity[NPCState]):
         return success
 
     def can_buy_item(self, item_slug: str, qty: int, unit_price: int) -> bool:
-        current_money = self.game_variables.get("money", None)
-        if current_money != None:
+        current_money = self.game_variables.get("money")
+        if current_money is not None:
             return current_money >= qty * unit_price
         # If no 'money' variable, must be an NPC. Always allow buying:
         return True
@@ -877,7 +877,7 @@ class NPC(Entity[NPCState]):
 
         # Only players will have money in game_variables, so only update money or raise
         # exception if it exists:
-        if self.game_variables.get("money", None):
+        if self.game_variables.get("money"):
             if not self.can_buy_item(item_slug, qty, unit_price):
                 raise Exception(
                     f"Tried to buy item with {self.game_variables['money']} coins "
@@ -909,7 +909,7 @@ class NPC(Entity[NPCState]):
 
         # Only players will have money in game_variables, so only update money
         # if it exists:
-        if self.game_variables.get("money", None):
+        if self.game_variables.get("money"):
             self.game_variables["money"] += qty * unit_price
 
     def buy_transaction(

--- a/tuxemon/states/items/__init__.py
+++ b/tuxemon/states/items/__init__.py
@@ -26,6 +26,7 @@
 #
 # states.ItemMenuState The item menu allows you to view and use items in your inventory.
 # states.ShopMenuState
+# states.ShopBuyMenuState Shop Buy menu allows you to buy items that cost money
 #
 from __future__ import annotations
 
@@ -405,13 +406,19 @@ class ShopBuyMenuState(ShopMenuState):
         item_dict = self.seller.inventory[item.slug]
 
         price = (
-            1
+            0
             if not self.economy
             or not self.economy.lookup_item_price(item.slug)
             else self.economy.lookup_item_price(item.slug)
         )
         money = self.buyer.game_variables.get("money")
-        qty_buyer_can_afford = int(money / price) if money else 0
+        qty_buyer_can_afford = (
+            999
+            if int(price) == 0
+            else int(money / price)
+            if money
+            else 0
+        )
         max_quantity = (
             qty_buyer_can_afford
             if item_dict.get("infinite")

--- a/tuxemon/states/items/__init__.py
+++ b/tuxemon/states/items/__init__.py
@@ -410,14 +410,8 @@ class ShopBuyMenuState(ShopMenuState):
             or not self.economy.lookup_item_price(item.slug)
             else self.economy.lookup_item_price(item.slug)
         )
-        qty_buyer_can_afford = (
-            0
-            if not (
-                self.buyer.game_variables
-                and self.buyer.game_variables["money"]
-            )
-            else int(self.buyer.game_variables["money"] / price)
-        )
+        money = self.buyer.game_variables.get("money")
+        qty_buyer_can_afford = int(money / price) if money else 0
         max_quantity = (
             qty_buyer_can_afford
             if item_dict.get("infinite")

--- a/tuxemon/states/items/__init__.py
+++ b/tuxemon/states/items/__init__.py
@@ -388,6 +388,7 @@ class ShopBuyMenuState(ShopMenuState):
             menu_item: Selected menu item.
 
         """
+        MAX_QTY = 999
         item = menu_item.game_object
 
         def buy_item(quantity: int) -> None:
@@ -411,19 +412,18 @@ class ShopBuyMenuState(ShopMenuState):
             or not self.economy.lookup_item_price(item.slug)
             else self.economy.lookup_item_price(item.slug)
         )
-        money = self.buyer.game_variables.get("money")
-        qty_buyer_can_afford = (
-            999
-            if int(price) == 0
-            else int(money / price)
-            if money
-            else 0
-        )
-        max_quantity = (
-            qty_buyer_can_afford
-            if item_dict.get("infinite")
-            else min(item_dict["quantity"], qty_buyer_can_afford)
-        )
+        money = self.buyer.game_variables.get("money", 0)
+        if int(price) == 0:
+            max_quantity = (
+                MAX_QTY
+                if item_dict.get("infinite")
+                else min(MAX_QTY, item_dict["quantity"])
+            )
+        else:
+            qty_can_afford = int(money / price)
+            max_quantity = (
+                min(MAX_QTY, qty_can_afford, item_dict["quantity"])
+            )
 
         self.client.push_state(
             QuantityAndPriceMenu,

--- a/tuxemon/states/items/__init__.py
+++ b/tuxemon/states/items/__init__.py
@@ -411,7 +411,7 @@ class ShopBuyMenuState(ShopMenuState):
             else self.economy.lookup_item_price(item.slug)
         )
         qty_buyer_can_afford = (
-            None
+            0
             if not (
                 self.buyer.game_variables
                 and self.buyer.game_variables["money"]


### PR DESCRIPTION
Currently, opening a shop shows how much everything will cost, but you can still buy everything without paying for it.

This PR stops the player from buying items unless they have enough money. 
It also exchanges money between NPC's during the buying transaction. 

It doesn't change anything for the Selling menu (if you sell something, you still don't get any money), but that should be a small PR in the future that uses the same NPC.buy_transaction function from this PR. 

This is hard to test in the normal mods so you can test on this map:
[shops_test.zip](https://github.com/Tuxemon/Tuxemon/files/8862822/shops_test.zip)

You start with no money, and walking 1 step gets you $100 on this map, so you can quickly make money and test the functions work properly. 