### PR TITLE
Fix error where translation loading for db validation failed on first start

### DIFF
--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -53,6 +53,7 @@ from tuxemon.locale import T
 logger = logging.getLogger(__name__)
 
 # Load the default translator for data validation
+T.collect_languages(prepare.CONFIG.recompile_translations)
 T.load_translator()
 
 # Target is a mapping of who this targets


### PR DESCRIPTION
This fixes an error introduced by the latest db validation change. If you had a clean locale cache in `~/.tuxemon`, the game would fail to start:

```
pygame 2.1.2 (SDL 2.0.22, Python 3.10.4)
Hello from the pygame community. https://www.pygame.org/contribute.html
pygame-menu 4.2.8
Traceback (most recent call last):
  File "/home/william/Projects/Tuxemon/run_tuxemon.py", line 32, in <module>
    from tuxemon import main, prepare
  File "/home/william/Projects/Tuxemon/tuxemon/main.py", line 35, in <module>
    from tuxemon.states.persistance.load_menu import LoadMenuState
  File "/home/william/Projects/Tuxemon/tuxemon/states/persistance/__init__.py", line 1, in <module>
    from .load_menu import LoadMenuState
  File "/home/william/Projects/Tuxemon/tuxemon/states/persistance/load_menu.py", line 34, in <module>
    from tuxemon import prepare, save
  File "/home/william/Projects/Tuxemon/tuxemon/save.py", line 44, in <module>
    from tuxemon.client import LocalPygameClient
  File "/home/william/Projects/Tuxemon/tuxemon/client.py", line 65, in <module>
    from tuxemon.states.world.worldstate import WorldState
  File "/home/william/Projects/Tuxemon/tuxemon/states/world/__init__.py", line 28, in <module>
    from .world_menus import WorldMenuState
  File "/home/william/Projects/Tuxemon/tuxemon/states/world/world_menus.py", line 41, in <module>
    from tuxemon.menu.menu import PygameMenuState
  File "/home/william/Projects/Tuxemon/tuxemon/menu/menu.py", line 22, in <module>
    from tuxemon import audio, graphics, prepare, state, tools
  File "/home/william/Projects/Tuxemon/tuxemon/audio.py", line 11, in <module>
    from tuxemon.db import db
  File "/home/william/Projects/Tuxemon/tuxemon/db.py", line 56, in <module>
    T.load_translator()
  File "/home/william/Projects/Tuxemon/tuxemon/locale.py", line 179, in load_translator
    fallback = gettext.translation("base", localedir, [FALLBACK_LOCALE])
  File "/usr/lib/python3.10/gettext.py", line 592, in translation
    raise FileNotFoundError(ENOENT,
FileNotFoundError: [Errno 2] No translation file found for domain: 'base'
```