### PR TITLE
Fix crash when swapping tuxemon in battle

### DIFF
--- a/tuxemon/technique.py
+++ b/tuxemon/technique.py
@@ -304,7 +304,7 @@ class Technique:
                     else:
                         result = getattr(self, self.category)(target)
             else:
-                result = getattr(self, str(effect))(user, target)
+                result = getattr(self, effect)(user, target)
             meta_result = merge_results(result, meta_result)
 
         self.next_use = self.recharge_length


### PR DESCRIPTION
Fixes a bug if you try to swap Tuxemon during battle, the game was crashing with the following error:

``` 
File "~/src/tuxemon/tuxemon/technique.py", line 308, in use
    result = getattr(self, str(effect))(user, target)
AttributeError: 'Technique' object has no attribute 'TechniqueEffect.swap'
```

A change in db.py recently turned technique effects from strings into TechniqueEffects, which is a string enum, apparently you don't need to cast a TechniqueEffect/string enum back to a string, just use it and it evaluates to the string 'swap'. 
Using str(effect) seems to evaluate it to 'TechniqueEffect.swap' which is weird, but this fix works on python 3.8 at least. 