### PR TITLE
Allow using items on any monster in your party during combat. Closes #794

### DIFF
--- a/mods/tuxemon/db/item/apple.json
+++ b/mods/tuxemon/db/item/apple.json
@@ -25,5 +25,6 @@
   "usable_in": [
     "MainCombatMenuState",
     "WorldState"
-  ]
+  ],
+  "battle_menu": "monster"
 }

--- a/mods/tuxemon/db/item/berry.json
+++ b/mods/tuxemon/db/item/berry.json
@@ -25,5 +25,6 @@
   "usable_in": [
     "MainCombatMenuState",
     "WorldState"
-  ]
+  ],
+  "battle_menu": "monster"
 }

--- a/mods/tuxemon/db/item/capture_device.json
+++ b/mods/tuxemon/db/item/capture_device.json
@@ -23,5 +23,6 @@
   "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState"
-  ]
+  ],
+  "battle_menu": "combat"
 }

--- a/mods/tuxemon/db/item/cherry.json
+++ b/mods/tuxemon/db/item/cherry.json
@@ -25,5 +25,6 @@
   "usable_in": [
     "MainCombatMenuState",
     "WorldState"
-  ]
+  ],
+  "battle_menu": "monster"
 }

--- a/mods/tuxemon/db/item/imperial_potion.json
+++ b/mods/tuxemon/db/item/imperial_potion.json
@@ -25,5 +25,6 @@
   "usable_in": [
     "MainCombatMenuState",
     "WorldState"
-  ]
+  ],
+  "battle_menu": "monster"
 }

--- a/mods/tuxemon/db/item/orange.json
+++ b/mods/tuxemon/db/item/orange.json
@@ -25,5 +25,6 @@
   "usable_in": [
     "MainCombatMenuState",
     "WorldState"
-  ]
+  ],
+  "battle_menu": "monster"
 }

--- a/mods/tuxemon/db/item/potion.json
+++ b/mods/tuxemon/db/item/potion.json
@@ -25,5 +25,6 @@
   "usable_in": [
     "MainCombatMenuState",
     "WorldState"
-  ]
+  ],
+  "battle_menu": "monster"
 }

--- a/mods/tuxemon/db/item/revive.json
+++ b/mods/tuxemon/db/item/revive.json
@@ -26,5 +26,6 @@
   "usable_in": [
     "MainCombatMenuState",
     "WorldState"
-  ]
+  ],
+  "battle_menu": "monster"
 }

--- a/mods/tuxemon/db/item/super_potion.json
+++ b/mods/tuxemon/db/item/super_potion.json
@@ -25,5 +25,6 @@
   "usable_in": [
     "MainCombatMenuState",
     "WorldState"
-  ]
+  ],
+  "battle_menu": "monster"
 }

--- a/schemas/item-schema.json
+++ b/schemas/item-schema.json
@@ -77,6 +77,14 @@
       "items": {
         "type": "string"
       }
+    },
+    "battle_menu": {
+      "description": "Which menu should be used to choose the target of the item",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ItemBattleMenu"
+        }
+      ]
     }
   },
   "required": [

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -35,15 +35,7 @@ import logging
 import os
 from enum import Enum
 from operator import itemgetter
-from typing import (
-    Any,
-    Dict,
-    Literal,
-    Mapping,
-    Optional,
-    Sequence,
-    overload,
-)
+from typing import Any, Dict, Literal, Mapping, Optional, Sequence, overload
 
 from pydantic import BaseModel, Field, ValidationError, validator
 
@@ -71,6 +63,12 @@ class ItemSort(str, Enum):
 class ItemType(str, Enum):
     consumable = "Consumable"
     key_item = "KeyItem"
+
+
+# ItemBattleMenu is which menu you want to use to choose the target.
+class ItemBattleMenu(str, Enum):
+    monster = "monster"
+    combat = "combat"
 
 
 # TODO: Automatically generate state enum through discovery
@@ -112,6 +110,10 @@ class ItemModel(BaseModel):
     )
     effects: Sequence[str] = Field(
         [], description="Effects this item will have"
+    )
+    ## Optional fields:
+    battle_menu: Optional[ItemBattleMenu] = Field(
+        "", description="Which menu should be used to choose the target of the item."
     )
 
     class Config:

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -104,6 +104,7 @@ class Item:
         self.use_failure = ""
         self.usable_in: Sequence[str] = []
         self.target: Sequence[str] = []
+        self.battle_menu = ""
 
         # load effect and condition plugins if it hasn't been done already
         if not Item.effects_classes:
@@ -154,6 +155,7 @@ class Item:
         self.usable_in = results["usable_in"]
         self.target = process_targets(results["target"])
         self.effects = self.parse_effects(results.get("effects", []))
+        self.battle_menu = (results["battle_menu"] if "battle_menu" in results else "")
         self.conditions = self.parse_conditions(results.get("conditions", []))
         self.surface = graphics.load_and_scale(self.sprite)
         self.surface_size_original = self.surface.get_size()

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -155,7 +155,7 @@ class Item:
         self.usable_in = results["usable_in"]
         self.target = process_targets(results["target"])
         self.effects = self.parse_effects(results.get("effects", []))
-        self.battle_menu = (results["battle_menu"] if "battle_menu" in results else "")
+        self.battle_menu = results.get("battle_menu", "")
         self.conditions = self.parse_conditions(results.get("conditions", []))
         self.surface = graphics.load_and_scale(self.sprite)
         self.surface_size_original = self.surface.get_size()

--- a/tuxemon/states/combat/combat_menus.py
+++ b/tuxemon/states/combat/combat_menus.py
@@ -145,13 +145,18 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
             self.client.pop_state()  # close the item menu
             # TODO: don't hardcode to player0
             combat_state = self.client.get_state_by_name(CombatState)
-            state = self.client.push_state(
-                CombatTargetMenuState,
-                player=combat_state.players[0],
-                user=combat_state.players[0],
-                action=item,
-            )
-            state.on_menu_selection = partial(enqueue_item, item)
+
+            if item.battle_menu == "monster":
+                state = self.client.push_state(MonsterMenuState)
+                state.on_menu_selection = partial(enqueue_item, item)
+            else:
+                state = self.client.push_state(
+                    CombatTargetMenuState,
+                    player=combat_state.players[0],
+                    user=combat_state.players[0],
+                    action=item,
+                )
+                state.on_menu_selection = partial(enqueue_item, item)
 
         def enqueue_item(item: Item, menu_item: MenuItem[Monster]) -> None:
             target = menu_item.game_object


### PR DESCRIPTION
This PR allows you to use items on any monster in your party, during a battle. 

It adds a new optional property to Items - battle_menu. 

If battle_menu is == "monster", then when you use this item during battle, the Monster menu will appear, and you can select any monster in your party to use the item on. 
If battle_menu is == "combat", or not set, then you can choose between your current monster and the enemy monster, as normal. 

I've also added battle_menu to the db.py validation and schemas/item-schema.json, which seems to work (it gets rid of the error messages) but it's my first time updating them so it could be wrong. 

Hopefully adding the battle_menu property was a good idea, but if anyone has any better suggestions I'm happy to change it to something else! 

This should close issue #794 