### PR TITLE
Small fixes and lock/unlock controls for Xero campaign

### DIFF
--- a/mods/tuxemon/maps/player_house_downstairs.tmx
+++ b/mods/tuxemon/maps/player_house_downstairs.tmx
@@ -115,6 +115,7 @@
   </object>
   <object id="32" name="announcement" type="event" x="32" y="96" width="16" height="16">
    <properties>
+    <property name="act001" value="lock_controls"/>
     <property name="act1" value="translated_dialog announcement1"/>
     <property name="act2" value="translated_dialog announcement2"/>
     <property name="act3" value="translated_dialog announcement3"/>
@@ -152,6 +153,7 @@
     <property name="act5" value="translated_dialog ohnoes2"/>
     <property name="act6" value="npc_face npc_mom,left"/>
     <property name="act7" value="set_variable comeinside:plsbedone"/>
+    <property name="act8" value="unlock_controls"/>
     <property name="cond1" value="is variable_set comeinside:forreal"/>
     <property name="cond2" value="not variable_set stahp:no"/>
     <property name="cond3" value="not variable_set stahp:stop"/>

--- a/mods/tuxemon/maps/professor_lab.tmx
+++ b/mods/tuxemon/maps/professor_lab.tmx
@@ -89,7 +89,7 @@
     <property name="cond3" value="is player_facing down"/>
     <property name="cond4" value="is button_pressed K_RETURN"/>
     <property name="cond5" value="is variable_set gettuxemon:now"/>
-    <property name="cond6" value="not variable_set letmechoose:pls"/>
+    <property name="cond6" value="not variable_set havetuxemon:yes"/>
    </properties>
   </object>
   <object id="75" name="Choose Tweesher" type="event" x="224" y="112" width="16" height="16">
@@ -103,7 +103,7 @@
     <property name="cond3" value="is player_facing down"/>
     <property name="cond4" value="is button_pressed K_RETURN"/>
     <property name="cond5" value="is variable_set gettuxemon:now"/>
-    <property name="cond6" value="not variable_set letmechoose:pls"/>
+    <property name="cond6" value="not variable_set havetuxemon:yes"/>
    </properties>
   </object>
   <object id="93" name="Player Spawn" type="event" x="144" y="240" width="16" height="16"/>
@@ -119,12 +119,13 @@
   <object id="97" name="whyhellothere" type="event" x="144" y="272" width="16" height="16">
    <properties>
     <property name="act1" value="player_stop"/>
-    <property name="act2" value="translated_dialog tuxemontime"/>
-    <property name="act3" value="pathfind professor,9,12"/>
-    <property name="act4" value="npc_face professor,down"/>
-    <property name="act5" value="pathfind player,9,13"/>
-    <property name="act6" value="translated_dialog tuxemontime1.5"/>
-    <property name="act7" value="translated_dialog_choice yes:no,startchoice"/>
+    <property name="act2" value="lock_controls"/>
+    <property name="act3" value="translated_dialog tuxemontime"/>
+    <property name="act4" value="pathfind professor,9,12"/>
+    <property name="act5" value="npc_face professor,down"/>
+    <property name="act6" value="pathfind player,9,13"/>
+    <property name="act7" value="translated_dialog tuxemontime1.5"/>
+    <property name="act8" value="translated_dialog_choice yes:no,startchoice"/>
     <property name="cond1" value="is player_at"/>
     <property name="cond2" value="is variable_set dancininthemoonlight:heckyeah"/>
     <property name="cond3" value="is player_facing up"/>
@@ -137,6 +138,7 @@
    <properties>
     <property name="act1" value="translated_dialog tuxemontimechoiceno"/>
     <property name="act2" value="set_variable startchoice:maybe"/>
+    <property name="act3" value="unlock_controls"/>
     <property name="cond1" value="is variable_set startchoice:no"/>
    </properties>
   </object>
@@ -209,6 +211,7 @@
     <property name="act1" value="translated_dialog tuxemontime4"/>
     <property name="act2" value="translated_dialog chooseyerfate"/>
     <property name="act3" value="set_variable letmechoose:pls"/>
+    <property name="act4" value="unlock_controls"/>
     <property name="cond1" value="is variable_set gettuxemon:now"/>
     <property name="cond2" value="not variable_set letmechoose:pls"/>
    </properties>
@@ -217,6 +220,7 @@
    <properties>
     <property name="act10" value="translated_dialog choseRockitten"/>
     <property name="act11" value="play_sound sound_confirm"/>
+    <property name="act12" value="lock_controls"/>
     <property name="act20" value="translated_dialog rockitten!"/>
     <property name="act30" value="add_monster rockitten,5"/>
     <property name="act40" value="pathfind professor,13,9"/>
@@ -229,6 +233,7 @@
     <property name="act80" value="pathfind player,9,9"/>
     <property name="act81" value="npc_face player,up"/>
     <property name="act90" value="translated_dialog chosefight"/>
+    <property name="act91" value="unlock_controls"/>
     <property name="act97" value="set_variable havetuxemon:yes"/>
     <property name="act98" value="set_variable rockittenchoice:finished"/>
     <property name="act99" value="set_variable startfirstbattle:yes"/>
@@ -255,6 +260,7 @@
    <properties>
     <property name="act10" value="translated_dialog choseCardiling"/>
     <property name="act11" value="play_sound sound_confirm"/>
+    <property name="act12" value="lock_controls"/>
     <property name="act20" value="translated_dialog cardiling!"/>
     <property name="act30" value="add_monster cardiling,5"/>
     <property name="act40" value="pathfind professor,14,9"/>
@@ -267,6 +273,7 @@
     <property name="act80" value="pathfind player,9,9"/>
     <property name="act81" value="npc_face player,up"/>
     <property name="act90" value="translated_dialog chosefight"/>
+    <property name="act91" value="unlock_controls"/>
     <property name="act97" value="set_variable havetuxemon:yes"/>
     <property name="act98" value="set_variable cardilingchoice:finished"/>
     <property name="act99" value="set_variable startfirstbattle:yes"/>
@@ -277,6 +284,7 @@
    <properties>
     <property name="act10" value="translated_dialog choseTweesher"/>
     <property name="act11" value="play_sound sound_confirm"/>
+    <property name="act12" value="lock_controls"/>
     <property name="act20" value="translated_dialog tweesher!"/>
     <property name="act30" value="add_monster tweesher,5"/>
     <property name="act40" value="pathfind professor,12,9"/>
@@ -289,6 +297,7 @@
     <property name="act80" value="pathfind player,9,9"/>
     <property name="act81" value="npc_face player,up"/>
     <property name="act90" value="translated_dialog chosefight"/>
+    <property name="act91" value="unlock_controls"/>
     <property name="act97" value="set_variable havetuxemon:yes"/>
     <property name="act98" value="set_variable tweesherchoice:finished"/>
     <property name="act99" value="set_variable startfirstbattle:yes"/>

--- a/mods/tuxemon/maps/taba_town.tmx
+++ b/mods/tuxemon/maps/taba_town.tmx
@@ -644,16 +644,16 @@
   <object id="130" name="waitdontleave" type="event" x="592" y="624" width="32" height="16">
    <properties>
     <property name="act1" value="player_stop"/>
-    <property name="act11" value="lock_controls"/>
-    <property name="act2" value="translated_dialog waitdontgo"/>
-    <property name="act3" value="create_npc npc_mom, 39,46"/>
-    <property name="act4" value="pathfind npc_mom,37,40"/>
-    <property name="act5" value="npc_face npc_mom,up"/>
-    <property name="act6" value="translated_dialog thetvbescreamin"/>
-    <property name="act7" value="set_variable comeinside:yes"/>
-    <property name="act8" value="pathfind npc_mom,43,46"/>
-    <property name="act9" value="npc_face npc_mom, up"/>
-    <property name="act99" value="remove_npc npc_mom"/>
+    <property name="act2" value="lock_controls"/>
+    <property name="act3" value="translated_dialog waitdontgo"/>
+    <property name="act4" value="create_npc npc_mom, 39,46"/>
+    <property name="act5" value="pathfind npc_mom,37,40"/>
+    <property name="act6" value="npc_face npc_mom,up"/>
+    <property name="act7" value="translated_dialog thetvbescreamin"/>
+    <property name="act8" value="set_variable comeinside:yes"/>
+    <property name="act9" value="pathfind npc_mom,43,46"/>
+    <property name="act91" value="npc_face npc_mom, up"/>
+    <property name="act92" value="remove_npc npc_mom"/>
     <property name="cond1" value="is variable_set goodbyeoldknight:finallydone"/>
     <property name="cond2" value="not variable_set comeinside:yes"/>
     <property name="cond3" value="is player_at"/>
@@ -665,10 +665,10 @@
   <object id="131" name="timetogroove" type="event" x="528" y="592" width="16" height="16">
    <properties>
     <property name="act10" value="pathfind player,43,45"/>
-    <property name="act11" value="transition_teleport player_house_downstairs.tmx,5,7,0.5"/>
+    <property name="act12" value="unlock_controls"/>
     <property name="act15" value="set_variable comeinside:done"/>
-    <property name="act20" value="player_resume"/>
-    <property name="act21" value="unlock_controls"/>
+    <property name="act17" value="player_resume"/>
+    <property name="act18" value="transition_teleport player_house_downstairs.tmx,5,7,0.5"/>
     <property name="cond1" value="is variable_set comeinside:yes"/>
    </properties>
   </object>
@@ -827,10 +827,12 @@
   <object id="148" name="myrock" type="event" x="592" y="624" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog moverocky"/>
-    <property name="act2" value="player_stop"/>
-    <property name="act3" value="wait 2"/>
-    <property name="act4" value="translated_dialog moverocky2"/>
-    <property name="act5" value="player_resume"/>
+    <property name="act2" value="lock_controls"/>
+    <property name="act3" value="player_stop"/>
+    <property name="act4" value="wait 2"/>
+    <property name="act5" value="translated_dialog moverocky2"/>
+    <property name="act6" value="player_resume"/>
+    <property name="act7" value="unlock_controls"/>
     <property name="cond1" value="is variable_set dancininthemoonlight:heckyeah"/>
     <property name="cond2" value="is player_facing up"/>
     <property name="cond3" value="is button_pressed K_RETURN"/>
@@ -905,8 +907,9 @@
     <property name="act10" value="wait 0.7"/>
     <property name="act20" value="pathfind player, 43,46"/>
     <property name="act30" value="npc_face player,up"/>
+    <property name="act35" value="unlock_controls"/>
+    <property name="act36" value="set_variable moveplayer:false"/>
     <property name="act40" value="transition_teleport player_house_downstairs.tmx,5,7,0.5"/>
-    <property name="act50" value="unlock_controls"/>
     <property name="cond1" value="is variable_set moveplayer:true"/>
    </properties>
   </object>


### PR DESCRIPTION
1. Fixes a crash in taba town, after leaving the house after the 2nd announcement - this is because a lock_controls action was appearing after a transition_teleport, so it was never called (so the next unlock_controls caused an exception)

2. Fixes a bug where tweesher and cardiling couldn't be selected in professor's lab, you could only take rockitten

3. Add lock_controls and unlock_controls to a couple more cutscenes, to stop player being able to change maps during cutscenes and possibly causing problems

@Qiangong2 - just checking you don't have any changes in taba_town.tmx, professor_lab.tmx or player_house_downstairs.tmx ? I can wait to make these changes after you've checked anything in if you do. :smiley: