### PR TITLE
Fix bag not opening from world menu

### DIFF
--- a/tuxemon/states/items/__init__.py
+++ b/tuxemon/states/items/__init__.py
@@ -44,6 +44,7 @@ from tuxemon.session import local_session
 from tuxemon.sprite import Sprite
 from tuxemon.states.monster import MonsterMenuState
 from tuxemon.ui.text import TextArea
+from tuxemon.db import State
 
 # The import is required for PushState to work.
 # But linters may say the import is unused.
@@ -149,7 +150,7 @@ class ItemMenuState(Menu[Item]):
         ):
             msg = T.format("item_no_available_target", {"name": item.name})
             tools.open_dialog(local_session, [msg])
-        elif state not in item.usable_in:
+        elif State[state] not in item.usable_in:
             msg = T.format("item_cannot_use_here", {"name": item.name})
             tools.open_dialog(local_session, [msg])
         else:


### PR DESCRIPTION
I noticed the bag isn't opening from the World state - again because of a small change in tuxemon/db.py 

Not sure if this change is the best one, but there's a TODO saying the State enum will change in the future, so I'm not going to worry about it too much. Maybe when it changes, we won't need the change I made, but this will make it work for now. 