### PR TITLE
Add ids for yaml events

### DIFF
--- a/tuxemon/map_loader.py
+++ b/tuxemon/map_loader.py
@@ -152,7 +152,7 @@ class YAMLEventLoader:
                 )
                 conds.append(cond_data)
 
-            yield EventObject(None, name, x, y, w, h, conds, acts)
+            yield EventObject(name, name, x, y, w, h, conds, acts)
 
 
 class TMXMapLoader:


### PR DESCRIPTION
Fixes https://github.com/Tuxemon/Tuxemon/issues/1225 (bug where Player Spawn event would stop other events from running).

As all the ids were "None", the game considered them to all by the same event, and would only allow one to be activate at a time. If the "Player Spawn" action is first then it will trigger first, and other events won't be allowed to start.

I'm using the event name as the id, as yaml requires the event names to be unique. I could have generated a number using enumerate, but, in theory, events could also have been defined within the tmx file with the same id. 