### PR TITLE
Don't convert pydantic models to dicts

### DIFF
--- a/schemas/environment-schema.json
+++ b/schemas/environment-schema.json
@@ -35,6 +35,11 @@
           "title": "Island Front",
           "description": "Sprite used for front combat",
           "type": "string"
+        },
+        "background": {
+          "title": "Background",
+          "description": "Sprite used for combat background",
+          "type": "string"
         }
       },
       "required": [

--- a/tests/tuxemon/item/test_economy.py
+++ b/tests/tuxemon/item/test_economy.py
@@ -1,5 +1,6 @@
 import unittest
 
+from tuxemon.db import EconomyItemModel
 from tuxemon.item.economy import Economy
 
 
@@ -12,9 +13,9 @@ class GetDefaultPriceAndCost(EconomyTestBase):
         self.economy = Economy()
         self.economy.slug = "test_economy"
         self.economy.items = [
-            {"item_name": "potion", "price": 20, "cost": 5},
-            {"item_name": "revive", "price": 100},
-            {"item_name": "capture_device", "cost": 10},
+            EconomyItemModel(item_name="potion", price=20, cost=5),
+            EconomyItemModel(item_name="revive", price=100),
+            EconomyItemModel(item_name="capture_device", cost=10),
         ]
 
     def test_potion_price(self):

--- a/tests/tuxemon/item/test_economy.py
+++ b/tests/tuxemon/item/test_economy.py
@@ -30,10 +30,20 @@ class GetDefaultPriceAndCost(EconomyTestBase):
 
     def test_missing_price(self):
         economy = self.economy
-        with self.assertRaises(RuntimeError):
-            price = economy.lookup_item_price("capture_device")
+        price = economy.lookup_item_price("capture_device")
+        self.assertEqual(price, 0)
 
     def test_missing_cost(self):
         economy = self.economy
+        cost = economy.lookup_item_cost("revive")
+        self.assertEqual(cost,0)
+
+    def test_unknown_item_price(self):
+        economy = self.economy
         with self.assertRaises(RuntimeError):
-            cost = economy.lookup_item_cost("revive")
+            cost = economy.lookup_item_cost("unknown_item")
+
+    def test_unknown_item_price(self):
+        economy = self.economy
+        with self.assertRaises(RuntimeError):
+            price = economy.lookup_item_price("unknown_item")

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -266,15 +266,15 @@ class MonsterModel(BaseModel):
 
 
 class StatModel(BaseModel):
-    value: Optional[int] = Field(None, description="The value of the stat")
-    max_deviation: Optional[int] = Field(
-        None, description="The maximum deviation of the stat"
+    value: int = Field(0, description="The value of the stat")
+    max_deviation: int = Field(
+        0, description="The maximum deviation of the stat"
     )
     operation: str = Field(
-        ..., description="The operation to be done to the stat"
+        "+", description="The operation to be done to the stat"
     )
-    overridetofull: Optional[bool] = Field(
-        None, description="Whether or not to override to full"
+    overridetofull: bool = Field(
+        False, description="Whether or not to override to full"
     )
 
 

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -242,10 +242,8 @@ class MonsterModel(BaseModel):
     flairs: Sequence[MonsterFlairItemModel] = Field(
         [], description="The flairs this monster has"
     )
-    sounds: MonsterSoundsModel = Field(
-        MonsterSoundsModel(
-            combat_call="sound_cry1", faint_call="sound_faint1"
-        ),
+    sounds: Optional[MonsterSoundsModel] = Field(
+        None,
         description="The sounds this monster has",
     )
 
@@ -830,7 +828,7 @@ class JSONDatabase:
 
         """
 
-        filename = self.database[table][slug].dict()["file"] or slug
+        filename = self.database[table][slug].file or slug
         if filename == slug:
             logger.debug(
                 f"Could not find a file record for slug {slug}, did you remember to create a database record?"

--- a/tuxemon/event/actions/random_encounter.py
+++ b/tuxemon/event/actions/random_encounter.py
@@ -93,7 +93,7 @@ class RandomEncounterAction(EventAction[RandomEncounterActionParameters]):
             env_slug = "grass"
             if "environment" in player.game_variables:
                 env_slug = player.game_variables["environment"]
-            env = db.lookup(env_slug, table="environment").dict()
+            env = db.lookup(env_slug, table="environment")
 
             # Add our players and setup combat
             # "queueing" it will mean it starts after the top of the stack
@@ -102,7 +102,7 @@ class RandomEncounterAction(EventAction[RandomEncounterActionParameters]):
                 "CombatState",
                 players=(player, npc),
                 combat_type="monster",
-                graphics=env["battle_graphics"],
+                graphics=env.battle_graphics,
             )
 
             # stop the player
@@ -113,7 +113,7 @@ class RandomEncounterAction(EventAction[RandomEncounterActionParameters]):
             self.session.client.push_state(FlashTransition)
 
             # Start some music!
-            filename = env["battle_music"]
+            filename = env.battle_music
             self.session.client.event_engine.execute_action(
                 "play_music",
                 [filename],

--- a/tuxemon/event/actions/set_inventory.py
+++ b/tuxemon/event/actions/set_inventory.py
@@ -60,13 +60,9 @@ class SetInventoryAction(EventAction[SetInventoryActionParameters]):
             npc.inventory = {}
             return
 
-        entry = (
-            db.lookup(
-                self.parameters.inventory_slug,
-                table="inventory",
-            )
-            .dict()
-            .get("inventory", {})
-        )
+        entry = db.lookup(
+            self.parameters.inventory_slug,
+            table="inventory",
+        ).inventory
 
         npc.inventory = decode_inventory(self.session, npc, entry)

--- a/tuxemon/event/actions/start_battle.py
+++ b/tuxemon/event/actions/start_battle.py
@@ -75,7 +75,7 @@ class StartBattleAction(EventAction[StartBattleActionParameters]):
 
         # Lookup the environment
         env_slug = player.game_variables.get("environment", "grass")
-        env = db.lookup(env_slug, table="environment").dict()
+        env = db.lookup(env_slug, table="environment")
 
         # Add our players and setup combat
         logger.info("Starting battle with '{self.parameters.npc_slug}'!")
@@ -83,11 +83,11 @@ class StartBattleAction(EventAction[StartBattleActionParameters]):
             CombatState,
             players=(player, npc),
             combat_type="trainer",
-            graphics=env["battle_graphics"],
+            graphics=env.battle_graphics,
         )
 
         # Start some music!
-        filename = env["battle_music"]
+        filename = env.battle_music
         self.session.client.event_engine.execute_action(
             "play_music",
             [filename],

--- a/tuxemon/event/actions/update_inventory.py
+++ b/tuxemon/event/actions/update_inventory.py
@@ -69,8 +69,6 @@ class UpdateInventoryAction(EventAction[UpdateInventoryActionParameters]):
                 db.lookup(
                     self.parameters.inventory_slug,
                     table="inventory",
-                )
-                .dict()
-                .get("inventory", {}),
+                ).inventory,
             )
         )

--- a/tuxemon/item/economy.py
+++ b/tuxemon/item/economy.py
@@ -60,12 +60,12 @@ class Economy:
         """
 
         try:
-            results = db.lookup(slug, table="economy").dict()
+            results = db.lookup(slug, table="economy")
         except KeyError:
             raise RuntimeError(f"Failed to find economy with slug {slug}")
 
-        self.slug = results["slug"]
-        self.items = results["items"]
+        self.slug = results.slug
+        self.items = results.items
 
     def lookup_item_field(self, item_slug: str, field: str) -> Optional[int]:
         """Looks up the item's field from this economy.
@@ -81,9 +81,8 @@ class Economy:
             Field of item for this economy.
         """
         for item in self.items:
-            if item["item_name"] == item_slug and field in item:
-                value = item[field]
-                return value
+            if item.item_name == item_slug and hasattr(item, field):
+                return getattr(item, field)
 
         return None
 

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -48,7 +48,7 @@ import pygame
 
 from tuxemon import graphics, plugin, prepare
 from tuxemon.constants import paths
-from tuxemon.db import db, process_targets
+from tuxemon.db import ItemBattleMenu, State, db, process_targets
 from tuxemon.item.itemcondition import ItemCondition
 from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
 from tuxemon.locale import T
@@ -102,9 +102,9 @@ class Item:
         self.use_item = ""
         self.use_success = ""
         self.use_failure = ""
-        self.usable_in: Sequence[str] = []
+        self.usable_in: Sequence[State] = []
         self.target: Sequence[str] = []
-        self.battle_menu = ""
+        self.battle_menu: Optional[ItemBattleMenu] = None
 
         # load effect and condition plugins if it hasn't been done already
         if not Item.effects_classes:
@@ -133,30 +133,30 @@ class Item:
         """
 
         try:
-            results = db.lookup(slug, table="item").dict()
+            results = db.lookup(slug, table="item")
         except KeyError:
             logger.error(f"Failed to find item with slug {slug}")
             return
 
-        self.slug = results["slug"]
+        self.slug = results.slug
         self.name = T.translate(self.slug)
         self.description = T.translate(f"{self.slug}_description")
 
         # item use notifications (translated!)
-        self.use_item = T.translate(results["use_item"])
-        self.use_success = T.translate(results["use_success"])
-        self.use_failure = T.translate(results["use_failure"])
+        self.use_item = T.translate(results.use_item)
+        self.use_success = T.translate(results.use_success)
+        self.use_failure = T.translate(results.use_failure)
 
         # misc attributes (not translated!)
-        self.sort = results["sort"]
+        self.sort = results.sort
         assert self.sort
-        self.type = results["type"]
-        self.sprite = results["sprite"]
-        self.usable_in = results["usable_in"]
-        self.target = process_targets(results["target"])
-        self.effects = self.parse_effects(results.get("effects", []))
-        self.battle_menu = results.get("battle_menu", "")
-        self.conditions = self.parse_conditions(results.get("conditions", []))
+        self.type = results.type
+        self.sprite = results.sprite
+        self.usable_in = results.usable_in
+        self.target = process_targets(results.target)
+        self.effects = self.parse_effects(results.effects or [])
+        self.battle_menu = results.battle_menu or ""
+        self.conditions = self.parse_conditions(results.conditions or [])
         self.surface = graphics.load_and_scale(self.sprite)
         self.surface_size_original = self.surface.get_size()
 

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -154,9 +154,9 @@ class Item:
         self.sprite = results.sprite
         self.usable_in = results.usable_in
         self.target = process_targets(results.target)
-        self.effects = self.parse_effects(results.effects or [])
-        self.battle_menu = results.battle_menu or ""
-        self.conditions = self.parse_conditions(results.conditions or [])
+        self.effects = self.parse_effects(results.effects)
+        self.battle_menu = results.battle_menu
+        self.conditions = self.parse_conditions(results.conditions)
         self.surface = graphics.load_and_scale(self.sprite)
         self.surface_size_original = self.surface.get_size()
 

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -480,13 +480,13 @@ class Monster:
 
         # Learn New Moves
         for move in self.moveset:
-            if move["level_learned"] == self.level:
+            if move.level_learned == self.level:
                 logger.info(
                     "{} learned technique {}!".format(
-                        self.name, move["technique"]
+                        self.name, move.technique
                     )
                 )
-                technique = Technique(move["technique"])
+                technique = Technique(move.technique)
                 self.learn(technique)
 
     def set_level(self, level: int = 5) -> None:

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -150,23 +150,18 @@ class NPC(Entity[NPCState]):
         super().__init__(slug=npc_slug, world=world)
 
         # load initial data from the npc database
-        npc_data = db.lookup(npc_slug, table="npc").dict()
+        npc_data = db.lookup(npc_slug, table="npc")
 
         # This is the NPC's name to be used in dialog
         self.name = T.translate(self.slug)
 
         if sprite_name is None:
             # Try to use the sprites defined in the JSON data
-            sprite_name = npc_data["sprite_name"]
+            sprite_name = npc_data.sprite_name
         if combat_front is None:
-            combat_front = npc_data["combat_front"]
+            combat_front = npc_data.combat_front
         if combat_back is None:
-            combat_back = npc_data["combat_back"]
-
-        # enforced by pydantic
-        assert sprite_name
-        assert combat_front
-        assert combat_back
+            combat_back = npc_data.combat_back
 
         # Hold on the the string so it can be sent over the network
         self.sprite_name = sprite_name
@@ -828,16 +823,16 @@ class NPC(Entity[NPCState]):
         self.monsters = []
 
         # Look up the NPC's details from our NPC database
-        npc_details = db.lookup(self.slug, "npc").dict()
-        npc_party = npc_details.get("monsters") or []
+        npc_details = db.lookup(self.slug, "npc")
+        npc_party = npc_details.monsters or []
         for npc_monster_details in npc_party:
-            monster = Monster(save_data=npc_monster_details)
-            monster.experience_give_modifier = npc_monster_details[
-                "exp_give_mod"
-            ]
-            monster.experience_required_modifier = npc_monster_details[
-                "exp_req_mod"
-            ]
+            # This seems slightly wrong. The only useable element in
+            # npc_monsters_details, which is a PartyMemberModel, is "slug"
+            monster = Monster(save_data=npc_monster_details.dict())
+            monster.experience_give_modifier = npc_monster_details.exp_give_mod
+            monster.experience_required_modifier = (
+                npc_monster_details.exp_req_mod
+            )
             monster.set_level(monster.level)
             monster.current_hp = monster.hp
 

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -824,7 +824,7 @@ class NPC(Entity[NPCState]):
 
         # Look up the NPC's details from our NPC database
         npc_details = db.lookup(self.slug, "npc")
-        npc_party = npc_details.monsters or []
+        npc_party = npc_details.monsters
         for npc_monster_details in npc_party:
             # This seems slightly wrong. The only useable element in
             # npc_monsters_details, which is a PartyMemberModel, is "slug"

--- a/tuxemon/states/combat/combat_animations.py
+++ b/tuxemon/states/combat/combat_animations.py
@@ -14,7 +14,6 @@ from typing import (
     Any,
     List,
     Literal,
-    Mapping,
     MutableMapping,
     Optional,
     Sequence,
@@ -35,6 +34,7 @@ from tuxemon.surfanim import SurfaceAnimation
 from tuxemon.tools import scale, scale_sequence
 
 if TYPE_CHECKING:
+    from tuxemon.db import BattleGraphicsModel
     from tuxemon.npc import NPC
 
 logger = logging.getLogger(__name__)
@@ -69,7 +69,7 @@ class CombatAnimations(ABC, Menu[None]):
         self,
         *,
         players: Sequence[NPC] = (),
-        graphics: Optional[Mapping[str, str]] = None,
+        graphics: Optional[BattleGraphicsModel] = None,
         **kwargs: Any,
     ) -> None:
         # The defaults are a lie to stop mypy complaining about us violating
@@ -561,7 +561,7 @@ class CombatAnimations(ABC, Menu[None]):
 
         # Get background image if passed in
         self.background = self.load_sprite(
-            "gfx/ui/combat/" + self.graphics["background"]
+            "gfx/ui/combat/" + self.graphics.background
         )
 
         # TODO: not hardcode this
@@ -572,7 +572,7 @@ class CombatAnimations(ABC, Menu[None]):
         duration = 3
 
         back_island = self.load_sprite(
-            "gfx/ui/combat/" + self.graphics["island_back"],
+            "gfx/ui/combat/" + self.graphics.island_back,
             bottom=opp_home.bottom + y_mod,
             right=0,
         )
@@ -612,7 +612,7 @@ class CombatAnimations(ABC, Menu[None]):
             )
 
         front_island = self.load_sprite(
-            "gfx/ui/combat/" + self.graphics["island_front"],
+            "gfx/ui/combat/" + self.graphics.island_front,
             bottom=player_home.bottom - y_mod,
             left=w,
         )

--- a/tuxemon/states/combat/combat_menus.py
+++ b/tuxemon/states/combat/combat_menus.py
@@ -17,6 +17,7 @@ from typing import (
 import pygame
 
 from tuxemon import graphics, tools
+from tuxemon.db import ItemBattleMenu
 from tuxemon.item.item import Item
 from tuxemon.locale import T
 from tuxemon.menu.interface import MenuItem
@@ -157,7 +158,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
             combat_state = self.client.get_state_by_name(CombatState)
 
             state: State
-            if item.battle_menu == "monster":
+            if item.battle_menu == ItemBattleMenu.monster:
                 state = self.client.push_state(MonsterMenuState)
                 state.on_menu_selection = partial(enqueue_item, item)  # type: ignore[assignment]
             else:

--- a/tuxemon/technique.py
+++ b/tuxemon/technique.py
@@ -329,10 +329,10 @@ class Technique:
         for stat, slugdata in zip(statsmaster, statslugs):
             if not stat:
                 continue
-            value = stat.value or 0
-            max_deviation = stat.max_deviation or 0
-            operation = stat.operation or "+"
-            override = stat.overridetofull or False
+            value = stat.value
+            max_deviation = stat.max_deviation
+            operation = stat.operation
+            override = stat.overridetofull
             basestatvalue = getattr(target, slugdata)
             if max_deviation:
                 value = random.randint(

--- a/tuxemon/technique.py
+++ b/tuxemon/technique.py
@@ -141,53 +141,54 @@ class Technique:
             The slug of the technique to look up in the database.
         """
 
-        results = db.lookup(slug, table="technique").dict()
-        self.name = T.translate(slug)
+        results = db.lookup(slug, table="technique")
+        self.slug = results.slug  # a short English identifier
+        self.name = T.translate(self.slug)
 
-        self.sort = results["sort"]
+        self.sort = results.sort
 
         # technique use notifications (translated!)
         # NOTE: should be `self.use_tech`, but Technique and Item have
         # overlapping checks
-        self.use_item = T.maybe_translate(results.get("use_tech"))
-        self.use_success = T.maybe_translate(results.get("use_success"))
-        self.use_failure = T.maybe_translate(results.get("use_failure"))
+        self.use_item = T.maybe_translate(results.use_tech)
+        self.use_success = T.maybe_translate(results.use_success)
+        self.use_failure = T.maybe_translate(results.use_failure)
 
-        self.category = results["category"]
-        self.icon = results["icon"]
+        self.category = results.category
+        self.icon = results.icon
         self._combat_counter = 0
         self._life_counter = 0
 
-        if results.get("types"):
-            self.type1 = results["types"][0]
-            if len(results["types"]) > 1:
-                self.type2 = results["types"][1]
+        if results.types:
+            self.type1 = results.types[0]
+            if len(results.types) > 1:
+                self.type2 = results.types[1]
             else:
                 self.type2 = None
         else:
             self.type1 = self.type2 = None
 
-        self.power = results.get("power", self.power)
+        self.power = results.power or self.power
 
-        self.statspeed = results.get("statspeed")
-        self.stathp = results.get("stathp")
-        self.statarmour = results.get("statarmour")
-        self.statmelee = results.get("statmelee")
-        self.statranged = results.get("statranged")
-        self.statdodge = results.get("statdodge")
+        self.statspeed = results.statspeed
+        self.stathp = results.stathp
+        self.statarmour = results.statarmour
+        self.statmelee = results.statmelee
+        self.statranged = results.statranged
+        self.statdodge = results.statdodge
 
-        self.is_fast = results.get("is_fast", self.is_fast)
-        self.recharge_length = results.get("recharge", self.recharge_length)
-        self.is_area = results.get("is_area", self.is_area)
-        self.range = results.get("range", self.range)
-        self.tech_id = results.get("tech_id", self.tech_id)
-        self.accuracy = results.get("accuracy", self.accuracy)
-        self.potency = results.get("potency", self.potency)
-        self.effect = results["effects"]
-        self.target = process_targets(results["target"])
+        self.is_fast = results.is_fast or self.is_fast
+        self.recharge_length = results.recharge or self.recharge_length
+        self.is_area = results.is_area or self.is_area
+        self.range = results.range or self.range
+        self.tech_id = results.tech_id or self.tech_id
+        self.accuracy = results.accuracy or self.accuracy
+        self.potency = results.potency or self.potency
+        self.effect = results.effects
+        self.target = process_targets(results.target)
 
         # Load the animation sprites that will be used for this technique
-        self.animation = results["animation"]
+        self.animation = results.animation
         if self.animation:
             directory = prepare.fetch("animations", "technique")
             self.images = animation_frame_files(directory, self.animation)
@@ -197,7 +198,7 @@ class Technique:
                 )
 
         # Load the sound effect for this technique
-        self.sfx = results["sfx"]
+        self.sfx = results.sfx
 
     def advance_round(self, number: int = 1) -> None:
         """
@@ -328,10 +329,10 @@ class Technique:
         for stat, slugdata in zip(statsmaster, statslugs):
             if not stat:
                 continue
-            value = stat.get("value", 0)
-            max_deviation = stat.get("max_deviation", 0)
-            operation = stat.get("operation", "+")
-            override = stat.get("overridetofull", False)
+            value = stat.value or 0
+            max_deviation = stat.max_deviation or 0
+            operation = stat.operation or "+"
+            override = stat.overridetofull or False
             basestatvalue = getattr(target, slugdata)
             if max_deviation:
                 value = random.randint(


### PR DESCRIPTION
Using classes is much nicer, IMO. It also allows more specific type hints. Many of the type hints specify the Model, but this is wrong because the type was actually a Mapping.

This PR removes all cases where we convert the model into a dict before using it (well, there's one case where a function requires a dict, and it didn't make sense to change it).

It also fixes two bugs introduced by pydantic:
- Combat background not loaded (as it wasn't part of the model).
- Monster sounds defaulting to sound_cry1 instead of sound_{type}_cry1.