### PR TITLE
Stop looping over running_events if the map changes

### DIFF
--- a/tuxemon/event/eventengine.py
+++ b/tuxemon/event/eventengine.py
@@ -410,9 +410,21 @@ class EventEngine:
 
         """
         to_remove = set()
+        current_map = self.current_map
 
         # Loop through the list of actions and update them
         for i, e in self.running_events.items():
+            # If the current map has changed, then `reset` has also been
+            # called, which replaced self.running_events with an empty dict.
+            # We need to stop processing the running_events, as they may not
+            # make sense on the new map. We need to explicitly guard for this
+            # because actions within this loop can change the map.
+            if current_map != self.current_map:
+                # The map has just changed, so running_events should have been
+                # emptied.
+                assert not self.running_events
+                return
+
             while 1:
                 """
                 * if RunningEvent is currently running an action, then continue


### PR DESCRIPTION
Fixes https://github.com/Tuxemon/Tuxemon/issues/1204: create_npc action without a guard condition was being applied to the next map.