### PR TITLE
player.battle_history

### DIFF
--- a/mods/tuxemon/maps/maple_bedroom.tmx
+++ b/mods/tuxemon/maps/maple_bedroom.tmx
@@ -86,7 +86,7 @@
     <property name="cond40" value="is npc_exists maple_girl"/>
    </properties>
   </object>
-  <object id="28" name="Maple Pathfind to stairs" type="event" x="95.75" y="80" width="16" height="16">
+  <object id="28" name="Maple Pathfind to stairs" type="event" x="96" y="80" width="16" height="16">
    <properties>
     <property name="act10" value="pathfind maple_girl,8,3"/>
     <property name="act20" value="player_stop"/>

--- a/mods/tuxemon/maps/paper_scoop.tmx
+++ b/mods/tuxemon/maps/paper_scoop.tmx
@@ -89,7 +89,7 @@
     <property name="cond50" value="not variable_set tuxchoice:fruitera"/>
    </properties>
   </object>
-  <object id="46" name="choiceHydrone" type="event" x="112" y="127.667" width="16" height="16">
+  <object id="46" name="choiceHydrone" type="event" x="112" y="128" width="16" height="16">
    <properties>
     <property name="act10" value="add_monster hydrone,5"/>
     <property name="act20" value="set_variable tuxchoice:end"/>
@@ -101,7 +101,7 @@
     <property name="cond10" value="is variable_set tuxchoice:hydrone"/>
    </properties>
   </object>
-  <object id="47" name="choiceRockitten" type="event" x="111.333" y="127.667" width="16" height="16">
+  <object id="47" name="choiceRockitten" type="event" x="112" y="128" width="16" height="16">
    <properties>
     <property name="act10" value="add_monster rockitten,5"/>
     <property name="act20" value="set_variable tuxchoice:end"/>
@@ -113,7 +113,7 @@
     <property name="cond10" value="is variable_set tuxchoice:rockitten"/>
    </properties>
   </object>
-  <object id="51" name="choiceFruitera" type="event" x="111.667" y="127.667" width="16" height="16">
+  <object id="51" name="choiceFruitera" type="event" x="112" y="128" width="16" height="16">
    <properties>
     <property name="act10" value="add_monster fruitera,5"/>
     <property name="act20" value="set_variable tuxchoice:end"/>

--- a/mods/tuxemon/maps/spyder_bedroom.tmx
+++ b/mods/tuxemon/maps/spyder_bedroom.tmx
@@ -62,11 +62,12 @@
    </properties>
   </object>
   <object id="26" name="Player Spawn" type="event" x="64" y="80" width="16" height="16"/>
-  <object id="27" name="Resting in Bed" type="interact" x="16" y="48" width="16" height="32">
+  <object id="27" name="Resting in Bed" type="event" x="16" y="48" width="16" height="32">
    <properties>
     <property name="act1" value="translated_dialog spyder_papertown_restinbed"/>
     <property name="act2" value="set_monster_health ,"/>
     <property name="act3" value="set_monster_status ,"/>
+    <property name="cond1" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_candy_house1.tmx
+++ b/mods/tuxemon/maps/spyder_candy_house1.tmx
@@ -60,7 +60,7 @@
   <object id="74" type="collision" x="128" y="112" width="32" height="16"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="6" name="Events">
-  <object id="59" name="Go outside" type="event" x="80" y="112" width="48.002" height="16">
+  <object id="59" name="Go outside" type="event" x="80" y="112" width="48" height="16">
    <properties>
     <property name="act1" value="transition_teleport spyder_candy_town.tmx,4,31,0.3"/>
     <property name="cond1" value="is player_at"/>

--- a/mods/tuxemon/maps/spyder_candy_town.tmx
+++ b/mods/tuxemon/maps/spyder_candy_town.tmx
@@ -115,7 +115,7 @@
   <object id="313" type="collision" x="416" y="368" width="64" height="16"/>
   <object id="315" type="collision" x="320" y="304" width="160" height="64"/>
   <object id="316" type="collision" x="464" y="384" width="128" height="16"/>
-  <object id="317" type="collision" x="576" y="320.667" width="16" height="63.3333"/>
+  <object id="317" type="collision" x="576" y="320" width="16" height="64"/>
   <object id="318" type="collision" x="464" y="192" width="128" height="16"/>
   <object id="319" type="collision" x="576" y="208" width="16" height="80"/>
   <object id="320" type="collision" x="528" y="528" width="48" height="32"/>

--- a/mods/tuxemon/maps/spyder_citypark.tmx
+++ b/mods/tuxemon/maps/spyder_citypark.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="275">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="276">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -71,7 +71,7 @@
   <object id="194" type="collision" x="112" y="288" width="16" height="32"/>
   <object id="195" type="collision" x="496" y="352" width="16" height="32"/>
   <object id="196" type="collision" x="496" y="272" width="16" height="32"/>
-  <object id="197" type="collision" x="608" y="160" width="32" height="63.8182"/>
+  <object id="197" type="collision" x="608" y="160" width="32" height="64"/>
   <object id="198" type="collision" x="512" y="48" width="16" height="16"/>
   <object id="200" type="collision" x="32" y="224" width="32" height="32"/>
   <object id="201" type="collision" x="0" y="0" width="32" height="192"/>
@@ -551,6 +551,12 @@
     <property name="act4" value="set_variable citypark_bobette:yes"/>
     <property name="cond1" value="not variable_set citypark_bobette:yes"/>
     <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="275" name="Exhausted" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport spyder_healing_center.tmx,7,12,0.3"/>
+    <property name="cond1" value="is player_defeated"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_cotton_town.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_town.tmx
@@ -159,7 +159,7 @@
   <object id="506" type="collision" x="208" y="144" width="64" height="16"/>
   <object id="507" type="collision" x="288" y="144" width="80" height="16"/>
   <object id="508" type="collision" x="240" y="208" width="112" height="48"/>
-  <object id="509" type="collision" x="352" y="224" width="65.0417" height="48"/>
+  <object id="509" type="collision" x="352" y="224" width="64" height="48"/>
   <object id="512" type="collision" x="416" y="256" width="32" height="16"/>
   <object id="513" type="collision" x="432" y="224" width="96" height="32"/>
   <object id="514" type="collision" x="464" y="256" width="64" height="16"/>

--- a/mods/tuxemon/maps/spyder_flower_house1.tmx
+++ b/mods/tuxemon/maps/spyder_flower_house1.tmx
@@ -52,14 +52,14 @@
   <object id="65" type="collision" x="80" y="32" width="80" height="16"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="6" name="Events">
-  <object id="59" name="Go outside" type="event" x="79.998" y="112" width="48.002" height="16">
+  <object id="59" name="Go outside" type="event" x="80" y="112" width="48" height="16">
    <properties>
     <property name="act1" value="transition_teleport spyder_flower_city.tmx,15,22,0.3"/>
     <property name="cond1" value="is player_at"/>
     <property name="cond2" value="is player_facing down"/>
    </properties>
   </object>
-  <object id="60" name="TV" type="event" x="80" y="32" width="32.002" height="16">
+  <object id="60" name="TV" type="event" x="80" y="32" width="32" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_flowerhouse1_tv"/>
     <property name="cond1" value="is player_facing_tile"/>

--- a/mods/tuxemon/maps/spyder_greenwash.tmx
+++ b/mods/tuxemon/maps/spyder_greenwash.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="16" height="32" tilewidth="16" tileheight="16" infinite="0" nextlayerid="11" nextobjectid="79">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="16" height="32" tilewidth="16" tileheight="16" infinite="0" nextlayerid="11" nextobjectid="80">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -224,6 +224,12 @@
    <properties>
     <property name="act1" value="npc_move player,right"/>
     <property name="cond1" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="79" name="Exhausted" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport spyder_candy_center.tmx,6,10,0.3"/>
+    <property name="cond1" value="is player_defeated"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_greenwash_greenhouse.tmx
+++ b/mods/tuxemon/maps/spyder_greenwash_greenhouse.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="32" height="16" tilewidth="16" tileheight="16" infinite="0" nextlayerid="12" nextobjectid="90">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="32" height="16" tilewidth="16" tileheight="16" infinite="0" nextlayerid="12" nextobjectid="91">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -263,6 +263,12 @@
     <property name="act6" value="set_variable greenwashgregor:yes"/>
     <property name="cond1" value="not variable_set greenwashgregor:yes"/>
     <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="90" name="Exhausted" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport spyder_candy_center.tmx,6,10,0.3"/>
+    <property name="cond1" value="is player_defeated"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_greenwash_level2.tmx
+++ b/mods/tuxemon/maps/spyder_greenwash_level2.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="16" height="32" tilewidth="16" tileheight="16" infinite="0" nextlayerid="13" nextobjectid="105">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="16" height="32" tilewidth="16" tileheight="16" infinite="0" nextlayerid="13" nextobjectid="106">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -207,6 +207,12 @@
     <property name="act6" value="set_variable greenwashmoreau:yes"/>
     <property name="cond1" value="not variable_set greenwashmoreau:yes"/>
     <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="105" name="Exhausted" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport spyder_candy_center.tmx,6,10,0.3"/>
+    <property name="cond1" value="is player_defeated"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_leather_house1.tmx
+++ b/mods/tuxemon/maps/spyder_leather_house1.tmx
@@ -76,7 +76,7 @@
     <property name="behav1" value="talk spyder_florist"/>
    </properties>
   </object>
-  <object id="67" name="Radio" type="event" x="112" y="80" width="16" height="32.002">
+  <object id="67" name="Radio" type="event" x="112" y="80" width="16" height="32">
    <properties>
     <property name="act1" value="translated_dialog spyder_leatherhouse1_radio"/>
     <property name="cond1" value="is player_facing_tile"/>

--- a/mods/tuxemon/maps/spyder_leather_house2.tmx
+++ b/mods/tuxemon/maps/spyder_leather_house2.tmx
@@ -57,7 +57,7 @@
     <property name="cond2" value="is player_facing down"/>
    </properties>
   </object>
-  <object id="63" name="TV" type="event" x="48" y="32.002" width="32.002" height="16">
+  <object id="63" name="TV" type="event" x="48" y="32" width="32" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_leatherhouse2_tv"/>
     <property name="cond1" value="is player_facing_tile"/>

--- a/mods/tuxemon/maps/spyder_nimrod_bottom.tmx
+++ b/mods/tuxemon/maps/spyder_nimrod_bottom.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" width="18" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="56">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" width="18" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="57">
  <tileset firstgid="1" name="factory" tilewidth="16" tileheight="16" tilecount="32" columns="8">
   <image source="../gfx/tilesets/factory.png" width="128" height="64"/>
  </tileset>
@@ -187,6 +187,12 @@
     <property name="act6" value="set_variable nimrodbowie:yes"/>
     <property name="cond1" value="not variable_set nimrodbowie:yes"/>
     <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="56" name="Exhausted" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport spyder_flower_center.tmx,7,12,0.3"/>
+    <property name="cond1" value="is player_defeated"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_nimrod_middle.tmx
+++ b/mods/tuxemon/maps/spyder_nimrod_middle.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" width="18" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="44">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" width="18" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="45">
  <tileset firstgid="1" name="factory" tilewidth="16" tileheight="16" tilecount="32" columns="8">
   <image source="../gfx/tilesets/factory.png" width="128" height="64"/>
  </tileset>
@@ -314,6 +314,12 @@
     <property name="act6" value="set_variable nimrodantimony:yes"/>
     <property name="cond1" value="not variable_set nimrodantimony:yes"/>
     <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="44" name="Exhausted" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport spyder_flower_center.tmx,7,12,0.3"/>
+    <property name="cond1" value="is player_defeated"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_nimrod_top.tmx
+++ b/mods/tuxemon/maps/spyder_nimrod_top.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" width="18" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="43">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" width="18" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="44">
  <tileset firstgid="1" name="factory" tilewidth="16" tileheight="16" tilecount="32" columns="8">
   <image source="../gfx/tilesets/factory.png" width="128" height="64"/>
  </tileset>
@@ -161,6 +161,12 @@
     <property name="act6" value="set_variable nimrodmaverick:yes"/>
     <property name="cond1" value="not variable_set nimrodmaverick:yes"/>
     <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="43" name="Exhausted" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport spyder_flower_center.tmx,7,12,0.3"/>
+    <property name="cond1" value="is player_defeated"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_omnichannel1.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel1.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="14" height="21" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="30">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="14" height="21" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="31">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -129,6 +129,12 @@
    <properties>
     <property name="act1" value="set_variable environment:snow"/>
     <property name="cond1" value="not variable_set environment:snow"/>
+   </properties>
+  </object>
+  <object id="30" name="Exhausted" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport spyder_healing_center.tmx,7,12,0.3"/>
+    <property name="cond1" value="is player_defeated"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_omnichannel2.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel2.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.5" tiledversion="1.7.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="14" height="21" tilewidth="16" tileheight="16" infinite="0" nextlayerid="5" nextobjectid="15">
+<map version="1.5" tiledversion="1.7.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="14" height="21" tilewidth="16" tileheight="16" infinite="0" nextlayerid="5" nextobjectid="16">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -92,6 +92,12 @@
    <properties>
     <property name="act1" value="set_variable environment:snow"/>
     <property name="cond1" value="not variable_set environment:snow"/>
+   </properties>
+  </object>
+  <object id="15" name="Exhausted" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport spyder_healing_center.tmx,7,12,0.3"/>
+    <property name="cond1" value="is player_defeated"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_omnichannel3.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel3.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="14" height="21" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="38">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="14" height="21" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="39">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -199,6 +199,12 @@
     <property name="act6" value="set_variable omnichannelbyrne:yes"/>
     <property name="cond1" value="not variable_set omnichannelbyrne:yes"/>
     <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="38" name="Exhausted" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport spyder_healing_center.tmx,7,12,0.3"/>
+    <property name="cond1" value="is player_defeated"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_omnichannel4.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel4.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="14" height="21" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="24">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="14" height="21" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="25">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -116,6 +116,12 @@
    <properties>
     <property name="act1" value="set_variable environment:snow"/>
     <property name="cond1" value="not variable_set environment:snow"/>
+   </properties>
+  </object>
+  <object id="24" name="Exhausted" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport spyder_healing_center.tmx,7,12,0.3"/>
+    <property name="cond1" value="is player_defeated"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_paper_mart.tmx
+++ b/mods/tuxemon/maps/spyder_paper_mart.tmx
@@ -86,7 +86,7 @@
     <property name="cond7" value="not variable_set serenademe:no"/>
    </properties>
   </object>
-  <object id="46" name="choiceHydrone" type="event" x="112.333" y="128.667" width="16" height="16">
+  <object id="46" name="choiceHydrone" type="event" x="112" y="128" width="16" height="16">
    <properties>
     <property name="act1" value="add_monster hydrone,5"/>
     <property name="act2" value="set_variable tuxchoice:end"/>
@@ -98,7 +98,7 @@
     <property name="cond1" value="is variable_set tuxchoice:hydrone"/>
    </properties>
   </object>
-  <object id="47" name="choiceRockitten" type="event" x="112.333" y="128.333" width="16" height="16">
+  <object id="47" name="choiceRockitten" type="event" x="112" y="128" width="16" height="16">
    <properties>
     <property name="act1" value="add_monster rockitten,5"/>
     <property name="act2" value="set_variable tuxchoice:end"/>
@@ -110,7 +110,7 @@
     <property name="cond1" value="is variable_set tuxchoice:rockitten"/>
    </properties>
   </object>
-  <object id="51" name="choiceFruitera" type="event" x="112.333" y="128" width="16" height="16">
+  <object id="51" name="choiceFruitera" type="event" x="112" y="128" width="16" height="16">
    <properties>
     <property name="act1" value="add_monster fruitera,5"/>
     <property name="act2" value="set_variable tuxchoice:end"/>

--- a/mods/tuxemon/maps/spyder_route1.tmx
+++ b/mods/tuxemon/maps/spyder_route1.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.4" tiledversion="1.4.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="191">
+<map version="1.4" tiledversion="1.4.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="192">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -185,7 +185,7 @@
     <property name="cond2" value="is player_facing down"/>
    </properties>
   </object>
-  <object id="151" name="Encounters" type="event" x="320" y="176" width="128.091" height="63.8636">
+  <object id="151" name="Encounters" type="event" x="320" y="176" width="128" height="64">
    <properties>
     <property name="act1" value="random_encounter route1,11"/>
     <property name="act2" value="play_map_animation grass,0.1,noloop,player"/>
@@ -291,6 +291,12 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set environment:grass"/>
+   </properties>
+  </object>
+  <object id="191" name="Exhausted" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport spyder_downstairs.tmx,1,2,0.3"/>
+    <property name="cond1" value="is player_defeated"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_route2.tmx
+++ b/mods/tuxemon/maps/spyder_route2.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="2" nextobjectid="191">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="2" nextobjectid="192">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -440,7 +440,7 @@
     <property name="cond2" value="is player_moved"/>
    </properties>
   </object>
-  <object id="125" name="random battle25" type="event" x="64" y="128" width="16" height="32.5">
+  <object id="125" name="random battle25" type="event" x="64" y="128" width="16" height="32">
    <properties>
     <property name="act1" value="random_encounter route2"/>
     <property name="act2" value="play_map_animation grass,0.1,noloop,player"/>
@@ -628,6 +628,12 @@
     <property name="act4" value="set_variable route2graf:yes"/>
     <property name="cond1" value="not variable_set route2graf:yes"/>
     <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="191" name="Exhausted" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport spyder_healing_center.tmx,7,12,0.3"/>
+    <property name="cond1" value="is player_defeated"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_route3.tmx
+++ b/mods/tuxemon/maps/spyder_route3.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="686">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="687">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -115,7 +115,7 @@
   <object id="513" type="collision" x="448" y="368" width="16" height="16"/>
   <object id="514" type="collision" x="400" y="320" width="16" height="80"/>
   <object id="515" type="collision" x="176" y="336" width="224" height="64"/>
-  <object id="516" type="collision" x="62.9091" y="351.273" width="208" height="80"/>
+  <object id="516" type="collision" x="64" y="352" width="208" height="80"/>
   <object id="517" type="collision" x="32" y="496" width="16" height="16"/>
   <object id="518" type="collision" x="32" y="528" width="16" height="16"/>
   <object id="519" type="collision" x="32" y="144" width="32" height="16"/>
@@ -801,6 +801,12 @@
     <property name="act8" value="remove_npc spyder_route3_qqq"/>
     <property name="cond1" value="not variable_set ambushedbyqqq:yes"/>
     <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="686" name="Exhausted" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport spyder_leather_center.tmx,7,12,0.3"/>
+    <property name="cond1" value="is player_defeated"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_route3_trainer.tmx
+++ b/mods/tuxemon/maps/spyder_route3_trainer.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="-1" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="688">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="-1" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="689">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -116,7 +116,7 @@
   <object id="513" type="collision" x="448" y="368" width="16" height="16"/>
   <object id="514" type="collision" x="400" y="320" width="16" height="80"/>
   <object id="515" type="collision" x="176" y="336" width="224" height="64"/>
-  <object id="516" type="collision" x="62.9091" y="351.273" width="208" height="80"/>
+  <object id="516" type="collision" x="64" y="352" width="208" height="80"/>
   <object id="517" type="collision" x="32" y="496" width="16" height="16"/>
   <object id="518" type="collision" x="32" y="528" width="16" height="16"/>
   <object id="519" type="collision" x="32" y="144" width="32" height="16"/>
@@ -790,6 +790,12 @@
     <property name="cond1" value="is variable_set battle_last_result:won"/>
     <property name="cond2" value="not variable_set spyder_weaver_won:yes"/>
     <property name="cond3" value="is variable_set after_spyder_weaver:yes"/>
+   </properties>
+  </object>
+  <object id="688" name="Exhausted" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport spyder_leather_center.tmx,7,12,0.3"/>
+    <property name="cond1" value="is player_defeated"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_route4.tmx
+++ b/mods/tuxemon/maps/spyder_route4.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="86">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="87">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -405,6 +405,12 @@
     <property name="act6" value="set_variable route4rosamund:yes"/>
     <property name="cond1" value="not variable_set route4rosamund:yes"/>
     <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="86" name="Exhausted" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport spyder_leather_center.tmx,7,12,0.3"/>
+    <property name="cond1" value="is player_defeated"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_route5.tmx
+++ b/mods/tuxemon/maps/spyder_route5.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="66">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="67">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -396,6 +396,12 @@
     <property name="act6" value="set_variable route5edith:yes"/>
     <property name="cond1" value="not variable_set route5edith:yes"/>
     <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="66" name="Exhausted" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport spyder_flower_center.tmx,7,12,0.3"/>
+    <property name="cond1" value="is player_defeated"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_route6.tmx
+++ b/mods/tuxemon/maps/spyder_route6.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="5" nextobjectid="218">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="5" nextobjectid="219">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -433,6 +433,12 @@
     <property name="act6" value="set_variable route6mungo:yes"/>
     <property name="cond1" value="not variable_set route6mungo:yes"/>
     <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="218" name="Exhausted" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport spyder_candy_center.tmx,6,10,0.3"/>
+    <property name="cond1" value="is player_defeated"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_routea.tmx
+++ b/mods/tuxemon/maps/spyder_routea.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.4" tiledversion="1.4.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="67">
+<map version="1.4" tiledversion="1.4.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="68">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -131,6 +131,12 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set environment:grass"/>
+   </properties>
+  </object>
+  <object id="67" name="Exhausted" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport spyder_downstairs.tmx,1,2,0.3"/>
+    <property name="cond1" value="is player_defeated"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_routec.tmx
+++ b/mods/tuxemon/maps/spyder_routec.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="227">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="228">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -329,6 +329,12 @@
     <property name="act6" value="set_variable searoutecsandy:yes"/>
     <property name="cond1" value="not variable_set searoutecsandy:yes"/>
     <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="227" name="Exhausted" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport spyder_candy_center.tmx,6,10,0.3"/>
+    <property name="cond1" value="is player_defeated"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_tunnel.tmx
+++ b/mods/tuxemon/maps/spyder_tunnel.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="342">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="343">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -168,6 +168,12 @@
     <property name="act6" value="set_variable tunnelbgreta:yes"/>
     <property name="cond1" value="not variable_set tunnelbgreta:yes"/>
     <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="342" name="Exhausted" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport spyder_timber_center.tmx,7,12,0.3"/>
+    <property name="cond1" value="is player_defeated"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_tunnel_below.tmx
+++ b/mods/tuxemon/maps/spyder_tunnel_below.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="53">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="54">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -206,6 +206,12 @@
     <property name="act6" value="set_variable tunnelbberyll:yes"/>
     <property name="cond1" value="not variable_set tunnelbberyll:yes"/>
     <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="53" name="Exhausted" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport spyder_timber_center.tmx,7,12,0.3"/>
+    <property name="cond1" value="is player_defeated"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/taba_town.tmx
+++ b/mods/tuxemon/maps/taba_town.tmx
@@ -876,7 +876,7 @@
     <property name="cond20" value="is variable_set greeter_greets:yes"/>
    </properties>
   </object>
-  <object id="135" name="secret_tuxeball" type="event" x="625" y="240.5" width="16" height="16">
+  <object id="135" name="secret_tuxeball" type="event" x="624" y="240" width="16" height="16">
    <properties>
     <property name="act10" value="set_variable secret_ball:found"/>
     <property name="act20" value="add_item capture_device,5"/>

--- a/tuxemon/event/actions/battles_print.py
+++ b/tuxemon/event/actions/battles_print.py
@@ -1,0 +1,67 @@
+#
+# Tuxemon
+# Copyright (c) 2014-2017 William Edwards <shadowapex@gmail.com>,
+#                         Benjamin Bean <superman2k5@gmail.com>
+#
+# This file is part of Tuxemon
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import annotations
+
+import logging
+from typing import NamedTuple, Optional, final
+
+from tuxemon.event.eventaction import EventAction
+
+logger = logging.getLogger(__name__)
+
+
+class BattlesPrintActionParameters(NamedTuple):
+    variable: Optional[str]
+
+
+@final
+class BattlesAction(EventAction[BattlesPrintActionParameters]):
+    """
+    Print the current value of battle history to the console.
+
+    If no variable is specified, print out values of all battles.
+
+    Script usage:
+        .. code-block::
+
+            battles_print
+            battles_print <variable>
+
+        Script parameters:
+            variable: Optional, prints out the value of this variable.
+
+    """
+
+    name = "battles_print"
+    param_class = BattlesPrintActionParameters
+
+    def start(self) -> None:
+        player = self.session.player
+
+        variable = self.parameters.variable
+        if variable:
+            if variable in player.battle_history:
+                print(f"{variable}: {player.battle_history[variable]}")
+            else:
+                print(f"'{variable}' has not been set yet.")
+        else:
+            print(player.battle_history)

--- a/tuxemon/event/conditions/battle_is.py
+++ b/tuxemon/event/conditions/battle_is.py
@@ -1,0 +1,95 @@
+#
+# Tuxemon
+# Copyright (c) 2014-2017 William Edwards <shadowapex@gmail.com>,
+#                         Benjamin Bean <superman2k5@gmail.com>
+#
+# This file is part of Tuxemon
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import annotations
+
+import logging
+
+from tuxemon.event import MapCondition
+from tuxemon.event.eventcondition import EventCondition
+from tuxemon.session import Session
+
+logger = logging.getLogger(__name__)
+
+
+class BattleIsCondition(EventCondition):
+    """
+    Check an operation over a battle.
+
+    Script usage:
+        .. code-block::
+
+            is battle_is <character>,<result>,<operation>,<value1>
+
+    Script parameters:
+        character: Npc slug name (e.g. "npc_maple").
+        result: One of "won", "lost" or "draw"
+        operation: One of "==", "!=", ">", ">=", "<" or "<=".
+        value2: A number.
+
+    """
+
+    name = "battle_is"
+
+    def test(self, session: Session, condition: MapCondition) -> bool:
+        """
+        Check an operation over a variable.
+
+        Parameters:
+            session: The session object
+            condition: The map condition object.
+
+        Returns:
+            Result of the operation over the variable.
+
+        """
+        player = session.player
+
+        # Read the parameters
+        npc = condition.parameters[0]
+        result = condition.parameters[1]
+        operation = condition.parameters[2]
+        value1 = condition.parameters[3]
+
+        # Union
+        battle_mix = str(npc) + " - " + result
+
+        # Count
+        count = 0
+        for val in player.battle_history.values():
+            if val == battle_mix:
+                count += 1
+
+        # Check if the condition is true
+        if operation == "==":
+            return int(count) == int(value1)
+        elif operation == "!=":
+            return int(count) != int(value1)
+        elif operation == ">":
+            return int(count) > int(value1)
+        elif operation == ">=":
+            return int(count) >= int(value1)
+        elif operation == "<":
+            return int(count) < int(value1)
+        elif operation == "<=":
+            return int(count) <= int(value1)
+        else:
+            logger.error(f"invalid operation type {operation}")
+            raise ValueError

--- a/tuxemon/event/conditions/battle_is.py
+++ b/tuxemon/event/conditions/battle_is.py
@@ -36,13 +36,13 @@ class BattleIsCondition(EventCondition):
     Script usage:
         .. code-block::
 
-            is battle_is <character>,<result>,<operation>,<value1>
+            is battle_is <character>,<result>,<operation>,<value>
 
     Script parameters:
         character: Npc slug name (e.g. "npc_maple").
         result: One of "won", "lost" or "draw"
         operation: One of "==", "!=", ">", ">=", "<" or "<=".
-        value2: A number.
+        value: A number.
 
     """
 
@@ -66,7 +66,7 @@ class BattleIsCondition(EventCondition):
         npc = condition.parameters[0]
         result = condition.parameters[1]
         operation = condition.parameters[2]
-        value1 = condition.parameters[3]
+        value = condition.parameters[3]
 
         # Union
         battle_mix = str(npc) + " - " + result
@@ -79,17 +79,17 @@ class BattleIsCondition(EventCondition):
 
         # Check if the condition is true
         if operation == "==":
-            return int(count) == int(value1)
+            return int(count) == int(value)
         elif operation == "!=":
-            return int(count) != int(value1)
+            return int(count) != int(value)
         elif operation == ">":
-            return int(count) > int(value1)
+            return int(count) > int(value)
         elif operation == ">=":
-            return int(count) >= int(value1)
+            return int(count) >= int(value)
         elif operation == "<":
-            return int(count) < int(value1)
+            return int(count) < int(value)
         elif operation == "<=":
-            return int(count) <= int(value1)
+            return int(count) <= int(value)
         else:
             logger.error(f"invalid operation type {operation}")
             raise ValueError

--- a/tuxemon/event/conditions/battle_result.py
+++ b/tuxemon/event/conditions/battle_result.py
@@ -1,0 +1,69 @@
+#
+# Tuxemon
+# Copyright (c) 2014-2017 William Edwards <shadowapex@gmail.com>,
+#                         Benjamin Bean <superman2k5@gmail.com>
+#
+# This file is part of Tuxemon
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import annotations
+
+from tuxemon.event import MapCondition
+from tuxemon.event.eventcondition import EventCondition
+from tuxemon.session import Session
+
+
+class BattleResultCondition(EventCondition):
+    """
+    Check to see if the player has fought against NPC and won, lost or draw.
+
+    Script usage:
+        .. code-block::
+
+            is battle_result <character>,<result>
+
+    Script parameters:
+        character: Npc slug name (e.g. "npc_maple").
+        result: One of "won", "lost" or "draw"
+
+    """
+
+    name = "battle_result"
+
+    def test(self, session: Session, condition: MapCondition) -> bool:
+        """
+        Check to see if the player has fought against NPC and won, lost or draw.
+
+        Parameters:
+            session: The session object
+            condition: The map condition object.
+
+        Returns:
+            Whether the player has lost against character or not.
+
+        """
+        player = session.player
+
+        # Read the parameters
+        npc = condition.parameters[0]
+        result = condition.parameters[1]
+
+        # Union
+        battle_mix = str(npc) + " - " + result
+
+        if battle_mix in player.battle_history.values():
+            return True
+        else:
+            return False

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -91,6 +91,7 @@ class NPCState(TypedDict):
     current_map: str
     facing: Direction
     game_variables: Dict[str, Any]
+    battle_history: Dict[str, Any]
     inventory: Mapping[str, Optional[int]]
     monsters: Sequence[Mapping[str, Any]]
     player_name: str
@@ -167,6 +168,7 @@ class NPC(Entity[NPCState]):
         # general
         self.behavior = "wander"  # not used for now
         self.game_variables: Dict[str, Any] = {}  # Tracks the game state
+        self.battle_history: Dict[str, Any] = {}  # Tracks the battles
         self.interactions: Sequence[
             str
         ] = []  # List of ways player can interact with the Npc
@@ -257,6 +259,7 @@ class NPC(Entity[NPCState]):
             "current_map": session.client.get_map_name(),
             "facing": self.facing,
             "game_variables": self.game_variables,
+            "battle_history": self.battle_history,
             "inventory": encode_inventory(self.inventory),
             "monsters": encode_monsters(self.monsters),
             "player_name": self.name,
@@ -284,6 +287,7 @@ class NPC(Entity[NPCState]):
         """
         self.facing = save_data.get("facing", "down")
         self.game_variables = save_data["game_variables"]
+        self.battle_history = save_data["battle_history"]
         self.inventory = decode_inventory(
             session, self, save_data.get("inventory", {})
         )

--- a/tuxemon/save_upgrader.py
+++ b/tuxemon/save_upgrader.py
@@ -78,6 +78,8 @@ def upgrade_save(save_data: Dict[str, Any]) -> Dict[str, Any]:
     if "steps" not in save_data["game_variables"]:
         save_data["game_variables"]["steps"] = 0
 
+    save_data["battle_history"] = save_data.get("battle_history", {})
+
     version = save_data.get("version", 0)
     for i in range(version, SAVE_VERSION):
         _update_current_map(i, save_data)

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -387,10 +387,6 @@ class CombatState(CombatAnimations):
                 var["battle_last_monster_category"] = monster_record.category
                 var["battle_last_monster_shape"] = monster_record.shape
 
-            # update battle_total only once after each battle
-            if self.is_trainer_battle:
-                var["battle_total"] = +1
-
         elif phase == "decision phase":
             self.reset_status_icons()
             if not self._decision_queue:
@@ -413,7 +409,10 @@ class CombatState(CombatAnimations):
                     self.enqueue_action(None, technique, monster)
 
         elif phase == "resolve match":
-            pass
+            # update battle_total only once after each battle
+            if self.is_trainer_battle:
+                var = self.players[0].game_variables
+                var["battle_total"] = +1
 
         elif phase == "ran away":
             self.players[0].set_party_status()

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -387,7 +387,7 @@ class CombatState(CombatAnimations):
                 var["battle_last_monster_category"] = monster_record.category
                 var["battle_last_monster_shape"] = monster_record.shape
 
-            # update total number of battles (trainers)
+            # update battle_total only once after each battle
             if self.is_trainer_battle:
                 var["battle_total"] = +1
 

--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -376,6 +376,7 @@ class WorldState(state.State):
 
         logger.debug("*** Game Loop Started ***")
         logger.debug("Player Variables:" + str(self.player.game_variables))
+        logger.debug("Battle History:" + str(self.player.battle_history))
 
     def draw(self, surface: pygame.surface.Surface) -> None:
         """


### PR DESCRIPTION
Here the PR as described in #1234 

In details:

**1. Teleporting to the closest Center (updating maps)**
I'm aware there is teleport_faint, but I opted for the classic teleport for two reasons:

- (1) it allows me the condition "is player defeated"
- (2) it allows me to specify the place without being fixed.

So if I'm on Route 3 > Leather Center, etc. By the way the event is active on all the map (width and height), so if someone adventures himself in the route with fainted monsters, then it would be teleported to the center.

This is a piece of the code:
```
  <object id="69" name="Exhausted" type="event" x="0" y="0" width="320" height="640">
   <properties>
    <property name="act1" value="transition_teleport spyder_xxx_center.tmx,4,20,0.3"/>
    <property name="cond1" value="is player_defeated"/>
   </properties>
  </object>
```
Here a list of "where you're going to be teleported":
- Route 1 > Downstairs Home Sweet Home (it can be removed or we can reintroduce the bed for restoring in Paper)
- Route 2 > Cotton Center
- Route 3 trainer > Leather 
- Route 4 > Leather Center
- Route 5 > Flower Center
- Route 6 > Candy Center
- Route A > Downstairs Home Sweet Home
- Route C > Candy Center
- Tunnel > Timber Center
- Tunnel below > Timber Center
- Citipark > Cotton Center
- Omnichannel (all) > Cotton Center
- Nimrod (all) > Flower Center
- Greenwash (all) > Candy Center

Cotton Tunnel, Dragonscave and Dryadsgrove are missing because I'm unsure about the destination.

**2. Creating new dict called "battle history" and editing the following files: combat.py, worldstate.py, npc.py and save_upgrader.py**
Here is a list:

- combat.py
- worldstate.py
- save_upgrader.py

**2.a. combat.py**
As follows.

Datetime
```
import datetime
insert the following datetime string:
        self.players[0].game_variables["date"] = dt.datetime.now().strftime("%x")
```
Creation of new variables (game_variables) called:
```game_variables["battle_total"] = number of battles (only NPC, not Random)
game_variables["battle_draw"] = number of battles draw
game_variables["battle_won"] = number of battles won
game_variables["battle_lost"] = number of battles lost
game_variables["percent_draw"] = round(value) (i.e. 42 or 69)
game_variables["percent_won"] = round(value) (i.e. 42 or 69)
game_variables["percent_lost"] = round(value) (i.e. 42 or 69)
```

Reason? Modders. They can create a story, a tournament, etc. where they need this data, because only people with xx% of victories can access.

Creation of new variable (based on battle_history) called:
`self.players[0].battle_history[self.players[0].game_variables["date"]] = self.players[1].slug + str(" - draw")`

Output:
`{'08/16/22': 'spyder_route2_billie - lost'}`

Why the date? I thought about it.
- putting npc.slug as key, it would ended up "updated", probably replaced by "-win"
- no possibility of creating a substantial output

Like:
```
{'08/16/22': 'spyder_route2_billie - lost'}
{'08/17/22': 'spyder_route2_billie - lost'}
{'08/18/22': 'spyder_route2_billie - lost'}
{'08/22/22': 'spyder_route2_billie - lost'}
{'08/31/22': 'spyder_route2_billie - win'}
```

Of course, it's going to be updated if you fight again in the same day. So...

So... why the 08/16/22 format? I wasn't sure at the beginning.

I considered:
- the number of days (i.e. today is 228th day of the year)
- the actual hh:mm:ss, but it was missing the day
- the actual complete format mm/dd/yyyy hh:mm:ss

Considering the above reasons, well, I opted for the 08/16/2022 format.

**2.b. worldstate.py**
An addition related to battle_history()

**2.c. npc.py**
A series of additions related to battle_history()

**2.d. save_upgrader.py**
Updated the savegame.

**3. Developing an event action called: battles_print**
So it's possible to print all the battles (date + npc.slug + result). It's the copy of "print".

Reason? Modders. So they can have a complete map of battle_history.

**4. Developing an event condition called: battle_result**
As you can see below, it checks if you won, lost or draw against a specific npc.slug

```
    Script usage:
        .. code-block::

            is battle_result <character>,<result>

    Script parameters:
        character: Npc slug name (e.g. "npc_maple").
        result: One of "won", "lost" or "draw"
```
Reason? Modders. So they can check if a player won a single time against a NPC (i.e. spyder_route2_billie).

**5. Creating an event condition called: battle_is**
As you can see below, it checks an operation over a battle:

```
    Script usage:
        .. code-block::

            is battle_is <character>,<result>,<operation>,<value1>

    Script parameters:
        character: Npc slug name (e.g. "npc_maple").
        result: One of "won", "lost" or "draw"
        operation: One of "==", "!=", ">", ">=", "<" or "<=".
        value2: A number.
```
Reason? Modders. So they can check how many times the player lost, won or draw against a NPC (i.e. spyder_route2_billie).

Everything wrote above runs. It took me almost a week, but of course when you're inspired things go fast.

In addition:
- small fixes to coordinates inside maps (sometimes there was 32.00442, so I fixed at 32, etc.);
- fixed the bed inside the bedroom, now it can be used, before it wasn't possible;