### PR TITLE
time of the day

### DIFF
--- a/tuxemon/player.py
+++ b/tuxemon/player.py
@@ -83,7 +83,7 @@ class Player(NPC):
         """
         var = self.game_variables
         var["hour"] = dt.datetime.now().strftime("%H")
-        var["daynr"] = dt.datetime.now().strftime("%j")
+        var["day_of_year"] = dt.datetime.now().strftime("%j")
 
         # Day and night basic cycle (12h cycle)
         if int(var["hour"]) < 6:
@@ -95,14 +95,14 @@ class Player(NPC):
 
         # Day and night complex cycle (4h cycle)
         if int(var["hour"]) < 4:
-            var["stageofday"] = "night"
+            var["stage_of_day"] = "night"
         elif 4 <= int(var["hour"]) < 8:
-            var["stageofday"] = "dawn"
+            var["stage_of_day"] = "dawn"
         elif 8 <= int(var["hour"]) < 12:
-            var["stageofday"] = "morning"
+            var["stage_of_day"] = "morning"
         elif 12 <= int(var["hour"]) < 16:
-            var["stageofday"] = "afternoon"
+            var["stage_of_day"] = "afternoon"
         elif 16 <= int(var["hour"]) < 20:
-            var["stageofday"] = "dusk"
+            var["stage_of_day"] = "dusk"
         else:
-            var["stageofday"] = "night"
+            var["stage_of_day"] = "night"

--- a/tuxemon/player.py
+++ b/tuxemon/player.py
@@ -86,22 +86,22 @@ class Player(NPC):
 
         # Day and night basic cycle (12h cycle)
         if int(dt.datetime.now().strftime("%H")) < 6:
-            self.game_variables["b_timeofday"] = "night"
+            self.game_variables["daytime"] = False
         elif 6 <= int(dt.datetime.now().strftime("%H")) < 18:
-            self.game_variables["b_timeofday"] = "day"
+            self.game_variables["daytime"] = True
         else:
-            self.game_variables["b_timeofday"] = "night"
+            self.game_variables["daytime"] = False
 
         # Day and night complex cycle (4h cycle)
         if int(dt.datetime.now().strftime("%H")) < 4:
-            self.game_variables["c_timeofday"] = "night"
+            self.game_variables["stageofday"] = "night"
         elif 4 <= int(dt.datetime.now().strftime("%H")) < 8:
-            self.game_variables["c_timeofday"] = "dawn"
+            self.game_variables["stageofday"] = "dawn"
         elif 8 <= int(dt.datetime.now().strftime("%H")) < 12:
-            self.game_variables["c_timeofday"] = "morning"
+            self.game_variables["stageofday"] = "morning"
         elif 12 <= int(dt.datetime.now().strftime("%H")) < 16:
-            self.game_variables["c_timeofday"] = "afternoon"
+            self.game_variables["stageofday"] = "afternoon"
         elif 16 <= int(dt.datetime.now().strftime("%H")) < 20:
-            self.game_variables["c_timeofday"] = "dusk"
+            self.game_variables["stageofday"] = "dusk"
         else:
-            self.game_variables["c_timeofday"] = "night"
+            self.game_variables["stageofday"] = "night"

--- a/tuxemon/player.py
+++ b/tuxemon/player.py
@@ -30,6 +30,7 @@
 from __future__ import annotations
 
 import logging
+import datetime as dt
 
 from tuxemon.map import proj
 from tuxemon.npc import NPC
@@ -76,3 +77,31 @@ class Player(NPC):
         diff_y = abs(after.y - before.y)
 
         self.game_variables["steps"] += diff_x + diff_y
+        """
+        %H - Hour 00-23
+        %j - Day number of year 001-366
+        """
+        self.game_variables["hour"] = dt.datetime.now().strftime("%H")
+        self.game_variables["daynr"] = dt.datetime.now().strftime("%j")
+
+        # Day and night basic cycle (12h cycle)
+        if int(dt.datetime.now().strftime("%H")) < 6:
+            self.game_variables["b_timeofday"] = "night"
+        elif 6 <= int(dt.datetime.now().strftime("%H")) < 18:
+            self.game_variables["b_timeofday"] = "day"
+        else:
+            self.game_variables["b_timeofday"] = "night"
+
+        # Day and night complex cycle (4h cycle)
+        if int(dt.datetime.now().strftime("%H")) < 4:
+            self.game_variables["c_timeofday"] = "night"
+        elif 4 <= int(dt.datetime.now().strftime("%H")) < 8:
+            self.game_variables["c_timeofday"] = "dawn"
+        elif 8 <= int(dt.datetime.now().strftime("%H")) < 12:
+            self.game_variables["c_timeofday"] = "morning"
+        elif 12 <= int(dt.datetime.now().strftime("%H")) < 16:
+            self.game_variables["c_timeofday"] = "afternoon"
+        elif 16 <= int(dt.datetime.now().strftime("%H")) < 20:
+            self.game_variables["c_timeofday"] = "dusk"
+        else:
+            self.game_variables["c_timeofday"] = "night"

--- a/tuxemon/player.py
+++ b/tuxemon/player.py
@@ -81,27 +81,28 @@ class Player(NPC):
         %H - Hour 00-23
         %j - Day number of year 001-366
         """
-        self.game_variables["hour"] = dt.datetime.now().strftime("%H")
-        self.game_variables["daynr"] = dt.datetime.now().strftime("%j")
+        var = self.game_variables
+        var["hour"] = dt.datetime.now().strftime("%H")
+        var["daynr"] = dt.datetime.now().strftime("%j")
 
         # Day and night basic cycle (12h cycle)
-        if int(dt.datetime.now().strftime("%H")) < 6:
-            self.game_variables["daytime"] = False
-        elif 6 <= int(dt.datetime.now().strftime("%H")) < 18:
-            self.game_variables["daytime"] = True
+        if int(var["hour"]) < 6:
+            var["daytime"] = False
+        elif 6 <= int(var["hour"]) < 18:
+            var["daytime"] = True
         else:
-            self.game_variables["daytime"] = False
+            var["daytime"] = False
 
         # Day and night complex cycle (4h cycle)
-        if int(dt.datetime.now().strftime("%H")) < 4:
-            self.game_variables["stageofday"] = "night"
-        elif 4 <= int(dt.datetime.now().strftime("%H")) < 8:
-            self.game_variables["stageofday"] = "dawn"
-        elif 8 <= int(dt.datetime.now().strftime("%H")) < 12:
-            self.game_variables["stageofday"] = "morning"
-        elif 12 <= int(dt.datetime.now().strftime("%H")) < 16:
-            self.game_variables["stageofday"] = "afternoon"
-        elif 16 <= int(dt.datetime.now().strftime("%H")) < 20:
-            self.game_variables["stageofday"] = "dusk"
+        if int(var["hour"]) < 4:
+            var["stageofday"] = "night"
+        elif 4 <= int(var["hour"]) < 8:
+            var["stageofday"] = "dawn"
+        elif 8 <= int(var["hour"]) < 12:
+            var["stageofday"] = "morning"
+        elif 12 <= int(var["hour"]) < 16:
+            var["stageofday"] = "afternoon"
+        elif 16 <= int(var["hour"]) < 20:
+            var["stageofday"] = "dusk"
         else:
-            self.game_variables["stageofday"] = "night"
+            var["stageofday"] = "night"


### PR DESCRIPTION
While I was working on battle_history, precisely after the datetime string, I realized the absence of time inside Tuxemon. It pushed me to create the following variables (game_variables):

`game_variables["hour"] `
it gives us the HOUR (from 00 to 23)

`game_variables["daynr"]`
it gives us the DAY (001-366) - today is the 229th

`game_variables["b_timeofday"]`
it gives us (day or night) and it's based on hour

`game_variables["c_timeofday"] `
it gives us (dawn, morning, afternoon, dusk or night) and it's based on hour

Reason? Modders.

For example we can:
- decide if some NPC are going to appear or disappear during specific part of the day;
- decide if some location can be accessed or not during some parts of the day;
- set specific days where some events take place (i.e. a different days for each city, holidays, etc.);

Most of it can be done through the following condition:
is variable_set b_timeofday:day
is variable_set c_timeofday:afternoon
is variable_set daynr:333

Next possible developments? 
We can integrate the month, it could give us the variable to set the season (winter 1 - 2 - 3, spring 4 - 5 - 6, summer 7 - 8 - 9 and autumn 10 - 11 - 12)