### PR TITLE
Fix 994 - Bad Teleport

### DIFF
--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -264,7 +264,7 @@ class WorldState(state.State):
         self.remove_animations_of(self)
         self.remove_animations_of(cleanup)
 
-        self.stop_player()
+        self.stop_and_reset_player()
 
         self.in_transition = True
         self.trigger_fade_out(duration)


### PR DESCRIPTION
Fixes #994 
Teleport would sometimes put the player on the current position on the new map, rather than the expected position defined by the action parameters.