### PR TITLE
Shop menu cursor fix

### DIFF
--- a/tuxemon/menu/menu.py
+++ b/tuxemon/menu/menu.py
@@ -358,23 +358,32 @@ class Menu(Generic[T], state.State):
         self._needs_refresh = True
         items = self.initialize_items()
 
-        if items:
-            self.menu_items.empty()
+        if not items:
+            return
 
-            for item in items:
-                self.add(item)
-                if item.enabled:
-                    item.enabled = self.is_valid_entry(item.game_object)
+        self.menu_items.empty()
 
-            self.menu_items.arrange_menu_items()
-            for index, item in enumerate(self.menu_items):
-                # TODO: avoid introspection of the items to implement
-                # different behavior
-                if item.game_object.__class__.__name__ != "Monster":
-                    break
-                self.selected_index = index
-                if item.enabled:
-                    break
+        for item in items:
+            self.add(item)
+            if item.enabled:
+                item.enabled = self.is_valid_entry(item.game_object)
+
+        self.menu_items.arrange_menu_items()
+
+        selected_item = self.get_selected_item()
+        if selected_item and selected_item.enabled:
+            return
+
+        # Choose new cursor position. We can't use the prev position, so we
+        # will use the closest valid option.
+        score = None
+        prev_index = self.selected_index
+        for index, item in enumerate(self.menu_items):
+            if item.enabled:
+                new_score = abs(prev_index - index)
+                if score is None or new_score < score:
+                    self.selected_index = index
+                    score = new_score
 
     def build_item(
         self: Menu[Callable[[], object]],

--- a/tuxemon/states/items/__init__.py
+++ b/tuxemon/states/items/__init__.py
@@ -373,6 +373,9 @@ class ShopMenuState(Menu[Item]):
             self.item_sprite.image = image
             self.item_sprite.rect = image.get_rect(center=self.image_center)
             self.alert(item.description)
+        else:
+            self.item_sprite.image = None
+            self.alert("")
 
 
 class ShopBuyMenuState(ShopMenuState):

--- a/tuxemon/states/world/world_menus.py
+++ b/tuxemon/states/world/world_menus.py
@@ -169,6 +169,7 @@ class WorldMenuState(PygameMenuState):
                     [T.format("tuxemon_released", {"name": monster.name})],
                 )
                 monster_menu.refresh_menu_items()
+                monster_menu.on_menu_selection_change()
             else:
                 open_dialog(local_session, [T.translate("cant_release")])
 


### PR DESCRIPTION
Fix issue where the game would crash if you sold the last item in the menu. Fixes (https://github.com/Tuxemon/Tuxemon/issues/677) display issue where the image wouldn't be updated when you sold the last item.