### PR TITLE
Add config option to skip dialog animation

### DIFF
--- a/tuxemon/config.py
+++ b/tuxemon/config.py
@@ -135,6 +135,11 @@ class TuxemonConfig:
             "gameplay",
             "default_lower_monster_catch_resistance",
         )
+        self.dialog_speed = cfg.get(
+            "gameplay",
+            "dialog_speed",
+        )
+        assert self.dialog_speed in ("slow", "max")
 
         # [player]
         self.player_animation_speed = cfg.getfloat("player", "animation_speed")
@@ -287,6 +292,7 @@ def get_defaults() -> Mapping[str, Any]:
                         ("default_monster_catch_rate", 125),
                         ("default_upper_monster_catch_resistance", 1),
                         ("default_lower_monster_catch_resistance", 1),
+                        ("dialog_speed", "slow"),
                     )
                 ),
             ),

--- a/tuxemon/menu/menu.py
+++ b/tuxemon/menu/menu.py
@@ -27,6 +27,7 @@ from tuxemon.menu.interface import MenuCursor, MenuItem
 from tuxemon.menu.theme import get_sound_engine, get_theme
 from tuxemon.platform.const import buttons, intentions
 from tuxemon.platform.events import PlayerInput
+from tuxemon.prepare import CONFIG
 from tuxemon.sprite import (
     MenuSpriteGroup,
     RelativeGroup,
@@ -292,7 +293,15 @@ class Menu(Generic[T], state.State):
 
         """
         text_area.text = text
-        self.start_text_animation(text_area, callback)
+        if CONFIG.dialog_speed == "max":
+            # exhaust the iterator to immediately blit every char to the dialog
+            # box
+            for _ in text_area:
+                pass
+            if callback:
+                callback()
+        else:
+            self.start_text_animation(text_area, callback)
 
     def alert(
         self,


### PR DESCRIPTION
The dialog animation is a bit slow, especially if you're debugging a script and reading the same text over and over.

Add option to config: "dialog_speed"
Options:
slow - (default option, current implementation)
max - no animation

Can add "medium" and "fast" later, but I think this is constrained by the clock speed and will be a bit more work.

