### PR TITLE
spyder maps fixes

### DIFF
--- a/mods/tuxemon/maps/cotton_scoop.tmx
+++ b/mods/tuxemon/maps/cotton_scoop.tmx
@@ -95,12 +95,6 @@
   </data>
  </layer>
  <objectgroup color="#ffff00" id="6" name="Events">
-  <properties>
-   <property name="act1" value="transition_teleport cotton_town.tmx,9,35,0.3"/>
-   <property name="act2" value="player_face down"/>
-   <property name="cond1" value="is player_at"/>
-   <property name="cond2" value="is player_facing down"/>
-  </properties>
   <object id="13" name="Teleport to Cotton Town" type="event" x="80" y="160" width="32" height="16">
    <properties>
     <property name="act10" value="transition_teleport cotton_town.tmx,9,35,0.3"/>

--- a/mods/tuxemon/maps/spyder_candy_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_candy_scoop.tmx
@@ -95,12 +95,6 @@
   <object id="27" type="collision" x="16" y="64" width="16" height="16"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="6" name="Events">
-  <properties>
-   <property name="act1" value="transition_teleport cotton_town.tmx,9,35,0.3"/>
-   <property name="act2" value="player_face down"/>
-   <property name="cond1" value="is player_at"/>
-   <property name="cond2" value="is player_facing down"/>
-  </properties>
   <object id="13" name="Teleport to Candy City" type="event" x="80" y="160" width="32" height="16">
    <properties>
     <property name="act1" value="transition_teleport spyder_candy_town.tmx,3,13,0.3"/>

--- a/mods/tuxemon/maps/spyder_cotton_artshop.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_artshop.tmx
@@ -81,12 +81,6 @@
   <object id="34" type="collision" x="64" y="112" width="16" height="16"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="6" name="Events">
-  <properties>
-   <property name="act1" value="transition_teleport cotton_town.tmx,9,35,0.3"/>
-   <property name="act2" value="player_face down"/>
-   <property name="cond1" value="is player_at"/>
-   <property name="cond2" value="is player_facing down"/>
-  </properties>
   <object id="13" name="Teleport to Cotton Town" type="event" x="16" y="160" width="32" height="16">
    <properties>
     <property name="act1" value="transition_teleport spyder_cotton_town.tmx,16,17,0.3"/>

--- a/mods/tuxemon/maps/spyder_cotton_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_scoop.tmx
@@ -95,12 +95,6 @@
   <object id="27" type="collision" x="16" y="64" width="16" height="16"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="6" name="Events">
-  <properties>
-   <property name="act1" value="transition_teleport cotton_town.tmx,9,35,0.3"/>
-   <property name="act2" value="player_face down"/>
-   <property name="cond1" value="is player_at"/>
-   <property name="cond2" value="is player_facing down"/>
-  </properties>
   <object id="13" name="Teleport to Cotton Town" type="event" x="80" y="160" width="32" height="16">
    <properties>
     <property name="act1" value="transition_teleport spyder_cotton_town.tmx,30,35,0.3"/>

--- a/mods/tuxemon/maps/spyder_flower_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_flower_scoop.tmx
@@ -95,12 +95,6 @@
   <object id="27" type="collision" x="16" y="64" width="16" height="16"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="6" name="Events">
-  <properties>
-   <property name="act1" value="transition_teleport cotton_town.tmx,9,35,0.3"/>
-   <property name="act2" value="player_face down"/>
-   <property name="cond1" value="is player_at"/>
-   <property name="cond2" value="is player_facing down"/>
-  </properties>
   <object id="13" name="Teleport to Flower City" type="event" x="80" y="160" width="32" height="16">
    <properties>
     <property name="act1" value="transition_teleport spyder_flower_city.tmx,25,24,0.3"/>

--- a/mods/tuxemon/maps/spyder_leather_museum.tmx
+++ b/mods/tuxemon/maps/spyder_leather_museum.tmx
@@ -93,12 +93,6 @@
   <object id="54" type="collision" x="64" y="112" width="16" height="16"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="6" name="Events">
-  <properties>
-   <property name="act1" value="transition_teleport cotton_town.tmx,9,35,0.3"/>
-   <property name="act2" value="player_face down"/>
-   <property name="cond1" value="is player_at"/>
-   <property name="cond2" value="is player_facing down"/>
-  </properties>
   <object id="13" name="Teleport to Leather Town" type="event" x="16" y="160" width="32" height="16">
    <properties>
     <property name="act1" value="transition_teleport spyder_leather_town.tmx,25,15,0.3"/>

--- a/mods/tuxemon/maps/spyder_timber_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_timber_scoop.tmx
@@ -95,12 +95,6 @@
   <object id="27" type="collision" x="16" y="64" width="16" height="16"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="6" name="Events">
-  <properties>
-   <property name="act1" value="transition_teleport cotton_town.tmx,9,35,0.3"/>
-   <property name="act2" value="player_face down"/>
-   <property name="cond1" value="is player_at"/>
-   <property name="cond2" value="is player_facing down"/>
-  </properties>
   <object id="13" name="Teleport to Timber City" type="event" x="80" y="160" width="32" height="16">
    <properties>
     <property name="act1" value="transition_teleport spyder_timber_town.tmx,14,12,0.3"/>


### PR DESCRIPTION
During the "teleport on lose" I noticed some unlinked properties in these maps:
- spyder_candy_scoop.tmx
- spyder_cotton_artshop.tmx
- spyder_cotton_scoop.tmx
- spyder_flower_scoop.tmx
- spyder_leather_museum.tmx
- spyder_timber_scoop.tmx
- cotton_scoop.tmx