### PR TITLE
Get monsters id

### DIFF
--- a/mods/tuxemon/db/monster/aardart.json
+++ b/mods/tuxemon/db/monster/aardart.json
@@ -28,9 +28,9 @@
     "types": [
         "Earth"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 42,
+    "height": 185,
+    "weight": 45,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/aardart.json
+++ b/mods/tuxemon/db/monster/aardart.json
@@ -28,7 +28,9 @@
     "types": [
         "Earth"
     ],
-    "weight": 25,
+    "txmn_id": 42,
+    "height": 185,
+    "weight": 45,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/aardart.json
+++ b/mods/tuxemon/db/monster/aardart.json
@@ -28,6 +28,8 @@
     "types": [
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/aardart.json
+++ b/mods/tuxemon/db/monster/aardart.json
@@ -28,7 +28,7 @@
     "types": [
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/aardorn.json
+++ b/mods/tuxemon/db/monster/aardorn.json
@@ -28,9 +28,9 @@
     "types": [
         "Earth"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 41,
+    "height": 40,
+    "weight": 18,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/aardorn.json
+++ b/mods/tuxemon/db/monster/aardorn.json
@@ -28,6 +28,8 @@
     "types": [
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/aardorn.json
+++ b/mods/tuxemon/db/monster/aardorn.json
@@ -28,7 +28,9 @@
     "types": [
         "Earth"
     ],
-    "weight": 25,
+    "txmn_id": 41,
+    "height": 40,
+    "weight": 18,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/aardorn.json
+++ b/mods/tuxemon/db/monster/aardorn.json
@@ -28,7 +28,7 @@
     "types": [
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/abesnaki.json
+++ b/mods/tuxemon/db/monster/abesnaki.json
@@ -20,9 +20,9 @@
     "types": [
         "Fire"
     ],
-    "txmn_id": 0,
+    "txmn_id": 98,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/abesnaki.json
+++ b/mods/tuxemon/db/monster/abesnaki.json
@@ -20,7 +20,9 @@
     "types": [
         "Fire"
     ],
-    "weight": 25,
+    "txmn_id": 98,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/abesnaki.json
+++ b/mods/tuxemon/db/monster/abesnaki.json
@@ -20,6 +20,8 @@
     "types": [
         "Fire"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/abesnaki.json
+++ b/mods/tuxemon/db/monster/abesnaki.json
@@ -20,7 +20,7 @@
     "types": [
         "Fire"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/agnidon.json
+++ b/mods/tuxemon/db/monster/agnidon.json
@@ -20,7 +20,9 @@
     "types": [
         "Fire"
     ],
-    "weight": 25,
+    "txmn_id": 14,
+    "height": 320,
+    "weight": 230,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/agnidon.json
+++ b/mods/tuxemon/db/monster/agnidon.json
@@ -20,9 +20,9 @@
     "types": [
         "Fire"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 14,
+    "height": 320,
+    "weight": 230,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/agnidon.json
+++ b/mods/tuxemon/db/monster/agnidon.json
@@ -20,7 +20,7 @@
     "types": [
         "Fire"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/agnidon.json
+++ b/mods/tuxemon/db/monster/agnidon.json
@@ -20,6 +20,8 @@
     "types": [
         "Fire"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/agnigon.json
+++ b/mods/tuxemon/db/monster/agnigon.json
@@ -20,9 +20,9 @@
     "types": [
         "Fire"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 15,
+    "height": 600,
+    "weight": 2000,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/agnigon.json
+++ b/mods/tuxemon/db/monster/agnigon.json
@@ -20,7 +20,7 @@
     "types": [
         "Fire"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/agnigon.json
+++ b/mods/tuxemon/db/monster/agnigon.json
@@ -20,6 +20,8 @@
     "types": [
         "Fire"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,

--- a/mods/tuxemon/db/monster/agnigon.json
+++ b/mods/tuxemon/db/monster/agnigon.json
@@ -20,7 +20,9 @@
     "types": [
         "Fire"
     ],
-    "weight": 25,
+    "txmn_id": 15,
+    "height": 600,
+    "weight": 2000,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/agnite.json
+++ b/mods/tuxemon/db/monster/agnite.json
@@ -20,9 +20,9 @@
     "types": [
         "Fire"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 13,
+    "height": 80,
+    "weight": 24,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/agnite.json
+++ b/mods/tuxemon/db/monster/agnite.json
@@ -20,6 +20,8 @@
     "types": [
         "Fire"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/agnite.json
+++ b/mods/tuxemon/db/monster/agnite.json
@@ -20,7 +20,9 @@
     "types": [
         "Fire"
     ],
-    "weight": 25,
+    "txmn_id": 13,
+    "height": 80,
+    "weight": 24,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/agnite.json
+++ b/mods/tuxemon/db/monster/agnite.json
@@ -20,7 +20,7 @@
     "types": [
         "Fire"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/allagon.json
+++ b/mods/tuxemon/db/monster/allagon.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
+    "txmn_id": 153,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 3.0,
     "lower_catch_resistance": 0.8,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/allagon.json
+++ b/mods/tuxemon/db/monster/allagon.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 3.0,

--- a/mods/tuxemon/db/monster/allagon.json
+++ b/mods/tuxemon/db/monster/allagon.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 153,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 3.0,
     "lower_catch_resistance": 0.8,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/allagon.json
+++ b/mods/tuxemon/db/monster/allagon.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 3.0,
     "lower_catch_resistance": 0.8,

--- a/mods/tuxemon/db/monster/angrito.json
+++ b/mods/tuxemon/db/monster/angrito.json
@@ -22,8 +22,8 @@
         "Metal"
     ],
     "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "height": 90,
+    "weight": 55,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/angrito.json
+++ b/mods/tuxemon/db/monster/angrito.json
@@ -21,6 +21,8 @@
         "Fire",
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/angrito.json
+++ b/mods/tuxemon/db/monster/angrito.json
@@ -21,7 +21,7 @@
         "Fire",
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/angrito.json
+++ b/mods/tuxemon/db/monster/angrito.json
@@ -21,7 +21,9 @@
         "Fire",
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 0,
+    "height": 90,
+    "weight": 55,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/anoleaf.json
+++ b/mods/tuxemon/db/monster/anoleaf.json
@@ -20,7 +20,9 @@
     "types": [
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 64,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/anoleaf.json
+++ b/mods/tuxemon/db/monster/anoleaf.json
@@ -20,6 +20,8 @@
     "types": [
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/anoleaf.json
+++ b/mods/tuxemon/db/monster/anoleaf.json
@@ -20,7 +20,7 @@
     "types": [
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/anoleaf.json
+++ b/mods/tuxemon/db/monster/anoleaf.json
@@ -20,9 +20,9 @@
     "types": [
         "Wood"
     ],
-    "txmn_id": 0,
+    "txmn_id": 64,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/anu.json
+++ b/mods/tuxemon/db/monster/anu.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/anu.json
+++ b/mods/tuxemon/db/monster/anu.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/anu.json
+++ b/mods/tuxemon/db/monster/anu.json
@@ -21,8 +21,8 @@
         "Metal"
     ],
     "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "height": 100,
+    "weight": 10,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/anu.json
+++ b/mods/tuxemon/db/monster/anu.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 0,
+    "height": 100,
+    "weight": 10,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/araignee.json
+++ b/mods/tuxemon/db/monster/araignee.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/araignee.json
+++ b/mods/tuxemon/db/monster/araignee.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/araignee.json
+++ b/mods/tuxemon/db/monster/araignee.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
+    "txmn_id": 99,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/araignee.json
+++ b/mods/tuxemon/db/monster/araignee.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 99,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/arthrobolt.json
+++ b/mods/tuxemon/db/monster/arthrobolt.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/arthrobolt.json
+++ b/mods/tuxemon/db/monster/arthrobolt.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 6,
+    "height": 110,
+    "weight": 125,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/arthrobolt.json
+++ b/mods/tuxemon/db/monster/arthrobolt.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,

--- a/mods/tuxemon/db/monster/arthrobolt.json
+++ b/mods/tuxemon/db/monster/arthrobolt.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 6,
+    "height": 110,
+    "weight": 125,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/av8r.json
+++ b/mods/tuxemon/db/monster/av8r.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 125,
+    "height": 0,
+    "weight": 0,
     "sounds": {
         "combat_call": "sound_av8r",
         "faint_call": "sound_av8r_faint"

--- a/mods/tuxemon/db/monster/av8r.json
+++ b/mods/tuxemon/db/monster/av8r.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
+    "txmn_id": 125,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "sounds": {
         "combat_call": "sound_av8r",
         "faint_call": "sound_av8r_faint"

--- a/mods/tuxemon/db/monster/av8r.json
+++ b/mods/tuxemon/db/monster/av8r.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "sounds": {
         "combat_call": "sound_av8r",

--- a/mods/tuxemon/db/monster/av8r.json
+++ b/mods/tuxemon/db/monster/av8r.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "sounds": {

--- a/mods/tuxemon/db/monster/axylightl.json
+++ b/mods/tuxemon/db/monster/axylightl.json
@@ -20,6 +20,8 @@
     "types": [
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/axylightl.json
+++ b/mods/tuxemon/db/monster/axylightl.json
@@ -20,9 +20,9 @@
     "types": [
         "Water"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 100,
+    "height": 80,
+    "weight": 15,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/axylightl.json
+++ b/mods/tuxemon/db/monster/axylightl.json
@@ -20,7 +20,7 @@
     "types": [
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/axylightl.json
+++ b/mods/tuxemon/db/monster/axylightl.json
@@ -20,7 +20,9 @@
     "types": [
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 100,
+    "height": 80,
+    "weight": 15,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/bamboon.json
+++ b/mods/tuxemon/db/monster/bamboon.json
@@ -20,6 +20,8 @@
     "types": [
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/bamboon.json
+++ b/mods/tuxemon/db/monster/bamboon.json
@@ -20,7 +20,9 @@
     "types": [
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 27,
+    "height": 120,
+    "weight": 40,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/bamboon.json
+++ b/mods/tuxemon/db/monster/bamboon.json
@@ -20,7 +20,7 @@
     "types": [
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/bamboon.json
+++ b/mods/tuxemon/db/monster/bamboon.json
@@ -20,9 +20,9 @@
     "types": [
         "Wood"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 27,
+    "height": 120,
+    "weight": 40,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/bigfin.json
+++ b/mods/tuxemon/db/monster/bigfin.json
@@ -20,6 +20,8 @@
     "types": [
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,

--- a/mods/tuxemon/db/monster/bigfin.json
+++ b/mods/tuxemon/db/monster/bigfin.json
@@ -20,7 +20,9 @@
     "types": [
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 24,
+    "height": 1200,
+    "weight": 50000,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/bigfin.json
+++ b/mods/tuxemon/db/monster/bigfin.json
@@ -20,7 +20,7 @@
     "types": [
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/bigfin.json
+++ b/mods/tuxemon/db/monster/bigfin.json
@@ -20,9 +20,9 @@
     "types": [
         "Water"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 24,
+    "height": 1200,
+    "weight": 50000,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/birb_robo.json
+++ b/mods/tuxemon/db/monster/birb_robo.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "txmn_id": 0,
+    "height": 0,
     "weight": 100,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/birb_robo.json
+++ b/mods/tuxemon/db/monster/birb_robo.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 100,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/birb_robo.json
+++ b/mods/tuxemon/db/monster/birb_robo.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 100,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/birdling.json
+++ b/mods/tuxemon/db/monster/birdling.json
@@ -20,9 +20,9 @@
     "types": [
         "Wood"
     ],
-    "txmn_id": 0,
+    "txmn_id": 81,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/birdling.json
+++ b/mods/tuxemon/db/monster/birdling.json
@@ -20,6 +20,8 @@
     "types": [
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/birdling.json
+++ b/mods/tuxemon/db/monster/birdling.json
@@ -20,7 +20,9 @@
     "types": [
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 81,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/birdling.json
+++ b/mods/tuxemon/db/monster/birdling.json
@@ -20,7 +20,7 @@
     "types": [
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/bolt.json
+++ b/mods/tuxemon/db/monster/bolt.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/bolt.json
+++ b/mods/tuxemon/db/monster/bolt.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 5,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/bolt.json
+++ b/mods/tuxemon/db/monster/bolt.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
+    "txmn_id": 5,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/bolt.json
+++ b/mods/tuxemon/db/monster/bolt.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/botbot.json
+++ b/mods/tuxemon/db/monster/botbot.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/botbot.json
+++ b/mods/tuxemon/db/monster/botbot.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/botbot.json
+++ b/mods/tuxemon/db/monster/botbot.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 124,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/botbot.json
+++ b/mods/tuxemon/db/monster/botbot.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
+    "txmn_id": 124,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/budaye.json
+++ b/mods/tuxemon/db/monster/budaye.json
@@ -20,6 +20,8 @@
     "types": [
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/budaye.json
+++ b/mods/tuxemon/db/monster/budaye.json
@@ -20,7 +20,7 @@
     "types": [
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/budaye.json
+++ b/mods/tuxemon/db/monster/budaye.json
@@ -20,7 +20,9 @@
     "types": [
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 26,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/budaye.json
+++ b/mods/tuxemon/db/monster/budaye.json
@@ -20,9 +20,9 @@
     "types": [
         "Wood"
     ],
-    "txmn_id": 0,
+    "txmn_id": 26,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/bugnin.json
+++ b/mods/tuxemon/db/monster/bugnin.json
@@ -21,7 +21,9 @@
         "Metal",
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 57,
+    "height": 150,
+    "weight": 52,
     "catch_rate": 3.0,
     "lower_catch_resistance": 0.8,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/bugnin.json
+++ b/mods/tuxemon/db/monster/bugnin.json
@@ -21,7 +21,7 @@
         "Metal",
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 3.0,

--- a/mods/tuxemon/db/monster/bugnin.json
+++ b/mods/tuxemon/db/monster/bugnin.json
@@ -21,6 +21,8 @@
         "Metal",
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 3.0,
     "lower_catch_resistance": 0.8,

--- a/mods/tuxemon/db/monster/bugnin.json
+++ b/mods/tuxemon/db/monster/bugnin.json
@@ -21,9 +21,9 @@
         "Metal",
         "Wood"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 57,
+    "height": 150,
+    "weight": 52,
     "catch_rate": 3.0,
     "lower_catch_resistance": 0.8,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/bursa.json
+++ b/mods/tuxemon/db/monster/bursa.json
@@ -20,9 +20,9 @@
     "types": [
         "Fire"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 82,
+    "height": 180,
+    "weight": 110,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/bursa.json
+++ b/mods/tuxemon/db/monster/bursa.json
@@ -20,6 +20,8 @@
     "types": [
         "Fire"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/bursa.json
+++ b/mods/tuxemon/db/monster/bursa.json
@@ -20,7 +20,9 @@
     "types": [
         "Fire"
     ],
-    "weight": 25,
+    "txmn_id": 82,
+    "height": 180,
+    "weight": 110,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/bursa.json
+++ b/mods/tuxemon/db/monster/bursa.json
@@ -20,7 +20,7 @@
     "types": [
         "Fire"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/cairfrey.json
+++ b/mods/tuxemon/db/monster/cairfrey.json
@@ -20,9 +20,9 @@
     "types": [
         "Earth"
     ],
-    "txmn_id": 0,
+    "txmn_id": 70,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/cairfrey.json
+++ b/mods/tuxemon/db/monster/cairfrey.json
@@ -20,7 +20,9 @@
     "types": [
         "Earth"
     ],
-    "weight": 25,
+    "txmn_id": 70,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/cairfrey.json
+++ b/mods/tuxemon/db/monster/cairfrey.json
@@ -20,7 +20,7 @@
     "types": [
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/cairfrey.json
+++ b/mods/tuxemon/db/monster/cairfrey.json
@@ -20,6 +20,8 @@
     "types": [
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/capiti.json
+++ b/mods/tuxemon/db/monster/capiti.json
@@ -20,6 +20,8 @@
     "types": [
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/capiti.json
+++ b/mods/tuxemon/db/monster/capiti.json
@@ -20,7 +20,7 @@
     "types": [
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/capiti.json
+++ b/mods/tuxemon/db/monster/capiti.json
@@ -20,9 +20,9 @@
     "types": [
         "Wood"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 101,
+    "height": 100,
+    "weight": 20,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/capiti.json
+++ b/mods/tuxemon/db/monster/capiti.json
@@ -20,7 +20,9 @@
     "types": [
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 101,
+    "height": 100,
+    "weight": 20,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/cardiling.json
+++ b/mods/tuxemon/db/monster/cardiling.json
@@ -20,9 +20,9 @@
     "types": [
         "Fire"
     ],
-    "txmn_id": 0,
+    "txmn_id": 61,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/cardiling.json
+++ b/mods/tuxemon/db/monster/cardiling.json
@@ -20,7 +20,9 @@
     "types": [
         "Fire"
     ],
-    "weight": 25,
+    "txmn_id": 61,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/cardiling.json
+++ b/mods/tuxemon/db/monster/cardiling.json
@@ -20,6 +20,8 @@
     "types": [
         "Fire"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/cardiling.json
+++ b/mods/tuxemon/db/monster/cardiling.json
@@ -20,7 +20,7 @@
     "types": [
         "Fire"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/cardinale.json
+++ b/mods/tuxemon/db/monster/cardinale.json
@@ -20,7 +20,9 @@
     "types": [
         "Fire"
     ],
-    "weight": 25,
+    "txmn_id": 63,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/cardinale.json
+++ b/mods/tuxemon/db/monster/cardinale.json
@@ -20,7 +20,7 @@
     "types": [
         "Fire"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/cardinale.json
+++ b/mods/tuxemon/db/monster/cardinale.json
@@ -20,9 +20,9 @@
     "types": [
         "Fire"
     ],
-    "txmn_id": 0,
+    "txmn_id": 63,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/cardinale.json
+++ b/mods/tuxemon/db/monster/cardinale.json
@@ -20,6 +20,8 @@
     "types": [
         "Fire"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,

--- a/mods/tuxemon/db/monster/cardiwing.json
+++ b/mods/tuxemon/db/monster/cardiwing.json
@@ -20,7 +20,9 @@
     "types": [
         "Fire"
     ],
-    "weight": 25,
+    "txmn_id": 62,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/cardiwing.json
+++ b/mods/tuxemon/db/monster/cardiwing.json
@@ -20,9 +20,9 @@
     "types": [
         "Fire"
     ],
-    "txmn_id": 0,
+    "txmn_id": 62,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/cardiwing.json
+++ b/mods/tuxemon/db/monster/cardiwing.json
@@ -20,7 +20,7 @@
     "types": [
         "Fire"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/cardiwing.json
+++ b/mods/tuxemon/db/monster/cardiwing.json
@@ -20,6 +20,8 @@
     "types": [
         "Fire"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/cataspike.json
+++ b/mods/tuxemon/db/monster/cataspike.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/cataspike.json
+++ b/mods/tuxemon/db/monster/cataspike.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/cataspike.json
+++ b/mods/tuxemon/db/monster/cataspike.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 32,
+    "height": 12,
+    "weight": 1,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/cataspike.json
+++ b/mods/tuxemon/db/monster/cataspike.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 32,
+    "height": 12,
+    "weight": 1,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/cateye.json
+++ b/mods/tuxemon/db/monster/cateye.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/cateye.json
+++ b/mods/tuxemon/db/monster/cateye.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/cateye.json
+++ b/mods/tuxemon/db/monster/cateye.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 102,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/cateye.json
+++ b/mods/tuxemon/db/monster/cateye.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
+    "txmn_id": 102,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/chenipode.json
+++ b/mods/tuxemon/db/monster/chenipode.json
@@ -20,9 +20,9 @@
     "types": [
         "Earth"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 59,
+    "height": 15,
+    "weight": 0.5,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/chenipode.json
+++ b/mods/tuxemon/db/monster/chenipode.json
@@ -20,7 +20,7 @@
     "types": [
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/chenipode.json
+++ b/mods/tuxemon/db/monster/chenipode.json
@@ -20,7 +20,9 @@
     "types": [
         "Earth"
     ],
-    "weight": 25,
+    "txmn_id": 59,
+    "height": 15,
+    "weight": 0.5,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/chenipode.json
+++ b/mods/tuxemon/db/monster/chenipode.json
@@ -20,6 +20,8 @@
     "types": [
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/chillimp.json
+++ b/mods/tuxemon/db/monster/chillimp.json
@@ -21,7 +21,9 @@
         "Water",
         "Earth"
     ],
-    "weight": 25,
+    "txmn_id": 149,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/chillimp.json
+++ b/mods/tuxemon/db/monster/chillimp.json
@@ -21,7 +21,7 @@
         "Water",
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/chillimp.json
+++ b/mods/tuxemon/db/monster/chillimp.json
@@ -21,6 +21,8 @@
         "Water",
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,

--- a/mods/tuxemon/db/monster/chillimp.json
+++ b/mods/tuxemon/db/monster/chillimp.json
@@ -21,9 +21,9 @@
         "Water",
         "Earth"
     ],
-    "txmn_id": 0,
+    "txmn_id": 149,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/chloragon.json
+++ b/mods/tuxemon/db/monster/chloragon.json
@@ -20,9 +20,9 @@
     "types": [
         "Wood"
     ],
-    "txmn_id": 0,
+    "txmn_id": 136,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/chloragon.json
+++ b/mods/tuxemon/db/monster/chloragon.json
@@ -20,6 +20,8 @@
     "types": [
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/chloragon.json
+++ b/mods/tuxemon/db/monster/chloragon.json
@@ -20,7 +20,7 @@
     "types": [
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/chloragon.json
+++ b/mods/tuxemon/db/monster/chloragon.json
@@ -20,7 +20,9 @@
     "types": [
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 136,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/chrome_robo.json
+++ b/mods/tuxemon/db/monster/chrome_robo.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "txmn_id": 0,
+    "height": 0,
     "weight": 100,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/chrome_robo.json
+++ b/mods/tuxemon/db/monster/chrome_robo.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 100,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/chrome_robo.json
+++ b/mods/tuxemon/db/monster/chrome_robo.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 100,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/chromeye.json
+++ b/mods/tuxemon/db/monster/chromeye.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/chromeye.json
+++ b/mods/tuxemon/db/monster/chromeye.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/chromeye.json
+++ b/mods/tuxemon/db/monster/chromeye.json
@@ -21,8 +21,8 @@
         "Metal"
     ],
     "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "height": 38,
+    "weight": 3.5,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/chromeye.json
+++ b/mods/tuxemon/db/monster/chromeye.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 0,
+    "height": 38,
+    "weight": 3.5,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/cochini.json
+++ b/mods/tuxemon/db/monster/cochini.json
@@ -20,9 +20,9 @@
     "types": [
         "Earth"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 103,
+    "height": 80,
+    "weight": 15,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/cochini.json
+++ b/mods/tuxemon/db/monster/cochini.json
@@ -20,6 +20,8 @@
     "types": [
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/cochini.json
+++ b/mods/tuxemon/db/monster/cochini.json
@@ -20,7 +20,7 @@
     "types": [
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/cochini.json
+++ b/mods/tuxemon/db/monster/cochini.json
@@ -20,7 +20,9 @@
     "types": [
         "Earth"
     ],
-    "weight": 25,
+    "txmn_id": 103,
+    "height": 80,
+    "weight": 15,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/coleorus.json
+++ b/mods/tuxemon/db/monster/coleorus.json
@@ -21,9 +21,9 @@
         "Wood",
         "Earth"
     ],
-    "txmn_id": 0,
+    "txmn_id": 104,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/coleorus.json
+++ b/mods/tuxemon/db/monster/coleorus.json
@@ -21,7 +21,9 @@
         "Wood",
         "Earth"
     ],
-    "weight": 25,
+    "txmn_id": 104,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/coleorus.json
+++ b/mods/tuxemon/db/monster/coleorus.json
@@ -21,6 +21,8 @@
         "Wood",
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/coleorus.json
+++ b/mods/tuxemon/db/monster/coleorus.json
@@ -21,7 +21,7 @@
         "Wood",
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/conifrost.json
+++ b/mods/tuxemon/db/monster/conifrost.json
@@ -21,9 +21,9 @@
         "Water",
         "Wood"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 105,
+    "height": 250,
+    "weight": 371,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/conifrost.json
+++ b/mods/tuxemon/db/monster/conifrost.json
@@ -21,6 +21,8 @@
         "Water",
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/conifrost.json
+++ b/mods/tuxemon/db/monster/conifrost.json
@@ -21,7 +21,9 @@
         "Water",
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 105,
+    "height": 250,
+    "weight": 371,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/conifrost.json
+++ b/mods/tuxemon/db/monster/conifrost.json
@@ -21,7 +21,7 @@
         "Water",
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/conileaf.json
+++ b/mods/tuxemon/db/monster/conileaf.json
@@ -20,6 +20,8 @@
     "types": [
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/conileaf.json
+++ b/mods/tuxemon/db/monster/conileaf.json
@@ -20,9 +20,9 @@
     "types": [
         "Wood"
     ],
-    "txmn_id": 0,
+    "txmn_id": 144,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/conileaf.json
+++ b/mods/tuxemon/db/monster/conileaf.json
@@ -20,7 +20,9 @@
     "types": [
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 144,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/conileaf.json
+++ b/mods/tuxemon/db/monster/conileaf.json
@@ -20,7 +20,7 @@
     "types": [
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/coproblight.json
+++ b/mods/tuxemon/db/monster/coproblight.json
@@ -20,6 +20,8 @@
     "types": [
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 1,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/coproblight.json
+++ b/mods/tuxemon/db/monster/coproblight.json
@@ -20,7 +20,7 @@
     "types": [
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 1,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/coproblight.json
+++ b/mods/tuxemon/db/monster/coproblight.json
@@ -20,6 +20,8 @@
     "types": [
         "Earth"
     ],
+    "txmn_id": 0,
+    "height": 0,
     "weight": 1,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/corvix.json
+++ b/mods/tuxemon/db/monster/corvix.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/corvix.json
+++ b/mods/tuxemon/db/monster/corvix.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 151,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/corvix.json
+++ b/mods/tuxemon/db/monster/corvix.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
+    "txmn_id": 151,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/corvix.json
+++ b/mods/tuxemon/db/monster/corvix.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,

--- a/mods/tuxemon/db/monster/cowpignon.json
+++ b/mods/tuxemon/db/monster/cowpignon.json
@@ -21,7 +21,9 @@
         "Wood",
         "Earth"
     ],
-    "weight": 25,
+    "txmn_id": 106,
+    "height": 30.48,
+    "weight": 2,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/cowpignon.json
+++ b/mods/tuxemon/db/monster/cowpignon.json
@@ -21,6 +21,8 @@
         "Wood",
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/cowpignon.json
+++ b/mods/tuxemon/db/monster/cowpignon.json
@@ -21,7 +21,7 @@
         "Wood",
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/cowpignon.json
+++ b/mods/tuxemon/db/monster/cowpignon.json
@@ -21,9 +21,9 @@
         "Wood",
         "Earth"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 106,
+    "height": 30.48,
+    "weight": 2,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/criniotherme.json
+++ b/mods/tuxemon/db/monster/criniotherme.json
@@ -20,9 +20,9 @@
     "types": [
         "Fire"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 20,
+    "height": 210,
+    "weight": 170,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/criniotherme.json
+++ b/mods/tuxemon/db/monster/criniotherme.json
@@ -20,7 +20,9 @@
     "types": [
         "Fire"
     ],
-    "weight": 25,
+    "txmn_id": 20,
+    "height": 210,
+    "weight": 170,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/criniotherme.json
+++ b/mods/tuxemon/db/monster/criniotherme.json
@@ -20,7 +20,7 @@
     "types": [
         "Fire"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/criniotherme.json
+++ b/mods/tuxemon/db/monster/criniotherme.json
@@ -20,6 +20,8 @@
     "types": [
         "Fire"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/d0llf1n.json
+++ b/mods/tuxemon/db/monster/d0llf1n.json
@@ -21,7 +21,7 @@
         "Glitch",
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/d0llf1n.json
+++ b/mods/tuxemon/db/monster/d0llf1n.json
@@ -21,6 +21,8 @@
         "Glitch",
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/d0llf1n.json
+++ b/mods/tuxemon/db/monster/d0llf1n.json
@@ -21,6 +21,8 @@
         "Glitch",
         "Water"
     ],
+    "txmn_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/dandicub.json
+++ b/mods/tuxemon/db/monster/dandicub.json
@@ -20,6 +20,8 @@
     "types": [
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/dandicub.json
+++ b/mods/tuxemon/db/monster/dandicub.json
@@ -20,7 +20,7 @@
     "types": [
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/dandicub.json
+++ b/mods/tuxemon/db/monster/dandicub.json
@@ -20,7 +20,9 @@
     "types": [
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 72,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/dandicub.json
+++ b/mods/tuxemon/db/monster/dandicub.json
@@ -20,9 +20,9 @@
     "types": [
         "Wood"
     ],
-    "txmn_id": 0,
+    "txmn_id": 72,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/dandylion.json
+++ b/mods/tuxemon/db/monster/dandylion.json
@@ -20,7 +20,9 @@
     "types": [
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 73,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/dandylion.json
+++ b/mods/tuxemon/db/monster/dandylion.json
@@ -20,9 +20,9 @@
     "types": [
         "Wood"
     ],
-    "txmn_id": 0,
+    "txmn_id": 73,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/dandylion.json
+++ b/mods/tuxemon/db/monster/dandylion.json
@@ -20,6 +20,8 @@
     "types": [
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/dandylion.json
+++ b/mods/tuxemon/db/monster/dandylion.json
@@ -20,7 +20,7 @@
     "types": [
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/dark_robo.json
+++ b/mods/tuxemon/db/monster/dark_robo.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "txmn_id": 0,
+    "height": 0,
     "weight": 100,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/dark_robo.json
+++ b/mods/tuxemon/db/monster/dark_robo.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 100,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/dark_robo.json
+++ b/mods/tuxemon/db/monster/dark_robo.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 100,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/dinoflop.json
+++ b/mods/tuxemon/db/monster/dinoflop.json
@@ -20,7 +20,9 @@
     "types": [
         "Earth"
     ],
-    "weight": 25,
+    "txmn_id": 0,
+    "height": 120,
+    "weight": 120,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/dinoflop.json
+++ b/mods/tuxemon/db/monster/dinoflop.json
@@ -20,6 +20,8 @@
     "types": [
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/dinoflop.json
+++ b/mods/tuxemon/db/monster/dinoflop.json
@@ -20,7 +20,7 @@
     "types": [
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/dinoflop.json
+++ b/mods/tuxemon/db/monster/dinoflop.json
@@ -21,8 +21,8 @@
         "Earth"
     ],
     "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "height": 120,
+    "weight": 120,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/djinnbo.json
+++ b/mods/tuxemon/db/monster/djinnbo.json
@@ -20,9 +20,9 @@
     "types": [
         "Fire"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 107,
+    "height": 160,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/djinnbo.json
+++ b/mods/tuxemon/db/monster/djinnbo.json
@@ -20,7 +20,9 @@
     "types": [
         "Fire"
     ],
-    "weight": 25,
+    "txmn_id": 107,
+    "height": 160,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/djinnbo.json
+++ b/mods/tuxemon/db/monster/djinnbo.json
@@ -20,7 +20,7 @@
     "types": [
         "Fire"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/djinnbo.json
+++ b/mods/tuxemon/db/monster/djinnbo.json
@@ -20,6 +20,8 @@
     "types": [
         "Fire"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/dollfin.json
+++ b/mods/tuxemon/db/monster/dollfin.json
@@ -20,7 +20,9 @@
     "types": [
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 23,	
+    "height": 250,
+    "weight": 190,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/dollfin.json
+++ b/mods/tuxemon/db/monster/dollfin.json
@@ -20,6 +20,8 @@
     "types": [
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/dollfin.json
+++ b/mods/tuxemon/db/monster/dollfin.json
@@ -20,9 +20,9 @@
     "types": [
         "Water"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 23,	
+    "height": 250,
+    "weight": 190,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/dollfin.json
+++ b/mods/tuxemon/db/monster/dollfin.json
@@ -20,7 +20,7 @@
     "types": [
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/dracune.json
+++ b/mods/tuxemon/db/monster/dracune.json
@@ -20,6 +20,8 @@
     "types": [
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/dracune.json
+++ b/mods/tuxemon/db/monster/dracune.json
@@ -20,7 +20,9 @@
     "types": [
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 36,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/dracune.json
+++ b/mods/tuxemon/db/monster/dracune.json
@@ -20,9 +20,9 @@
     "types": [
         "Water"
     ],
-    "txmn_id": 0,
+    "txmn_id": 36,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/dracune.json
+++ b/mods/tuxemon/db/monster/dracune.json
@@ -20,7 +20,7 @@
     "types": [
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/dragarbor.json
+++ b/mods/tuxemon/db/monster/dragarbor.json
@@ -20,6 +20,8 @@
     "types": [
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,

--- a/mods/tuxemon/db/monster/dragarbor.json
+++ b/mods/tuxemon/db/monster/dragarbor.json
@@ -20,7 +20,7 @@
     "types": [
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/dragarbor.json
+++ b/mods/tuxemon/db/monster/dragarbor.json
@@ -20,9 +20,9 @@
     "types": [
         "Wood"
     ],
-    "txmn_id": 0,
+    "txmn_id": 138,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/dragarbor.json
+++ b/mods/tuxemon/db/monster/dragarbor.json
@@ -20,7 +20,9 @@
     "types": [
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 138,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/drokoro.json
+++ b/mods/tuxemon/db/monster/drokoro.json
@@ -20,9 +20,9 @@
     "types": [
         "Fire"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 141,
+    "height": 1200,
+    "weight": 10000,
     "catch_rate": 3.0,
     "lower_catch_resistance": 0.8,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/drokoro.json
+++ b/mods/tuxemon/db/monster/drokoro.json
@@ -20,7 +20,9 @@
     "types": [
         "Fire"
     ],
-    "weight": 25,
+    "txmn_id": 141,
+    "height": 1200,
+    "weight": 10000,
     "catch_rate": 3.0,
     "lower_catch_resistance": 0.8,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/drokoro.json
+++ b/mods/tuxemon/db/monster/drokoro.json
@@ -20,7 +20,7 @@
     "types": [
         "Fire"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 3.0,

--- a/mods/tuxemon/db/monster/drokoro.json
+++ b/mods/tuxemon/db/monster/drokoro.json
@@ -20,6 +20,8 @@
     "types": [
         "Fire"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 3.0,
     "lower_catch_resistance": 0.8,

--- a/mods/tuxemon/db/monster/dune_pincher.json
+++ b/mods/tuxemon/db/monster/dune_pincher.json
@@ -20,6 +20,8 @@
     "types": [
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/dune_pincher.json
+++ b/mods/tuxemon/db/monster/dune_pincher.json
@@ -20,9 +20,9 @@
     "types": [
         "Water"
     ],
-    "txmn_id": 0,
+    "txmn_id": 108,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/dune_pincher.json
+++ b/mods/tuxemon/db/monster/dune_pincher.json
@@ -20,7 +20,9 @@
     "types": [
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 108,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/dune_pincher.json
+++ b/mods/tuxemon/db/monster/dune_pincher.json
@@ -20,7 +20,7 @@
     "types": [
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/eaglace.json
+++ b/mods/tuxemon/db/monster/eaglace.json
@@ -20,6 +20,8 @@
     "types": [
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,

--- a/mods/tuxemon/db/monster/eaglace.json
+++ b/mods/tuxemon/db/monster/eaglace.json
@@ -20,7 +20,9 @@
     "types": [
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 9,
+    "height": 150,
+    "weight": 36,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/eaglace.json
+++ b/mods/tuxemon/db/monster/eaglace.json
@@ -20,7 +20,7 @@
     "types": [
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/eaglace.json
+++ b/mods/tuxemon/db/monster/eaglace.json
@@ -20,9 +20,9 @@
     "types": [
         "Water"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 9,
+    "height": 150,
+    "weight": 36,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/elofly.json
+++ b/mods/tuxemon/db/monster/elofly.json
@@ -20,6 +20,8 @@
     "types": [
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/elofly.json
+++ b/mods/tuxemon/db/monster/elofly.json
@@ -20,7 +20,9 @@
     "types": [
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 38,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/elofly.json
+++ b/mods/tuxemon/db/monster/elofly.json
@@ -20,9 +20,9 @@
     "types": [
         "Water"
     ],
-    "txmn_id": 0,
+    "txmn_id": 38,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/elofly.json
+++ b/mods/tuxemon/db/monster/elofly.json
@@ -20,7 +20,7 @@
     "types": [
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/elostorm.json
+++ b/mods/tuxemon/db/monster/elostorm.json
@@ -20,6 +20,8 @@
     "types": [
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,

--- a/mods/tuxemon/db/monster/elostorm.json
+++ b/mods/tuxemon/db/monster/elostorm.json
@@ -20,9 +20,9 @@
     "types": [
         "Water"
     ],
-    "txmn_id": 0,
+    "txmn_id": 40,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/elostorm.json
+++ b/mods/tuxemon/db/monster/elostorm.json
@@ -20,7 +20,7 @@
     "types": [
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/elostorm.json
+++ b/mods/tuxemon/db/monster/elostorm.json
@@ -20,7 +20,9 @@
     "types": [
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 40,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/elowind.json
+++ b/mods/tuxemon/db/monster/elowind.json
@@ -20,6 +20,8 @@
     "types": [
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/elowind.json
+++ b/mods/tuxemon/db/monster/elowind.json
@@ -20,9 +20,9 @@
     "types": [
         "Water"
     ],
-    "txmn_id": 0,
+    "txmn_id": 39,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/elowind.json
+++ b/mods/tuxemon/db/monster/elowind.json
@@ -20,7 +20,9 @@
     "types": [
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 39,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/elowind.json
+++ b/mods/tuxemon/db/monster/elowind.json
@@ -20,7 +20,7 @@
     "types": [
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/embazook.json
+++ b/mods/tuxemon/db/monster/embazook.json
@@ -21,7 +21,7 @@
         "Fire",
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/embazook.json
+++ b/mods/tuxemon/db/monster/embazook.json
@@ -21,9 +21,9 @@
         "Fire",
         "Metal"
     ],
-    "txmn_id": 0,
+    "txmn_id": 30,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/embazook.json
+++ b/mods/tuxemon/db/monster/embazook.json
@@ -21,7 +21,9 @@
         "Fire",
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 30,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/embazook.json
+++ b/mods/tuxemon/db/monster/embazook.json
@@ -21,6 +21,8 @@
         "Fire",
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/embra.json
+++ b/mods/tuxemon/db/monster/embra.json
@@ -20,7 +20,9 @@
     "types": [
         "Fire"
     ],
-    "weight": 25,
+    "txmn_id": 74,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/embra.json
+++ b/mods/tuxemon/db/monster/embra.json
@@ -20,6 +20,8 @@
     "types": [
         "Fire"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/embra.json
+++ b/mods/tuxemon/db/monster/embra.json
@@ -20,9 +20,9 @@
     "types": [
         "Fire"
     ],
-    "txmn_id": 0,
+    "txmn_id": 74,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/embra.json
+++ b/mods/tuxemon/db/monster/embra.json
@@ -20,7 +20,7 @@
     "types": [
         "Fire"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/enduros.json
+++ b/mods/tuxemon/db/monster/enduros.json
@@ -20,6 +20,8 @@
     "types": [
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/enduros.json
+++ b/mods/tuxemon/db/monster/enduros.json
@@ -21,8 +21,8 @@
         "Earth"
     ],
     "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "height": 170,
+    "weight": 65,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/enduros.json
+++ b/mods/tuxemon/db/monster/enduros.json
@@ -20,7 +20,7 @@
     "types": [
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/enduros.json
+++ b/mods/tuxemon/db/monster/enduros.json
@@ -20,7 +20,9 @@
     "types": [
         "Earth"
     ],
-    "weight": 25,
+    "txmn_id": 0,
+    "height": 170,
+    "weight": 65,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/eruptibus.json
+++ b/mods/tuxemon/db/monster/eruptibus.json
@@ -20,7 +20,7 @@
     "types": [
         "Fire"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/eruptibus.json
+++ b/mods/tuxemon/db/monster/eruptibus.json
@@ -20,6 +20,8 @@
     "types": [
         "Fire"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,

--- a/mods/tuxemon/db/monster/eruptibus.json
+++ b/mods/tuxemon/db/monster/eruptibus.json
@@ -20,7 +20,9 @@
     "types": [
         "Fire"
     ],
-    "weight": 25,
+    "txmn_id": 31,
+    "height": 600,
+    "weight": 12000,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/eruptibus.json
+++ b/mods/tuxemon/db/monster/eruptibus.json
@@ -20,9 +20,9 @@
     "types": [
         "Fire"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 31,
+    "height": 600,
+    "weight": 12000,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/exapode.json
+++ b/mods/tuxemon/db/monster/exapode.json
@@ -20,7 +20,9 @@
     "types": [
         "Earth"
     ],
-    "weight": 25,
+    "txmn_id": 60,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/exapode.json
+++ b/mods/tuxemon/db/monster/exapode.json
@@ -20,6 +20,8 @@
     "types": [
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/exapode.json
+++ b/mods/tuxemon/db/monster/exapode.json
@@ -20,9 +20,9 @@
     "types": [
         "Earth"
     ],
-    "txmn_id": 0,
+    "txmn_id": 60,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/exapode.json
+++ b/mods/tuxemon/db/monster/exapode.json
@@ -20,7 +20,7 @@
     "types": [
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/eyenemy.json
+++ b/mods/tuxemon/db/monster/eyenemy.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/eyenemy.json
+++ b/mods/tuxemon/db/monster/eyenemy.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/eyenemy.json
+++ b/mods/tuxemon/db/monster/eyenemy.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
+    "txmn_id": 45,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/eyenemy.json
+++ b/mods/tuxemon/db/monster/eyenemy.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 45,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/eyesore.json
+++ b/mods/tuxemon/db/monster/eyesore.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/eyesore.json
+++ b/mods/tuxemon/db/monster/eyesore.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/eyesore.json
+++ b/mods/tuxemon/db/monster/eyesore.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
+    "txmn_id": 46,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/eyesore.json
+++ b/mods/tuxemon/db/monster/eyesore.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 46,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/f7u1t3ra.json
+++ b/mods/tuxemon/db/monster/f7u1t3ra.json
@@ -21,6 +21,8 @@
         "Glitch",
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/f7u1t3ra.json
+++ b/mods/tuxemon/db/monster/f7u1t3ra.json
@@ -21,6 +21,8 @@
         "Glitch",
         "Wood"
     ],
+    "txmn_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/f7u1t3ra.json
+++ b/mods/tuxemon/db/monster/f7u1t3ra.json
@@ -21,7 +21,7 @@
         "Glitch",
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/fancair.json
+++ b/mods/tuxemon/db/monster/fancair.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/fancair.json
+++ b/mods/tuxemon/db/monster/fancair.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/fancair.json
+++ b/mods/tuxemon/db/monster/fancair.json
@@ -21,8 +21,8 @@
         "Metal"
     ],
     "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "height": 45,
+    "weight": 18,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/fancair.json
+++ b/mods/tuxemon/db/monster/fancair.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 0,
+    "height": 45,
+    "weight": 18,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/flacono.json
+++ b/mods/tuxemon/db/monster/flacono.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/flacono.json
+++ b/mods/tuxemon/db/monster/flacono.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 150,
+    "height": 70,
+    "weight": 6,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/flacono.json
+++ b/mods/tuxemon/db/monster/flacono.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 150,
+    "height": 70,
+    "weight": 6,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/flacono.json
+++ b/mods/tuxemon/db/monster/flacono.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/flambear.json
+++ b/mods/tuxemon/db/monster/flambear.json
@@ -20,7 +20,9 @@
     "types": [
         "Fire"
     ],
-    "weight": 25,
+    "txmn_id": 83,
+    "height": 250,
+    "weight": 500,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/flambear.json
+++ b/mods/tuxemon/db/monster/flambear.json
@@ -20,7 +20,7 @@
     "types": [
         "Fire"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/flambear.json
+++ b/mods/tuxemon/db/monster/flambear.json
@@ -20,6 +20,8 @@
     "types": [
         "Fire"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/flambear.json
+++ b/mods/tuxemon/db/monster/flambear.json
@@ -20,9 +20,9 @@
     "types": [
         "Fire"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 83,
+    "height": 250,
+    "weight": 500,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/fluoresfin.json
+++ b/mods/tuxemon/db/monster/fluoresfin.json
@@ -20,6 +20,8 @@
     "types": [
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/fluoresfin.json
+++ b/mods/tuxemon/db/monster/fluoresfin.json
@@ -20,9 +20,9 @@
     "types": [
         "Water"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 67,
+    "height": 80,
+    "weight": 11,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/fluoresfin.json
+++ b/mods/tuxemon/db/monster/fluoresfin.json
@@ -20,7 +20,7 @@
     "types": [
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/fluoresfin.json
+++ b/mods/tuxemon/db/monster/fluoresfin.json
@@ -20,7 +20,9 @@
     "types": [
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 67,
+    "height": 80,
+    "weight": 11,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/fluttaflap.json
+++ b/mods/tuxemon/db/monster/fluttaflap.json
@@ -20,6 +20,8 @@
     "types": [
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/fluttaflap.json
+++ b/mods/tuxemon/db/monster/fluttaflap.json
@@ -20,9 +20,9 @@
     "types": [
         "Water"
     ],
-    "txmn_id": 0,
+    "txmn_id": 37,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/fluttaflap.json
+++ b/mods/tuxemon/db/monster/fluttaflap.json
@@ -20,7 +20,7 @@
     "types": [
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/fluttaflap.json
+++ b/mods/tuxemon/db/monster/fluttaflap.json
@@ -20,7 +20,9 @@
     "types": [
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 37,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/foofle.json
+++ b/mods/tuxemon/db/monster/foofle.json
@@ -20,6 +20,8 @@
     "types": [
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/foofle.json
+++ b/mods/tuxemon/db/monster/foofle.json
@@ -20,9 +20,9 @@
     "types": [
         "Earth"
     ],
-    "txmn_id": 0,
+    "txmn_id": 109,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/foofle.json
+++ b/mods/tuxemon/db/monster/foofle.json
@@ -20,7 +20,7 @@
     "types": [
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/foofle.json
+++ b/mods/tuxemon/db/monster/foofle.json
@@ -20,7 +20,9 @@
     "types": [
         "Earth"
     ],
-    "weight": 25,
+    "txmn_id": 109,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/forturtle.json
+++ b/mods/tuxemon/db/monster/forturtle.json
@@ -20,7 +20,9 @@
     "types": [
         "Earth"
     ],
-    "weight": 25,
+    "txmn_id": 86,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/forturtle.json
+++ b/mods/tuxemon/db/monster/forturtle.json
@@ -20,9 +20,9 @@
     "types": [
         "Earth"
     ],
-    "txmn_id": 0,
+    "txmn_id": 86,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/forturtle.json
+++ b/mods/tuxemon/db/monster/forturtle.json
@@ -20,7 +20,7 @@
     "types": [
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/forturtle.json
+++ b/mods/tuxemon/db/monster/forturtle.json
@@ -20,6 +20,8 @@
     "types": [
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/foxfire.json
+++ b/mods/tuxemon/db/monster/foxfire.json
@@ -20,7 +20,9 @@
     "types": [
         "Fire"
     ],
-    "weight": 25,
+    "txmn_id": 145,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/foxfire.json
+++ b/mods/tuxemon/db/monster/foxfire.json
@@ -20,9 +20,9 @@
     "types": [
         "Fire"
     ],
-    "txmn_id": 0,
+    "txmn_id": 145,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/foxfire.json
+++ b/mods/tuxemon/db/monster/foxfire.json
@@ -20,6 +20,8 @@
     "types": [
         "Fire"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/foxfire.json
+++ b/mods/tuxemon/db/monster/foxfire.json
@@ -20,7 +20,7 @@
     "types": [
         "Fire"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/frondly.json
+++ b/mods/tuxemon/db/monster/frondly.json
@@ -20,7 +20,7 @@
     "types": [
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 3.0,

--- a/mods/tuxemon/db/monster/frondly.json
+++ b/mods/tuxemon/db/monster/frondly.json
@@ -20,7 +20,9 @@
     "types": [
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 28,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 3.0,
     "lower_catch_resistance": 0.8,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/frondly.json
+++ b/mods/tuxemon/db/monster/frondly.json
@@ -20,6 +20,8 @@
     "types": [
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 3.0,
     "lower_catch_resistance": 0.8,

--- a/mods/tuxemon/db/monster/frondly.json
+++ b/mods/tuxemon/db/monster/frondly.json
@@ -20,9 +20,9 @@
     "types": [
         "Wood"
     ],
-    "txmn_id": 0,
+    "txmn_id": 28,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 3.0,
     "lower_catch_resistance": 0.8,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/fruitera.json
+++ b/mods/tuxemon/db/monster/fruitera.json
@@ -20,6 +20,8 @@
     "types": [
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/fruitera.json
+++ b/mods/tuxemon/db/monster/fruitera.json
@@ -20,7 +20,7 @@
     "types": [
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/fruitera.json
+++ b/mods/tuxemon/db/monster/fruitera.json
@@ -21,8 +21,8 @@
         "Wood"
     ],
     "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "height": 30,
+    "weight": 2,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/fruitera.json
+++ b/mods/tuxemon/db/monster/fruitera.json
@@ -20,7 +20,9 @@
     "types": [
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 0,
+    "height": 30,
+    "weight": 2,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/galnec.json
+++ b/mods/tuxemon/db/monster/galnec.json
@@ -21,8 +21,8 @@
         "Earth"
     ],
     "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "height": 40,
+    "weight": 6,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/galnec.json
+++ b/mods/tuxemon/db/monster/galnec.json
@@ -20,6 +20,8 @@
     "types": [
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/galnec.json
+++ b/mods/tuxemon/db/monster/galnec.json
@@ -20,7 +20,7 @@
     "types": [
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/galnec.json
+++ b/mods/tuxemon/db/monster/galnec.json
@@ -20,7 +20,9 @@
     "types": [
         "Earth"
     ],
-    "weight": 25,
+    "txmn_id": 0,
+    "height": 40,
+    "weight": 6,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/gectile.json
+++ b/mods/tuxemon/db/monster/gectile.json
@@ -20,9 +20,9 @@
     "types": [
         "Wood"
     ],
-    "txmn_id": 0,
+    "txmn_id": 65,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/gectile.json
+++ b/mods/tuxemon/db/monster/gectile.json
@@ -20,6 +20,8 @@
     "types": [
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/gectile.json
+++ b/mods/tuxemon/db/monster/gectile.json
@@ -20,7 +20,7 @@
     "types": [
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/gectile.json
+++ b/mods/tuxemon/db/monster/gectile.json
@@ -20,7 +20,9 @@
     "types": [
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 65,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/ghosteeth.json
+++ b/mods/tuxemon/db/monster/ghosteeth.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/ghosteeth.json
+++ b/mods/tuxemon/db/monster/ghosteeth.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/ghosteeth.json
+++ b/mods/tuxemon/db/monster/ghosteeth.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 110,
+    "height": 70,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/ghosteeth.json
+++ b/mods/tuxemon/db/monster/ghosteeth.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 110,
+    "height": 70,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/grimachin.json
+++ b/mods/tuxemon/db/monster/grimachin.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/grimachin.json
+++ b/mods/tuxemon/db/monster/grimachin.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/grimachin.json
+++ b/mods/tuxemon/db/monster/grimachin.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 92,
+    "height": 45,
+    "weight": 3,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/grimachin.json
+++ b/mods/tuxemon/db/monster/grimachin.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 92,
+    "height": 45,
+    "weight": 3,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/grinflare.json
+++ b/mods/tuxemon/db/monster/grinflare.json
@@ -21,9 +21,9 @@
         "Earth",
         "Fire"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 17,
+    "height": 160,
+    "weight": 3000,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/grinflare.json
+++ b/mods/tuxemon/db/monster/grinflare.json
@@ -21,7 +21,9 @@
         "Earth",
         "Fire"
     ],
-    "weight": 25,
+    "txmn_id": 17,
+    "height": 160,
+    "weight": 3000,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/grinflare.json
+++ b/mods/tuxemon/db/monster/grinflare.json
@@ -21,7 +21,7 @@
         "Earth",
         "Fire"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/grinflare.json
+++ b/mods/tuxemon/db/monster/grinflare.json
@@ -21,6 +21,8 @@
         "Earth",
         "Fire"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/grintot.json
+++ b/mods/tuxemon/db/monster/grintot.json
@@ -20,7 +20,9 @@
     "types": [
         "Earth"
     ],
-    "weight": 25,
+    "txmn_id": 16,
+    "height": 70,
+    "weight": 375,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/grintot.json
+++ b/mods/tuxemon/db/monster/grintot.json
@@ -20,7 +20,7 @@
     "types": [
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/grintot.json
+++ b/mods/tuxemon/db/monster/grintot.json
@@ -20,9 +20,9 @@
     "types": [
         "Earth"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 16,
+    "height": 70,
+    "weight": 375,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/grintot.json
+++ b/mods/tuxemon/db/monster/grintot.json
@@ -20,6 +20,8 @@
     "types": [
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/grintrock.json
+++ b/mods/tuxemon/db/monster/grintrock.json
@@ -21,6 +21,8 @@
         "Earth",
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/grintrock.json
+++ b/mods/tuxemon/db/monster/grintrock.json
@@ -21,7 +21,7 @@
         "Earth",
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/grintrock.json
+++ b/mods/tuxemon/db/monster/grintrock.json
@@ -21,7 +21,9 @@
         "Earth",
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 18,
+    "height": 160,
+    "weight": 3000,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/grintrock.json
+++ b/mods/tuxemon/db/monster/grintrock.json
@@ -21,9 +21,9 @@
         "Earth",
         "Metal"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 18,
+    "height": 160,
+    "weight": 3000,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/hampotamos.json
+++ b/mods/tuxemon/db/monster/hampotamos.json
@@ -20,6 +20,8 @@
     "types": [
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/hampotamos.json
+++ b/mods/tuxemon/db/monster/hampotamos.json
@@ -20,7 +20,7 @@
     "types": [
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/hampotamos.json
+++ b/mods/tuxemon/db/monster/hampotamos.json
@@ -20,9 +20,9 @@
     "types": [
         "Earth"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 146,
+    "height": 150,
+    "weight": 180,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/hampotamos.json
+++ b/mods/tuxemon/db/monster/hampotamos.json
@@ -20,7 +20,9 @@
     "types": [
         "Earth"
     ],
-    "weight": 25,
+    "txmn_id": 146,
+    "height": 150,
+    "weight": 180,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/happito.json
+++ b/mods/tuxemon/db/monster/happito.json
@@ -21,7 +21,7 @@
         "Earth",
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/happito.json
+++ b/mods/tuxemon/db/monster/happito.json
@@ -22,8 +22,8 @@
         "Metal"
     ],
     "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "height": 90,
+    "weight": 55,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/happito.json
+++ b/mods/tuxemon/db/monster/happito.json
@@ -21,7 +21,9 @@
         "Earth",
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 0,
+    "height": 90,
+    "weight": 55,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/happito.json
+++ b/mods/tuxemon/db/monster/happito.json
@@ -21,6 +21,8 @@
         "Earth",
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/hatchling.json
+++ b/mods/tuxemon/db/monster/hatchling.json
@@ -20,6 +20,8 @@
     "types": [
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/hatchling.json
+++ b/mods/tuxemon/db/monster/hatchling.json
@@ -20,7 +20,7 @@
     "types": [
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/hatchling.json
+++ b/mods/tuxemon/db/monster/hatchling.json
@@ -20,7 +20,9 @@
     "types": [
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 80,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/hatchling.json
+++ b/mods/tuxemon/db/monster/hatchling.json
@@ -20,9 +20,9 @@
     "types": [
         "Wood"
     ],
-    "txmn_id": 0,
+    "txmn_id": 80,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/heronquak.json
+++ b/mods/tuxemon/db/monster/heronquak.json
@@ -20,9 +20,9 @@
     "types": [
         "Water"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 8,
+    "height": 150,
+    "weight": 12,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/heronquak.json
+++ b/mods/tuxemon/db/monster/heronquak.json
@@ -20,6 +20,8 @@
     "types": [
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/heronquak.json
+++ b/mods/tuxemon/db/monster/heronquak.json
@@ -20,7 +20,9 @@
     "types": [
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 8,
+    "height": 150,
+    "weight": 12,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/heronquak.json
+++ b/mods/tuxemon/db/monster/heronquak.json
@@ -20,7 +20,7 @@
     "types": [
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/hydrone.json
+++ b/mods/tuxemon/db/monster/hydrone.json
@@ -21,7 +21,9 @@
         "Metal",
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 111,
+    "height": 155,
+    "weight": 200,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/hydrone.json
+++ b/mods/tuxemon/db/monster/hydrone.json
@@ -21,7 +21,7 @@
         "Metal",
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/hydrone.json
+++ b/mods/tuxemon/db/monster/hydrone.json
@@ -21,9 +21,9 @@
         "Metal",
         "Water"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 111,
+    "height": 155,
+    "weight": 200,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/hydrone.json
+++ b/mods/tuxemon/db/monster/hydrone.json
@@ -21,6 +21,8 @@
         "Metal",
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/ignibus.json
+++ b/mods/tuxemon/db/monster/ignibus.json
@@ -20,6 +20,8 @@
     "types": [
         "Fire"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/ignibus.json
+++ b/mods/tuxemon/db/monster/ignibus.json
@@ -20,9 +20,9 @@
     "types": [
         "Fire"
     ],
-    "txmn_id": 0,
+    "txmn_id": 29,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/ignibus.json
+++ b/mods/tuxemon/db/monster/ignibus.json
@@ -20,7 +20,9 @@
     "types": [
         "Fire"
     ],
-    "weight": 25,
+    "txmn_id": 29,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/ignibus.json
+++ b/mods/tuxemon/db/monster/ignibus.json
@@ -20,7 +20,7 @@
     "types": [
         "Fire"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/incandesfin.json
+++ b/mods/tuxemon/db/monster/incandesfin.json
@@ -20,6 +20,8 @@
     "types": [
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/incandesfin.json
+++ b/mods/tuxemon/db/monster/incandesfin.json
@@ -20,9 +20,9 @@
     "types": [
         "Water"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 68,
+    "height": 250,
+    "weight": 150,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/incandesfin.json
+++ b/mods/tuxemon/db/monster/incandesfin.json
@@ -20,7 +20,9 @@
     "types": [
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 68,
+    "height": 250,
+    "weight": 150,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/incandesfin.json
+++ b/mods/tuxemon/db/monster/incandesfin.json
@@ -20,7 +20,7 @@
     "types": [
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/jemuar.json
+++ b/mods/tuxemon/db/monster/jemuar.json
@@ -20,6 +20,8 @@
     "types": [
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,

--- a/mods/tuxemon/db/monster/jemuar.json
+++ b/mods/tuxemon/db/monster/jemuar.json
@@ -20,7 +20,7 @@
     "types": [
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/jemuar.json
+++ b/mods/tuxemon/db/monster/jemuar.json
@@ -20,9 +20,9 @@
     "types": [
         "Earth"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 3,
+    "height": 160,
+    "weight": 150,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/jemuar.json
+++ b/mods/tuxemon/db/monster/jemuar.json
@@ -20,7 +20,9 @@
     "types": [
         "Earth"
     ],
-    "weight": 25,
+    "txmn_id": 3,
+    "height": 160,
+    "weight": 150,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/k9.json
+++ b/mods/tuxemon/db/monster/k9.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/k9.json
+++ b/mods/tuxemon/db/monster/k9.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 128,
+    "height": 60,
+    "weight": 5,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/k9.json
+++ b/mods/tuxemon/db/monster/k9.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/k9.json
+++ b/mods/tuxemon/db/monster/k9.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 128,
+    "height": 60,
+    "weight": 5,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/katacoon.json
+++ b/mods/tuxemon/db/monster/katacoon.json
@@ -21,7 +21,9 @@
         "Metal",
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 56,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/katacoon.json
+++ b/mods/tuxemon/db/monster/katacoon.json
@@ -21,9 +21,9 @@
         "Metal",
         "Wood"
     ],
-    "txmn_id": 0,
+    "txmn_id": 56,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/katacoon.json
+++ b/mods/tuxemon/db/monster/katacoon.json
@@ -21,7 +21,7 @@
         "Metal",
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/katacoon.json
+++ b/mods/tuxemon/db/monster/katacoon.json
@@ -21,6 +21,8 @@
         "Metal",
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/katapill.json
+++ b/mods/tuxemon/db/monster/katapill.json
@@ -21,7 +21,7 @@
         "Metal",
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/katapill.json
+++ b/mods/tuxemon/db/monster/katapill.json
@@ -21,7 +21,9 @@
         "Metal",
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 55,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/katapill.json
+++ b/mods/tuxemon/db/monster/katapill.json
@@ -21,9 +21,9 @@
         "Metal",
         "Wood"
     ],
-    "txmn_id": 0,
+    "txmn_id": 55,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/katapill.json
+++ b/mods/tuxemon/db/monster/katapill.json
@@ -21,6 +21,8 @@
         "Metal",
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/komodraw.json
+++ b/mods/tuxemon/db/monster/komodraw.json
@@ -20,7 +20,9 @@
     "types": [
         "Fire"
     ],
-    "weight": 25,
+    "txmn_id": 91,
+    "height": 155,
+    "weight": 55,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/komodraw.json
+++ b/mods/tuxemon/db/monster/komodraw.json
@@ -20,9 +20,9 @@
     "types": [
         "Fire"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 91,
+    "height": 155,
+    "weight": 55,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/komodraw.json
+++ b/mods/tuxemon/db/monster/komodraw.json
@@ -20,6 +20,8 @@
     "types": [
         "Fire"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/komodraw.json
+++ b/mods/tuxemon/db/monster/komodraw.json
@@ -20,7 +20,7 @@
     "types": [
         "Fire"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/l3gk0.json
+++ b/mods/tuxemon/db/monster/l3gk0.json
@@ -21,6 +21,8 @@
         "Glitch",
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/l3gk0.json
+++ b/mods/tuxemon/db/monster/l3gk0.json
@@ -21,6 +21,8 @@
         "Glitch",
         "Wood"
     ],
+    "txmn_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/l3gk0.json
+++ b/mods/tuxemon/db/monster/l3gk0.json
@@ -21,7 +21,7 @@
         "Glitch",
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/lambert.json
+++ b/mods/tuxemon/db/monster/lambert.json
@@ -20,7 +20,9 @@
     "types": [
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 10,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/lambert.json
+++ b/mods/tuxemon/db/monster/lambert.json
@@ -20,6 +20,8 @@
     "types": [
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/lambert.json
+++ b/mods/tuxemon/db/monster/lambert.json
@@ -20,7 +20,7 @@
     "types": [
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/lambert.json
+++ b/mods/tuxemon/db/monster/lambert.json
@@ -20,9 +20,9 @@
     "types": [
         "Wood"
     ],
-    "txmn_id": 0,
+    "txmn_id": 10,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/lapinou.json
+++ b/mods/tuxemon/db/monster/lapinou.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/lapinou.json
+++ b/mods/tuxemon/db/monster/lapinou.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/lapinou.json
+++ b/mods/tuxemon/db/monster/lapinou.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 112,
+    "height": 60,
+    "weight": 8,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/lapinou.json
+++ b/mods/tuxemon/db/monster/lapinou.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 112,
+    "height": 60,
+    "weight": 8,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/legko.json
+++ b/mods/tuxemon/db/monster/legko.json
@@ -20,7 +20,9 @@
     "types": [
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 11,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/legko.json
+++ b/mods/tuxemon/db/monster/legko.json
@@ -20,9 +20,9 @@
     "types": [
         "Wood"
     ],
-    "txmn_id": 0,
+    "txmn_id": 11,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/legko.json
+++ b/mods/tuxemon/db/monster/legko.json
@@ -20,6 +20,8 @@
     "types": [
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/legko.json
+++ b/mods/tuxemon/db/monster/legko.json
@@ -20,7 +20,7 @@
     "types": [
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/lightmare.json
+++ b/mods/tuxemon/db/monster/lightmare.json
@@ -20,6 +20,8 @@
     "types": [
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,

--- a/mods/tuxemon/db/monster/lightmare.json
+++ b/mods/tuxemon/db/monster/lightmare.json
@@ -20,9 +20,9 @@
     "types": [
         "Water"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 69,
+    "height": 300,
+    "weight": 200,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/lightmare.json
+++ b/mods/tuxemon/db/monster/lightmare.json
@@ -20,7 +20,7 @@
     "types": [
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/lightmare.json
+++ b/mods/tuxemon/db/monster/lightmare.json
@@ -20,7 +20,9 @@
     "types": [
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 69,
+    "height": 300,
+    "weight": 200,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/manosting.json
+++ b/mods/tuxemon/db/monster/manosting.json
@@ -20,6 +20,8 @@
     "types": [
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/manosting.json
+++ b/mods/tuxemon/db/monster/manosting.json
@@ -20,9 +20,9 @@
     "types": [
         "Water"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 113,
+    "height": 180,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/manosting.json
+++ b/mods/tuxemon/db/monster/manosting.json
@@ -20,7 +20,7 @@
     "types": [
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/manosting.json
+++ b/mods/tuxemon/db/monster/manosting.json
@@ -20,7 +20,9 @@
     "types": [
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 113,
+    "height": 180,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/masknake.json
+++ b/mods/tuxemon/db/monster/masknake.json
@@ -20,7 +20,9 @@
     "types": [
         "Fire"
     ],
-    "weight": 25,
+    "txmn_id": 114,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/masknake.json
+++ b/mods/tuxemon/db/monster/masknake.json
@@ -20,9 +20,9 @@
     "types": [
         "Fire"
     ],
-    "txmn_id": 0,
+    "txmn_id": 114,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/masknake.json
+++ b/mods/tuxemon/db/monster/masknake.json
@@ -20,6 +20,8 @@
     "types": [
         "Fire"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/masknake.json
+++ b/mods/tuxemon/db/monster/masknake.json
@@ -20,7 +20,7 @@
     "types": [
         "Fire"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/memnomnom.json
+++ b/mods/tuxemon/db/monster/memnomnom.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 19,
+    "height": 70,
+    "weight": 7,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/memnomnom.json
+++ b/mods/tuxemon/db/monster/memnomnom.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/memnomnom.json
+++ b/mods/tuxemon/db/monster/memnomnom.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/memnomnom.json
+++ b/mods/tuxemon/db/monster/memnomnom.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 19,
+    "height": 70,
+    "weight": 7,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/miaownolith.json
+++ b/mods/tuxemon/db/monster/miaownolith.json
@@ -21,9 +21,9 @@
         "Metal",
         "Earth"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 21,
+    "height": 210,
+    "weight": 255,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/miaownolith.json
+++ b/mods/tuxemon/db/monster/miaownolith.json
@@ -21,7 +21,9 @@
         "Metal",
         "Earth"
     ],
-    "weight": 25,
+    "txmn_id": 21,
+    "height": 210,
+    "weight": 255,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/miaownolith.json
+++ b/mods/tuxemon/db/monster/miaownolith.json
@@ -21,6 +21,8 @@
         "Metal",
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/miaownolith.json
+++ b/mods/tuxemon/db/monster/miaownolith.json
@@ -21,7 +21,7 @@
         "Metal",
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/mk01_alpha.json
+++ b/mods/tuxemon/db/monster/mk01_alpha.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "txmn_id": 0,
+    "height": 0,
     "weight": 100,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/mk01_alpha.json
+++ b/mods/tuxemon/db/monster/mk01_alpha.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 100,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/mk01_alpha.json
+++ b/mods/tuxemon/db/monster/mk01_alpha.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 100,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/mk01_beta.json
+++ b/mods/tuxemon/db/monster/mk01_beta.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "txmn_id": 0,
+    "height": 0,
     "weight": 100,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/mk01_beta.json
+++ b/mods/tuxemon/db/monster/mk01_beta.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 100,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/mk01_beta.json
+++ b/mods/tuxemon/db/monster/mk01_beta.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 100,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/moloch.json
+++ b/mods/tuxemon/db/monster/moloch.json
@@ -20,6 +20,8 @@
     "types": [
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,

--- a/mods/tuxemon/db/monster/moloch.json
+++ b/mods/tuxemon/db/monster/moloch.json
@@ -20,7 +20,9 @@
     "types": [
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 12,
+    "height": 216,
+    "weight": 90,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/moloch.json
+++ b/mods/tuxemon/db/monster/moloch.json
@@ -20,9 +20,9 @@
     "types": [
         "Wood"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 12,
+    "height": 216,
+    "weight": 90,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/moloch.json
+++ b/mods/tuxemon/db/monster/moloch.json
@@ -20,7 +20,7 @@
     "types": [
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/mrmoswitch.json
+++ b/mods/tuxemon/db/monster/mrmoswitch.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/mrmoswitch.json
+++ b/mods/tuxemon/db/monster/mrmoswitch.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/mrmoswitch.json
+++ b/mods/tuxemon/db/monster/mrmoswitch.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 127,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/mrmoswitch.json
+++ b/mods/tuxemon/db/monster/mrmoswitch.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
+    "txmn_id": 127,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/narcileaf.json
+++ b/mods/tuxemon/db/monster/narcileaf.json
@@ -20,7 +20,9 @@
     "types": [
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 77,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/narcileaf.json
+++ b/mods/tuxemon/db/monster/narcileaf.json
@@ -20,9 +20,9 @@
     "types": [
         "Wood"
     ],
-    "txmn_id": 0,
+    "txmn_id": 77,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/narcileaf.json
+++ b/mods/tuxemon/db/monster/narcileaf.json
@@ -20,6 +20,8 @@
     "types": [
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/narcileaf.json
+++ b/mods/tuxemon/db/monster/narcileaf.json
@@ -20,7 +20,7 @@
     "types": [
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/neutrito.json
+++ b/mods/tuxemon/db/monster/neutrito.json
@@ -21,7 +21,9 @@
         "Metal",
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 0,
+    "height": 90,
+    "weight": 55,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/neutrito.json
+++ b/mods/tuxemon/db/monster/neutrito.json
@@ -21,7 +21,7 @@
         "Metal",
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/neutrito.json
+++ b/mods/tuxemon/db/monster/neutrito.json
@@ -21,6 +21,8 @@
         "Metal",
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/neutrito.json
+++ b/mods/tuxemon/db/monster/neutrito.json
@@ -22,8 +22,8 @@
         "Wood"
     ],
     "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "height": 90,
+    "weight": 55,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/noctalo.json
+++ b/mods/tuxemon/db/monster/noctalo.json
@@ -20,6 +20,8 @@
     "types": [
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/noctalo.json
+++ b/mods/tuxemon/db/monster/noctalo.json
@@ -20,7 +20,9 @@
     "types": [
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 50,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/noctalo.json
+++ b/mods/tuxemon/db/monster/noctalo.json
@@ -20,9 +20,9 @@
     "types": [
         "Water"
     ],
-    "txmn_id": 0,
+    "txmn_id": 50,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/noctalo.json
+++ b/mods/tuxemon/db/monster/noctalo.json
@@ -20,7 +20,7 @@
     "types": [
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/noctula.json
+++ b/mods/tuxemon/db/monster/noctula.json
@@ -20,6 +20,8 @@
     "types": [
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/noctula.json
+++ b/mods/tuxemon/db/monster/noctula.json
@@ -20,7 +20,7 @@
     "types": [
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/noctula.json
+++ b/mods/tuxemon/db/monster/noctula.json
@@ -20,7 +20,9 @@
     "types": [
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 49,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/noctula.json
+++ b/mods/tuxemon/db/monster/noctula.json
@@ -20,9 +20,9 @@
     "types": [
         "Water"
     ],
-    "txmn_id": 0,
+    "txmn_id": 49,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/nostray.json
+++ b/mods/tuxemon/db/monster/nostray.json
@@ -20,7 +20,9 @@
     "types": [
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 148,
+    "height": 120,
+    "weight": 30,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/nostray.json
+++ b/mods/tuxemon/db/monster/nostray.json
@@ -20,6 +20,8 @@
     "types": [
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/nostray.json
+++ b/mods/tuxemon/db/monster/nostray.json
@@ -20,9 +20,9 @@
     "types": [
         "Water"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 148,
+    "height": 120,
+    "weight": 30,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/nostray.json
+++ b/mods/tuxemon/db/monster/nostray.json
@@ -20,7 +20,7 @@
     "types": [
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/nudiflot_female.json
+++ b/mods/tuxemon/db/monster/nudiflot_female.json
@@ -20,7 +20,9 @@
     "types": [
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 53,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/nudiflot_female.json
+++ b/mods/tuxemon/db/monster/nudiflot_female.json
@@ -20,6 +20,8 @@
     "types": [
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/nudiflot_female.json
+++ b/mods/tuxemon/db/monster/nudiflot_female.json
@@ -20,9 +20,9 @@
     "types": [
         "Water"
     ],
-    "txmn_id": 0,
+    "txmn_id": 53,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/nudiflot_female.json
+++ b/mods/tuxemon/db/monster/nudiflot_female.json
@@ -20,7 +20,7 @@
     "types": [
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/nudiflot_male.json
+++ b/mods/tuxemon/db/monster/nudiflot_male.json
@@ -20,6 +20,8 @@
     "types": [
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/nudiflot_male.json
+++ b/mods/tuxemon/db/monster/nudiflot_male.json
@@ -20,7 +20,9 @@
     "types": [
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 51,
+    "height": 36,
+    "weight": 3,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/nudiflot_male.json
+++ b/mods/tuxemon/db/monster/nudiflot_male.json
@@ -20,9 +20,9 @@
     "types": [
         "Water"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 51,
+    "height": 36,
+    "weight": 3,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/nudiflot_male.json
+++ b/mods/tuxemon/db/monster/nudiflot_male.json
@@ -20,7 +20,7 @@
     "types": [
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/nudikill.json
+++ b/mods/tuxemon/db/monster/nudikill.json
@@ -20,7 +20,9 @@
     "types": [
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 52,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/nudikill.json
+++ b/mods/tuxemon/db/monster/nudikill.json
@@ -20,6 +20,8 @@
     "types": [
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/nudikill.json
+++ b/mods/tuxemon/db/monster/nudikill.json
@@ -20,7 +20,7 @@
     "types": [
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/nudikill.json
+++ b/mods/tuxemon/db/monster/nudikill.json
@@ -20,9 +20,9 @@
     "types": [
         "Water"
     ],
-    "txmn_id": 0,
+    "txmn_id": 52,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/nudimind.json
+++ b/mods/tuxemon/db/monster/nudimind.json
@@ -20,7 +20,9 @@
     "types": [
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 54,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/nudimind.json
+++ b/mods/tuxemon/db/monster/nudimind.json
@@ -20,6 +20,8 @@
     "types": [
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/nudimind.json
+++ b/mods/tuxemon/db/monster/nudimind.json
@@ -20,9 +20,9 @@
     "types": [
         "Water"
     ],
-    "txmn_id": 0,
+    "txmn_id": 54,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/nudimind.json
+++ b/mods/tuxemon/db/monster/nudimind.json
@@ -20,7 +20,7 @@
     "types": [
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/nut.json
+++ b/mods/tuxemon/db/monster/nut.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/nut.json
+++ b/mods/tuxemon/db/monster/nut.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/nut.json
+++ b/mods/tuxemon/db/monster/nut.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 4,
+    "height": 45,
+    "weight": 4,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/nut.json
+++ b/mods/tuxemon/db/monster/nut.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 4,
+    "height": 45,
+    "weight": 4,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/ouroboutlet.json
+++ b/mods/tuxemon/db/monster/ouroboutlet.json
@@ -21,6 +21,8 @@
         "Metal",
         "Fire"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/ouroboutlet.json
+++ b/mods/tuxemon/db/monster/ouroboutlet.json
@@ -21,9 +21,9 @@
         "Metal",
         "Fire"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 89,
+    "height": 62,
+    "weight": 4,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/ouroboutlet.json
+++ b/mods/tuxemon/db/monster/ouroboutlet.json
@@ -21,7 +21,9 @@
         "Metal",
         "Fire"
     ],
-    "weight": 25,
+    "txmn_id": 89,
+    "height": 62,
+    "weight": 4,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/ouroboutlet.json
+++ b/mods/tuxemon/db/monster/ouroboutlet.json
@@ -21,7 +21,7 @@
         "Metal",
         "Fire"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/pairagrim.json
+++ b/mods/tuxemon/db/monster/pairagrim.json
@@ -24,6 +24,8 @@
     "types": [
         "wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 10,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/pairagrim.json
+++ b/mods/tuxemon/db/monster/pairagrim.json
@@ -24,7 +24,7 @@
     "types": [
         "wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 10,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/pairagrim.json
+++ b/mods/tuxemon/db/monster/pairagrim.json
@@ -24,6 +24,8 @@
     "types": [
         "wood"
     ],
+    "txmn_id": 0,
+    "height": 0,
     "weight": 10,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/pairagrin.json
+++ b/mods/tuxemon/db/monster/pairagrin.json
@@ -20,7 +20,7 @@
     "types": [
         "wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 4,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/pairagrin.json
+++ b/mods/tuxemon/db/monster/pairagrin.json
@@ -20,6 +20,8 @@
     "types": [
         "wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 4,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/pairagrin.json
+++ b/mods/tuxemon/db/monster/pairagrin.json
@@ -20,6 +20,8 @@
     "types": [
         "wood"
     ],
+    "txmn_id": 0,
+    "height": 70,
     "weight": 4,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/pairagrin.json
+++ b/mods/tuxemon/db/monster/pairagrin.json
@@ -21,7 +21,7 @@
         "wood"
     ],
     "txmn_id": 0,
-    "height": 0,
+    "height": 70,
     "weight": 4,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/pharfan.json
+++ b/mods/tuxemon/db/monster/pharfan.json
@@ -20,6 +20,8 @@
     "types": [
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/pharfan.json
+++ b/mods/tuxemon/db/monster/pharfan.json
@@ -20,7 +20,9 @@
     "types": [
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 147,
+    "height": 200,
+    "weight": 500,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/pharfan.json
+++ b/mods/tuxemon/db/monster/pharfan.json
@@ -20,7 +20,7 @@
     "types": [
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/pharfan.json
+++ b/mods/tuxemon/db/monster/pharfan.json
@@ -20,9 +20,9 @@
     "types": [
         "Water"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 147,
+    "height": 200,
+    "weight": 500,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/picc.json
+++ b/mods/tuxemon/db/monster/picc.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 126,
+    "height": 55,
+    "weight": 4,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/picc.json
+++ b/mods/tuxemon/db/monster/picc.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/picc.json
+++ b/mods/tuxemon/db/monster/picc.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 126,
+    "height": 55,
+    "weight": 4,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/picc.json
+++ b/mods/tuxemon/db/monster/picc.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/pigabyte.json
+++ b/mods/tuxemon/db/monster/pigabyte.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/pigabyte.json
+++ b/mods/tuxemon/db/monster/pigabyte.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/pigabyte.json
+++ b/mods/tuxemon/db/monster/pigabyte.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 115,
+    "height": 155,
+    "weight": 180,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/pigabyte.json
+++ b/mods/tuxemon/db/monster/pigabyte.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 115,
+    "height": 155,
+    "weight": 180,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/pilthropus.json
+++ b/mods/tuxemon/db/monster/pilthropus.json
@@ -20,6 +20,8 @@
     "types": [
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 50,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/pilthropus.json
+++ b/mods/tuxemon/db/monster/pilthropus.json
@@ -20,7 +20,7 @@
     "types": [
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 50,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/pilthropus.json
+++ b/mods/tuxemon/db/monster/pilthropus.json
@@ -20,6 +20,8 @@
     "types": [
         "Earth"
     ],
+    "txmn_id": 0,
+    "height": 0,
     "weight": 50,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/pipis.json
+++ b/mods/tuxemon/db/monster/pipis.json
@@ -20,7 +20,9 @@
     "types": [
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 47,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/pipis.json
+++ b/mods/tuxemon/db/monster/pipis.json
@@ -20,6 +20,8 @@
     "types": [
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/pipis.json
+++ b/mods/tuxemon/db/monster/pipis.json
@@ -20,7 +20,7 @@
     "types": [
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/pipis.json
+++ b/mods/tuxemon/db/monster/pipis.json
@@ -20,9 +20,9 @@
     "types": [
         "Wood"
     ],
-    "txmn_id": 0,
+    "txmn_id": 47,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/poinchin.json
+++ b/mods/tuxemon/db/monster/poinchin.json
@@ -20,6 +20,8 @@
     "types": [
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/poinchin.json
+++ b/mods/tuxemon/db/monster/poinchin.json
@@ -20,7 +20,9 @@
     "types": [
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 0,
+    "height": 30,
+    "weight": 6,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/poinchin.json
+++ b/mods/tuxemon/db/monster/poinchin.json
@@ -20,7 +20,7 @@
     "types": [
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/poinchin.json
+++ b/mods/tuxemon/db/monster/poinchin.json
@@ -21,8 +21,8 @@
         "Water"
     ],
     "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "height": 30,
+    "weight": 6,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/polyrock.json
+++ b/mods/tuxemon/db/monster/polyrock.json
@@ -20,6 +20,8 @@
     "types": [
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/polyrock.json
+++ b/mods/tuxemon/db/monster/polyrock.json
@@ -20,7 +20,7 @@
     "types": [
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/polyrock.json
+++ b/mods/tuxemon/db/monster/polyrock.json
@@ -20,7 +20,9 @@
     "types": [
         "Earth"
     ],
-    "weight": 25,
+    "txmn_id": 116,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/polyrock.json
+++ b/mods/tuxemon/db/monster/polyrock.json
@@ -20,9 +20,9 @@
     "types": [
         "Earth"
     ],
-    "txmn_id": 0,
+    "txmn_id": 116,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/possessun.json
+++ b/mods/tuxemon/db/monster/possessun.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
+    "txmn_id": 71,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/possessun.json
+++ b/mods/tuxemon/db/monster/possessun.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/possessun.json
+++ b/mods/tuxemon/db/monster/possessun.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 71,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/possessun.json
+++ b/mods/tuxemon/db/monster/possessun.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/propellercat.json
+++ b/mods/tuxemon/db/monster/propellercat.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 117,
+    "height": 55,
+    "weight": 6,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/propellercat.json
+++ b/mods/tuxemon/db/monster/propellercat.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/propellercat.json
+++ b/mods/tuxemon/db/monster/propellercat.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/propellercat.json
+++ b/mods/tuxemon/db/monster/propellercat.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 117,
+    "height": 55,
+    "weight": 6,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/prophetoise.json
+++ b/mods/tuxemon/db/monster/prophetoise.json
@@ -20,7 +20,9 @@
     "types": [
         "Fire"
     ],
-    "weight": 25,
+    "txmn_id": 87,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/prophetoise.json
+++ b/mods/tuxemon/db/monster/prophetoise.json
@@ -20,9 +20,9 @@
     "types": [
         "Fire"
     ],
-    "txmn_id": 0,
+    "txmn_id": 87,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/prophetoise.json
+++ b/mods/tuxemon/db/monster/prophetoise.json
@@ -20,7 +20,7 @@
     "types": [
         "Fire"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/prophetoise.json
+++ b/mods/tuxemon/db/monster/prophetoise.json
@@ -20,6 +20,8 @@
     "types": [
         "Fire"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/puparmor.json
+++ b/mods/tuxemon/db/monster/puparmor.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/puparmor.json
+++ b/mods/tuxemon/db/monster/puparmor.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
+    "txmn_id": 33,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/puparmor.json
+++ b/mods/tuxemon/db/monster/puparmor.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 33,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/puparmor.json
+++ b/mods/tuxemon/db/monster/puparmor.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/pyraminx.json
+++ b/mods/tuxemon/db/monster/pyraminx.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 22,
+    "height": 210,
+    "weight": 190,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/pyraminx.json
+++ b/mods/tuxemon/db/monster/pyraminx.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/pyraminx.json
+++ b/mods/tuxemon/db/monster/pyraminx.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 22,
+    "height": 210,
+    "weight": 190,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/pyraminx.json
+++ b/mods/tuxemon/db/monster/pyraminx.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,

--- a/mods/tuxemon/db/monster/pythwire.json
+++ b/mods/tuxemon/db/monster/pythwire.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/pythwire.json
+++ b/mods/tuxemon/db/monster/pythwire.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 88,
+    "height": 200,
+    "weight": 4,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/pythwire.json
+++ b/mods/tuxemon/db/monster/pythwire.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/pythwire.json
+++ b/mods/tuxemon/db/monster/pythwire.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 88,
+    "height": 200,
+    "weight": 4,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/r0ck1tt3n.json
+++ b/mods/tuxemon/db/monster/r0ck1tt3n.json
@@ -21,7 +21,7 @@
         "Glitch",
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/r0ck1tt3n.json
+++ b/mods/tuxemon/db/monster/r0ck1tt3n.json
@@ -21,6 +21,8 @@
         "Glitch",
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/r0ck1tt3n.json
+++ b/mods/tuxemon/db/monster/r0ck1tt3n.json
@@ -21,6 +21,8 @@
         "Glitch",
         "Earth"
     ],
+    "txmn_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/rabbitosaur.json
+++ b/mods/tuxemon/db/monster/rabbitosaur.json
@@ -20,9 +20,9 @@
     "types": [
         "Earth"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 44,
+    "height": 120,
+    "weight": 80,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/rabbitosaur.json
+++ b/mods/tuxemon/db/monster/rabbitosaur.json
@@ -20,6 +20,8 @@
     "types": [
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/rabbitosaur.json
+++ b/mods/tuxemon/db/monster/rabbitosaur.json
@@ -20,7 +20,9 @@
     "types": [
         "Earth"
     ],
-    "weight": 25,
+    "txmn_id": 44,
+    "height": 120,
+    "weight": 80,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/rabbitosaur.json
+++ b/mods/tuxemon/db/monster/rabbitosaur.json
@@ -20,7 +20,7 @@
     "types": [
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/rhincus.json
+++ b/mods/tuxemon/db/monster/rhincus.json
@@ -20,7 +20,9 @@
     "types": [
         "Earth"
     ],
-    "weight": 25,
+    "txmn_id": 139,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/rhincus.json
+++ b/mods/tuxemon/db/monster/rhincus.json
@@ -20,9 +20,9 @@
     "types": [
         "Earth"
     ],
-    "txmn_id": 0,
+    "txmn_id": 139,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/rhincus.json
+++ b/mods/tuxemon/db/monster/rhincus.json
@@ -20,6 +20,8 @@
     "types": [
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/rhincus.json
+++ b/mods/tuxemon/db/monster/rhincus.json
@@ -20,7 +20,7 @@
     "types": [
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/rockat.json
+++ b/mods/tuxemon/db/monster/rockat.json
@@ -20,7 +20,9 @@
     "types": [
         "Earth"
     ],
-    "weight": 25,
+    "txmn_id": 2,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/rockat.json
+++ b/mods/tuxemon/db/monster/rockat.json
@@ -20,6 +20,8 @@
     "types": [
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/rockat.json
+++ b/mods/tuxemon/db/monster/rockat.json
@@ -20,7 +20,7 @@
     "types": [
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/rockat.json
+++ b/mods/tuxemon/db/monster/rockat.json
@@ -20,9 +20,9 @@
     "types": [
         "Earth"
     ],
-    "txmn_id": 0,
+    "txmn_id": 2,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/rockitten.json
+++ b/mods/tuxemon/db/monster/rockitten.json
@@ -20,7 +20,9 @@
     "types": [
         "Earth"
     ],
-    "weight": 25,
+    "txmn_id": 1,
+    "height": 55,
+    "weight": 9,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/rockitten.json
+++ b/mods/tuxemon/db/monster/rockitten.json
@@ -20,7 +20,7 @@
     "types": [
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/rockitten.json
+++ b/mods/tuxemon/db/monster/rockitten.json
@@ -20,6 +20,8 @@
     "types": [
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/rockitten.json
+++ b/mods/tuxemon/db/monster/rockitten.json
@@ -20,9 +20,9 @@
     "types": [
         "Earth"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 1,
+    "height": 55,
+    "weight": 9,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/ruption.json
+++ b/mods/tuxemon/db/monster/ruption.json
@@ -20,9 +20,9 @@
     "types": [
         "Fire"
     ],
-    "txmn_id": 0,
+    "txmn_id": 75,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/ruption.json
+++ b/mods/tuxemon/db/monster/ruption.json
@@ -20,7 +20,9 @@
     "types": [
         "Fire"
     ],
-    "weight": 25,
+    "txmn_id": 75,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/ruption.json
+++ b/mods/tuxemon/db/monster/ruption.json
@@ -20,7 +20,7 @@
     "types": [
         "Fire"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/ruption.json
+++ b/mods/tuxemon/db/monster/ruption.json
@@ -20,6 +20,8 @@
     "types": [
         "Fire"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/sadito.json
+++ b/mods/tuxemon/db/monster/sadito.json
@@ -21,7 +21,7 @@
         "Metal",
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/sadito.json
+++ b/mods/tuxemon/db/monster/sadito.json
@@ -22,8 +22,8 @@
         "Water"
     ],
     "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "height": 90,
+    "weight": 55,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/sadito.json
+++ b/mods/tuxemon/db/monster/sadito.json
@@ -21,6 +21,8 @@
         "Metal",
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/sadito.json
+++ b/mods/tuxemon/db/monster/sadito.json
@@ -21,7 +21,9 @@
         "Metal",
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 0,
+    "height": 90,
+    "weight": 55,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/sampsack.json
+++ b/mods/tuxemon/db/monster/sampsack.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 96,
+    "height": 225,
+    "weight": 235,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/sampsack.json
+++ b/mods/tuxemon/db/monster/sampsack.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/sampsack.json
+++ b/mods/tuxemon/db/monster/sampsack.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 96,
+    "height": 225,
+    "weight": 235,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/sampsack.json
+++ b/mods/tuxemon/db/monster/sampsack.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/sampsage.json
+++ b/mods/tuxemon/db/monster/sampsage.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/sampsage.json
+++ b/mods/tuxemon/db/monster/sampsage.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
+    "txmn_id": 97,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/sampsage.json
+++ b/mods/tuxemon/db/monster/sampsage.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 97,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/sampsage.json
+++ b/mods/tuxemon/db/monster/sampsage.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,

--- a/mods/tuxemon/db/monster/sapragon.json
+++ b/mods/tuxemon/db/monster/sapragon.json
@@ -20,6 +20,8 @@
     "types": [
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/sapragon.json
+++ b/mods/tuxemon/db/monster/sapragon.json
@@ -20,9 +20,9 @@
     "types": [
         "Wood"
     ],
-    "txmn_id": 0,
+    "txmn_id": 137,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/sapragon.json
+++ b/mods/tuxemon/db/monster/sapragon.json
@@ -20,7 +20,7 @@
     "types": [
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/sapragon.json
+++ b/mods/tuxemon/db/monster/sapragon.json
@@ -20,7 +20,9 @@
     "types": [
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 137,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/sapsnap.json
+++ b/mods/tuxemon/db/monster/sapsnap.json
@@ -20,9 +20,9 @@
     "types": [
         "Wood"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 85,
+    "height": 210,
+    "weight": 125,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/sapsnap.json
+++ b/mods/tuxemon/db/monster/sapsnap.json
@@ -20,6 +20,8 @@
     "types": [
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/sapsnap.json
+++ b/mods/tuxemon/db/monster/sapsnap.json
@@ -20,7 +20,7 @@
     "types": [
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/sapsnap.json
+++ b/mods/tuxemon/db/monster/sapsnap.json
@@ -20,7 +20,9 @@
     "types": [
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 85,
+    "height": 210,
+    "weight": 125,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/saurchin.json
+++ b/mods/tuxemon/db/monster/saurchin.json
@@ -20,6 +20,8 @@
     "types": [
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/saurchin.json
+++ b/mods/tuxemon/db/monster/saurchin.json
@@ -21,8 +21,8 @@
         "Water"
     ],
     "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "height": 800,
+    "weight": 3000,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/saurchin.json
+++ b/mods/tuxemon/db/monster/saurchin.json
@@ -20,7 +20,9 @@
     "types": [
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 0,
+    "height": 800,
+    "weight": 3000,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/saurchin.json
+++ b/mods/tuxemon/db/monster/saurchin.json
@@ -20,7 +20,7 @@
     "types": [
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/sclairus.json
+++ b/mods/tuxemon/db/monster/sclairus.json
@@ -20,6 +20,8 @@
     "types": [
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/sclairus.json
+++ b/mods/tuxemon/db/monster/sclairus.json
@@ -20,7 +20,9 @@
     "types": [
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 118,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/sclairus.json
+++ b/mods/tuxemon/db/monster/sclairus.json
@@ -20,9 +20,9 @@
     "types": [
         "Wood"
     ],
-    "txmn_id": 0,
+    "txmn_id": 118,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/sclairus.json
+++ b/mods/tuxemon/db/monster/sclairus.json
@@ -20,7 +20,7 @@
     "types": [
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/seirein.json
+++ b/mods/tuxemon/db/monster/seirein.json
@@ -21,7 +21,7 @@
         "Fire",
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/seirein.json
+++ b/mods/tuxemon/db/monster/seirein.json
@@ -21,7 +21,9 @@
         "Fire",
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 154,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/seirein.json
+++ b/mods/tuxemon/db/monster/seirein.json
@@ -21,9 +21,9 @@
         "Fire",
         "Water"
     ],
-    "txmn_id": 0,
+    "txmn_id": 154,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/seirein.json
+++ b/mods/tuxemon/db/monster/seirein.json
@@ -21,6 +21,8 @@
         "Fire",
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,

--- a/mods/tuxemon/db/monster/shammer.json
+++ b/mods/tuxemon/db/monster/shammer.json
@@ -20,6 +20,8 @@
     "types": [
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/shammer.json
+++ b/mods/tuxemon/db/monster/shammer.json
@@ -20,9 +20,9 @@
     "types": [
         "Earth"
     ],
-    "txmn_id": 0,
+    "txmn_id": 140,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/shammer.json
+++ b/mods/tuxemon/db/monster/shammer.json
@@ -20,7 +20,9 @@
     "types": [
         "Earth"
     ],
-    "weight": 25,
+    "txmn_id": 140,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/shammer.json
+++ b/mods/tuxemon/db/monster/shammer.json
@@ -20,7 +20,7 @@
     "types": [
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/sharpfin.json
+++ b/mods/tuxemon/db/monster/sharpfin.json
@@ -21,7 +21,7 @@
         "Water",
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/sharpfin.json
+++ b/mods/tuxemon/db/monster/sharpfin.json
@@ -21,7 +21,9 @@
         "Water",
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 25,
+    "height": 300,
+    "weight": 200,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/sharpfin.json
+++ b/mods/tuxemon/db/monster/sharpfin.json
@@ -21,9 +21,9 @@
         "Water",
         "Wood"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 25,
+    "height": 300,
+    "weight": 200,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/sharpfin.json
+++ b/mods/tuxemon/db/monster/sharpfin.json
@@ -21,6 +21,8 @@
         "Water",
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,

--- a/mods/tuxemon/db/monster/shybulb.json
+++ b/mods/tuxemon/db/monster/shybulb.json
@@ -20,6 +20,8 @@
     "types": [
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/shybulb.json
+++ b/mods/tuxemon/db/monster/shybulb.json
@@ -20,7 +20,7 @@
     "types": [
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/shybulb.json
+++ b/mods/tuxemon/db/monster/shybulb.json
@@ -20,9 +20,9 @@
     "types": [
         "Wood"
     ],
-    "txmn_id": 0,
+    "txmn_id": 76,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/shybulb.json
+++ b/mods/tuxemon/db/monster/shybulb.json
@@ -20,7 +20,9 @@
     "types": [
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 76,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/skwib.json
+++ b/mods/tuxemon/db/monster/skwib.json
@@ -20,6 +20,8 @@
     "types": [
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/skwib.json
+++ b/mods/tuxemon/db/monster/skwib.json
@@ -20,7 +20,7 @@
     "types": [
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/skwib.json
+++ b/mods/tuxemon/db/monster/skwib.json
@@ -20,7 +20,9 @@
     "types": [
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 0,
+    "height": 30,
+    "weight": 9,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/skwib.json
+++ b/mods/tuxemon/db/monster/skwib.json
@@ -21,8 +21,8 @@
         "Water"
     ],
     "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "height": 30,
+    "weight": 9,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/sludgehog.json
+++ b/mods/tuxemon/db/monster/sludgehog.json
@@ -20,6 +20,8 @@
     "types": [
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/sludgehog.json
+++ b/mods/tuxemon/db/monster/sludgehog.json
@@ -20,9 +20,9 @@
     "types": [
         "Earth"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 119,
+    "height": 125,
+    "weight": 95,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/sludgehog.json
+++ b/mods/tuxemon/db/monster/sludgehog.json
@@ -20,7 +20,9 @@
     "types": [
         "Earth"
     ],
-    "weight": 25,
+    "txmn_id": 119,
+    "height": 125,
+    "weight": 95,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/sludgehog.json
+++ b/mods/tuxemon/db/monster/sludgehog.json
@@ -20,7 +20,7 @@
     "types": [
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/snarlon.json
+++ b/mods/tuxemon/db/monster/snarlon.json
@@ -20,9 +20,9 @@
     "types": [
         "Earth"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 143,
+    "height": 160,
+    "weight": 130,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/snarlon.json
+++ b/mods/tuxemon/db/monster/snarlon.json
@@ -20,6 +20,8 @@
     "types": [
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/snarlon.json
+++ b/mods/tuxemon/db/monster/snarlon.json
@@ -20,7 +20,7 @@
     "types": [
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/snarlon.json
+++ b/mods/tuxemon/db/monster/snarlon.json
@@ -20,7 +20,9 @@
     "types": [
         "Earth"
     ],
-    "weight": 25,
+    "txmn_id": 143,
+    "height": 160,
+    "weight": 130,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/sockeserp.json
+++ b/mods/tuxemon/db/monster/sockeserp.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/sockeserp.json
+++ b/mods/tuxemon/db/monster/sockeserp.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 90,
+    "height": 100,
+    "weight": 1,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/sockeserp.json
+++ b/mods/tuxemon/db/monster/sockeserp.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 90,
+    "height": 100,
+    "weight": 1,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/sockeserp.json
+++ b/mods/tuxemon/db/monster/sockeserp.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,

--- a/mods/tuxemon/db/monster/spighter.json
+++ b/mods/tuxemon/db/monster/spighter.json
@@ -20,6 +20,8 @@
     "types": [
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/spighter.json
+++ b/mods/tuxemon/db/monster/spighter.json
@@ -20,9 +20,9 @@
     "types": [
         "Wood"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 120,
+    "height": 30,
+    "weight": 2,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/spighter.json
+++ b/mods/tuxemon/db/monster/spighter.json
@@ -20,7 +20,9 @@
     "types": [
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 120,
+    "height": 30,
+    "weight": 2,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/spighter.json
+++ b/mods/tuxemon/db/monster/spighter.json
@@ -20,7 +20,7 @@
     "types": [
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/squabbit.json
+++ b/mods/tuxemon/db/monster/squabbit.json
@@ -20,9 +20,9 @@
     "types": [
         "Earth"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 43,
+    "height": 60,
+    "weight": 10,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/squabbit.json
+++ b/mods/tuxemon/db/monster/squabbit.json
@@ -20,7 +20,9 @@
     "types": [
         "Earth"
     ],
-    "weight": 25,
+    "txmn_id": 43,
+    "height": 60,
+    "weight": 10,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/squabbit.json
+++ b/mods/tuxemon/db/monster/squabbit.json
@@ -20,7 +20,7 @@
     "types": [
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/squabbit.json
+++ b/mods/tuxemon/db/monster/squabbit.json
@@ -20,6 +20,8 @@
     "types": [
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/strella.json
+++ b/mods/tuxemon/db/monster/strella.json
@@ -20,9 +20,9 @@
     "types": [
         "Wood"
     ],
-    "txmn_id": 0,
+    "txmn_id": 48,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/strella.json
+++ b/mods/tuxemon/db/monster/strella.json
@@ -20,7 +20,9 @@
     "types": [
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 48,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/strella.json
+++ b/mods/tuxemon/db/monster/strella.json
@@ -20,6 +20,8 @@
     "types": [
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/strella.json
+++ b/mods/tuxemon/db/monster/strella.json
@@ -20,7 +20,7 @@
     "types": [
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/sumchon.json
+++ b/mods/tuxemon/db/monster/sumchon.json
@@ -21,7 +21,7 @@
         "Metal",
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/sumchon.json
+++ b/mods/tuxemon/db/monster/sumchon.json
@@ -21,6 +21,8 @@
         "Metal",
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/sumchon.json
+++ b/mods/tuxemon/db/monster/sumchon.json
@@ -21,9 +21,9 @@
         "Metal",
         "Wood"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 58,
+    "height": 150,
+    "weight": 125,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/sumchon.json
+++ b/mods/tuxemon/db/monster/sumchon.json
@@ -21,7 +21,9 @@
         "Metal",
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 58,
+    "height": 150,
+    "weight": 125,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/teddisun.json
+++ b/mods/tuxemon/db/monster/teddisun.json
@@ -20,6 +20,8 @@
     "types": [
         "Fire"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 60,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/teddisun.json
+++ b/mods/tuxemon/db/monster/teddisun.json
@@ -20,7 +20,7 @@
     "types": [
         "Fire"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 60,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/teddisun.json
+++ b/mods/tuxemon/db/monster/teddisun.json
@@ -20,6 +20,8 @@
     "types": [
         "Fire"
     ],
+    "txmn_id": 0,
+    "height": 0,
     "weight": 60,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/tigrock.json
+++ b/mods/tuxemon/db/monster/tigrock.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/tigrock.json
+++ b/mods/tuxemon/db/monster/tigrock.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
+    "txmn_id": 93,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/tigrock.json
+++ b/mods/tuxemon/db/monster/tigrock.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 93,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/tigrock.json
+++ b/mods/tuxemon/db/monster/tigrock.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/tikoal.json
+++ b/mods/tuxemon/db/monster/tikoal.json
@@ -21,7 +21,9 @@
         "Fire",
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 78,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/tikoal.json
+++ b/mods/tuxemon/db/monster/tikoal.json
@@ -21,9 +21,9 @@
         "Fire",
         "Wood"
     ],
-    "txmn_id": 0,
+    "txmn_id": 78,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/tikoal.json
+++ b/mods/tuxemon/db/monster/tikoal.json
@@ -21,6 +21,8 @@
         "Fire",
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/tikoal.json
+++ b/mods/tuxemon/db/monster/tikoal.json
@@ -21,7 +21,7 @@
         "Fire",
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/tikorch.json
+++ b/mods/tuxemon/db/monster/tikorch.json
@@ -21,6 +21,8 @@
         "Fire",
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/tikorch.json
+++ b/mods/tuxemon/db/monster/tikorch.json
@@ -21,9 +21,9 @@
         "Fire",
         "Wood"
     ],
-    "txmn_id": 0,
+    "txmn_id": 79,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/tikorch.json
+++ b/mods/tuxemon/db/monster/tikorch.json
@@ -21,7 +21,7 @@
         "Fire",
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/tikorch.json
+++ b/mods/tuxemon/db/monster/tikorch.json
@@ -21,7 +21,9 @@
         "Fire",
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 79,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/toufigel.json
+++ b/mods/tuxemon/db/monster/toufigel.json
@@ -21,6 +21,8 @@
         "Earth",
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/toufigel.json
+++ b/mods/tuxemon/db/monster/toufigel.json
@@ -21,7 +21,9 @@
         "Earth",
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 121,
+    "height": 40,
+    "weight": 3,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/toufigel.json
+++ b/mods/tuxemon/db/monster/toufigel.json
@@ -21,7 +21,7 @@
         "Earth",
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/toufigel.json
+++ b/mods/tuxemon/db/monster/toufigel.json
@@ -21,9 +21,9 @@
         "Earth",
         "Water"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 121,
+    "height": 40,
+    "weight": 3,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/tourbidi.json
+++ b/mods/tuxemon/db/monster/tourbidi.json
@@ -20,7 +20,9 @@
     "types": [
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 122,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/tourbidi.json
+++ b/mods/tuxemon/db/monster/tourbidi.json
@@ -20,6 +20,8 @@
     "types": [
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/tourbidi.json
+++ b/mods/tuxemon/db/monster/tourbidi.json
@@ -20,7 +20,7 @@
     "types": [
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/tourbidi.json
+++ b/mods/tuxemon/db/monster/tourbidi.json
@@ -20,9 +20,9 @@
     "types": [
         "Wood"
     ],
-    "txmn_id": 0,
+    "txmn_id": 122,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/trapsnap.json
+++ b/mods/tuxemon/db/monster/trapsnap.json
@@ -20,7 +20,9 @@
     "types": [
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 84,
+    "height": 120,
+    "weight": 60,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/trapsnap.json
+++ b/mods/tuxemon/db/monster/trapsnap.json
@@ -20,9 +20,9 @@
     "types": [
         "Wood"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 84,
+    "height": 120,
+    "weight": 60,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/trapsnap.json
+++ b/mods/tuxemon/db/monster/trapsnap.json
@@ -20,6 +20,8 @@
     "types": [
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/trapsnap.json
+++ b/mods/tuxemon/db/monster/trapsnap.json
@@ -20,7 +20,7 @@
     "types": [
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/tumblebee.json
+++ b/mods/tuxemon/db/monster/tumblebee.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 95,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/tumblebee.json
+++ b/mods/tuxemon/db/monster/tumblebee.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/tumblebee.json
+++ b/mods/tuxemon/db/monster/tumblebee.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
+    "txmn_id": 95,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/tumblebee.json
+++ b/mods/tuxemon/db/monster/tumblebee.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/tumbleworm.json
+++ b/mods/tuxemon/db/monster/tumbleworm.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/tumbleworm.json
+++ b/mods/tuxemon/db/monster/tumbleworm.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/tumbleworm.json
+++ b/mods/tuxemon/db/monster/tumbleworm.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
+    "txmn_id": 94,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/tumbleworm.json
+++ b/mods/tuxemon/db/monster/tumbleworm.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 94,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/tweesher.json
+++ b/mods/tuxemon/db/monster/tweesher.json
@@ -20,6 +20,8 @@
     "types": [
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/tweesher.json
+++ b/mods/tuxemon/db/monster/tweesher.json
@@ -20,7 +20,9 @@
     "types": [
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 7,
+    "height": 45,
+    "weight": 1,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/tweesher.json
+++ b/mods/tuxemon/db/monster/tweesher.json
@@ -20,9 +20,9 @@
     "types": [
         "Water"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 7,
+    "height": 45,
+    "weight": 1,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/tweesher.json
+++ b/mods/tuxemon/db/monster/tweesher.json
@@ -20,7 +20,7 @@
     "types": [
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/vamporm.json
+++ b/mods/tuxemon/db/monster/vamporm.json
@@ -20,6 +20,8 @@
     "types": [
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/vamporm.json
+++ b/mods/tuxemon/db/monster/vamporm.json
@@ -20,7 +20,9 @@
     "types": [
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 35,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/vamporm.json
+++ b/mods/tuxemon/db/monster/vamporm.json
@@ -20,9 +20,9 @@
     "types": [
         "Water"
     ],
-    "txmn_id": 0,
+    "txmn_id": 35,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/vamporm.json
+++ b/mods/tuxemon/db/monster/vamporm.json
@@ -20,7 +20,7 @@
     "types": [
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/velocitile.json
+++ b/mods/tuxemon/db/monster/velocitile.json
@@ -20,7 +20,9 @@
     "types": [
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 66,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/velocitile.json
+++ b/mods/tuxemon/db/monster/velocitile.json
@@ -20,6 +20,8 @@
     "types": [
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,

--- a/mods/tuxemon/db/monster/velocitile.json
+++ b/mods/tuxemon/db/monster/velocitile.json
@@ -20,7 +20,7 @@
     "types": [
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/velocitile.json
+++ b/mods/tuxemon/db/monster/velocitile.json
@@ -20,9 +20,9 @@
     "types": [
         "Wood"
     ],
-    "txmn_id": 0,
+    "txmn_id": 66,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/vivicinder.json
+++ b/mods/tuxemon/db/monster/vivicinder.json
@@ -20,7 +20,9 @@
     "types": [
         "Fire"
     ],
-    "weight": 25,
+    "txmn_id": 131,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/vivicinder.json
+++ b/mods/tuxemon/db/monster/vivicinder.json
@@ -20,9 +20,9 @@
     "types": [
         "Fire"
     ],
-    "txmn_id": 0,
+    "txmn_id": 131,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/vivicinder.json
+++ b/mods/tuxemon/db/monster/vivicinder.json
@@ -20,7 +20,7 @@
     "types": [
         "Fire"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/vivicinder.json
+++ b/mods/tuxemon/db/monster/vivicinder.json
@@ -20,6 +20,8 @@
     "types": [
         "Fire"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/vivipere.json
+++ b/mods/tuxemon/db/monster/vivipere.json
@@ -20,9 +20,9 @@
     "types": [
         "Earth"
     ],
-    "txmn_id": 0,
+    "txmn_id": 130,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/vivipere.json
+++ b/mods/tuxemon/db/monster/vivipere.json
@@ -20,7 +20,9 @@
     "types": [
         "Earth"
     ],
-    "weight": 25,
+    "txmn_id": 130,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/vivipere.json
+++ b/mods/tuxemon/db/monster/vivipere.json
@@ -20,7 +20,7 @@
     "types": [
         "Earth"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/vivipere.json
+++ b/mods/tuxemon/db/monster/vivipere.json
@@ -20,6 +20,8 @@
     "types": [
         "Earth"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/viviphyta.json
+++ b/mods/tuxemon/db/monster/viviphyta.json
@@ -20,6 +20,8 @@
     "types": [
         "Wood"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,

--- a/mods/tuxemon/db/monster/viviphyta.json
+++ b/mods/tuxemon/db/monster/viviphyta.json
@@ -20,7 +20,7 @@
     "types": [
         "Wood"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/viviphyta.json
+++ b/mods/tuxemon/db/monster/viviphyta.json
@@ -20,7 +20,9 @@
     "types": [
         "Wood"
     ],
-    "weight": 25,
+    "txmn_id": 132,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/viviphyta.json
+++ b/mods/tuxemon/db/monster/viviphyta.json
@@ -20,9 +20,9 @@
     "types": [
         "Wood"
     ],
-    "txmn_id": 0,
+    "txmn_id": 132,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/viviteel.json
+++ b/mods/tuxemon/db/monster/viviteel.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
+    "txmn_id": 133,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/viviteel.json
+++ b/mods/tuxemon/db/monster/viviteel.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/viviteel.json
+++ b/mods/tuxemon/db/monster/viviteel.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/viviteel.json
+++ b/mods/tuxemon/db/monster/viviteel.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 133,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/vivitrans.json
+++ b/mods/tuxemon/db/monster/vivitrans.json
@@ -21,7 +21,9 @@
         "Metal",
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 134,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/vivitrans.json
+++ b/mods/tuxemon/db/monster/vivitrans.json
@@ -21,6 +21,8 @@
         "Metal",
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/vivitrans.json
+++ b/mods/tuxemon/db/monster/vivitrans.json
@@ -21,7 +21,7 @@
         "Metal",
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/vivitrans.json
+++ b/mods/tuxemon/db/monster/vivitrans.json
@@ -21,9 +21,9 @@
         "Metal",
         "Water"
     ],
-    "txmn_id": 0,
+    "txmn_id": 134,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/vivitron.json
+++ b/mods/tuxemon/db/monster/vivitron.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/vivitron.json
+++ b/mods/tuxemon/db/monster/vivitron.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
+    "txmn_id": 135,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/vivitron.json
+++ b/mods/tuxemon/db/monster/vivitron.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 135,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/vivitron.json
+++ b/mods/tuxemon/db/monster/vivitron.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,

--- a/mods/tuxemon/db/monster/volcoli.json
+++ b/mods/tuxemon/db/monster/volcoli.json
@@ -20,9 +20,9 @@
     "types": [
         "Fire"
     ],
-    "txmn_id": 0,
+    "txmn_id": 123,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/volcoli.json
+++ b/mods/tuxemon/db/monster/volcoli.json
@@ -20,7 +20,7 @@
     "types": [
         "Fire"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/volcoli.json
+++ b/mods/tuxemon/db/monster/volcoli.json
@@ -20,7 +20,9 @@
     "types": [
         "Fire"
     ],
-    "weight": 25,
+    "txmn_id": 123,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/volcoli.json
+++ b/mods/tuxemon/db/monster/volcoli.json
@@ -20,6 +20,8 @@
     "types": [
         "Fire"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/weavifly.json
+++ b/mods/tuxemon/db/monster/weavifly.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/weavifly.json
+++ b/mods/tuxemon/db/monster/weavifly.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 34,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/weavifly.json
+++ b/mods/tuxemon/db/monster/weavifly.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
+    "txmn_id": 34,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/weavifly.json
+++ b/mods/tuxemon/db/monster/weavifly.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/windeye.json
+++ b/mods/tuxemon/db/monster/windeye.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/windeye.json
+++ b/mods/tuxemon/db/monster/windeye.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/windeye.json
+++ b/mods/tuxemon/db/monster/windeye.json
@@ -21,8 +21,8 @@
         "Metal"
     ],
     "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "height": 300,
+    "weight": 600,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/windeye.json
+++ b/mods/tuxemon/db/monster/windeye.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 0,
+    "height": 300,
+    "weight": 600,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/wrougon.json
+++ b/mods/tuxemon/db/monster/wrougon.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/wrougon.json
+++ b/mods/tuxemon/db/monster/wrougon.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
+    "txmn_id": 152,
     "height": 0,
-    "weight": 25,
+    "weight": 0,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/wrougon.json
+++ b/mods/tuxemon/db/monster/wrougon.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 152,
+    "height": 0,
+    "weight": 0,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/wrougon.json
+++ b/mods/tuxemon/db/monster/wrougon.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,

--- a/mods/tuxemon/db/monster/xeon.json
+++ b/mods/tuxemon/db/monster/xeon.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "txmn_id": 0,
+    "height": 0,
     "weight": 100,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/xeon.json
+++ b/mods/tuxemon/db/monster/xeon.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 100,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/xeon.json
+++ b/mods/tuxemon/db/monster/xeon.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 100,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/xeon_2.json
+++ b/mods/tuxemon/db/monster/xeon_2.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "txmn_id": 0,
+    "height": 0,
     "weight": 100,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/xeon_2.json
+++ b/mods/tuxemon/db/monster/xeon_2.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 100,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/xeon_2.json
+++ b/mods/tuxemon/db/monster/xeon_2.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 100,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/yiinaang.json
+++ b/mods/tuxemon/db/monster/yiinaang.json
@@ -21,7 +21,9 @@
         "Fire",
         "Water"
     ],
-    "weight": 25,
+    "txmn_id": 142,
+    "height": 200,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/yiinaang.json
+++ b/mods/tuxemon/db/monster/yiinaang.json
@@ -21,6 +21,8 @@
         "Fire",
         "Water"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/yiinaang.json
+++ b/mods/tuxemon/db/monster/yiinaang.json
@@ -21,9 +21,9 @@
         "Fire",
         "Water"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 142,
+    "height": 200,
+    "weight": 0,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/yiinaang.json
+++ b/mods/tuxemon/db/monster/yiinaang.json
@@ -21,7 +21,7 @@
         "Fire",
         "Water"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/zunna.json
+++ b/mods/tuxemon/db/monster/zunna.json
@@ -20,6 +20,8 @@
     "types": [
         "Metal"
     ],
+    "tmx_id": 0,
+    "height": 0,
     "weight": 25,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/zunna.json
+++ b/mods/tuxemon/db/monster/zunna.json
@@ -20,7 +20,7 @@
     "types": [
         "Metal"
     ],
-    "tmx_id": 0,
+    "txmn_id": 0,
     "height": 0,
     "weight": 25,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/zunna.json
+++ b/mods/tuxemon/db/monster/zunna.json
@@ -20,7 +20,9 @@
     "types": [
         "Metal"
     ],
-    "weight": 25,
+    "txmn_id": 129,
+    "height": 90,
+    "weight": 2,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/zunna.json
+++ b/mods/tuxemon/db/monster/zunna.json
@@ -20,9 +20,9 @@
     "types": [
         "Metal"
     ],
-    "txmn_id": 0,
-    "height": 0,
-    "weight": 25,
+    "txmn_id": 129,
+    "height": 90,
+    "weight": 2,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -792,7 +792,7 @@ msgid "bigfin"
 msgstr "Bigfin"
 
 msgid "bolt_description"
-msgstr "The presence of a BOLT makes a NUT clamp down harder and spark more energy."
+msgstr ""
 
 msgid "bolt"
 msgstr "Bolt"
@@ -888,7 +888,7 @@ msgid "dragarbor"
 msgstr "Dragarbor"
 
 msgid "dune_pincher_description"
-msgstr "These hermits will wrap themselves in whatever is closest. In the desert, that is the burial shrouds of long-dead pharaohs."
+msgstr ""
 
 msgid "dune_pincher"
 msgstr "Dune Pincher"
@@ -936,7 +936,7 @@ msgid "fluttaflap"
 msgstr "Fluttaflap"
 
 msgid "fruitera_description"
-msgstr "FRUITERA is greedy for fruit, and carries as much as it can. When startled, it drops all its fruit, gathers it all up again, and only then runs away."
+msgstr ""
 
 msgid "fruitera"
 msgstr "Fruitera"
@@ -954,7 +954,7 @@ msgid "heronquak"
 msgstr "Heronquak"
 
 msgid "hydrone_description"
-msgstr "It utilises an experimental technology that creates power from water."
+msgstr ""
 
 msgid "hydrone"
 msgstr "Hydrone"
@@ -1017,7 +1017,7 @@ msgid "nudiflot_female_description"
 msgstr "It eats and stores the poison of the sea creatures that it feeds upon."
 
 msgid "nudiflot_male_description"
-msgstr "Its feathery antennas snap off if it is attacked, confusing the predator."
+msgstr "It eats and stores the poison of the sea creatures that it feeds upon."
 
 msgid "nudiflot_female"
 msgstr "Nudiflot (F)"
@@ -1026,13 +1026,13 @@ msgid "nudiflot_male"
 msgstr "Nudiflot (M)"
 
 msgid "nut_description"
-msgstr "In the great ships that cross the oceans, thousands of NUT and BOLT provide power and hold the steel plating together."
+msgstr ""
 
 msgid "nut"
 msgstr "Nut"
 
 msgid "pigabyte_description"
-msgstr "Scientists found that the best computers have organic implants."
+msgstr ""
 
 msgid "pigabyte"
 msgstr "Pigabyte"
@@ -1050,19 +1050,19 @@ msgid "possessun"
 msgstr "Possessun"
 
 msgid "propellercat_description"
-msgstr "Is it a new species, or just the pet of an inventor?"
+msgstr ""
 
 msgid "propellercat"
 msgstr "Propellercat"
 
 msgid "rockat_description"
-msgstr "Despite its considerable weight, its footfalls are silent."
+msgstr ""
 
 msgid "rockat"
 msgstr "Rockat"
 
 msgid "rockitten_description"
-msgstr "It uses its tiny rock ears for snuggling."
+msgstr ""
 
 msgid "rockitten"
 msgstr "Rockitten"
@@ -1074,13 +1074,13 @@ msgid "sapragon"
 msgstr "Sapragon"
 
 msgid "selket_description"
-msgstr "Lying in wait beneath the sand, they can feel their prey through the vibrations of their footsteps."
+msgstr ""
 
 msgid "selket"
 msgstr "Selket"
 
 msgid "selmatek_description"
-msgstr "Kept by the ancient kings of the deserts, SELMATEK served as watchdogs, hunting companions and - now - defenders against grave robbers."
+msgstr ""
 
 msgid "selmatek"
 msgstr "Selmatek"
@@ -1092,7 +1092,7 @@ msgid "sharpfin"
 msgstr "Sharpfin"
 
 msgid "sludgehog_description"
-msgstr "It lives in rubbish, and eats it too. Its spikes seem sharp, but it can soften them at will."
+msgstr ""
 
 msgid "sludgehog"
 msgstr "Sludgehog"
@@ -1104,7 +1104,7 @@ msgid "snowrilla"
 msgstr "Snowrilla"
 
 msgid "spycozeus_description"
-msgstr "The whispered communications of the forest are given physical form in SPYCOZEUS, which thinks like the trees."
+msgstr ""
 
 msgid "spycozeus"
 msgstr "Spycozeus"
@@ -1137,7 +1137,7 @@ msgid "tigrock"
 msgstr "Tigrock"
 
 msgid "tumbleworm_description"
-msgstr "When they have outgrown their honeycomb eggs, they drop to the ground face first."
+msgstr ""
 
 msgid "tumbleworm"
 msgstr "Tumbleworm"

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -792,7 +792,7 @@ msgid "bigfin"
 msgstr "Bigfin"
 
 msgid "bolt_description"
-msgstr ""
+msgstr "The presence of a BOLT makes a NUT clamp down harder and spark more energy."
 
 msgid "bolt"
 msgstr "Bolt"
@@ -888,7 +888,7 @@ msgid "dragarbor"
 msgstr "Dragarbor"
 
 msgid "dune_pincher_description"
-msgstr ""
+msgstr "These hermits will wrap themselves in whatever is closest. In the desert, that is the burial shrouds of long-dead pharaohs."
 
 msgid "dune_pincher"
 msgstr "Dune Pincher"
@@ -936,7 +936,7 @@ msgid "fluttaflap"
 msgstr "Fluttaflap"
 
 msgid "fruitera_description"
-msgstr ""
+msgstr "FRUITERA is greedy for fruit, and carries as much as it can. When startled, it drops all its fruit, gathers it all up again, and only then runs away."
 
 msgid "fruitera"
 msgstr "Fruitera"
@@ -954,7 +954,7 @@ msgid "heronquak"
 msgstr "Heronquak"
 
 msgid "hydrone_description"
-msgstr ""
+msgstr "It utilises an experimental technology that creates power from water."
 
 msgid "hydrone"
 msgstr "Hydrone"
@@ -1017,7 +1017,7 @@ msgid "nudiflot_female_description"
 msgstr "It eats and stores the poison of the sea creatures that it feeds upon."
 
 msgid "nudiflot_male_description"
-msgstr "It eats and stores the poison of the sea creatures that it feeds upon."
+msgstr "Its feathery antennas snap off if it is attacked, confusing the predator."
 
 msgid "nudiflot_female"
 msgstr "Nudiflot (F)"
@@ -1026,13 +1026,13 @@ msgid "nudiflot_male"
 msgstr "Nudiflot (M)"
 
 msgid "nut_description"
-msgstr ""
+msgstr "In the great ships that cross the oceans, thousands of NUT and BOLT provide power and hold the steel plating together."
 
 msgid "nut"
 msgstr "Nut"
 
 msgid "pigabyte_description"
-msgstr ""
+msgstr "Scientists found that the best computers have organic implants."
 
 msgid "pigabyte"
 msgstr "Pigabyte"
@@ -1050,19 +1050,19 @@ msgid "possessun"
 msgstr "Possessun"
 
 msgid "propellercat_description"
-msgstr ""
+msgstr "Is it a new species, or just the pet of an inventor?"
 
 msgid "propellercat"
 msgstr "Propellercat"
 
 msgid "rockat_description"
-msgstr ""
+msgstr "Despite its considerable weight, its footfalls are silent."
 
 msgid "rockat"
 msgstr "Rockat"
 
 msgid "rockitten_description"
-msgstr ""
+msgstr "It uses its tiny rock ears for snuggling."
 
 msgid "rockitten"
 msgstr "Rockitten"
@@ -1074,13 +1074,13 @@ msgid "sapragon"
 msgstr "Sapragon"
 
 msgid "selket_description"
-msgstr ""
+msgstr "Lying in wait beneath the sand, they can feel their prey through the vibrations of their footsteps."
 
 msgid "selket"
 msgstr "Selket"
 
 msgid "selmatek_description"
-msgstr ""
+msgstr "Kept by the ancient kings of the deserts, SELMATEK served as watchdogs, hunting companions and - now - defenders against grave robbers."
 
 msgid "selmatek"
 msgstr "Selmatek"
@@ -1092,7 +1092,7 @@ msgid "sharpfin"
 msgstr "Sharpfin"
 
 msgid "sludgehog_description"
-msgstr ""
+msgstr "It lives in rubbish, and eats it too. Its spikes seem sharp, but it can soften them at will."
 
 msgid "sludgehog"
 msgstr "Sludgehog"
@@ -1104,7 +1104,7 @@ msgid "snowrilla"
 msgstr "Snowrilla"
 
 msgid "spycozeus_description"
-msgstr ""
+msgstr "The whispered communications of the forest are given physical form in SPYCOZEUS, which thinks like the trees."
 
 msgid "spycozeus"
 msgstr "Spycozeus"
@@ -1137,7 +1137,7 @@ msgid "tigrock"
 msgstr "Tigrock"
 
 msgid "tumbleworm_description"
-msgstr ""
+msgstr "When they have outgrown their honeycomb eggs, they drop to the ground face first."
 
 msgid "tumbleworm"
 msgstr "Tumbleworm"

--- a/schemas/monster-schema.json
+++ b/schemas/monster-schema.json
@@ -17,6 +17,16 @@
       "description": "The AI to use for this monster",
       "type": "string"
     },
+    "txm_id": {
+      "title": "Tuxemon ID",
+      "description": "The id of the monster",
+      "type": "number"
+    },
+    "height": {
+      "title": "Height",
+      "description": "The height of the monster",
+      "type": "number"
+    },
     "weight": {
       "title": "Weight",
       "description": "The weight of the monster",

--- a/schemas/monster-schema.json
+++ b/schemas/monster-schema.json
@@ -17,7 +17,7 @@
       "description": "The AI to use for this monster",
       "type": "string"
     },
-    "txm_id": {
+    "txmn_id": {
       "title": "Tuxemon ID",
       "description": "The id of the monster",
       "type": "number"

--- a/schemas/monster-schema.json
+++ b/schemas/monster-schema.json
@@ -17,6 +17,16 @@
       "description": "The AI to use for this monster",
       "type": "string"
     },
+    "txmn_id": {
+      "title": "Tuxemon ID",
+      "description": "The id of the monster",
+      "type": "number"
+    },
+    "height": {
+      "title": "Height",
+      "description": "The height of the monster",
+      "type": "number"
+    },
     "weight": {
       "title": "Weight",
       "description": "The weight of the monster",

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -218,6 +218,8 @@ class MonsterModel(BaseModel):
     slug: str = Field(..., description="The slug of the monster")
     category: str = Field(..., description="The category of monster")
     ai: str = Field(..., description="The AI to use for this monster")
+    txmn_id: float = Field(..., description="The id of the monster")
+    height: float = Field(..., description="The height of the monster")
     weight: float = Field(..., description="The weight of the monster")
 
     # Optional fields

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -218,6 +218,8 @@ class MonsterModel(BaseModel):
     slug: str = Field(..., description="The slug of the monster")
     category: str = Field(..., description="The category of monster")
     ai: str = Field(..., description="The AI to use for this monster")
+    txmn_id: int = Field(..., description="The id of the monster")
+    height: float = Field(..., description="The height of the monster")
     weight: float = Field(..., description="The weight of the monster")
 
     # Optional fields

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -218,7 +218,7 @@ class MonsterModel(BaseModel):
     slug: str = Field(..., description="The slug of the monster")
     category: str = Field(..., description="The category of monster")
     ai: str = Field(..., description="The AI to use for this monster")
-    txmn_id: float = Field(..., description="The id of the monster")
+    txmn_id: int = Field(..., description="The id of the monster")
     height: float = Field(..., description="The height of the monster")
     weight: float = Field(..., description="The weight of the monster")
 

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -244,6 +244,8 @@ class Monster:
         self.status_damage = 0
         self.status_turn = 0
 
+        self.txmn_id = 0
+        self.height = 0.0
         self.weight = 0.0
 
         # The multiplier for checks when a monster ball is thrown this should be a value betwen 0-255 meaning that
@@ -338,6 +340,8 @@ class Monster:
             if len(types) > 1:
                 self.type2 = results["types"][1].lower()
 
+        self.txmn_id = results["txmn_id"]
+        self.height = results["height"]
         self.weight = results["weight"]
         self.catch_rate = results.get(
             "catch_rate",

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -244,7 +244,7 @@ class Monster:
         self.status_damage = 0
         self.status_turn = 0
 
-        self.txmn_id = 0.0
+        self.txmn_id = 0
         self.height = 0.0
         self.weight = 0.0
 

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -244,6 +244,8 @@ class Monster:
         self.status_damage = 0
         self.status_turn = 0
 
+        self.txmn_id = 0.0
+        self.height = 0.0
         self.weight = 0.0
 
         # The multiplier for checks when a monster ball is thrown this should be a value betwen 0-255 meaning that

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -338,7 +338,7 @@ class Monster:
             if len(types) > 1:
                 self.type2 = results["types"][1].lower()
 
-        self.txm_id = results["txm_id"]
+        self.txmn_id = results["txmn_id"]
         self.height = results["height"]
         self.weight = results["weight"]
         self.catch_rate = results.get(

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -338,6 +338,8 @@ class Monster:
             if len(types) > 1:
                 self.type2 = results["types"][1].lower()
 
+        self.txm_id = results["txm_id"]
+        self.height = results["height"]
         self.weight = results["weight"]
         self.catch_rate = results.get(
             "catch_rate",


### PR DESCRIPTION
I wasn't able to update api.py and extractor.py, but using another tool I extracted the information regarding txmn_id, weight and height.

The source: https://wiki.tuxemon.org/Completed_Tuxemon

The PR updates all the monsters with txmn_id, height and weight. Since it imports the weight and height, the majority of the value weight has been replaced by 0. If something doesn't convince, no problem, I can go back to 25 again.

The PR updates all the monsters with txmn_id, height and weight. Since it imports the weight and height, the majority of the value weight has been replaced by 0. If something doesn't convince, no problem, I can go back to 25 again.

The txmn_id goes from 1 to 154.

Among the monsters updated (already in the system), these 31 have id = 0: (> list in the following comment)
Among the monsters updated (already in the system), these 88 have weight = 0: (> list in the following comment)
Among the monsters updated (already in the system), these 99 have height = 0: (> list in the following comment)

Among the monsters updated, these 12 aren't on Tuxepedia: _birb_robo, chrome_robo, coproblight, dark_robo, mk01_alpha, mk01_beta, pilthropus, xeon_2, xeon, d0llf1n, f7u1t3ra, l3gk0, r0ck1tt3n_

But among these 12, I suspect these 4 are double (can be deleted?): _d0llf1n, f7u1t3ra, l3gk0, r0ck1tt3n_

Worth notice that there are some monsters (56) that only exist in Tuxepedia (no monstername.json under db/Monster):

_Altie, Apeoro, B-ver.1, Banling, Baobaraffe, Baoby, Beenstalker, Boltnu, Boxali, Brewdin, Bumbulus, Chibiro, Drashimi, Exclawvate, Ferricran, Fordin, Furnursus, Graffiki, Grumpi, Gryfix, Jelillow, Loliferno, Lunight, Medushock, Merlicun, Metesaur, Mystikapi, Nuenflu, Octabode, Pantherafira, Pythock, Qetzlrokilus, Rosarin, Selket, Selmatek, Shelagu, Shnark, Snaki, Tarpeur, Taupypus, Tetrchimp, Tobishimi, Tsushimi, Tumblequill, Turnipper, Urcine, Vigueur, Vividactil, Vivisource, Snock, Snokari, Snowrilla, Solight, Spoilurm, Spycozeus, Statursus_

But out of 56, these 6 have a translation in base.po: _Ferricran, Merlicun, Selket, Selmatek, Snowrilla, Spycozeus._
But out of 56, these 2 appear in a dialogue: _Vividactil, Vivisource._

In details:
```
Ferricran (various files as db/locale/en_US.json, es_ES.json and it_IT.json)
Merlicun (various files as db/locale/en_US.json, es_ES.json and it_IT.json)
Selket (various files as db/locale/en_US.json, es_ES.json and it_IT.json)
Selmatek (various files as db/locale/en_US.json, es_ES.json and it_IT.json)
Vividactil (it appears in a dialogue in spyder_flower_petshop.tmx)
Vivisource (it appears in a dialogue in spyder_flower_petshop.tmx)
Snowrilla (various files as db/locale/en_US.json, es_ES.json and it_IT.json)
Spycozeus (various files as db/locale/en_US.json, es_ES.json and it_IT.json)

Questions: 
Can we generate the missing ids?
Can we generate the missing weights?
Can we generate the missing heights?
Can we delete the double monsters?