### PR TITLE
Make spyder scenario's First Fight have a win and lose dialogue

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -3615,8 +3615,11 @@ msgstr "I'll give the rest of these to other kids who missed out on their own tu
 msgid "spyder_papertown_firstfight"
 msgstr "Hey, what are you doing rummaging in bins? That's gross - and it's against the rules! \n ... \n What, they were throwing out perfectly good tuxemon? \n ... \n Well, if they were perfectly good, they wouldn't throw them out, would they? \n They must be inferior to the new models. Here, I'll show you! "
 
-msgid "spyder_papertown_firstfight2"
+msgid "spyder_papertown_firstfight_win"
 msgstr "Huh, must be a fluke. There's no way the new model would be worse than the old!"
+
+msgid "spyder_papertown_firstfight_lose"
+msgstr "As expected! Old models can't compare to new ones!"
 
 msgid "spyder_cottontown_monk"
 msgstr "I am assigned by the Dojo of the Five Elements to tend the statues here. \n But Omnichannel is planning to expand its offices into this space. \n I don't know what will happen to the statues when they do."

--- a/mods/tuxemon/l18n/es_ES/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/es_ES/LC_MESSAGES/base.po
@@ -2080,7 +2080,7 @@ msgstr ""
 "Pero Omnichannel planea expandir sus oficinas a este lugar.\n"
 "No sé qué ocurrirá con las estatuas cuando lo hagan."
 
-msgid "spyder_papertown_firstfight2"
+msgid "spyder_papertown_firstfight_win"
 msgstr ""
 "Ugh, debe ser casualidad. ¡No hay forma de que el nuevo modelo sea peor que "
 "el viejo!"

--- a/mods/tuxemon/l18n/fr_FR/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/fr_FR/LC_MESSAGES/base.po
@@ -4120,7 +4120,7 @@ msgstr ""
 msgid "spyder_papertown_agnitechosen"
 msgstr "Ce qui se fait de mieux ! Agnite est un Tuxemon de type Feu."
 
-msgid "spyder_papertown_firstfight2"
+msgid "spyder_papertown_firstfight_win"
 msgstr ""
 "Hum, c'est de la chance. Parce qu'il n'y a aucune raison que le nouveau "
 "modèle soit moins bien que l'ancien !"

--- a/mods/tuxemon/maps/spyder_paper_town.tmx
+++ b/mods/tuxemon/maps/spyder_paper_town.tmx
@@ -433,7 +433,7 @@
   <object id="425" name="First Fight - Win" type="event" x="384" y="144" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_billie,26,12"/>
-    <property name="act10" value="npc_face spyder_billie,down"/>
+    <property name="act10" value="npc_face spyder_billie,up"/>
     <property name="act20" value="translated_dialog spyder_papertown_firstfight_win"/>
     <property name="act30" value="pathfind spyder_billie,15,14"/>
     <property name="act40" value="remove_npc spyder_billie"/>
@@ -446,7 +446,7 @@
   <object id="426" name="First Fight - Lose" type="event" x="416" y="144" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_billie,26,12"/>
-    <property name="act10" value="npc_face spyder_billie,down"/>
+    <property name="act10" value="npc_face spyder_billie,up"/>
     <property name="act20" value="translated_dialog spyder_papertown_firstfight_lose"/>
     <property name="act30" value="pathfind spyder_billie,15,14"/>
     <property name="act40" value="remove_npc spyder_billie"/>

--- a/mods/tuxemon/maps/spyder_paper_town.tmx
+++ b/mods/tuxemon/maps/spyder_paper_town.tmx
@@ -423,13 +423,14 @@
     <property name="act61" value="npc_face player,down"/>
     <property name="act70" value="translated_dialog spyder_papertown_firstfight"/>
     <property name="act80" value="start_battle spyder_billie"/>
-    <property name="act81" value="translated_dialog spyder_papertown_firstfight2"/>
+    <property name="act81" value="translated_dialog spyder_papertown_firstfight_win"/>
+    <property name="cond1" value="is player_defeated"/>
     <property name="act90" value="set_variable firstfightdue:no"/>
     <property name="act91" value="set_variable teleport_faint:spyder_bedroom.tmx 7 6"/>
     <property name="act94" value="pathfind spyder_billie,15,14"/>
     <property name="act95" value="remove_npc spyder_billie"/>
     <property name="act96" value="unlock_controls"/>
-    <property name="cond1" value="is variable_set firstfightdue:yes"/>
+    <property name="cond2" value="is variable_set firstfightdue:yes"/>
    </properties>
   </object>
   <object id="428" name="Play Music" type="event" x="0" y="0" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_paper_town.tmx
+++ b/mods/tuxemon/maps/spyder_paper_town.tmx
@@ -411,7 +411,7 @@
     <property name="cond2" value="is party_size less_than,1"/>
    </properties>
   </object>
-  <object id="424" name="First Fight" type="event" x="384" y="144" width="16" height="16">
+  <object id="424" name="First Fight - Start" type="event" x="400" y="160" width="16" height="16">
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act10" value="translated_dialog spyder_papertown_wrapup"/>
@@ -423,15 +423,38 @@
     <property name="act61" value="npc_face player,down"/>
     <property name="act70" value="translated_dialog spyder_papertown_firstfight"/>
     <property name="act80" value="start_battle spyder_billie"/>
-    <property name="act81" value="translated_dialog spyder_papertown_firstfight_win"/>
-    <property name="cond1" value="is player_defeated"/>
+    <property name="act81" value="remove_npc spyder_billie"/>
     <property name="act90" value="set_variable firstfightdue:no"/>
     <property name="act91" value="set_variable teleport_faint:spyder_bedroom.tmx 7 6"/>
-    <property name="act94" value="pathfind spyder_billie,15,14"/>
-    <property name="act95" value="remove_npc spyder_billie"/>
-    <property name="act96" value="unlock_controls"/>
-    <property name="cond2" value="is variable_set firstfightdue:yes"/>
+    <property name="act92" value="set_variable firstfightend:yes"/>
+    <property name="cond1" value="is variable_set firstfightdue:yes"/>
    </properties>
+  </object>
+  <object id="425" name="First Fight - Win" type="event" x="384" y="144" width="16" height="16">
+   <properties>
+    <property name="act1" value="create_npc spyder_billie,26,12"/>
+    <property name="act10" value="npc_face spyder_billie,down"/>
+    <property name="act20" value="translated_dialog spyder_papertown_firstfight_win"/>
+    <property name="act30" value="pathfind spyder_billie,15,14"/>
+    <property name="act40" value="remove_npc spyder_billie"/>
+    <property name="act50" value="set_variable firstfightend:no"/>
+    <property name="act60" value="unlock_controls"/>
+    <property name="cond1" value="is variable_set battle_last_result:won"/>
+    <property name="cond2" value="is variable_set firstfightend:yes"/>
+   </properties>
+  </object>
+  <object id="426" name="First Fight - Lose" type="event" x="416" y="144" width="16" height="16">
+   <properties>
+    <property name="act1" value="create_npc spyder_billie,26,12"/>
+    <property name="act10" value="npc_face spyder_billie,down"/>
+    <property name="act20" value="translated_dialog spyder_papertown_firstfight_lose"/>
+    <property name="act30" value="pathfind spyder_billie,15,14"/>
+    <property name="act40" value="remove_npc spyder_billie"/>
+    <property name="act50" value="set_variable firstfightend:no"/>
+    <property name="act60" value="unlock_controls"/>
+    <property name="cond1" value="is variable_set battle_last_result:lost"/>
+    <property name="cond2" value="is variable_set firstfightend:yes"/>
+    </properties>
   </object>
   <object id="428" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>

--- a/mods/tuxemon/maps/spyder_paper_town.tmx
+++ b/mods/tuxemon/maps/spyder_paper_town.tmx
@@ -423,7 +423,6 @@
     <property name="act61" value="npc_face player,down"/>
     <property name="act70" value="translated_dialog spyder_papertown_firstfight"/>
     <property name="act80" value="start_battle spyder_billie"/>
-    <property name="act81" value="remove_npc spyder_billie"/>
     <property name="act90" value="set_variable firstfightdue:no"/>
     <property name="act91" value="set_variable teleport_faint:spyder_bedroom.tmx 7 6"/>
     <property name="act92" value="set_variable firstfightend:yes"/>
@@ -432,26 +431,22 @@
   </object>
   <object id="425" name="First Fight - Win" type="event" x="384" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc spyder_billie,26,12"/>
-    <property name="act10" value="npc_face spyder_billie,up"/>
-    <property name="act20" value="translated_dialog spyder_papertown_firstfight_win"/>
-    <property name="act30" value="pathfind spyder_billie,15,14"/>
-    <property name="act40" value="remove_npc spyder_billie"/>
-    <property name="act50" value="set_variable firstfightend:no"/>
-    <property name="act60" value="unlock_controls"/>
+    <property name="act10" value="translated_dialog spyder_papertown_firstfight_win"/>
+    <property name="act20" value="pathfind spyder_billie,15,14"/>
+    <property name="act30" value="remove_npc spyder_billie"/>
+    <property name="act40" value="set_variable firstfightend:no"/>
+    <property name="act50" value="unlock_controls"/>
     <property name="cond1" value="is variable_set battle_last_result:won"/>
     <property name="cond2" value="is variable_set firstfightend:yes"/>
    </properties>
   </object>
   <object id="426" name="First Fight - Lose" type="event" x="416" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc spyder_billie,26,12"/>
-    <property name="act10" value="npc_face spyder_billie,up"/>
-    <property name="act20" value="translated_dialog spyder_papertown_firstfight_lose"/>
-    <property name="act30" value="pathfind spyder_billie,15,14"/>
-    <property name="act40" value="remove_npc spyder_billie"/>
-    <property name="act50" value="set_variable firstfightend:no"/>
-    <property name="act60" value="unlock_controls"/>
+    <property name="act10" value="translated_dialog spyder_papertown_firstfight_lose"/>
+    <property name="act20" value="pathfind spyder_billie,15,14"/>
+    <property name="act30" value="remove_npc spyder_billie"/>
+    <property name="act40" value="set_variable firstfightend:no"/>
+    <property name="act50" value="unlock_controls"/>
     <property name="cond1" value="is variable_set battle_last_result:lost"/>
     <property name="cond2" value="is variable_set firstfightend:yes"/>
     </properties>

--- a/tuxemon/event/actions/start_battle.py
+++ b/tuxemon/event/actions/start_battle.py
@@ -68,17 +68,15 @@ class StartBattleAction(EventAction[StartBattleActionParameters]):
         npc = world.get_entity(self.parameters.npc_slug)
         assert npc
         if len(npc.monsters) == 0:
-            logger.warning("npc has no monsters, won't start")
+            logger.warning(f"npc '{self.parameters.npc_slug}' has no monsters, won't start trainer battle.")
             return
 
         # Lookup the environment
-        env_slug = "grass"
-        if "environment" in player.game_variables:
-            env_slug = player.game_variables["environment"]
+        env_slug = player.game_variables.get("environment", "grass")
         env = db.lookup(env_slug, table="environment").dict()
 
         # Add our players and setup combat
-        logger.info("Starting battle!")
+        logger.info("Starting battle with '{self.parameters.npc_slug}'!")
         self.session.client.push_state(
             CombatState,
             players=(player, npc),


### PR DESCRIPTION
As it is now, the result message for the `First Fight` with `spyder_billie` seems as if the player actually won even if they lost
![battle_encounter_fail](https://user-images.githubusercontent.com/15969405/187546805-155bd1e4-447b-4ccf-90f9-cbdd7e822aa9.png)

I haven't played through the first battle thoroughly enough, but we could add "success" and "defeat" conditions with separate dialogue slugs. I already added the initial pieces, but am not sure how to set a "player won" condition in the Tiled TMX file.

Any pointers?

---
Current behavior:
1. Start first battle with Spyder Bille as usual via the "First Battle - Start" event
2. If battle is lost, trigger the one-time "First Battle - Lose" event
3. If battle is won, trigger the one-time "First Battle - Win" event