### PR TITLE
Fix animations regex

### DIFF
--- a/tuxemon/graphics.py
+++ b/tuxemon/graphics.py
@@ -271,7 +271,7 @@ def animation_frame_files(
 
     """
     frames = list()
-    pattern = re.compile(rf"{name}\.[0-9]+\.png")
+    pattern = re.compile(rf"{name}\.?[0-9]+\.png")
     # might be slow on large folders
     for filename in os.listdir(directory):
         if pattern.match(filename):


### PR DESCRIPTION
Animations have been broken since 737d8c474, which refactored the animations loading to use a function that expects a different animation format. I have edited the regex to work with both formats.