### PR TITLE
fix JSON data tech_id

### DIFF
--- a/mods/tuxemon/db/technique/all_in.json
+++ b/mods/tuxemon/db/technique/all_in.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 54,
   "accuracy": 0.75,
   "animation": "sparks_gold_alt",
   "category": "physical",

--- a/mods/tuxemon/db/technique/amnesia.json
+++ b/mods/tuxemon/db/technique/amnesia.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 53,
   "accuracy": 0.75,
   "animation": "sparks_gold_alt",
   "category": "physical",

--- a/mods/tuxemon/db/technique/avalanche.json
+++ b/mods/tuxemon/db/technique/avalanche.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 33,
   "accuracy": 0.8,
   "animation": "thud",
   "category": "physical",

--- a/mods/tuxemon/db/technique/battery_acid.json
+++ b/mods/tuxemon/db/technique/battery_acid.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 88,
   "accuracy": 0.8,
   "animation": "disintegrate",
   "category": "physical",

--- a/mods/tuxemon/db/technique/battery_discharge.json
+++ b/mods/tuxemon/db/technique/battery_discharge.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 83,
   "accuracy": 0.8,
   "animation": "disintegrate",
   "category": "physical",

--- a/mods/tuxemon/db/technique/beam.json
+++ b/mods/tuxemon/db/technique/beam.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 18,
   "accuracy": 0.8,
   "animation": "crystal",
   "category": "physical",

--- a/mods/tuxemon/db/technique/berserk.json
+++ b/mods/tuxemon/db/technique/berserk.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 44,
   "accuracy": 0.8,
   "animation": "constantburn",
   "category": "physical",

--- a/mods/tuxemon/db/technique/biting_winds.json
+++ b/mods/tuxemon/db/technique/biting_winds.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 24,
   "accuracy": 0.8,
   "animation": "ice blast",
   "category": "physical",

--- a/mods/tuxemon/db/technique/blade.json
+++ b/mods/tuxemon/db/technique/blade.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 7,
   "accuracy": 0.85,
   "animation": "slash_power",
   "category": "physical",

--- a/mods/tuxemon/db/technique/blood_bond.json
+++ b/mods/tuxemon/db/technique/blood_bond.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 79,
   "accuracy": 0.8,
   "animation": "sparks_red",
   "category": "physical",

--- a/mods/tuxemon/db/technique/blossom.json
+++ b/mods/tuxemon/db/technique/blossom.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 26,
   "accuracy": 0.75,
   "animation": "gloop_orange",
   "category": "physical",

--- a/mods/tuxemon/db/technique/boulder.json
+++ b/mods/tuxemon/db/technique/boulder.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 11,
   "accuracy": 1,
   "animation": "shield_rock",
   "category": "physical",

--- a/mods/tuxemon/db/technique/breathe_fire.json
+++ b/mods/tuxemon/db/technique/breathe_fire.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 64,
   "accuracy": 0.8,
   "animation": "fire lion right",
   "category": "physical",

--- a/mods/tuxemon/db/technique/bubble_trap.json
+++ b/mods/tuxemon/db/technique/bubble_trap.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 57,
   "accuracy": 0.75,
   "animation": "bomb_bright",
   "category": "physical",

--- a/mods/tuxemon/db/technique/bullet.json
+++ b/mods/tuxemon/db/technique/bullet.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 8,
   "accuracy": 0.85,
   "animation": "sparks_red",
   "category": "physical",

--- a/mods/tuxemon/db/technique/chill_mist.json
+++ b/mods/tuxemon/db/technique/chill_mist.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 77,
   "accuracy": 1,
   "animation": "water_spurt",
   "category": "physical",

--- a/mods/tuxemon/db/technique/clamp_on.json
+++ b/mods/tuxemon/db/technique/clamp_on.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 17,
   "accuracy": 1,
   "animation": "bite",
   "category": "physical",

--- a/mods/tuxemon/db/technique/constrict.json
+++ b/mods/tuxemon/db/technique/constrict.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 75,
   "accuracy": 0.75,
   "animation": "metal tentacle",
   "category": "physical",

--- a/mods/tuxemon/db/technique/electrical_storm.json
+++ b/mods/tuxemon/db/technique/electrical_storm.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 76,
   "accuracy": 0.75,
   "animation": "lightning_claw",
   "category": "physical",

--- a/mods/tuxemon/db/technique/energy_claws.json
+++ b/mods/tuxemon/db/technique/energy_claws.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 31,
   "accuracy": 0.8,
   "animation": "slash_power",
   "category": "physical",

--- a/mods/tuxemon/db/technique/energy_field.json
+++ b/mods/tuxemon/db/technique/energy_field.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 22,
   "accuracy": 1,
   "animation": "screen",
   "category": "physical",

--- a/mods/tuxemon/db/technique/eyebite.json
+++ b/mods/tuxemon/db/technique/eyebite.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 35,
   "accuracy": 1,
   "animation": "bite",
   "category": "physical",

--- a/mods/tuxemon/db/technique/feint.json
+++ b/mods/tuxemon/db/technique/feint.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 36,
   "accuracy": 1,
   "animation": "bolt",
   "category": "physical",

--- a/mods/tuxemon/db/technique/fester.json
+++ b/mods/tuxemon/db/technique/fester.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 78,
   "accuracy": 1,
   "animation": "drip_green",
   "category": "physical",

--- a/mods/tuxemon/db/technique/fire_ball.json
+++ b/mods/tuxemon/db/technique/fire_ball.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 4,
   "accuracy": 0.7,
   "animation": "darkfire",
   "category": "physical",

--- a/mods/tuxemon/db/technique/fire_claw.json
+++ b/mods/tuxemon/db/technique/fire_claw.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 3,
   "accuracy": 0.7,
   "animation": "slash_power",
   "category": "physical",

--- a/mods/tuxemon/db/technique/flamethrower.json
+++ b/mods/tuxemon/db/technique/flamethrower.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 73,
   "accuracy": 0.8,
   "animation": "fire lion right",
   "category": "physical",

--- a/mods/tuxemon/db/technique/flood.json
+++ b/mods/tuxemon/db/technique/flood.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 10,
   "accuracy": 0.5,
   "animation": "shot",
   "category": "physical",

--- a/mods/tuxemon/db/technique/flow.json
+++ b/mods/tuxemon/db/technique/flow.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 9,
   "accuracy": 0.5,
   "animation": "water_spurt",
   "category": "physical",

--- a/mods/tuxemon/db/technique/fluff_up.json
+++ b/mods/tuxemon/db/technique/fluff_up.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 71,
   "accuracy": 0.75,
   "animation": "smokebomb",
   "category": "physical",

--- a/mods/tuxemon/db/technique/font.json
+++ b/mods/tuxemon/db/technique/font.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 48,
   "accuracy": 0.75,
   "animation": "water_spurt",
   "category": "physical",

--- a/mods/tuxemon/db/technique/frostbite.json
+++ b/mods/tuxemon/db/technique/frostbite.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 87,
   "accuracy": 0.8,
   "animation": "lance_ice",
   "category": "physical",

--- a/mods/tuxemon/db/technique/fume.json
+++ b/mods/tuxemon/db/technique/fume.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 28,
   "accuracy": 1,
   "animation": "buff_rage",
   "category": "physical",

--- a/mods/tuxemon/db/technique/give_all.json
+++ b/mods/tuxemon/db/technique/give_all.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 34,
   "accuracy": 1,
   "animation": "fire lion front",
   "category": "physical",

--- a/mods/tuxemon/db/technique/glower.json
+++ b/mods/tuxemon/db/technique/glower.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 13,
   "accuracy": 1,
   "animation": null,
   "category": "physical",

--- a/mods/tuxemon/db/technique/goad.json
+++ b/mods/tuxemon/db/technique/goad.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 39,
   "accuracy": 0.8,
   "animation": "buff_rage",
   "category": "physical",

--- a/mods/tuxemon/db/technique/headbutt.json
+++ b/mods/tuxemon/db/technique/headbutt.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 72,
   "accuracy": 1,
   "animation": "slash_power",
   "category": "physical",

--- a/mods/tuxemon/db/technique/hibernate.json
+++ b/mods/tuxemon/db/technique/hibernate.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 45,
   "accuracy": 1,
   "animation": null,
   "category": "physical",

--- a/mods/tuxemon/db/technique/ice_claw.json
+++ b/mods/tuxemon/db/technique/ice_claw.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 21,
   "accuracy": 0.8,
   "animation": "icetacle",
   "category": "physical",

--- a/mods/tuxemon/db/technique/icicle_spear.json
+++ b/mods/tuxemon/db/technique/icicle_spear.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 23,
   "accuracy": 0.75,
   "animation": "icelance",
   "category": "physical",

--- a/mods/tuxemon/db/technique/invictus.json
+++ b/mods/tuxemon/db/technique/invictus.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 63,
   "accuracy": 0.75,
   "animation": "triforce",
   "category": "physical",

--- a/mods/tuxemon/db/technique/kindling_flame.json
+++ b/mods/tuxemon/db/technique/kindling_flame.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 30,
   "accuracy": 0.8,
   "animation": "constantburn",
   "category": "physical",

--- a/mods/tuxemon/db/technique/levitate.json
+++ b/mods/tuxemon/db/technique/levitate.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 82,
   "accuracy": 1,
   "animation": null,
   "category": "physical",

--- a/mods/tuxemon/db/technique/midnight_mantle.json
+++ b/mods/tuxemon/db/technique/midnight_mantle.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 55,
   "accuracy": 0.7,
   "animation": "claw_blue",
   "category": "physical",

--- a/mods/tuxemon/db/technique/muddle.json
+++ b/mods/tuxemon/db/technique/muddle.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 43,
   "accuracy": 0.75,
   "animation": "sparks_white",
   "category": "physical",

--- a/mods/tuxemon/db/technique/mudslide.json
+++ b/mods/tuxemon/db/technique/mudslide.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 89,
   "accuracy": 0.8,
   "animation": "spikes_rock",
   "category": "physical",

--- a/mods/tuxemon/db/technique/one_two.json
+++ b/mods/tuxemon/db/technique/one_two.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 52,
   "accuracy": 1,
   "animation": "triple whammy",
   "category": "physical",

--- a/mods/tuxemon/db/technique/overfeed.json
+++ b/mods/tuxemon/db/technique/overfeed.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 91,
   "accuracy": 1,
   "animation": "drip_green",
   "can_apply_status": true,

--- a/mods/tuxemon/db/technique/overgrowth.json
+++ b/mods/tuxemon/db/technique/overgrowth.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 27,
   "accuracy": 0.8,
   "animation": null,
   "category": "physical",

--- a/mods/tuxemon/db/technique/peck.json
+++ b/mods/tuxemon/db/technique/peck.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 70,
   "accuracy": 1,
   "animation": "pound",
   "category": "physical",

--- a/mods/tuxemon/db/technique/peregrine.json
+++ b/mods/tuxemon/db/technique/peregrine.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 65,
   "accuracy": 0.8,
   "animation": "smash",
   "category": "physical",

--- a/mods/tuxemon/db/technique/perfect_cut.json
+++ b/mods/tuxemon/db/technique/perfect_cut.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 61,
   "accuracy": 0.8,
   "animation": "slash_power",
   "category": "physical",

--- a/mods/tuxemon/db/technique/petrify.json
+++ b/mods/tuxemon/db/technique/petrify.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 37,
   "accuracy": 1,
   "animation": "shield_rock",
   "category": "physical",

--- a/mods/tuxemon/db/technique/probiscus.json
+++ b/mods/tuxemon/db/technique/probiscus.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 47,
   "accuracy": 0.8,
   "animation": "icelance",
   "category": "physical",

--- a/mods/tuxemon/db/technique/pseudopod.json
+++ b/mods/tuxemon/db/technique/pseudopod.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 68,
   "accuracy": 1,
   "animation": "snake right 64px",
   "category": "physical",

--- a/mods/tuxemon/db/technique/quicksand.json
+++ b/mods/tuxemon/db/technique/quicksand.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 90,
   "accuracy": 0.8,
   "animation": "spikes_rock",
   "category": "physical",

--- a/mods/tuxemon/db/technique/ram.json
+++ b/mods/tuxemon/db/technique/ram.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 5,
   "accuracy": 1,
   "animation": "pound",
   "category": "physical",

--- a/mods/tuxemon/db/technique/refresh.json
+++ b/mods/tuxemon/db/technique/refresh.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 40,
   "accuracy": 1,
   "animation": "heal (no cross)",
   "category": "physical",

--- a/mods/tuxemon/db/technique/rock.json
+++ b/mods/tuxemon/db/technique/rock.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 6,
   "accuracy": 1,
   "animation": "crushingball",
   "category": "physical",

--- a/mods/tuxemon/db/technique/rot.json
+++ b/mods/tuxemon/db/technique/rot.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 38,
   "accuracy": 1,
   "animation": "drip_green",
   "category": "physical",

--- a/mods/tuxemon/db/technique/run.json
+++ b/mods/tuxemon/db/technique/run.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 92,
   "slug": "menu_run",
   "use_tech": "combat_used_x",
   "use_success": "generic_success",

--- a/mods/tuxemon/db/technique/rust_bomb.json
+++ b/mods/tuxemon/db/technique/rust_bomb.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 86,
   "accuracy": 0.5,
   "animation": "puff",
   "category": "physical",

--- a/mods/tuxemon/db/technique/salamander.json
+++ b/mods/tuxemon/db/technique/salamander.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 85,
   "accuracy": 0.8,
   "animation": "fire enemy death 1",
   "category": "physical",

--- a/mods/tuxemon/db/technique/sand_spray.json
+++ b/mods/tuxemon/db/technique/sand_spray.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 32,
   "accuracy": 0.8,
   "animation": "dusty explosion",
   "category": "physical",

--- a/mods/tuxemon/db/technique/shadow_boxing.json
+++ b/mods/tuxemon/db/technique/shadow_boxing.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 51,
   "accuracy": 1,
   "animation": "triple whammy",
   "category": "physical",

--- a/mods/tuxemon/db/technique/shrapnel.json
+++ b/mods/tuxemon/db/technique/shrapnel.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 60,
   "accuracy": 0.5,
   "animation": "explosion_small",
   "category": "physical",

--- a/mods/tuxemon/db/technique/shuriken.json
+++ b/mods/tuxemon/db/technique/shuriken.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 16,
   "accuracy": 0.75,
   "animation": "explosion_small",
   "category": "physical",

--- a/mods/tuxemon/db/technique/sleep_bomb.json
+++ b/mods/tuxemon/db/technique/sleep_bomb.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 59,
   "accuracy": 0.75,
   "animation": "sparks_white",
   "category": "physical",

--- a/mods/tuxemon/db/technique/sleeping_powder.json
+++ b/mods/tuxemon/db/technique/sleeping_powder.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 49,
   "accuracy": 1,
   "animation": "dusty explosion",
   "category": "physical",

--- a/mods/tuxemon/db/technique/snowstorm.json
+++ b/mods/tuxemon/db/technique/snowstorm.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 25,
   "accuracy": 0.5,
   "animation": "ice blast",
   "category": "physical",

--- a/mods/tuxemon/db/technique/splinter.json
+++ b/mods/tuxemon/db/technique/splinter.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 41,
   "accuracy": 0.8,
   "animation": "snake right 64px",
   "category": "physical",

--- a/mods/tuxemon/db/technique/spray.json
+++ b/mods/tuxemon/db/technique/spray.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 2,
   "accuracy": 0.8,
   "animation": null,
   "category": "physical",

--- a/mods/tuxemon/db/technique/stampede.json
+++ b/mods/tuxemon/db/technique/stampede.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 14,
   "accuracy": 1,
   "animation": "dusty explosion",
   "category": "physical",

--- a/mods/tuxemon/db/technique/starfall.json
+++ b/mods/tuxemon/db/technique/starfall.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 56,
   "accuracy": 0.7,
   "animation": "bolt",
   "category": "physical",

--- a/mods/tuxemon/db/technique/static_field.json
+++ b/mods/tuxemon/db/technique/static_field.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 15,
   "accuracy": 1,
   "animation": "disintegrate",
   "category": "physical",

--- a/mods/tuxemon/db/technique/status_faint.json
+++ b/mods/tuxemon/db/technique/status_faint.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 93,
   "slug": "status_faint",
   "use_tech": "combat_used_x",
   "use_success": "generic_success",

--- a/mods/tuxemon/db/technique/status_lifeleech.json
+++ b/mods/tuxemon/db/technique/status_lifeleech.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 94,
   "slug": "status_lifeleech",
   "name_trans": "status_lifeleech_name",
   "execute_trans": "combat_state_lifeleech_get",

--- a/mods/tuxemon/db/technique/status_poison.json
+++ b/mods/tuxemon/db/technique/status_poison.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 95,
   "slug": "status_poison",
   "use_tech": "combat_used_x",
   "use_success": "generic_success",

--- a/mods/tuxemon/db/technique/status_recover.json
+++ b/mods/tuxemon/db/technique/status_recover.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 96,
   "slug": "status_recover",
   "name_trans": "status_recover_name",
   "execute_trans": "combat_state_recover_get",

--- a/mods/tuxemon/db/technique/sting.json
+++ b/mods/tuxemon/db/technique/sting.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 1,
   "accuracy": 0.8,
   "animation": "pound",
   "category": "physical",

--- a/mods/tuxemon/db/technique/stone_rot.json
+++ b/mods/tuxemon/db/technique/stone_rot.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 84,
   "accuracy": 1,
   "animation": "drip_green",
   "category": "physical",

--- a/mods/tuxemon/db/technique/strike.json
+++ b/mods/tuxemon/db/technique/strike.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 74,
   "accuracy": 1,
   "animation": "slash_power",
   "category": "physical",

--- a/mods/tuxemon/db/technique/suck_poison.json
+++ b/mods/tuxemon/db/technique/suck_poison.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 58,
   "accuracy": 0.8,
   "animation": "drip_green",
   "category": "physical",

--- a/mods/tuxemon/db/technique/sudden_glow.json
+++ b/mods/tuxemon/db/technique/sudden_glow.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 67,
   "accuracy": 1,
   "animation": "heal (no cross)",
   "category": "physical",

--- a/mods/tuxemon/db/technique/supernova.json
+++ b/mods/tuxemon/db/technique/supernova.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 81,
   "accuracy": 0.75,
   "animation": "darkfire",
   "category": "physical",

--- a/mods/tuxemon/db/technique/surge.json
+++ b/mods/tuxemon/db/technique/surge.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 19,
   "accuracy": 0.75,
   "animation": "bolt",
   "category": "physical",

--- a/mods/tuxemon/db/technique/swap.json
+++ b/mods/tuxemon/db/technique/swap.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 97,
   "slug": "swap",
   "use_tech": "combat_swap",
   "use_success": null,

--- a/mods/tuxemon/db/technique/take_cover.json
+++ b/mods/tuxemon/db/technique/take_cover.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 29,
   "accuracy": 1,
   "animation": "smokebomb",
   "category": "physical",

--- a/mods/tuxemon/db/technique/thunderball.json
+++ b/mods/tuxemon/db/technique/thunderball.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 12,
   "accuracy": 1,
   "animation": "pound",
   "category": "physical",

--- a/mods/tuxemon/db/technique/thunderclap.json
+++ b/mods/tuxemon/db/technique/thunderclap.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 20,
   "accuracy": 0.75,
   "animation": "thunderstrike",
   "category": "physical",

--- a/mods/tuxemon/db/technique/tonguespear.json
+++ b/mods/tuxemon/db/technique/tonguespear.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 50,
   "accuracy": 0.8,
   "animation": "icelance",
   "category": "physical",

--- a/mods/tuxemon/db/technique/venomous_tentacle.json
+++ b/mods/tuxemon/db/technique/venomous_tentacle.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 80,
   "accuracy": 0.8,
   "animation": "torrentacle",
   "category": "physical",

--- a/mods/tuxemon/db/technique/wall_of_steel.json
+++ b/mods/tuxemon/db/technique/wall_of_steel.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 62,
   "accuracy": 0.75,
   "animation": "screen",
   "category": "physical",

--- a/mods/tuxemon/db/technique/wallow.json
+++ b/mods/tuxemon/db/technique/wallow.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 46,
   "accuracy": 1,
   "animation": "water_spurt",
   "category": "physical",

--- a/mods/tuxemon/db/technique/web.json
+++ b/mods/tuxemon/db/technique/web.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 42,
   "accuracy": 0.75,
   "animation": "snake right 64px",
   "category": "physical",

--- a/mods/tuxemon/db/technique/whirlwind.json
+++ b/mods/tuxemon/db/technique/whirlwind.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 66,
   "accuracy": 1,
   "animation": "whirlwind",
   "category": "physical",

--- a/mods/tuxemon/db/technique/wing_tip.json
+++ b/mods/tuxemon/db/technique/wing_tip.json
@@ -1,4 +1,5 @@
 {
+  "tech_id": 69,
   "accuracy": 0.8,
   "animation": "pound",
   "category": "physical",

--- a/schemas/technique-schema.json
+++ b/schemas/technique-schema.json
@@ -104,6 +104,11 @@
         }
       ]
     },
+    "tech_id": {
+      "title": "Technique ID",
+      "description": "The id of this technique",
+      "type": "number"
+    },
     "accuracy": {
       "title": "Accuracy",
       "description": "The accuracy of the technique",

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -346,6 +346,10 @@ class TechniqueModel(BaseModel):
     range: Range = Field(
         "melee", description="The attack range of this technique"
     )
+    tech_id: int = Field(..., description="The id of this technique")
+    potency: Optional[float] = Field(
+        None, description="How potetent the technique is"
+    )
     accuracy: float = Field(0, description="The accuracy of the technique")
     potency: Optional[float] = Field(
         None, description="How potetent the technique is"

--- a/tuxemon/technique.py
+++ b/tuxemon/technique.py
@@ -98,6 +98,7 @@ class Technique:
         # number of turns that this technique has been active
         self._combat_counter = 0
         self._life_counter = 0
+        self.tech_id = 0
         self.accuracy = 0.0
         self.animation = ""
         self.can_apply_status = False
@@ -179,6 +180,7 @@ class Technique:
         self.recharge_length = results.get("recharge", self.recharge_length)
         self.is_area = results.get("is_area", self.is_area)
         self.range = results.get("range", self.range)
+        self.tech_id = results.get("tech_id", self.tech_id)
         self.accuracy = results.get("accuracy", self.accuracy)
         self.potency = results.get("potency", self.potency)
         self.effect = results["effects"]


### PR DESCRIPTION
Here the PR for inserting the tech_id field inside technique.json.

Everything is based as starting point on this Excel file: sanglorian.github.io/downloads/Tuxemon/techniques.xlsx

Here at least I had the first 10 numbers, while on Tuxepedia only the number 10.

From this list are missing (7):
overfeed, run, status_faint, status_lifeleech, status_poison, status_recover, swap.

Since I had no idea about the other tech_id, I tried to come up with a valid, but not banal (sort in alphabetical order), logic. If it's not satisfyng, then I can easily revert all the numbers >10 to 0 waiting for the official numeration. If nothing is acceptable, then I'll close the PR.

Logic: if you look at the sheet movesets, then you can see all the monsters up to the last (rockitten, rockat, etc - following the txmn_id). I came up with this method: boulder 11, thunderball 12, glower 13, stampede 14, etc.

A progressive method that follows the Tuxemon order as well as the techniques associated for each monster (look at the screenshot).

It took me some time, but I hope that it shows the respect for the creator.

Attached also a list with all the monsters sorted in both ways (alphabetical and tech_id).

![Screenshot from 2022-09-04 14-48-35](https://user-images.githubusercontent.com/64643719/188315728-4532eded-dbc7-4ff7-9af0-6a06b9f4f2d1.png)
[tech_id.txt](https://github.com/Tuxemon/Tuxemon/files/9484783/tech_id.txt)
