### PR TITLE
add evolution JSON monsters

### DIFF
--- a/mods/tuxemon/db/monster/aardart.json
+++ b/mods/tuxemon/db/monster/aardart.json
@@ -24,6 +24,7 @@
             "technique": "feint"
         }
     ],
+    "evolutions": [],
     "shape": "Varmint",
     "types": [
         "Earth"

--- a/mods/tuxemon/db/monster/aardorn.json
+++ b/mods/tuxemon/db/monster/aardorn.json
@@ -24,6 +24,13 @@
             "technique": "feint"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "aardart"
+        }
+    ],
     "shape": "Varmint",
     "types": [
         "Earth"

--- a/mods/tuxemon/db/monster/abesnaki.json
+++ b/mods/tuxemon/db/monster/abesnaki.json
@@ -16,6 +16,7 @@
             "technique": "sleep_bomb"
         }
     ],
+    "evolutions": [],
     "shape": "Serpent",
     "types": [
         "Fire"

--- a/mods/tuxemon/db/monster/agnidon.json
+++ b/mods/tuxemon/db/monster/agnidon.json
@@ -16,6 +16,13 @@
             "technique": "energy_claws"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 36,
+            "monster_slug": "agnigon"
+        }
+    ],
     "shape": "Dragon",
     "types": [
         "Fire"

--- a/mods/tuxemon/db/monster/agnigon.json
+++ b/mods/tuxemon/db/monster/agnigon.json
@@ -16,6 +16,7 @@
             "technique": "take_cover"
         }
     ],
+    "evolutions": [],
     "shape": "Dragon",
     "types": [
         "Fire"

--- a/mods/tuxemon/db/monster/agnite.json
+++ b/mods/tuxemon/db/monster/agnite.json
@@ -16,6 +16,13 @@
             "technique": "fume"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 24,
+            "monster_slug": "agnidon"
+        }
+    ],
     "shape": "Dragon",
     "types": [
         "Fire"

--- a/mods/tuxemon/db/monster/allagon.json
+++ b/mods/tuxemon/db/monster/allagon.json
@@ -16,6 +16,7 @@
             "technique": "rust_bomb"
         }
     ],
+    "evolutions": [],
     "shape": "Dragon",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/angrito.json
+++ b/mods/tuxemon/db/monster/angrito.json
@@ -16,6 +16,7 @@
             "technique": "flamethrower"
         }
     ],
+    "evolutions": [],
     "shape": "Blob",
     "types": [
         "Fire",

--- a/mods/tuxemon/db/monster/anoleaf.json
+++ b/mods/tuxemon/db/monster/anoleaf.json
@@ -16,6 +16,13 @@
             "technique": "whirlwind"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 18,
+            "monster_slug": "gectile"
+        }
+    ],
     "shape": "Varmint",
     "types": [
         "Wood"

--- a/mods/tuxemon/db/monster/anu.json
+++ b/mods/tuxemon/db/monster/anu.json
@@ -16,6 +16,7 @@
             "technique": "wall_of_steel"
         }
     ],
+    "evolutions": [],
     "shape": "Varmint",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/araignee.json
+++ b/mods/tuxemon/db/monster/araignee.json
@@ -16,6 +16,7 @@
             "technique": "shrapnel"
         }
     ],
+    "evolutions": [],
     "shape": "Grub",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/arthrobolt.json
+++ b/mods/tuxemon/db/monster/arthrobolt.json
@@ -16,6 +16,7 @@
             "technique": "thunderclap"
         }
     ],
+    "evolutions": [],
     "shape": "Humanoid",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/av8r.json
+++ b/mods/tuxemon/db/monster/av8r.json
@@ -16,6 +16,7 @@
             "technique": "battery_discharge"
         }
     ],
+    "evolutions": [],
     "shape": "Flier",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/axylightl.json
+++ b/mods/tuxemon/db/monster/axylightl.json
@@ -16,6 +16,7 @@
             "technique": "beam"
         }
     ],
+    "evolutions": [],
     "shape": "Polliwog",
     "types": [
         "Water"

--- a/mods/tuxemon/db/monster/bamboon.json
+++ b/mods/tuxemon/db/monster/bamboon.json
@@ -16,6 +16,7 @@
             "technique": "ram"
         }
     ],
+    "evolutions": [],
     "shape": "Sprite",
     "types": [
         "Wood"

--- a/mods/tuxemon/db/monster/bigfin.json
+++ b/mods/tuxemon/db/monster/bigfin.json
@@ -16,6 +16,7 @@
             "technique": "goad"
         }
     ],
+    "evolutions": [],
     "shape": "Leviathan",
     "types": [
         "Water"

--- a/mods/tuxemon/db/monster/birb_robo.json
+++ b/mods/tuxemon/db/monster/birb_robo.json
@@ -16,6 +16,7 @@
             "technique": "shrapnel"
         }
     ],
+    "evolutions": [],
     "shape": "Flier",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/birdling.json
+++ b/mods/tuxemon/db/monster/birdling.json
@@ -16,6 +16,7 @@
             "technique": "peregrine"
         }
     ],
+    "evolutions": [],
     "shape": "Flier",
     "types": [
         "Wood"

--- a/mods/tuxemon/db/monster/bolt.json
+++ b/mods/tuxemon/db/monster/bolt.json
@@ -16,6 +16,13 @@
             "technique": "clamp_on"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 12,
+            "monster_slug": "arthrobolt"
+        }
+    ],
     "shape": "Blob",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/botbot.json
+++ b/mods/tuxemon/db/monster/botbot.json
@@ -18,23 +18,23 @@
     ],
     "evolutions": [
         {
-            "path": "",
-            "at_level": 20,
+            "path": "booster_tech",
+            "at_level": 0,
             "monster_slug": "av8r"
         },
         {
-            "path": "",
-            "at_level": 20,
+            "path": "booster_tech",
+            "at_level": 0,
             "monster_slug": "picc"
         },
         {
-            "path": "",
-            "at_level": 20,
+            "path": "booster_tech",
+            "at_level": 0,
             "monster_slug": "mrmoswitch"
         },
         {
-            "path": "",
-            "at_level": 20,
+            "path": "booster_tech",
+            "at_level": 0,
             "monster_slug": "k9"
         }
     ],

--- a/mods/tuxemon/db/monster/botbot.json
+++ b/mods/tuxemon/db/monster/botbot.json
@@ -16,6 +16,28 @@
             "technique": "battery_discharge"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "av8r"
+        },
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "picc"
+        },
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "mrmoswitch"
+        },
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "k9"
+        }
+    ],
     "shape": "Grub",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/budaye.json
+++ b/mods/tuxemon/db/monster/budaye.json
@@ -16,6 +16,18 @@
             "technique": "ram"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "bamboon"
+        },
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "frondly"
+        }
+    ],
     "shape": "Sprite",
     "types": [
         "Wood"

--- a/mods/tuxemon/db/monster/budaye.json
+++ b/mods/tuxemon/db/monster/budaye.json
@@ -18,13 +18,23 @@
     ],
     "evolutions": [
         {
-            "path": "",
-            "at_level": 20,
+            "path": "wood_booster",
+            "at_level": 0,
             "monster_slug": "bamboon"
         },
         {
-            "path": "",
-            "at_level": 20,
+            "path": "lucky_bamboo",
+            "at_level": 0,
+            "monster_slug": "bamboon"
+        },
+        {
+            "path": "water_booster",
+            "at_level": 0,
+            "monster_slug": "frondly"
+        },
+        {
+            "path": "peace_lily",
+            "at_level": 0,
             "monster_slug": "frondly"
         }
     ],

--- a/mods/tuxemon/db/monster/bugnin.json
+++ b/mods/tuxemon/db/monster/bugnin.json
@@ -16,6 +16,7 @@
             "technique": "blade"
         }
     ],
+    "evolutions": [],
     "shape": "Brute",
     "types": [
         "Metal",

--- a/mods/tuxemon/db/monster/bursa.json
+++ b/mods/tuxemon/db/monster/bursa.json
@@ -16,6 +16,13 @@
             "technique": "fire_ball"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 30,
+            "monster_slug": "flambear"
+        }
+    ],
     "shape": "Humanoid",
     "types": [
         "Fire"

--- a/mods/tuxemon/db/monster/cairfrey.json
+++ b/mods/tuxemon/db/monster/cairfrey.json
@@ -16,6 +16,13 @@
             "technique": "muddle"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 30,
+            "monster_slug": "possessun"
+        }
+    ],
     "shape": "Blob",
     "types": [
         "Earth"

--- a/mods/tuxemon/db/monster/capiti.json
+++ b/mods/tuxemon/db/monster/capiti.json
@@ -16,6 +16,7 @@
             "technique": "sting"
         }
     ],
+    "evolutions": [],
     "shape": "Sprite",
     "types": [
         "Wood"

--- a/mods/tuxemon/db/monster/cardiling.json
+++ b/mods/tuxemon/db/monster/cardiling.json
@@ -16,6 +16,13 @@
             "technique": "fire_claw"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 18,
+            "monster_slug": "cardiwing"
+        }
+    ],
     "shape": "Flier",
     "types": [
         "Fire"

--- a/mods/tuxemon/db/monster/cardinale.json
+++ b/mods/tuxemon/db/monster/cardinale.json
@@ -16,6 +16,7 @@
             "technique": "peregrine"
         }
     ],
+    "evolutions": [],
     "shape": "Flier",
     "types": [
         "Fire"

--- a/mods/tuxemon/db/monster/cardiwing.json
+++ b/mods/tuxemon/db/monster/cardiwing.json
@@ -16,6 +16,13 @@
             "technique": "peregrine"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 36,
+            "monster_slug": "cardinale"
+        }
+    ],
     "shape": "Flier",
     "types": [
         "Fire"

--- a/mods/tuxemon/db/monster/cataspike.json
+++ b/mods/tuxemon/db/monster/cataspike.json
@@ -16,6 +16,13 @@
             "technique": "wallow"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 9,
+            "monster_slug": "puparmor"
+        }
+    ],
     "shape": "Grub",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/cateye.json
+++ b/mods/tuxemon/db/monster/cateye.json
@@ -16,6 +16,7 @@
             "technique": "flow"
         }
     ],
+    "evolutions": [],
     "shape": "Hunter",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/chenipode.json
+++ b/mods/tuxemon/db/monster/chenipode.json
@@ -16,6 +16,13 @@
             "technique": "take_cover"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "exapode"
+        }
+    ],
     "shape": "Grub",
     "types": [
         "Earth"

--- a/mods/tuxemon/db/monster/chillimp.json
+++ b/mods/tuxemon/db/monster/chillimp.json
@@ -16,6 +16,7 @@
             "technique": "snowstorm"
         }
     ],
+    "evolutions": [],
     "shape": "Brute",
     "types": [
         "Water",

--- a/mods/tuxemon/db/monster/chloragon.json
+++ b/mods/tuxemon/db/monster/chloragon.json
@@ -16,6 +16,13 @@
             "technique": "hibernate"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 30,
+            "monster_slug": "sapragon"
+        }
+    ],
     "shape": "Dragon",
     "types": [
         "Wood"

--- a/mods/tuxemon/db/monster/chrome_robo.json
+++ b/mods/tuxemon/db/monster/chrome_robo.json
@@ -16,6 +16,7 @@
             "technique": "shrapnel"
         }
     ],
+    "evolutions": [],
     "shape": "Humanoid",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/chromeye.json
+++ b/mods/tuxemon/db/monster/chromeye.json
@@ -16,6 +16,28 @@
             "technique": "wall_of_steel"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "angrito"
+        },
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "happito"
+        },
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "neutrito"
+        },
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "sadito"
+        }
+    ],
     "shape": "Blob",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/cochini.json
+++ b/mods/tuxemon/db/monster/cochini.json
@@ -16,6 +16,7 @@
             "technique": "headbutt"
         }
     ],
+    "evolutions": [],
     "shape": "Varmint",
     "types": [
         "Earth"

--- a/mods/tuxemon/db/monster/coleorus.json
+++ b/mods/tuxemon/db/monster/coleorus.json
@@ -16,6 +16,7 @@
             "technique": "fluff_up"
         }
     ],
+    "evolutions": [],
     "shape": "Sprite",
     "types": [
         "Wood",

--- a/mods/tuxemon/db/monster/conifrost.json
+++ b/mods/tuxemon/db/monster/conifrost.json
@@ -16,6 +16,7 @@
             "technique": "whirlwind"
         }
     ],
+    "evolutions": [],
     "shape": "Blob",
     "types": [
         "Water",

--- a/mods/tuxemon/db/monster/conileaf.json
+++ b/mods/tuxemon/db/monster/conileaf.json
@@ -16,6 +16,7 @@
             "technique": "overgrowth"
         }
     ],
+    "evolutions": [],
     "shape": "Blob",
     "types": [
         "Wood"

--- a/mods/tuxemon/db/monster/coproblight.json
+++ b/mods/tuxemon/db/monster/coproblight.json
@@ -16,6 +16,7 @@
             "technique": "suck_poison"
         }
     ],
+    "evolutions": [],
     "shape": "Blob",
     "types": [
         "Earth"

--- a/mods/tuxemon/db/monster/corvix.json
+++ b/mods/tuxemon/db/monster/corvix.json
@@ -16,6 +16,7 @@
             "technique": "all_in"
         }
     ],
+    "evolutions": [],
     "shape": "Flier",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/cowpignon.json
+++ b/mods/tuxemon/db/monster/cowpignon.json
@@ -16,6 +16,7 @@
             "technique": "petrify"
         }
     ],
+    "evolutions": [],
     "shape": "Sprite",
     "types": [
         "Wood",

--- a/mods/tuxemon/db/monster/criniotherme.json
+++ b/mods/tuxemon/db/monster/criniotherme.json
@@ -16,6 +16,7 @@
             "technique": "fire_claw"
         }
     ],
+    "evolutions": [],
     "shape": "Hunter",
     "types": [
         "Fire"

--- a/mods/tuxemon/db/monster/d0llf1n.json
+++ b/mods/tuxemon/db/monster/d0llf1n.json
@@ -16,6 +16,7 @@
             "technique": "flow"
         }
     ],
+    "evolutions": [],
     "shape": "Aquatic",
     "types": [
         "Glitch",

--- a/mods/tuxemon/db/monster/dandicub.json
+++ b/mods/tuxemon/db/monster/dandicub.json
@@ -16,6 +16,13 @@
             "technique": "sleeping_powder"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "dandylion"
+        }
+    ],
     "shape": "Blob",
     "types": [
         "Wood"

--- a/mods/tuxemon/db/monster/dandylion.json
+++ b/mods/tuxemon/db/monster/dandylion.json
@@ -16,6 +16,7 @@
             "technique": "sleeping_powder"
         }
     ],
+    "evolutions": [],
     "shape": "Hunter",
     "types": [
         "Wood"

--- a/mods/tuxemon/db/monster/dark_robo.json
+++ b/mods/tuxemon/db/monster/dark_robo.json
@@ -16,6 +16,7 @@
             "technique": "shrapnel"
         }
     ],
+    "evolutions": [],
     "shape": "Humanoid",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/dinoflop.json
+++ b/mods/tuxemon/db/monster/dinoflop.json
@@ -16,6 +16,7 @@
             "technique": "rock"
         }
     ],
+    "evolutions": [],
     "shape": "Dragon",
     "types": [
         "Earth"

--- a/mods/tuxemon/db/monster/djinnbo.json
+++ b/mods/tuxemon/db/monster/djinnbo.json
@@ -16,6 +16,7 @@
             "technique": "flamethrower"
         }
     ],
+    "evolutions": [],
     "shape": "Humanoid",
     "types": [
         "Fire"

--- a/mods/tuxemon/db/monster/dollfin.json
+++ b/mods/tuxemon/db/monster/dollfin.json
@@ -18,13 +18,23 @@
     ],
     "evolutions": [
         {
-            "path": "",
-            "at_level": 20,
+            "path": "water_booster",
+            "at_level": 0,
             "monster_slug": "bigfin"
         },
         {
-            "path": "",
-            "at_level": 20,
+            "path": "sweet_sand",
+            "at_level": 0,
+            "monster_slug": "bigfin"
+        },
+        {
+            "path": "metal_booster",
+            "at_level": 0,
+            "monster_slug": "sharpfin"
+        },
+        {
+            "path": "sea_girdle",
+            "at_level": 0,
             "monster_slug": "sharpfin"
         }
     ],

--- a/mods/tuxemon/db/monster/dollfin.json
+++ b/mods/tuxemon/db/monster/dollfin.json
@@ -16,6 +16,18 @@
             "technique": "flow"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "bigfin"
+        },
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "sharpfin"
+        }
+    ],
     "shape": "Aquatic",
     "types": [
         "Water"

--- a/mods/tuxemon/db/monster/dracune.json
+++ b/mods/tuxemon/db/monster/dracune.json
@@ -16,6 +16,13 @@
             "technique": "hibernate"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 12,
+            "monster_slug": "fluttaflap"
+        }
+    ],
     "shape": "Blob",
     "types": [
         "Water"

--- a/mods/tuxemon/db/monster/dragarbor.json
+++ b/mods/tuxemon/db/monster/dragarbor.json
@@ -16,6 +16,7 @@
             "technique": "whirlwind"
         }
     ],
+    "evolutions": [],
     "shape": "Dragon",
     "types": [
         "Wood"

--- a/mods/tuxemon/db/monster/drokoro.json
+++ b/mods/tuxemon/db/monster/drokoro.json
@@ -16,6 +16,7 @@
             "technique": "breathe_fire"
         }
     ],
+    "evolutions": [],
     "shape": "Dragon",
     "types": [
         "Fire"

--- a/mods/tuxemon/db/monster/dune_pincher.json
+++ b/mods/tuxemon/db/monster/dune_pincher.json
@@ -16,6 +16,7 @@
             "technique": "refresh"
         }
     ],
+    "evolutions": [],
     "shape": "Grub",
     "types": [
         "Water"

--- a/mods/tuxemon/db/monster/eaglace.json
+++ b/mods/tuxemon/db/monster/eaglace.json
@@ -16,6 +16,7 @@
             "technique": "snowstorm"
         }
     ],
+    "evolutions": [],
     "shape": "Flier",
     "types": [
         "Water"

--- a/mods/tuxemon/db/monster/elofly.json
+++ b/mods/tuxemon/db/monster/elofly.json
@@ -16,6 +16,13 @@
             "technique": "fume"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 18,
+            "monster_slug": "elowind"
+        }
+    ],
     "shape": "Flier",
     "types": [
         "Water"

--- a/mods/tuxemon/db/monster/elostorm.json
+++ b/mods/tuxemon/db/monster/elostorm.json
@@ -16,6 +16,7 @@
             "technique": "snowstorm"
         }
     ],
+    "evolutions": [],
     "shape": "Flier",
     "types": [
         "Water"

--- a/mods/tuxemon/db/monster/elowind.json
+++ b/mods/tuxemon/db/monster/elowind.json
@@ -16,6 +16,13 @@
             "technique": "biting_winds"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 38,
+            "monster_slug": "elostorm"
+        }
+    ],
     "shape": "Flier",
     "types": [
         "Water"

--- a/mods/tuxemon/db/monster/embazook.json
+++ b/mods/tuxemon/db/monster/embazook.json
@@ -16,6 +16,7 @@
             "technique": "static_field"
         }
     ],
+    "evolutions": [],
     "shape": "Polliwog",
     "types": [
         "Fire",

--- a/mods/tuxemon/db/monster/embra.json
+++ b/mods/tuxemon/db/monster/embra.json
@@ -16,6 +16,13 @@
             "technique": "kindling_flame"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 30,
+            "monster_slug": "ruption"
+        }
+    ],
     "shape": "Blob",
     "types": [
         "Fire"

--- a/mods/tuxemon/db/monster/enduros.json
+++ b/mods/tuxemon/db/monster/enduros.json
@@ -16,6 +16,7 @@
             "technique": "rock"
         }
     ],
+    "evolutions": [],
     "shape": "Brute",
     "types": [
         "Earth"

--- a/mods/tuxemon/db/monster/eruptibus.json
+++ b/mods/tuxemon/db/monster/eruptibus.json
@@ -16,6 +16,7 @@
             "technique": "energy_field"
         }
     ],
+    "evolutions": [],
     "shape": "Landrace",
     "types": [
         "Fire"

--- a/mods/tuxemon/db/monster/exapode.json
+++ b/mods/tuxemon/db/monster/exapode.json
@@ -16,6 +16,7 @@
             "technique": "avalanche"
         }
     ],
+    "evolutions": [],
     "shape": "Grub",
     "types": [
         "Earth"

--- a/mods/tuxemon/db/monster/eyenemy.json
+++ b/mods/tuxemon/db/monster/eyenemy.json
@@ -16,6 +16,13 @@
             "technique": "glower"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "eyesore"
+        }
+    ],
     "shape": "Serpent",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/eyesore.json
+++ b/mods/tuxemon/db/monster/eyesore.json
@@ -16,6 +16,7 @@
             "technique": "eyebite"
         }
     ],
+    "evolutions": [],
     "shape": "Serpent",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/f7u1t3ra.json
+++ b/mods/tuxemon/db/monster/f7u1t3ra.json
@@ -16,6 +16,7 @@
             "technique": "splinter"
         }
     ],
+    "evolutions": [],
     "shape": "Flier",
     "types": [
         "Glitch",

--- a/mods/tuxemon/db/monster/fancair.json
+++ b/mods/tuxemon/db/monster/fancair.json
@@ -16,6 +16,13 @@
             "technique": "wall_of_steel"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "windeye"
+        }
+    ],
     "shape": "Sprite",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/flacono.json
+++ b/mods/tuxemon/db/monster/flacono.json
@@ -16,6 +16,13 @@
             "technique": "one_two"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 18,
+            "monster_slug": "corvix"
+        }
+    ],
     "shape": "Flier",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/flambear.json
+++ b/mods/tuxemon/db/monster/flambear.json
@@ -16,6 +16,7 @@
             "technique": "give_all"
         }
     ],
+    "evolutions": [],
     "shape": "Brute",
     "types": [
         "Fire"

--- a/mods/tuxemon/db/monster/fluoresfin.json
+++ b/mods/tuxemon/db/monster/fluoresfin.json
@@ -16,6 +16,13 @@
             "technique": "glower"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 18,
+            "monster_slug": "incandesfin"
+        }
+    ],
     "shape": "Aquatic",
     "types": [
         "Water"

--- a/mods/tuxemon/db/monster/fluttaflap.json
+++ b/mods/tuxemon/db/monster/fluttaflap.json
@@ -16,6 +16,7 @@
             "technique": "sleeping_powder"
         }
     ],
+    "evolutions": [],
     "shape": "Grub",
     "types": [
         "Water"

--- a/mods/tuxemon/db/monster/foofle.json
+++ b/mods/tuxemon/db/monster/foofle.json
@@ -16,6 +16,7 @@
             "technique": "refresh"
         }
     ],
+    "evolutions": [],
     "shape": "Varmint",
     "types": [
         "Earth"

--- a/mods/tuxemon/db/monster/forturtle.json
+++ b/mods/tuxemon/db/monster/forturtle.json
@@ -16,6 +16,13 @@
             "technique": "sleep_bomb"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "prophetoise"
+        }
+    ],
     "shape": "Humanoid",
     "types": [
         "Earth"

--- a/mods/tuxemon/db/monster/foxfire.json
+++ b/mods/tuxemon/db/monster/foxfire.json
@@ -16,6 +16,7 @@
             "technique": "fluff_up"
         }
     ],
+    "evolutions": [],
     "shape": "Varmint",
     "types": [
         "Fire"

--- a/mods/tuxemon/db/monster/frondly.json
+++ b/mods/tuxemon/db/monster/frondly.json
@@ -16,6 +16,7 @@
             "technique": "ram"
         }
     ],
+    "evolutions": [],
     "shape": "Sprite",
     "types": [
         "Wood"

--- a/mods/tuxemon/db/monster/fruitera.json
+++ b/mods/tuxemon/db/monster/fruitera.json
@@ -16,6 +16,7 @@
             "technique": "splinter"
         }
     ],
+    "evolutions": [],
     "shape": "Flier",
     "types": [
         "Wood"

--- a/mods/tuxemon/db/monster/galnec.json
+++ b/mods/tuxemon/db/monster/galnec.json
@@ -16,6 +16,7 @@
             "technique": "rock"
         }
     ],
+    "evolutions": [],
     "shape": "Hunter",
     "types": [
         "Earth"

--- a/mods/tuxemon/db/monster/gectile.json
+++ b/mods/tuxemon/db/monster/gectile.json
@@ -16,6 +16,13 @@
             "technique": "whirlwind"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 36,
+            "monster_slug": "velocitile"
+        }
+    ],
     "shape": "Humanoid",
     "types": [
         "Wood"

--- a/mods/tuxemon/db/monster/ghosteeth.json
+++ b/mods/tuxemon/db/monster/ghosteeth.json
@@ -16,6 +16,7 @@
             "technique": "chill_mist"
         }
     ],
+    "evolutions": [],
     "shape": "Blob",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/grimachin.json
+++ b/mods/tuxemon/db/monster/grimachin.json
@@ -16,6 +16,13 @@
             "technique": "fume"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 30,
+            "monster_slug": "tigrock"
+        }
+    ],
     "shape": "Hunter",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/grinflare.json
+++ b/mods/tuxemon/db/monster/grinflare.json
@@ -16,6 +16,7 @@
             "technique": "give_all"
         }
     ],
+    "evolutions": [],
     "shape": "Brute",
     "types": [
         "Earth",

--- a/mods/tuxemon/db/monster/grintot.json
+++ b/mods/tuxemon/db/monster/grintot.json
@@ -18,13 +18,23 @@
     ],
     "evolutions": [
         {
-            "path": "",
-            "at_level": 20,
+            "path": "earth_booster",
+            "at_level": 0,
             "monster_slug": "grinflare"
         },
         {
-            "path": "",
-            "at_level": 20,
+            "path": "flintstone",
+            "at_level": 0,
+            "monster_slug": "grinflare"
+        },
+        {
+            "path": "metal_booster",
+            "at_level": 0,
+            "monster_slug": "grintrock"
+        },
+        {
+            "path": "thunderstone",
+            "at_level": 0,
             "monster_slug": "grintrock"
         }
     ],

--- a/mods/tuxemon/db/monster/grintot.json
+++ b/mods/tuxemon/db/monster/grintot.json
@@ -16,6 +16,18 @@
             "technique": "avalanche"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "grinflare"
+        },
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "grintrock"
+        }
+    ],
     "shape": "Brute",
     "types": [
         "Earth"

--- a/mods/tuxemon/db/monster/grintrock.json
+++ b/mods/tuxemon/db/monster/grintrock.json
@@ -16,6 +16,7 @@
             "technique": "stampede"
         }
     ],
+    "evolutions": [],
     "shape": "Brute",
     "types": [
         "Earth",

--- a/mods/tuxemon/db/monster/hampotamos.json
+++ b/mods/tuxemon/db/monster/hampotamos.json
@@ -16,6 +16,7 @@
             "technique": "ram"
         }
     ],
+    "evolutions": [],
     "shape": "Landrace",
     "types": [
         "Earth"

--- a/mods/tuxemon/db/monster/happito.json
+++ b/mods/tuxemon/db/monster/happito.json
@@ -16,6 +16,7 @@
             "technique": "rock"
         }
     ],
+    "evolutions": [],
     "shape": "Blob",
     "types": [
         "Earth",

--- a/mods/tuxemon/db/monster/hatchling.json
+++ b/mods/tuxemon/db/monster/hatchling.json
@@ -16,6 +16,13 @@
             "technique": "fluff_up"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "birdling"
+        }
+    ],
     "shape": "Flier",
     "types": [
         "Wood"

--- a/mods/tuxemon/db/monster/heronquak.json
+++ b/mods/tuxemon/db/monster/heronquak.json
@@ -16,6 +16,13 @@
             "technique": "energy_field"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 36,
+            "monster_slug": "eaglace"
+        }
+    ],
     "shape": "Flier",
     "types": [
         "Water"

--- a/mods/tuxemon/db/monster/hydrone.json
+++ b/mods/tuxemon/db/monster/hydrone.json
@@ -16,6 +16,7 @@
             "technique": "shrapnel"
         }
     ],
+    "evolutions": [],
     "shape": "Humanoid",
     "types": [
         "Metal",

--- a/mods/tuxemon/db/monster/ignibus.json
+++ b/mods/tuxemon/db/monster/ignibus.json
@@ -16,6 +16,18 @@
             "technique": "static_field"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "eruptibus"
+        },
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "embazook"
+        }
+    ],
     "shape": "Polliwog",
     "types": [
         "Fire"

--- a/mods/tuxemon/db/monster/ignibus.json
+++ b/mods/tuxemon/db/monster/ignibus.json
@@ -18,13 +18,23 @@
     ],
     "evolutions": [
         {
-            "path": "",
-            "at_level": 20,
+            "path": "earth_booster",
+            "at_level": 0,
             "monster_slug": "eruptibus"
         },
         {
-            "path": "",
-            "at_level": 20,
+            "path": "tectonic_drill",
+            "at_level": 0,
+            "monster_slug": "eruptibus"
+        },
+        {
+            "path": "metal_booster",
+            "at_level": 0,
+            "monster_slug": "embazook"
+        },
+        {
+            "path": "stovepipe",
+            "at_level": 0,
             "monster_slug": "embazook"
         }
     ],

--- a/mods/tuxemon/db/monster/incandesfin.json
+++ b/mods/tuxemon/db/monster/incandesfin.json
@@ -16,6 +16,13 @@
             "technique": "starfall"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 36,
+            "monster_slug": "lightmare"
+        }
+    ],
     "shape": "Aquatic",
     "types": [
         "Water"

--- a/mods/tuxemon/db/monster/jemuar.json
+++ b/mods/tuxemon/db/monster/jemuar.json
@@ -16,6 +16,7 @@
             "technique": "stampede"
         }
     ],
+    "evolutions": [],
     "shape": "Hunter",
     "types": [
         "Earth"

--- a/mods/tuxemon/db/monster/k9.json
+++ b/mods/tuxemon/db/monster/k9.json
@@ -16,6 +16,7 @@
             "technique": "battery_discharge"
         }
     ],
+    "evolutions": [],
     "shape": "Hunter",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/katacoon.json
+++ b/mods/tuxemon/db/monster/katacoon.json
@@ -16,6 +16,18 @@
             "technique": "font"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 12,
+            "monster_slug": "bugnin"
+        },
+        {
+            "path": "",
+            "at_level": 12,
+            "monster_slug": "sumchon"
+        }
+    ],
     "shape": "Grub",
     "types": [
         "Metal",

--- a/mods/tuxemon/db/monster/katacoon.json
+++ b/mods/tuxemon/db/monster/katacoon.json
@@ -18,13 +18,13 @@
     ],
     "evolutions": [
         {
-            "path": "",
-            "at_level": 12,
+            "path": "melee_is_higher_than_armour",
+            "at_level": 10,
             "monster_slug": "bugnin"
         },
         {
-            "path": "",
-            "at_level": 12,
+            "path": "armour_is_higher_than_melee",
+            "at_level": 10,
             "monster_slug": "sumchon"
         }
     ],

--- a/mods/tuxemon/db/monster/katacoon.json
+++ b/mods/tuxemon/db/monster/katacoon.json
@@ -18,13 +18,13 @@
     ],
     "evolutions": [
         {
-            "path": "melee_is_higher_than_armour",
-            "at_level": 10,
+            "path": "stat_melee",
+            "at_level": 12,
             "monster_slug": "bugnin"
         },
         {
-            "path": "armour_is_higher_than_melee",
-            "at_level": 10,
+            "path": "stat_armour",
+            "at_level": 12,
             "monster_slug": "sumchon"
         }
     ],

--- a/mods/tuxemon/db/monster/katapill.json
+++ b/mods/tuxemon/db/monster/katapill.json
@@ -16,6 +16,13 @@
             "technique": "splinter"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 9,
+            "monster_slug": "katacoon"
+        }
+    ],
     "shape": "Grub",
     "types": [
         "Metal",

--- a/mods/tuxemon/db/monster/komodraw.json
+++ b/mods/tuxemon/db/monster/komodraw.json
@@ -16,6 +16,7 @@
             "technique": "sudden_glow"
         }
     ],
+    "evolutions": [],
     "shape": "Humanoid",
     "types": [
         "Fire"

--- a/mods/tuxemon/db/monster/l3gk0.json
+++ b/mods/tuxemon/db/monster/l3gk0.json
@@ -16,6 +16,7 @@
             "technique": "boulder"
         }
     ],
+    "evolutions": [],
     "shape": "Serpent",
     "types": [
         "Glitch",

--- a/mods/tuxemon/db/monster/lambert.json
+++ b/mods/tuxemon/db/monster/lambert.json
@@ -16,6 +16,13 @@
             "technique": "boulder"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 24,
+            "monster_slug": "legko"
+        }
+    ],
     "shape": "Sprite",
     "types": [
         "Wood"

--- a/mods/tuxemon/db/monster/lapinou.json
+++ b/mods/tuxemon/db/monster/lapinou.json
@@ -16,6 +16,7 @@
             "technique": "perfect_cut"
         }
     ],
+    "evolutions": [],
     "shape": "Varmint",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/legko.json
+++ b/mods/tuxemon/db/monster/legko.json
@@ -16,6 +16,13 @@
             "technique": "boulder"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 36,
+            "monster_slug": "moloch"
+        }
+    ],
     "shape": "Serpent",
     "types": [
         "Wood"

--- a/mods/tuxemon/db/monster/lightmare.json
+++ b/mods/tuxemon/db/monster/lightmare.json
@@ -16,6 +16,7 @@
             "technique": "starfall"
         }
     ],
+    "evolutions": [],
     "shape": "Leviathan",
     "types": [
         "Water"

--- a/mods/tuxemon/db/monster/manosting.json
+++ b/mods/tuxemon/db/monster/manosting.json
@@ -16,6 +16,7 @@
             "technique": "flood"
         }
     ],
+    "evolutions": [],
     "shape": "Blob",
     "types": [
         "Water"

--- a/mods/tuxemon/db/monster/masknake.json
+++ b/mods/tuxemon/db/monster/masknake.json
@@ -16,6 +16,7 @@
             "technique": "supernova"
         }
     ],
+    "evolutions": [],
     "shape": "Serpent",
     "types": [
         "Fire"

--- a/mods/tuxemon/db/monster/memnomnom.json
+++ b/mods/tuxemon/db/monster/memnomnom.json
@@ -16,6 +16,18 @@
             "technique": "sand_spray"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "miaownolith"
+        },
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "pyraminx"
+        }
+    ],
     "shape": "Hunter",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/memnomnom.json
+++ b/mods/tuxemon/db/monster/memnomnom.json
@@ -18,13 +18,23 @@
     ],
     "evolutions": [
         {
-            "path": "",
-            "at_level": 20,
+            "path": "earth_booster",
+            "at_level": 0,
             "monster_slug": "miaownolith"
         },
         {
-            "path": "",
-            "at_level": 20,
+            "path": "miaow_milk",
+            "at_level": 0,
+            "monster_slug": "miaownolith"
+        },
+        {
+            "path": "metal_booster",
+            "at_level": 0,
+            "monster_slug": "pyraminx"
+        },
+        {
+            "path": "pyramidion",
+            "at_level": 0,
             "monster_slug": "pyraminx"
         }
     ],

--- a/mods/tuxemon/db/monster/miaownolith.json
+++ b/mods/tuxemon/db/monster/miaownolith.json
@@ -16,6 +16,7 @@
             "technique": "sand_spray"
         }
     ],
+    "evolutions": [],
     "shape": "Hunter",
     "types": [
         "Metal",

--- a/mods/tuxemon/db/monster/mk01_alpha.json
+++ b/mods/tuxemon/db/monster/mk01_alpha.json
@@ -16,6 +16,7 @@
             "technique": "shrapnel"
         }
     ],
+    "evolutions": [],
     "shape": "Dragon",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/mk01_beta.json
+++ b/mods/tuxemon/db/monster/mk01_beta.json
@@ -16,6 +16,7 @@
             "technique": "shrapnel"
         }
     ],
+    "evolutions": [],
     "shape": "Dragon",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/moloch.json
+++ b/mods/tuxemon/db/monster/moloch.json
@@ -16,6 +16,7 @@
             "technique": "boulder"
         }
     ],
+    "evolutions": [],
     "shape": "Brute",
     "types": [
         "Wood"

--- a/mods/tuxemon/db/monster/mrmoswitch.json
+++ b/mods/tuxemon/db/monster/mrmoswitch.json
@@ -16,6 +16,7 @@
             "technique": "battery_discharge"
         }
     ],
+    "evolutions": [],
     "shape": "Sprite",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/narcileaf.json
+++ b/mods/tuxemon/db/monster/narcileaf.json
@@ -16,6 +16,7 @@
             "technique": "sleeping_powder"
         }
     ],
+    "evolutions": [],
     "shape": "Blob",
     "types": [
         "Wood"

--- a/mods/tuxemon/db/monster/neutrito.json
+++ b/mods/tuxemon/db/monster/neutrito.json
@@ -16,6 +16,7 @@
             "technique": "wall_of_steel"
         }
     ],
+    "evolutions": [],
     "shape": "Blob",
     "types": [
         "Metal",

--- a/mods/tuxemon/db/monster/noctalo.json
+++ b/mods/tuxemon/db/monster/noctalo.json
@@ -16,6 +16,7 @@
             "technique": "take_cover"
         }
     ],
+    "evolutions": [],
     "shape": "Flier",
     "types": [
         "Water"

--- a/mods/tuxemon/db/monster/noctula.json
+++ b/mods/tuxemon/db/monster/noctula.json
@@ -16,6 +16,13 @@
             "technique": "take_cover"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "noctalo"
+        }
+    ],
     "shape": "Flier",
     "types": [
         "Water"

--- a/mods/tuxemon/db/monster/nostray.json
+++ b/mods/tuxemon/db/monster/nostray.json
@@ -16,6 +16,7 @@
             "technique": "snowstorm"
         }
     ],
+    "evolutions": [],
     "shape": "Aquatic",
     "types": [
         "Water"

--- a/mods/tuxemon/db/monster/nudiflot_female.json
+++ b/mods/tuxemon/db/monster/nudiflot_female.json
@@ -16,6 +16,13 @@
             "technique": "flood"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 18,
+            "monster_slug": "nudimind"
+        }
+    ],
     "shape": "Polliwog",
     "types": [
         "Water"

--- a/mods/tuxemon/db/monster/nudiflot_male.json
+++ b/mods/tuxemon/db/monster/nudiflot_male.json
@@ -16,6 +16,13 @@
             "technique": "flood"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 18,
+            "monster_slug": "nudikill"
+        }
+    ],
     "shape": "Polliwog",
     "types": [
         "Water"

--- a/mods/tuxemon/db/monster/nudikill.json
+++ b/mods/tuxemon/db/monster/nudikill.json
@@ -16,6 +16,7 @@
             "technique": "bubble_trap"
         }
     ],
+    "evolutions": [],
     "shape": "Polliwog",
     "types": [
         "Water"

--- a/mods/tuxemon/db/monster/nudimind.json
+++ b/mods/tuxemon/db/monster/nudimind.json
@@ -16,6 +16,7 @@
             "technique": "sleep_bomb"
         }
     ],
+    "evolutions": [],
     "shape": "Polliwog",
     "types": [
         "Water"

--- a/mods/tuxemon/db/monster/nut.json
+++ b/mods/tuxemon/db/monster/nut.json
@@ -16,6 +16,13 @@
             "technique": "shuriken"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 9,
+            "monster_slug": "bolt"
+        }
+    ],
     "shape": "Blob",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/ouroboutlet.json
+++ b/mods/tuxemon/db/monster/ouroboutlet.json
@@ -16,6 +16,7 @@
             "technique": "constrict"
         }
     ],
+    "evolutions": [],
     "shape": "Serpent",
     "types": [
         "Metal",

--- a/mods/tuxemon/db/monster/pairagrim.json
+++ b/mods/tuxemon/db/monster/pairagrim.json
@@ -20,6 +20,7 @@
             "technique": "peregrine"
         }
     ],
+    "evolutions": [],
     "shape": "flier",
     "types": [
         "wood"

--- a/mods/tuxemon/db/monster/pairagrin.json
+++ b/mods/tuxemon/db/monster/pairagrin.json
@@ -16,6 +16,13 @@
             "technique": "wing_tip"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 26,
+            "monster_slug": "pairagrim"
+        }
+    ],
     "shape": "flier",
     "types": [
         "wood"

--- a/mods/tuxemon/db/monster/pharfan.json
+++ b/mods/tuxemon/db/monster/pharfan.json
@@ -16,6 +16,7 @@
             "technique": "stampede"
         }
     ],
+    "evolutions": [],
     "shape": "Landrace",
     "types": [
         "Water"

--- a/mods/tuxemon/db/monster/picc.json
+++ b/mods/tuxemon/db/monster/picc.json
@@ -16,6 +16,7 @@
             "technique": "battery_discharge"
         }
     ],
+    "evolutions": [],
     "shape": "Aquatic",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/pigabyte.json
+++ b/mods/tuxemon/db/monster/pigabyte.json
@@ -16,6 +16,7 @@
             "technique": "shrapnel"
         }
     ],
+    "evolutions": [],
     "shape": "Blob",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/pilthropus.json
+++ b/mods/tuxemon/db/monster/pilthropus.json
@@ -16,6 +16,7 @@
             "technique": "blade"
         }
     ],
+    "evolutions": [],
     "shape": "Humanoid",
     "types": [
         "Earth"

--- a/mods/tuxemon/db/monster/pipis.json
+++ b/mods/tuxemon/db/monster/pipis.json
@@ -16,6 +16,13 @@
             "technique": "take_cover"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "strella"
+        }
+    ],
     "shape": "Flier",
     "types": [
         "Wood"

--- a/mods/tuxemon/db/monster/poinchin.json
+++ b/mods/tuxemon/db/monster/poinchin.json
@@ -16,6 +16,13 @@
             "technique": "font"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "saurchin"
+        }
+    ],
     "shape": "Grub",
     "types": [
         "Water"

--- a/mods/tuxemon/db/monster/polyrock.json
+++ b/mods/tuxemon/db/monster/polyrock.json
@@ -16,6 +16,7 @@
             "technique": "one_two"
         }
     ],
+    "evolutions": [],
     "shape": "Brute",
     "types": [
         "Earth"

--- a/mods/tuxemon/db/monster/possessun.json
+++ b/mods/tuxemon/db/monster/possessun.json
@@ -16,6 +16,7 @@
             "technique": "muddle"
         }
     ],
+    "evolutions": [],
     "shape": "Blob",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/propellercat.json
+++ b/mods/tuxemon/db/monster/propellercat.json
@@ -16,6 +16,7 @@
             "technique": "fluff_up"
         }
     ],
+    "evolutions": [],
     "shape": "Flier",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/prophetoise.json
+++ b/mods/tuxemon/db/monster/prophetoise.json
@@ -16,6 +16,7 @@
             "technique": "sleep_bomb"
         }
     ],
+    "evolutions": [],
     "shape": "Humanoid",
     "types": [
         "Fire"

--- a/mods/tuxemon/db/monster/puparmor.json
+++ b/mods/tuxemon/db/monster/puparmor.json
@@ -16,6 +16,13 @@
             "technique": "wallow"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 12,
+            "monster_slug": "weavifly"
+        }
+    ],
     "shape": "Blob",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/pyraminx.json
+++ b/mods/tuxemon/db/monster/pyraminx.json
@@ -16,6 +16,7 @@
             "technique": "blade"
         }
     ],
+    "evolutions": [],
     "shape": "Hunter",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/pythwire.json
+++ b/mods/tuxemon/db/monster/pythwire.json
@@ -16,6 +16,18 @@
             "technique": "constrict"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "ouroboutlet"
+        },
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "sockeserp"
+        }
+    ],
     "shape": "Serpent",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/pythwire.json
+++ b/mods/tuxemon/db/monster/pythwire.json
@@ -18,13 +18,13 @@
     ],
     "evolutions": [
         {
-            "path": "",
-            "at_level": 20,
+            "path": "fire_booster",
+            "at_level": 0,
             "monster_slug": "ouroboutlet"
         },
         {
-            "path": "",
-            "at_level": 20,
+            "path": "metal_booster",
+            "at_level": 0,
             "monster_slug": "sockeserp"
         }
     ],

--- a/mods/tuxemon/db/monster/r0ck1tt3n.json
+++ b/mods/tuxemon/db/monster/r0ck1tt3n.json
@@ -16,6 +16,7 @@
             "technique": "thunderball"
         }
     ],
+    "evolutions": [],
     "shape": "Hunter",
     "types": [
         "Glitch",

--- a/mods/tuxemon/db/monster/rabbitosaur.json
+++ b/mods/tuxemon/db/monster/rabbitosaur.json
@@ -16,6 +16,7 @@
             "technique": "one_two"
         }
     ],
+    "evolutions": [],
     "shape": "Varmint",
     "types": [
         "Earth"

--- a/mods/tuxemon/db/monster/rhincus.json
+++ b/mods/tuxemon/db/monster/rhincus.json
@@ -16,6 +16,7 @@
             "technique": "peck"
         }
     ],
+    "evolutions": [],
     "shape": "Flier",
     "types": [
         "Earth"

--- a/mods/tuxemon/db/monster/rockat.json
+++ b/mods/tuxemon/db/monster/rockat.json
@@ -16,6 +16,13 @@
             "technique": "thunderball"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 36,
+            "monster_slug": "jemuar"
+        }
+    ],
     "shape": "Hunter",
     "types": [
         "Earth"

--- a/mods/tuxemon/db/monster/rockitten.json
+++ b/mods/tuxemon/db/monster/rockitten.json
@@ -16,6 +16,13 @@
             "technique": "thunderball"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 24,
+            "monster_slug": "rockat"
+        }
+    ],
     "shape": "Hunter",
     "types": [
         "Earth"

--- a/mods/tuxemon/db/monster/ruption.json
+++ b/mods/tuxemon/db/monster/ruption.json
@@ -16,6 +16,7 @@
             "technique": "kindling_flame"
         }
     ],
+    "evolutions": [],
     "shape": "Brute",
     "types": [
         "Fire"

--- a/mods/tuxemon/db/monster/sadito.json
+++ b/mods/tuxemon/db/monster/sadito.json
@@ -16,6 +16,7 @@
             "technique": "wall_of_steel"
         }
     ],
+    "evolutions": [],
     "shape": "Blob",
     "types": [
         "Metal",

--- a/mods/tuxemon/db/monster/sampsack.json
+++ b/mods/tuxemon/db/monster/sampsack.json
@@ -16,6 +16,7 @@
             "technique": "strike"
         }
     ],
+    "evolutions": [],
     "shape": "Brute",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/sampsage.json
+++ b/mods/tuxemon/db/monster/sampsage.json
@@ -16,6 +16,7 @@
             "technique": "strike"
         }
     ],
+    "evolutions": [],
     "shape": "Humanoid",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/sapragon.json
+++ b/mods/tuxemon/db/monster/sapragon.json
@@ -16,6 +16,13 @@
             "technique": "sting"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 55,
+            "monster_slug": "dragarbor"
+        }
+    ],
     "shape": "Dragon",
     "types": [
         "Wood"

--- a/mods/tuxemon/db/monster/sapsnap.json
+++ b/mods/tuxemon/db/monster/sapsnap.json
@@ -16,6 +16,7 @@
             "technique": "fluff_up"
         }
     ],
+    "evolutions": [],
     "shape": "Brute",
     "types": [
         "Wood"

--- a/mods/tuxemon/db/monster/saurchin.json
+++ b/mods/tuxemon/db/monster/saurchin.json
@@ -16,6 +16,7 @@
             "technique": "font"
         }
     ],
+    "evolutions": [],
     "shape": "Dragon",
     "types": [
         "Water"

--- a/mods/tuxemon/db/monster/sclairus.json
+++ b/mods/tuxemon/db/monster/sclairus.json
@@ -16,6 +16,7 @@
             "technique": "blossom"
         }
     ],
+    "evolutions": [],
     "shape": "Blob",
     "types": [
         "Wood"

--- a/mods/tuxemon/db/monster/seirein.json
+++ b/mods/tuxemon/db/monster/seirein.json
@@ -16,6 +16,7 @@
             "technique": "midnight_mantle"
         }
     ],
+    "evolutions": [],
     "shape": "Blob",
     "types": [
         "Fire",

--- a/mods/tuxemon/db/monster/shammer.json
+++ b/mods/tuxemon/db/monster/shammer.json
@@ -16,6 +16,7 @@
             "technique": "quicksand"
         }
     ],
+    "evolutions": [],
     "shape": "Hunter",
     "types": [
         "Earth"

--- a/mods/tuxemon/db/monster/sharpfin.json
+++ b/mods/tuxemon/db/monster/sharpfin.json
@@ -16,6 +16,7 @@
             "technique": "web"
         }
     ],
+    "evolutions": [],
     "shape": "Aquatic",
     "types": [
         "Water",

--- a/mods/tuxemon/db/monster/shybulb.json
+++ b/mods/tuxemon/db/monster/shybulb.json
@@ -16,6 +16,13 @@
             "technique": "sting"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "narcileaf"
+        }
+    ],
     "shape": "Sprite",
     "types": [
         "Wood"

--- a/mods/tuxemon/db/monster/skwib.json
+++ b/mods/tuxemon/db/monster/skwib.json
@@ -16,6 +16,7 @@
             "technique": "font"
         }
     ],
+    "evolutions": [],
     "shape": "Polliwog",
     "types": [
         "Water"

--- a/mods/tuxemon/db/monster/sludgehog.json
+++ b/mods/tuxemon/db/monster/sludgehog.json
@@ -16,6 +16,7 @@
             "technique": "energy_claws"
         }
     ],
+    "evolutions": [],
     "shape": "Landrace",
     "types": [
         "Earth"

--- a/mods/tuxemon/db/monster/snarlon.json
+++ b/mods/tuxemon/db/monster/snarlon.json
@@ -16,6 +16,7 @@
             "technique": "sand_spray"
         }
     ],
+    "evolutions": [],
     "shape": "Hunter",
     "types": [
         "Earth"

--- a/mods/tuxemon/db/monster/sockeserp.json
+++ b/mods/tuxemon/db/monster/sockeserp.json
@@ -16,6 +16,7 @@
             "technique": "constrict"
         }
     ],
+    "evolutions": [],
     "shape": "Serpent",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/spighter.json
+++ b/mods/tuxemon/db/monster/spighter.json
@@ -16,6 +16,7 @@
             "technique": "splinter"
         }
     ],
+    "evolutions": [],
     "shape": "Grub",
     "types": [
         "Wood"

--- a/mods/tuxemon/db/monster/squabbit.json
+++ b/mods/tuxemon/db/monster/squabbit.json
@@ -16,6 +16,13 @@
             "technique": "one_two"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "rabbitosaur"
+        }
+    ],
     "shape": "Varmint",
     "types": [
         "Earth"

--- a/mods/tuxemon/db/monster/strella.json
+++ b/mods/tuxemon/db/monster/strella.json
@@ -16,6 +16,7 @@
             "technique": "all_in"
         }
     ],
+    "evolutions": [],
     "shape": "Flier",
     "types": [
         "Wood"

--- a/mods/tuxemon/db/monster/sumchon.json
+++ b/mods/tuxemon/db/monster/sumchon.json
@@ -16,6 +16,7 @@
             "technique": "blade"
         }
     ],
+    "evolutions": [],
     "shape": "Brute",
     "types": [
         "Metal",

--- a/mods/tuxemon/db/monster/teddisun.json
+++ b/mods/tuxemon/db/monster/teddisun.json
@@ -16,6 +16,7 @@
             "technique": "supernova"
         }
     ],
+    "evolutions": [],
     "shape": "Humanoid",
     "types": [
         "Fire"

--- a/mods/tuxemon/db/monster/tigrock.json
+++ b/mods/tuxemon/db/monster/tigrock.json
@@ -16,6 +16,7 @@
             "technique": "energy_field"
         }
     ],
+    "evolutions": [],
     "shape": "Hunter",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/tikoal.json
+++ b/mods/tuxemon/db/monster/tikoal.json
@@ -16,6 +16,13 @@
             "technique": "petrify"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 30,
+            "monster_slug": "tikorch"
+        }
+    ],
     "shape": "Blob",
     "types": [
         "Fire",

--- a/mods/tuxemon/db/monster/tikorch.json
+++ b/mods/tuxemon/db/monster/tikorch.json
@@ -16,6 +16,7 @@
             "technique": "rock"
         }
     ],
+    "evolutions": [],
     "shape": "Blob",
     "types": [
         "Fire",

--- a/mods/tuxemon/db/monster/toufigel.json
+++ b/mods/tuxemon/db/monster/toufigel.json
@@ -16,6 +16,7 @@
             "technique": "snowstorm"
         }
     ],
+    "evolutions": [],
     "shape": "Varmint",
     "types": [
         "Earth",

--- a/mods/tuxemon/db/monster/tourbidi.json
+++ b/mods/tuxemon/db/monster/tourbidi.json
@@ -16,6 +16,7 @@
             "technique": "sleeping_powder"
         }
     ],
+    "evolutions": [],
     "shape": "Humanoid",
     "types": [
         "Wood"

--- a/mods/tuxemon/db/monster/trapsnap.json
+++ b/mods/tuxemon/db/monster/trapsnap.json
@@ -16,6 +16,13 @@
             "technique": "fluff_up"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 30,
+            "monster_slug": "sapsnap"
+        }
+    ],
     "shape": "Brute",
     "types": [
         "Wood"

--- a/mods/tuxemon/db/monster/tumblebee.json
+++ b/mods/tuxemon/db/monster/tumblebee.json
@@ -16,6 +16,7 @@
             "technique": "overgrowth"
         }
     ],
+    "evolutions": [],
     "shape": "Flier",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/tumbleworm.json
+++ b/mods/tuxemon/db/monster/tumbleworm.json
@@ -16,6 +16,13 @@
             "technique": "constrict"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 20,
+            "monster_slug": "tumblebee"
+        }
+    ],
     "shape": "Grub",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/tweesher.json
+++ b/mods/tuxemon/db/monster/tweesher.json
@@ -16,6 +16,13 @@
             "technique": "energy_field"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 24,
+            "monster_slug": "heronquak"
+        }
+    ],
     "shape": "Flier",
     "types": [
         "Water"

--- a/mods/tuxemon/db/monster/vamporm.json
+++ b/mods/tuxemon/db/monster/vamporm.json
@@ -16,6 +16,13 @@
             "technique": "refresh"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 9,
+            "monster_slug": "dracune"
+        }
+    ],
     "shape": "Grub",
     "types": [
         "Water"

--- a/mods/tuxemon/db/monster/velocitile.json
+++ b/mods/tuxemon/db/monster/velocitile.json
@@ -16,6 +16,7 @@
             "technique": "whirlwind"
         }
     ],
+    "evolutions": [],
     "shape": "Humanoid",
     "types": [
         "Wood"

--- a/mods/tuxemon/db/monster/vivicinder.json
+++ b/mods/tuxemon/db/monster/vivicinder.json
@@ -16,6 +16,7 @@
             "technique": "refresh"
         }
     ],
+    "evolutions": [],
     "shape": "Serpent",
     "types": [
         "Fire"

--- a/mods/tuxemon/db/monster/vivipere.json
+++ b/mods/tuxemon/db/monster/vivipere.json
@@ -16,6 +16,33 @@
             "technique": "wallow"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 25,
+            "monster_slug": "vivicinder"
+        },
+        {
+            "path": "",
+            "at_level": 25,
+            "monster_slug": "viviphyta"
+        },
+        {
+            "path": "",
+            "at_level": 24,
+            "monster_slug": "viviteel"
+        },
+        {
+            "path": "",
+            "at_level": 25,
+            "monster_slug": "vivitrans"
+        },
+        {
+            "path": "",
+            "at_level": 25,
+            "monster_slug": "vivitron"
+        }
+    ],
     "shape": "Serpent",
     "types": [
         "Earth"

--- a/mods/tuxemon/db/monster/viviphyta.json
+++ b/mods/tuxemon/db/monster/viviphyta.json
@@ -16,6 +16,7 @@
             "technique": "web"
         }
     ],
+    "evolutions": [],
     "shape": "Serpent",
     "types": [
         "Wood"

--- a/mods/tuxemon/db/monster/viviteel.json
+++ b/mods/tuxemon/db/monster/viviteel.json
@@ -16,6 +16,7 @@
             "technique": "perfect_cut"
         }
     ],
+    "evolutions": [],
     "shape": "Serpent",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/vivitrans.json
+++ b/mods/tuxemon/db/monster/vivitrans.json
@@ -16,6 +16,7 @@
             "technique": "frostbite"
         }
     ],
+    "evolutions": [],
     "shape": "Serpent",
     "types": [
         "Metal",

--- a/mods/tuxemon/db/monster/vivitron.json
+++ b/mods/tuxemon/db/monster/vivitron.json
@@ -16,6 +16,7 @@
             "technique": "battery_acid"
         }
     ],
+    "evolutions": [],
     "shape": "Serpent",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/volcoli.json
+++ b/mods/tuxemon/db/monster/volcoli.json
@@ -16,6 +16,7 @@
             "technique": "sudden_glow"
         }
     ],
+    "evolutions": [],
     "shape": "Humanoid",
     "types": [
         "Fire"

--- a/mods/tuxemon/db/monster/weavifly.json
+++ b/mods/tuxemon/db/monster/weavifly.json
@@ -16,6 +16,7 @@
             "technique": "eyebite"
         }
     ],
+    "evolutions": [],
     "shape": "Grub",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/windeye.json
+++ b/mods/tuxemon/db/monster/windeye.json
@@ -16,6 +16,7 @@
             "technique": "wall_of_steel"
         }
     ],
+    "evolutions": [],
     "shape": "Humanoid",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/wrougon.json
+++ b/mods/tuxemon/db/monster/wrougon.json
@@ -16,6 +16,13 @@
             "technique": "strike"
         }
     ],
+    "evolutions": [
+        {
+            "path": "",
+            "at_level": 30,
+            "monster_slug": "allagon"
+        }
+    ],
     "shape": "Dragon",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/xeon.json
+++ b/mods/tuxemon/db/monster/xeon.json
@@ -16,6 +16,7 @@
             "technique": "shrapnel"
         }
     ],
+    "evolutions": [],
     "shape": "Humanoid",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/xeon_2.json
+++ b/mods/tuxemon/db/monster/xeon_2.json
@@ -16,6 +16,7 @@
             "technique": "shrapnel"
         }
     ],
+    "evolutions": [],
     "shape": "Humanoid",
     "types": [
         "Metal"

--- a/mods/tuxemon/db/monster/yiinaang.json
+++ b/mods/tuxemon/db/monster/yiinaang.json
@@ -16,6 +16,7 @@
             "technique": "electrical_storm"
         }
     ],
+    "evolutions": [],
     "shape": "Blob",
     "types": [
         "Fire",

--- a/mods/tuxemon/db/monster/zunna.json
+++ b/mods/tuxemon/db/monster/zunna.json
@@ -16,6 +16,7 @@
             "technique": "strike"
         }
     ],
+    "evolutions": [],
     "shape": "Blob",
     "types": [
         "Metal"


### PR DESCRIPTION
Everything is based on Tuxepedia.

I was looking again at the monster JSON and I realized there was something missing: evolutions. Inside the Monster Model there are three fields: path, level_at and monster_slug and I realized that evolution was impossible because we miss the data. So after another deep dive in Tuxepedia, here the PR.

Among our monsters JSON there are 76 evolutions in 59 files.

What I've added (eg. memnomnom.json):
```
    "evolutions": [
        {
            "path": "",
            "at_level": 20,
            "monster_slug": "miaownolith"
        },
        {
            "path": "",
            "at_level": 20,
            "monster_slug": "pyraminx"
        }
    ],
```
I left the path empty, because it wasn't clear what to put there. I can always update everything with the right value. I think the important part is having the right structure.

If there is no evolution: **"evolutions": [],**

@Sanglorian if there is something amiss, I can fix without problems. The value I put inside are only describing the situation, and are temporary as always. I wanted to tell you that now we have the game_variable **daytime** (TRUE and FALSE) as well as **stage_of_day** (dawn, morning, afternoon, dusk, night), so we can make evolve some monster during the night, the day, the dawn, etc.

Some suggestions about the structure:
add another fields for the stage_of_day or daytime;
using path merely for objects;
eventually another field for tech;

I can implement these without problems.

Attached evolutions.pdf that resume the evolution situation, so everyone can understand.
[evolutions.pdf](https://github.com/Tuxemon/Tuxemon/files/9506815/evolutions.pdf)
