### PR TITLE
Spyder - Add screen transition to sleeping in bedroom

### DIFF
--- a/mods/tuxemon/maps/spyder_bedroom.tmx
+++ b/mods/tuxemon/maps/spyder_bedroom.tmx
@@ -64,10 +64,12 @@
   <object id="26" name="Player Spawn" type="event" x="64" y="80" width="16" height="16"/>
   <object id="27" name="Resting in Bed" type="event" x="16" y="48" width="16" height="32">
    <properties>
-    <property name="act1" value="translated_dialog spyder_papertown_restinbed"/>
-    <property name="act2" value="set_monster_health ,"/>
-    <property name="act3" value="set_monster_status ,"/>
-    <property name="act4" value="set_variable teleport_faint:spyder_bedroom.tmx 7 6"/>
+    <property name="act1" value="screen_transition 1"/>
+    <property name="act2" value="wait 0.5"/>
+    <property name="act3" value="translated_dialog spyder_papertown_restinbed"/>
+    <property name="act4" value="set_monster_health ,"/>
+    <property name="act5" value="set_monster_status ,"/>
+    <property name="act6" value="set_variable teleport_faint:spyder_bedroom.tmx 7 6"/>
     <property name="cond1" value="is button_pressed K_RETURN"/>
     <property name="cond2" value="is player_facing_tile"/>
    </properties>


### PR DESCRIPTION
As it is now, the rest action lacks a bit of immersion, because there is only the dialogue box and no change in scenery otherwise:
![image](https://user-images.githubusercontent.com/15969405/189220745-b813aa5e-e8cd-4740-bd58-97c8904aea74.png)

The PR adds a fade out - fade in transition with the dialogue box appearing while asleep:
![image](https://user-images.githubusercontent.com/15969405/189221161-cb7ea0c3-fb5b-4ebf-ab5b-0150afbef5f2.png)

