### PR TITLE
Support arbitrary dimensions in technique animations - clean

### DIFF
--- a/scripts/download_technique_animations.py
+++ b/scripts/download_technique_animations.py
@@ -17,7 +17,6 @@ import requests
 from lxml import html
 from PIL import Image
 
-FRAME_SIZE = 64
 WIKI_URL = "https://wiki.tuxemon.org"
 
 TUXEMON_ROOT_DIR = pathlib.Path(__file__).resolve().parent.parent
@@ -45,6 +44,7 @@ def process_filename(filepath: str) -> str:
     """Extract base filename from an animation file path."""
     cleaned_filename = os.path.splitext(os.path.basename(filepath))[0]
     cleaned_filename = cleaned_filename.strip("0123456789_")
+    cleaned_filename = cleaned_filename.split("px-")[-1]
     cleaned_filename = cleaned_filename.lower()
     return cleaned_filename
 
@@ -94,9 +94,6 @@ def gif_to_frames(filepath: str) -> None:
     with Image.open(filepath) as image:
         if not image.is_animated:
             print(f"{filepath} is not animated, skipped")
-            return
-        if not image.width == image.height == FRAME_SIZE:
-            print(f"{filepath} is not {FRAME_SIZE}x{FRAME_SIZE}, skipped")
             return
 
         base_name = process_filename(filepath)


### PR DESCRIPTION
Cleaned up version of: https://github.com/Tuxemon/Tuxemon/pull/1285

Split off effort from: https://github.com/Tuxemon/Tuxemon/issues/1267

The goal is to be able to download animations regardless of their size.

Here's how the animations look like in-game now (using a modified version of Agnite for testing)
- Breathe Fire - [Wiki entry](https://wiki.tuxemon.org/File:Breath_fire.gif)
![breathe_fire](https://user-images.githubusercontent.com/15969405/189487986-58147c77-63a7-4137-a8ad-a77198cd92e9.png)
- Disintegrate - [Wiki entry](https://wiki.tuxemon.org/File:Disintegrate_83.gif)
![disintegrate](https://user-images.githubusercontent.com/15969405/189487988-d28afb6e-37b3-4fde-8f4b-54d2784db088.png)
