### PR TITLE
fix logger

### DIFF
--- a/tuxemon/animation.py
+++ b/tuxemon/animation.py
@@ -100,9 +100,10 @@ class TaskBase(pygame.sprite.Sprite):
             when = self._valid_schedules[0]
 
         if when not in self._valid_schedules:
-            logger.critical("invalid time to schedule a callback")
-            logger.critical("valid:", self._valid_schedules)
-            raise ValueError
+            raise ValueError(
+                "invalid time to schedule a callback"
+                f"valid: {self._valid_schedules}"
+            )
         self._callbacks[when].append(func)
 
     def _execute_callbacks(self, when: str) -> None:

--- a/tuxemon/audio.py
+++ b/tuxemon/audio.py
@@ -45,8 +45,7 @@ def get_sound_filename(slug: Optional[str]) -> Optional[str]:
     # On some platforms, pygame will silently fail loading
     # a sound if the filename is incorrect so we check here
     if not os.path.exists(filename):
-        msg = f"audio file does not exist: {filename}"
-        logger.error(msg)
+        logger.error(f"audio file does not exist: {filename}")
         return None
 
     return filename

--- a/tuxemon/event/actions/play_map_animation.py
+++ b/tuxemon/event/actions/play_map_animation.py
@@ -77,8 +77,7 @@ class PlayMapAnimationAction(EventAction[PlayMapAnimationActionParameters]):
         elif self.parameters.loop == "noloop":
             loop = False
         else:
-            logger.error('animation loop value must be "loop" or "noloop"')
-            raise ValueError
+            raise ValueError('animation loop value must be "loop" or "noloop"')
 
         # Check to see if this animation has already been loaded.
         # If it has, play the animation.

--- a/tuxemon/event/actions/set_monster_health.py
+++ b/tuxemon/event/actions/set_monster_health.py
@@ -63,8 +63,7 @@ class SetMonsterHealthAction(EventAction[SetMonsterHealthActionParameters]):
             monster.current_hp = monster.hp
         else:
             if not 0 <= value <= 1:
-                logger.error("monster health must between 0 and 1")
-                raise ValueError
+                raise ValueError("monster health must between 0 and 1")
 
             monster.current_hp = int(monster.hp * value)
 

--- a/tuxemon/event/actions/variable_math.py
+++ b/tuxemon/event/actions/variable_math.py
@@ -87,5 +87,4 @@ class VariableMathAction(EventAction[VariableMathActionParameters]):
         elif operation == "=":
             player.game_variables[result] = operand2
         else:
-            logger.error(f"invalid operation type {operation}")
-            raise ValueError
+            raise ValueError(f"invalid operation type {operation}")

--- a/tuxemon/event/conditions/variable_is.py
+++ b/tuxemon/event/conditions/variable_is.py
@@ -80,5 +80,4 @@ class VariableIsCondition(EventCondition):
         elif operation == "<=":
             return operand1 <= operand2
         else:
-            logger.error(f"invalid operation type {operation}")
-            raise ValueError
+            raise ValueError(f"invalid operation type {operation}")

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -122,12 +122,11 @@ def simple_damage_calculate(
         user_strength = 7 + user.level
         target_resist = 1
     else:
-        logger.error(
+        raise RuntimeError(
             "unhandled damage category %s %s",
             technique.category,
             technique.range,
         )
-        raise RuntimeError
 
     mult = simple_damage_multiplier(
         (technique.type1, technique.type2),

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -135,7 +135,7 @@ class Item:
         try:
             results = db.lookup(slug, table="item").dict()
         except KeyError:
-            logger.error(msg=f"Failed to find item with slug {slug}")
+            logger.error(f"Failed to find item with slug {slug}")
             return
 
         self.slug = results["slug"]
@@ -187,9 +187,8 @@ class Item:
                 params = None
             try:
                 effect = Item.effects_classes[name]
-            except KeyError:
-                error = f'Error: ItemEffect "{name}" not implemented'
-                logger.error(error)
+            except KeyError:                
+                logger.error(f'Error: ItemEffect "{name}" not implemented')
             else:
                 ret.append(effect(self.session, self.user, params))
 
@@ -223,8 +222,7 @@ class Item:
             try:
                 condition = Item.conditions_classes[name]
             except KeyError:
-                error = f'Error: ItemCondition "{name}" not implemented'
-                logger.error(error)
+                logger.error(f'Error: ItemCondition "{name}" not implemented')
             else:
                 ret.append(condition(context, self.session, self.user, params))
 

--- a/tuxemon/item/itemcondition.py
+++ b/tuxemon/item/itemcondition.py
@@ -125,7 +125,7 @@ class ItemCondition(Generic[ParameterClass]):
         except ValueError:
             logger.error(f"error while parsing for {self.name}")
             logger.error(f"cannot parse parameters: {parameters}")
-            logger.error(self.param_class)
+            logger.error(f"{self.param_class}")
             logger.error(
                 "please check the parameters and verify they are correct"
             )

--- a/tuxemon/item/itemeffect.py
+++ b/tuxemon/item/itemeffect.py
@@ -131,7 +131,7 @@ class ItemEffect(Generic[ParameterClass]):
         except ValueError:
             logger.error(f"error while parsing for {self.name}")
             logger.error(f"cannot parse parameters: {parameters}")
-            logger.error(self.param_class)
+            logger.error(f"{self.param_class}")
             logger.error(
                 "please check the parameters and verify they are correct"
             )

--- a/tuxemon/menu/menu.py
+++ b/tuxemon/menu/menu.py
@@ -326,11 +326,10 @@ class Menu(Generic[T], state.State):
             for sprite in self.sprites:
                 if isinstance(sprite, TextArea):
                     return sprite
-            logger.error(
+            raise RuntimeError(
                 "attempted to use 'alert' on state without a TextArea",
                 message,
             )
-            raise RuntimeError
 
         self.animate_text(find_textarea(), message, callback)
 

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -324,8 +324,7 @@ class Monster:
         results = db.lookup(slug, table="monster").dict()
 
         if results is None:
-            logger.error(f"monster {slug} is not found")
-            raise RuntimeError
+            raise RuntimeError(f"monster {slug} is not found")
         self.level = random.randint(2, 5)
         self.slug = results["slug"]
         self.name = T.translate(results["slug"])

--- a/tuxemon/plugin.py
+++ b/tuxemon/plugin.py
@@ -117,11 +117,10 @@ class PluginManager:
             pattern = re.compile("tuxemon/.*$")
             matches = pattern.findall(folder)
             if len(matches) == 0:
-                logger.exception(
+                raise RuntimeError(
                     f"Unable to determine plugin module path for: %s",
                     folder,
                 )
-                raise RuntimeError
             module_path = matches[0].replace("/", ".")
 
             # Look for a ".plugin" in the plugin folder to create a list

--- a/tuxemon/state.py
+++ b/tuxemon/state.py
@@ -358,8 +358,7 @@ class StateManager:
         try:
             state = self._state_dict[state_name]
         except KeyError:
-            logger.critical(f"Cannot find state: {state_name}")
-            raise RuntimeError
+            raise RuntimeError(f"Cannot find state: {state_name}")
         instance = state(self)
         return instance
 
@@ -494,8 +493,7 @@ class StateManager:
 
         # raise error if stack is empty
         if not self._state_stack:
-            logger.critical("Attempted to pop state when stack was empty.")
-            raise RuntimeError
+            raise RuntimeError("Attempted to pop state when stack was empty.")
 
         # pop the top state
         if state is None:
@@ -504,10 +502,9 @@ class StateManager:
         try:
             index = self._state_stack.index(state)
         except IndexError:
-            logger.critical(
+            raise RuntimeError(
                 "Attempted to pop state when state was not active.",
             )
-            raise RuntimeError
 
         if index == 0:
             logger.debug("pop state: %s", state.name)
@@ -632,8 +629,7 @@ class StateManager:
         logger.debug("replace state: %s", state_name)
         # raise error if stack is empty
         if not self._state_stack:
-            logger.critical("Attempted to replace state when stack was empty.")
-            raise RuntimeError
+            raise RuntimeError("Attempted to replace state when stack was empty.")
 
         previous = self._state_stack[0]
         instance = self.push_state(state_name, **kwargs)

--- a/tuxemon/tools.py
+++ b/tuxemon/tools.py
@@ -244,8 +244,7 @@ def number_or_variable(
         try:
             return float(player.game_variables[value])
         except (KeyError, ValueError, TypeError):
-            logger.error(f"invalid number or game variable {value}")
-            raise ValueError
+            raise ValueError(f"invalid number or game variable {value}")
 
 
 def cast_values(

--- a/tuxemon/ui/draw.py
+++ b/tuxemon/ui/draw.py
@@ -234,8 +234,7 @@ def constrain_width(
             token_width = font.size(test)[0]
             if token_width >= width:
                 if scrap is None:
-                    logger.error("message is too large for width", text)
-                    raise RuntimeError
+                    raise RuntimeError("message is too large for width", text)
                 yield scrap
                 scrap = word
             else:


### PR DESCRIPTION
After a discussion in #1304 Here a PR that addresses some changes related to loggers. I would like to know if it makes sense as well as if there are plans to replace some loggers with something else. Some sort of guidelines. 

loggers based on import logging:
```
logger.warning, logger.debug, logger.critical, logger.exception, logger.info, logger.error
```
After a deep dive, I noticed that a series of file got this:
```
import logging
logger = logging.getLogger(__name__)
```
but without having a third **logger.something**. So it's only **import logging** and **logger = logging.getLogger(__name__)**

(if changes accepted)
```
formula.py
event/actions/play_map_animation
event/actions/variable_math
menu/menu.py
ui/draw.py
```
(no loggers inside)
```
map.py 
middleware.py 
player.py 
event/__init__.py (there is a logger but after #)
event/actions/battles_print 
event/actions/clear_variable 
event/actions/copy_variable 
event/actions/get_player_monster 
event/actions/print 
event/actions/random_integer 
event/actions/store_monster 
event/actions/withdraw_monster 
event/conditions/__init__.py 
event/conditions/variable_is 
item/economy.py 
item/conditions/__init__.py 
item/conditions/status.py 
item/effects/__init__.py 
menu/quantity.py 
states/combat/combat_animations.py 
states/combat/combat_menus.py 
states/pc/__init__.py 
states/persistance/load_menu.py 
states/splash/__init__.py 
states/start/__init__.py 
states/transition/__init__.py 
states/world/world_menus.py 
```