### PR TITLE
Only apply status effect once

### DIFF
--- a/tuxemon/technique.py
+++ b/tuxemon/technique.py
@@ -283,15 +283,14 @@ class Technique:
             elif effect == "hardshell":
                 result = self.hardshell(user)
             elif effect == "status":
-                for category in self.category:
-                    if category == "poison":
-                        result = self.poison(target)
-                    elif category == "lifeleech":
-                        result = self.lifeleech(target)
-                    elif category == "recover":
-                        result = self.recover(target)
-                    else:
-                        result = getattr(self, self.category)(target)
+                if self.category == "poison":
+                    result = self.poison(target)
+                elif self.category == "lifeleech":
+                    result = self.lifeleech(target)
+                elif self.category == "recover":
+                    result = self.recover(target)
+                else:
+                    result = getattr(self, self.category)(target)
             else:
                 result = getattr(self, effect)(user, target)
             meta_result = merge_results(result, meta_result)


### PR DESCRIPTION
A bug in https://github.com/Tuxemon/Tuxemon/pull/957 meant that we were applying poison damage six times, instead of once. This meant poison damage was 75% of max health, not 12.5%.

I can see no reason to be looping over category.

Tested in battle, poison damage seems reasonable now, and other techniques work.