### PR TITLE
teleport faint and healing

### DIFF
--- a/mods/tuxemon/maps/cotton_cathedral.tmx
+++ b/mods/tuxemon/maps/cotton_cathedral.tmx
@@ -96,8 +96,7 @@
    <properties>
     <property name="act1" value="set_monster_health ,"/>
     <property name="act2" value="set_monster_status ,"/>
-    <property name="act3" value="wait 1"/>
-    <property name="act90" value="set_variable teleport_faint:cotton_cathedral.tmx 7 10"/>
+    <property name="act3" value="set_variable battle_last_result:none"/>
     <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/cotton_cathedral.tmx
+++ b/mods/tuxemon/maps/cotton_cathedral.tmx
@@ -92,5 +92,14 @@
     <property name="cond10" value="is variable_set healme:yes"/>
    </properties>
   </object>
+  <object id="29" name="Auto Healing Teleported" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_monster_health ,"/>
+    <property name="act2" value="set_monster_status ,"/>
+    <property name="act3" value="wait 1"/>
+    <property name="act90" value="set_variable teleport_faint:cotton_cathedral.tmx 7 10"/>
+    <property name="cond1" value="is variable_set battle_last_result:lost"/>
+   </properties>
+  </object>
  </objectgroup>
 </map>

--- a/mods/tuxemon/maps/healing_center.tmx
+++ b/mods/tuxemon/maps/healing_center.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.4" tiledversion="1.4.3" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="34">
+<map version="1.4" tiledversion="1.4.3" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="35">
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>
  </tileset>
@@ -119,6 +119,15 @@
     <property name="act10" value="transition_teleport taba_town.tmx,40,4,0.3"/>
     <property name="cond10" value="is player_at"/>
     <property name="cond20" value="is player_facing down"/>
+   </properties>
+  </object>
+  <object id="34" name="Auto Healing Teleported" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_monster_health ,"/>
+    <property name="act2" value="set_monster_status ,"/>
+    <property name="act3" value="wait 1"/>
+    <property name="act4" value="set_variable teleport_faint:healing_center.tmx 7 10"/>
+    <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/healing_center.tmx
+++ b/mods/tuxemon/maps/healing_center.tmx
@@ -125,8 +125,7 @@
    <properties>
     <property name="act1" value="set_monster_health ,"/>
     <property name="act2" value="set_monster_status ,"/>
-    <property name="act3" value="wait 1"/>
-    <property name="act4" value="set_variable teleport_faint:healing_center.tmx 7 10"/>
+    <property name="act3" value="set_variable battle_last_result:none"/>
     <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/healing_center_sphalian.tmx
+++ b/mods/tuxemon/maps/healing_center_sphalian.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="23">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="24">
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>
  </tileset>
@@ -70,6 +70,15 @@
     <property name="act10" value="dialog It says that it is under repair"/>
     <property name="cond10" value="is player_at"/>
     <property name="cond20" value="is player_facing left"/>
+   </properties>
+  </object>
+  <object id="23" name="Auto Healing Teleported" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_monster_health ,"/>
+    <property name="act2" value="set_monster_status ,"/>
+    <property name="act3" value="wait 1"/>
+    <property name="act4" value="set_variable teleport_faint:healing_center_sphalian.tmx 7 10"/>
+    <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>
   </object>
   <object id="22" name="Player Spawn" type="event" x="112" y="160" width="16" height="16"/>

--- a/mods/tuxemon/maps/healing_center_sphalian.tmx
+++ b/mods/tuxemon/maps/healing_center_sphalian.tmx
@@ -76,8 +76,7 @@
    <properties>
     <property name="act1" value="set_monster_health ,"/>
     <property name="act2" value="set_monster_status ,"/>
-    <property name="act3" value="wait 1"/>
-    <property name="act4" value="set_variable teleport_faint:healing_center_sphalian.tmx 7 10"/>
+    <property name="act3" value="set_variable battle_last_result:none"/>
     <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/player_house_bedroom.yaml
+++ b/mods/tuxemon/maps/player_house_bedroom.yaml
@@ -37,3 +37,32 @@ events:
     width: 1
     x: 4
     y: 5
+  Resting in Bed:
+    actions:
+    - screen_transition 1
+    - wait 0.5
+    - translated_dialog spyder_papertown_restinbed
+    - set_monster_health ,
+    - set_monster_status ,
+    - set_variable teleport_faint:player_house_bedroom.tmx 7 6
+    conditions:
+    - is button_pressed K_RETURN
+    - is player_facing_tile
+    height: 2
+    width: 1
+    x: 1
+    y: 3
+    type: "event"
+  Auto Healing Teleported:
+    actions:
+    - set_monster_health ,
+    - set_monster_status ,
+    - wait 1
+    - set_variable teleport_faint:player_house_bedroom.tmx 7 6
+    conditions:
+    - is variable_set battle_last_result:lost
+    height: 1
+    width: 1
+    x: 0
+    y: 0
+    type: "event"

--- a/mods/tuxemon/maps/player_house_bedroom.yaml
+++ b/mods/tuxemon/maps/player_house_bedroom.yaml
@@ -57,8 +57,7 @@ events:
     actions:
     - set_monster_health ,
     - set_monster_status ,
-    - wait 1
-    - set_variable teleport_faint:player_house_bedroom.tmx 7 6
+    - set_variable battle_last_result:none
     conditions:
     - is variable_set battle_last_result:lost
     height: 1

--- a/mods/tuxemon/maps/spyder_bedroom.tmx
+++ b/mods/tuxemon/maps/spyder_bedroom.tmx
@@ -85,8 +85,7 @@
    <properties>
     <property name="act1" value="set_monster_health ,"/>
     <property name="act2" value="set_monster_status ,"/>
-    <property name="act3" value="wait 1"/>
-    <property name="act4" value="set_variable teleport_faint:spyder_bedroom.tmx 7 6"/>
+    <property name="act3" value="set_variable battle_last_result:none"/>
     <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_bedroom.tmx
+++ b/mods/tuxemon/maps/spyder_bedroom.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="11" height="9" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="29">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="11" height="9" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="30">
  <tileset firstgid="1" name="floors and walls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>
  </tileset>
@@ -79,6 +79,15 @@
     <property name="act30" value="variable_math money,+,1000000"/>
     <property name="act40" value="set_variable spyder_starting_money:yes"/>
     <property name="cond1" value="not variable_set spyder_starting_money:yes"/>
+   </properties>
+  </object>
+  <object id="29" name="Auto Healing Teleported" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_monster_health ,"/>
+    <property name="act2" value="set_monster_status ,"/>
+    <property name="act3" value="wait 1"/>
+    <property name="act4" value="set_variable teleport_faint:spyder_bedroom.tmx 7 6"/>
+    <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_candy_center.tmx
+++ b/mods/tuxemon/maps/spyder_candy_center.tmx
@@ -104,8 +104,7 @@
    <properties>
     <property name="act1" value="set_monster_health ,"/>
     <property name="act2" value="set_monster_status ,"/>
-    <property name="act3" value="wait 1"/>
-    <property name="act4" value="set_variable teleport_faint:spyder_candy_center.tmx 7 10"/>
+    <property name="act3" value="set_variable battle_last_result:none"/>
     <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_candy_center.tmx
+++ b/mods/tuxemon/maps/spyder_candy_center.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.4" tiledversion="1.4.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="31">
+<map version="1.4" tiledversion="1.4.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="32">
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>
  </tileset>
@@ -98,6 +98,15 @@
     <property name="act2" value="player_face up"/>
     <property name="cond1" value="is player_at"/>
     <property name="cond2" value="is player_facing left"/>
+   </properties>
+  </object>
+  <object id="31" name="Auto Healing Teleported" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_monster_health ,"/>
+    <property name="act2" value="set_monster_status ,"/>
+    <property name="act3" value="wait 1"/>
+    <property name="act4" value="set_variable teleport_faint:spyder_candy_center.tmx 7 10"/>
+    <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_cotton_cafe.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_cafe.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.5" tiledversion="1.7.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="12" height="12" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="28">
+<map version="1.5" tiledversion="1.7.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="12" height="12" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="29">
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>
  </tileset>
@@ -210,6 +210,7 @@
     <property name="act50" value="npc_face spyder_cottontown_barmaid,down"/>
     <property name="act60" value="translated_dialog okaythen2"/>
     <property name="act70" value="set_variable chooses:none"/>
+    <property name="act80" value="set_variable teleport_faint:spyder_cotton_cafe.tmx 1 10"/>
     <property name="cond1" value="is variable_set chooses:yes"/>
    </properties>
   </object>
@@ -224,6 +225,15 @@
     <property name="cond4" value="is player_at"/>
     <property name="cond5" value="is player_facing up"/>
     <property name="cond6" value="is button_pressed K_RETURN"/>
+   </properties>
+  </object>
+  <object id="31" name="Auto Healing Teleported" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_monster_health ,"/>
+    <property name="act2" value="set_monster_status ,"/>
+    <property name="act3" value="wait 1"/>
+    <property name="act4" value="set_variable teleport_faint:spyder_cotton_cafe.tmx 1 10"/>
+    <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_cotton_cafe.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_cafe.tmx
@@ -231,8 +231,7 @@
    <properties>
     <property name="act1" value="set_monster_health ,"/>
     <property name="act2" value="set_monster_status ,"/>
-    <property name="act3" value="wait 1"/>
-    <property name="act4" value="set_variable teleport_faint:spyder_cotton_cafe.tmx 1 10"/>
+    <property name="act3" value="set_variable battle_last_result:none"/>
     <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_dragonscave.tmx
+++ b/mods/tuxemon/maps/spyder_dragonscave.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="102">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="103">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -446,6 +446,12 @@
     <property name="act6" value="set_variable dragonscavemal:yes"/>
     <property name="cond1" value="not variable_set dragonscavemal:yes"/>
     <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="102" name="Exhausted" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="teleport_faint"/>
+    <property name="cond1" value="is player_defeated"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_flower_center.tmx
+++ b/mods/tuxemon/maps/spyder_flower_center.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.4" tiledversion="1.4.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="29">
+<map version="1.4" tiledversion="1.4.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="30">
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>
  </tileset>
@@ -90,6 +90,15 @@
     <property name="cond1" value="is player_at 11,6"/>
     <property name="cond2" value="is player_facing up"/>
     <property name="cond3" value="is button_pressed K_RETURN"/>
+   </properties>
+  </object>
+  <object id="29" name="Auto Healing Teleported" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_monster_health ,"/>
+    <property name="act2" value="set_monster_status ,"/>
+    <property name="act3" value="wait 1"/>
+    <property name="act4" value="set_variable teleport_faint:spyder_flower_center.tmx 7 10"/>
+    <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_flower_center.tmx
+++ b/mods/tuxemon/maps/spyder_flower_center.tmx
@@ -96,8 +96,7 @@
    <properties>
     <property name="act1" value="set_monster_health ,"/>
     <property name="act2" value="set_monster_status ,"/>
-    <property name="act3" value="wait 1"/>
-    <property name="act4" value="set_variable teleport_faint:spyder_flower_center.tmx 7 10"/>
+    <property name="act3" value="set_variable battle_last_result:none"/>
     <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_healing_center.tmx
+++ b/mods/tuxemon/maps/spyder_healing_center.tmx
@@ -97,8 +97,7 @@
    <properties>
     <property name="act1" value="set_monster_health ,"/>
     <property name="act2" value="set_monster_status ,"/>
-    <property name="act3" value="wait 1"/>
-    <property name="act4" value="set_variable teleport_faint:spyder_healing_center.tmx 7 10"/>
+    <property name="act3" value="set_variable battle_last_result:none"/>
     <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_healing_center.tmx
+++ b/mods/tuxemon/maps/spyder_healing_center.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.5" tiledversion="1.7.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="29">
+<map version="1.5" tiledversion="1.7.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="30">
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>
  </tileset>
@@ -91,6 +91,15 @@
     <property name="cond1" value="is player_at 11,6"/>
     <property name="cond2" value="is player_facing up"/>
     <property name="cond3" value="is button_pressed K_RETURN"/>
+   </properties>
+  </object>
+  <object id="29" name="Auto Healing Teleported" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_monster_health ,"/>
+    <property name="act2" value="set_monster_status ,"/>
+    <property name="act3" value="wait 1"/>
+    <property name="act4" value="set_variable teleport_faint:spyder_healing_center.tmx 7 10"/>
+    <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_leather_center.tmx
+++ b/mods/tuxemon/maps/spyder_leather_center.tmx
@@ -97,8 +97,7 @@
    <properties>
     <property name="act1" value="set_monster_health ,"/>
     <property name="act2" value="set_monster_status ,"/>
-    <property name="act3" value="wait 1"/>
-    <property name="act4" value="set_variable teleport_faint:spyder_leather_center.tmx 7 10"/>
+    <property name="act3" value="set_variable battle_last_result:none"/>
     <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_leather_center.tmx
+++ b/mods/tuxemon/maps/spyder_leather_center.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.4" tiledversion="1.4.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="29">
+<map version="1.4" tiledversion="1.4.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="30">
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>
  </tileset>
@@ -91,6 +91,15 @@
     <property name="cond1" value="is player_at 11,6"/>
     <property name="cond2" value="is player_facing up"/>
     <property name="cond3" value="is button_pressed K_RETURN"/>
+   </properties>
+  </object>
+  <object id="29" name="Auto Healing Teleported" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_monster_health ,"/>
+    <property name="act2" value="set_monster_status ,"/>
+    <property name="act3" value="wait 1"/>
+    <property name="act4" value="set_variable teleport_faint:spyder_leather_center.tmx 7 10"/>
+    <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_leather_town.tmx
+++ b/mods/tuxemon/maps/spyder_leather_town.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.5" tiledversion="1.7.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="303">
+<map version="1.5" tiledversion="1.7.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="304">
  <properties>
   <property name="edges" value="clamped"/>
  </properties>
@@ -273,6 +273,7 @@
     <property name="act50" value="npc_face spyder_barmaid,down"/>
     <property name="act60" value="translated_dialog okaythen2"/>
     <property name="act70" value="set_variable chooses:none"/>
+    <property name="act80" value="set_variable teleport_faint:spyder_leather_town.tmx 4 14"/>
     <property name="cond1" value="is variable_set chooses:yes"/>
    </properties>
   </object>
@@ -399,6 +400,15 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set environment:grass"/>
+   </properties>
+  </object>
+  <object id="31" name="Auto Healing Teleported" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_monster_health ,"/>
+    <property name="act2" value="set_monster_status ,"/>
+    <property name="act3" value="wait 1"/>
+    <property name="act4" value="set_variable teleport_faint:spyder_leather_town.tmx 4 14"/>
+    <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_leather_town.tmx
+++ b/mods/tuxemon/maps/spyder_leather_town.tmx
@@ -406,8 +406,7 @@
    <properties>
     <property name="act1" value="set_monster_health ,"/>
     <property name="act2" value="set_monster_status ,"/>
-    <property name="act3" value="wait 1"/>
-    <property name="act4" value="set_variable teleport_faint:spyder_leather_town.tmx 4 14"/>
+    <property name="act3" value="set_variable battle_last_result:none"/>
     <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_scoop1.tmx
+++ b/mods/tuxemon/maps/spyder_scoop1.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="21" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="70">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="21" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="71">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -382,6 +382,12 @@
     <property name="act6" value="set_variable scooprubid:yes"/>
     <property name="cond1" value="not variable_set scooprubid:yes"/>
     <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="70" name="Exhausted" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="teleport_faint"/>
+    <property name="cond1" value="is player_defeated"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_scoop2.tmx
+++ b/mods/tuxemon/maps/spyder_scoop2.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.5" tiledversion="1.7.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="8" height="5" tilewidth="16" tileheight="16" infinite="0" nextlayerid="5" nextobjectid="18">
+<map version="1.5" tiledversion="1.7.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="8" height="5" tilewidth="16" tileheight="16" infinite="0" nextlayerid="5" nextobjectid="19">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -115,6 +115,14 @@
    <properties>
     <property name="act1" value="set_variable environment:snow"/>
     <property name="cond1" value="not variable_set environment:snow"/>
+   </properties>
+  </object>
+  <object id="18" name="Auto Healing Teleported" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_monster_health ,"/>
+    <property name="act2" value="set_monster_status ,"/>
+    <property name="act3" value="set_variable battle_last_result:none"/>
+    <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_scoop3.tmx
+++ b/mods/tuxemon/maps/spyder_scoop3.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="12" height="12" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="29">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="12" height="12" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="30">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -211,6 +211,12 @@
     <property name="act6" value="set_variable scoopdonald:yes"/>
     <property name="cond1" value="not variable_set scoopdonald:yes"/>
     <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="29" name="Exhausted" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport spyder_scoop2.tmx,9,6,0.3"/>
+    <property name="cond1" value="is player_defeated"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_scoop4.tmx
+++ b/mods/tuxemon/maps/spyder_scoop4.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="12" height="22" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="58">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="12" height="22" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="59">
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>
  </tileset>
@@ -379,6 +379,12 @@
     <property name="act6" value="set_variable scoopweaver:yes"/>
     <property name="cond1" value="not variable_set scoopweaver:yes"/>
     <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="58" name="Exhausted" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport spyder_scoop2.tmx,9,6,0.3"/>
+    <property name="cond1" value="is player_defeated"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_timber_center.tmx
+++ b/mods/tuxemon/maps/spyder_timber_center.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.4" tiledversion="1.4.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="29">
+<map version="1.4" tiledversion="1.4.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="30">
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>
  </tileset>
@@ -90,6 +90,15 @@
     <property name="cond1" value="is player_at 11,6"/>
     <property name="cond2" value="is player_facing up"/>
     <property name="cond3" value="is button_pressed K_RETURN"/>
+   </properties>
+  </object>
+  <object id="29" name="Auto Healing Teleported" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_monster_health ,"/>
+    <property name="act2" value="set_monster_status ,"/>
+    <property name="act3" value="wait 1"/>
+    <property name="act4" value="set_variable teleport_faint:spyder_timber_center.tmx 7 10"/>
+    <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_timber_center.tmx
+++ b/mods/tuxemon/maps/spyder_timber_center.tmx
@@ -96,8 +96,7 @@
    <properties>
     <property name="act1" value="set_monster_health ,"/>
     <property name="act2" value="set_monster_status ,"/>
-    <property name="act3" value="wait 1"/>
-    <property name="act4" value="set_variable teleport_faint:spyder_timber_center.tmx 7 10"/>
+    <property name="act3" value="set_variable battle_last_result:none"/>
     <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
+++ b/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="16" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="73">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="16" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="75">
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>
  </tileset>
@@ -315,6 +315,20 @@
     <property name="act6" value="set_variable wayfarer1victor:yes"/>
     <property name="cond1" value="not variable_set wayfarer1victor:yes"/>
     <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="73" name="Exhausted" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport spyder_wayfarer_inn1.tmx,9,6,0.3"/>
+    <property name="cond1" value="is player_defeated"/>
+   </properties>
+  </object>
+  <object id="74" name="Auto Healing Teleported" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_monster_health ,"/>
+    <property name="act2" value="set_monster_status ,"/>
+    <property name="act3" value="set_variable battle_last_result:none"/>
+    <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_wayfarer_inn2.tmx
+++ b/mods/tuxemon/maps/spyder_wayfarer_inn2.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="16" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="50">
+<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="16" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="51">
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>
  </tileset>
@@ -224,6 +224,12 @@
     <property name="act6" value="set_variable wayfarer1bravo:yes"/>
     <property name="cond1" value="not variable_set wayfarer1bravo:yes"/>
     <property name="cond2" value="is player_at"/>
+   </properties>
+  </object>
+  <object id="50" name="Exhausted" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport spyder_wayfarer_inn1.tmx,9,6,0.3"/>
+    <property name="cond1" value="is player_defeated"/>
    </properties>
   </object>
  </objectgroup>


### PR DESCRIPTION
Related to #1247 and #1269. It involves the integration of healing during the teleport. This is important in scenarios where you cannot exit from a dungeon.

~~The code works, the monsters heal, but there are two problem:
1 the health bar of the monster is red (as if it was fainted)
2 if the player exits from the center to go to another map (eg. routes or location with battles), then the player is unable to use teleport and it's stuck inside a map.
3 if you lose the random_encounter or battle, then the player gets teleported (correctly) but it's stuck inside the center.
Point 2 and 3 don't happen if the player, after getting teleported, heal again the monsters inside the center~~

**Update:**
Fixed autohealing and defined the following mechanism:

```
spyder_cotton_cafe -> set variable teleport_faint
spyder_leather_center -> set variable teleport_faint
```
_if you faint, then you'll get teleported back there - close by_
```
spyder_scoop1 -> teleport faint
spyder_scoop2 -> autohealing and set variable spyder_scoop2
spyder_scoop3 -> teleport faint -> spyder_scoop2
spyder_scoop4 -> teleport faint -> spyder_scoop2
```
_eg someone faints in scoop1, is teleported to the last center_
_eg someone faints in scoop3, is teleported to scoop2, auto heals in scoop2, then can choose if progress or go back to the city_
_eg someone faints in scoop4, is teleported to scoop2, auto heals in scoop2, then can choose if progress or go back to the city_

_**spyder_dragonscave -> teleport faint**_

_as requested, if you faint, then you'll be teleported back to the last center, no autohealing on place, you'll get autohealing in the center_
```
spyder_wayfarer_inn1 -> teleport faint close to the nurse + autohealing
spyder_wayfarer_inn2 -> teleport faint in spyder_wayfarer_inn1 (+ autohealing)
```
- autohealing in spyder_wayfarer_inn1
- no setting of teleport_faint variable
- if you faint, then you'll be teleported close to the nurse

