### PR TITLE
flatpak manifest not available as artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -219,6 +219,5 @@ jobs:
           automatic_release_tag: ${{ steps.release_tag.outputs.value }}
           files: |
             **/artifacts/tuxemon_windows_installer/*.exe
-            **/artifacts/Tuxemon Flatpak/org.tuxemon.Tuxemon.yml
             **/Tuxemon-x86_64/Tuxemon.flatpak
 ...


### PR DESCRIPTION
Fixes annotation error in the CI
![image](https://user-images.githubusercontent.com/10099533/189996300-359078ab-4890-47fa-954d-04692fd4acc3.png)
