### PR TITLE
Maybe_translate and replace

### DIFF
--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -980,9 +980,14 @@ class CombatState(CombatAnimations):
                     msg_type = (
                         "use_success" if result["success"] else "use_failure"
                     )
+                    context = {
+                        "user": getattr(user, "name", ""),
+                        "name": technique.name,
+                        "target": target.name,
+                    }
                     template = getattr(technique, msg_type)
                     if template:
-                        message += "\n" + T.translate(template)
+                        message += "\n" + T.format(template, context)
 
             self.alert(message)
             self.suppress_phase_change(action_time)


### PR DESCRIPTION
I discovered it after working on #1331 

1. The strings in _use_success_  as well as _use_failure_ weren't properly treated.  Eg {user} wasn't replaced, now it's replaced.

~~Getting rid of **maybe_translate** for **translate**, and since there are no other uses of maybe_translate, I have deleted it from **locale.py**.
I understand that the function was there because, I guess, the null value in use_success. About this we can utilize a similar function to use_tech. It was combat X on Y.~~ I'm not sure about what I wrote, because until now it works fine.

![maybe_translate](https://user-images.githubusercontent.com/64643719/190896724-101f9a21-18fe-42bb-bf40-a2b56a5a5eeb.png)