### PR TITLE
fix status_poison

### DIFF
--- a/mods/tuxemon/db/technique/status_poison.json
+++ b/mods/tuxemon/db/technique/status_poison.json
@@ -1,8 +1,8 @@
 {
   "tech_id": 95,
   "slug": "status_poison",
-  "use_tech": "combat_used_x",
-  "use_success": "generic_success",
+  "use_tech": "combat_state_poison_damage",
+  "use_success": "combat_state_poison_get",
   "use_failure": "generic_failure",
   "animation": "drip_green",
   "sfx": "sfx_pulse",


### PR DESCRIPTION
Connected to the previous #1331 :
1. Fix status_poison.json

About status_poison.json, these two strings were buried in po files and unused:
```
msgid "combat_state_poison_get"
msgstr "{target} is poisoned."
msgid "combat_state_poison_damage"
msgstr "{name} took poison damage!"
```
status_poison before
```
status_poison before
  "use_tech": "combat_used_x",
  "use_success": "generic_success",
  "use_failure": "generic_failure",
```
status_poison after
```
  "use_tech": "combat_state_poison_damage",
  "use_success": "combat_state_poison_get",
  "use_failure": "generic_failure",
```