### PR TITLE
evolution and evolved by item

### DIFF
--- a/tuxemon/item/conditions/has_path.py
+++ b/tuxemon/item/conditions/has_path.py
@@ -1,0 +1,52 @@
+#
+# Tuxemon
+# Copyright (c) 2014-2017 William Edwards <shadowapex@gmail.com>,
+#                         Benjamin Bean <superman2k5@gmail.com>
+#
+# This file is part of Tuxemon
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Contributor(s):
+#
+# Adam Chevalier <chevalieradam2@gmail.com>
+#
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+from tuxemon.item.itemcondition import ItemCondition
+from tuxemon.monster import Monster
+
+
+class HasPathConditionParameters(NamedTuple):
+    expected: str
+
+
+class HasPathCondition(ItemCondition[HasPathConditionParameters]):
+    """
+    Checks against the creature's evolution paths.
+
+    Accepts a single parameter and returns whether it is applied.
+
+    """
+
+    name = "has_path"
+    param_class = HasPathConditionParameters
+
+    def test(self, target: Monster) -> bool:
+        expect = self.parameters.expected
+
+        return any(d["path"] == expect for d in target.evolutions)

--- a/tuxemon/item/conditions/level.py
+++ b/tuxemon/item/conditions/level.py
@@ -1,0 +1,67 @@
+#
+# Tuxemon
+# Copyright (c) 2014-2017 William Edwards <shadowapex@gmail.com>,
+#                         Benjamin Bean <superman2k5@gmail.com>
+#
+# This file is part of Tuxemon
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Contributor(s):
+#
+# Adam Chevalier <chevalieradam2@gmail.com>
+#
+
+from __future__ import annotations
+
+from operator import eq, ge, gt, le, lt
+from typing import Callable, Mapping, NamedTuple, Optional
+
+from tuxemon.item.itemcondition import ItemCondition
+from tuxemon.monster import Monster
+
+cmp_dict: Mapping[Optional[str], Callable[[float, float], bool]] = {
+    None: ge,
+    "<": lt,
+    "<=": le,
+    ">": gt,
+    ">=": ge,
+    "==": eq,
+    "=": eq,
+}
+
+
+class LevelConditionParameters(NamedTuple):
+    comparison: str
+    value: int
+
+
+class LevelCondition(ItemCondition[LevelConditionParameters]):
+    """
+    Compares the target Monster's level against the given value.
+
+    Example: To make an item only usable if a monster is at a
+    certain level, you would use the condition "level target,<,5"
+
+    """
+
+    name = "level"
+    param_class = LevelConditionParameters
+
+    def test(self, target: Monster) -> bool:
+        level = target.level
+        operator = cmp_dict[self.parameters.comparison]
+        level_reached = self.parameters.value
+
+        return operator(level, level_reached)

--- a/tuxemon/item/effects/evolve.py
+++ b/tuxemon/item/effects/evolve.py
@@ -1,0 +1,54 @@
+#
+# Tuxemon
+# Copyright (c) 2014-2017 William Edwards <shadowapex@gmail.com>,
+#                         Benjamin Bean <superman2k5@gmail.com>
+#
+# This file is part of Tuxemon
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Contributor(s):
+# Adam Chevalier <chevalieradam2@gmail.com>
+#
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
+from tuxemon.monster import Monster
+
+
+class EvolveEffectResult(ItemEffectResult):
+    pass
+
+
+class EvolveEffectParameters(NamedTuple):
+    monster_evolve: str
+
+
+class EvolveEffect(ItemEffect[EvolveEffectParameters]):
+    """This effect evolves the target into the monster in the parameters."""
+
+    name = "evolve"
+    param_class = EvolveEffectParameters
+
+    def apply(self, target: Monster) -> EvolveEffectResult:
+        monster_evolve = self.parameters.monster_evolve
+
+        if any(d["monster_slug"] == monster_evolve for d in target.evolutions):
+            self.user.evolve_monster(target, monster_evolve)
+            return {"success": True}
+        else:
+            return {"success": False}

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -754,6 +754,34 @@ class NPC(Entity[NPCState]):
             self.monsters.remove(monster)
             self.set_party_status()
 
+    def evolve_monster(self, old_monster: Monster, evolution: str) -> None:
+        """
+        Evolve a monster from this npc's party.
+
+        Parameters:
+            old_monster: Monster to remove from the npc's party.
+            evolution: Monster to add to the npc's party.
+
+        """
+        if old_monster not in self.monsters:
+            return
+
+        # TODO: implement an evolution animation
+        slot = self.monsters.index(old_monster)
+        new_monster = Monster()
+        new_monster.load_from_db(evolution)
+        new_monster.set_level(old_monster.level)
+        new_monster.current_hp = min(old_monster.current_hp, new_monster.hp)
+        new_monster.moves = old_monster.moves
+        new_monster.instance_id = old_monster.instance_id
+        self.monsters[slot] = new_monster
+
+        # If evolution has a flair matching, copy it
+        for new_flair in new_monster.flairs.values():
+            for old_flair in old_monster.flairs.values():
+                if new_flair.category == old_flair.category:
+                    new_monster.flairs[new_flair.category] = old_flair
+
     def remove_monster_from_storage(self, monster: Monster) -> None:
         """
         Removes the monster from the npc's storage.

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -472,6 +472,7 @@ class CombatState(CombatAnimations):
         elif phase == "end combat":
             self.players[0].set_party_status()
             self.end_combat()
+            self.evolve()
 
         else:
             assert_never(phase)
@@ -1148,6 +1149,21 @@ class CombatState(CombatAnimations):
         # TODO: non SP things
         del self.monsters_in_play[player]
         self.players.remove(player)
+
+    def evolve(self) -> None:
+        for monster in self.players[0].monsters:
+            for evolution in monster.evolutions:
+                # check the path field, path field signals evolution item based
+                if not evolution["path"]:
+                    if evolution["at_level"] <= monster.level:
+                        logger.info(
+                            "{} evolved into {}!".format(
+                                monster.name, evolution["monster_slug"]
+                            )
+                        )
+                        self.players[0].evolve_monster(
+                            monster, evolution["monster_slug"]
+                        )
 
     def end_combat(self) -> None:
         """End the combat."""


### PR DESCRIPTION
This PR includes:
1. evolution through objects (like boosters);
2. related to the 1, I added the following object conditions: _has_path_ (to get the object) and _level_ (to get the level);
3. related to the 1, I added the _evolve_ object action, it allows to address the evolution;
4. evolution through combat (traditional evolution after leveling up, like rockitten that at level 24 evolves in rockat);

Already run with isort and black

What's missing?
1. evolution through stats (**katacoon** and **vivipere** cases);
2. evolution animation;
3. new object type #1334 

Inside the earth_booster.json object, something like this:
```
  "effects": [
    "evolve eruptibus"
  ],
  "conditions": [
    "level target,>=,0",
    "has_path target,earth_booster"
  ],
```