### PR TITLE
fix Amnesia technique

### DIFF
--- a/mods/tuxemon/db/technique/amnesia.json
+++ b/mods/tuxemon/db/technique/amnesia.json
@@ -13,7 +13,7 @@
   "potency": 1,
   "power": 2.25,
   "statdodge": {
-    "minvalue": 0, "max_deviation": 3, "operation":"-"
+    "value": 0, "max_deviation": 3, "operation":"-"
   },
   "statmelee": {
     "value": 2, "operation":"+"

--- a/tuxemon/technique.py
+++ b/tuxemon/technique.py
@@ -323,7 +323,7 @@ class Technique:
             self.statranged,
             self.statdodge,
         ]
-        statslugs = ["speed", "hp", "armour", "melee", "ranged", "dodge"]
+        statslugs = ["speed", "current_hp", "armour", "melee", "ranged", "dodge"]
         newstatvalue = 0
         for stat, slugdata in zip(statsmaster, statslugs):
             if not stat:
@@ -347,15 +347,12 @@ class Technique:
                     "/": operator.floordiv,
                 }
                 newstatvalue = ops_dict[operation](basestatvalue, value)
-                setattr(target, slugdata, newstatvalue)
-            if slugdata == "hp":
+            if slugdata == "current_hp":
                 if override:
                     target.current_hp = target.hp
-                newstatvalue = 1
-                setattr(target, slugdata, newstatvalue)
             if newstatvalue <= 0:
                 newstatvalue = 1
-                setattr(target, slugdata, newstatvalue)
+            setattr(target, slugdata, newstatvalue)
         return {"success": bool(newstatvalue)}
 
     def calculate_damage(


### PR DESCRIPTION
The use of Amnesia caused crash. Big impact, if we consider that Billie in Route2 - plot line battle - has in her party a monster with Amnesia. The crash was caused by this "minvalue". I thought it was fixed, but... I noticed that after using the technique something weird happened.

Cataspike HP bar
![Amensia 2022-09-21 09-06-58](https://user-images.githubusercontent.com/64643719/191440883-ceee36ec-7f8b-4465-b2c6-164acf6b4430.png)
This brought me to technique.py were there was the issue. It was caused by a misplaced newstatvalue = 1 and settattr.
![Amensia 2022-09-21 09-15-37](https://user-images.githubusercontent.com/64643719/191440898-9f95d603-f268-4647-89aa-25d0103efbdb.png)
I can return to hp instead of current_hp, but I think current_hp address the right field.
