### PR TITLE
get player party

### DIFF
--- a/tuxemon/event/actions/get_player_party.py
+++ b/tuxemon/event/actions/get_player_party.py
@@ -1,0 +1,60 @@
+#
+# Tuxemon
+# Copyright (c) 2020      William Edwards <shadowapex@gmail.com>,
+#                         Benjamin Bean <superman2k5@gmail.com>
+#
+# This file is part of Tuxemon
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Contributor(s):
+#
+# Adam Chevalier <chevalierAdam2@gmail.com>
+
+from __future__ import annotations
+
+from typing import NamedTuple, final
+
+from tuxemon.event.eventaction import EventAction
+
+
+class GetPlayerPartyActionParameters(NamedTuple):
+    pass
+
+
+@final
+class GetPlayerPartyAction(EventAction[GetPlayerPartyActionParameters]):
+    """
+    Store the party monsters ids in Slot(number) variable.
+    Slot0: instance_id, Slot1: instance_id, etc.
+
+    Script usage:
+        .. code-block::
+
+            get_player_party
+
+    """
+
+    name = "get_player_party"
+    param_class = GetPlayerPartyActionParameters
+
+    def start(self) -> None:
+        player = self.session.player
+        slot = 0
+
+        for monsters in player.monsters:
+            player.game_variables[
+                "slot" + str(slot)
+            ] = monsters.instance_id.hex
+            slot += 1


### PR DESCRIPTION
What is get_player_party? It's the upgraded version of get_player_monster.

**get_player_monster** helps you to store the instance_id in a variable of your choice, but get_player_monster opens a menu, you choose your monster, then your instance_id is associated to the variable (you need to come up with a name, but which name?)

**get_player_party** speeds things up for the modders. In one action you get all the instance_ids of the party. No need to choose your monster. No need to come up with a name for your variable.

You got 4 monsters, then you got this:
![Screenshot from 2022-09-21 09-59-10](https://user-images.githubusercontent.com/64643719/191451384-f16d5abe-9cb7-4810-97ad-b1d81ef53199.png)

I wanted to implement this format because it's simple and it updates automatically the slot variables if you run again the action, so there is no risk of creating other (unused) variables.

(run isort and black)