### PR TITLE
seen or caught

### DIFF
--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -99,6 +99,12 @@ class MonsterShape(str, Enum):
     varmint = "varmint"
 
 
+class SeenStatus(str, Enum):
+    unseen = "unseen"
+    seen = "seen"
+    caught = "caught"
+
+
 # TODO: Automatically generate state enum through discovery
 State = Enum(
     "State",

--- a/tuxemon/event/actions/add_monster.py
+++ b/tuxemon/event/actions/add_monster.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 from typing import NamedTuple, Optional, Union, final
 
 from tuxemon import monster
+from tuxemon.db import SeenStatus
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.npc import NPC
@@ -76,3 +77,4 @@ class AddMonsterAction(EventAction[AddMonsterActionParameters]):
         current_monster.current_hp = current_monster.hp
 
         trainer.add_monster(current_monster)
+        trainer.tuxepedia[monster_slug] = SeenStatus.caught.value

--- a/tuxemon/event/actions/add_monster.py
+++ b/tuxemon/event/actions/add_monster.py
@@ -77,4 +77,4 @@ class AddMonsterAction(EventAction[AddMonsterActionParameters]):
         current_monster.current_hp = current_monster.hp
 
         trainer.add_monster(current_monster)
-        trainer.tuxepedia[monster_slug] = SeenStatus.caught.value
+        trainer.tuxepedia[monster_slug] = SeenStatus.caught

--- a/tuxemon/event/actions/random_monster.py
+++ b/tuxemon/event/actions/random_monster.py
@@ -21,12 +21,11 @@
 
 from __future__ import annotations
 
-import os
 import random as rd
 from typing import NamedTuple, Optional, Union, final
 
 from tuxemon import monster
-from tuxemon.db import db
+from tuxemon.db import db, SeenStatus
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.npc import NPC
@@ -80,3 +79,4 @@ class RandomMonsterAction(EventAction[RandomMonsterActionParameters]):
         current_monster.current_hp = current_monster.hp
 
         trainer.add_monster(current_monster)
+        trainer.tuxepedia[monster_slug] = SeenStatus.caught.value

--- a/tuxemon/event/actions/random_monster.py
+++ b/tuxemon/event/actions/random_monster.py
@@ -25,7 +25,7 @@ import random as rd
 from typing import NamedTuple, Optional, Union, final
 
 from tuxemon import monster
-from tuxemon.db import db, SeenStatus
+from tuxemon.db import SeenStatus, db
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.npc import NPC
@@ -69,14 +69,14 @@ class RandomMonsterAction(EventAction[RandomMonsterActionParameters]):
         assert trainer, "No Trainer found with slug '{}'".format(
             trainer_slug or "player"
         )
-        
+
         # list is required as choice expects a sequence
         monster_slug = rd.choice(list(db.database["monster"]))
-      
+
         current_monster = monster.Monster()
         current_monster.load_from_db(monster_slug)
         current_monster.set_level(monster_level)
         current_monster.current_hp = current_monster.hp
 
         trainer.add_monster(current_monster)
-        trainer.tuxepedia[monster_slug] = SeenStatus.caught.value
+        trainer.tuxepedia[monster_slug] = SeenStatus.caught

--- a/tuxemon/event/actions/set_tuxepedia.py
+++ b/tuxemon/event/actions/set_tuxepedia.py
@@ -1,0 +1,61 @@
+#
+# Tuxemon
+# Copyright (c) 2014-2017 William Edwards <shadowapex@gmail.com>,
+#                         Benjamin Bean <superman2k5@gmail.com>
+#
+# This file is part of Tuxemon
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import annotations
+
+from typing import NamedTuple, final
+
+from tuxemon.event.eventaction import EventAction
+
+
+class SetTuxepediaActionParameters(NamedTuple):
+    monster_key: str
+    monster_str: str
+
+
+@final
+class SetTuxepediaAction(EventAction[SetTuxepediaActionParameters]):
+    """
+    Set the key and value in the Tuxepedia dictionary.
+
+    Script usage:
+        .. code-block::
+
+            set_tuxepedia <monster_slug>,<string>
+
+    Script parameters:
+        monster_slug: Monster slug name (e.g. "rockitten").
+        string: seen / caught
+
+    """
+
+    name = "set_tuxepedia"
+    param_class = SetTuxepediaActionParameters
+
+    def start(self) -> None:
+        player = self.session.player.tuxepedia
+
+        # Read the parameters
+        monster_key = self.parameters[0]
+        monster_str = self.parameters[1]
+
+        # Append the tuxepedia with a key
+        player[str(monster_key)] = monster_str

--- a/tuxemon/event/actions/set_tuxepedia.py
+++ b/tuxemon/event/actions/set_tuxepedia.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 from typing import NamedTuple, final
 
+from tuxemon.db import SeenStatus
 from tuxemon.event.eventaction import EventAction
 
 
@@ -58,4 +59,7 @@ class SetTuxepediaAction(EventAction[SetTuxepediaActionParameters]):
         monster_str = self.parameters[1]
 
         # Append the tuxepedia with a key
-        player[str(monster_key)] = monster_str
+        if monster_str == "caught":
+            player[str(monster_key)] = SeenStatus.caught
+        elif monster_str == "seen":
+            player[str(monster_key)] = SeenStatus.seen

--- a/tuxemon/event/actions/tuxepedia_print.py
+++ b/tuxemon/event/actions/tuxepedia_print.py
@@ -1,0 +1,64 @@
+#
+# Tuxemon
+# Copyright (c) 2014-2017 William Edwards <shadowapex@gmail.com>,
+#                         Benjamin Bean <superman2k5@gmail.com>
+#
+# This file is part of Tuxemon
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import annotations
+
+from typing import NamedTuple, Optional, final
+
+from tuxemon.event.eventaction import EventAction
+
+
+class TuxepediaPrintActionParameters(NamedTuple):
+    monster_slug: Optional[str]
+
+
+@final
+class TuxepediaPrintAction(EventAction[TuxepediaPrintActionParameters]):
+    """
+    Print the current value of Tuxepedia to the console.
+
+    If no monster is specified, print out values of all Tuxepedia.
+
+    Script usage:
+        .. code-block::
+
+            tuxepedia_print
+            tuxepedia_print <monster_slug>
+
+        Script parameters:
+            monster_slug: Monster slug name (e.g. "rockitten").
+
+    """
+
+    name = "tuxepedia_print"
+    param_class = TuxepediaPrintActionParameters
+
+    def start(self) -> None:
+        var = self.session.player.tuxepedia
+
+        monster_slug = self.parameters.monster_slug
+        if monster_slug:
+            if monster_slug in var:
+                print(f"{monster_slug}: {var[monster_slug]}")
+            else:
+                print(f"'{monster_slug}' has not been seen yet.")
+        else:
+            print(var)

--- a/tuxemon/event/conditions/tuxepedia_is.py
+++ b/tuxemon/event/conditions/tuxepedia_is.py
@@ -20,6 +20,7 @@
 #
 from __future__ import annotations
 
+from tuxemon.db import SeenStatus
 from tuxemon.event import MapCondition
 from tuxemon.event.eventcondition import EventCondition
 from tuxemon.session import Session
@@ -61,9 +62,11 @@ class TuxepediaIsCondition(EventCondition):
         monster_str = condition.parameters[1]
 
         if monster_key in player.tuxepedia:
-            if player.tuxepedia[monster_key] == monster_str:
-                return True
+            if monster_str == "caught":
+                if player.tuxepedia[monster_key] == SeenStatus.caught:
+                    return True
+            elif monster_str == "seen":
+                if player.tuxepedia[monster_key] == SeenStatus.seen:
+                    return True
             else:
                 return False
-        else:
-            return False

--- a/tuxemon/event/conditions/tuxepedia_is.py
+++ b/tuxemon/event/conditions/tuxepedia_is.py
@@ -68,5 +68,7 @@ class TuxepediaIsCondition(EventCondition):
             elif monster_str == "seen":
                 if player.tuxepedia[monster_key] == SeenStatus.seen:
                     return True
+                elif player.tuxepedia[monster_key] == SeenStatus.caught:
+                    return True
             else:
                 return False

--- a/tuxemon/event/conditions/tuxepedia_is.py
+++ b/tuxemon/event/conditions/tuxepedia_is.py
@@ -1,0 +1,69 @@
+#
+# Tuxemon
+# Copyright (c) 2014-2017 William Edwards <shadowapex@gmail.com>,
+#                         Benjamin Bean <superman2k5@gmail.com>
+#
+# This file is part of Tuxemon
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import annotations
+
+from tuxemon.event import MapCondition
+from tuxemon.event.eventcondition import EventCondition
+from tuxemon.session import Session
+
+
+class TuxepediaIsCondition(EventCondition):
+    """
+    Check to see if the player has seen or caught a monster.
+
+    Script usage:
+        .. code-block::
+
+            is tuxepedia_is <monster_slug>,<string>
+
+    Script parameters:
+        monster_slug: Monster slug name (e.g. "rockitten").
+        string: seen / caught
+
+    """
+
+    name = "tuxepedia_is"
+
+    def test(self, session: Session, condition: MapCondition) -> bool:
+        """
+        Check to see if the player has been seen or caught a monster.
+
+        Parameters:
+            session: The session object
+            condition: The map condition object.
+
+        Returns:
+            Whether the player has seen or caught a monster.
+
+        """
+        player = session.player
+
+        # Read the parameters
+        monster_key = condition.parameters[0]
+        monster_str = condition.parameters[1]
+
+        if monster_key in player.tuxepedia:
+            if player.tuxepedia[monster_key] == monster_str:
+                return True
+            else:
+                return False
+        else:
+            return False

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -51,7 +51,7 @@ from typing import (
 from tuxemon import surfanim
 from tuxemon.ai import AI
 from tuxemon.compat import Rect
-from tuxemon.db import db
+from tuxemon.db import db, SeenStatus
 from tuxemon.entity import Entity
 from tuxemon.graphics import load_and_scale
 from tuxemon.item.item import (
@@ -94,6 +94,7 @@ class NPCState(TypedDict):
     facing: Direction
     game_variables: Dict[str, Any]
     battle_history: Dict[str, Any]
+    tuxepedia: Dict[str, SeenStatus]
     money: Dict[str, int]
     inventory: Mapping[str, Optional[int]]
     monsters: Sequence[Mapping[str, Any]]
@@ -172,6 +173,8 @@ class NPC(Entity[NPCState]):
         self.behavior: Optional[str] = "wander"  # not used for now
         self.game_variables: Dict[str, Any] = {}  # Tracks the game state
         self.battle_history: Dict[str, Any] = {}  # Tracks the battles
+        # Tracks Tuxepedia (monster seen or caught)
+        self.tuxepedia: Dict[str, SeenStatus] = {}
         self.money: Dict[str, int] = {}  # Tracks money
         self.interactions: Sequence[
             str
@@ -265,6 +268,7 @@ class NPC(Entity[NPCState]):
             "facing": self.facing,
             "game_variables": self.game_variables,
             "battle_history": self.battle_history,
+            "tuxepedia": self.tuxepedia,
             "money": self.money,
             "inventory": encode_inventory(self.inventory),
             "monsters": encode_monsters(self.monsters),
@@ -294,6 +298,7 @@ class NPC(Entity[NPCState]):
         self.facing = save_data.get("facing", "down")
         self.game_variables = save_data["game_variables"]
         self.battle_history = save_data["battle_history"]
+        self.tuxepedia = save_data["tuxepedia"]
         self.money = save_data["money"]
         self.inventory = decode_inventory(
             session, self, save_data.get("inventory", {})
@@ -780,6 +785,9 @@ class NPC(Entity[NPCState]):
         new_monster.instance_id = old_monster.instance_id
         self.remove_monster(old_monster)
         self.add_monster(new_monster, slot)
+        
+        # set evolution as caught
+        self.tuxepedia[evolution] = SeenStatus.caught.value
 
         # If evolution has a flair matching, copy it
         for new_flair in new_monster.flairs.values():

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -51,7 +51,7 @@ from typing import (
 from tuxemon import surfanim
 from tuxemon.ai import AI
 from tuxemon.compat import Rect
-from tuxemon.db import db, SeenStatus
+from tuxemon.db import SeenStatus, db
 from tuxemon.entity import Entity
 from tuxemon.graphics import load_and_scale
 from tuxemon.item.item import (
@@ -785,9 +785,9 @@ class NPC(Entity[NPCState]):
         new_monster.instance_id = old_monster.instance_id
         self.remove_monster(old_monster)
         self.add_monster(new_monster, slot)
-        
+
         # set evolution as caught
-        self.tuxepedia[evolution] = SeenStatus.caught.value
+        self.tuxepedia[evolution] = SeenStatus.caught
 
         # If evolution has a flair matching, copy it
         for new_flair in new_monster.flairs.values():

--- a/tuxemon/save_upgrader.py
+++ b/tuxemon/save_upgrader.py
@@ -89,7 +89,10 @@ def upgrade_save(save_data: Dict[str, Any]) -> SaveData:
     # set as captured the party monsters
     if not save_data["tuxepedia"]:
         for mons in save_data.get("monsters", []):
-            save_data["tuxepedia"][mons["slug"]] = SeenStatus.caught.value
+            save_data["tuxepedia"][mons["slug"]] = SeenStatus.caught
+        for monsters in save_data.get("monster_boxes", {}).values():
+            for monster in monsters:
+                save_data["tuxepedia"][monster["slug"]] = SeenStatus.caught
 
     # set money old savegame and avoid getting the starter
     if not save_data["money"]:

--- a/tuxemon/save_upgrader.py
+++ b/tuxemon/save_upgrader.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Dict, Mapping
 
+from tuxemon.db import SeenStatus
 from tuxemon.prepare import CONFIG
 
 if TYPE_CHECKING:
@@ -83,6 +84,12 @@ def upgrade_save(save_data: Dict[str, Any]) -> SaveData:
 
     save_data["battle_history"] = save_data.get("battle_history", {})
     save_data["money"] = save_data.get("money", {})
+    save_data["tuxepedia"] = save_data.get("tuxepedia", {})
+
+    # set as captured the party monsters
+    if not save_data["tuxepedia"]:
+        for mons in save_data.get("monsters", []):
+            save_data["tuxepedia"][mons["slug"]] = SeenStatus.caught.value
 
     # set money old savegame and avoid getting the starter
     if not save_data["money"]:

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -381,7 +381,7 @@ class CombatState(CombatAnimations):
                 var["battle_last_monster_category"] = monster_record.category
                 var["battle_last_monster_shape"] = monster_record.shape
                 # Avoid reset string to seen if monster has already been caught
-                if monster_record.slug not in self.players[0].tuxepedia.keys():
+                if monster_record.slug not in self.players[0].tuxepedia:
                     self.players[0].tuxepedia[monster_record.slug] = SeenStatus.seen.value
 
         elif phase == "decision phase":

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -56,6 +56,7 @@ from pygame.rect import Rect
 from tuxemon import audio, graphics, state, tools
 from tuxemon.animation import Task
 from tuxemon.combat import check_status, defeated, fainted, get_awake_monsters
+from tuxemon.db import SeenStatus
 from tuxemon.item.item import Item
 from tuxemon.locale import T
 from tuxemon.menu.interface import MenuItem
@@ -379,6 +380,9 @@ class CombatState(CombatAnimations):
                 var["battle_last_monster_type"] = monster_record.slug
                 var["battle_last_monster_category"] = monster_record.category
                 var["battle_last_monster_shape"] = monster_record.shape
+                # Avoid reset string to seen if monster has already been caught
+                if monster_record.slug not in self.players[0].tuxepedia.keys():
+                    self.players[0].tuxepedia[monster_record.slug] = SeenStatus.seen.value
 
         elif phase == "decision phase":
             self.reset_status_icons()
@@ -977,6 +981,10 @@ class CombatState(CombatAnimations):
                     # TODO: Don't end combat right away; only works with SP,
                     # and 1 member parties end combat right here
                     if result["success"]:
+                        # Tuxepedia: set monster as caught (2)
+                        self.players[0].tuxepedia[
+                            self.monsters_in_play[self.players[1]][0].slug
+                        ] = SeenStatus.caught.value
                         # Display 'Gotcha!' first.
                         self.task(self.end_combat, action_time + 0.5)
                         self.task(

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -382,7 +382,9 @@ class CombatState(CombatAnimations):
                 var["battle_last_monster_shape"] = monster_record.shape
                 # Avoid reset string to seen if monster has already been caught
                 if monster_record.slug not in self.players[0].tuxepedia:
-                    self.players[0].tuxepedia[monster_record.slug] = SeenStatus.seen.value
+                    self.players[0].tuxepedia[
+                        monster_record.slug
+                    ] = SeenStatus.seen
 
         elif phase == "decision phase":
             self.reset_status_icons()
@@ -983,8 +985,8 @@ class CombatState(CombatAnimations):
                     if result["success"]:
                         # Tuxepedia: set monster as caught (2)
                         self.players[0].tuxepedia[
-                            self.monsters_in_play[self.players[1]][0].slug
-                        ] = SeenStatus.caught.value
+                            target.slug
+                        ] = SeenStatus.caught
                         # Display 'Gotcha!' first.
                         self.task(self.end_combat, action_time + 0.5)
                         self.task(

--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -387,6 +387,7 @@ class WorldState(state.State):
         logger.debug("Player Variables:" + str(self.player.game_variables))
         logger.debug("Battle History:" + str(self.player.battle_history))
         logger.debug("Money:" + str(self.player.money))
+        logger.debug("Tuxepedia:" + str(self.player.tuxepedia))
 
     def draw(self, surface: pygame.surface.Surface) -> None:
         """


### PR DESCRIPTION
It was a request from #1121 

Implementing a dictionary that allows to track the monsters seen or caught, and obviously unseen if there is no value. I opted for an int, because maybe in a future someone can expand the "levels". At the moment there is seen (1) and caught (2).

As usual the fix for add_monster and random_monster, included evolve_monster. Save_upgrader that automatically set caught (2) your monsters as well as in combat.py for a capture result. A couple of actions and one condition for modders.