### PR TITLE
set_gender

### DIFF
--- a/mods/tuxemon/db/npc/spyder_route3_wanda.json
+++ b/mods/tuxemon/db/npc/spyder_route3_wanda.json
@@ -4,7 +4,7 @@
   "sprite_name": "fisher",
   "monsters": [
     {
-      "name": "Nudiflot M",
+      "name": "Nudiflot",
       "level": 8,
       "slug": "nudiflot_male",
       "exp_give_mod": 3,
@@ -12,7 +12,7 @@
       "gender": "male"
     },
     {
-      "name": "Nudiflot F",
+      "name": "Nudiflot",
       "level": 8,
       "slug": "nudiflot_female",
       "exp_give_mod": 3,
@@ -20,7 +20,7 @@
       "gender": "female"
     },
     {
-      "name": "Nudiflot M",
+      "name": "Nudiflot",
       "level": 8,
       "slug": "nudiflot_male",
       "exp_give_mod": 3,
@@ -28,7 +28,7 @@
       "gender": "male"
     },
     {
-      "name": "Nudiflot F",
+      "name": "Nudiflot",
       "level": 8,
       "slug": "nudiflot_female",
       "exp_give_mod": 3,
@@ -36,7 +36,7 @@
       "gender": "female"
     },
     {
-      "name": "Nudiflot M",
+      "name": "Nudiflot",
       "level": 8,
       "slug": "nudiflot_male",
       "exp_give_mod": 3,
@@ -44,7 +44,7 @@
       "gender": "male"
     },
     {
-      "name": "Nudiflot F",
+      "name": "Nudiflot",
       "level": 8,
       "slug": "nudiflot_female",
       "exp_give_mod": 3,

--- a/mods/tuxemon/db/npc/spyder_searoutec_gil.json
+++ b/mods/tuxemon/db/npc/spyder_searoutec_gil.json
@@ -4,7 +4,7 @@
   "sprite_name": "swimmer",
   "monsters": [
     {
-      "name": "Nudiflot F",
+      "name": "Nudiflot",
       "level": 22,
       "slug": "nudiflot_female",
       "exp_give_mod": 3,
@@ -12,7 +12,7 @@
       "gender": "female"
     },
     {
-      "name": "Nudiflot F",
+      "name": "Nudiflot",
       "level": 22,
       "slug": "nudiflot_female",
       "exp_give_mod": 3,

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -1569,13 +1569,13 @@ msgid "nudiflot_female_description"
 msgstr "It eats and stores the poison of the sea creatures that it feeds upon."
 
 msgid "nudiflot_female"
-msgstr "Nudiflot (F)"
+msgstr "Nudiflot"
 
 msgid "nudiflot_male_description"
 msgstr "Its feathery antennas snap off if it is attacked, confusing the predator."
 
 msgid "nudiflot_male"
-msgstr "Nudiflot (M)"
+msgstr "Nudiflot"
 
 msgid "nudikill_description"
 msgstr "They are called Dark Bishops because their heads are reminiscent of a bishop's hat."

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -63,6 +63,7 @@ SIMPLE_PERSISTANCE_ATTRIBUTES = (
     "status",
     "total_experience",
     "flairs",
+    "gender",
 )
 
 SHAPES = {
@@ -338,7 +339,7 @@ class Monster:
         self.txmn_id = results.txmn_id
         self.height = results.height
         self.weight = results.weight
-        self.possible_genders = results.possible_genders
+        self.gender = random.choice(list(results.possible_genders))
         self.catch_rate = (
             results.catch_rate
             or TuxemonConfig().default_monster_catch_rate

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -836,7 +836,7 @@ class NPC(Entity[NPCState]):
             )
             monster.set_level(monster.level)
             monster.current_hp = monster.hp
-            monster.possible_genders = npc_monster_details.gender
+            monster.gender = npc_monster_details.gender
 
             # Add our monster to the NPC's party
             self.add_monster(monster)

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -778,6 +778,7 @@ class NPC(Entity[NPCState]):
         new_monster.current_hp = min(old_monster.current_hp, new_monster.hp)
         new_monster.moves = old_monster.moves
         new_monster.instance_id = old_monster.instance_id
+        new_monster.gender = old_monster.gender
         self.remove_monster(old_monster)
         self.add_monster(new_monster, slot)
 
@@ -835,6 +836,7 @@ class NPC(Entity[NPCState]):
             )
             monster.set_level(monster.level)
             monster.current_hp = monster.hp
+            monster.possible_genders = npc_monster_details.gender
 
             # Add our monster to the NPC's party
             self.add_monster(monster)

--- a/tuxemon/states/combat/combat_animations.py
+++ b/tuxemon/states/combat/combat_animations.py
@@ -377,7 +377,15 @@ class CombatAnimations(ABC, Menu[None]):
             Surface with the name and level of the monster written.
 
         """
-        return self.shadow_text(f"{monster.name: <12}Lv.{monster.level: >2}")
+        if monster.gender == "male":
+            icon = "(M)"
+        elif monster.gender == "female":
+            icon = "(F)"
+        else:
+            icon = "(N)"
+        return self.shadow_text(
+            f"{monster.name+icon: <12}Lv.{monster.level: >2}"
+        )
 
     def get_side(self, rect: Rect) -> Literal["left", "right"]:
         """

--- a/tuxemon/states/monster/__init__.py
+++ b/tuxemon/states/monster/__init__.py
@@ -221,9 +221,15 @@ class MonsterMenuState(Menu[Optional[Monster]]):
         self.hp_bar.value = monster.current_hp / monster.hp
         self.hp_bar.draw(surface, hp_rect)
 
-        # draw the name
+        # draw the name + gender
+        if monster.gender == "male":
+            icon = "(M)"
+        elif monster.gender == "female":
+            icon = "(F)"
+        else:
+            icon = "(N)"
         text_rect = rect.inflate(-tools.scale(6), -tools.scale(6))
-        draw_text(surface, monster.name, text_rect, font=self.font)
+        draw_text(surface, monster.name + icon, text_rect, font=self.font)
 
         # draw the level info
         text_rect.top = rect.bottom - tools.scale(7)


### PR DESCRIPTION
Following #1354

**(1) integrate set_gender inside the add_monster function (the main one in npc.py) --> draft is based on this**

Files:
- addition of (M), (F) and (N) close the name in the menu (screenshot);
- addition of (M), (F) and (N) close the name in the combat menu (screenshot);
- gender among SIMPLE_PERSISTANCE_ATTRIBUTES, it saves correctly, there are no problems with old versions;
- inserted line in evolve, because if not there was the risk of changing gender after the evolution;
- inserted monster.possible_genders = npc_monster_details.gender so there is the correct display of the adversary gender (trainer battles);
- fixed Nudiflot male and female because of Nudiflot (M) (M) or (F) (F);
- make validate no problems

-> I tried to use ♂, etc, but I got **?** as result (symbol 1 character, (N) 3 characters)
chr(9794)  # ♂ unicodedata.lookup("MALE SIGN")
chr(9792)  # ♀unicodedata.lookup("FEMALE SIGN") 
chr(9906)  # ⚲ unicodedata.lookup("NEUTER") 
It looks like the font doesn't support the symbol.

Monster menu
![Screenshot from 2022-09-28 21-28-27](https://user-images.githubusercontent.com/64643719/192871742-52530f80-731b-42bf-a384-6ccc5b015643.png)
Battle menu
![Screenshot from 2022-09-28 10-56-36](https://user-images.githubusercontent.com/64643719/192736332-f13a173a-cd2b-4a02-a2fd-664987772fec.png)
