### PR TITLE
fix moves

### DIFF
--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -512,6 +512,12 @@ class Monster:
         self.total_experience = self.experience_required()
         self.set_stats()
 
+        # Update moves
+        self.moves = []
+        for move in self.moveset:
+            if move not in self.moves and move.level_learned <= level:                
+                self.learn(Technique(move.technique))
+
     def experience_required(self, level_ofs: int = 0) -> int:
         """
         Gets the experience requirement for the given level.

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -513,7 +513,6 @@ class Monster:
         self.set_stats()
 
         # Update moves
-        self.moves = []
         for move in self.moveset:
             if move not in self.moves and move.level_learned <= level:                
                 self.learn(Technique(move.technique))


### PR DESCRIPTION
I was working on #1365 and I needed to test overfeed. So I used **add_monster aardorn,18**, because the level_learned is 11 for overfeed, but I noticed the following behavior. This PR is only for the actions, I don't know if we need to apply it somewhere else or maybe create a separate function.

Before. Why? because of the **load_from_db**, since the level is **random.randint(2, 5)**, it gives you the moves in this range, so 1 or 2 moves (it depends if you're lucky in the randint).
![Screenshot from 2022-10-02 11-55-04](https://user-images.githubusercontent.com/64643719/193448391-99a53fe5-8e25-4814-b047-fedf873bd889.png)

After the PR, since the level is 18:
![Screenshot from 2022-10-02 11-43-17](https://user-images.githubusercontent.com/64643719/193448389-60815718-0714-45d6-a5be-0932a242fc90.png)