### PR TITLE
fix sell item

### DIFF
--- a/tuxemon/event/actions/open_shop.py
+++ b/tuxemon/event/actions/open_shop.py
@@ -27,7 +27,7 @@ from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.item.economy import Economy
 from tuxemon.states.choice import ChoiceState
-from tuxemon.states.items import ShopBuyMenuState, ShopMenuState
+from tuxemon.states.items import ShopBuyMenuState, ShopSellMenuState
 from tuxemon.tools import assert_never
 
 
@@ -74,7 +74,7 @@ class OpenShopAction(EventAction[OpenShopActionParameters]):
 
         def push_sell_menu():
             self.session.client.push_state(
-                ShopMenuState,
+                ShopSellMenuState,
                 buyer=None,
                 seller=self.session.player,
                 economy=economy,

--- a/tuxemon/menu/quantity.py
+++ b/tuxemon/menu/quantity.py
@@ -23,6 +23,7 @@ class QuantityMenu(Menu[None]):
         callback: Optional[Callable[[int], None]] = None,
         shrink_to_items: bool = False,
         price: int = 0,
+        cost: int = 0,
         **kwargs: Any,
     ) -> None:
         """
@@ -39,6 +40,7 @@ class QuantityMenu(Menu[None]):
         super().startup()
         self.quantity = quantity
         self.price = price
+        self.cost = cost
         self.max_quantity = max_quantity
         assert callback
         self.callback = callback
@@ -119,5 +121,30 @@ class QuantityAndPriceMenu(QuantityMenu):
             price = T.translate("shop_buy_free")
 
         formatted_name = label_format(price, count_len=count_len)
+        image = self.shadow_text(formatted_name, bg=(128, 128, 128))
+        yield MenuItem(image, formatted_name, None, None)
+
+
+class QuantityAndCostMenu(QuantityMenu):
+    """Menu used to select quantities, and also shows the cost of items."""
+
+    def on_open(self) -> None:
+        # Do this to force the menu to resize when first opened, as currently
+        # it's way too big initially and then resizes after you change quantity.
+        self.menu_items.arrange_menu_items()
+
+    def initialize_items(self) -> Generator[MenuItem[None], None, None]:
+        # Show the quantity by using the method from the parent class:
+        yield from super().initialize_items()
+
+        # Now, show the cost:
+        label_format = "$ {:>{count_len}}".format
+        count_len = 3
+
+        cost = self.cost if self.quantity == 0 else self.quantity * self.cost
+        if int(cost) == 0:
+            cost = T.translate("shop_buy_free")
+
+        formatted_name = label_format(cost, count_len=count_len)
         image = self.shadow_text(formatted_name, bg=(128, 128, 128))
         yield MenuItem(image, formatted_name, None, None)

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -912,11 +912,9 @@ class NPC(Entity[NPCState]):
         qty: int,
         unit_price: int,
     ) -> None:
-        """Decreases current money during a buy transaction, but doesn't change
-        an item's quantity.
-
-        Raises an exception if there's not enough money to pay the price."""
-
+        """
+        Decreases player money during a buy transaction.
+        """
         # Update player's money.
         if self.money.get("player"):
             if not self.can_buy_item(item_slug, qty, unit_price):
@@ -939,10 +937,9 @@ class NPC(Entity[NPCState]):
         qty: int,
         unit_price: int,
     ) -> None:
-        """Increases current money during a sell transaction, but doesn't change
-        an item's quantity.
-
-        Raises an exception if there's not enough items in the inventory."""
+        """
+        Increases player money during a sell transaction.
+        """
         current_item = self.inventory.get(item_slug)
         if not current_item or not self.can_sell_item(
             item_slug, qty, unit_price
@@ -965,11 +962,9 @@ class NPC(Entity[NPCState]):
         qty: int,
         unit_price: int,
     ) -> None:
-        """Handles the entire buy transaction, for both this NPC (the
-        buyer) and the seller.
-
-        Raises an exception if the transaction can't be completed."""
-
+        """
+        Handles the entire buy transaction, NPC (seller) and buyer.
+        """
         self.buy_decrease_money(session, seller, item_slug, qty, unit_price)
         self.alter_item_quantity(session, item_slug, qty)
         seller.alter_item_quantity(session, item_slug, -qty)
@@ -982,11 +977,9 @@ class NPC(Entity[NPCState]):
         qty: int,
         unit_price: int,
     ) -> None:
-        """Handles the entire sell transaction, for both this NPC (the
-        buyer) and the seller.
-
-        Raises an exception if the transaction can't be completed."""
-
+        """
+        Handles the entire sell transaction, NPC (buyer) and seller.
+        """
         seller.sell_increase_money(session, self, item_slug, qty, unit_price)
         seller.alter_item_quantity(session, item_slug, -qty)
 

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -972,12 +972,27 @@ class NPC(Entity[NPCState]):
         qty: int,
         unit_price: int,
     ) -> None:
-        """Handles the entire buy/sell transaction, for both this NPC (the
+        """Handles the entire buy transaction, for both this NPC (the
         buyer) and the seller.
 
         Raises an exception if the transaction can't be completed."""
 
         self.buy_decrease_money(session, seller, item_slug, qty, unit_price)
+        seller.give_item(session, self, db.lookup(item_slug, "item"), qty)
+
+    def sell_transaction(
+        self,
+        session: Session,
+        seller: NPC,
+        item_slug: str,
+        qty: int,
+        unit_price: int,
+    ) -> None:
+        """Handles the entire sell transaction, for both this NPC (the
+        buyer) and the seller.
+
+        Raises an exception if the transaction can't be completed."""
+
         seller.sell_increase_money(session, self, item_slug, qty, unit_price)
         seller.give_item(session, self, db.lookup(item_slug, "item"), qty)
 

--- a/tuxemon/states/items/__init__.py
+++ b/tuxemon/states/items/__init__.py
@@ -40,7 +40,11 @@ from tuxemon.item.item import InventoryItem, Item
 from tuxemon.locale import T
 from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.menu import Menu
-from tuxemon.menu.quantity import QuantityAndPriceMenu, QuantityMenu
+from tuxemon.menu.quantity import (
+    QuantityAndCostMenu,
+    QuantityAndPriceMenu,
+    QuantityMenu,
+)
 from tuxemon.monster import Monster
 from tuxemon.session import local_session
 from tuxemon.sprite import Sprite
@@ -50,6 +54,7 @@ from tuxemon.ui.text import TextArea
 # The import is required for PushState to work.
 # But linters may say the import is unused.
 assert QuantityMenu
+assert QuantityAndCostMenu
 assert QuantityAndPriceMenu
 
 
@@ -290,48 +295,6 @@ class ShopMenuState(Menu[Item]):
         rect.height = int(self.rect.height * 0.60)
         return rect
 
-    def on_menu_selection(self, menu_item: MenuItem[Item]) -> None:
-        """
-        Called when player has selected something from the inventory.
-
-        Currently, opens a new menu depending on the state context.
-
-        Parameters:
-            menu_item: Selected menu item.
-
-        """
-        item = menu_item.game_object
-
-        def use_item(quantity: int) -> None:
-            if not quantity:
-                return
-
-            if self.buyer:
-                self.seller.give_item(self.client, self.buyer, item, quantity)
-            else:
-                self.seller.alter_item_quantity(
-                    self.client,
-                    item.slug,
-                    -quantity,
-                )
-            self.reload_items()
-            if not self.seller.has_item(item.slug):
-                # We're pointing at a new item
-                self.on_menu_selection_change()
-
-        item_dict = self.seller.inventory[item.slug]
-        max_quantity = (
-            None if item_dict.get("infinite") else item_dict["quantity"]
-        )
-
-        self.client.push_state(
-            QuantityMenu,
-            callback=use_item,
-            max_quantity=max_quantity,
-            quantity=1,
-            shrink_to_items=True,
-        )
-
     def initialize_items(self) -> Generator[MenuItem[Item], None, None]:
         """Get all player inventory items and add them to menu."""
         inventory = [
@@ -434,4 +397,54 @@ class ShopBuyMenuState(ShopMenuState):
             quantity=0 if max_quantity == 0 else 1,
             shrink_to_items=True,
             price=price,
+        )
+
+
+class ShopSellMenuState(ShopMenuState):
+    """This is the state for when a player wants to buy something."""
+
+    def on_menu_selection(self, menu_item: MenuItem[Item]) -> None:
+        """
+        Called when player has selected something from the inventory.
+
+        Currently, opens a new menu depending on the state context.
+
+        Parameters:
+            menu_item: Selected menu item.
+
+        """
+        item = menu_item.game_object
+
+        def sell_item(quantity: int) -> None:
+            if not quantity:
+                return
+
+            self.seller.sell_transaction(
+                self.client, self.seller, item.slug, quantity, cost
+            )
+
+            self.reload_items()
+            if not self.seller.has_item(item.slug):
+                # We're pointing at a new item
+                self.on_menu_selection_change()
+
+        item_dict = self.seller.inventory[item.slug]
+
+        cost = (
+            0
+            if not self.economy or not self.economy.lookup_item_cost(item.slug)
+            else self.economy.lookup_item_cost(item.slug)
+        )
+
+        max_quantity = (
+            None if item_dict.get("infinite") else item_dict["quantity"]
+        )
+
+        self.client.push_state(
+            QuantityAndCostMenu,
+            callback=sell_item,
+            max_quantity=max_quantity,
+            quantity=1,
+            shrink_to_items=True,
+            cost=cost,
         )


### PR DESCRIPTION
Fix for #1366

It was necessary a ShopSellMenuState as well as a QuantityAndCostMenu. It takes the cost from economy, for instance you buy 5 potions for 100 and you can resell 5 for 25. Because until now everything was based on price. There was a duplicate in the init, now there is only one. 

![Screenshot from 2022-10-02 19-55-16](https://user-images.githubusercontent.com/64643719/193468751-f74bd56b-9459-4e28-8c17-f0a04e03ab13.png)
 
It goes down of 100 and it goes up of 25.
So if someone wants to edit the cost, he or she needs to edit the value in economy.

We can solve #1367 too by inserting the money here (both):
```
        formatted_name = label_format(cost, count_len=count_len)
        image = self.shadow_text(formatted_name, bg=(128, 128, 128))
        yield MenuItem(image, formatted_name, None, None)
```
To be precise, below $20
![Screenshot from 2022-10-02 20-48-40](https://user-images.githubusercontent.com/64643719/193470948-db7426b3-4f0d-4770-8ce8-76d63a559e2e.png)
