### PR TITLE
cannot escape wild monster

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -123,6 +123,9 @@ msgstr "It missed..."
 msgid "combat_can't_run_from_trainer"
 msgstr "Can't run from trainer battles!"
 
+msgid "combat_cannot_escape"
+msgstr "Can't escape! You're weak!"
+
 msgid "combat_player_run"
 msgstr "You have run away!"
 

--- a/tuxemon/states/combat/combat_menus.py
+++ b/tuxemon/states/combat/combat_menus.py
@@ -101,7 +101,31 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                 open_menu,
             )
         else:
-            combat_state.trigger_player_run(combat_state.players[0])
+            # Wild monster level is higher than party_level_average.
+            level = combat_state.players[0].game_variables[
+                "party_level_average"
+            ]
+            monster_record = combat_state.players[0].game_variables[
+                "battle_last_monster_level"
+            ]
+            if level < monster_record:
+
+                def open_menu() -> None:
+                    combat_state.task(
+                        partial(
+                            combat_state.show_monster_action_menu,
+                            self.monster,
+                        ),
+                        1,
+                    )
+
+                combat_state.alert(
+                    T.translate("combat_cannot_escape"),
+                    open_menu,
+                )
+            # Wild monster level is equal or lower than party_level_average.
+            else:
+                combat_state.trigger_player_run(combat_state.players[0])
 
     def open_swap_menu(self) -> None:
         """Open menus to swap monsters in party."""


### PR DESCRIPTION
I had this for a while among my branches.
I developed with the idea of impeding players to run from wild monsters.
If the _level of the party_ is less than the _level of the wild monster_, then you can't run because "you're weak".

I'm not sure about this, because after starting working on techniques (refactoring) I bumped into the concept of conditions as well as this https://wiki.tuxemon.org/Category:Condition

Again, if it's not useful, then no big deal.