### PR TITLE
remove hard-coded name selection

### DIFF
--- a/tuxemon/event/actions/assign_name.py
+++ b/tuxemon/event/actions/assign_name.py
@@ -1,0 +1,53 @@
+#
+# Tuxemon
+# Copyright (c) 2014-2017 William Edwards <shadowapex@gmail.com>,
+#                         Benjamin Bean <superman2k5@gmail.com>
+#
+# This file is part of Tuxemon
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Contributor(s):
+#
+# Adam Chevalier <chevalierAdam2@gmail.com>
+#
+
+from __future__ import annotations
+
+from typing import NamedTuple, final
+
+from tuxemon.event.eventaction import EventAction
+
+
+class AssignNameActionParameters(NamedTuple):
+    slug: str
+
+
+@final
+class AssignNameAction(EventAction[AssignNameActionParameters]):
+    """
+    Assign name to the player without opening the input.
+
+    Script usage:
+        .. code-block::
+
+            assign_name <slug>
+
+    """
+
+    name = "assign_name"
+    param_class = AssignNameActionParameters
+
+    def start(self) -> None:
+        self.session.player.name = self.parameters.slug

--- a/tuxemon/states/start/__init__.py
+++ b/tuxemon/states/start/__init__.py
@@ -131,24 +131,14 @@ class ModChooserMenuState(PopUpMenu[StartGameObj]):
         ) -> Callable:
             return partial(new_game, map_name)
 
-        def set_player_name(text: str) -> None:
-            map_path = prepare.fetch("maps", self.map_name)
-            self.client.push_state("WorldState", map_name=map_path)
-            self.client.push_state(FadeInTransition)
-            local_session.player.name = text
-            self.client.pop_state(self)
-
         def new_game(map_name: str) -> None:
             self.map_name = map_name
             # load the starting map
-            self.client.push_state(
-                state_name=InputMenu,
-                prompt=T.translate("input_name"),
-                callback=set_player_name,
-                escape_key_exits=True,
-                char_limit=prepare.PLAYER_NAME_LIMIT,
-            )
+            # default name is RED ("player_npc", "npc_red")
+            map_path = prepare.fetch("maps", self.map_name)
+            self.client.push_state("WorldState", map_name=map_path)
             self.client.push_state(FadeInTransition)
+            self.client.pop_state(self)
 
         # Build a menu of the default mod choices:
         menu_items_map: Tuple[Tuple[str, Callable], ...] = tuple()


### PR DESCRIPTION
as requested in #1014 
- the PR removes the hard-coded input at the beginning of the game;
- the default name is Red ("player_npc", "npc_red") both Spyder and Xero;
- to help modders, now there is **assign_name <slug>** action, so they can assign the protagonist name in case Red isn't the right one, especially if there is a precise plot and story-line;

Now I don't know, maybe someone has the intention of inserting the classic discussion "Are you called Red?" then the "Yes or No" reply, then the **rename_player** action. I can implement if it's necessary.

This will help the ones - #524 and me - that don't care much about the name.
By they way, I tried a couple of times starting the game and it's so fast without the name selection.
In medias res starting point!