### PR TITLE
Move EventAction parameter attributes into Action class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ $(SCHEMAS) &: tuxemon/db.py
 .PHONY: validate
 validate:
 	PYTHONPATH=. python scripts/schema.py --validate
+	PYTHONPATH=. python scripts/test_actions.py
 
 # Install dependencies
 .PHONY: setup

--- a/mods/tuxemon/maps/city1_mart_junkyard.tmx
+++ b/mods/tuxemon/maps/city1_mart_junkyard.tmx
@@ -169,7 +169,7 @@
   </object>
   <object id="37" type="event" x="64" y="352" width="16" height="16">
    <properties>
-    <property name="act10" value="cfanatic2 pathfind,8,21"/>
+    <property name="act10" value="pathfind cfanatic2,8,21"/>
     <property name="act20" value="set_variable fanatics_in_junkyard2:true"/>
     <property name="cond10" value="is variable_set fanatics_in_junkyard:true"/>
     <property name="cond20" value="not variable_set fanatics_in_junkyard2:true"/>
@@ -177,7 +177,7 @@
   </object>
   <object id="38" type="event" x="256" y="352" width="16" height="16">
    <properties>
-    <property name="act10" value="cfanatic1 pathfind,11,21"/>
+    <property name="act10" value="pathfind cfanatic1,11,21"/>
     <property name="act20" value="set_variable fanatics_in_junkyard2:true"/>
     <property name="cond10" value="is variable_set fanatics_in_junkyard:true"/>
     <property name="cond20" value="not variable_set fanatics_in_junkyard2:true"/>
@@ -214,7 +214,7 @@
   </object>
   <object id="42" type="event" x="304" y="224" width="16" height="16">
    <properties>
-    <property name="act10" value="cfanatic1 pathfind,11,32"/>
+    <property name="act10" value="pathfind cfanatic1,11,32"/>
     <property name="act20" value="set_variable fanatics_in_junkyard5:true"/>
     <property name="cond10" value="is variable_set fanatics_in_junkyard4:true"/>
     <property name="cond20" value="not variable_set fanatics_in_junkyard5:true"/>
@@ -222,7 +222,7 @@
   </object>
   <object id="44" type="event" x="272" y="224" width="16" height="16">
    <properties>
-    <property name="act10" value="cfanatic2 pathfind,8,33"/>
+    <property name="act10" value="pathfind cfanatic2,8,33"/>
     <property name="act20" value="set_variable fanatics_in_junkyard5:true"/>
     <property name="cond10" value="is variable_set fought_fanatics_in_junkyard:true"/>
     <property name="cond20" value="not variable_set fanatics_in_junkyard4:true"/>

--- a/mods/tuxemon/maps/spyder_cotton_cafe.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_cafe.tmx
@@ -105,7 +105,7 @@
   <object id="16" name="Talk Barmaid Intro" type="event" x="160" y="144" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_cottoncafe_barmaidintro"/>
-    <property name="act2" value="act1 set_variable introdcottoncafe:yes"/>
+    <property name="act2" value="set_variable introdcottoncafe:yes"/>
     <property name="behav1" value="talk spyder_cottontown_barmaid"/>
     <property name="cond1" value="not variable_set introdcottoncafe:yes"/>
    </properties>

--- a/scripts/test_actions.py
+++ b/scripts/test_actions.py
@@ -1,0 +1,28 @@
+"""
+Script to validate map actions
+"""
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from tuxemon.constants import paths
+from tuxemon.db import db
+from tuxemon.event.eventengine import EventEngine
+from tuxemon.map_loader import TMXMapLoader
+from tuxemon.prepare import CONFIG
+from tuxemon.session import Session
+
+
+db.load("monster")
+engine = EventEngine(Session(None, None, None))
+loader = TMXMapLoader()
+loader.image_loader = MagicMock()
+
+for mod_name in CONFIG.mods:
+    for path in (
+        Path().joinpath(paths.mods_folder, mod_name, "maps").glob("*.tmx")
+    ):
+        txmn_map = loader.load(str(path))
+        for event in txmn_map.events:
+            for act in event.acts:
+                if not engine.get_action(act.type, act.parameters):
+                    print(f"{path} failed")

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -880,6 +880,13 @@ class JSONDatabase:
 
         return filename
 
+    def has_entry(self, slug: str, table: TableName) -> bool:
+        table_entry = self.database[table]
+        if not table_entry:
+            logger.exception(f"{table} table wasn't loaded")
+            sys.exit()
+        return slug in table_entry
+
     def log_missing_entry_and_exit(self, table: str, slug: str):
         options = difflib.get_close_matches(slug, self.database[table].keys())
         options = [repr(s) for s in options]

--- a/tuxemon/event/actions/add_item.py
+++ b/tuxemon/event/actions/add_item.py
@@ -21,18 +21,15 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, Union, final
+from dataclasses import dataclass
+from typing import Union, final
 
 from tuxemon.event.eventaction import EventAction
 
 
-class AddItemActionParameters(NamedTuple):
-    item_slug: str
-    quantity: Union[int, None]
-
-
 @final
-class AddItemAction(EventAction[AddItemActionParameters]):
+@dataclass
+class AddItemAction(EventAction):
     """
     Add an item to the current player's inventory.
 
@@ -48,16 +45,17 @@ class AddItemAction(EventAction[AddItemActionParameters]):
     """
 
     name = "add_item"
-    param_class = AddItemActionParameters
+    item_slug: str
+    quantity: Union[int, None] = None
 
     def start(self) -> None:
         player = self.session.player
-        if self.parameters.quantity is None:
+        if self.quantity is None:
             quantity = 1
         else:
-            quantity = self.parameters.quantity
+            quantity = self.quantity
         player.alter_item_quantity(
             self.session,
-            self.parameters.item_slug,
+            self.item_slug,
             quantity,
         )

--- a/tuxemon/event/actions/add_monster.py
+++ b/tuxemon/event/actions/add_monster.py
@@ -21,7 +21,8 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, Optional, Union, final
+from dataclasses import dataclass
+from typing import Optional, Union, final
 
 from tuxemon import monster
 from tuxemon.db import SeenStatus
@@ -30,14 +31,9 @@ from tuxemon.event.eventaction import EventAction
 from tuxemon.npc import NPC
 
 
-class AddMonsterActionParameters(NamedTuple):
-    monster_slug: str
-    monster_level: int
-    trainer_slug: Union[str, None]
-
-
 @final
-class AddMonsterAction(EventAction[AddMonsterActionParameters]):
+@dataclass
+class AddMonsterAction(EventAction):
     """
     Add a monster to the specified trainer's party if there is room.
 
@@ -55,26 +51,26 @@ class AddMonsterAction(EventAction[AddMonsterActionParameters]):
     """
 
     name = "add_monster"
-    param_class = AddMonsterActionParameters
+    monster_slug: str
+    monster_level: int
+    trainer_slug: Union[str, None] = None
 
     def start(self) -> None:
 
-        monster_slug, monster_level, trainer_slug = self.parameters
-
         trainer: Optional[NPC]
-        if trainer_slug is None:
+        if self.trainer_slug is None:
             trainer = self.session.player
         else:
-            trainer = get_npc(self.session, trainer_slug)
+            trainer = get_npc(self.session, self.trainer_slug)
 
         assert trainer, "No Trainer found with slug '{}'".format(
-            trainer_slug or "player"
+            self.trainer_slug or "player"
         )
 
         current_monster = monster.Monster()
-        current_monster.load_from_db(monster_slug)
-        current_monster.set_level(monster_level)
+        current_monster.load_from_db(self.monster_slug)
+        current_monster.set_level(self.monster_level)
         current_monster.current_hp = current_monster.hp
 
         trainer.add_monster(current_monster)
-        trainer.tuxepedia[monster_slug] = SeenStatus.caught
+        trainer.tuxepedia[self.monster_slug] = SeenStatus.caught

--- a/tuxemon/event/actions/battles_print.py
+++ b/tuxemon/event/actions/battles_print.py
@@ -22,19 +22,17 @@
 from __future__ import annotations
 
 import logging
-from typing import NamedTuple, Optional, final
+from dataclasses import dataclass
+from typing import Optional, final
 
 from tuxemon.event.eventaction import EventAction
 
 logger = logging.getLogger(__name__)
 
 
-class BattlesPrintActionParameters(NamedTuple):
-    variable: Optional[str]
-
-
 @final
-class BattlesAction(EventAction[BattlesPrintActionParameters]):
+@dataclass
+class BattlesAction(EventAction):
     """
     Print the current value of battle history to the console.
 
@@ -52,12 +50,12 @@ class BattlesAction(EventAction[BattlesPrintActionParameters]):
     """
 
     name = "battles_print"
-    param_class = BattlesPrintActionParameters
+    variable: Optional[str] = None
 
     def start(self) -> None:
         player = self.session.player
 
-        variable = self.parameters.variable
+        variable = self.variable
         if variable:
             if variable in player.battle_history:
                 print(f"{variable}: {player.battle_history[variable]}")

--- a/tuxemon/event/actions/call_event.py
+++ b/tuxemon/event/actions/call_event.py
@@ -21,17 +21,15 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event.eventaction import EventAction
 
 
-class CallEventActionParameters(NamedTuple):
-    event_id: int
-
-
 @final
-class CallEventAction(EventAction[CallEventActionParameters]):
+@dataclass
+class CallEventAction(EventAction):
     """
     Execute the specified event's actions by id.
 
@@ -46,12 +44,12 @@ class CallEventAction(EventAction[CallEventActionParameters]):
     """
 
     name = "call_event"
-    param_class = CallEventActionParameters
+    event_id: int
 
     def start(self) -> None:
         event_engine = self.session.client.event_engine
         events = self.session.client.events
 
         for e in events:
-            if e.id == self.parameters.event_id:
+            if e.id == self.event_id:
                 event_engine.start_event(e)

--- a/tuxemon/event/actions/change_state.py
+++ b/tuxemon/event/actions/change_state.py
@@ -21,17 +21,15 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event.eventaction import EventAction
 
 
-class ChangeStateActionParameters(NamedTuple):
-    state_name: str
-
-
 @final
-class ChangeStateAction(EventAction[ChangeStateActionParameters]):
+@dataclass
+class ChangeStateAction(EventAction):
     """
     Change to the specified state.
 
@@ -46,7 +44,7 @@ class ChangeStateAction(EventAction[ChangeStateActionParameters]):
     """
 
     name = "change_state"
-    param_class = ChangeStateActionParameters
+    state_name: str
 
     def start(self) -> None:
         # Don't override previous state if we are still in the state.
@@ -54,5 +52,5 @@ class ChangeStateAction(EventAction[ChangeStateActionParameters]):
         if current_state is None:
             # obligatory "should not happen"
             raise RuntimeError
-        if current_state.name != self.parameters.state_name:
-            self.session.client.push_state(self.parameters.state_name)
+        if current_state.name != self.state_name:
+            self.session.client.push_state(self.state_name)

--- a/tuxemon/event/actions/clear_variable.py
+++ b/tuxemon/event/actions/clear_variable.py
@@ -25,20 +25,18 @@
 from __future__ import annotations
 
 import logging
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event.eventaction import EventAction
 
 logger = logging.getLogger(__name__)
 
 
-class ClearVariableActionParameters(NamedTuple):
-    variable: str
-
-
 # noinspection PyAttributeOutsideInit
 @final
-class ClearVariableAction(EventAction[ClearVariableActionParameters]):
+@dataclass
+class ClearVariableAction(EventAction):
     """
     Clear the value of a variable from the game.
 
@@ -53,9 +51,9 @@ class ClearVariableAction(EventAction[ClearVariableActionParameters]):
     """
 
     name = "clear_variable"
-    param_class = ClearVariableActionParameters
+    variable: str
 
     def start(self) -> None:
         player = self.session.player
-        key = self.parameters.variable
+        key = self.variable
         player.game_variables.pop(key, None)

--- a/tuxemon/event/actions/copy_variable.py
+++ b/tuxemon/event/actions/copy_variable.py
@@ -25,21 +25,18 @@
 from __future__ import annotations
 
 import logging
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event.eventaction import EventAction
 
 logger = logging.getLogger(__name__)
 
 
-class CopyVariableActionParameters(NamedTuple):
-    var1: str
-    var2: str
-
-
 # noinspection PyAttributeOutsideInit
 @final
-class CopyVariableAction(EventAction[CopyVariableActionParameters]):
+@dataclass
+class CopyVariableAction(EventAction):
     """
     Copy the value of var2 into var1 (e.g. var1 = var 2).
 
@@ -55,10 +52,11 @@ class CopyVariableAction(EventAction[CopyVariableActionParameters]):
     """
 
     name = "copy_variable"
-    param_class = CopyVariableActionParameters
+    var1: str
+    var2: str
 
     def start(self) -> None:
         player = self.session.player
-        first = self.parameters.var1
-        second = self.parameters.var2
+        first = self.var1
+        second = self.var2
         player.game_variables[first] = player.game_variables[second]

--- a/tuxemon/event/actions/create_npc.py
+++ b/tuxemon/event/actions/create_npc.py
@@ -21,7 +21,8 @@
 from __future__ import annotations
 
 import logging
-from typing import NamedTuple, Union, final
+from dataclasses import dataclass
+from typing import Union, final
 
 import tuxemon.npc
 from tuxemon import ai
@@ -32,16 +33,9 @@ from tuxemon.states.world.worldstate import WorldState
 logger = logging.getLogger(__name__)
 
 
-class CreateNpcActionParameters(NamedTuple):
-    npc_slug: str
-    tile_pos_x: int
-    tile_pos_y: int
-    animations: Union[str, None]
-    behavior: Union[str, None]
-
-
 @final
-class CreateNpcAction(EventAction[CreateNpcActionParameters]):
+@dataclass
+class CreateNpcAction(EventAction):
     """
     Create an NPC object and adds it to the game's current list of NPC's.
 
@@ -60,25 +54,24 @@ class CreateNpcAction(EventAction[CreateNpcActionParameters]):
     """
 
     name = "create_npc"
-    param_class = CreateNpcActionParameters
+    npc_slug: str
+    tile_pos_x: int
+    tile_pos_y: int
+    animations: Union[str, None] = None
+    behavior: Union[str, None] = None
 
     def start(self) -> None:
         # Get a copy of the world state.
         world = self.session.client.get_state_by_name(WorldState)
 
         # Get the npc's parameters from the action
-        slug = self.parameters.npc_slug
+        slug = self.npc_slug
 
         # Ensure that the NPC doesn't already exist on the map.
         if slug in world.npcs:
             return
 
-        # Get the npc's parameters from the action
-        pos_x = self.parameters.tile_pos_x
-        pos_y = self.parameters.tile_pos_y
-        behavior = self.parameters.behavior
-
-        sprite = self.parameters.animations
+        sprite = self.animations
         if sprite:
             logger.warning(
                 "%s: setting npc sprites within a map is deprecated, and may be removed in the future. "
@@ -90,9 +83,9 @@ class CreateNpcAction(EventAction[CreateNpcActionParameters]):
 
         # Create a new NPC object
         npc = tuxemon.npc.NPC(slug, sprite_name=sprite, world=world)
-        npc.set_position((pos_x, pos_y))
+        npc.set_position((self.tile_pos_x, self.tile_pos_y))
 
         # Set the NPC object's variables
-        npc.behavior = behavior
+        npc.behavior = self.behavior
         npc.ai = ai.RandomAI()
         npc.load_party()

--- a/tuxemon/event/actions/delayed_teleport.py
+++ b/tuxemon/event/actions/delayed_teleport.py
@@ -21,20 +21,16 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.states.world.worldstate import WorldState
 
 
-class DelayedTeleportActionParameters(NamedTuple):
-    map_name: str
-    position_x: int
-    position_y: int
-
-
 @final
-class DelayedTeleportAction(EventAction[DelayedTeleportActionParameters]):
+@dataclass
+class DelayedTeleportAction(EventAction):
     """
     Set teleport information.
 
@@ -55,7 +51,9 @@ class DelayedTeleportAction(EventAction[DelayedTeleportActionParameters]):
     """
 
     name = "delayed_teleport"
-    param_class = DelayedTeleportActionParameters
+    map_name: str
+    position_x: int
+    position_y: int
 
     def start(self) -> None:
         # Get the world object from the session
@@ -66,6 +64,6 @@ class DelayedTeleportAction(EventAction[DelayedTeleportActionParameters]):
             return
 
         world.delayed_teleport = True
-        world.delayed_mapname = self.parameters.map_name
-        world.delayed_x = self.parameters.position_x
-        world.delayed_y = self.parameters.position_y
+        world.delayed_mapname = self.map_name
+        world.delayed_x = self.position_x
+        world.delayed_y = self.position_y

--- a/tuxemon/event/actions/fadeout_music.py
+++ b/tuxemon/event/actions/fadeout_music.py
@@ -22,7 +22,8 @@
 from __future__ import annotations
 
 import logging
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.platform import mixer
@@ -30,12 +31,9 @@ from tuxemon.platform import mixer
 logger = logging.getLogger(__name__)
 
 
-class FadeoutMusicActionParameters(NamedTuple):
-    duration: int
-
-
 @final
-class FadeoutMusicAction(EventAction[FadeoutMusicActionParameters]):
+@dataclass
+class FadeoutMusicAction(EventAction):
     """
     Fade out the music over a set amount of time in milliseconds.
 
@@ -50,11 +48,10 @@ class FadeoutMusicAction(EventAction[FadeoutMusicActionParameters]):
     """
 
     name = "fadeout_music"
-    param_class = FadeoutMusicActionParameters
+    duration: int
 
     def start(self) -> None:
-        time = self.parameters.duration
-        mixer.music.fadeout(time)
+        mixer.music.fadeout(self.duration)
         if self.session.client.current_music["song"]:
             self.session.client.current_music["status"] = "stopped"
         else:

--- a/tuxemon/event/actions/get_player_monster.py
+++ b/tuxemon/event/actions/get_player_monster.py
@@ -25,7 +25,8 @@
 from __future__ import annotations
 
 import logging
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.menu.interface import MenuItem
@@ -35,13 +36,10 @@ from tuxemon.states.monster import MonsterMenuState
 logger = logging.getLogger(__name__)
 
 
-class GetPlayerMonsterActionParameters(NamedTuple):
-    variable_name: str
-
-
 # noinspection PyAttributeOutsideInit
 @final
-class GetPlayerMonsterAction(EventAction[GetPlayerMonsterActionParameters]):
+@dataclass
+class GetPlayerMonsterAction(EventAction):
     """
     Select a monster in the player party and store its id in a variable.
 
@@ -56,18 +54,15 @@ class GetPlayerMonsterAction(EventAction[GetPlayerMonsterActionParameters]):
     """
 
     name = "get_player_monster"
-    param_class = GetPlayerMonsterActionParameters
+    variable_name: str
 
     def set_var(self, menu_item: MenuItem[Monster]) -> None:
-        self.player.game_variables[
-            self.variable
+        self.session.player.game_variables[
+            self.variable_name
         ] = menu_item.game_object.instance_id.hex
         self.session.client.pop_state()
 
     def start(self) -> None:
-        self.player = self.session.player
-        self.variable = self.parameters.variable_name
-
         # pull up the monster menu so we know which one we are saving
         menu = self.session.client.push_state(MonsterMenuState)
         menu.on_menu_selection = self.set_var  # type: ignore[assignment]

--- a/tuxemon/event/actions/lock_controls.py
+++ b/tuxemon/event/actions/lock_controls.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.states.sink import SinkState
 
 
-class LockControlsActionParameters(NamedTuple):
-    pass
-
-
 @final
+@dataclass
 class LockControlsAction(
-    EventAction[LockControlsActionParameters],
+    EventAction,
 ):
     """
     Lock player controls
@@ -25,8 +23,6 @@ class LockControlsAction(
     """
 
     name = "lock_controls"
-
-    param_class = LockControlsActionParameters
 
     def start(self) -> None:
         self.session.client.push_state(SinkState)

--- a/tuxemon/event/actions/modify_npc_attribute.py
+++ b/tuxemon/event/actions/modify_npc_attribute.py
@@ -21,22 +21,18 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event import get_npc
 from tuxemon.event.actions.common import CommonAction
 from tuxemon.event.eventaction import EventAction
 
 
-class ModifyNpcAttributeActionParameters(NamedTuple):
-    npc_slug: str
-    name: str
-    value: str
-
-
 @final
+@dataclass
 class ModifyNpcAttributeAction(
-    EventAction[ModifyNpcAttributeActionParameters],
+    EventAction,
 ):
     """
     Modify the given attribute of the npc by modifier.
@@ -47,21 +43,23 @@ class ModifyNpcAttributeAction(
     Script usage:
         .. code-block::
 
-            modify_npc_attribute <npc_slug>,<name>,<value>
+            modify_npc_attribute <npc_slug>,<attribute>,<value>
 
     Script parameters:
         npc_slug: Either "player" or npc slug name (e.g. "npc_maple").
-        name: Name of the attribute to modify.
+        attribute: Name of the attribute to modify.
         value: Value of the attribute modifier.
 
     """
 
     name = "modify_npc_attribute"
-    param_class = ModifyNpcAttributeActionParameters
+    npc_slug: str
+    attribute: str
+    value: str
 
     def start(self) -> None:
-        npc = get_npc(self.session, self.parameters[0])
+        npc = get_npc(self.session, self.npc_slug)
         assert npc
-        attribute = self.parameters[1]
-        modifier = self.parameters[2]
-        CommonAction.modify_character_attribute(npc, attribute, modifier)
+        CommonAction.modify_character_attribute(
+            npc, self.attribute, self.value
+        )

--- a/tuxemon/event/actions/modify_player_attribute.py
+++ b/tuxemon/event/actions/modify_player_attribute.py
@@ -21,20 +21,17 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event.actions.common import CommonAction
 from tuxemon.event.eventaction import EventAction
 
 
-class ModifyPlayerAttributeActionParameters(NamedTuple):
-    name: str
-    value: str
-
-
 @final
+@dataclass
 class ModifyPlayerAttributeAction(
-    EventAction[ModifyPlayerAttributeActionParameters],
+    EventAction,
 ):
     """
     Modify the given attribute of the player character by modifier.
@@ -45,22 +42,21 @@ class ModifyPlayerAttributeAction(
     Script usage:
         .. code-block::
 
-            modify_player_attribute <name>,<value>
+            modify_player_attribute <attribute>,<value>
 
     Script parameters:
-        name: Name of the attribute to modify.
+        attribute: Name of the attribute to modify.
         value: Value of the attribute modifier.
 
     """
 
     name = "modify_player_attribute"
-    param_class = ModifyPlayerAttributeActionParameters
+    attribute: str
+    value: str
 
     def start(self) -> None:
-        attribute = self.parameters[0]
-        modifier = self.parameters[1]
         CommonAction.modify_character_attribute(
             self.session.player,
-            attribute,
-            modifier,
+            self.attribute,
+            self.value,
         )

--- a/tuxemon/event/actions/money_print.py
+++ b/tuxemon/event/actions/money_print.py
@@ -22,19 +22,17 @@
 from __future__ import annotations
 
 import logging
-from typing import NamedTuple, Optional, final
+from dataclasses import dataclass
+from typing import Optional, final
 
 from tuxemon.event.eventaction import EventAction
 
 logger = logging.getLogger(__name__)
 
 
-class MoneyPrintActionParameters(NamedTuple):
-    slug: Optional[str]
-
-
 @final
-class MoneyPrintAction(EventAction[MoneyPrintActionParameters]):
+@dataclass
+class MoneyPrintAction(EventAction):
     """
     Print the current value of money dictionary to the console.
 
@@ -52,12 +50,12 @@ class MoneyPrintAction(EventAction[MoneyPrintActionParameters]):
     """
 
     name = "money_print"
-    param_class = MoneyPrintActionParameters
+    slug: Optional[str] = None
 
     def start(self) -> None:
         var = self.session.player.money
 
-        slug = self.parameters.slug
+        slug = self.slug
         if slug:
             if slug in var:
                 print(f"{slug}: {var[slug]}")

--- a/tuxemon/event/actions/npc_face.py
+++ b/tuxemon/event/actions/npc_face.py
@@ -21,7 +21,8 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
@@ -29,13 +30,9 @@ from tuxemon.map import dirs2, get_direction
 from tuxemon.npc import NPC
 
 
-class NpcFaceActionParameters(NamedTuple):
-    npc_slug: str
-    direction: str  # Using Direction as the typehint breaks the Action
-
-
 @final
-class NpcFaceAction(EventAction[NpcFaceActionParameters]):
+@dataclass
+class NpcFaceAction(EventAction):
     """
     Make the NPC face a certain direction.
 
@@ -52,12 +49,13 @@ class NpcFaceAction(EventAction[NpcFaceActionParameters]):
     """
 
     name = "npc_face"
-    param_class = NpcFaceActionParameters
+    npc_slug: str
+    direction: str  # Using Direction as the typehint breaks the Action
 
     def start(self) -> None:
-        npc = get_npc(self.session, self.parameters.npc_slug)
+        npc = get_npc(self.session, self.npc_slug)
         assert npc
-        direction = self.parameters.direction
+        direction = self.direction
 
         target: NPC
         if direction not in dirs2:

--- a/tuxemon/event/actions/npc_move.py
+++ b/tuxemon/event/actions/npc_move.py
@@ -21,7 +21,8 @@
 
 from __future__ import annotations
 
-from typing import Generator, NamedTuple, Sequence, Tuple, cast, final
+from dataclasses import dataclass, field
+from typing import Generator, Sequence, Tuple, cast, final
 
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
@@ -58,12 +59,9 @@ def parse_path_parameters(
         origin = point
 
 
-class NpcMoveActionParameters(NamedTuple):
-    pass
-
-
 @final
-class NpcMoveAction(EventAction[NpcMoveActionParameters]):
+@dataclass
+class NpcMoveAction(EventAction):
     """
     Relative tile movement for NPC.
 
@@ -87,7 +85,11 @@ class NpcMoveAction(EventAction[NpcMoveActionParameters]):
     """
 
     name = "npc_move"
-    param_class = NpcMoveActionParameters
+    raw_parameters: Sequence[str] = field(init=False)
+
+    def __init__(self, *args):
+        super().__init__()
+        self.raw_parameters = args
 
     # parameter checking not supported due to undefined number of parameters
 

--- a/tuxemon/event/actions/npc_run.py
+++ b/tuxemon/event/actions/npc_run.py
@@ -20,18 +20,16 @@
 #
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 
 
-class NpcRunActionParameters(NamedTuple):
-    npc_slug: str
-
-
 @final
-class NpcRun(EventAction[NpcRunActionParameters]):
+@dataclass
+class NpcRun(EventAction):
     """
     Set the NPC movement speed to the global run speed.
 
@@ -46,9 +44,9 @@ class NpcRun(EventAction[NpcRunActionParameters]):
     """
 
     name = "npc_run"
-    param_class = NpcRunActionParameters
+    npc_slug: str
 
     def start(self) -> None:
-        npc = get_npc(self.session, self.parameters.npc_slug)
+        npc = get_npc(self.session, self.npc_slug)
         assert npc
         npc.moverate = self.session.client.config.player_runrate

--- a/tuxemon/event/actions/npc_speed.py
+++ b/tuxemon/event/actions/npc_speed.py
@@ -21,19 +21,16 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 
 
-class NpcSpeedActionParameters(NamedTuple):
-    npc_slug: str
-    speed: float
-
-
 @final
-class NpcSpeed(EventAction[NpcSpeedActionParameters]):
+@dataclass
+class NpcSpeed(EventAction):
     """
     Set the NPC movement speed to a custom value.
 
@@ -49,11 +46,12 @@ class NpcSpeed(EventAction[NpcSpeedActionParameters]):
     """
 
     name = "npc_speed"
-    param_class = NpcSpeedActionParameters
+    npc_slug: str
+    speed: float
 
     def start(self) -> None:
-        npc = get_npc(self.session, self.parameters.npc_slug)
+        npc = get_npc(self.session, self.npc_slug)
         assert npc
-        npc.moverate = self.parameters.speed
+        npc.moverate = self.speed
         # Just set some sane limit to avoid losing sprites
         assert 0 < npc.moverate < 20

--- a/tuxemon/event/actions/npc_walk.py
+++ b/tuxemon/event/actions/npc_walk.py
@@ -21,18 +21,16 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 
 
-class NpcWalkActionParameters(NamedTuple):
-    npc_slug: str
-
-
 @final
-class NpcWalk(EventAction[NpcWalkActionParameters]):
+@dataclass
+class NpcWalk(EventAction):
     """
     Set the NPC movement speed to the global walk speed.
 
@@ -47,9 +45,9 @@ class NpcWalk(EventAction[NpcWalkActionParameters]):
     """
 
     name = "npc_walk"
-    param_class = NpcWalkActionParameters
+    npc_slug: str
 
     def start(self) -> None:
-        npc = get_npc(self.session, self.parameters.npc_slug)
+        npc = get_npc(self.session, self.npc_slug)
         assert npc
         npc.moverate = self.session.client.config.player_walkrate

--- a/tuxemon/event/actions/npc_wander.py
+++ b/tuxemon/event/actions/npc_wander.py
@@ -22,7 +22,8 @@
 from __future__ import annotations
 
 import random
-from typing import NamedTuple, Union, final
+from dataclasses import dataclass
+from typing import Union, final
 
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
@@ -30,13 +31,9 @@ from tuxemon.npc import NPC
 from tuxemon.states.world.worldstate import WorldState
 
 
-class NpcWanderActionParameters(NamedTuple):
-    npc_slug: str
-    frequency: Union[float, None]
-
-
 @final
-class NpcWanderAction(EventAction[NpcWanderActionParameters]):
+@dataclass
+class NpcWanderAction(EventAction):
     """
     Make an NPC wander around the map.
 
@@ -54,10 +51,11 @@ class NpcWanderAction(EventAction[NpcWanderActionParameters]):
     """
 
     name = "npc_wander"
-    param_class = NpcWanderActionParameters
+    npc_slug: str
+    frequency: Union[float, None] = None
 
     def start(self) -> None:
-        npc = get_npc(self.session, self.parameters.npc_slug)
+        npc = get_npc(self.session, self.npc_slug)
         world = self.session.client.get_state_by_name(WorldState)
 
         def move(world: WorldState, npc: NPC) -> None:
@@ -85,12 +83,12 @@ class NpcWanderAction(EventAction[NpcWanderActionParameters]):
             # Frequency can be set to 0 to indicate that we want to stop
             # wandering
             world.remove_animations_of(schedule)
-            if npc is None or self.parameters.frequency == 0:
+            if npc is None or self.frequency == 0:
                 return
             else:
                 frequency = 1.0
-                if self.parameters.frequency:
-                    frequency = min(5, max(0.5, self.parameters.frequency))
+                if self.frequency:
+                    frequency = min(5, max(0.5, self.frequency))
                 time = (0.5 + 0.5 * random.random()) * frequency
                 world.task(schedule, time)
 

--- a/tuxemon/event/actions/open_shop.py
+++ b/tuxemon/event/actions/open_shop.py
@@ -21,7 +21,8 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, Optional, final
+from dataclasses import dataclass
+from typing import Optional, final
 
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
@@ -31,13 +32,9 @@ from tuxemon.states.items import ShopBuyMenuState, ShopSellMenuState
 from tuxemon.tools import assert_never
 
 
-class OpenShopActionParameters(NamedTuple):
-    npc_slug: str
-    menu: Optional[str]
-
-
 @final
-class OpenShopAction(EventAction[OpenShopActionParameters]):
+@dataclass
+class OpenShopAction(EventAction):
     """
     Open the shop menu for a NPC.
 
@@ -53,10 +50,11 @@ class OpenShopAction(EventAction[OpenShopActionParameters]):
     """
 
     name = "open_shop"
-    param_class = OpenShopActionParameters
+    npc_slug: str
+    menu: Optional[str] = None
 
     def start(self) -> None:
-        npc = get_npc(self.session, self.parameters.npc_slug)
+        npc = get_npc(self.session, self.npc_slug)
 
         assert npc
         if npc.economy:
@@ -80,7 +78,7 @@ class OpenShopAction(EventAction[OpenShopActionParameters]):
                 economy=economy,
             )
 
-        menu = self.parameters.menu or "both"
+        menu = self.menu or "both"
         if menu == "both":
 
             def buy_menu() -> None:

--- a/tuxemon/event/actions/pathfind.py
+++ b/tuxemon/event/actions/pathfind.py
@@ -21,20 +21,16 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 
 
-class PathfindActionParameters(NamedTuple):
-    npc_slug: str
-    tile_pos_x: int
-    tile_pos_y: int
-
-
 @final
-class PathfindAction(EventAction[PathfindActionParameters]):
+@dataclass
+class PathfindAction(EventAction):
     """
     Pathfind the player / npc to the given location.
 
@@ -51,14 +47,14 @@ class PathfindAction(EventAction[PathfindActionParameters]):
     """
 
     name = "pathfind"
-    param_class = PathfindActionParameters
+    npc_slug: str
+    tile_pos_x: int
+    tile_pos_y: int
 
     def start(self) -> None:
-        self.npc = get_npc(self.session, self.parameters.npc_slug)
+        self.npc = get_npc(self.session, self.npc_slug)
         assert self.npc
-        self.npc.pathfind(
-            (self.parameters.tile_pos_x, self.parameters.tile_pos_y)
-        )
+        self.npc.pathfind((self.tile_pos_x, self.tile_pos_y))
 
     def update(self) -> None:
         assert self.npc

--- a/tuxemon/event/actions/pause_music.py
+++ b/tuxemon/event/actions/pause_music.py
@@ -22,7 +22,8 @@
 from __future__ import annotations
 
 import logging
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.platform import mixer
@@ -30,12 +31,9 @@ from tuxemon.platform import mixer
 logger = logging.getLogger(__name__)
 
 
-class PauseMusicActionParameters(NamedTuple):
-    pass
-
-
 @final
-class PauseMusicAction(EventAction[PauseMusicActionParameters]):
+@dataclass
+class PauseMusicAction(EventAction):
     """
     Pause the current music playback.
 
@@ -47,7 +45,6 @@ class PauseMusicAction(EventAction[PauseMusicActionParameters]):
     """
 
     name = "pause_music"
-    param_class = PauseMusicActionParameters
 
     def start(self) -> None:
         mixer.music.pause()

--- a/tuxemon/event/actions/play_map_animation.py
+++ b/tuxemon/event/actions/play_map_animation.py
@@ -22,7 +22,8 @@
 from __future__ import annotations
 
 import logging
-from typing import NamedTuple, Union, final
+from dataclasses import dataclass
+from typing import Union, final
 
 from tuxemon import prepare
 from tuxemon.event.eventaction import EventAction
@@ -32,16 +33,9 @@ from tuxemon.states.world.worldstate import WorldState
 logger = logging.getLogger(__name__)
 
 
-class PlayMapAnimationActionParameters(NamedTuple):
-    animation_name: str
-    duration: float
-    loop: str
-    tile_pos_x: Union[int, str]
-    tile_pos_y: Union[int, None]
-
-
 @final
-class PlayMapAnimationAction(EventAction[PlayMapAnimationActionParameters]):
+@dataclass
+class PlayMapAnimationAction(EventAction):
     """
     Play a map animation at a given position in the world map.
 
@@ -63,18 +57,21 @@ class PlayMapAnimationAction(EventAction[PlayMapAnimationActionParameters]):
     """
 
     name = "play_map_animation"
-    param_class = PlayMapAnimationActionParameters
+    animation_name: str
+    duration: float
+    loop: str
+    tile_pos_x: Union[int, str]
+    tile_pos_y: Union[int, None] = None
 
     def start(self) -> None:
         # ('play_animation', 'grass,1.5,noloop,player', '1', 6)
         # "position" can be either a (x, y) tile coordinate or "player"
-        animation_name = self.parameters.animation_name
-        duration = self.parameters.duration
+        animation_name = self.animation_name
         directory = prepare.fetch("animations", "tileset")
 
-        if self.parameters.loop == "loop":
+        if self.loop == "loop":
             loop = True
-        elif self.parameters.loop == "noloop":
+        elif self.loop == "noloop":
             loop = False
         else:
             raise ValueError('animation loop value must be "loop" or "noloop"')
@@ -85,13 +82,13 @@ class PlayMapAnimationAction(EventAction[PlayMapAnimationActionParameters]):
 
         # Determine the tile position where to draw the animation.
         # TODO: unify npc/player sprites and map animations
-        if self.parameters[3] == "player":
+        if self.tile_pos_x == "player":
             position = self.session.player.tile_pos
         else:
-            assert self.parameters.tile_pos_y
+            assert self.tile_pos_y
             position = (
-                int(self.parameters.tile_pos_x),
-                int(self.parameters.tile_pos_y),
+                int(self.tile_pos_x),
+                int(self.tile_pos_y),
             )
 
         animations = world_state.map_animations
@@ -104,7 +101,7 @@ class PlayMapAnimationAction(EventAction[PlayMapAnimationActionParameters]):
             animation = load_animation_from_frames(
                 directory,
                 animation_name,
-                duration,
+                self.duration,
                 loop,
             )
 

--- a/tuxemon/event/actions/play_music.py
+++ b/tuxemon/event/actions/play_music.py
@@ -22,7 +22,8 @@
 from __future__ import annotations
 
 import logging
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon import prepare
 from tuxemon.db import db
@@ -32,12 +33,9 @@ from tuxemon.platform import mixer
 logger = logging.getLogger(__name__)
 
 
-class PlayMusicActionParameters(NamedTuple):
-    filename: str
-
-
 @final
-class PlayMusicAction(EventAction[PlayMusicActionParameters]):
+@dataclass
+class PlayMusicAction(EventAction):
     """
     Play a music file from "resources/music/".
 
@@ -52,13 +50,13 @@ class PlayMusicAction(EventAction[PlayMusicActionParameters]):
     """
 
     name = "play_music"
-    param_class = PlayMusicActionParameters
+    filename: str
 
     def start(self) -> None:
-        filename = self.parameters.filename
-
         try:
-            path = prepare.fetch("music", db.lookup_file("music", filename))
+            path = prepare.fetch(
+                "music", db.lookup_file("music", self.filename)
+            )
             mixer.music.load(path)
             mixer.music.set_volume(prepare.CONFIG.music_volume)
             mixer.music.play(-1)
@@ -72,4 +70,4 @@ class PlayMusicAction(EventAction[PlayMusicActionParameters]):
                 "previoussong"
             ] = self.session.client.current_music["song"]
         self.session.client.current_music["status"] = "playing"
-        self.session.client.current_music["song"] = filename
+        self.session.client.current_music["song"] = self.filename

--- a/tuxemon/event/actions/play_sound.py
+++ b/tuxemon/event/actions/play_sound.py
@@ -21,18 +21,16 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon import audio
 from tuxemon.event.eventaction import EventAction
 
 
-class PlaySoundActionParameters(NamedTuple):
-    filename: str
-
-
 @final
-class PlaySoundAction(EventAction[PlaySoundActionParameters]):
+@dataclass
+class PlaySoundAction(EventAction):
     """
     Play a sound from "resources/sounds/".
 
@@ -47,9 +45,8 @@ class PlaySoundAction(EventAction[PlaySoundActionParameters]):
     """
 
     name = "play_sound"
-    param_class = PlaySoundActionParameters
+    filename: str
 
     def start(self) -> None:
-        filename = self.parameters.filename
-        sound = audio.load_sound(filename)
+        sound = audio.load_sound(self.filename)
         sound.play()

--- a/tuxemon/event/actions/player_face.py
+++ b/tuxemon/event/actions/player_face.py
@@ -21,7 +21,8 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
@@ -29,12 +30,9 @@ from tuxemon.map import dirs2, get_direction
 from tuxemon.states.world.worldstate import WorldState
 
 
-class PlayerFaceActionParameters(NamedTuple):
-    direction: str  # Using Direction as the typehint breaks the Action
-
-
 @final
-class PlayerFaceAction(EventAction[PlayerFaceActionParameters]):
+@dataclass
+class PlayerFaceAction(EventAction):
     """
     Make the player face a certain direction.
 
@@ -50,11 +48,11 @@ class PlayerFaceAction(EventAction[PlayerFaceActionParameters]):
     """
 
     name = "player_face"
-    param_class = PlayerFaceActionParameters
+    direction: str  # Using Direction as the typehint breaks the Action
 
     def start(self) -> None:
         # Get the parameters to determine what direction the player will face.
-        direction = self.parameters.direction
+        direction = self.direction
         if direction not in dirs2:
             target = get_npc(self.session, direction)
             assert target

--- a/tuxemon/event/actions/player_resume.py
+++ b/tuxemon/event/actions/player_resume.py
@@ -21,18 +21,16 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.states.world.worldstate import WorldState
 
 
-class PlayerResumeActionParameters(NamedTuple):
-    pass
-
-
 @final
-class PlayerResumeAction(EventAction[PlayerResumeActionParameters]):
+@dataclass
+class PlayerResumeAction(EventAction):
     """
     Make the player resume movement.
 
@@ -44,7 +42,6 @@ class PlayerResumeAction(EventAction[PlayerResumeActionParameters]):
     """
 
     name = "player_resume"
-    param_class = PlayerResumeActionParameters
 
     def start(self) -> None:
         # Get a copy of the world state.

--- a/tuxemon/event/actions/player_stop.py
+++ b/tuxemon/event/actions/player_stop.py
@@ -21,18 +21,16 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.states.world.worldstate import WorldState
 
 
-class PlayerStopActionParameters(NamedTuple):
-    pass
-
-
 @final
-class PlayerStopAction(EventAction[PlayerStopActionParameters]):
+@dataclass
+class PlayerStopAction(EventAction):
     """
     Make the player stop moving.
 
@@ -44,7 +42,6 @@ class PlayerStopAction(EventAction[PlayerStopActionParameters]):
     """
 
     name = "player_stop"
-    param_class = PlayerStopActionParameters
 
     def start(self) -> None:
         # Get a copy of the world state.

--- a/tuxemon/event/actions/print.py
+++ b/tuxemon/event/actions/print.py
@@ -22,19 +22,17 @@
 from __future__ import annotations
 
 import logging
-from typing import NamedTuple, Optional, final
+from dataclasses import dataclass
+from typing import Optional, final
 
 from tuxemon.event.eventaction import EventAction
 
 logger = logging.getLogger(__name__)
 
 
-class PrintActionParameters(NamedTuple):
-    variable: Optional[str]
-
-
 @final
-class PrintAction(EventAction[PrintActionParameters]):
+@dataclass
+class PrintAction(EventAction):
     """
     Print the current value of a game variable to the console.
 
@@ -52,12 +50,12 @@ class PrintAction(EventAction[PrintActionParameters]):
     """
 
     name = "print"
-    param_class = PrintActionParameters
+    variable: Optional[str] = None
 
     def start(self) -> None:
         player = self.session.player
 
-        variable = self.parameters.variable
+        variable = self.variable
         if variable:
             if variable in player.game_variables:
                 print(f"{variable}: {player.game_variables[variable]}")

--- a/tuxemon/event/actions/quit.py
+++ b/tuxemon/event/actions/quit.py
@@ -21,17 +21,15 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event.eventaction import EventAction
 
 
-class QuitActionParameters(NamedTuple):
-    pass
-
-
 @final
-class QuitAction(EventAction[QuitActionParameters]):
+@dataclass
+class QuitAction(EventAction):
     """
     Completely quit the game.
 
@@ -43,7 +41,6 @@ class QuitAction(EventAction[QuitActionParameters]):
     """
 
     name = "quit"
-    param_class = QuitActionParameters
 
     def start(self) -> None:
         # TODO: API

--- a/tuxemon/event/actions/random_encounter.py
+++ b/tuxemon/event/actions/random_encounter.py
@@ -23,7 +23,8 @@ from __future__ import annotations
 
 import logging
 import random
-from typing import NamedTuple, Optional, Sequence, Union, final
+from dataclasses import dataclass
+from typing import Optional, Sequence, Union, final
 
 from tuxemon import ai, monster, prepare
 from tuxemon.combat import check_battle_legal
@@ -37,13 +38,9 @@ from tuxemon.states.world.worldstate import WorldState
 logger = logging.getLogger(__name__)
 
 
-class RandomEncounterActionParameters(NamedTuple):
-    encounter_slug: str
-    total_prob: Union[float, None]
-
-
 @final
-class RandomEncounterAction(EventAction[RandomEncounterActionParameters]):
+@dataclass
+class RandomEncounterAction(EventAction):
     """
     Randomly start a encounter.
 
@@ -67,7 +64,8 @@ class RandomEncounterAction(EventAction[RandomEncounterActionParameters]):
     """
 
     name = "random_encounter"
-    param_class = RandomEncounterActionParameters
+    encounter_slug: str
+    total_prob: Union[float, None] = None
 
     def start(self) -> None:
         player = self.session.player
@@ -77,9 +75,9 @@ class RandomEncounterAction(EventAction[RandomEncounterActionParameters]):
         if not check_battle_legal(player):
             return
 
-        slug = self.parameters.encounter_slug
+        slug = self.encounter_slug
         encounters = db.lookup(slug, table="encounter").monsters
-        encounter = _choose_encounter(encounters, self.parameters.total_prob)
+        encounter = _choose_encounter(encounters, self.total_prob)
 
         # If a random encounter was successfully rolled, look up the monster
         # and start the battle.

--- a/tuxemon/event/actions/random_integer.py
+++ b/tuxemon/event/actions/random_integer.py
@@ -22,22 +22,18 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from random import randint
-from typing import NamedTuple, final
+from typing import final
 
 from tuxemon.event.eventaction import EventAction
 
 logger = logging.getLogger(__name__)
 
 
-class RandomIntegerActionParameters(NamedTuple):
-    var: str
-    lower_bound: int
-    upper_bound: int
-
-
 @final
-class RandomIntegerAction(EventAction[RandomIntegerActionParameters]):
+@dataclass
+class RandomIntegerAction(EventAction):
     """
     Randomly choose an integer between 2 numbers (inclusive), and set the key in the
     player.game_variables dictionary to be this value.
@@ -58,13 +54,15 @@ class RandomIntegerAction(EventAction[RandomIntegerActionParameters]):
     """
 
     name = "random_integer"
-    param_class = RandomIntegerActionParameters
+    var: str
+    lower_bound: int
+    upper_bound: int
 
     def start(self) -> None:
         player = self.session.player
 
-        var, lower_bound, upper_bound = self.parameters
-
         # Append the game_variables dictionary with a random number between
         # upper and lower bound, inclusive:
-        player.game_variables[var] = randint(lower_bound, upper_bound)
+        player.game_variables[self.var] = randint(
+            self.lower_bound, self.upper_bound
+        )

--- a/tuxemon/event/actions/remove_monster.py
+++ b/tuxemon/event/actions/remove_monster.py
@@ -21,19 +21,16 @@
 from __future__ import annotations
 
 import uuid
-from typing import NamedTuple, Union, final
+from dataclasses import dataclass
+from typing import Union, final
 
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 
 
-class RemoveMonsterActionParameters(NamedTuple):
-    instance_id: str
-    trainer_slug: Union[str, None]
-
-
 @final
-class RemoveMonsterAction(EventAction[RemoveMonsterActionParameters]):
+@dataclass
+class RemoveMonsterAction(EventAction):
     """
     Remove a monster from the given trainer's party if the monster is there.
 
@@ -53,12 +50,13 @@ class RemoveMonsterAction(EventAction[RemoveMonsterActionParameters]):
     """
 
     name = "remove_monster"
-    param_class = RemoveMonsterActionParameters
+    instance_id: str
+    trainer_slug: Union[str, None] = None
 
     def start(self) -> None:
-        iid = self.session.player.game_variables[self.parameters.instance_id]
+        iid = self.session.player.game_variables[self.instance_id]
         instance_id = uuid.UUID(iid)
-        trainer_slug = self.parameters.trainer_slug
+        trainer_slug = self.trainer_slug
 
         trainer = (
             self.session.player

--- a/tuxemon/event/actions/remove_npc.py
+++ b/tuxemon/event/actions/remove_npc.py
@@ -21,18 +21,16 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.states.world.worldstate import WorldState
 
 
-class RemoveNpcActionParameters(NamedTuple):
-    npc_slug: str
-
-
 @final
-class RemoveNpcAction(EventAction[RemoveNpcActionParameters]):
+@dataclass
+class RemoveNpcAction(EventAction):
     """
     Remove an NPC object from the list of NPCs.
 
@@ -47,11 +45,11 @@ class RemoveNpcAction(EventAction[RemoveNpcActionParameters]):
     """
 
     name = "remove_npc"
-    param_class = RemoveNpcActionParameters
+    npc_slug: str
 
     def start(self) -> None:
         # Get a copy of the world state.
         world = self.session.client.get_state_by_name(WorldState)
 
         # Get the npc's parameters from the action
-        world.remove_entity(self.parameters.npc_slug)
+        world.remove_entity(self.npc_slug)

--- a/tuxemon/event/actions/rename_monster.py
+++ b/tuxemon/event/actions/rename_monster.py
@@ -25,7 +25,8 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.locale import T
@@ -36,12 +37,9 @@ from tuxemon.states.monster import MonsterMenuState
 from tuxemon.states.world.worldstate import WorldState
 
 
-class RenameMonsterActionParameters(NamedTuple):
-    pass
-
-
 @final
-class RenameMonsterAction(EventAction[RenameMonsterActionParameters]):
+@dataclass
+class RenameMonsterAction(EventAction):
     """
     Open the monster menu and text input screens to rename a selected monster.
 
@@ -53,7 +51,6 @@ class RenameMonsterAction(EventAction[RenameMonsterActionParameters]):
     """
 
     name = "rename_monster"
-    param_class = RenameMonsterActionParameters
 
     def start(self) -> None:
         # Get a copy of the world state.

--- a/tuxemon/event/actions/rename_player.py
+++ b/tuxemon/event/actions/rename_player.py
@@ -25,7 +25,8 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon import prepare
 from tuxemon.event.eventaction import EventAction
@@ -33,12 +34,9 @@ from tuxemon.locale import T
 from tuxemon.menu.input import InputMenu
 
 
-class RenamePlayerActionParameters(NamedTuple):
-    pass
-
-
 @final
-class RenamePlayerAction(EventAction[RenamePlayerActionParameters]):
+@dataclass
+class RenamePlayerAction(EventAction):
     """
     Open the text input screen to rename the player.
 
@@ -50,7 +48,6 @@ class RenamePlayerAction(EventAction[RenamePlayerActionParameters]):
     """
 
     name = "rename_player"
-    param_class = RenamePlayerActionParameters
 
     def set_player_name(self, name: str) -> None:
         self.session.player.name = name

--- a/tuxemon/event/actions/rumble.py
+++ b/tuxemon/event/actions/rumble.py
@@ -21,18 +21,15 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event.eventaction import EventAction
 
 
-class RumbleActionParameters(NamedTuple):
-    duration: float
-    power: int
-
-
 @final
-class RumbleAction(EventAction[RumbleActionParameters]):
+@dataclass
+class RumbleAction(EventAction):
     """
     Rumble available controllers with rumble support.
 
@@ -48,11 +45,12 @@ class RumbleAction(EventAction[RumbleActionParameters]):
     """
 
     name = "rumble"
-    param_class = RumbleActionParameters
+    duration: float
+    power: int
 
     def start(self) -> None:
-        duration = float(self.parameters[0])
-        power = int(self.parameters[1])
+        duration = float(self.duration)
+        power = int(self.power)
 
         min_power = 0
         max_power = 24576

--- a/tuxemon/event/actions/screen_transition.py
+++ b/tuxemon/event/actions/screen_transition.py
@@ -21,18 +21,16 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.states.world.worldstate import WorldState
 
 
-class ScreenTransitionActionParameters(NamedTuple):
-    transition_time: float
-
-
 @final
-class ScreenTransitionAction(EventAction[ScreenTransitionActionParameters]):
+@dataclass
+class ScreenTransitionAction(EventAction):
     """
     Initiate a screen transition.
 
@@ -47,7 +45,7 @@ class ScreenTransitionAction(EventAction[ScreenTransitionActionParameters]):
     """
 
     name = "screen_transition"
-    param_class = ScreenTransitionActionParameters
+    transition_time: float
 
     def start(self) -> None:
         pass
@@ -56,5 +54,5 @@ class ScreenTransitionAction(EventAction[ScreenTransitionActionParameters]):
         world = self.session.client.get_state_by_name(WorldState)
 
         if not world.in_transition:
-            world.fade_and_teleport(self.parameters.transition_time)
+            world.fade_and_teleport(self.transition_time)
             self.stop()

--- a/tuxemon/event/actions/set_battle.py
+++ b/tuxemon/event/actions/set_battle.py
@@ -21,17 +21,15 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event.eventaction import EventAction
 
 
-class SetBattleActionParameters(NamedTuple):
-    battle_list: str
-
-
 @final
-class SetBattleAction(EventAction[SetBattleActionParameters]):
+@dataclass
+class SetBattleAction(EventAction):
     """
     Set the key in the player.battle_history dictionary.
 
@@ -47,13 +45,13 @@ class SetBattleAction(EventAction[SetBattleActionParameters]):
     """
 
     name = "set_battle"
-    param_class = SetBattleActionParameters
+    battle_list: str
 
     def start(self) -> None:
         player = self.session.player
 
         # Split the variable into a key: value pair
-        battle_list = self.parameters[0].split(":")
+        battle_list = self.battle_list.split(":")
         battle_key = str(battle_list[0])
         battle_value = str(battle_list[1])
 

--- a/tuxemon/event/actions/set_economy.py
+++ b/tuxemon/event/actions/set_economy.py
@@ -21,20 +21,17 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, Union, final
+from dataclasses import dataclass
+from typing import Union, final
 
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.item.economy import Economy
 
 
-class SetEconomyActionParameters(NamedTuple):
-    npc_slug: str
-    economy_slug: Union[str, None]
-
-
 @final
-class SetEconomyAction(EventAction[SetEconomyActionParameters]):
+@dataclass
+class SetEconomyAction(EventAction):
     """
     Set the economy (prices of items) of the npc or player.
 
@@ -50,14 +47,15 @@ class SetEconomyAction(EventAction[SetEconomyActionParameters]):
     """
 
     name = "set_economy"
-    param_class = SetEconomyActionParameters
+    npc_slug: str
+    economy_slug: Union[str, None] = None
 
     def start(self) -> None:
-        npc = get_npc(self.session, self.parameters.npc_slug)
+        npc = get_npc(self.session, self.npc_slug)
         assert npc
-        if self.parameters.economy_slug is None:
+        if self.economy_slug is None:
             npc.economy = Economy("default")
 
             return
 
-        npc.economy = Economy(self.parameters.economy_slug)
+        npc.economy = Economy(self.economy_slug)

--- a/tuxemon/event/actions/set_inventory.py
+++ b/tuxemon/event/actions/set_inventory.py
@@ -21,7 +21,8 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, Union, final
+from dataclasses import dataclass
+from typing import Union, final
 
 from tuxemon.db import db
 from tuxemon.event import get_npc
@@ -29,13 +30,9 @@ from tuxemon.event.eventaction import EventAction
 from tuxemon.item.item import decode_inventory
 
 
-class SetInventoryActionParameters(NamedTuple):
-    npc_slug: str
-    inventory_slug: Union[str, None]
-
-
 @final
-class SetInventoryAction(EventAction[SetInventoryActionParameters]):
+@dataclass
+class SetInventoryAction(EventAction):
     """
     Overwrite the inventory of the npc or player.
 
@@ -51,17 +48,18 @@ class SetInventoryAction(EventAction[SetInventoryActionParameters]):
     """
 
     name = "set_inventory"
-    param_class = SetInventoryActionParameters
+    npc_slug: str
+    inventory_slug: Union[str, None] = None
 
     def start(self) -> None:
-        npc = get_npc(self.session, self.parameters.npc_slug)
+        npc = get_npc(self.session, self.npc_slug)
         assert npc
-        if self.parameters.inventory_slug is None:
+        if self.inventory_slug is None:
             npc.inventory = {}
             return
 
         entry = db.lookup(
-            self.parameters.inventory_slug,
+            self.inventory_slug,
             table="inventory",
         ).inventory
 

--- a/tuxemon/event/actions/set_money.py
+++ b/tuxemon/event/actions/set_money.py
@@ -21,18 +21,15 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event.eventaction import EventAction
 
 
-class SetMoneyActionParameters(NamedTuple):
-    wallet: str
-    amount: int
-
-
 @final
-class SetMoneyAction(EventAction[SetMoneyActionParameters]):
+@dataclass
+class SetMoneyAction(EventAction):
     """
     Set the key and value in the money dictionary.
 
@@ -48,14 +45,9 @@ class SetMoneyAction(EventAction[SetMoneyActionParameters]):
     """
 
     name = "set_money"
-    param_class = SetMoneyActionParameters
+    wallet: str
+    amount: int
 
     def start(self) -> None:
-        player = self.session.player.money
-
-        # Read the parameters
-        wallet = self.parameters[0]
-        amount = self.parameters[1]
-
         # Append the money with a key
-        player[str(wallet)] = amount
+        self.session.player.money[str(self.wallet)] = self.amount

--- a/tuxemon/event/actions/set_monster_flair.py
+++ b/tuxemon/event/actions/set_monster_flair.py
@@ -21,42 +21,40 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.monster import Flair
 
 
-class SetMonsterFlairActionParameters(NamedTuple):
-    slot: int
-    category: str
-    name: str
-
-
 @final
-class SetMonsterFlairAction(EventAction[SetMonsterFlairActionParameters]):
+@dataclass
+class SetMonsterFlairAction(EventAction):
     """
     Set a monster's flair to the given value.
 
     Script usage:
         .. code-block::
 
-            set_monster_flair <slot>,<category>,<name>
+            set_monster_flair <slot>,<category>,<flair>
 
     Script parameters:
         slot: Slot of the monster in the party.
         category: Category of the monster flair.
-        name: Name of the monster flair.
+        flair: Name of the monster flair.
 
     """
 
     name = "set_monster_flair"
-    param_class = SetMonsterFlairActionParameters
+    slot: int
+    category: str
+    flair: str
 
     def start(self) -> None:
-        monster = self.session.player.monsters[self.parameters.slot]
-        if self.parameters.category in monster.flairs:
-            monster.flairs[self.parameters.category] = Flair(
-                self.parameters.category,
-                self.parameters.name,
+        monster = self.session.player.monsters[self.slot]
+        if self.category in monster.flairs:
+            monster.flairs[self.category] = Flair(
+                self.category,
+                self.flair,
             )

--- a/tuxemon/event/actions/set_monster_health.py
+++ b/tuxemon/event/actions/set_monster_health.py
@@ -22,7 +22,8 @@
 from __future__ import annotations
 
 import logging
-from typing import NamedTuple, Optional, Union, final
+from dataclasses import dataclass
+from typing import Optional, Union, final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.monster import Monster
@@ -30,13 +31,9 @@ from tuxemon.monster import Monster
 logger = logging.getLogger(__name__)
 
 
-class SetMonsterHealthActionParameters(NamedTuple):
-    slot: Union[int, None]
-    health: Union[float, None]
-
-
 @final
-class SetMonsterHealthAction(EventAction[SetMonsterHealthActionParameters]):
+@dataclass
+class SetMonsterHealthAction(EventAction):
     """
     Change the hp of a monster in the current player's party.
 
@@ -55,7 +52,8 @@ class SetMonsterHealthAction(EventAction[SetMonsterHealthActionParameters]):
     """
 
     name = "set_monster_health"
-    param_class = SetMonsterHealthActionParameters
+    slot: Union[int, None] = None
+    health: Union[float, None] = None
 
     @staticmethod
     def set_health(monster: Monster, value: Optional[float]) -> None:
@@ -71,8 +69,8 @@ class SetMonsterHealthAction(EventAction[SetMonsterHealthActionParameters]):
         if not self.session.player.monsters:
             return
 
-        monster_slot = self.parameters[0]
-        monster_health = self.parameters[1]
+        monster_slot = self.slot
+        monster_health = self.health
 
         if monster_slot is None:
             for monster in self.session.player.monsters:

--- a/tuxemon/event/actions/set_monster_level.py
+++ b/tuxemon/event/actions/set_monster_level.py
@@ -21,42 +21,40 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, Union, final
+from dataclasses import dataclass
+from typing import Union, final
 
 from tuxemon.event.eventaction import EventAction
 
 
-class SetMonsterLevelActionParameters(NamedTuple):
-    slot: Union[int, None]
-    level: int
-
-
 @final
-class SetMonsterLevelAction(EventAction[SetMonsterLevelActionParameters]):
+@dataclass
+class SetMonsterLevelAction(EventAction):
     """
     Change the level of a monster in the current player's party.
 
     Script usage:
         .. code-block::
 
-            set_monster_level [slot][,level]
+            set_monster_level [level][,slot]
 
     Script parameters:
+        level: Number of levels to add. Negative numbers are allowed.
         slot: Slot of the monster in the party. If no slot is specified, all
             monsters are leveled.
-        level: Number of levels to add. Negative numbers are allowed.
 
     """
 
     name = "set_monster_level"
-    param_class = SetMonsterLevelActionParameters
+    level: int
+    slot: Union[int, None] = None
 
     def start(self) -> None:
         if not self.session.player.monsters:
             return
 
-        monster_slot = self.parameters[0]
-        monster_level = self.parameters[1]
+        monster_slot = self.slot
+        monster_level = self.level
 
         if monster_slot:
             if len(self.session.player.monsters) < int(monster_slot):

--- a/tuxemon/event/actions/set_monster_status.py
+++ b/tuxemon/event/actions/set_monster_status.py
@@ -22,7 +22,8 @@
 from __future__ import annotations
 
 import logging
-from typing import NamedTuple, Optional, Union, final
+from dataclasses import dataclass
+from typing import Optional, Union, final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.monster import Monster
@@ -31,13 +32,9 @@ from tuxemon.technique.technique import Technique
 logger = logging.getLogger(__name__)
 
 
-class SetMonsterStatusActionParameters(NamedTuple):
-    slot: Union[int, None]
-    status: Union[str, None]
-
-
 @final
-class SetMonsterStatusAction(EventAction[SetMonsterStatusActionParameters]):
+@dataclass
+class SetMonsterStatusAction(EventAction):
     """
     Change the status of a monster in the current player's party.
 
@@ -55,7 +52,8 @@ class SetMonsterStatusAction(EventAction[SetMonsterStatusActionParameters]):
     """
 
     name = "set_monster_status"
-    param_class = SetMonsterStatusActionParameters
+    slot: Union[int, None] = None
+    status: Union[str, None] = None
 
     @staticmethod
     def set_status(monster: Monster, value: Optional[str]) -> None:
@@ -71,16 +69,13 @@ class SetMonsterStatusAction(EventAction[SetMonsterStatusActionParameters]):
         if not self.session.player.monsters:
             return
 
-        monster_slot = self.parameters[0]
-        monster_status = self.parameters[1]
-
-        if monster_slot is None:
+        if self.slot is None:
             for monster in self.session.player.monsters:
-                self.set_status(monster, monster_status)
+                self.set_status(monster, self.status)
         else:
             try:
-                monster = self.session.player.monsters[monster_slot]
+                monster = self.session.player.monsters[self.slot]
             except IndexError:
                 logger.error("invalid monster slot")
             else:
-                self.set_status(monster, monster_status)
+                self.set_status(monster, self.status)

--- a/tuxemon/event/actions/set_npc_attribute.py
+++ b/tuxemon/event/actions/set_npc_attribute.py
@@ -21,42 +21,38 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event import get_npc
 from tuxemon.event.actions.common import CommonAction
 from tuxemon.event.eventaction import EventAction
 
 
-class SetNpcAttributeActionParameters(NamedTuple):
-    npc_slug: str
-    name: str
-    value: str
-
-
 @final
-class SetNpcAttributeAction(EventAction[SetNpcAttributeActionParameters]):
+@dataclass
+class SetNpcAttributeAction(EventAction):
     """
     Set the given attribute of the npc to the given value.
 
     Script usage:
         .. code-block::
 
-            set_npc_attribute <npc_slug>,<name>,<value>
+            set_npc_attribute <npc_slug>,<attribute>,<value>
 
     Script parameters:
         npc_slug: Either "player" or npc slug name (e.g. "npc_maple").
-        name: Name of the attribute.
+        attribute: Name of the attribute.
         value: Value of the attribute.
 
     """
 
     name = "set_npc_attribute"
-    param_class = SetNpcAttributeActionParameters
+    npc_slug: str
+    attribute: str
+    value: str
 
     def start(self) -> None:
-        npc = get_npc(self.session, self.parameters[0])
+        npc = get_npc(self.session, self.npc_slug)
         assert npc
-        attribute = self.parameters[1]
-        value = self.parameters[2]
-        CommonAction.set_character_attribute(npc, attribute, value)
+        CommonAction.set_character_attribute(npc, self.attribute, self.value)

--- a/tuxemon/event/actions/set_player_attribute.py
+++ b/tuxemon/event/actions/set_player_attribute.py
@@ -21,43 +21,37 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event.actions.common import CommonAction
 from tuxemon.event.eventaction import EventAction
 
 
-class SetPlayerAttributeActionParameters(NamedTuple):
-    name: str
-    value: str
-
-
 @final
-class SetPlayerAttributeAction(
-    EventAction[SetPlayerAttributeActionParameters]
-):
+@dataclass
+class SetPlayerAttributeAction(EventAction):
     """
     Set the given attribute of the player character to the given value.
 
     Script usage:
         .. code-block::
 
-            set_player_attribute <name>,<value>
+            set_player_attribute <attribute>,<value>
 
     Script parameters:
-        name: Name of the attribute.
+        attribute: Name of the attribute.
         value: Value of the attribute.
 
     """
 
     name = "set_player_attribute"
-    param_class = SetPlayerAttributeActionParameters
+    attribute: str
+    value: str
 
     def start(self) -> None:
-        attribute = self.parameters[0]
-        value = self.parameters[1]
         CommonAction.set_character_attribute(
             self.session.player,
-            attribute,
-            value,
+            self.attribute,
+            self.value,
         )

--- a/tuxemon/event/actions/set_tuxepedia.py
+++ b/tuxemon/event/actions/set_tuxepedia.py
@@ -21,19 +21,16 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.db import SeenStatus
 from tuxemon.event.eventaction import EventAction
 
 
-class SetTuxepediaActionParameters(NamedTuple):
-    monster_key: str
-    monster_str: str
-
-
 @final
-class SetTuxepediaAction(EventAction[SetTuxepediaActionParameters]):
+@dataclass
+class SetTuxepediaAction(EventAction):
     """
     Set the key and value in the Tuxepedia dictionary.
 
@@ -49,17 +46,14 @@ class SetTuxepediaAction(EventAction[SetTuxepediaActionParameters]):
     """
 
     name = "set_tuxepedia"
-    param_class = SetTuxepediaActionParameters
+    monster_key: str
+    monster_str: str
 
     def start(self) -> None:
         player = self.session.player.tuxepedia
 
-        # Read the parameters
-        monster_key = self.parameters[0]
-        monster_str = self.parameters[1]
-
         # Append the tuxepedia with a key
-        if monster_str == "caught":
-            player[str(monster_key)] = SeenStatus.caught
-        elif monster_str == "seen":
-            player[str(monster_key)] = SeenStatus.seen
+        if self.monster_str == "caught":
+            player[str(self.monster_key)] = SeenStatus.caught
+        elif self.monster_str == "seen":
+            player[str(self.monster_key)] = SeenStatus.seen

--- a/tuxemon/event/actions/set_variable.py
+++ b/tuxemon/event/actions/set_variable.py
@@ -21,17 +21,15 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event.eventaction import EventAction
 
 
-class SetVariableActionParameters(NamedTuple):
-    var_list: str
-
-
 @final
-class SetVariableAction(EventAction[SetVariableActionParameters]):
+@dataclass
+class SetVariableAction(EventAction):
     """
     Set the key in the player.game_variables dictionary.
 
@@ -47,13 +45,13 @@ class SetVariableAction(EventAction[SetVariableActionParameters]):
     """
 
     name = "set_variable"
-    param_class = SetVariableActionParameters
+    var_list: str
 
     def start(self) -> None:
         player = self.session.player
 
         # Split the variable into a key: value pair
-        var_list = self.parameters[0].split(":")
+        var_list = self.var_list.split(":")
         var_key = str(var_list[0])
         var_value = str(var_list[1])
 

--- a/tuxemon/event/actions/spawn_monster.py
+++ b/tuxemon/event/actions/spawn_monster.py
@@ -25,7 +25,8 @@ from __future__ import annotations
 
 import logging
 import uuid
-from typing import NamedTuple, Optional, Sequence, final
+from dataclasses import dataclass
+from typing import Optional, Sequence, final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.graphics import get_avatar
@@ -38,15 +39,10 @@ from tuxemon.tools import open_dialog
 logger = logging.getLogger(__name__)
 
 
-class SpawnMonsterActionParameters(NamedTuple):
-    npc_slug: str
-    breeding_mother: str
-    breeding_father: str
-
-
 # noinspection PyAttributeOutsideInit
 @final
-class SpawnMonsterAction(EventAction[SpawnMonsterActionParameters]):
+@dataclass
+class SpawnMonsterAction(EventAction):
     """
     Breed a new monster.
 
@@ -70,13 +66,14 @@ class SpawnMonsterAction(EventAction[SpawnMonsterActionParameters]):
     """
 
     name = "spawn_monster"
-    param_class = SpawnMonsterActionParameters
+    npc_slug: str
+    breeding_mother: str
+    breeding_father: str
 
     def start(self) -> None:
-        npc_slug, breeding_mother, breeding_father = self.parameters
         world = self.session.client.get_state_by_name(WorldState)
 
-        npc_slug = npc_slug.replace("player", "npc_red")
+        npc_slug = self.npc_slug.replace("player", "npc_red")
         trainer = world.get_entity(npc_slug)
         if trainer is None:
             logger.error(
@@ -84,8 +81,8 @@ class SpawnMonsterAction(EventAction[SpawnMonsterActionParameters]):
             )
             return
 
-        mother_id = uuid.UUID(trainer.game_variables[breeding_mother])
-        father_id = uuid.UUID(trainer.game_variables[breeding_father])
+        mother_id = uuid.UUID(trainer.game_variables[self.breeding_mother])
+        father_id = uuid.UUID(trainer.game_variables[self.breeding_father])
 
         mother = trainer.find_monster_by_id(mother_id)
         if mother is None:

--- a/tuxemon/event/actions/start_cinema_mode.py
+++ b/tuxemon/event/actions/start_cinema_mode.py
@@ -21,18 +21,16 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.states.world.worldstate import WorldState
 
 
-class StartCinemaModeActionParameters(NamedTuple):
-    pass
-
-
 @final
-class StartCinemaModeAction(EventAction[StartCinemaModeActionParameters]):
+@dataclass
+class StartCinemaModeAction(EventAction):
     """
     Start cinema mode by animating black bars to narrow the aspect ratio.
 
@@ -44,7 +42,6 @@ class StartCinemaModeAction(EventAction[StartCinemaModeActionParameters]):
     """
 
     name = "start_cinema_mode"
-    param_class = StartCinemaModeActionParameters
 
     def start(self) -> None:
         world = self.session.client.current_state

--- a/tuxemon/event/actions/stop_cinema_mode.py
+++ b/tuxemon/event/actions/stop_cinema_mode.py
@@ -22,7 +22,8 @@
 from __future__ import annotations
 
 import logging
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.states.world.worldstate import WorldState
@@ -30,12 +31,9 @@ from tuxemon.states.world.worldstate import WorldState
 logger = logging.getLogger(__name__)
 
 
-class StopCinemaModeActionParameters(NamedTuple):
-    pass
-
-
 @final
-class StopCinemaModeAction(EventAction[StopCinemaModeActionParameters]):
+@dataclass
+class StopCinemaModeAction(EventAction):
     """
     Stop cinema mode by animating black bars back to the normal aspect ratio.
 
@@ -47,7 +45,6 @@ class StopCinemaModeAction(EventAction[StopCinemaModeActionParameters]):
     """
 
     name = "stop_cinema_mode"
-    param_class = StopCinemaModeActionParameters
 
     def start(self) -> None:
         world = self.session.client.current_state

--- a/tuxemon/event/actions/store_monster.py
+++ b/tuxemon/event/actions/store_monster.py
@@ -26,7 +26,8 @@ from __future__ import annotations
 
 import logging
 import uuid
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.prepare import CONFIG
@@ -34,14 +35,10 @@ from tuxemon.prepare import CONFIG
 logger = logging.getLogger(__name__)
 
 
-class StoreMonsterActionParameters(NamedTuple):
-    monster_id: str
-    box: str
-
-
 # noinspection PyAttributeOutsideInit
 @final
-class StoreMonsterAction(EventAction[StoreMonsterActionParameters]):
+@dataclass
+class StoreMonsterAction(EventAction):
     """
     Store a monster in a box.
 
@@ -60,14 +57,15 @@ class StoreMonsterAction(EventAction[StoreMonsterActionParameters]):
     """
 
     name = "store_monster"
-    param_class = StoreMonsterActionParameters
+    monster_id: str
+    box: str
 
     def start(self) -> None:
         player = self.session.player
         instance_id = uuid.UUID(
-            player.game_variables[self.parameters.monster_id],
+            player.game_variables[self.monster_id],
         )
-        box = self.parameters.box
+        box = self.box
         monster = player.find_monster_by_id(instance_id)
         if monster is None:
             raise ValueError(

--- a/tuxemon/event/actions/teleport.py
+++ b/tuxemon/event/actions/teleport.py
@@ -21,21 +21,17 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import Optional, final
 
 from tuxemon import prepare
 from tuxemon.event.eventaction import EventAction
 from tuxemon.states.world.worldstate import WorldState
 
 
-class TeleportActionParameters(NamedTuple):
-    map_name: str
-    x: int
-    y: int
-
-
 @final
-class TeleportAction(EventAction[TeleportActionParameters]):
+@dataclass
+class TeleportAction(EventAction):
     """
     Teleport the player to a particular map and tile coordinates.
 
@@ -52,31 +48,33 @@ class TeleportAction(EventAction[TeleportActionParameters]):
     """
 
     name = "teleport"
-    param_class = TeleportActionParameters
+    map_name: str
+    x: int
+    y: int
+    # This value is unused, but in too many places to remove right now
+    _: Optional[float] = None
 
     def start(self) -> None:
         player = self.session.player
         world = self.session.client.get_state_by_name(WorldState)
 
-        map_name = self.parameters.map_name
-
         # If we're doing a screen transition with this teleport, set the map
         # name that we'll load during the apex of the transition.
         # TODO: This only needs to happen once.
         if world.in_transition:
-            world.delayed_mapname = map_name
+            world.delayed_mapname = self.map_name
 
         # Check to see if we're also performing a transition. If we are, wait
         # to perform the teleport at the apex of the transition
         if world.in_transition:
             # the world state will handle the teleport/transition, hopefully
             world.delayed_teleport = True
-            world.delayed_x = self.parameters.x
-            world.delayed_y = self.parameters.y
+            world.delayed_x = self.x
+            world.delayed_y = self.y
 
         else:
             # If we're not doing a transition, then just do the teleport
-            map_path = prepare.fetch("maps", map_name)
+            map_path = prepare.fetch("maps", self.map_name)
 
             if world.current_map is None:
                 world.change_map(map_path)
@@ -89,7 +87,7 @@ class TeleportAction(EventAction[TeleportActionParameters]):
             player.cancel_path()
 
             # must change position after the map is loaded
-            player.set_position((self.parameters.x, self.parameters.y))
+            player.set_position((self.x, self.y))
 
             # unlock_controls will reset controls, but start moving if keys
             # are pressed

--- a/tuxemon/event/actions/teleport_faint.py
+++ b/tuxemon/event/actions/teleport_faint.py
@@ -22,19 +22,17 @@
 from __future__ import annotations
 
 import logging
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event.eventaction import EventAction
 
 logger = logging.getLogger(__name__)
 
 
-class TeleportFaintActionParameters(NamedTuple):
-    pass
-
-
 @final
-class TeleportFaintAction(EventAction[TeleportFaintActionParameters]):
+@dataclass
+class TeleportFaintAction(EventAction):
     """
     Teleport the player to the point in the teleport_faint variable.
 
@@ -49,7 +47,6 @@ class TeleportFaintAction(EventAction[TeleportFaintActionParameters]):
     """
 
     name = "teleport_faint"
-    param_class = TeleportFaintActionParameters
 
     def start(self) -> None:
         player = self.session.player

--- a/tuxemon/event/actions/transfer_money.py
+++ b/tuxemon/event/actions/transfer_money.py
@@ -22,21 +22,17 @@
 from __future__ import annotations
 
 import logging
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event.eventaction import EventAction
 
 logger = logging.getLogger(__name__)
 
 
-class MoneyMathActionParameters(NamedTuple):
-    transaction: str
-    amount: int
-    slug: str
-
-
 @final
-class MoneyMathAction(EventAction[MoneyMathActionParameters]):
+@dataclass
+class MoneyMathAction(EventAction):
     """
     Perform a mathematical transaction on the player's money.
 
@@ -55,15 +51,17 @@ class MoneyMathAction(EventAction[MoneyMathActionParameters]):
     """
 
     name = "transfer_money"
-    param_class = MoneyMathActionParameters
+    transaction: str
+    amount: int
+    slug: str
 
     def start(self) -> None:
         player = self.session.player
 
         # Read the parameters
-        transaction = self.parameters.transaction
-        amount = self.parameters.amount
-        destination = self.parameters.slug
+        transaction = self.transaction
+        amount = self.amount
+        destination = self.slug
 
         # Data
         wallet_player = player.money.get("player")

--- a/tuxemon/event/actions/translated_dialog.py
+++ b/tuxemon/event/actions/translated_dialog.py
@@ -22,7 +22,8 @@
 from __future__ import annotations
 
 import logging
-from typing import NamedTuple, Optional, Sequence, final
+from dataclasses import dataclass, field
+from typing import Optional, Sequence, final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.graphics import get_avatar
@@ -34,12 +35,9 @@ from tuxemon.tools import open_dialog
 logger = logging.getLogger(__name__)
 
 
-class TranslatedDialogActionParameters(NamedTuple):
-    pass
-
-
 @final
-class TranslatedDialogAction(EventAction[TranslatedDialogActionParameters]):
+@dataclass
+class TranslatedDialogAction(EventAction):
     """
     Open a dialog window with translated text according to the passed
     translation key. Parameters passed to the translation string will also
@@ -72,7 +70,11 @@ class TranslatedDialogAction(EventAction[TranslatedDialogActionParameters]):
     """
 
     name = "translated_dialog"
-    param_class = TranslatedDialogActionParameters
+    raw_parameters: Sequence[str] = field(init=False)
+
+    def __init__(self, *args):
+        super().__init__()
+        self.raw_parameters = args
 
     def start(self) -> None:
         key = self.raw_parameters[0]

--- a/tuxemon/event/actions/translated_dialog_chain.py
+++ b/tuxemon/event/actions/translated_dialog_chain.py
@@ -22,7 +22,8 @@
 from __future__ import annotations
 
 import logging
-from typing import NamedTuple, Optional, Sequence, final
+from dataclasses import dataclass, field
+from typing import Optional, Sequence, final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.graphics import get_avatar
@@ -34,13 +35,10 @@ from tuxemon.tools import open_dialog
 logger = logging.getLogger(__name__)
 
 
-class TranslatedDialogChainActionParameters(NamedTuple):
-    pass
-
-
 @final
+@dataclass
 class TranslatedDialogChainAction(
-    EventAction[TranslatedDialogChainActionParameters],
+    EventAction,
 ):
     """
     Open a chain of dialogs in order.
@@ -51,7 +49,6 @@ class TranslatedDialogChainAction(
     * ${{name}} - The current player's name.
     * ${{end}} - Ends the dialog chain.
 
-    Parameters following the translation name may represent one of two things:
     If a parameter is var1=value1, it represents a value replacement.
     If it's a single value (an integer or a string), it will be used as an
     avatar image.
@@ -72,7 +69,11 @@ class TranslatedDialogChainAction(
     """
 
     name = "translated_dialog_chain"
-    param_class = TranslatedDialogChainActionParameters
+    raw_parameters: Sequence[str] = field(init=False)
+
+    def __init__(self, *args):
+        super().__init__()
+        self.raw_parameters = args
 
     def start(self) -> None:
         key = self.raw_parameters[0]

--- a/tuxemon/event/actions/translated_dialog_choice.py
+++ b/tuxemon/event/actions/translated_dialog_choice.py
@@ -22,8 +22,9 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from functools import partial
-from typing import Callable, NamedTuple, Sequence, Tuple, final
+from typing import Callable, Sequence, Tuple, final
 
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
@@ -34,14 +35,10 @@ from tuxemon.states.choice import ChoiceState
 logger = logging.getLogger(__name__)
 
 
-class TranslatedDialogChoiceActionParameters(NamedTuple):
-    choices: str
-    variable: str
-
-
 @final
+@dataclass
 class TranslatedDialogChoiceAction(
-    EventAction[TranslatedDialogChoiceActionParameters],
+    EventAction,
 ):
     """
     Ask the player to make a choice.
@@ -59,15 +56,16 @@ class TranslatedDialogChoiceAction(
 
     name = "translated_dialog_choice"
 
-    param_class = TranslatedDialogChoiceActionParameters
+    choices: str
+    variable: str
 
     def start(self) -> None:
         def set_variable(var_value: str) -> None:
-            player.game_variables[self.parameters.variable] = var_value
+            player.game_variables[self.variable] = var_value
             self.session.client.pop_state()
 
         # perform text substitutions
-        choices = replace_text(self.session, self.parameters.choices)
+        choices = replace_text(self.session, self.choices)
         maybe_player = get_npc(self.session, "player")
         assert maybe_player
         player = maybe_player

--- a/tuxemon/event/actions/tuxepedia_print.py
+++ b/tuxemon/event/actions/tuxepedia_print.py
@@ -21,17 +21,15 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, Optional, final
+from dataclasses import dataclass
+from typing import Optional, final
 
 from tuxemon.event.eventaction import EventAction
 
 
-class TuxepediaPrintActionParameters(NamedTuple):
-    monster_slug: Optional[str]
-
-
 @final
-class TuxepediaPrintAction(EventAction[TuxepediaPrintActionParameters]):
+@dataclass
+class TuxepediaPrintAction(EventAction):
     """
     Print the current value of Tuxepedia to the console.
 
@@ -49,12 +47,12 @@ class TuxepediaPrintAction(EventAction[TuxepediaPrintActionParameters]):
     """
 
     name = "tuxepedia_print"
-    param_class = TuxepediaPrintActionParameters
+    monster_slug: Optional[str] = None
 
     def start(self) -> None:
         var = self.session.player.tuxepedia
 
-        monster_slug = self.parameters.monster_slug
+        monster_slug = self.monster_slug
         if monster_slug:
             if monster_slug in var:
                 print(f"{monster_slug}: {var[monster_slug]}")

--- a/tuxemon/event/actions/unlock_controls.py
+++ b/tuxemon/event/actions/unlock_controls.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.states.sink import SinkState
 
 
-class UnlockControlsActionParameters(NamedTuple):
-    pass
-
-
 @final
+@dataclass
 class UnlockControlsAction(
-    EventAction[UnlockControlsActionParameters],
+    EventAction,
 ):
     """
     Unlock player controls
@@ -25,8 +23,6 @@ class UnlockControlsAction(
     """
 
     name = "unlock_controls"
-
-    param_class = UnlockControlsActionParameters
 
     def start(self) -> None:
         sink_state = self.session.client.get_state_by_name(SinkState)

--- a/tuxemon/event/actions/update_inventory.py
+++ b/tuxemon/event/actions/update_inventory.py
@@ -21,7 +21,8 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.db import db
 from tuxemon.event import get_npc
@@ -29,13 +30,9 @@ from tuxemon.event.eventaction import EventAction
 from tuxemon.item.item import decode_inventory
 
 
-class UpdateInventoryActionParameters(NamedTuple):
-    npc_slug: str
-    inventory_slug: str
-
-
 @final
-class UpdateInventoryAction(EventAction[UpdateInventoryActionParameters]):
+@dataclass
+class UpdateInventoryAction(EventAction):
     """
     Update the inventory of the npc or player.
 
@@ -54,12 +51,13 @@ class UpdateInventoryAction(EventAction[UpdateInventoryActionParameters]):
     """
 
     name = "update_inventory"
-    param_class = UpdateInventoryActionParameters
+    npc_slug: str
+    inventory_slug: str
 
     def start(self) -> None:
-        npc = get_npc(self.session, self.parameters.npc_slug)
+        npc = get_npc(self.session, self.npc_slug)
         assert npc
-        if self.parameters.inventory_slug is None:
+        if self.inventory_slug is None:
             return
 
         npc.inventory.update(
@@ -67,7 +65,7 @@ class UpdateInventoryAction(EventAction[UpdateInventoryActionParameters]):
                 self.session,
                 npc,
                 db.lookup(
-                    self.parameters.inventory_slug,
+                    self.inventory_slug,
                     table="inventory",
                 ).inventory,
             )

--- a/tuxemon/event/actions/variable_math.py
+++ b/tuxemon/event/actions/variable_math.py
@@ -22,7 +22,8 @@
 from __future__ import annotations
 
 import logging
-from typing import NamedTuple, Union, final
+from dataclasses import dataclass
+from typing import Union, final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.tools import number_or_variable
@@ -30,15 +31,9 @@ from tuxemon.tools import number_or_variable
 logger = logging.getLogger(__name__)
 
 
-class VariableMathActionParameters(NamedTuple):
-    var1: str
-    operation: str
-    var2: str
-    result: Union[str, None]
-
-
 @final
-class VariableMathAction(EventAction[VariableMathActionParameters]):
+@dataclass
+class VariableMathAction(EventAction):
     """
     Perform a mathematical operation on the player.game_variables dictionary.
 
@@ -61,19 +56,22 @@ class VariableMathAction(EventAction[VariableMathActionParameters]):
     """
 
     name = "variable_math"
-    param_class = VariableMathActionParameters
+    var1: str
+    operation: str
+    var2: str
+    result: Union[str, None] = None
 
     def start(self) -> None:
         player = self.session.player
 
         # Read the parameters
-        var = self.parameters.var1
-        result = self.parameters.result
+        var = self.var1
+        result = self.result
         if result is None:
             result = var
         operand1 = number_or_variable(self.session, var)
-        operation = self.parameters.operation
-        operand2 = number_or_variable(self.session, self.parameters.var2)
+        operation = self.operation
+        operand2 = number_or_variable(self.session, self.var2)
 
         # Perform the operation on the variable
         if operation == "+":

--- a/tuxemon/event/actions/wait.py
+++ b/tuxemon/event/actions/wait.py
@@ -22,17 +22,15 @@
 from __future__ import annotations
 
 import time
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event.eventaction import EventAction
 
 
-class WaitActionParameters(NamedTuple):
-    seconds: float
-
-
 @final
-class WaitAction(EventAction[WaitActionParameters]):
+@dataclass
+class WaitAction(EventAction):
     """
     Block event chain for some time.
 
@@ -47,11 +45,11 @@ class WaitAction(EventAction[WaitActionParameters]):
     """
 
     name = "wait"
-    param_class = WaitActionParameters
+    seconds: float
 
     # TODO: use event loop time, not wall clock
     def start(self) -> None:
-        self.finish_time = time.time() + self.parameters.seconds
+        self.finish_time = time.time() + self.seconds
 
     def update(self) -> None:
         if time.time() >= self.finish_time:

--- a/tuxemon/event/actions/withdraw_monster.py
+++ b/tuxemon/event/actions/withdraw_monster.py
@@ -26,7 +26,8 @@ from __future__ import annotations
 
 import logging
 import uuid
-from typing import NamedTuple, final
+from dataclasses import dataclass
+from typing import final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.states.world.worldstate import WorldState
@@ -34,13 +35,9 @@ from tuxemon.states.world.worldstate import WorldState
 logger = logging.getLogger(__name__)
 
 
-class WithdrawMonsterActionParameters(NamedTuple):
-    trainer: str
-    monster_id: str
-
-
 @final
-class WithdrawMonsterAction(EventAction[WithdrawMonsterActionParameters]):
+@dataclass
+class WithdrawMonsterAction(EventAction):
     """
     Pull a monster from the given trainer's storage and puts it in their party.
 
@@ -60,16 +57,16 @@ class WithdrawMonsterAction(EventAction[WithdrawMonsterActionParameters]):
     """
 
     name = "withdraw_monster"
-    param_class = WithdrawMonsterActionParameters
+    trainer: str
+    monster_id: str
 
     def start(self) -> None:
-        trainer, monster_id = self.parameters
         world = self.session.client.get_state_by_name(WorldState)
 
-        trainer = trainer.replace("player", "npc_red")
+        trainer = self.trainer.replace("player", "npc_red")
         npc = world.get_entity(trainer)
         assert npc
-        instance_id = uuid.UUID(npc.game_variables[monster_id])
+        instance_id = uuid.UUID(npc.game_variables[self.monster_id])
         mon = npc.find_monster_in_storage(instance_id)
         assert mon
 

--- a/tuxemon/event/eventengine.py
+++ b/tuxemon/event/eventengine.py
@@ -205,8 +205,13 @@ class EventEngine:
             logger.warning(error)
             return None
 
-        else:
-            return action(self.session, parameters)
+        try:
+            return action(*parameters)
+        except Exception as e:
+            logger.warning(
+                f"Error running {name}. Could not instantiate {action} with parameters {parameters}: {e}"
+            )
+            return None
 
     def get_actions(self) -> List[Type[EventAction]]:
         """

--- a/tuxemon/map_loader.py
+++ b/tuxemon/map_loader.py
@@ -164,6 +164,10 @@ class TMXMapLoader:
 
     """
 
+    def __init__(self):
+        # Makes mocking easier during tests
+        self.image_loader = scaled_image_loader
+
     def load(self, filename: str) -> TuxemonMap:
         """Load map data from a tmx map file.
 
@@ -196,7 +200,7 @@ class TMXMapLoader:
         """
         data = pytmx.TiledMap(
             filename=filename,
-            image_loader=scaled_image_loader,
+            image_loader=self.image_loader,
             pixelalpha=True,
         )
         tile_size = (data.tilewidth, data.tileheight)

--- a/tuxemon/tools.py
+++ b/tuxemon/tools.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import logging
 import typing
+from dataclasses import fields
 from itertools import zip_longest
 from typing import (
     TYPE_CHECKING,
@@ -247,6 +248,46 @@ def number_or_variable(
             raise ValueError(f"invalid number or game variable {value}")
 
 
+# TODO: stability/testing
+def cast_value(
+    i: Tuple[Tuple[ValidParameterTypes, str], Any],
+) -> Any:
+
+    (type_constructors, param_name), value = i
+
+    if not isinstance(type_constructors, Sequence):
+        type_constructors = [type_constructors]
+
+    if (value is None or value == "") and (
+        None in type_constructors or type(None) in type_constructors
+    ):
+        return None
+
+    for constructor in type_constructors:
+
+        if not constructor:
+            continue
+
+        if isinstance(value, constructor):
+            return value
+
+        elif typing.get_origin(constructor) is typing.Literal:
+            allowed_values = typing.get_args(constructor)
+            if value in allowed_values:
+                return value
+
+        else:
+            try:
+                return constructor(value)
+            except (ValueError, TypeError):
+                pass
+
+    raise ValueError(
+        f"Error parsing parameter {param_name} with value {value} and "
+        f"constructor list {type_constructors}",
+    )
+
+
 def cast_values(
     parameters: Sequence[Any],
     valid_parameters: Sequence[Tuple[ValidParameterTypes, str]],
@@ -265,36 +306,8 @@ def cast_values(
 
     """
 
-    # TODO: stability/testing
-    def cast(
-        i: Tuple[Tuple[ValidParameterTypes, str], Any],
-    ) -> Any:
-
-        (type_constructors, param_name), value = i
-
-        if not isinstance(type_constructors, Sequence):
-            type_constructors = [type_constructors]
-
-        if (value is None or value == "") and (
-            None in type_constructors or type(None) in type_constructors
-        ):
-            return None
-
-        for constructor in type_constructors:
-
-            if constructor:
-                try:
-                    return constructor(value)
-                except (ValueError, TypeError):
-                    pass
-
-        raise ValueError(
-            f"Error parsing parameter {param_name} with value {value} and "
-            f"constructor list {type_constructors}",
-        )
-
     try:
-        return list(map(cast, zip_longest(valid_parameters, parameters)))
+        return list(map(cast_value, zip_longest(valid_parameters, parameters)))
     except ValueError:
         logger.warning("Invalid parameters passed:")
         logger.warning(f"expected: {valid_parameters}")
@@ -309,6 +322,23 @@ def get_types_tuple(
         return typing.get_args(param_type)
     else:
         return (param_type,)
+
+
+def cast_dataclass_parameters(self):
+    """
+    Takes a dataclass object and casts its __init__ values to the correct type
+    """
+    type_hints = typing.get_type_hints(self.__class__)
+    for field in fields(self):
+        if field.init:
+            field_name = field.name  # e.g "map_name"
+            type_hint = type_hints[field_name]  # e.g. Optional[str]
+            constructors = get_types_tuple(
+                type_hint
+            )  # e.g. (<class 'str'>, <class 'NoneType'>)
+            old_value = getattr(self, field_name)
+            new_value = cast_value(((constructors, field_name), old_value))
+            setattr(self, field_name, new_value)
 
 
 def cast_parameters_to_namedtuple(


### PR DESCRIPTION
It was annoying me that we have the attributes nested within another attribute. The parameter namedtuple has been removed, the attributes are now on the class. We still have automatic type-casting.

Optional values now need to be explicitly defaulted to None. I can try to bring back automatic defaulting to None if necessary.

I tried using pydantic, rather than dataclasses, but it was a bit too awkward and opinionated.

Also implemented:
A script which performs basic validation on every action in the game.
A couple of minor script fixes discovered by the above.
Fix dialog + dialog chain: the action would fail crash if you had too many commas in the text (I know they're deprecated, but why not).
Support for "Literal" typehint.
