### PR TITLE
missing effects

### DIFF
--- a/mods/tuxemon/db/technique/amnesia.json
+++ b/mods/tuxemon/db/technique/amnesia.json
@@ -4,7 +4,7 @@
   "animation": "sparks_gold_alt",
   "category": "physical",
   "effects": [
-    "statchange"
+    "status status_exhausted"
   ],
   "flip_axes": "",
   "healing_power": 0,
@@ -13,18 +13,6 @@
   "is_fast": false,
   "potency": 1,
   "power": 2.25,
-  "statdodge": {
-    "value": 0, "max_deviation": 3, "operation":"-"
-  },
-  "statmelee": {
-    "value": 2, "operation":"+"
-  },
-  "statranged": {
-    "value": 2,  "operation":"+"
-  },
-  "stathp": {
-    "value": 4, "operation":"-"
-  },
   "range": "reach",
   "recharge": 2,
   "sfx": "sfx_shine",

--- a/mods/tuxemon/db/technique/avalanche.json
+++ b/mods/tuxemon/db/technique/avalanche.json
@@ -4,7 +4,8 @@
   "animation": "thud",
   "category": "physical",
   "effects": [
-    "damage"
+    "damage",
+    "status status_exhausted"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/battery_acid.json
+++ b/mods/tuxemon/db/technique/battery_acid.json
@@ -4,7 +4,8 @@
   "animation": "disintegrate",
   "category": "physical",
   "effects": [
-    "damage"
+    "damage",
+    "poison"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/beam.json
+++ b/mods/tuxemon/db/technique/beam.json
@@ -4,7 +4,8 @@
   "animation": "crystal",
   "category": "physical",
   "effects": [
-    "damage"
+    "damage",
+    "status status_blinded"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/biting_winds.json
+++ b/mods/tuxemon/db/technique/biting_winds.json
@@ -4,7 +4,8 @@
   "animation": "ice blast",
   "category": "physical",
   "effects": [
-    "damage"
+    "damage",
+    "status status_softened"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/blood_bond.json
+++ b/mods/tuxemon/db/technique/blood_bond.json
@@ -4,7 +4,8 @@
   "animation": "sparks_red",
   "category": "physical",
   "effects": [
-    "damage"
+    "damage",
+    "lifeleech"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/energy_field.json
+++ b/mods/tuxemon/db/technique/energy_field.json
@@ -3,7 +3,9 @@
   "accuracy": 1,
   "animation": "screen",
   "category": "physical",
-  "effects": [],
+  "effects": [
+    "status status_exhausted"
+  ],
   "flip_axes": "x",
   "healing_power": 0,
   "icon": "",

--- a/mods/tuxemon/db/technique/eyebite.json
+++ b/mods/tuxemon/db/technique/eyebite.json
@@ -3,7 +3,9 @@
   "accuracy": 1,
   "animation": "bite",
   "category": "physical",
-  "effects": [],
+  "effects": [
+    "status status_exhausted"
+  ],
   "flip_axes": "",
   "healing_power": 0,
   "icon": "",

--- a/mods/tuxemon/db/technique/fester.json
+++ b/mods/tuxemon/db/technique/fester.json
@@ -4,7 +4,8 @@
   "animation": "drip_green",
   "category": "physical",
   "effects": [
-    "damage"
+    "damage",
+    "poison"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/frostbite.json
+++ b/mods/tuxemon/db/technique/frostbite.json
@@ -4,7 +4,8 @@
   "animation": "lance_ice",
   "category": "physical",
   "effects": [
-    "damage"
+    "damage",
+    "poison"
   ],
   "flip_axes": "xy",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/glower.json
+++ b/mods/tuxemon/db/technique/glower.json
@@ -3,7 +3,9 @@
   "accuracy": 1,
   "animation": null,
   "category": "physical",
-  "effects": [],
+  "effects": [
+    "status status_softened"
+  ],
   "flip_axes": "",
   "healing_power": 0,
   "icon": "",

--- a/mods/tuxemon/db/technique/goad.json
+++ b/mods/tuxemon/db/technique/goad.json
@@ -4,7 +4,8 @@
   "animation": "buff_rage",
   "category": "physical",
   "effects": [
-    "damage"
+    "damage",
+    "status status_enraged"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/levitate.json
+++ b/mods/tuxemon/db/technique/levitate.json
@@ -4,7 +4,7 @@
   "animation": null,
   "category": "physical",
   "effects": [
-    "statchange"
+    "status status_sniping"
   ],
   "flip_axes": "",
   "healing_power": 0,
@@ -13,9 +13,6 @@
   "is_fast": false,
   "potency": 1,
   "power": 0,
-  "statdodge": {
-    "value": 4, "max_deviation": 2, "operation":"+", "overridetofull":false
-  },
   "range": "special",
   "recharge": 2,
   "sfx": "sfx_blaster",

--- a/mods/tuxemon/db/technique/muddle.json
+++ b/mods/tuxemon/db/technique/muddle.json
@@ -4,7 +4,8 @@
   "animation": "sparks_white",
   "category": "physical",
   "effects": [
-    "damage"
+    "damage",
+    "status status_focused"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/mudslide.json
+++ b/mods/tuxemon/db/technique/mudslide.json
@@ -4,7 +4,8 @@
   "animation": "spikes_rock",
   "category": "physical",
   "effects": [
-    "damage"
+    "damage",
+    "status status_softened"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/overfeed.json
+++ b/mods/tuxemon/db/technique/overfeed.json
@@ -15,7 +15,7 @@
   "potency": 1,
   "power": 0,
   "statspeed": {
-    "value": 2, "operation":"/"
+    "value": 2, "operation":"-"
   },
   "stathp": {
     "value": 0, "operation":".", "overridetofull":true

--- a/mods/tuxemon/db/technique/probiscus.json
+++ b/mods/tuxemon/db/technique/probiscus.json
@@ -4,7 +4,8 @@
   "animation": "lance_ice",
   "category": "physical",
   "effects": [
-    "damage"
+    "damage",
+    "lifeleech"
   ],
   "flip_axes": "xy",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/rot.json
+++ b/mods/tuxemon/db/technique/rot.json
@@ -3,7 +3,9 @@
   "accuracy": 1,
   "animation": "drip_green",
   "category": "physical",
-  "effects": [],
+  "effects": [
+    "poison"
+  ],
   "flip_axes": "",
   "healing_power": 0,
   "icon": "",

--- a/mods/tuxemon/db/technique/rust_bomb.json
+++ b/mods/tuxemon/db/technique/rust_bomb.json
@@ -4,7 +4,8 @@
   "animation": "puff",
   "category": "physical",
   "effects": [
-    "damage"
+    "damage",
+    "poison"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/salamander.json
+++ b/mods/tuxemon/db/technique/salamander.json
@@ -4,7 +4,8 @@
   "animation": "fire enemy death 1",
   "category": "physical",
   "effects": [
-    "damage"
+    "damage",
+    "poison"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/sand_spray.json
+++ b/mods/tuxemon/db/technique/sand_spray.json
@@ -4,7 +4,8 @@
   "animation": "explosion_dusty_96",
   "category": "physical",
   "effects": [
-    "damage"
+    "damage",
+    "status status_blinded"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/snowstorm.json
+++ b/mods/tuxemon/db/technique/snowstorm.json
@@ -4,7 +4,8 @@
   "animation": "ice blast",
   "category": "physical",
   "effects": [
-    "damage"
+    "damage",
+    "status status_exhausted"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/splinter.json
+++ b/mods/tuxemon/db/technique/splinter.json
@@ -4,7 +4,8 @@
   "animation": "snake_right",
   "category": "physical",
   "effects": [
-    "damage"
+    "damage",
+    "status status_blinded"
   ],
   "flip_axes": "x",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/spray.json
+++ b/mods/tuxemon/db/technique/spray.json
@@ -4,7 +4,8 @@
   "animation": null,
   "category": "physical",
   "effects": [
-    "damage"
+    "damage",
+    "poison"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/static_field.json
+++ b/mods/tuxemon/db/technique/static_field.json
@@ -3,7 +3,9 @@
   "accuracy": 1,
   "animation": "disintegrate",
   "category": "physical",
-  "effects": [],
+  "effects": [
+    "status status_exhausted"
+  ],
   "flip_axes": "",
   "healing_power": 0,
   "icon": "",

--- a/mods/tuxemon/db/technique/status_blinded.json
+++ b/mods/tuxemon/db/technique/status_blinded.json
@@ -1,0 +1,31 @@
+{
+  "tech_id": 98,
+  "slug": "status_blinded",
+  "use_failure": "generic_failure",
+  "use_success": "generic_success",
+  "use_tech": "combat_used_x",
+  "animation": "drip_green",
+  "sfx": "sfx_pulse",
+  "icon": "",
+  "category": "blinded",
+  "sort": "meta",
+  "effects": [
+    "statchange"
+  ],
+  "statspeed": {
+    "value": 0.5, "operation":"-"
+  },
+  "statdodge": {
+    "value": 0.5, "operation":"-"
+  },
+  "flip_axes": "",
+  "target": {
+    "enemy monster": 0,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0,
+    "item": 0
+  }
+}

--- a/mods/tuxemon/db/technique/status_chargedup.json
+++ b/mods/tuxemon/db/technique/status_chargedup.json
@@ -1,0 +1,40 @@
+{
+  "tech_id": 99,
+  "slug": "status_chargedup",
+  "use_failure": "generic_failure",
+  "use_success": "generic_success",
+  "use_tech": "combat_used_x",
+  "animation": "drip_green",
+  "sfx": "sfx_pulse",
+  "icon": "",
+  "category": "chargedup",
+  "sort": "meta",
+  "effects": [
+    "statchange"
+  ],
+  "statspeed": {
+    "value": 2, "operation":"-"
+  },
+  "statmelee": {
+    "value": 2, "operation":"-"
+  },
+  "statranged": {
+    "value": 2, "operation":"-"
+  },
+  "statarmour": {
+    "value": 2, "operation":"-"
+  },
+  "statdodge": {
+    "value": 2, "operation":"-"
+  },
+  "flip_axes": "",
+  "target": {
+    "enemy monster": 0,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0,
+    "item": 0
+  }
+}

--- a/mods/tuxemon/db/technique/status_enraged.json
+++ b/mods/tuxemon/db/technique/status_enraged.json
@@ -1,0 +1,31 @@
+{
+  "tech_id": 100,
+  "slug": "status_enraged",
+  "use_failure": "generic_failure",
+  "use_success": "generic_success",
+  "use_tech": "combat_used_x",
+  "animation": "drip_green",
+  "sfx": "sfx_pulse",
+  "icon": "",
+  "category": "enraged",
+  "sort": "meta",
+  "effects": [
+    "statchange"
+  ],
+  "statmelee": {
+    "value": 2, "operation":"-"
+  },
+  "statranged": {
+    "value": 0.5, "operation":"-"
+  },
+  "flip_axes": "",
+  "target": {
+    "enemy monster": 0,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0,
+    "item": 0
+  }
+}

--- a/mods/tuxemon/db/technique/status_exhausted.json
+++ b/mods/tuxemon/db/technique/status_exhausted.json
@@ -1,0 +1,31 @@
+{
+  "tech_id": 101,
+  "slug": "status_exhausted",
+  "use_failure": "generic_failure",
+  "use_success": "generic_success",
+  "use_tech": "combat_used_x",
+  "animation": "drip_green",
+  "sfx": "sfx_pulse",
+  "icon": "",
+  "category": "exhausted",
+  "sort": "meta",
+  "effects": [
+    "statchange"
+  ],
+  "statmelee": {
+    "value": 0.5, "operation":"-"
+  },
+  "statranged": {
+    "value": 0.5, "operation":"-"
+  },
+  "flip_axes": "",
+  "target": {
+    "enemy monster": 0,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0,
+    "item": 0
+  }
+}

--- a/mods/tuxemon/db/technique/status_focused.json
+++ b/mods/tuxemon/db/technique/status_focused.json
@@ -1,0 +1,28 @@
+{
+  "tech_id": 102,
+  "slug": "status_focused",
+  "use_failure": "generic_failure",
+  "use_success": "generic_success",
+  "use_tech": "combat_used_x",
+  "animation": "drip_green",
+  "sfx": "sfx_pulse",
+  "icon": "",
+  "category": "focused",
+  "sort": "meta",
+  "effects": [
+    "statchange"
+  ],
+  "statdodge": {
+    "value": 1.5, "operation":"-"
+  },
+  "flip_axes": "",
+  "target": {
+    "enemy monster": 0,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0,
+    "item": 0
+  }
+}

--- a/mods/tuxemon/db/technique/status_sniping.json
+++ b/mods/tuxemon/db/technique/status_sniping.json
@@ -1,0 +1,31 @@
+{
+  "tech_id": 103,
+  "slug": "status_sniping",
+  "use_failure": "generic_failure",
+  "use_success": "generic_success",
+  "use_tech": "combat_used_x",
+  "animation": "drip_green",
+  "sfx": "sfx_pulse",
+  "icon": "",
+  "category": "sniping",
+  "sort": "meta",
+  "effects": [
+    "statchange"
+  ],
+  "statmelee": {
+    "value": 0.5, "operation":"-"
+  },
+  "statranged": {
+    "value": 2, "operation":"-"
+  },
+  "flip_axes": "",
+  "target": {
+    "enemy monster": 0,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0,
+    "item": 0
+  }
+}

--- a/mods/tuxemon/db/technique/status_softened.json
+++ b/mods/tuxemon/db/technique/status_softened.json
@@ -1,0 +1,31 @@
+{
+  "tech_id": 104,
+  "slug": "status_softened",
+  "use_failure": "generic_failure",
+  "use_success": "generic_success",
+  "use_tech": "combat_used_x",
+  "animation": "drip_green",
+  "sfx": "sfx_pulse",
+  "icon": "",
+  "category": "softened",
+  "sort": "meta",
+  "effects": [
+    "statchange"
+  ],
+  "statspeed": {
+    "value": 0.5, "operation":"-"
+  },
+  "statarmour": {
+    "value": 0.5, "operation":"-"
+  },
+  "flip_axes": "",
+  "target": {
+    "enemy monster": 0,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0,
+    "item": 0
+  }
+}

--- a/mods/tuxemon/db/technique/sting.json
+++ b/mods/tuxemon/db/technique/sting.json
@@ -4,7 +4,8 @@
   "animation": "pound",
   "category": "physical",
   "effects": [
-    "damage"
+    "damage",
+    "poison"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/stone_rot.json
+++ b/mods/tuxemon/db/technique/stone_rot.json
@@ -3,7 +3,9 @@
   "accuracy": 1,
   "animation": "drip_green",
   "category": "physical",
-  "effects": [],
+  "effects": [
+    "poison"
+  ],
   "flip_axes": "",
   "healing_power": 0,
   "icon": "",

--- a/mods/tuxemon/db/technique/suck_poison.json
+++ b/mods/tuxemon/db/technique/suck_poison.json
@@ -4,8 +4,8 @@
   "animation": "drip_green",
   "category": "physical",
   "effects": [
-    "poison",
-    "damage"
+    "damage",
+    "poison"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/sudden_glow.json
+++ b/mods/tuxemon/db/technique/sudden_glow.json
@@ -3,7 +3,9 @@
   "accuracy": 1,
   "animation": "heal_burst_120",
   "category": "physical",
-  "effects": [],
+  "effects": [
+    "status status_focused"
+  ],
   "flip_axes": "",
   "healing_power": 2.0,
   "icon": "",

--- a/mods/tuxemon/db/technique/supernova.json
+++ b/mods/tuxemon/db/technique/supernova.json
@@ -4,7 +4,8 @@
   "animation": "fireball_114",
   "category": "physical",
   "effects": [
-    "damage"
+    "damage",
+    "status status_chargedup"
   ],
   "flip_axes": "x",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/thunderclap.json
+++ b/mods/tuxemon/db/technique/thunderclap.json
@@ -4,7 +4,8 @@
   "animation": "thunderstrike",
   "category": "physical",
   "effects": [
-    "damage"
+    "damage",
+    "status status_exhausted"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/tonguespear.json
+++ b/mods/tuxemon/db/technique/tonguespear.json
@@ -4,7 +4,8 @@
   "animation": "lance_ice",
   "category": "physical",
   "effects": [
-    "damage"
+    "damage",
+    "lifeleech"
   ],
   "flip_axes": "xy",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/venomous_tentacle.json
+++ b/mods/tuxemon/db/technique/venomous_tentacle.json
@@ -4,8 +4,8 @@
   "animation": "torrentacle",
   "category": "physical",
   "effects": [
-    "poison",
-    "damage"
+    "damage",
+    "poison"
   ],
   "flip_axes": "",
   "healing_power": 0,


### PR DESCRIPTION
Source: https://sanglorian.github.io/downloads/Tuxemon/techniques.xlsx

During the refactoring I noticed that there wasn't any lifeleech effects among the techniques as well as only a couple of poison effects. PR addresses:
- the missing effects
- statchange for the following effects: blinded, chargedup, enraged, exhausted, focused, sniping, softened

The JSON structure, no code.

Missing effects (target conditions):
```
dozing
grabbed
noddingoff
stuck
tired
```

Missing conditions (user conditions):
```
charging
diehard
enraged
exhausted
focused
grabbed
hardshell
lifeleech
noddingoff
poisoned
recovering
sniping
```
-> there is no conditions field, I have ready the structure ready for the JSONs files (conditions field).

As you can see our **recover** and **hardshell** need to be moved in conditions. As soon as there is the structure, we can move it.

https://wiki.tuxemon.org/index.php?title=Category:Condition