### PR TITLE
fix double move

### DIFF
--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -514,7 +514,10 @@ class Monster:
 
         # Update moves
         for move in self.moveset:
-            if move not in self.moves and move.level_learned <= level:
+            if (
+                move.technique not in (m.slug for m in self.moves)
+                and move.level_learned <= level
+            ):
                 self.learn(Technique(move.technique))
 
     def experience_required(self, level_ofs: int = 0) -> int:


### PR DESCRIPTION
I was doing some testing and I needed some monsters.
add_monster and random_monster keep trying to sneak the moves two times - screenshot.
The cause is the randint 2-5 of load_from_db (monster.py).

The PR addresses the issue, the fix is applied only in add_monster and random_monster.
I'm open to discuss other fixes if this is considered too much.

![Screenshot from 2022-10-09 15-09-02](https://user-images.githubusercontent.com/64643719/194761097-7b0dac58-c7a7-43bd-9d76-be3322bc42f9.png)