### PR TITLE
node js warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Command copied from flathub build process
     - name: Validate appdata file
@@ -35,7 +35,7 @@ jobs:
     name: "Flatpak"
     runs-on: ubuntu-latest
     container:
-      image: bilelmoussaoui/flatpak-github-actions:kde-5.15-21.08
+      image: bilelmoussaoui/flatpak-github-actions:kde-6.3
       options: --privileged
     steps:
     - name: Show environment variables
@@ -94,7 +94,7 @@ jobs:
       run: cat org.tuxemon.Tuxemon/org.tuxemon.Tuxemon.yaml
 
     - name: Build package
-      uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4
+      uses: flatpak/flatpak-github-actions/flatpak-builder@v4
       with:
         bundle: Tuxemon.flatpak
         manifest-path: org.tuxemon.Tuxemon/org.tuxemon.Tuxemon.yaml
@@ -105,8 +105,8 @@ jobs:
     runs-on: windows-latest
     steps:
       # Checkout the repo
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2.2.2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
             # Version range or exact version of a Python version to use, using SemVer's version range syntax.
             python-version: 3.9 # optional, default is 3.x
@@ -146,9 +146,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Install nsis
         run: |
-          Invoke-WebRequest -Uri "https://netcologne.dl.sourceforge.net/project/nsis/NSIS%203/3.06.1/nsis-3.06.1-setup.exe" -OutFile "nsis.exe"
+          Invoke-WebRequest -Uri "https://netcologne.dl.sourceforge.net/project/nsis/NSIS%203/3.08/nsis-3.08-setup.exe" -OutFile "nsis.exe"
 
       - name: Build Installer
         run: |
@@ -136,7 +136,7 @@ jobs:
           mv tuxemon-installer.exe ../dist/.
 
       - name: Upload installer
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@v3
         with:
             name: tuxemon_windows_installer
             path: dist
@@ -181,7 +181,7 @@ jobs:
     if: ${{ github.ref == 'refs/heads/development' || (github.event_name == 'push' && github.ref_type == 'tag' && startswith(github.ref_name, 'v'))  }}
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: artifacts
 


### PR DESCRIPTION
PR addresses 3 warnings (see below) and it updates kde in flatpack (there is already the 6.4, but it's only 16 hours old).

While checking the actions I noticed that there is a new version of:
actions/download-artifact@v2 -> v3
actions/upload-artifact@v2 -> v3
included the link for the builder

Warnings solved:
- python-app
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/setup-python, actions/setup-python, actions/checkout
- Appdata Validation
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/checkout
- build_installer_windows
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/setup-python, actions/checkout

It remains only, related to flatpak:
Please update the following actions to use Node.js 16: flatpak/flatpak-github-actions
I guess we need to wait for v4.x or v5