### PR TITLE
status statchange

### DIFF
--- a/mods/tuxemon/db/technique/amnesia.json
+++ b/mods/tuxemon/db/technique/amnesia.json
@@ -3,7 +3,8 @@
   "accuracy": 0.75,
   "animation": "sparks_gold_alt",
   "effects": [
-    "statchange"
+    "exhausted target",
+    "exhausted user"
   ],
   "flip_axes": "",
   "healing_power": 0,
@@ -12,12 +13,6 @@
   "is_fast": false,
   "potency": 1,
   "power": 2.25,
-  "statmelee": {
-    "value": 0.5, "operation":"-"
-  },
-  "statranged": {
-    "value": 0.5, "operation":"-"
-  },
   "range": "reach",
   "recharge": 2,
   "sfx": "sfx_shine",

--- a/mods/tuxemon/db/technique/avalanche.json
+++ b/mods/tuxemon/db/technique/avalanche.json
@@ -3,7 +3,8 @@
   "accuracy": 0.8,
   "animation": "thud",
   "effects": [
-    "damage"
+    "damage",
+    "exhausted target"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/beam.json
+++ b/mods/tuxemon/db/technique/beam.json
@@ -3,6 +3,7 @@
   "accuracy": 0.8,
   "animation": "crystal",
   "effects": [
+    "blinded target",
     "damage"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/berserk.json
+++ b/mods/tuxemon/db/technique/berserk.json
@@ -3,7 +3,8 @@
   "accuracy": 0.8,
   "animation": "constantburn",
   "effects": [
-    "damage"
+    "damage",
+    "enraged user"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/biting_winds.json
+++ b/mods/tuxemon/db/technique/biting_winds.json
@@ -3,7 +3,8 @@
   "accuracy": 0.8,
   "animation": "ice blast",
   "effects": [
-    "damage"
+    "damage",
+    "softened target"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/boulder.json
+++ b/mods/tuxemon/db/technique/boulder.json
@@ -3,7 +3,7 @@
   "accuracy": 1,
   "animation": "shield_rock",
   "effects": [
-    "hardshell"
+    "hardshell user"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/energy_claws.json
+++ b/mods/tuxemon/db/technique/energy_claws.json
@@ -3,7 +3,8 @@
   "accuracy": 0.8,
   "animation": "slash_power",
   "effects": [
-    "damage"
+    "damage",
+    "sniping user"
   ],
   "flip_axes": "x",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/energy_field.json
+++ b/mods/tuxemon/db/technique/energy_field.json
@@ -2,7 +2,9 @@
   "tech_id": 22,
   "accuracy": 1,
   "animation": "screen",
-  "effects": [],
+  "effects": [
+    "exhausted target"
+  ],
   "flip_axes": "x",
   "healing_power": 0,
   "icon": "",

--- a/mods/tuxemon/db/technique/eyebite.json
+++ b/mods/tuxemon/db/technique/eyebite.json
@@ -2,7 +2,9 @@
   "tech_id": 35,
   "accuracy": 1,
   "animation": "bite",
-  "effects": [],
+  "effects": [
+    "exhausted target"
+  ],
   "flip_axes": "",
   "healing_power": 0,
   "icon": "",

--- a/mods/tuxemon/db/technique/feint.json
+++ b/mods/tuxemon/db/technique/feint.json
@@ -3,7 +3,8 @@
   "accuracy": 1,
   "animation": "bolt",
   "effects": [
-    "damage"
+    "damage",
+    "focused user"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/fume.json
+++ b/mods/tuxemon/db/technique/fume.json
@@ -2,7 +2,9 @@
   "tech_id": 28,
   "accuracy": 1,
   "animation": "buff_rage",
-  "effects": [],
+  "effects": [
+    "enraged user"
+  ],
   "flip_axes": "",
   "healing_power": 0,
   "icon": "",

--- a/mods/tuxemon/db/technique/give_all.json
+++ b/mods/tuxemon/db/technique/give_all.json
@@ -3,7 +3,8 @@
   "accuracy": 1,
   "animation": "firelion_front",
   "effects": [
-    "damage"
+    "damage",
+    "exhausted user"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/glower.json
+++ b/mods/tuxemon/db/technique/glower.json
@@ -2,7 +2,9 @@
   "tech_id": 13,
   "accuracy": 1,
   "animation": null,
-  "effects": [],
+  "effects": [
+    "softened target"
+  ],
   "flip_axes": "",
   "healing_power": 0,
   "icon": "",

--- a/mods/tuxemon/db/technique/goad.json
+++ b/mods/tuxemon/db/technique/goad.json
@@ -3,7 +3,8 @@
   "accuracy": 0.8,
   "animation": "buff_rage",
   "effects": [
-    "damage"
+    "damage",
+    "enraged target"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/invictus.json
+++ b/mods/tuxemon/db/technique/invictus.json
@@ -3,7 +3,8 @@
   "accuracy": 0.75,
   "animation": "triforce",
   "effects": [
-    "damage"
+    "damage",
+    "enraged user"
   ],
   "flip_axes": "xy",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/kindling_flame.json
+++ b/mods/tuxemon/db/technique/kindling_flame.json
@@ -3,7 +3,8 @@
   "accuracy": 0.8,
   "animation": "constantburn",
   "effects": [
-    "damage"
+    "damage",
+    "enraged user"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/levitate.json
+++ b/mods/tuxemon/db/technique/levitate.json
@@ -3,7 +3,8 @@
   "accuracy": 1,
   "animation": null,
   "effects": [
-    "statchange"
+    "sniping target",
+    "sniping user"
   ],
   "flip_axes": "",
   "healing_power": 0,
@@ -12,12 +13,6 @@
   "is_fast": false,
   "potency": 1,
   "power": 0,
-  "statmelee": {
-    "value": 0.5, "operation":"-"
-  },
-  "statranged": {
-    "value": 2, "operation":"-"
-  },
   "range": "special",
   "recharge": 2,
   "sfx": "sfx_blaster",

--- a/mods/tuxemon/db/technique/muddle.json
+++ b/mods/tuxemon/db/technique/muddle.json
@@ -3,7 +3,9 @@
   "accuracy": 0.75,
   "animation": "sparks_white",
   "effects": [
-    "damage"
+    "damage",
+    "focused target",
+    "focused user"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/mudslide.json
+++ b/mods/tuxemon/db/technique/mudslide.json
@@ -3,7 +3,8 @@
   "accuracy": 0.8,
   "animation": "spikes_rock",
   "effects": [
-    "damage"
+    "damage",
+    "softened target"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/overfeed.json
+++ b/mods/tuxemon/db/technique/overfeed.json
@@ -17,7 +17,7 @@
     "value": 2, "operation":"/"
   },
   "stathp": {
-    "value": 0, "operation":".", "overridetofull":true
+    "value": 0, "operation":"+", "overridetofull":true
   },
   "range": "melee",
   "recharge": 8,

--- a/mods/tuxemon/db/technique/sand_spray.json
+++ b/mods/tuxemon/db/technique/sand_spray.json
@@ -3,6 +3,7 @@
   "accuracy": 0.8,
   "animation": "explosion_dusty_96",
   "effects": [
+    "blinded target",
     "damage"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/sleeping_powder.json
+++ b/mods/tuxemon/db/technique/sleeping_powder.json
@@ -2,7 +2,9 @@
   "tech_id": 49,
   "accuracy": 1,
   "animation": "explosion_dusty_96",
-  "effects": [],
+  "effects": [
+    "focused user"
+  ],
   "flip_axes": "",
   "healing_power": 0,
   "icon": "",

--- a/mods/tuxemon/db/technique/snowstorm.json
+++ b/mods/tuxemon/db/technique/snowstorm.json
@@ -3,7 +3,8 @@
   "accuracy": 0.5,
   "animation": "ice blast",
   "effects": [
-    "damage"
+    "damage",
+    "exhausted target"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/splinter.json
+++ b/mods/tuxemon/db/technique/splinter.json
@@ -3,6 +3,7 @@
   "accuracy": 0.8,
   "animation": "snake_right",
   "effects": [
+    "blinded target",
     "damage"
   ],
   "flip_axes": "x",

--- a/mods/tuxemon/db/technique/starfall.json
+++ b/mods/tuxemon/db/technique/starfall.json
@@ -3,7 +3,8 @@
   "accuracy": 0.7,
   "animation": "bolt",
   "effects": [
-    "damage"
+    "damage",
+    "focused user"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/static_field.json
+++ b/mods/tuxemon/db/technique/static_field.json
@@ -2,7 +2,10 @@
   "tech_id": 15,
   "accuracy": 1,
   "animation": "disintegrate",
-  "effects": [],
+  "effects": [
+    "exhausted target",
+    "hardshell user"
+  ],
   "flip_axes": "",
   "healing_power": 0,
   "icon": "",

--- a/mods/tuxemon/db/technique/status_blinded.json
+++ b/mods/tuxemon/db/technique/status_blinded.json
@@ -1,21 +1,23 @@
 {
   "animation": "drip_green",
-  "category": "blinded",
+  "category": "negative",
   "effects": [
     "statchange"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_blinded.png",
+  "repl_pos": "replace",
+  "repl_neg": "replace",
   "sfx": "sfx_pulse",
   "slug": "status_blinded",
   "sort": "meta",
   "statdodge": {
     "value": 0.5,
-    "operation": "-"
+    "operation": "*"
   },
   "statspeed": {
     "value": 0.5,
-    "operation": "-"
+    "operation": "*"
   },
   "target": {
     "enemy monster": 0,

--- a/mods/tuxemon/db/technique/status_chargedup.json
+++ b/mods/tuxemon/db/technique/status_chargedup.json
@@ -1,33 +1,34 @@
 {
   "animation": "drip_green",
-  "category": "chargedup",
+  "category": "positive",
   "effects": [
     "statchange"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_chargedup.png",
+  "repl_pos": "replace",
   "sfx": "sfx_pulse",
   "slug": "status_chargedup",
   "sort": "meta",
   "statarmour": {
     "value": 2,
-    "operation": "-"
+    "operation": "*"
   },
   "statdodge": {
     "value": 2,
-    "operation": "-"
+    "operation": "*"
   },
   "statmelee": {
     "value": 2,
-    "operation": "-"
+    "operation": "*"
   },
   "statranged": {
     "value": 2,
-    "operation": "-"
+    "operation": "*"
   },
   "statspeed": {
     "value": 2,
-    "operation": "-"
+    "operation": "*"
   },
   "target": {
     "enemy monster": 0,

--- a/mods/tuxemon/db/technique/status_charging.json
+++ b/mods/tuxemon/db/technique/status_charging.json
@@ -1,9 +1,10 @@
 {
   "animation": "drip_green",
-  "category": "charging",
+  "category": "positive",
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_charging.png",
+  "repl_pos": "replace",
   "sfx": "sfx_pulse",
   "slug": "status_charging",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_confused.json
+++ b/mods/tuxemon/db/technique/status_confused.json
@@ -1,9 +1,11 @@
 {
   "animation": "drip_green",
-  "category": "confused",
+  "category": "negative",
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_confused.png",
+  "repl_pos": "replace",
+  "repl_neg": "replace",
   "sfx": "sfx_pulse",
   "slug": "status_confused",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_diehard.json
+++ b/mods/tuxemon/db/technique/status_diehard.json
@@ -1,9 +1,11 @@
 {
   "animation": "drip_green",
-  "category": "diehard",
+  "category": "positive",
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_diehard.png",
+  "repl_pos": "replace",
+  "repl_neg": "replace",
   "sfx": "sfx_pulse",
   "slug": "status_diehard",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_dozing.json
+++ b/mods/tuxemon/db/technique/status_dozing.json
@@ -1,6 +1,6 @@
 {
   "animation": "drip_green",
-  "category": "dozing",
+  "category": "negative",
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_dozing.png",

--- a/mods/tuxemon/db/technique/status_eliminated.json
+++ b/mods/tuxemon/db/technique/status_eliminated.json
@@ -1,6 +1,5 @@
 {
   "animation": "drip_green",
-  "category": "eliminated",
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_eliminated.png",

--- a/mods/tuxemon/db/technique/status_enraged.json
+++ b/mods/tuxemon/db/technique/status_enraged.json
@@ -1,21 +1,23 @@
 {
   "animation": "drip_green",
-  "category": "enraged",
+  "category": "positive",
   "effects": [
     "statchange"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_enraged.png",
+  "repl_pos": "replace",
+  "repl_neg": "replace",
   "sfx": "sfx_pulse",
   "slug": "status_enraged",
   "sort": "meta",
   "statmelee": {
     "value": 2,
-    "operation": "-"
+    "operation": "*"
   },
   "statranged": {
     "value": 0.5,
-    "operation": "-"
+    "operation": "*"
   },
   "target": {
     "enemy monster": 0,

--- a/mods/tuxemon/db/technique/status_exhausted.json
+++ b/mods/tuxemon/db/technique/status_exhausted.json
@@ -1,21 +1,22 @@
 {
   "animation": "drip_green",
-  "category": "exhausted",
+  "category": "negative",
   "effects": [
     "statchange"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_exhausted.png",
+  "repl_neg": "replace",
   "sfx": "sfx_pulse",
   "slug": "status_exhausted",
   "sort": "meta",
   "statmelee": {
     "value": 0.5,
-    "operation": "-"
+    "operation": "*"
   },
   "statranged": {
     "value": 0.5,
-    "operation": "-"
+    "operation": "*"
   },
   "target": {
     "enemy monster": 0,

--- a/mods/tuxemon/db/technique/status_festering.json
+++ b/mods/tuxemon/db/technique/status_festering.json
@@ -1,9 +1,10 @@
 {
   "animation": "drip_green",
-  "category": "festering",
+  "category": "negative",
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_festering.png",
+  "repl_neg": "replace",
   "sfx": "sfx_pulse",
   "slug": "status_festering",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_focused.json
+++ b/mods/tuxemon/db/technique/status_focused.json
@@ -1,17 +1,19 @@
 {
   "animation": "drip_green",
-  "category": "focused",
+  "category": "positive",
   "effects": [
     "statchange"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_focused.png",
+  "repl_pos": "replace",
+  "repl_neg": "remove",
   "sfx": "sfx_pulse",
   "slug": "status_focused",
   "sort": "meta",
   "statdodge": {
     "value": 1.5,
-    "operation": "-"
+    "operation": "*"
   },
   "target": {
     "enemy monster": 0,

--- a/mods/tuxemon/db/technique/status_grabbed.json
+++ b/mods/tuxemon/db/technique/status_grabbed.json
@@ -1,9 +1,11 @@
 {
   "animation": "drip_green",
-  "category": "grabbed",
+  "category": "negative",
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_grabbed.png",
+  "repl_pos": "replace",
+  "repl_neg": "replace",
   "sfx": "sfx_pulse",
   "slug": "status_grabbed",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_hardshell.json
+++ b/mods/tuxemon/db/technique/status_hardshell.json
@@ -1,17 +1,19 @@
 {
   "animation": "drip_green",
-  "category": "hardshell",
+  "category": "positive",
   "effects": [
     "statchange"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_hardshell.png",
+  "repl_pos": "replace",
+  "repl_neg": "remove",
   "sfx": "sfx_bite",
   "slug": "status_hardshell",
   "sort": "meta",
   "statarmour": {
     "value": 1.5,
-    "operation": "-"
+    "operation": "*"
   },
   "target": {
     "enemy monster": 0,

--- a/mods/tuxemon/db/technique/status_lifeleech.json
+++ b/mods/tuxemon/db/technique/status_lifeleech.json
@@ -1,10 +1,13 @@
 {
   "animation": "drip_green",
+  "category": "negative",
   "effects": [
     "lifeleech"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_lifeleech.png",
+  "repl_pos": "replace",
+  "repl_neg": "replace",
   "sfx": "sfx_bite",
   "slug": "status_lifeleech",
   "sort": "meta",
@@ -18,7 +21,7 @@
     "item": 0
   },
   "tech_id": 94,
-  "use_failure": "combat_state_lifeleech_failure",
-  "use_success": "combat_state_lifeleech_success",
-  "use_tech": "combat_state_lifeleech_get"
+  "use_failure": "generic_failure",
+  "use_success": "combat_state_lifeleech_get",
+  "use_tech": "combat_used_x"
 }

--- a/mods/tuxemon/db/technique/status_noddingoff.json
+++ b/mods/tuxemon/db/technique/status_noddingoff.json
@@ -1,9 +1,10 @@
 {
   "animation": "drip_green",
-  "category": "noddingoff",
+  "category": "negative",
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_noddingoff.png",
+  "repl_neg": "replace",
   "sfx": "sfx_pulse",
   "slug": "status_noddingoff",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_poison.json
+++ b/mods/tuxemon/db/technique/status_poison.json
@@ -1,10 +1,13 @@
 {
   "animation": "drip_green",
+  "category": "negative",
   "effects": [
     "poison"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_poison.png",
+  "repl_pos": "replace",
+  "repl_neg": "replace",
   "sfx": "sfx_pulse",
   "slug": "status_poison",
   "sort": "meta",
@@ -20,5 +23,5 @@
   "tech_id": 95,
   "use_failure": "generic_failure",
   "use_success": "combat_state_poison_get",
-  "use_tech": "combat_state_poison_damage"
+  "use_tech": "combat_used_x"
 }

--- a/mods/tuxemon/db/technique/status_recover.json
+++ b/mods/tuxemon/db/technique/status_recover.json
@@ -1,10 +1,13 @@
 {
   "animation": "greendrip",
+  "category": "positive",
   "effects": [
     "recover"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_recover.png",
+  "repl_pos": "replace",
+  "repl_neg": "replace",
   "sfx": "sfx_bite",
   "slug": "status_recover",
   "sort": "meta",
@@ -18,7 +21,7 @@
     "item": 0
   },
   "tech_id": 96,
-  "use_failure": "combat_state_recover_failure",
-  "use_success": "combat_state_recover_success",
-  "use_tech": "combat_state_recover_get"
+  "use_failure": "generic_failure",
+  "use_success": "combat_state_recover_get",
+  "use_tech": "combat_used_x"
 }

--- a/mods/tuxemon/db/technique/status_recover.json
+++ b/mods/tuxemon/db/technique/status_recover.json
@@ -1,5 +1,5 @@
 {
-  "animation": "greendrip",
+  "animation": "drip_green",
   "category": "positive",
   "effects": [
     "recover"

--- a/mods/tuxemon/db/technique/status_sniping.json
+++ b/mods/tuxemon/db/technique/status_sniping.json
@@ -1,21 +1,23 @@
 {
   "animation": "drip_green",
-  "category": "sniping",
+  "category": "positive",
   "effects": [
     "statchange"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_sniping.png",
+  "repl_pos": "replace",
+  "repl_neg": "replace",
   "sfx": "sfx_pulse",
   "slug": "status_sniping",
   "sort": "meta",
   "statmelee": {
     "value": 0.5,
-    "operation": "-"
+    "operation": "*"
   },
   "statranged": {
     "value": 2,
-    "operation": "-"
+    "operation": "*"
   },
   "target": {
     "enemy monster": 0,

--- a/mods/tuxemon/db/technique/status_softened.json
+++ b/mods/tuxemon/db/technique/status_softened.json
@@ -1,21 +1,23 @@
 {
   "animation": "drip_green",
-  "category": "softened",
+  "category": "negative",
   "effects": [
     "statchange"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_softened.png",
+  "repl_pos": "replace",
+  "repl_neg": "replace",
   "sfx": "sfx_pulse",
   "slug": "status_softened",
   "sort": "meta",
   "statarmour": {
     "value": 0.5,
-    "operation": "-"
+    "operation": "*"
   },
   "statspeed": {
     "value": 0.5,
-    "operation": "-"
+    "operation": "*"
   },
   "target": {
     "enemy monster": 0,

--- a/mods/tuxemon/db/technique/status_spyderbite.json
+++ b/mods/tuxemon/db/technique/status_spyderbite.json
@@ -1,6 +1,5 @@
 {
   "animation": "drip_green",
-  "category": "spyderbite",
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_spyderbite.png",

--- a/mods/tuxemon/db/technique/status_stuck.json
+++ b/mods/tuxemon/db/technique/status_stuck.json
@@ -1,9 +1,11 @@
 {
   "animation": "drip_green",
-  "category": "stuck",
+  "category": "negative",
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_stuck.png",
+  "repl_pos": "replace",
+  "repl_neg": "replace",
   "sfx": "sfx_pulse",
   "slug": "status_stuck",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_tired.json
+++ b/mods/tuxemon/db/technique/status_tired.json
@@ -1,9 +1,11 @@
 {
   "animation": "drip_green",
-  "category": "tired",
+  "category": "negative",
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_tired.png",
+  "repl_pos": "remove",
+  "repl_neg": "replace",
   "sfx": "sfx_pulse",
   "slug": "status_tired",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/suck_poison.json
+++ b/mods/tuxemon/db/technique/suck_poison.json
@@ -4,7 +4,8 @@
   "animation": "drip_green",
   "effects": [
     "poison",
-    "damage"
+    "damage",
+    "focused user"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/sudden_glow.json
+++ b/mods/tuxemon/db/technique/sudden_glow.json
@@ -2,7 +2,9 @@
   "tech_id": 67,
   "accuracy": 1,
   "animation": "heal_burst_120",
-  "effects": [],
+  "effects": [
+    "focused target"
+  ],
   "flip_axes": "",
   "healing_power": 2.0,
   "icon": "",

--- a/mods/tuxemon/db/technique/supernova.json
+++ b/mods/tuxemon/db/technique/supernova.json
@@ -3,7 +3,8 @@
   "accuracy": 0.75,
   "animation": "fireball_114",
   "effects": [
-    "damage"
+    "damage",
+    "chargedup target"
   ],
   "flip_axes": "x",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/take_cover.json
+++ b/mods/tuxemon/db/technique/take_cover.json
@@ -2,7 +2,9 @@
   "tech_id": 29,
   "accuracy": 1,
   "animation": "smokebomb",
-  "effects": [],
+  "effects": [
+    "sniping user"
+  ],
   "flip_axes": "",
   "healing_power": 0,
   "icon": "",

--- a/mods/tuxemon/db/technique/thunderclap.json
+++ b/mods/tuxemon/db/technique/thunderclap.json
@@ -3,7 +3,8 @@
   "accuracy": 0.75,
   "animation": "thunderstrike",
   "effects": [
-    "damage"
+    "damage",
+    "exhausted target"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/wall_of_steel.json
+++ b/mods/tuxemon/db/technique/wall_of_steel.json
@@ -3,6 +3,7 @@
   "accuracy": 0.75,
   "animation": "screen",
   "effects": [
+    "hardshell user",
     "damage"
   ],
   "flip_axes": "x",

--- a/mods/tuxemon/db/technique/wallow.json
+++ b/mods/tuxemon/db/technique/wallow.json
@@ -2,7 +2,9 @@
   "tech_id": 46,
   "accuracy": 1,
   "animation": "waterspurt",
-  "effects": [],
+  "effects": [
+    "focused user"
+  ],
   "flip_axes": "",
   "healing_power": 4.0,
   "icon": "",

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -266,7 +266,7 @@ msgid "combat_state_lifeleech_failure"
 msgstr "{link} can't heal any further."
 
 msgid "combat_state_lifeleech_get"
-msgstr "{user} is leeching health from {target}."
+msgstr "{target}'s lifeforce is being leeched."
 
 msgid "combat_state_lifeleech_success"
 msgstr "{user} lost health to lifeleech!"

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -298,7 +298,7 @@ class MonsterModel(BaseModel):
 
 
 class StatModel(BaseModel):
-    value: int = Field(0, description="The value of the stat")
+    value: float = Field(0.0, description="The value of the stat")
     max_deviation: int = Field(
         0, description="The maximum deviation of the stat"
     )

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -440,13 +440,14 @@ class Monster:
         """
         count_status = len(self.status)
         if count_status == 0:
-            self.status.insert(0, status)
+            self.status.append(status)
         else:
             if self.status[0].category == "positive":
                 if status.repl_pos == "replace":
                     self.status.insert(0, status)
                     self.status.pop(1)
                 elif status.repl_pos == "remove":
+                    self.status.append(status)
                     self.status.pop(0)
                 else:
                     # noddingoff, exhausted, festering, dozing
@@ -456,6 +457,7 @@ class Monster:
                     self.status.insert(0, status)
                     self.status.pop(1)
                 elif status.repl_pos == "remove":
+                    self.status.append(status)
                     self.status.pop(0)
                 else:
                     # chargedup, charging and dozing

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -431,13 +431,38 @@ class Monster:
 
     def apply_status(self, status: Technique) -> None:
         """
-        Apply a status to the monster.
+        Apply a status to the monster by replacing or removing
+        the previous status.
 
         Parameters:
             status: The status technique.
 
         """
-        self.status.append(status)
+        count_status = len(self.status)
+        if count_status == 0:
+            self.status.insert(0, status)
+        else:
+            if self.status[0].category == "positive":
+                if status.repl_pos == "replace":
+                    self.status.insert(0, status)
+                    self.status.pop(1)
+                elif status.repl_pos == "remove":
+                    self.status.pop(0)
+                else:
+                    # noddingoff, exhausted, festering, dozing
+                    self.status.append(status)
+            elif self.status[0].category == "negative":
+                if status.repl_neg == "replace":
+                    self.status.insert(0, status)
+                    self.status.pop(1)
+                elif status.repl_pos == "remove":
+                    self.status.pop(0)
+                else:
+                    # chargedup, charging and dozing
+                    self.status.append(status)
+            else:
+                # spyderbite and eliminated
+                self.status.append(status)
 
     def set_stats(self) -> None:
         """
@@ -690,9 +715,9 @@ class Monster:
         assert isinstance(action.technique, Technique)
         technique = action.technique
         if technique.is_fast:
-            return int(random.randrange(0, self.speed) * 1.5)
+            return int(random.randrange(0, int(self.speed)) * 1.5)
         else:
-            return random.randrange(0, self.speed)
+            return random.randrange(0, int(self.speed))
 
 
 def decode_monsters(

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -412,6 +412,8 @@ class CombatState(CombatAnimations):
             for monster in self.active_monsters:
                 for technique in monster.status:
                     self.enqueue_action(None, technique, monster)
+                    # avoid multiple effect status
+                    monster.set_stats()
 
         elif phase == "resolve match":
             # update battle_total only once after each battle
@@ -963,17 +965,6 @@ class CombatState(CombatAnimations):
                     m = T.translate(element_damage_key)
                     message += "\n" + m
 
-                for status in result.get("statuses", []):
-                    m = T.format(
-                        status.use_item,
-                        {
-                            "name": technique.name,
-                            "user": status.link.name if status.link else "",
-                            "target": status.carrier.name,
-                        },
-                    )
-                    message += "\n" + m
-
             else:  # assume this was an item used
 
                 # handle the capture device
@@ -1022,12 +1013,15 @@ class CombatState(CombatAnimations):
         else:
             if result["success"]:
                 self.suppress_phase_change()
-                self.alert(
-                    T.format(
-                        "combat_status_damage",
-                        {"name": target.name, "status": technique.name},
-                    )
+                msg_type = (
+                    "use_success" if result["success"] else "use_failure"
                 )
+                context = {
+                    "name": technique.name,
+                    "target": target.name,
+                }
+                template = getattr(technique, msg_type)
+                self.alert(T.format(template, context))
 
         is_flipped = False
         for trainer in self.ai_players:
@@ -1207,6 +1201,8 @@ class CombatState(CombatAnimations):
         # TODO: End combat differently depending on winning or losing
         for player in self.active_players:
             for mon in player.monsters:
+                # reset status stats
+                mon.set_stats()
                 mon.end_combat()
 
         # clear action queue

--- a/tuxemon/technique/effects/blinded.py
+++ b/tuxemon/technique/effects/blinded.py
@@ -58,19 +58,20 @@ class BlindedEffect(TechEffect[BlindedEffectParameters]):
     param_class = BlindedEffectParameters
 
     def apply(self, user: Monster, target: Monster) -> BlindedEffectResult:
-        if self.parameters.objective == "user" and self.user is None:
+        obj = self.parameters.objective
+        if obj == "user":
             already_applied = check_status(user, "status_blinded")
-        elif self.parameters.objective == "target":
+        elif obj == "target":
             already_applied = check_status(target, "status_blinded")
-        else:
-            already_applied = check_status(self.user, "status_blinded")
         if not already_applied:
-            tech = Technique("status_blinded", link=user)
-            if self.parameters.objective == "user":
+            if obj == "user":
+                tech = Technique("status_blinded", link=user)
                 user.apply_status(tech)
-            elif self.parameters.objective == "target":
+                return {"status": tech}
+            elif obj == "target":
+                tech = Technique("status_blinded", carrier=target)
                 target.apply_status(tech)
-            return {"status": tech}
+                return {"status": tech}
 
         if already_applied:
             return {"damage": 0, "should_tackle": False, "success": False}

--- a/tuxemon/technique/effects/blinded.py
+++ b/tuxemon/technique/effects/blinded.py
@@ -28,51 +28,49 @@
 
 from __future__ import annotations
 
-import random
+import logging
 from typing import NamedTuple, Optional
 
-from tuxemon import formula
 from tuxemon.combat import check_status
 from tuxemon.monster import Monster
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
 from tuxemon.technique.technique import Technique
 
+logger = logging.getLogger(__name__)
 
-class PoisonEffectResult(TechEffectResult):
+
+class BlindedEffectResult(TechEffectResult):
     damage: int
     should_tackle: bool
     status: Optional[Technique]
 
 
-class PoisonEffectParameters(NamedTuple):
-    pass
+class BlindedEffectParameters(NamedTuple):
+    objective: str
 
 
-class PoisonEffect(TechEffect[PoisonEffectParameters]):
+class BlindedEffect(TechEffect[BlindedEffectParameters]):
     """
-    This effect has a chance to apply the poison status effect.
+    This effect has a chance to apply the blinded status effect.
     """
 
-    name = "poison"
-    param_class = PoisonEffectParameters
+    name = "blinded"
+    param_class = BlindedEffectParameters
 
-    def apply(self, user: Monster, target: Monster) -> PoisonEffectResult:
-        already_applied = check_status(target, "status_poison")
-        success = not already_applied and self.move.potency >= random.random()
-        if success:
-            tech = Technique("status_poison", carrier=target)
-            target.apply_status(tech)
-            # exception: applies status to the user
-            if self.move.slug == "fester":
+    def apply(self, user: Monster, target: Monster) -> BlindedEffectResult:
+        if self.parameters.objective == "user" and self.user is None:
+            already_applied = check_status(user, "status_blinded")
+        elif self.parameters.objective == "target":
+            already_applied = check_status(target, "status_blinded")
+        else:
+            already_applied = check_status(self.user, "status_blinded")
+        if not already_applied:
+            tech = Technique("status_blinded", link=user)
+            if self.parameters.objective == "user":
                 user.apply_status(tech)
+            elif self.parameters.objective == "target":
+                target.apply_status(tech)
             return {"status": tech}
 
         if already_applied:
-            damage = formula.simple_poison(self.move, target)
-            target.current_hp -= damage
-
-            return {
-                "damage": damage,
-                "should_tackle": bool(damage),
-                "success": bool(damage),
-            }
+            return {"damage": 0, "should_tackle": False, "success": False}

--- a/tuxemon/technique/effects/chargedup.py
+++ b/tuxemon/technique/effects/chargedup.py
@@ -58,19 +58,20 @@ class ChargedUpEffect(TechEffect[ChargedUpEffectParameters]):
     param_class = ChargedUpEffectParameters
 
     def apply(self, user: Monster, target: Monster) -> ChargedUpEffectResult:
-        if self.parameters.objective == "user" and self.user is None:
+        obj = self.parameters.objective
+        if obj == "user":
             already_applied = check_status(user, "status_chargedup")
-        elif self.parameters.objective == "target":
+        elif obj == "target":
             already_applied = check_status(target, "status_chargedup")
-        else:
-            already_applied = check_status(self.user, "status_chargedup")
         if not already_applied:
-            tech = Technique("status_chargedup", link=user)
-            if self.parameters.objective == "user":
+            if obj == "user":
+                tech = Technique("status_chargedup", link=user)
                 user.apply_status(tech)
-            elif self.parameters.objective == "target":
+                return {"status": tech}
+            elif obj == "target":
+                tech = Technique("status_chargedup", carrier=target)
                 target.apply_status(tech)
-            return {"status": tech}
+                return {"status": tech}
 
         if already_applied:
             return {"damage": 0, "should_tackle": False, "success": False}

--- a/tuxemon/technique/effects/chargedup.py
+++ b/tuxemon/technique/effects/chargedup.py
@@ -28,51 +28,49 @@
 
 from __future__ import annotations
 
-import random
+import logging
 from typing import NamedTuple, Optional
 
-from tuxemon import formula
 from tuxemon.combat import check_status
 from tuxemon.monster import Monster
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
 from tuxemon.technique.technique import Technique
 
+logger = logging.getLogger(__name__)
 
-class PoisonEffectResult(TechEffectResult):
+
+class ChargedUpEffectResult(TechEffectResult):
     damage: int
     should_tackle: bool
     status: Optional[Technique]
 
 
-class PoisonEffectParameters(NamedTuple):
-    pass
+class ChargedUpEffectParameters(NamedTuple):
+    objective: str
 
 
-class PoisonEffect(TechEffect[PoisonEffectParameters]):
+class ChargedUpEffect(TechEffect[ChargedUpEffectParameters]):
     """
-    This effect has a chance to apply the poison status effect.
+    This effect has a chance to apply the charged up status effect.
     """
 
-    name = "poison"
-    param_class = PoisonEffectParameters
+    name = "chargedup"
+    param_class = ChargedUpEffectParameters
 
-    def apply(self, user: Monster, target: Monster) -> PoisonEffectResult:
-        already_applied = check_status(target, "status_poison")
-        success = not already_applied and self.move.potency >= random.random()
-        if success:
-            tech = Technique("status_poison", carrier=target)
-            target.apply_status(tech)
-            # exception: applies status to the user
-            if self.move.slug == "fester":
+    def apply(self, user: Monster, target: Monster) -> ChargedUpEffectResult:
+        if self.parameters.objective == "user" and self.user is None:
+            already_applied = check_status(user, "status_chargedup")
+        elif self.parameters.objective == "target":
+            already_applied = check_status(target, "status_chargedup")
+        else:
+            already_applied = check_status(self.user, "status_chargedup")
+        if not already_applied:
+            tech = Technique("status_chargedup", link=user)
+            if self.parameters.objective == "user":
                 user.apply_status(tech)
+            elif self.parameters.objective == "target":
+                target.apply_status(tech)
             return {"status": tech}
 
         if already_applied:
-            damage = formula.simple_poison(self.move, target)
-            target.current_hp -= damage
-
-            return {
-                "damage": damage,
-                "should_tackle": bool(damage),
-                "success": bool(damage),
-            }
+            return {"damage": 0, "should_tackle": False, "success": False}

--- a/tuxemon/technique/effects/enraged.py
+++ b/tuxemon/technique/effects/enraged.py
@@ -58,19 +58,20 @@ class EnragedEffect(TechEffect[EnragedEffectParameters]):
     param_class = EnragedEffectParameters
 
     def apply(self, user: Monster, target: Monster) -> EnragedEffectResult:
-        if self.parameters.objective == "user" and self.user is None:
+        obj = self.parameters.objective
+        if obj == "user":
             already_applied = check_status(user, "status_enraged")
-        elif self.parameters.objective == "target":
+        elif obj == "target":
             already_applied = check_status(target, "status_enraged")
-        else:
-            already_applied = check_status(self.user, "status_enraged")
         if not already_applied:
-            tech = Technique("status_enraged", link=user)
-            if self.parameters.objective == "user":
+            if obj == "user":
+                tech = Technique("status_enraged", link=user)
                 user.apply_status(tech)
-            elif self.parameters.objective == "target":
+                return {"status": tech}
+            elif obj == "target":
+                tech = Technique("status_enraged", carrier=target)
                 target.apply_status(tech)
-            return {"status": tech}
+                return {"status": tech}
 
         if already_applied:
             return {"damage": 0, "should_tackle": False, "success": False}

--- a/tuxemon/technique/effects/enraged.py
+++ b/tuxemon/technique/effects/enraged.py
@@ -28,51 +28,49 @@
 
 from __future__ import annotations
 
-import random
+import logging
 from typing import NamedTuple, Optional
 
-from tuxemon import formula
 from tuxemon.combat import check_status
 from tuxemon.monster import Monster
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
 from tuxemon.technique.technique import Technique
 
+logger = logging.getLogger(__name__)
 
-class PoisonEffectResult(TechEffectResult):
+
+class EnragedEffectResult(TechEffectResult):
     damage: int
     should_tackle: bool
     status: Optional[Technique]
 
 
-class PoisonEffectParameters(NamedTuple):
-    pass
+class EnragedEffectParameters(NamedTuple):
+    objective: str
 
 
-class PoisonEffect(TechEffect[PoisonEffectParameters]):
+class EnragedEffect(TechEffect[EnragedEffectParameters]):
     """
-    This effect has a chance to apply the poison status effect.
+    This effect has a chance to apply the enraged status effect.
     """
 
-    name = "poison"
-    param_class = PoisonEffectParameters
+    name = "enraged"
+    param_class = EnragedEffectParameters
 
-    def apply(self, user: Monster, target: Monster) -> PoisonEffectResult:
-        already_applied = check_status(target, "status_poison")
-        success = not already_applied and self.move.potency >= random.random()
-        if success:
-            tech = Technique("status_poison", carrier=target)
-            target.apply_status(tech)
-            # exception: applies status to the user
-            if self.move.slug == "fester":
+    def apply(self, user: Monster, target: Monster) -> EnragedEffectResult:
+        if self.parameters.objective == "user" and self.user is None:
+            already_applied = check_status(user, "status_enraged")
+        elif self.parameters.objective == "target":
+            already_applied = check_status(target, "status_enraged")
+        else:
+            already_applied = check_status(self.user, "status_enraged")
+        if not already_applied:
+            tech = Technique("status_enraged", link=user)
+            if self.parameters.objective == "user":
                 user.apply_status(tech)
+            elif self.parameters.objective == "target":
+                target.apply_status(tech)
             return {"status": tech}
 
         if already_applied:
-            damage = formula.simple_poison(self.move, target)
-            target.current_hp -= damage
-
-            return {
-                "damage": damage,
-                "should_tackle": bool(damage),
-                "success": bool(damage),
-            }
+            return {"damage": 0, "should_tackle": False, "success": False}

--- a/tuxemon/technique/effects/exhausted.py
+++ b/tuxemon/technique/effects/exhausted.py
@@ -58,19 +58,20 @@ class ExhaustedEffect(TechEffect[ExhaustedEffectParameters]):
     param_class = ExhaustedEffectParameters
 
     def apply(self, user: Monster, target: Monster) -> ExhaustedEffectResult:
-        if self.parameters.objective == "user" and self.user is None:
+        obj = self.parameters.objective
+        if obj == "user":
             already_applied = check_status(user, "status_exhausted")
-        elif self.parameters.objective == "target":
+        elif obj == "target":
             already_applied = check_status(target, "status_exhausted")
-        else:
-            already_applied = check_status(self.user, "status_exhausted")
         if not already_applied:
-            tech = Technique("status_exhausted", link=user)
-            if self.parameters.objective == "user":
+            if obj == "user":
+                tech = Technique("status_exhausted", link=user)
                 user.apply_status(tech)
-            elif self.parameters.objective == "target":
+                return {"status": tech}
+            elif obj == "target":
+                tech = Technique("status_exhausted", carrier=target)
                 target.apply_status(tech)
-            return {"status": tech}
+                return {"status": tech}
 
         if already_applied:
             return {"damage": 0, "should_tackle": False, "success": False}

--- a/tuxemon/technique/effects/focused.py
+++ b/tuxemon/technique/effects/focused.py
@@ -58,19 +58,20 @@ class FocusedEffect(TechEffect[FocusedEffectParameters]):
     param_class = FocusedEffectParameters
 
     def apply(self, user: Monster, target: Monster) -> FocusedEffectResult:
-        if self.parameters.objective == "user" and self.user is None:
+        obj = self.parameters.objective
+        if obj == "user":
             already_applied = check_status(user, "status_focused")
-        elif self.parameters.objective == "target":
+        elif obj == "target":
             already_applied = check_status(target, "status_focused")
-        else:
-            already_applied = check_status(self.user, "status_focused")
         if not already_applied:
-            tech = Technique("status_focused", link=user)
-            if self.parameters.objective == "user":
+            if obj == "user":
+                tech = Technique("status_focused", link=user)
                 user.apply_status(tech)
-            elif self.parameters.objective == "target":
+                return {"status": tech}
+            elif obj == "target":
+                tech = Technique("status_focused", carrier=target)
                 target.apply_status(tech)
-            return {"status": tech}
+                return {"status": tech}
 
         if already_applied:
             return {"damage": 0, "should_tackle": False, "success": False}

--- a/tuxemon/technique/effects/focused.py
+++ b/tuxemon/technique/effects/focused.py
@@ -28,51 +28,49 @@
 
 from __future__ import annotations
 
-import random
+import logging
 from typing import NamedTuple, Optional
 
-from tuxemon import formula
 from tuxemon.combat import check_status
 from tuxemon.monster import Monster
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
 from tuxemon.technique.technique import Technique
 
+logger = logging.getLogger(__name__)
 
-class PoisonEffectResult(TechEffectResult):
+
+class FocusedEffectResult(TechEffectResult):
     damage: int
     should_tackle: bool
     status: Optional[Technique]
 
 
-class PoisonEffectParameters(NamedTuple):
-    pass
+class FocusedEffectParameters(NamedTuple):
+    objective: str
 
 
-class PoisonEffect(TechEffect[PoisonEffectParameters]):
+class FocusedEffect(TechEffect[FocusedEffectParameters]):
     """
-    This effect has a chance to apply the poison status effect.
+    This effect has a chance to apply the focused status effect.
     """
 
-    name = "poison"
-    param_class = PoisonEffectParameters
+    name = "focused"
+    param_class = FocusedEffectParameters
 
-    def apply(self, user: Monster, target: Monster) -> PoisonEffectResult:
-        already_applied = check_status(target, "status_poison")
-        success = not already_applied and self.move.potency >= random.random()
-        if success:
-            tech = Technique("status_poison", carrier=target)
-            target.apply_status(tech)
-            # exception: applies status to the user
-            if self.move.slug == "fester":
+    def apply(self, user: Monster, target: Monster) -> FocusedEffectResult:
+        if self.parameters.objective == "user" and self.user is None:
+            already_applied = check_status(user, "status_focused")
+        elif self.parameters.objective == "target":
+            already_applied = check_status(target, "status_focused")
+        else:
+            already_applied = check_status(self.user, "status_focused")
+        if not already_applied:
+            tech = Technique("status_focused", link=user)
+            if self.parameters.objective == "user":
                 user.apply_status(tech)
+            elif self.parameters.objective == "target":
+                target.apply_status(tech)
             return {"status": tech}
 
         if already_applied:
-            damage = formula.simple_poison(self.move, target)
-            target.current_hp -= damage
-
-            return {
-                "damage": damage,
-                "should_tackle": bool(damage),
-                "success": bool(damage),
-            }
+            return {"damage": 0, "should_tackle": False, "success": False}

--- a/tuxemon/technique/effects/hardshell.py
+++ b/tuxemon/technique/effects/hardshell.py
@@ -58,19 +58,20 @@ class HardShellEffect(TechEffect[HardShellEffectParameters]):
     param_class = HardShellEffectParameters
 
     def apply(self, user: Monster, target: Monster) -> HardShellEffectResult:
-        if self.parameters.objective == "user" and self.user is None:
+        obj = self.parameters.objective
+        if obj == "user":
             already_applied = check_status(user, "status_hardshell")
-        elif self.parameters.objective == "target":
+        elif obj == "target":
             already_applied = check_status(target, "status_hardshell")
-        else:
-            already_applied = check_status(self.user, "status_hardshell")
         if not already_applied:
-            tech = Technique("status_hardshell", link=user)
-            if self.parameters.objective == "user":
+            if obj == "user":
+                tech = Technique("status_hardshell", link=user)
                 user.apply_status(tech)
-            elif self.parameters.objective == "target":
+                return {"status": tech}
+            elif obj == "target":
+                tech = Technique("status_hardshell", carrier=target)
                 target.apply_status(tech)
-            return {"status": tech}
+                return {"status": tech}
 
         if already_applied:
             return {"damage": 0, "should_tackle": False, "success": False}

--- a/tuxemon/technique/effects/hardshell.py
+++ b/tuxemon/technique/effects/hardshell.py
@@ -29,10 +29,12 @@
 from __future__ import annotations
 
 import logging
-from typing import NamedTuple
+from typing import NamedTuple, Optional
 
+from tuxemon.combat import check_status
 from tuxemon.monster import Monster
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
+from tuxemon.technique.technique import Technique
 
 logger = logging.getLogger(__name__)
 
@@ -40,20 +42,35 @@ logger = logging.getLogger(__name__)
 class HardShellEffectResult(TechEffectResult):
     damage: int
     should_tackle: bool
+    status: Optional[Technique]
 
 
 class HardShellEffectParameters(NamedTuple):
-    pass
+    objective: str
 
 
 class HardShellEffect(TechEffect[HardShellEffectParameters]):
     """
-    Hardsheel increases armour?
+    This effect has a chance to apply the hard shell status effect.
     """
 
     name = "hardshell"
     param_class = HardShellEffectParameters
 
     def apply(self, user: Monster, target: Monster) -> HardShellEffectResult:
-        logger.warning("Hardshell effect is not yet implemented!")
-        return {"damage": 0, "should_tackle": False, "success": False}
+        if self.parameters.objective == "user" and self.user is None:
+            already_applied = check_status(user, "status_hardshell")
+        elif self.parameters.objective == "target":
+            already_applied = check_status(target, "status_hardshell")
+        else:
+            already_applied = check_status(self.user, "status_hardshell")
+        if not already_applied:
+            tech = Technique("status_hardshell", link=user)
+            if self.parameters.objective == "user":
+                user.apply_status(tech)
+            elif self.parameters.objective == "target":
+                target.apply_status(tech)
+            return {"status": tech}
+
+        if already_applied:
+            return {"damage": 0, "should_tackle": False, "success": False}

--- a/tuxemon/technique/effects/lifeleech.py
+++ b/tuxemon/technique/effects/lifeleech.py
@@ -92,3 +92,5 @@ class LifeLeechEffect(TechEffect[LifeLeechEffectParameters]):
                 "should_tackle": bool(damage),
                 "success": bool(damage),
             }
+
+        return {"success": False}

--- a/tuxemon/technique/effects/lifeleech.py
+++ b/tuxemon/technique/effects/lifeleech.py
@@ -32,6 +32,7 @@ import random
 from typing import NamedTuple, Optional
 
 from tuxemon import formula
+from tuxemon.combat import check_status
 from tuxemon.monster import Monster
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
 from tuxemon.technique.technique import Technique
@@ -64,9 +65,7 @@ class LifeLeechEffect(TechEffect[LifeLeechEffectParameters]):
     param_class = LifeLeechEffectParameters
 
     def apply(self, user: Monster, target: Monster) -> LifeLeechEffectResult:
-        already_applied = any(
-            t for t in target.status if t.slug == "status_lifeleech"
-        )
+        already_applied = check_status(target, "status_lifeleech")
         success = not already_applied and self.move.potency >= random.random()
         if success:
             tech = Technique("status_lifeleech", carrier=target, link=user)

--- a/tuxemon/technique/effects/poison.py
+++ b/tuxemon/technique/effects/poison.py
@@ -76,3 +76,5 @@ class PoisonEffect(TechEffect[PoisonEffectParameters]):
                 "should_tackle": bool(damage),
                 "success": bool(damage),
             }
+
+        return {"success": False}

--- a/tuxemon/technique/effects/recover.py
+++ b/tuxemon/technique/effects/recover.py
@@ -31,8 +31,8 @@ from __future__ import annotations
 import random
 from typing import NamedTuple, Optional
 
-from tuxemon.combat import check_status
 from tuxemon import formula
+from tuxemon.combat import check_status
 from tuxemon.monster import Monster
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
 from tuxemon.technique.technique import Technique
@@ -68,11 +68,18 @@ class RecoverEffect(TechEffect[RecoverEffectParameters]):
             return {"status": tech}
 
         if already_applied:
-            heal = formula.simple_recover(self.move, self.user)
-            self.user.current_hp += heal
+            # avoids Nonetype situation and reset the user
+            if self.user is None:
+                heal = formula.simple_recover(self.move, user)
+                user.current_hp += heal
+            else:
+                heal = formula.simple_recover(self.move, self.user)
+                self.user.current_hp += heal
 
             return {
                 "damage": heal,
                 "should_tackle": False,
                 "success": bool(heal),
             }
+
+        return {"success": False}

--- a/tuxemon/technique/effects/recover.py
+++ b/tuxemon/technique/effects/recover.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import random
 from typing import NamedTuple, Optional
 
+from tuxemon.combat import check_status
 from tuxemon import formula
 from tuxemon.monster import Monster
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
@@ -49,7 +50,7 @@ class RecoverEffectParameters(NamedTuple):
 
 class RecoverEffect(TechEffect[RecoverEffectParameters]):
     """
-    Recover HP
+    This effect has a chance to apply the recovering status effect.
     """
 
     name = "recover"
@@ -57,13 +58,9 @@ class RecoverEffect(TechEffect[RecoverEffectParameters]):
 
     def apply(self, user: Monster, target: Monster) -> RecoverEffectResult:
         if self.user is None:
-            already_applied = any(
-                t for t in user.status if t.slug == "status_recover"
-            )
+            already_applied = check_status(user, "status_recover")
         else:
-            already_applied = any(
-                t for t in self.user.status if t.slug == "status_recover"
-            )
+            already_applied = check_status(self.user, "status_recover")
         success = not already_applied and self.move.potency >= random.random()
         if success:
             tech = Technique("status_recover", link=user)

--- a/tuxemon/technique/effects/sniping.py
+++ b/tuxemon/technique/effects/sniping.py
@@ -58,19 +58,20 @@ class SnipingEffect(TechEffect[SnipingEffectParameters]):
     param_class = SnipingEffectParameters
 
     def apply(self, user: Monster, target: Monster) -> SnipingEffectResult:
-        if self.parameters.objective == "user" and self.user is None:
+        obj = self.parameters.objective
+        if obj == "user":
             already_applied = check_status(user, "status_sniping")
-        elif self.parameters.objective == "target":
+        elif obj == "target":
             already_applied = check_status(target, "status_sniping")
-        else:
-            already_applied = check_status(self.user, "status_sniping")
         if not already_applied:
-            tech = Technique("status_sniping", link=user)
-            if self.parameters.objective == "user":
+            if obj == "user":
+                tech = Technique("status_sniping", link=user)
                 user.apply_status(tech)
-            elif self.parameters.objective == "target":
+                return {"status": tech}
+            elif obj == "target":
+                tech = Technique("status_sniping", carrier=target)
                 target.apply_status(tech)
-            return {"status": tech}
+                return {"status": tech}
 
         if already_applied:
             return {"damage": 0, "should_tackle": False, "success": False}

--- a/tuxemon/technique/effects/softened.py
+++ b/tuxemon/technique/effects/softened.py
@@ -58,19 +58,20 @@ class SoftenedEffect(TechEffect[SoftenedEffectParameters]):
     param_class = SoftenedEffectParameters
 
     def apply(self, user: Monster, target: Monster) -> SoftenedEffectResult:
-        if self.parameters.objective == "user" and self.user is None:
+        obj = self.parameters.objective
+        if obj == "user":
             already_applied = check_status(user, "status_softened")
-        elif self.parameters.objective == "target":
+        elif obj == "target":
             already_applied = check_status(target, "status_softened")
-        else:
-            already_applied = check_status(self.user, "status_softened")
         if not already_applied:
-            tech = Technique("status_softened", link=user)
-            if self.parameters.objective == "user":
+            if obj == "user":
+                tech = Technique("status_softened", link=user)
                 user.apply_status(tech)
-            elif self.parameters.objective == "target":
+                return {"status": tech}
+            elif obj == "target":
+                tech = Technique("status_softened", carrier=target)
                 target.apply_status(tech)
-            return {"status": tech}
+                return {"status": tech}
 
         if already_applied:
             return {"damage": 0, "should_tackle": False, "success": False}

--- a/tuxemon/technique/effects/softened.py
+++ b/tuxemon/technique/effects/softened.py
@@ -28,51 +28,49 @@
 
 from __future__ import annotations
 
-import random
+import logging
 from typing import NamedTuple, Optional
 
-from tuxemon import formula
 from tuxemon.combat import check_status
 from tuxemon.monster import Monster
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
 from tuxemon.technique.technique import Technique
 
+logger = logging.getLogger(__name__)
 
-class PoisonEffectResult(TechEffectResult):
+
+class SoftenedEffectResult(TechEffectResult):
     damage: int
     should_tackle: bool
     status: Optional[Technique]
 
 
-class PoisonEffectParameters(NamedTuple):
-    pass
+class SoftenedEffectParameters(NamedTuple):
+    objective: str
 
 
-class PoisonEffect(TechEffect[PoisonEffectParameters]):
+class SoftenedEffect(TechEffect[SoftenedEffectParameters]):
     """
-    This effect has a chance to apply the poison status effect.
+    This effect has a chance to apply the softened status effect.
     """
 
-    name = "poison"
-    param_class = PoisonEffectParameters
+    name = "softened"
+    param_class = SoftenedEffectParameters
 
-    def apply(self, user: Monster, target: Monster) -> PoisonEffectResult:
-        already_applied = check_status(target, "status_poison")
-        success = not already_applied and self.move.potency >= random.random()
-        if success:
-            tech = Technique("status_poison", carrier=target)
-            target.apply_status(tech)
-            # exception: applies status to the user
-            if self.move.slug == "fester":
+    def apply(self, user: Monster, target: Monster) -> SoftenedEffectResult:
+        if self.parameters.objective == "user" and self.user is None:
+            already_applied = check_status(user, "status_softened")
+        elif self.parameters.objective == "target":
+            already_applied = check_status(target, "status_softened")
+        else:
+            already_applied = check_status(self.user, "status_softened")
+        if not already_applied:
+            tech = Technique("status_softened", link=user)
+            if self.parameters.objective == "user":
                 user.apply_status(tech)
+            elif self.parameters.objective == "target":
+                target.apply_status(tech)
             return {"status": tech}
 
         if already_applied:
-            damage = formula.simple_poison(self.move, target)
-            target.current_hp -= damage
-
-            return {
-                "damage": damage,
-                "should_tackle": bool(damage),
-                "success": bool(damage),
-            }
+            return {"damage": 0, "should_tackle": False, "success": False}

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -83,6 +83,7 @@ class Technique:
         self.animation = ""
         self.can_apply_status = False
         self.carrier = carrier
+        self.category = ""
         self.combat_state: Optional[CombatState] = None
         self.effects: Sequence[TechEffect[Any]] = []
         self.flip_axes = ""
@@ -97,6 +98,8 @@ class Technique:
         self.power = 1.0
         self.range: Optional[str] = None
         self.recharge_length = 0
+        self.repl_pos = ""
+        self.repl_neg = ""
         self.sfx = ""
         self.sort = ""
         self.slug = slug


### PR DESCRIPTION
PR addresses blinded, chargedup, enraged, exhausted, focused, hardshell, softened and sniping

Source: https://wiki.tuxemon.org/index.php?title=Category:Condition

**Changes:**
1. added blinded, blinded, chargedup, enraged, exhausted, focused, hardshell, softened and sniping;
2. value was **int** (db.py), I changed to **float**, because if not it wouldn't accept the statchange value (eg. 0.5, 1.5, etc.);
3. inserted the distinction between user or target (eg **exhausted user** or **exhausted target**, etc);
4. inserted self.category, self.repl_pos and self.repl_neg to mimic conditions (only techniques and statuses, no db.py); it was necessary for setting up an acceptable apply_status (look at point 5);
5. a couple of int() because I got a warning (look at issue 3);
6. updated apply_status in monster.py, it's a better version, still not optimal; we can optimize the formula to the level of complexity only when we have all the statuses in game;
7. updated the message at the end of the turn and removed the broken one; combat_status_damage will retire;
8. added two set_stats for reset stats after the turn (issue about constant increment) and at the end of the combat (look at logs);

**Behavior:**
As per apply_status, some status are added and other removed.
When added, it starts using the specific message (it varies for each status).
When removed, the specific message doesn't go away, it keeps being used until the end of the battle, but there is an explanation for this, it's because there was the stat modification (speed, armour, etc.).

**Remember:**
~~hardshell user (user condition): **Boulder**, Static Field, Wall of Steel~~
~~exhausted user (user conditions): **Amnesia**, Give All~~
~~exhausted target (target condition): **Amnesia**, Avalanche, Energy Field, Eyebite, Snowstorm, Static Field, Thunderclap;~~
~~sniping user (user condition): Energy Claws, **Levitate**, Take Cover~~
~~sniping target (target condition): **Levitate**~~
~~focused user: Feint, Muddle, Sleeping Powder, Starfall, Suck Poison, Wallow~~
~~enraged user: Berserk, Fume, Invictus, Kindling Flame~~
~~focused target: Muddle, Sudden Glow~~
~~enraged target: Goad~~
~~blinded target: Beam, Sand Spray, Splinter~~
~~softened target: Biting Winds, Glower, Mudslide~~
~~charged up target: Supernova~~


**Logs & Issue:**
1. ~~stat armor keeps increasing at the end of each turn (decreasing too);~~
2. ~~stats don't reset at the end of battle;~~

```
values are: armor, melee, ranged)
Before:
Rockitten	120 240 120	uses boulder
Target 1	136 102 102	
Rockitten	180.0 240 120	increased stat
Target 1	136 102 102	
Rockitten	270.0 240 120	like when there is poison, it keeps growing
Target 2	102 68 136	
Rockitten	405.0 240 120	Boulder + automatic increase end of the turn
Target 2	102 68 136	
(some rounds)
Rockitten	911.25 240 120 -> stats at the end of the battle
Target 2	102 34.0 68.0	used Amnesia

After the set_stats():
R = rockitten (boulder)
T = target (amnesia)
R 120 240 120
T 102 68 136
R 180.0 120.0 60.0 -> kicks hardshell (boulder)
Target uses Amnesia
T 102 34.0 68.0 -> kicks exhausted user
R 180.0 120.0 60.0 -> kicks exhausted target
T 102 34.0 68.0
R 180.0 120.0 60.0
T 102 34.0 68.0
R 180.0 120.0 60.0
T 102 34.0 68.0

ends battle, stats as at the beginning
```
Issue 1: combat.py
```
        elif phase == "post action phase":
            # apply status effects to the monsters
            for monster in self.active_monsters:
                for technique in monster.status:
                    self.enqueue_action(None, technique, monster)
                    # avoid multiple effect status --------> new
                    monster.set_stats() --------> new
```
Issue 2: combat.py
```
    def end_combat(self) -> None:
        """End the combat."""
        # TODO: End combat differently depending on winning or losing
        for player in self.active_players:
            for mon in player.monsters:
                # reset status stats
                mon.set_stats() --------> new
                mon.end_combat()
```
Issue 3:
```
DeprecationWarning: non-integer arguments to randrange() have been deprecated since Python 3.10 and will be removed in a subsequent version
  return random.randrange(0, self.speed) --> since I changed from int to float (value stats), now I put int(self.speed).
```

black done
tested with poison, recover and lifeleech, no troubles, because they operate on current_hp. 
set_stats() on stats + hp (no current_hp)