### PR TITLE
status icon

### DIFF
--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -723,8 +723,7 @@ class CombatState(CombatAnimations):
                     # load the sprite and add it to the display
                     self.load_sprite(
                         status.icon,
-                        layer=200,
-                        center=rect.topleft,
+                        center=rect.bottomleft,
                     )
 
     def show_combat_dialog(self) -> None:


### PR DESCRIPTION
PR addresses the position of the status icons in the battle screen.

As a draft because of the issue 2.

With the next PRs there will be a lot of new status icons and there are two issues to solve.

1. position of the icon;
at the moment the icon is set to topleft, but with some resolution the icon of the target (enemy) isn't visible, it's off-screen.
This proposal is for bottomleft, but we can move the icon anywhere, of course there is also the risk of hardcoding the position (which isn't advisable).

2. the icon appear, but it doesn't disappear;
if the monster faints, then the icon stays.
if the monster gets a second status, then the icon appears over the other and not next.
if you swap monster, then the icon stays.

About the appear/disappear, I was looking for an example of appear disappear. But at the end the only thing similar is the mutation of the small spheres (if the monster is affected by a status, fainted or alive). Here we have a load "over". Eventually we can consider to create an icon for no status (similar to CaptureDeviceSprite). Still investigating.

here everything is handled by **reset_status_icons** in **combat.py**
```
        # remove all status icons
        for s in self._status_icons:
            self.sprites.remove(s)

        # add status icons
        for monster in self.active_monsters:
            for status in monster.status:
                if status.icon:
                    # get the rect of the monster
                    rect = self._monster_sprite_map[monster].rect
                    # load the sprite and add it to the display
                    self.load_sprite(
                        status.icon,
                        layer=200,
                        center=rect.topleft, ----> change
                    )
```
Tracking:
```
self._status_icons ->
[]

_monster_sprite_map -> 
{<tuxemon.npc.NPC object at 0x7f4ffef52830>: <Sprite DirtySprite(in 1 groups)>,
<tuxemon.player.Player object at 0x7f4fff046a10>: <Sprite DirtySprite(in 1 groups)>,
<tuxemon.monster.Monster object at 0x7f4ffef99e10>: <Sprite DirtySprite(in 1 groups)>,
<tuxemon.monster.Monster object at 0x7f4fff222e00>: <Sprite DirtySprite(in 1 groups)>}
```