### PR TITLE
Add tox.ini

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,7 @@ run:
 # Run tests
 .PHONY: test
 test:
-	pip install pytest
-	PYTHONPATH=. pytest tests
+	tox -e py3
 
 # Format code
 .PHONY: format

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py3
+
+[testenv]
+usedevelop = True
+deps =
+    -rrequirements.txt
+    pytest
+commands = pytest tests


### PR DESCRIPTION
  * tests are now made in their own venvs
  * tox is widely used by python programmers, to automatise test in a virtual environment
  * "make test" still works but you also can run tests, using one of the following commands: $ tox $ tox -e py3 $ make test (still works, but tests are now made in a venv)