### PR TITLE
technique: accuracy, power and potency

### DIFF
--- a/mods/tuxemon/db/technique/run.json
+++ b/mods/tuxemon/db/technique/run.json
@@ -7,6 +7,7 @@
   "animation": null,
   "sfx": "sfx_blaster",
   "icon": "",
+  "range": "status",
   "sort": "meta",
   "effects": [],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/status_blinded.json
+++ b/mods/tuxemon/db/technique/status_blinded.json
@@ -6,6 +6,7 @@
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_blinded.png",
+  "range": "status",
   "sfx": "sfx_pulse",
   "slug": "status_blinded",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_chargedup.json
+++ b/mods/tuxemon/db/technique/status_chargedup.json
@@ -6,6 +6,7 @@
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_chargedup.png",
+  "range": "status",
   "sfx": "sfx_pulse",
   "slug": "status_chargedup",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_charging.json
+++ b/mods/tuxemon/db/technique/status_charging.json
@@ -4,6 +4,7 @@
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_charging.png",
+  "range": "status",
   "sfx": "sfx_pulse",
   "slug": "status_charging",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_confused.json
+++ b/mods/tuxemon/db/technique/status_confused.json
@@ -4,6 +4,7 @@
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_confused.png",
+  "range": "status",
   "sfx": "sfx_pulse",
   "slug": "status_confused",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_diehard.json
+++ b/mods/tuxemon/db/technique/status_diehard.json
@@ -4,6 +4,7 @@
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_diehard.png",
+  "range": "status",
   "sfx": "sfx_pulse",
   "slug": "status_diehard",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_dozing.json
+++ b/mods/tuxemon/db/technique/status_dozing.json
@@ -4,6 +4,7 @@
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_dozing.png",
+  "range": "status",
   "sfx": "sfx_pulse",
   "slug": "status_dozing",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_eliminated.json
+++ b/mods/tuxemon/db/technique/status_eliminated.json
@@ -4,6 +4,7 @@
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_eliminated.png",
+  "range": "status",
   "sfx": "sfx_pulse",
   "slug": "status_eliminated",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_enraged.json
+++ b/mods/tuxemon/db/technique/status_enraged.json
@@ -6,6 +6,7 @@
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_enraged.png",
+  "range": "status",
   "sfx": "sfx_pulse",
   "slug": "status_enraged",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_exhausted.json
+++ b/mods/tuxemon/db/technique/status_exhausted.json
@@ -6,6 +6,7 @@
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_exhausted.png",
+  "range": "status",
   "sfx": "sfx_pulse",
   "slug": "status_exhausted",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_faint.json
+++ b/mods/tuxemon/db/technique/status_faint.json
@@ -3,6 +3,7 @@
   "effects": [],
   "flip_axes": "",
   "icon": "",
+  "range": "status",
   "power": 10,
   "sfx": "sfx_faint",
   "slug": "status_faint",

--- a/mods/tuxemon/db/technique/status_festering.json
+++ b/mods/tuxemon/db/technique/status_festering.json
@@ -4,6 +4,7 @@
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_festering.png",
+  "range": "status",
   "sfx": "sfx_pulse",
   "slug": "status_festering",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_focused.json
+++ b/mods/tuxemon/db/technique/status_focused.json
@@ -6,6 +6,7 @@
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_focused.png",
+  "range": "status",
   "sfx": "sfx_pulse",
   "slug": "status_focused",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_grabbed.json
+++ b/mods/tuxemon/db/technique/status_grabbed.json
@@ -4,6 +4,7 @@
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_grabbed.png",
+  "range": "status",
   "sfx": "sfx_pulse",
   "slug": "status_grabbed",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_hardshell.json
+++ b/mods/tuxemon/db/technique/status_hardshell.json
@@ -6,6 +6,7 @@
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_hardshell.png",
+  "range": "status",
   "sfx": "sfx_bite",
   "slug": "status_hardshell",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_lifeleech.json
+++ b/mods/tuxemon/db/technique/status_lifeleech.json
@@ -5,6 +5,7 @@
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_lifeleech.png",
+  "range": "status",
   "sfx": "sfx_bite",
   "slug": "status_lifeleech",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_noddingoff.json
+++ b/mods/tuxemon/db/technique/status_noddingoff.json
@@ -4,6 +4,7 @@
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_noddingoff.png",
+  "range": "status",
   "sfx": "sfx_pulse",
   "slug": "status_noddingoff",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_poison.json
+++ b/mods/tuxemon/db/technique/status_poison.json
@@ -5,6 +5,7 @@
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_poison.png",
+  "range": "status",
   "sfx": "sfx_pulse",
   "slug": "status_poison",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_recover.json
+++ b/mods/tuxemon/db/technique/status_recover.json
@@ -5,6 +5,7 @@
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_recover.png",
+  "range": "status",
   "sfx": "sfx_bite",
   "slug": "status_recover",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_sniping.json
+++ b/mods/tuxemon/db/technique/status_sniping.json
@@ -6,6 +6,7 @@
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_sniping.png",
+  "range": "status",
   "sfx": "sfx_pulse",
   "slug": "status_sniping",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_softened.json
+++ b/mods/tuxemon/db/technique/status_softened.json
@@ -6,6 +6,7 @@
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_softened.png",
+  "range": "status",
   "sfx": "sfx_pulse",
   "slug": "status_softened",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_spyderbite.json
+++ b/mods/tuxemon/db/technique/status_spyderbite.json
@@ -4,6 +4,7 @@
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_spyderbite.png",
+  "range": "status",
   "sfx": "sfx_pulse",
   "slug": "status_spyderbite",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_stuck.json
+++ b/mods/tuxemon/db/technique/status_stuck.json
@@ -4,6 +4,7 @@
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_stuck.png",
+  "range": "status",
   "sfx": "sfx_pulse",
   "slug": "status_stuck",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_tired.json
+++ b/mods/tuxemon/db/technique/status_tired.json
@@ -4,6 +4,7 @@
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_tired.png",
+  "range": "status",
   "sfx": "sfx_pulse",
   "slug": "status_tired",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/swap.json
+++ b/mods/tuxemon/db/technique/swap.json
@@ -7,6 +7,7 @@
   "animation": null,
   "sfx": "sfx_blaster",
   "icon": "",
+  "range": "status",
   "sort": "meta",
   "effects": [
     "swap"

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -317,6 +317,7 @@ class Range(str, Enum):
     touch = "touch"
     reach = "reach"
     reliable = "reliable"
+    status = "status"
 
 
 # TechSort defines the sort of technique a technique is.
@@ -368,13 +369,11 @@ class TechniqueModel(BaseModel):
         False, description="Whether or not this is an area of effect technique"
     )
     recharge: int = Field(0, description="Recharge of this technique")
-    range: Range = Field(
-        "melee", description="The attack range of this technique"
-    )
+    range: Range = Field(..., description="The attack range of this technique")
     tech_id: int = Field(..., description="The id of this technique")
     accuracy: float = Field(0, description="The accuracy of the technique")
     potency: Optional[float] = Field(
-        None, description="How potetent the technique is"
+        None, description="How potent the technique is"
     )
     statspeed: Optional[StatModel] = Field(None)
     stathp: Optional[StatModel] = Field(None)


### PR DESCRIPTION
PR addresses the fields **power**, **potency** and **accuracy** (techniques).

I was working on the status_grabbed and status_stuck. These statuses have effects on power and potency. Unfortunately these fields are different than armour, etc (classical stats), so I developed this idea to simplify the system.

At the moment these values are defined in each JSON.
The idea is to centralize these values by range as you can see below (schema).

I admit my ignorance by saying that I don't know if there is a logic behind these values.
By running some tests, I discovered that all the techniques with **special** as range have:
- accuracy 1
- power 0
- potency 1

Advantages?
- centralized, we can get rid of the fields in the JSONs, as well as the ones in db.py;
- less values to maintain and update (in the case we add new techniques or statuses);
- simplify, we can implement variance in power, potency and accuracy more easily (thinking about status_grabbed and status_stuck, but it can be others too);
- using range, it exists, but it's not utilized much;

As usual, this is not definitive, just a draft. We can remove accuracy or potency or everything and trash everything, no problem.
As usual, @Sanglorian let us know what do you think. 

(tested in locale and works)

```
RANGES = {
    Range.melee: {
        "accuracy": 1,
        "potency": 1,
        "power": 1,
    },
    Range.ranged: {
        "accuracy": 2,
        "potency": 2,
        "power": 2,
    },
    Range.reach: {
        "accuracy": 3,
        "potency": 3,
        "power": 3,
    },
    Range.reliable: {
        "accuracy": 4,
        "potency": 4,
        "power": 4,
    },
    Range.special: {
        "accuracy": 5,
        "potency": 5,
        "power": 5,
    },
    Range.status: {
        "accuracy": 6,
        "potency": 6,
        "power": 6,
    },
    Range.touch: {
        "accuracy": 7,
        "potency": 7,
        "power": 7,
    },
}
```