### PR TITLE
Move parameter attributes into ItemCondition and ItemEffect class

### DIFF
--- a/mods/tuxemon/db/item/revive.json
+++ b/mods/tuxemon/db/item/revive.json
@@ -5,7 +5,7 @@
     "status target,status_faint"
   ],
   "effects": [
-    "revive",
+    "revive 1",
     "heal 20"
   ],
   "slug": "revive",

--- a/tuxemon/item/conditions/current_hp.py
+++ b/tuxemon/item/conditions/current_hp.py
@@ -25,8 +25,9 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from operator import eq, ge, gt, le, lt
-from typing import Callable, Mapping, NamedTuple, Optional, Union
+from typing import Callable, Mapping, Optional, Union
 
 from tuxemon.item.itemcondition import ItemCondition
 from tuxemon.monster import Monster
@@ -42,14 +43,8 @@ cmp_dict: Mapping[Optional[str], Callable[[float, float], bool]] = {
 }
 
 
-class CurrentHitPointsConditionParameters(NamedTuple):
-    comparison: str
-    value: Union[int, float]
-
-
-class CurrentHitPointsCondition(
-    ItemCondition[CurrentHitPointsConditionParameters]
-):
+@dataclass
+class CurrentHitPointsCondition(ItemCondition):
     """
     Compares the target Monster's current hitpoints against the given value.
 
@@ -63,14 +58,15 @@ class CurrentHitPointsCondition(
     """
 
     name = "current_hp"
-    param_class = CurrentHitPointsConditionParameters
+    comparison: str
+    value: Union[int, float]
 
     def test(self, target: Monster) -> bool:
         lhs = target.current_hp
-        op = cmp_dict[self.parameters.comparison]
-        if type(self.parameters.value) is float:
-            rhs = target.hp * self.parameters.value
+        op = cmp_dict[self.comparison]
+        if type(self.value) is float:
+            rhs = target.hp * self.value
         else:
-            rhs = self.parameters.value
+            rhs = self.value
 
         return op(lhs, rhs)

--- a/tuxemon/item/conditions/has_path.py
+++ b/tuxemon/item/conditions/has_path.py
@@ -25,17 +25,14 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple
+from dataclasses import dataclass
 
 from tuxemon.item.itemcondition import ItemCondition
 from tuxemon.monster import Monster
 
 
-class HasPathConditionParameters(NamedTuple):
-    expected: str
-
-
-class HasPathCondition(ItemCondition[HasPathConditionParameters]):
+@dataclass
+class HasPathCondition(ItemCondition):
     """
     Checks against the creature's evolution paths.
 
@@ -44,9 +41,9 @@ class HasPathCondition(ItemCondition[HasPathConditionParameters]):
     """
 
     name = "has_path"
-    param_class = HasPathConditionParameters
+    expected: str
 
     def test(self, target: Monster) -> bool:
-        expect = self.parameters.expected
+        expect = self.expected
 
         return any(d["path"] == expect for d in target.evolutions)

--- a/tuxemon/item/conditions/is_wild_monster.py
+++ b/tuxemon/item/conditions/is_wild_monster.py
@@ -25,21 +25,17 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple
+from dataclasses import dataclass
 
 from tuxemon.item.itemcondition import ItemCondition
 from tuxemon.monster import Monster
 
 
-class IsWildMonsterConditionParameters(NamedTuple):
-    pass
-
-
-class IsWildMonsterCondition(ItemCondition[IsWildMonsterConditionParameters]):
+@dataclass
+class IsWildMonsterCondition(ItemCondition):
     """True if not owned by a trainer."""
 
     name = "is_wild_monster"
-    param_class = IsWildMonsterConditionParameters
 
     def test(self, target: Monster) -> bool:
         return target.owner is None

--- a/tuxemon/item/conditions/level.py
+++ b/tuxemon/item/conditions/level.py
@@ -25,8 +25,9 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from operator import eq, ge, gt, le, lt
-from typing import Callable, Mapping, NamedTuple, Optional
+from typing import Callable, Mapping, Optional
 
 from tuxemon.item.itemcondition import ItemCondition
 from tuxemon.monster import Monster
@@ -42,12 +43,8 @@ cmp_dict: Mapping[Optional[str], Callable[[float, float], bool]] = {
 }
 
 
-class LevelConditionParameters(NamedTuple):
-    comparison: str
-    value: int
-
-
-class LevelCondition(ItemCondition[LevelConditionParameters]):
+@dataclass
+class LevelCondition(ItemCondition):
     """
     Compares the target Monster's level against the given value.
 
@@ -57,11 +54,12 @@ class LevelCondition(ItemCondition[LevelConditionParameters]):
     """
 
     name = "level"
-    param_class = LevelConditionParameters
+    comparison: str
+    value: int
 
     def test(self, target: Monster) -> bool:
         level = target.level
-        operator = cmp_dict[self.parameters.comparison]
-        level_reached = self.parameters.value
+        operator = cmp_dict[self.comparison]
+        level_reached = self.value
 
         return operator(level, level_reached)

--- a/tuxemon/item/conditions/shape.py
+++ b/tuxemon/item/conditions/shape.py
@@ -25,21 +25,15 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, Union
+from dataclasses import dataclass
+from typing import Union
 
 from tuxemon.item.itemcondition import ItemCondition
 from tuxemon.monster import Monster
 
 
-class ShapeConditionParameters(NamedTuple):
-    shape1: str
-    shape2: Union[str, None]
-    shape3: Union[str, None]
-    shape4: Union[str, None]
-    shape5: Union[str, None]
-
-
-class ShapeCondition(ItemCondition[ShapeConditionParameters]):
+@dataclass
+class ShapeCondition(ItemCondition):
     """
     Compares the target Monster's shape against the given types.
 
@@ -48,14 +42,18 @@ class ShapeCondition(ItemCondition[ShapeConditionParameters]):
     """
 
     name = "shape"
-    param_class = ShapeConditionParameters
+    shape1: str
+    shape2: Union[str, None] = None
+    shape3: Union[str, None] = None
+    shape4: Union[str, None] = None
+    shape5: Union[str, None] = None
 
     def test(self, target: Monster) -> bool:
         ret = False
         if target.shape is not None:
             ret = any(
                 target.shape.lower() == p.lower()
-                for p in self.parameters
+                for p in self.shape1
                 if p is not None
             )
 

--- a/tuxemon/item/conditions/status.py
+++ b/tuxemon/item/conditions/status.py
@@ -25,20 +25,14 @@
 
 from __future__ import annotations
 
-import logging
-from typing import NamedTuple
+from dataclasses import dataclass
 
 from tuxemon.item.itemcondition import ItemCondition
 from tuxemon.monster import Monster
 
-logger = logging.getLogger(__name__)
 
-
-class StatusConditionParameters(NamedTuple):
-    expected: str
-
-
-class StatusCondition(ItemCondition[StatusConditionParameters]):
+@dataclass
+class StatusCondition(ItemCondition):
     """
     Checks against the creature's current statuses.
 
@@ -47,9 +41,9 @@ class StatusCondition(ItemCondition[StatusConditionParameters]):
     """
 
     name = "status"
-    param_class = StatusConditionParameters
+    expected: str
 
     def test(self, target: Monster) -> bool:
-        return self.parameters.expected in [
+        return self.expected in [
             x.slug for x in target.status if hasattr(x, "slug")
         ]

--- a/tuxemon/item/conditions/type.py
+++ b/tuxemon/item/conditions/type.py
@@ -52,7 +52,7 @@ class TypeCondition(ItemCondition):
         ret = False
         if target.type1 is not None:
             ret = any(
-                target.type1.lower() == p.lower()
+                target.type1 == p
                 for p in (
                     self.type1,
                     self.type2,
@@ -64,7 +64,7 @@ class TypeCondition(ItemCondition):
             )
         if target.type2 is not None:
             ret = ret or any(
-                target.type2.lower() == p.lower()
+                target.type2 == p
                 for p in (
                     self.type1,
                     self.type2,

--- a/tuxemon/item/conditions/type.py
+++ b/tuxemon/item/conditions/type.py
@@ -25,21 +25,15 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, Union
+from dataclasses import dataclass
+from typing import Union
 
 from tuxemon.item.itemcondition import ItemCondition
 from tuxemon.monster import Monster
 
 
-class TypeConditionParameters(NamedTuple):
-    type1: str
-    type2: Union[str, None]
-    type3: Union[str, None]
-    type4: Union[str, None]
-    type5: Union[str, None]
-
-
-class TypeCondition(ItemCondition[TypeConditionParameters]):
+@dataclass
+class TypeCondition(ItemCondition):
     """
     Compares the target Monster's type1 and type2 against the given types.
 
@@ -48,20 +42,36 @@ class TypeCondition(ItemCondition[TypeConditionParameters]):
     """
 
     name = "type"
-    param_class = TypeConditionParameters
+    type1: str
+    type2: Union[str, None] = None
+    type3: Union[str, None] = None
+    type4: Union[str, None] = None
+    type5: Union[str, None] = None
 
     def test(self, target: Monster) -> bool:
         ret = False
         if target.type1 is not None:
             ret = any(
                 target.type1.lower() == p.lower()
-                for p in self.parameters
+                for p in (
+                    self.type1,
+                    self.type2,
+                    self.type3,
+                    self.type4,
+                    self.type5,
+                )
                 if p is not None
             )
         if target.type2 is not None:
             ret = ret or any(
                 target.type2.lower() == p.lower()
-                for p in self.parameters
+                for p in (
+                    self.type1,
+                    self.type2,
+                    self.type3,
+                    self.type4,
+                    self.type5,
+                )
                 if p is not None
             )
 

--- a/tuxemon/item/conditions/variable.py
+++ b/tuxemon/item/conditions/variable.py
@@ -25,31 +25,29 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, Union
+from dataclasses import dataclass
+from typing import Union
 
 from tuxemon.item.itemcondition import ItemCondition
 from tuxemon.monster import Monster
 from tuxemon.npc import NPC
 
 
-class VariableConditionParameters(NamedTuple):
-    var_name: str
-    expected: Union[str, int, None]
-
-
-class VariableCondition(ItemCondition[VariableConditionParameters]):
+@dataclass
+class VariableCondition(ItemCondition):
     """Checks against the variables of the context.
     Accepts two parameters; variable name and expected value.
     """
 
     name = "variable"
-    param_class = VariableConditionParameters
+    var_name: str
+    context: Union[NPC, Monster]
+    expected: Union[str, int, None] = None
 
     def test(self, target: Monster) -> bool:
-        var_name = self.parameters.var_name
-        expect = self.parameters.expected
+        var_name = self.var_name
+        expect = self.expected
 
-        context: Union[NPC, Monster]
         if self.context == "target":
             context = target
         else:

--- a/tuxemon/item/effects/capture.py
+++ b/tuxemon/item/effects/capture.py
@@ -30,8 +30,8 @@ from __future__ import annotations
 
 import logging
 import random
+from dataclasses import dataclass
 from math import sqrt
-from typing import NamedTuple
 
 from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
 from tuxemon.monster import Monster
@@ -44,15 +44,12 @@ class CaptureEffectResult(ItemEffectResult):
     num_shakes: int
 
 
-class CaptureEffectParameters(NamedTuple):
-    power: int
-
-
-class CaptureEffect(ItemEffect[CaptureEffectParameters]):
+@dataclass
+class CaptureEffect(ItemEffect):
     """Attempts to capture the target with 'power' capture strength."""
 
     name = "capture"
-    param_class = CaptureEffectParameters
+    power: int
 
     def apply(self, target: Monster) -> CaptureEffectResult:
         # Set up variables for capture equation

--- a/tuxemon/item/effects/evolve.py
+++ b/tuxemon/item/effects/evolve.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple
+from dataclasses import dataclass
 
 from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
 from tuxemon.monster import Monster
@@ -34,18 +34,15 @@ class EvolveEffectResult(ItemEffectResult):
     pass
 
 
-class EvolveEffectParameters(NamedTuple):
-    monster_evolve: str
-
-
-class EvolveEffect(ItemEffect[EvolveEffectParameters]):
+@dataclass
+class EvolveEffect(ItemEffect):
     """This effect evolves the target into the monster in the parameters."""
 
     name = "evolve"
-    param_class = EvolveEffectParameters
+    monster_evolve: str
 
     def apply(self, target: Monster) -> EvolveEffectResult:
-        monster_evolve = self.parameters.monster_evolve
+        monster_evolve = self.monster_evolve
 
         if any(d["monster_slug"] == monster_evolve for d in target.evolutions):
             self.user.evolve_monster(target, monster_evolve)

--- a/tuxemon/item/effects/heal.py
+++ b/tuxemon/item/effects/heal.py
@@ -28,7 +28,8 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, Union
+from dataclasses import dataclass
+from typing import Union
 
 from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
 from tuxemon.monster import Monster
@@ -38,11 +39,8 @@ class HealEffectResult(ItemEffectResult):
     pass
 
 
-class HealEffectParameters(NamedTuple):
-    amount: Union[int, float]
-
-
-class HealEffect(ItemEffect[HealEffectParameters]):
+@dataclass
+class HealEffect(ItemEffect):
     """
     Heals the target by 'amount' hp.
 
@@ -51,16 +49,16 @@ class HealEffect(ItemEffect[HealEffectParameters]):
 
     Examples:
     >>> potion = Item('potion')
-    >>> potion.parameters.amount = 0.5
+    >>> potion.amount = 0.5
     >>> potion.apply(bulbatux)
     >>> # bulbatux is healed by 50% of it's total hp
     """
 
     name = "heal"
-    param_class = HealEffectParameters
+    amount: Union[int, float]
 
     def apply(self, target: Monster) -> HealEffectResult:
-        healing_amount = self.parameters.amount
+        healing_amount = self.amount
         if type(healing_amount) is float:
             healing_amount *= target.hp
 

--- a/tuxemon/item/effects/learn.py
+++ b/tuxemon/item/effects/learn.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple
+from dataclasses import dataclass
 
 from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
 from tuxemon.monster import Monster
@@ -35,19 +35,16 @@ class LearnEffectResult(ItemEffectResult):
     pass
 
 
-class LearnEffectParameters(NamedTuple):
-    technique: str
-
-
-class LearnEffect(ItemEffect[LearnEffectParameters]):
+@dataclass
+class LearnEffect(ItemEffect):
     """This effect teaches the target the technique in the parameters."""
 
     name = "learn"
-    param_class = LearnEffectParameters
+    technique: str
 
     def apply(self, target: Monster) -> LearnEffectResult:
         tech = Technique()
-        tech.load(self.parameters.technique)
+        tech.load(self.technique)
         target.learn(tech)
 
         return {"success": True}

--- a/tuxemon/item/effects/revive.py
+++ b/tuxemon/item/effects/revive.py
@@ -28,7 +28,7 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple
+from dataclasses import dataclass
 
 from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
 from tuxemon.monster import Monster
@@ -38,20 +38,17 @@ class ReviveEffectResult(ItemEffectResult):
     pass
 
 
-class ReviveEffectParameters(NamedTuple):
-    pass
-
-
-class ReviveEffect(ItemEffect[ReviveEffectParameters]):
+@dataclass
+class ReviveEffect(ItemEffect):
     """
     Revives the target tuxemon, and sets HP to 1.
     """
 
     name = "revive"
-    param_class = ReviveEffectParameters
+    hp: int
 
     def apply(self, target: Monster) -> ReviveEffectResult:
         target.status = []
-        target.current_hp = 1
+        target.current_hp = self.hp
 
         return {"success": True}

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -190,7 +190,7 @@ class Item:
             except KeyError:
                 logger.error(f'Error: ItemEffect "{name}" not implemented')
             else:
-                ret.append(effect(self.session, self.user, params))
+                ret.append(effect(*params))
 
         return ret
 
@@ -224,7 +224,7 @@ class Item:
             except KeyError:
                 logger.error(f'Error: ItemCondition "{name}" not implemented')
             else:
-                ret.append(condition(context, self.session, self.user, params))
+                ret.append(condition(*params))
 
         return ret
 

--- a/tuxemon/item/itemcondition.py
+++ b/tuxemon/item/itemcondition.py
@@ -28,29 +28,20 @@
 from __future__ import annotations
 
 import logging
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    ClassVar,
-    Generic,
-    Sequence,
-    Type,
-    TypeVar,
-)
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, ClassVar
 
-from tuxemon.session import Session
-from tuxemon.tools import NamedTupleProtocol, cast_parameters_to_namedtuple
+from tuxemon.session import Session, local_session
+from tuxemon.tools import cast_dataclass_parameters
 
 if TYPE_CHECKING:
     from tuxemon.monster import Monster
-    from tuxemon.npc import NPC
 
 logger = logging.getLogger(__name__)
 
-ParameterClass = TypeVar("ParameterClass", bound=NamedTupleProtocol)
 
-
-class ItemCondition(Generic[ParameterClass]):
+@dataclass
+class ItemCondition:
     """
     ItemConditions are evaluated by items.
 
@@ -92,46 +83,14 @@ class ItemCondition(Generic[ParameterClass]):
     (Monster, "monster_slug")   => a Monster instance will be created
     """
 
-    name: ClassVar[str] = "GenericCondition"
-    param_class: ClassVar[Type[ParameterClass]]
+    name: ClassVar[str]
+    session: Session = field(init=False, repr=False)
+    _done: bool = field(default=False, init=False)
 
-    def __init__(
-        self,
-        context: str,
-        session: Session,
-        user: NPC,
-        parameters: Sequence[Any],
-    ) -> None:
-
-        self.session = session
-        self.user = user
-        self.context = context
-
-        # if you need the parameters before they are processed, use this
-        self.raw_parameters = parameters
-
-        # parse parameters
-        try:
-            if self.param_class._fields:
-
-                # cast the parameters to the correct type, as defined in cls.valid_parameters
-                self.parameters = cast_parameters_to_namedtuple(
-                    parameters,
-                    self.param_class,
-                )
-            else:
-                self.parameters = parameters
-
-        except ValueError:
-            logger.error(f"error while parsing for {self.name}")
-            logger.error(f"cannot parse parameters: {parameters}")
-            logger.error(f"{self.param_class}")
-            logger.error(
-                "please check the parameters and verify they are correct"
-            )
-            self.parameters = None
-
-        self._done = False
+    def __post_init__(self):
+        self.session = local_session
+        self.user = local_session.player
+        cast_dataclass_parameters(self)
 
     def test(self, target: Monster) -> bool:
         """

--- a/tuxemon/item/itemeffect.py
+++ b/tuxemon/item/itemeffect.py
@@ -32,34 +32,24 @@
 from __future__ import annotations
 
 import logging
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    ClassVar,
-    Generic,
-    Sequence,
-    Type,
-    TypedDict,
-    TypeVar,
-)
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, ClassVar, TypedDict
 
-from tuxemon.session import Session
-from tuxemon.tools import NamedTupleProtocol, cast_parameters_to_namedtuple
+from tuxemon.session import Session, local_session
+from tuxemon.tools import cast_dataclass_parameters
 
 if TYPE_CHECKING:
     from tuxemon.monster import Monster
-    from tuxemon.npc import NPC
 
 logger = logging.getLogger(__name__)
-
-ParameterClass = TypeVar("ParameterClass", bound=NamedTupleProtocol)
 
 
 class ItemEffectResult(TypedDict):
     success: bool
 
 
-class ItemEffect(Generic[ParameterClass]):
+@dataclass
+class ItemEffect:
     """ItemEffects are executed by items.
 
     ItemEffect subclasses implement "effects" defined in Tuxemon items.
@@ -100,44 +90,14 @@ class ItemEffect(Generic[ParameterClass]):
     (Monster, "monster_slug")   => a Monster instance will be created
     """
 
-    name: ClassVar[str] = "GenericEffect"
-    param_class: ClassVar[Type[ParameterClass]]
+    name: ClassVar[str]
+    session: Session = field(init=False, repr=False)
+    _done: bool = field(default=False, init=False)
 
-    def __init__(
-        self,
-        session: Session,
-        user: NPC,
-        parameters: Sequence[Any],
-    ) -> None:
-
-        self.session = session
-        self.user = user
-
-        # if you need the parameters before they are processed, use this
-        self.raw_parameters = parameters
-
-        # parse parameters
-        try:
-            if self.param_class._fields:
-
-                # cast the parameters to the correct type, as defined in cls.valid_parameters
-                self.parameters = cast_parameters_to_namedtuple(
-                    parameters,
-                    self.param_class,
-                )
-            else:
-                self.parameters = parameters
-
-        except ValueError:
-            logger.error(f"error while parsing for {self.name}")
-            logger.error(f"cannot parse parameters: {parameters}")
-            logger.error(f"{self.param_class}")
-            logger.error(
-                "please check the parameters and verify they are correct"
-            )
-            self.parameters = None
-
-        self._done = False
+    def __post_init__(self):
+        self.session = local_session
+        self.user = local_session.player
+        cast_dataclass_parameters(self)
 
     def apply(self, target: Monster) -> ItemEffectResult:
         pass

--- a/tuxemon/tools.py
+++ b/tuxemon/tools.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import logging
 import typing
+from dataclasses import fields
 from itertools import zip_longest
 from typing import (
     TYPE_CHECKING,
@@ -247,6 +248,46 @@ def number_or_variable(
             raise ValueError(f"invalid number or game variable {value}")
 
 
+# TODO: stability/testing
+def cast_value(
+    i: Tuple[Tuple[ValidParameterTypes, str], Any],
+) -> Any:
+
+    (type_constructors, param_name), value = i
+
+    if not isinstance(type_constructors, Sequence):
+        type_constructors = [type_constructors]
+
+    if (value is None or value == "") and (
+        None in type_constructors or type(None) in type_constructors
+    ):
+        return None
+
+    for constructor in type_constructors:
+
+        if not constructor:
+            continue
+
+        if isinstance(value, constructor):
+            return value
+
+        elif typing.get_origin(constructor) is typing.Literal:
+            allowed_values = typing.get_args(constructor)
+            if value in allowed_values:
+                return value
+
+        else:
+            try:
+                return constructor(value)
+            except (ValueError, TypeError):
+                pass
+
+    raise ValueError(
+        f"Error parsing parameter {param_name} with value {value} and "
+        f"constructor list {type_constructors}",
+    )
+
+
 def cast_values(
     parameters: Sequence[Any],
     valid_parameters: Sequence[Tuple[ValidParameterTypes, str]],
@@ -265,36 +306,8 @@ def cast_values(
 
     """
 
-    # TODO: stability/testing
-    def cast(
-        i: Tuple[Tuple[ValidParameterTypes, str], Any],
-    ) -> Any:
-
-        (type_constructors, param_name), value = i
-
-        if not isinstance(type_constructors, Sequence):
-            type_constructors = [type_constructors]
-
-        if (value is None or value == "") and (
-            None in type_constructors or type(None) in type_constructors
-        ):
-            return None
-
-        for constructor in type_constructors:
-
-            if constructor:
-                try:
-                    return constructor(value)
-                except (ValueError, TypeError):
-                    pass
-
-        raise ValueError(
-            f"Error parsing parameter {param_name} with value {value} and "
-            f"constructor list {type_constructors}",
-        )
-
     try:
-        return list(map(cast, zip_longest(valid_parameters, parameters)))
+        return list(map(cast_value, zip_longest(valid_parameters, parameters)))
     except ValueError:
         logger.warning("Invalid parameters passed:")
         logger.warning(f"expected: {valid_parameters}")
@@ -309,6 +322,23 @@ def get_types_tuple(
         return typing.get_args(param_type)
     else:
         return (param_type,)
+
+
+def cast_dataclass_parameters(self):
+    """
+    Takes a dataclass object and casts its __init__ values to the correct type
+    """
+    type_hints = typing.get_type_hints(self.__class__)
+    for field in fields(self):
+        if field.init:
+            field_name = field.name  # e.g "map_name"
+            type_hint = type_hints[field_name]  # e.g. Optional[str]
+            constructors = get_types_tuple(
+                type_hint
+            )  # e.g. (<class 'str'>, <class 'NoneType'>)
+            old_value = getattr(self, field_name)
+            new_value = cast_value(((constructors, field_name), old_value))
+            setattr(self, field_name, new_value)
 
 
 def cast_parameters_to_namedtuple(


### PR DESCRIPTION
PR addresses the removal of namedtuple from item (effects and conditions), now the attributes are on the class.
Inspired by #1385 

Addition:
- added **hp** parameter to **revive** as well as 1 in the JSON

Everything works, there is the message when you can use an item or not, you can use the capture device and capture monsters, you can use potion on monster, etc.