### PR TITLE
types in db.py

### DIFF
--- a/mods/tuxemon/db/item/tm_avalanche.json
+++ b/mods/tuxemon/db/item/tm_avalanche.json
@@ -1,6 +1,6 @@
 {
   "conditions": [
-    "type target,Earth,Water"
+    "type target,earth,water"
   ],
   "effects": [
     "learn avalanche"

--- a/mods/tuxemon/db/item/tm_blossom.json
+++ b/mods/tuxemon/db/item/tm_blossom.json
@@ -1,6 +1,6 @@
 {
   "conditions": [
-    "type target,Wood"
+    "type target,wood"
   ],
   "effects": [
     "learn blossom"

--- a/mods/tuxemon/db/monster/aardart.json
+++ b/mods/tuxemon/db/monster/aardart.json
@@ -23,7 +23,7 @@
     "evolutions": [],
     "shape": "varmint",
     "types": [
-        "Earth"
+        "earth"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 42,

--- a/mods/tuxemon/db/monster/aardorn.json
+++ b/mods/tuxemon/db/monster/aardorn.json
@@ -29,7 +29,7 @@
     ],
     "shape": "varmint",
     "types": [
-        "Earth"
+        "earth"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 41,

--- a/mods/tuxemon/db/monster/abesnaki.json
+++ b/mods/tuxemon/db/monster/abesnaki.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "serpent",
     "types": [
-        "Fire"
+        "fire"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 98,

--- a/mods/tuxemon/db/monster/agnidon.json
+++ b/mods/tuxemon/db/monster/agnidon.json
@@ -25,7 +25,7 @@
     ],
     "shape": "dragon",
     "types": [
-        "Fire"
+        "fire"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 14,

--- a/mods/tuxemon/db/monster/agnigon.json
+++ b/mods/tuxemon/db/monster/agnigon.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "dragon",
     "types": [
-        "Fire"
+        "fire"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 15,

--- a/mods/tuxemon/db/monster/agnite.json
+++ b/mods/tuxemon/db/monster/agnite.json
@@ -25,7 +25,7 @@
     ],
     "shape": "dragon",
     "types": [
-        "Fire"
+        "fire"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 13,

--- a/mods/tuxemon/db/monster/allagon.json
+++ b/mods/tuxemon/db/monster/allagon.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "dragon",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 153,

--- a/mods/tuxemon/db/monster/angrito.json
+++ b/mods/tuxemon/db/monster/angrito.json
@@ -19,8 +19,8 @@
     "evolutions": [],
     "shape": "blob",
     "types": [
-        "Fire",
-        "Metal"
+        "fire",
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 166,

--- a/mods/tuxemon/db/monster/anoleaf.json
+++ b/mods/tuxemon/db/monster/anoleaf.json
@@ -25,7 +25,7 @@
     ],
     "shape": "varmint",
     "types": [
-        "Wood"
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 64,

--- a/mods/tuxemon/db/monster/anu.json
+++ b/mods/tuxemon/db/monster/anu.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "varmint",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 162,

--- a/mods/tuxemon/db/monster/araignee.json
+++ b/mods/tuxemon/db/monster/araignee.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "grub",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 99,

--- a/mods/tuxemon/db/monster/arthrobolt.json
+++ b/mods/tuxemon/db/monster/arthrobolt.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "humanoid",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 6,

--- a/mods/tuxemon/db/monster/av8r.json
+++ b/mods/tuxemon/db/monster/av8r.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "flier",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["neuter"],
     "txmn_id": 125,

--- a/mods/tuxemon/db/monster/axylightl.json
+++ b/mods/tuxemon/db/monster/axylightl.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "polliwog",
     "types": [
-        "Water"
+        "water"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 100,

--- a/mods/tuxemon/db/monster/bamboon.json
+++ b/mods/tuxemon/db/monster/bamboon.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "sprite",
     "types": [
-        "Wood"
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 27,

--- a/mods/tuxemon/db/monster/bigfin.json
+++ b/mods/tuxemon/db/monster/bigfin.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "leviathan",
     "types": [
-        "Water"
+        "water"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 24,

--- a/mods/tuxemon/db/monster/birb_robo.json
+++ b/mods/tuxemon/db/monster/birb_robo.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "flier",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["neuter"],
     "txmn_id": 0,

--- a/mods/tuxemon/db/monster/birdling.json
+++ b/mods/tuxemon/db/monster/birdling.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "flier",
     "types": [
-        "Wood"
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 81,

--- a/mods/tuxemon/db/monster/bolt.json
+++ b/mods/tuxemon/db/monster/bolt.json
@@ -25,7 +25,7 @@
     ],
     "shape": "blob",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 5,

--- a/mods/tuxemon/db/monster/botbot.json
+++ b/mods/tuxemon/db/monster/botbot.json
@@ -40,7 +40,7 @@
     ],
     "shape": "grub",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["neuter"],
     "txmn_id": 124,

--- a/mods/tuxemon/db/monster/budaye.json
+++ b/mods/tuxemon/db/monster/budaye.json
@@ -40,7 +40,7 @@
     ],
     "shape": "sprite",
     "types": [
-        "Wood"
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 26,

--- a/mods/tuxemon/db/monster/bugnin.json
+++ b/mods/tuxemon/db/monster/bugnin.json
@@ -19,8 +19,8 @@
     "evolutions": [],
     "shape": "brute",
     "types": [
-        "Metal",
-        "Wood"
+        "metal",
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 57,

--- a/mods/tuxemon/db/monster/bursa.json
+++ b/mods/tuxemon/db/monster/bursa.json
@@ -25,7 +25,7 @@
     ],
     "shape": "humanoid",
     "types": [
-        "Fire"
+        "fire"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 82,

--- a/mods/tuxemon/db/monster/cairfrey.json
+++ b/mods/tuxemon/db/monster/cairfrey.json
@@ -25,7 +25,7 @@
     ],
     "shape": "blob",
     "types": [
-        "Earth"
+        "earth"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 70,

--- a/mods/tuxemon/db/monster/capiti.json
+++ b/mods/tuxemon/db/monster/capiti.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "sprite",
     "types": [
-        "Wood"
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 101,

--- a/mods/tuxemon/db/monster/cardiling.json
+++ b/mods/tuxemon/db/monster/cardiling.json
@@ -25,7 +25,7 @@
     ],
     "shape": "flier",
     "types": [
-        "Fire"
+        "fire"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 61,

--- a/mods/tuxemon/db/monster/cardinale.json
+++ b/mods/tuxemon/db/monster/cardinale.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "flier",
     "types": [
-        "Fire"
+        "fire"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 63,

--- a/mods/tuxemon/db/monster/cardiwing.json
+++ b/mods/tuxemon/db/monster/cardiwing.json
@@ -25,7 +25,7 @@
     ],
     "shape": "flier",
     "types": [
-        "Fire"
+        "fire"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 62,

--- a/mods/tuxemon/db/monster/cataspike.json
+++ b/mods/tuxemon/db/monster/cataspike.json
@@ -25,7 +25,7 @@
     ],
     "shape": "grub",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 32,

--- a/mods/tuxemon/db/monster/cateye.json
+++ b/mods/tuxemon/db/monster/cateye.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "hunter",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 102,

--- a/mods/tuxemon/db/monster/chenipode.json
+++ b/mods/tuxemon/db/monster/chenipode.json
@@ -25,7 +25,7 @@
     ],
     "shape": "grub",
     "types": [
-        "Earth"
+        "earth"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 59,

--- a/mods/tuxemon/db/monster/chillimp.json
+++ b/mods/tuxemon/db/monster/chillimp.json
@@ -19,8 +19,8 @@
     "evolutions": [],
     "shape": "brute",
     "types": [
-        "Water",
-        "Earth"
+        "water",
+        "earth"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 149,

--- a/mods/tuxemon/db/monster/chloragon.json
+++ b/mods/tuxemon/db/monster/chloragon.json
@@ -25,7 +25,7 @@
     ],
     "shape": "dragon",
     "types": [
-        "Wood"
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 136,

--- a/mods/tuxemon/db/monster/chrome_robo.json
+++ b/mods/tuxemon/db/monster/chrome_robo.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "humanoid",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["neuter"],
     "txmn_id": 0,

--- a/mods/tuxemon/db/monster/chromeye.json
+++ b/mods/tuxemon/db/monster/chromeye.json
@@ -40,7 +40,7 @@
     ],
     "shape": "blob",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 165,

--- a/mods/tuxemon/db/monster/cochini.json
+++ b/mods/tuxemon/db/monster/cochini.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "varmint",
     "types": [
-        "Earth"
+        "earth"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 103,

--- a/mods/tuxemon/db/monster/coleorus.json
+++ b/mods/tuxemon/db/monster/coleorus.json
@@ -19,8 +19,8 @@
     "evolutions": [],
     "shape": "sprite",
     "types": [
-        "Wood",
-        "Earth"
+        "wood",
+        "earth"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 104,

--- a/mods/tuxemon/db/monster/conifrost.json
+++ b/mods/tuxemon/db/monster/conifrost.json
@@ -19,8 +19,8 @@
     "evolutions": [],
     "shape": "blob",
     "types": [
-        "Water",
-        "Wood"
+        "water",
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 105,

--- a/mods/tuxemon/db/monster/conileaf.json
+++ b/mods/tuxemon/db/monster/conileaf.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "blob",
     "types": [
-        "Wood"
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 144,

--- a/mods/tuxemon/db/monster/coproblight.json
+++ b/mods/tuxemon/db/monster/coproblight.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "blob",
     "types": [
-        "Earth"
+        "earth"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 164,

--- a/mods/tuxemon/db/monster/corvix.json
+++ b/mods/tuxemon/db/monster/corvix.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "flier",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 151,

--- a/mods/tuxemon/db/monster/cowpignon.json
+++ b/mods/tuxemon/db/monster/cowpignon.json
@@ -19,8 +19,8 @@
     "evolutions": [],
     "shape": "sprite",
     "types": [
-        "Wood",
-        "Earth"
+        "wood",
+        "earth"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 106,

--- a/mods/tuxemon/db/monster/criniotherme.json
+++ b/mods/tuxemon/db/monster/criniotherme.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "hunter",
     "types": [
-        "Fire"
+        "fire"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 20,

--- a/mods/tuxemon/db/monster/d0llf1n.json
+++ b/mods/tuxemon/db/monster/d0llf1n.json
@@ -19,8 +19,8 @@
     "evolutions": [],
     "shape": "aquatic",
     "types": [
-        "Glitch",
-        "Water"
+        "glitch",
+        "water"
     ],
     "possible_genders": ["neuter"],
     "txmn_id": 0,

--- a/mods/tuxemon/db/monster/dandicub.json
+++ b/mods/tuxemon/db/monster/dandicub.json
@@ -25,7 +25,7 @@
     ],
     "shape": "blob",
     "types": [
-        "Wood"
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 72,

--- a/mods/tuxemon/db/monster/dandylion.json
+++ b/mods/tuxemon/db/monster/dandylion.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "hunter",
     "types": [
-        "Wood"
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 73,

--- a/mods/tuxemon/db/monster/dark_robo.json
+++ b/mods/tuxemon/db/monster/dark_robo.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "humanoid",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["neuter"],
     "txmn_id": 0,

--- a/mods/tuxemon/db/monster/dinoflop.json
+++ b/mods/tuxemon/db/monster/dinoflop.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "dragon",
     "types": [
-        "Earth"
+        "earth"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 157,

--- a/mods/tuxemon/db/monster/djinnbo.json
+++ b/mods/tuxemon/db/monster/djinnbo.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "humanoid",
     "types": [
-        "Fire"
+        "fire"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 107,

--- a/mods/tuxemon/db/monster/dollfin.json
+++ b/mods/tuxemon/db/monster/dollfin.json
@@ -40,7 +40,7 @@
     ],
     "shape": "aquatic",
     "types": [
-        "Water"
+        "water"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 23,	

--- a/mods/tuxemon/db/monster/dracune.json
+++ b/mods/tuxemon/db/monster/dracune.json
@@ -25,7 +25,7 @@
     ],
     "shape": "blob",
     "types": [
-        "Water"
+        "water"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 36,

--- a/mods/tuxemon/db/monster/dragarbor.json
+++ b/mods/tuxemon/db/monster/dragarbor.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "dragon",
     "types": [
-        "Wood"
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 138,

--- a/mods/tuxemon/db/monster/drokoro.json
+++ b/mods/tuxemon/db/monster/drokoro.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "dragon",
     "types": [
-        "Fire"
+        "fire"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 141,

--- a/mods/tuxemon/db/monster/dune_pincher.json
+++ b/mods/tuxemon/db/monster/dune_pincher.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "grub",
     "types": [
-        "Water"
+        "water"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 108,

--- a/mods/tuxemon/db/monster/eaglace.json
+++ b/mods/tuxemon/db/monster/eaglace.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "flier",
     "types": [
-        "Water"
+        "water"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 9,

--- a/mods/tuxemon/db/monster/elofly.json
+++ b/mods/tuxemon/db/monster/elofly.json
@@ -25,7 +25,7 @@
     ],
     "shape": "flier",
     "types": [
-        "Water"
+        "water"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 38,

--- a/mods/tuxemon/db/monster/elostorm.json
+++ b/mods/tuxemon/db/monster/elostorm.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "flier",
     "types": [
-        "Water"
+        "water"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 40,

--- a/mods/tuxemon/db/monster/elowind.json
+++ b/mods/tuxemon/db/monster/elowind.json
@@ -25,7 +25,7 @@
     ],
     "shape": "flier",
     "types": [
-        "Water"
+        "water"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 39,

--- a/mods/tuxemon/db/monster/embazook.json
+++ b/mods/tuxemon/db/monster/embazook.json
@@ -19,8 +19,8 @@
     "evolutions": [],
     "shape": "polliwog",
     "types": [
-        "Fire",
-        "Metal"
+        "fire",
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 30,

--- a/mods/tuxemon/db/monster/embra.json
+++ b/mods/tuxemon/db/monster/embra.json
@@ -25,7 +25,7 @@
     ],
     "shape": "blob",
     "types": [
-        "Fire"
+        "fire"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 74,

--- a/mods/tuxemon/db/monster/enduros.json
+++ b/mods/tuxemon/db/monster/enduros.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "brute",
     "types": [
-        "Earth"
+        "earth"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 158,

--- a/mods/tuxemon/db/monster/eruptibus.json
+++ b/mods/tuxemon/db/monster/eruptibus.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "landrace",
     "types": [
-        "Fire"
+        "fire"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 31,

--- a/mods/tuxemon/db/monster/exapode.json
+++ b/mods/tuxemon/db/monster/exapode.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "grub",
     "types": [
-        "Earth"
+        "earth"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 60,

--- a/mods/tuxemon/db/monster/eyenemy.json
+++ b/mods/tuxemon/db/monster/eyenemy.json
@@ -25,7 +25,7 @@
     ],
     "shape": "serpent",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 45,

--- a/mods/tuxemon/db/monster/eyesore.json
+++ b/mods/tuxemon/db/monster/eyesore.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "serpent",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 46,

--- a/mods/tuxemon/db/monster/f7u1t3ra.json
+++ b/mods/tuxemon/db/monster/f7u1t3ra.json
@@ -19,8 +19,8 @@
     "evolutions": [],
     "shape": "flier",
     "types": [
-        "Glitch",
-        "Wood"
+        "glitch",
+        "wood"
     ],
     "possible_genders": ["neuter"],
     "txmn_id": 0,

--- a/mods/tuxemon/db/monster/fancair.json
+++ b/mods/tuxemon/db/monster/fancair.json
@@ -25,7 +25,7 @@
     ],
     "shape": "sprite",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 170,

--- a/mods/tuxemon/db/monster/flacono.json
+++ b/mods/tuxemon/db/monster/flacono.json
@@ -25,7 +25,7 @@
     ],
     "shape": "flier",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 150,

--- a/mods/tuxemon/db/monster/flambear.json
+++ b/mods/tuxemon/db/monster/flambear.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "brute",
     "types": [
-        "Fire"
+        "fire"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 83,

--- a/mods/tuxemon/db/monster/fluoresfin.json
+++ b/mods/tuxemon/db/monster/fluoresfin.json
@@ -25,7 +25,7 @@
     ],
     "shape": "aquatic",
     "types": [
-        "Water"
+        "water"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 67,

--- a/mods/tuxemon/db/monster/fluttaflap.json
+++ b/mods/tuxemon/db/monster/fluttaflap.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "grub",
     "types": [
-        "Water"
+        "water"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 37,

--- a/mods/tuxemon/db/monster/foofle.json
+++ b/mods/tuxemon/db/monster/foofle.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "varmint",
     "types": [
-        "Earth"
+        "earth"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 109,

--- a/mods/tuxemon/db/monster/forturtle.json
+++ b/mods/tuxemon/db/monster/forturtle.json
@@ -25,7 +25,7 @@
     ],
     "shape": "humanoid",
     "types": [
-        "Earth"
+        "earth"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 86,

--- a/mods/tuxemon/db/monster/foxfire.json
+++ b/mods/tuxemon/db/monster/foxfire.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "varmint",
     "types": [
-        "Fire"
+        "fire"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 145,

--- a/mods/tuxemon/db/monster/frondly.json
+++ b/mods/tuxemon/db/monster/frondly.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "sprite",
     "types": [
-        "Wood"
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 28,

--- a/mods/tuxemon/db/monster/fruitera.json
+++ b/mods/tuxemon/db/monster/fruitera.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "flier",
     "types": [
-        "Wood"
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 160,

--- a/mods/tuxemon/db/monster/galnec.json
+++ b/mods/tuxemon/db/monster/galnec.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "hunter",
     "types": [
-        "Earth"
+        "earth"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 159,

--- a/mods/tuxemon/db/monster/gectile.json
+++ b/mods/tuxemon/db/monster/gectile.json
@@ -25,7 +25,7 @@
     ],
     "shape": "humanoid",
     "types": [
-        "Wood"
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 65,

--- a/mods/tuxemon/db/monster/ghosteeth.json
+++ b/mods/tuxemon/db/monster/ghosteeth.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "blob",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 110,

--- a/mods/tuxemon/db/monster/grimachin.json
+++ b/mods/tuxemon/db/monster/grimachin.json
@@ -25,7 +25,7 @@
     ],
     "shape": "hunter",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 92,

--- a/mods/tuxemon/db/monster/grinflare.json
+++ b/mods/tuxemon/db/monster/grinflare.json
@@ -19,8 +19,8 @@
     "evolutions": [],
     "shape": "brute",
     "types": [
-        "Earth",
-        "Fire"
+        "earth",
+        "fire"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 17,

--- a/mods/tuxemon/db/monster/grintot.json
+++ b/mods/tuxemon/db/monster/grintot.json
@@ -40,7 +40,7 @@
     ],
     "shape": "brute",
     "types": [
-        "Earth"
+        "earth"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 16,

--- a/mods/tuxemon/db/monster/grintrock.json
+++ b/mods/tuxemon/db/monster/grintrock.json
@@ -19,8 +19,8 @@
     "evolutions": [],
     "shape": "brute",
     "types": [
-        "Earth",
-        "Metal"
+        "earth",
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 18,

--- a/mods/tuxemon/db/monster/hampotamos.json
+++ b/mods/tuxemon/db/monster/hampotamos.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "landrace",
     "types": [
-        "Earth"
+        "earth"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 146,

--- a/mods/tuxemon/db/monster/happito.json
+++ b/mods/tuxemon/db/monster/happito.json
@@ -19,8 +19,8 @@
     "evolutions": [],
     "shape": "blob",
     "types": [
-        "Earth",
-        "Metal"
+        "earth",
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 167,

--- a/mods/tuxemon/db/monster/hatchling.json
+++ b/mods/tuxemon/db/monster/hatchling.json
@@ -25,7 +25,7 @@
     ],
     "shape": "flier",
     "types": [
-        "Wood"
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 80,

--- a/mods/tuxemon/db/monster/heronquak.json
+++ b/mods/tuxemon/db/monster/heronquak.json
@@ -25,7 +25,7 @@
     ],
     "shape": "flier",
     "types": [
-        "Water"
+        "water"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 8,

--- a/mods/tuxemon/db/monster/hydrone.json
+++ b/mods/tuxemon/db/monster/hydrone.json
@@ -19,8 +19,8 @@
     "evolutions": [],
     "shape": "humanoid",
     "types": [
-        "Metal",
-        "Water"
+        "metal",
+        "water"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 111,

--- a/mods/tuxemon/db/monster/ignibus.json
+++ b/mods/tuxemon/db/monster/ignibus.json
@@ -40,7 +40,7 @@
     ],
     "shape": "polliwog",
     "types": [
-        "Fire"
+        "fire"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 29,

--- a/mods/tuxemon/db/monster/incandesfin.json
+++ b/mods/tuxemon/db/monster/incandesfin.json
@@ -25,7 +25,7 @@
     ],
     "shape": "aquatic",
     "types": [
-        "Water"
+        "water"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 68,

--- a/mods/tuxemon/db/monster/jemuar.json
+++ b/mods/tuxemon/db/monster/jemuar.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "hunter",
     "types": [
-        "Earth"
+        "earth"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 3,

--- a/mods/tuxemon/db/monster/k9.json
+++ b/mods/tuxemon/db/monster/k9.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "hunter",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["neuter"],
     "txmn_id": 128,

--- a/mods/tuxemon/db/monster/katacoon.json
+++ b/mods/tuxemon/db/monster/katacoon.json
@@ -30,8 +30,8 @@
     ],
     "shape": "grub",
     "types": [
-        "Metal",
-        "Wood"
+        "metal",
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 56,

--- a/mods/tuxemon/db/monster/katapill.json
+++ b/mods/tuxemon/db/monster/katapill.json
@@ -25,8 +25,8 @@
     ],
     "shape": "grub",
     "types": [
-        "Metal",
-        "Wood"
+        "metal",
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 55,

--- a/mods/tuxemon/db/monster/komodraw.json
+++ b/mods/tuxemon/db/monster/komodraw.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "humanoid",
     "types": [
-        "Fire"
+        "fire"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 91,

--- a/mods/tuxemon/db/monster/l3gk0.json
+++ b/mods/tuxemon/db/monster/l3gk0.json
@@ -19,8 +19,8 @@
     "evolutions": [],
     "shape": "serpent",
     "types": [
-        "Glitch",
-        "Wood"
+        "glitch",
+        "wood"
     ],
     "possible_genders": ["neuter"],
     "txmn_id": 0,

--- a/mods/tuxemon/db/monster/lambert.json
+++ b/mods/tuxemon/db/monster/lambert.json
@@ -25,7 +25,7 @@
     ],
     "shape": "sprite",
     "types": [
-        "Wood"
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 10,

--- a/mods/tuxemon/db/monster/lapinou.json
+++ b/mods/tuxemon/db/monster/lapinou.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "varmint",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 112,

--- a/mods/tuxemon/db/monster/legko.json
+++ b/mods/tuxemon/db/monster/legko.json
@@ -25,7 +25,7 @@
     ],
     "shape": "serpent",
     "types": [
-        "Wood"
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 11,

--- a/mods/tuxemon/db/monster/lightmare.json
+++ b/mods/tuxemon/db/monster/lightmare.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "leviathan",
     "types": [
-        "Water"
+        "water"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 69,

--- a/mods/tuxemon/db/monster/manosting.json
+++ b/mods/tuxemon/db/monster/manosting.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "blob",
     "types": [
-        "Water"
+        "water"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 113,

--- a/mods/tuxemon/db/monster/masknake.json
+++ b/mods/tuxemon/db/monster/masknake.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "serpent",
     "types": [
-        "Fire"
+        "fire"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 114,

--- a/mods/tuxemon/db/monster/memnomnom.json
+++ b/mods/tuxemon/db/monster/memnomnom.json
@@ -40,7 +40,7 @@
     ],
     "shape": "hunter",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 19,

--- a/mods/tuxemon/db/monster/miaownolith.json
+++ b/mods/tuxemon/db/monster/miaownolith.json
@@ -19,8 +19,8 @@
     "evolutions": [],
     "shape": "hunter",
     "types": [
-        "Metal",
-        "Earth"
+        "metal",
+        "earth"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 21,

--- a/mods/tuxemon/db/monster/mk01_alpha.json
+++ b/mods/tuxemon/db/monster/mk01_alpha.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "dragon",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["neuter"],
     "txmn_id": 0,

--- a/mods/tuxemon/db/monster/mk01_beta.json
+++ b/mods/tuxemon/db/monster/mk01_beta.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "dragon",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["neuter"],
     "txmn_id": 0,

--- a/mods/tuxemon/db/monster/moloch.json
+++ b/mods/tuxemon/db/monster/moloch.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "brute",
     "types": [
-        "Wood"
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 12,

--- a/mods/tuxemon/db/monster/mrmoswitch.json
+++ b/mods/tuxemon/db/monster/mrmoswitch.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "sprite",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["neuter"],
     "txmn_id": 127,

--- a/mods/tuxemon/db/monster/narcileaf.json
+++ b/mods/tuxemon/db/monster/narcileaf.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "blob",
     "types": [
-        "Wood"
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 77,

--- a/mods/tuxemon/db/monster/neutrito.json
+++ b/mods/tuxemon/db/monster/neutrito.json
@@ -19,8 +19,8 @@
     "evolutions": [],
     "shape": "blob",
     "types": [
-        "Metal",
-        "Wood"
+        "metal",
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 168,

--- a/mods/tuxemon/db/monster/noctalo.json
+++ b/mods/tuxemon/db/monster/noctalo.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "flier",
     "types": [
-        "Water"
+        "water"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 50,

--- a/mods/tuxemon/db/monster/noctula.json
+++ b/mods/tuxemon/db/monster/noctula.json
@@ -25,7 +25,7 @@
     ],
     "shape": "flier",
     "types": [
-        "Water"
+        "water"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 49,

--- a/mods/tuxemon/db/monster/nostray.json
+++ b/mods/tuxemon/db/monster/nostray.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "aquatic",
     "types": [
-        "Water"
+        "water"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 148,

--- a/mods/tuxemon/db/monster/nudiflot_female.json
+++ b/mods/tuxemon/db/monster/nudiflot_female.json
@@ -25,7 +25,7 @@
     ],
     "shape": "polliwog",
     "types": [
-        "Water"
+        "water"
     ],
     "possible_genders": ["female"],
     "txmn_id": 53,

--- a/mods/tuxemon/db/monster/nudiflot_male.json
+++ b/mods/tuxemon/db/monster/nudiflot_male.json
@@ -25,7 +25,7 @@
     ],
     "shape": "polliwog",
     "types": [
-        "Water"
+        "water"
     ],
     "possible_genders": ["male"],
     "txmn_id": 51,

--- a/mods/tuxemon/db/monster/nudikill.json
+++ b/mods/tuxemon/db/monster/nudikill.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "polliwog",
     "types": [
-        "Water"
+        "water"
     ],
     "possible_genders": ["male"],
     "txmn_id": 52,

--- a/mods/tuxemon/db/monster/nudimind.json
+++ b/mods/tuxemon/db/monster/nudimind.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "polliwog",
     "types": [
-        "Water"
+        "water"
     ],
     "possible_genders": ["female"],
     "txmn_id": 54,

--- a/mods/tuxemon/db/monster/nut.json
+++ b/mods/tuxemon/db/monster/nut.json
@@ -25,7 +25,7 @@
     ],
     "shape": "blob",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 4,

--- a/mods/tuxemon/db/monster/ouroboutlet.json
+++ b/mods/tuxemon/db/monster/ouroboutlet.json
@@ -19,8 +19,8 @@
     "evolutions": [],
     "shape": "serpent",
     "types": [
-        "Metal",
-        "Fire"
+        "metal",
+        "fire"
     ],
     "possible_genders": ["neuter"],
     "txmn_id": 89,

--- a/mods/tuxemon/db/monster/pharfan.json
+++ b/mods/tuxemon/db/monster/pharfan.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "landrace",
     "types": [
-        "Water"
+        "water"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 147,

--- a/mods/tuxemon/db/monster/picc.json
+++ b/mods/tuxemon/db/monster/picc.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "aquatic",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["neuter"],
     "txmn_id": 126,

--- a/mods/tuxemon/db/monster/pigabyte.json
+++ b/mods/tuxemon/db/monster/pigabyte.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "blob",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 115,

--- a/mods/tuxemon/db/monster/pilthropus.json
+++ b/mods/tuxemon/db/monster/pilthropus.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "humanoid",
     "types": [
-        "Earth"
+        "earth"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 163,

--- a/mods/tuxemon/db/monster/pipis.json
+++ b/mods/tuxemon/db/monster/pipis.json
@@ -25,7 +25,7 @@
     ],
     "shape": "flier",
     "types": [
-        "Wood"
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 47,

--- a/mods/tuxemon/db/monster/poinchin.json
+++ b/mods/tuxemon/db/monster/poinchin.json
@@ -25,7 +25,7 @@
     ],
     "shape": "grub",
     "types": [
-        "Water"
+        "water"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 155,

--- a/mods/tuxemon/db/monster/polyrock.json
+++ b/mods/tuxemon/db/monster/polyrock.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "brute",
     "types": [
-        "Earth"
+        "earth"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 116,

--- a/mods/tuxemon/db/monster/possessun.json
+++ b/mods/tuxemon/db/monster/possessun.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "blob",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 71,

--- a/mods/tuxemon/db/monster/propellercat.json
+++ b/mods/tuxemon/db/monster/propellercat.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "flier",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 117,

--- a/mods/tuxemon/db/monster/prophetoise.json
+++ b/mods/tuxemon/db/monster/prophetoise.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "humanoid",
     "types": [
-        "Fire"
+        "fire"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 87,

--- a/mods/tuxemon/db/monster/puparmor.json
+++ b/mods/tuxemon/db/monster/puparmor.json
@@ -25,7 +25,7 @@
     ],
     "shape": "blob",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 33,

--- a/mods/tuxemon/db/monster/pyraminx.json
+++ b/mods/tuxemon/db/monster/pyraminx.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "hunter",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 22,

--- a/mods/tuxemon/db/monster/pythwire.json
+++ b/mods/tuxemon/db/monster/pythwire.json
@@ -30,7 +30,7 @@
     ],
     "shape": "serpent",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["neuter"],
     "txmn_id": 88,

--- a/mods/tuxemon/db/monster/r0ck1tt3n.json
+++ b/mods/tuxemon/db/monster/r0ck1tt3n.json
@@ -19,8 +19,8 @@
     "evolutions": [],
     "shape": "hunter",
     "types": [
-        "Glitch",
-        "Earth"
+        "glitch",
+        "earth"
     ],
     "possible_genders": ["neuter"],
     "txmn_id": 0,

--- a/mods/tuxemon/db/monster/rabbitosaur.json
+++ b/mods/tuxemon/db/monster/rabbitosaur.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "varmint",
     "types": [
-        "Earth"
+        "earth"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 44,

--- a/mods/tuxemon/db/monster/rhincus.json
+++ b/mods/tuxemon/db/monster/rhincus.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "flier",
     "types": [
-        "Earth"
+        "earth"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 139,

--- a/mods/tuxemon/db/monster/rockat.json
+++ b/mods/tuxemon/db/monster/rockat.json
@@ -25,7 +25,7 @@
     ],
     "shape": "hunter",
     "types": [
-        "Earth"
+        "earth"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 2,

--- a/mods/tuxemon/db/monster/rockitten.json
+++ b/mods/tuxemon/db/monster/rockitten.json
@@ -25,7 +25,7 @@
     ],
     "shape": "hunter",
     "types": [
-        "Earth"
+        "earth"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 1,

--- a/mods/tuxemon/db/monster/ruption.json
+++ b/mods/tuxemon/db/monster/ruption.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "brute",
     "types": [
-        "Fire"
+        "fire"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 75,

--- a/mods/tuxemon/db/monster/sadito.json
+++ b/mods/tuxemon/db/monster/sadito.json
@@ -19,8 +19,8 @@
     "evolutions": [],
     "shape": "blob",
     "types": [
-        "Metal",
-        "Water"
+        "metal",
+        "water"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 169,

--- a/mods/tuxemon/db/monster/sampsack.json
+++ b/mods/tuxemon/db/monster/sampsack.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "brute",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 96,

--- a/mods/tuxemon/db/monster/sampsage.json
+++ b/mods/tuxemon/db/monster/sampsage.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "humanoid",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 97,

--- a/mods/tuxemon/db/monster/sapragon.json
+++ b/mods/tuxemon/db/monster/sapragon.json
@@ -25,7 +25,7 @@
     ],
     "shape": "dragon",
     "types": [
-        "Wood"
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 137,

--- a/mods/tuxemon/db/monster/sapsnap.json
+++ b/mods/tuxemon/db/monster/sapsnap.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "brute",
     "types": [
-        "Wood"
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 85,

--- a/mods/tuxemon/db/monster/saurchin.json
+++ b/mods/tuxemon/db/monster/saurchin.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "dragon",
     "types": [
-        "Water"
+        "water"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 156,

--- a/mods/tuxemon/db/monster/sclairus.json
+++ b/mods/tuxemon/db/monster/sclairus.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "blob",
     "types": [
-        "Wood"
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 118,

--- a/mods/tuxemon/db/monster/seirein.json
+++ b/mods/tuxemon/db/monster/seirein.json
@@ -19,8 +19,8 @@
     "evolutions": [],
     "shape": "blob",
     "types": [
-        "Fire",
-        "Water"
+        "fire",
+        "water"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 154,

--- a/mods/tuxemon/db/monster/shammer.json
+++ b/mods/tuxemon/db/monster/shammer.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "hunter",
     "types": [
-        "Earth"
+        "earth"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 140,

--- a/mods/tuxemon/db/monster/sharpfin.json
+++ b/mods/tuxemon/db/monster/sharpfin.json
@@ -19,8 +19,8 @@
     "evolutions": [],
     "shape": "aquatic",
     "types": [
-        "Water",
-        "Wood"
+        "water",
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 25,

--- a/mods/tuxemon/db/monster/shybulb.json
+++ b/mods/tuxemon/db/monster/shybulb.json
@@ -25,7 +25,7 @@
     ],
     "shape": "sprite",
     "types": [
-        "Wood"
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 76,

--- a/mods/tuxemon/db/monster/skwib.json
+++ b/mods/tuxemon/db/monster/skwib.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "polliwog",
     "types": [
-        "Water"
+        "water"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 174,

--- a/mods/tuxemon/db/monster/sludgehog.json
+++ b/mods/tuxemon/db/monster/sludgehog.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "landrace",
     "types": [
-        "Earth"
+        "earth"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 119,

--- a/mods/tuxemon/db/monster/snarlon.json
+++ b/mods/tuxemon/db/monster/snarlon.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "hunter",
     "types": [
-        "Earth"
+        "earth"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 143,

--- a/mods/tuxemon/db/monster/sockeserp.json
+++ b/mods/tuxemon/db/monster/sockeserp.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "serpent",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["neuter"],
     "txmn_id": 90,

--- a/mods/tuxemon/db/monster/spighter.json
+++ b/mods/tuxemon/db/monster/spighter.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "grub",
     "types": [
-        "Wood"
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 120,

--- a/mods/tuxemon/db/monster/squabbit.json
+++ b/mods/tuxemon/db/monster/squabbit.json
@@ -25,7 +25,7 @@
     ],
     "shape": "varmint",
     "types": [
-        "Earth"
+        "earth"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 43,

--- a/mods/tuxemon/db/monster/strella.json
+++ b/mods/tuxemon/db/monster/strella.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "flier",
     "types": [
-        "Wood"
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 48,

--- a/mods/tuxemon/db/monster/sumchon.json
+++ b/mods/tuxemon/db/monster/sumchon.json
@@ -19,8 +19,8 @@
     "evolutions": [],
     "shape": "brute",
     "types": [
-        "Metal",
-        "Wood"
+        "metal",
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 58,

--- a/mods/tuxemon/db/monster/teddisun.json
+++ b/mods/tuxemon/db/monster/teddisun.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "humanoid",
     "types": [
-        "Fire"
+        "fire"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 161,

--- a/mods/tuxemon/db/monster/tigrock.json
+++ b/mods/tuxemon/db/monster/tigrock.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "hunter",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 93,

--- a/mods/tuxemon/db/monster/tikoal.json
+++ b/mods/tuxemon/db/monster/tikoal.json
@@ -25,8 +25,8 @@
     ],
     "shape": "blob",
     "types": [
-        "Fire",
-        "Wood"
+        "fire",
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 78,

--- a/mods/tuxemon/db/monster/tikorch.json
+++ b/mods/tuxemon/db/monster/tikorch.json
@@ -19,8 +19,8 @@
     "evolutions": [],
     "shape": "blob",
     "types": [
-        "Fire",
-        "Wood"
+        "fire",
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 79,

--- a/mods/tuxemon/db/monster/toufigel.json
+++ b/mods/tuxemon/db/monster/toufigel.json
@@ -19,8 +19,8 @@
     "evolutions": [],
     "shape": "varmint",
     "types": [
-        "Earth",
-        "Water"
+        "earth",
+        "water"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 121,

--- a/mods/tuxemon/db/monster/tourbidi.json
+++ b/mods/tuxemon/db/monster/tourbidi.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "humanoid",
     "types": [
-        "Wood"
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 122,

--- a/mods/tuxemon/db/monster/trapsnap.json
+++ b/mods/tuxemon/db/monster/trapsnap.json
@@ -25,7 +25,7 @@
     ],
     "shape": "brute",
     "types": [
-        "Wood"
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 84,

--- a/mods/tuxemon/db/monster/tumblebee.json
+++ b/mods/tuxemon/db/monster/tumblebee.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "flier",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 95,

--- a/mods/tuxemon/db/monster/tumbleworm.json
+++ b/mods/tuxemon/db/monster/tumbleworm.json
@@ -25,7 +25,7 @@
     ],
     "shape": "grub",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 94,

--- a/mods/tuxemon/db/monster/tweesher.json
+++ b/mods/tuxemon/db/monster/tweesher.json
@@ -25,7 +25,7 @@
     ],
     "shape": "flier",
     "types": [
-        "Water"
+        "water"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 7,

--- a/mods/tuxemon/db/monster/vamporm.json
+++ b/mods/tuxemon/db/monster/vamporm.json
@@ -25,7 +25,7 @@
     ],
     "shape": "grub",
     "types": [
-        "Water"
+        "water"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 35,

--- a/mods/tuxemon/db/monster/velocitile.json
+++ b/mods/tuxemon/db/monster/velocitile.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "humanoid",
     "types": [
-        "Wood"
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 66,

--- a/mods/tuxemon/db/monster/vivicinder.json
+++ b/mods/tuxemon/db/monster/vivicinder.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "serpent",
     "types": [
-        "Fire"
+        "fire"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 131,

--- a/mods/tuxemon/db/monster/vivipere.json
+++ b/mods/tuxemon/db/monster/vivipere.json
@@ -45,7 +45,7 @@
     ],
     "shape": "serpent",
     "types": [
-        "Earth"
+        "earth"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 130,

--- a/mods/tuxemon/db/monster/viviphyta.json
+++ b/mods/tuxemon/db/monster/viviphyta.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "serpent",
     "types": [
-        "Wood"
+        "wood"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 132,

--- a/mods/tuxemon/db/monster/viviteel.json
+++ b/mods/tuxemon/db/monster/viviteel.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "serpent",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 133,

--- a/mods/tuxemon/db/monster/vivitrans.json
+++ b/mods/tuxemon/db/monster/vivitrans.json
@@ -19,8 +19,8 @@
     "evolutions": [],
     "shape": "serpent",
     "types": [
-        "Metal",
-        "Water"
+        "metal",
+        "water"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 134,

--- a/mods/tuxemon/db/monster/vivitron.json
+++ b/mods/tuxemon/db/monster/vivitron.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "serpent",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 135,

--- a/mods/tuxemon/db/monster/volcoli.json
+++ b/mods/tuxemon/db/monster/volcoli.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "humanoid",
     "types": [
-        "Fire"
+        "fire"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 123,

--- a/mods/tuxemon/db/monster/weavifly.json
+++ b/mods/tuxemon/db/monster/weavifly.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "grub",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 34,

--- a/mods/tuxemon/db/monster/windeye.json
+++ b/mods/tuxemon/db/monster/windeye.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "humanoid",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 171,

--- a/mods/tuxemon/db/monster/wrougon.json
+++ b/mods/tuxemon/db/monster/wrougon.json
@@ -25,7 +25,7 @@
     ],
     "shape": "dragon",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 152,

--- a/mods/tuxemon/db/monster/xeon.json
+++ b/mods/tuxemon/db/monster/xeon.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "humanoid",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["neuter"],
     "txmn_id": 0,

--- a/mods/tuxemon/db/monster/xeon_2.json
+++ b/mods/tuxemon/db/monster/xeon_2.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "humanoid",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["neuter"],
     "txmn_id": 0,

--- a/mods/tuxemon/db/monster/yiinaang.json
+++ b/mods/tuxemon/db/monster/yiinaang.json
@@ -19,8 +19,8 @@
     "evolutions": [],
     "shape": "blob",
     "types": [
-        "Fire",
-        "Water"
+        "fire",
+        "water"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 142,

--- a/mods/tuxemon/db/monster/zunna.json
+++ b/mods/tuxemon/db/monster/zunna.json
@@ -19,7 +19,7 @@
     "evolutions": [],
     "shape": "blob",
     "types": [
-        "Metal"
+        "metal"
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 129,

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -77,6 +77,17 @@ class GenderType(str, Enum):
     female = "female"
 
 
+class ElementType(str, Enum):
+    aether = "aether"
+    wood = "wood"
+    fire = "fire"
+    earth = "earth"
+    metal = "metal"
+    water = "water"
+    normal = "normal"
+    glitch = "glitch"
+
+
 class ItemType(str, Enum):
     consumable = "Consumable"
     key_item = "KeyItem"
@@ -254,7 +265,9 @@ class MonsterModel(BaseModel):
     # Optional fields
     sprites: Optional[MonsterSpritesModel]
     shape: MonsterShape = Field(..., description="The shape of the monster")
-    types: Sequence[str] = Field([], description="The type(s) of this monster")
+    types: Sequence[ElementType] = Field(
+        [], description="The type(s) of this monster"
+    )
     catch_rate: float = Field(0, description="The catch rate of the monster")
     possible_genders: Sequence[GenderType] = Field(
         [], description="Valid genders for the monster"
@@ -359,7 +372,9 @@ class TechniqueModel(BaseModel):
         None,
         description="Slug of what string to display when technique fails",
     )
-    types: Sequence[str] = Field([], description="Type(s) of the technique")
+    types: Sequence[ElementType] = Field(
+        [], description="Type(s) of the technique"
+    )
     power: float = Field(0, description="Power of the technique")
     is_fast: bool = Field(
         False, description="Whether or not this is a fast technique"

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -37,6 +37,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Sequence
 from tuxemon import ai, fusion, graphics
 from tuxemon.config import TuxemonConfig
 from tuxemon.db import (
+    ElementType,
     GenderType,
     MonsterEvolutionItemModel,
     MonsterMovesetItemModel,
@@ -235,8 +236,8 @@ class Monster:
         self.experience_required_modifier = 1
         self.total_experience = 0
 
-        self.type1 = "aether"
-        self.type2: Optional[str] = None
+        self.type1 = ElementType.aether
+        self.type2: Optional[ElementType] = None
         self.shape = MonsterShape.landrace
 
         self.status: List[Technique] = []
@@ -330,9 +331,9 @@ class Monster:
         self.shape = results.shape or MonsterShape.landrace
         types = results.types
         if types:
-            self.type1 = results.types[0].lower()
+            self.type1 = results.types[0]
             if len(types) > 1:
-                self.type2 = results.types[1].lower()
+                self.type2 = results.types[1]
 
         self.txmn_id = results.txmn_id
         self.height = results.height

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -43,7 +43,7 @@ from typing import (
 
 from tuxemon import plugin, prepare
 from tuxemon.constants import paths
-from tuxemon.db import db, process_targets
+from tuxemon.db import ElementType, db, process_targets
 from tuxemon.graphics import animation_frame_files
 from tuxemon.locale import T
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
@@ -104,8 +104,8 @@ class Technique:
         self.sort = ""
         self.slug = slug
         self.target: Sequence[str] = []
-        self.type1: Optional[str] = "aether"
-        self.type2: Optional[str] = None
+        self.type1 = ElementType.aether
+        self.type2: Optional[ElementType] = None
         self.use_item = ""
         self.use_success = ""
         self.use_failure = ""


### PR DESCRIPTION
PR addresses:
- creation of the class ElementType(str, Enum) in db.py (see below);
- renaming of all Types (eg Water, Earth) to types (eg. water, earth) as technique types, so now everything is similar and centralized (there were some monster all lowercase -> pairaigrin?); if you want Earth instead of earth, no problem, we can switch.

I noticed it when I was working on type.py (the other PR). I hope it can be useful, if not I'll close it, no problem. If you want to add something, feel free to share.

```
class ElementType(str, Enum):
    aether = "aether"
    wood = "wood"
    fire = "fire"
    earth = "earth"
    metal = "metal"
    water = "water"
    normal = "normal"
    glitch = "glitch"
```

tested + black done