### PR TITLE
range techniques

### DIFF
--- a/mods/tuxemon/db/technique/run.json
+++ b/mods/tuxemon/db/technique/run.json
@@ -1,23 +1,24 @@
 {
-  "tech_id": 92,
-  "slug": "menu_run",
-  "use_tech": "combat_used_x",
-  "use_success": "generic_success",
-  "use_failure": "generic_failure",
-  "animation": null,
-  "sfx": "sfx_blaster",
-  "icon": "",
-  "sort": "meta",
-  "effects": [],
-  "flip_axes": "",
-  "target": {
-    "enemy monster": 0,
-    "enemy team": 0,
-    "enemy trainer": 0,
-    "own monster": 0,
-    "own team": 0,
-    "own trainer": 0,
-    "item": 0
-  },
-  "power": 50
+	"animation": null,
+	"effects": [],
+	"flip_axes": "",
+	"icon": "",
+	"power": 50,
+	"range": "special",
+	"sfx": "sfx_blaster",
+	"slug": "menu_run",
+	"sort": "meta",
+	"target": {
+		"enemy monster": 0,
+		"enemy team": 0,
+		"enemy trainer": 0,
+		"own monster": 0,
+		"own team": 0,
+		"own trainer": 0,
+		"item": 0
+	},
+	"tech_id": 92,
+	"use_failure": "generic_failure",
+	"use_success": "generic_success",
+	"use_tech": "combat_used_x"
 }

--- a/mods/tuxemon/db/technique/status_blinded.json
+++ b/mods/tuxemon/db/technique/status_blinded.json
@@ -6,6 +6,7 @@
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_blinded.png",
+  "range": "special",
   "repl_pos": "replace",
   "repl_neg": "replace",
   "sfx": "sfx_pulse",

--- a/mods/tuxemon/db/technique/status_chargedup.json
+++ b/mods/tuxemon/db/technique/status_chargedup.json
@@ -6,6 +6,7 @@
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_chargedup.png",
+  "range": "special",
   "repl_pos": "replace",
   "sfx": "sfx_pulse",
   "slug": "status_chargedup",

--- a/mods/tuxemon/db/technique/status_charging.json
+++ b/mods/tuxemon/db/technique/status_charging.json
@@ -4,6 +4,7 @@
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_charging.png",
+  "range": "special",
   "repl_pos": "replace",
   "sfx": "sfx_pulse",
   "slug": "status_charging",

--- a/mods/tuxemon/db/technique/status_confused.json
+++ b/mods/tuxemon/db/technique/status_confused.json
@@ -4,6 +4,7 @@
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_confused.png",
+  "range": "special",
   "repl_pos": "replace",
   "repl_neg": "replace",
   "sfx": "sfx_pulse",

--- a/mods/tuxemon/db/technique/status_diehard.json
+++ b/mods/tuxemon/db/technique/status_diehard.json
@@ -4,6 +4,7 @@
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_diehard.png",
+  "range": "special",
   "repl_pos": "replace",
   "repl_neg": "replace",
   "sfx": "sfx_pulse",

--- a/mods/tuxemon/db/technique/status_dozing.json
+++ b/mods/tuxemon/db/technique/status_dozing.json
@@ -4,6 +4,7 @@
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_dozing.png",
+  "range": "special",
   "sfx": "sfx_pulse",
   "slug": "status_dozing",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_eliminated.json
+++ b/mods/tuxemon/db/technique/status_eliminated.json
@@ -3,6 +3,7 @@
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_eliminated.png",
+  "range": "special",
   "sfx": "sfx_pulse",
   "slug": "status_eliminated",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_enraged.json
+++ b/mods/tuxemon/db/technique/status_enraged.json
@@ -6,6 +6,7 @@
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_enraged.png",
+  "range": "special",
   "repl_pos": "replace",
   "repl_neg": "replace",
   "sfx": "sfx_pulse",

--- a/mods/tuxemon/db/technique/status_exhausted.json
+++ b/mods/tuxemon/db/technique/status_exhausted.json
@@ -6,6 +6,7 @@
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_exhausted.png",
+  "range": "special",
   "repl_neg": "replace",
   "sfx": "sfx_pulse",
   "slug": "status_exhausted",

--- a/mods/tuxemon/db/technique/status_faint.json
+++ b/mods/tuxemon/db/technique/status_faint.json
@@ -6,6 +6,7 @@
   "power": 10,
   "sfx": "sfx_faint",
   "slug": "status_faint",
+  "range": "special",
   "sort": "meta",
   "target": {
     "enemy monster": 0,

--- a/mods/tuxemon/db/technique/status_festering.json
+++ b/mods/tuxemon/db/technique/status_festering.json
@@ -4,6 +4,7 @@
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_festering.png",
+  "range": "special",
   "repl_neg": "replace",
   "sfx": "sfx_pulse",
   "slug": "status_festering",

--- a/mods/tuxemon/db/technique/status_focused.json
+++ b/mods/tuxemon/db/technique/status_focused.json
@@ -6,6 +6,7 @@
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_focused.png",
+  "range": "special",
   "repl_pos": "replace",
   "repl_neg": "remove",
   "sfx": "sfx_pulse",

--- a/mods/tuxemon/db/technique/status_grabbed.json
+++ b/mods/tuxemon/db/technique/status_grabbed.json
@@ -4,6 +4,7 @@
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_grabbed.png",
+  "range": "special",
   "repl_pos": "replace",
   "repl_neg": "replace",
   "sfx": "sfx_pulse",

--- a/mods/tuxemon/db/technique/status_hardshell.json
+++ b/mods/tuxemon/db/technique/status_hardshell.json
@@ -6,6 +6,7 @@
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_hardshell.png",
+  "range": "special",
   "repl_pos": "replace",
   "repl_neg": "remove",
   "sfx": "sfx_bite",

--- a/mods/tuxemon/db/technique/status_lifeleech.json
+++ b/mods/tuxemon/db/technique/status_lifeleech.json
@@ -6,6 +6,7 @@
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_lifeleech.png",
+  "range": "special",
   "repl_pos": "replace",
   "repl_neg": "replace",
   "sfx": "sfx_bite",

--- a/mods/tuxemon/db/technique/status_noddingoff.json
+++ b/mods/tuxemon/db/technique/status_noddingoff.json
@@ -4,6 +4,7 @@
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_noddingoff.png",
+  "range": "special",
   "repl_neg": "replace",
   "sfx": "sfx_pulse",
   "slug": "status_noddingoff",

--- a/mods/tuxemon/db/technique/status_poison.json
+++ b/mods/tuxemon/db/technique/status_poison.json
@@ -6,6 +6,7 @@
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_poison.png",
+  "range": "special",
   "repl_pos": "replace",
   "repl_neg": "replace",
   "sfx": "sfx_pulse",

--- a/mods/tuxemon/db/technique/status_recover.json
+++ b/mods/tuxemon/db/technique/status_recover.json
@@ -6,6 +6,7 @@
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_recover.png",
+  "range": "special",
   "repl_pos": "replace",
   "repl_neg": "replace",
   "sfx": "sfx_bite",

--- a/mods/tuxemon/db/technique/status_sniping.json
+++ b/mods/tuxemon/db/technique/status_sniping.json
@@ -6,6 +6,7 @@
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_sniping.png",
+  "range": "special",
   "repl_pos": "replace",
   "repl_neg": "replace",
   "sfx": "sfx_pulse",

--- a/mods/tuxemon/db/technique/status_softened.json
+++ b/mods/tuxemon/db/technique/status_softened.json
@@ -6,6 +6,7 @@
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_softened.png",
+  "range": "special",
   "repl_pos": "replace",
   "repl_neg": "replace",
   "sfx": "sfx_pulse",

--- a/mods/tuxemon/db/technique/status_spyderbite.json
+++ b/mods/tuxemon/db/technique/status_spyderbite.json
@@ -3,6 +3,7 @@
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_spyderbite.png",
+  "range": "special",
   "sfx": "sfx_pulse",
   "slug": "status_spyderbite",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/status_stuck.json
+++ b/mods/tuxemon/db/technique/status_stuck.json
@@ -4,6 +4,7 @@
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_stuck.png",
+  "range": "special",
   "repl_pos": "replace",
   "repl_neg": "replace",
   "sfx": "sfx_pulse",

--- a/mods/tuxemon/db/technique/status_tired.json
+++ b/mods/tuxemon/db/technique/status_tired.json
@@ -4,6 +4,7 @@
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_tired.png",
+  "range": "special",
   "repl_pos": "remove",
   "repl_neg": "replace",
   "sfx": "sfx_pulse",

--- a/mods/tuxemon/db/technique/swap.json
+++ b/mods/tuxemon/db/technique/swap.json
@@ -1,26 +1,27 @@
 {
-  "tech_id": 97,
-  "slug": "swap",
-  "use_tech": "combat_swap",
-  "use_success": null,
-  "use_failure": null,
-  "animation": null,
-  "sfx": "sfx_blaster",
-  "icon": "",
-  "sort": "meta",
-  "effects": [
-    "swap"
-  ],
-  "flip_axes": "",
-  "target": {
-    "enemy monster": 0,
-    "enemy team": 0,
-    "enemy trainer": 0,
-    "own monster": 2,
-    "own team": 0,
-    "own trainer": 0,
-    "item": 0
-  },
-  "power": 0,
-  "types": []
+	"animation": null,
+	"effects": [
+		"swap"
+	],
+	"flip_axes": "",
+	"icon": "",
+	"power": 0,
+	"range": "special",
+	"sfx": "sfx_blaster",
+	"slug": "swap",
+	"sort": "meta",
+	"target": {
+		"enemy monster": 0,
+		"enemy team": 0,
+		"enemy trainer": 0,
+		"own monster": 2,
+		"own team": 0,
+		"own trainer": 0,
+		"item": 0
+	},
+	"tech_id": 97,
+	"types": [],
+	"use_failure": null,
+	"use_success": null,
+	"use_tech": "combat_swap"
 }

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -392,9 +392,7 @@ class TechniqueModel(BaseModel):
         False, description="Whether or not this is an area of effect technique"
     )
     recharge: int = Field(0, description="Recharge of this technique")
-    range: Range = Field(
-        "melee", description="The attack range of this technique"
-    )
+    range: Range = Field(..., description="The attack range of this technique")
     tech_id: int = Field(..., description="The id of this technique")
     accuracy: float = Field(0, description="The accuracy of the technique")
     potency: Optional[float] = Field(

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -13,7 +13,7 @@ from typing import (
 
 from tuxemon import plugin, prepare
 from tuxemon.constants import paths
-from tuxemon.db import ElementType, db, process_targets
+from tuxemon.db import ElementType, Range, db, process_targets
 from tuxemon.graphics import animation_frame_files
 from tuxemon.locale import T
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
@@ -66,7 +66,7 @@ class Technique:
         self.next_use = 0.0
         self.potency = 0.0
         self.power = 1.0
-        self.range: Optional[str] = None
+        self.range = Range.melee
         self.recharge_length = 0
         self.repl_pos = ""
         self.repl_neg = ""
@@ -144,7 +144,7 @@ class Technique:
         self.is_fast = results.is_fast or self.is_fast
         self.recharge_length = results.recharge or self.recharge_length
         self.is_area = results.is_area or self.is_area
-        self.range = results.range or self.range
+        self.range = results.range or Range.melee
         self.tech_id = results.tech_id or self.tech_id
         self.accuracy = results.accuracy or self.accuracy
         self.potency = results.potency or self.potency


### PR DESCRIPTION
During my tests I noticed that there was a discrepancy in the text. I was tracking moves and I noticed this:
```
Range.melee
special
Range.melee
melee
```
Now everything has Range before.

PR addresses:
1. added range class inside technique.py;
2. removed Optional[str] = None in favor of Range.melee;
3. edited Range in db.py, removed "melee" and put ...; 

Point 3 made me conscious that a bunch of techniques haven't range in the JSON. So:
- added range special, since there is no damage;
- sorted and beautified swap and run;
