### PR TITLE
Move parameter attributes into TechEffect class

### DIFF
--- a/mods/tuxemon/db/technique/all_in.json
+++ b/mods/tuxemon/db/technique/all_in.json
@@ -3,8 +3,8 @@
   "accuracy": 0.75,
   "animation": "sparks_gold_alt",
   "effects": [
-    "damage",
-    "recover"
+    "damage 100",
+    "recover all"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/avalanche.json
+++ b/mods/tuxemon/db/technique/avalanche.json
@@ -3,7 +3,7 @@
   "accuracy": 0.8,
   "animation": "thud",
   "effects": [
-    "damage",
+    "damage 100",
     "exhausted target"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/battery_acid.json
+++ b/mods/tuxemon/db/technique/battery_acid.json
@@ -3,8 +3,8 @@
   "accuracy": 0.8,
   "animation": "disintegrate",
   "effects": [
-    "poison",
-    "damage"
+    "poison target",
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/battery_discharge.json
+++ b/mods/tuxemon/db/technique/battery_discharge.json
@@ -3,7 +3,7 @@
   "accuracy": 0.8,
   "animation": "disintegrate",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 4.0,

--- a/mods/tuxemon/db/technique/beam.json
+++ b/mods/tuxemon/db/technique/beam.json
@@ -4,7 +4,7 @@
   "animation": "crystal",
   "effects": [
     "blinded target",
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/berserk.json
+++ b/mods/tuxemon/db/technique/berserk.json
@@ -3,7 +3,7 @@
   "accuracy": 0.8,
   "animation": "constantburn",
   "effects": [
-    "damage",
+    "damage 100",
     "enraged user"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/biting_winds.json
+++ b/mods/tuxemon/db/technique/biting_winds.json
@@ -3,7 +3,7 @@
   "accuracy": 0.8,
   "animation": "ice blast",
   "effects": [
-    "damage",
+    "damage 100",
     "softened target"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/blade.json
+++ b/mods/tuxemon/db/technique/blade.json
@@ -3,7 +3,7 @@
   "accuracy": 0.85,
   "animation": "slash_power",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "x",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/blood_bond.json
+++ b/mods/tuxemon/db/technique/blood_bond.json
@@ -3,8 +3,8 @@
   "accuracy": 0.8,
   "animation": "sparks_red",
   "effects": [
-    "damage",
-    "lifeleech"
+    "damage 100",
+    "lifeleech all"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/blossom.json
+++ b/mods/tuxemon/db/technique/blossom.json
@@ -3,8 +3,8 @@
   "accuracy": 0.75,
   "animation": "gloop_orange",
   "effects": [
-    "damage",
-    "recover"
+    "damage 100",
+    "recover all"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/breathe_fire.json
+++ b/mods/tuxemon/db/technique/breathe_fire.json
@@ -3,7 +3,7 @@
   "accuracy": 0.8,
   "animation": "firelion_right",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "x",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/bubble_trap.json
+++ b/mods/tuxemon/db/technique/bubble_trap.json
@@ -3,7 +3,7 @@
   "accuracy": 0.75,
   "animation": "bomb_bright",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/bullet.json
+++ b/mods/tuxemon/db/technique/bullet.json
@@ -3,7 +3,7 @@
   "accuracy": 0.85,
   "animation": "sparks_red",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/chill_mist.json
+++ b/mods/tuxemon/db/technique/chill_mist.json
@@ -3,7 +3,7 @@
   "accuracy": 1,
   "animation": "waterspurt",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/constrict.json
+++ b/mods/tuxemon/db/technique/constrict.json
@@ -3,7 +3,7 @@
   "accuracy": 0.75,
   "animation": "tentacle_metal",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/electrical_storm.json
+++ b/mods/tuxemon/db/technique/electrical_storm.json
@@ -3,7 +3,7 @@
   "accuracy": 0.75,
   "animation": "lightning_claw",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/energy_claws.json
+++ b/mods/tuxemon/db/technique/energy_claws.json
@@ -3,7 +3,7 @@
   "accuracy": 0.8,
   "animation": "slash_power",
   "effects": [
-    "damage",
+    "damage 100",
     "sniping user"
   ],
   "flip_axes": "x",

--- a/mods/tuxemon/db/technique/feint.json
+++ b/mods/tuxemon/db/technique/feint.json
@@ -3,7 +3,7 @@
   "accuracy": 1,
   "animation": "bolt",
   "effects": [
-    "damage",
+    "damage 100",
     "focused user"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/fester.json
+++ b/mods/tuxemon/db/technique/fester.json
@@ -3,8 +3,9 @@
   "accuracy": 1,
   "animation": "drip_green",
   "effects": [
-    "poison",
-    "damage"
+    "poison user",
+    "poison target",
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/fire_ball.json
+++ b/mods/tuxemon/db/technique/fire_ball.json
@@ -3,7 +3,7 @@
   "accuracy": 0.7,
   "animation": "fireball_114",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "x",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/fire_claw.json
+++ b/mods/tuxemon/db/technique/fire_claw.json
@@ -3,7 +3,7 @@
   "accuracy": 0.7,
   "animation": "slash_power",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "x",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/flamethrower.json
+++ b/mods/tuxemon/db/technique/flamethrower.json
@@ -3,7 +3,7 @@
   "accuracy": 0.8,
   "animation": "firelion_right",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "x",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/flood.json
+++ b/mods/tuxemon/db/technique/flood.json
@@ -3,7 +3,7 @@
   "accuracy": 0.5,
   "animation": "watershot",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "x",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/flow.json
+++ b/mods/tuxemon/db/technique/flow.json
@@ -3,7 +3,7 @@
   "accuracy": 0.5,
   "animation": "waterspurt",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/fluff_up.json
+++ b/mods/tuxemon/db/technique/fluff_up.json
@@ -3,8 +3,8 @@
   "accuracy": 0.75,
   "animation": "smokebomb",
   "effects": [
-    "damage",
-    "recover"
+    "damage 100",
+    "recover all"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/font.json
+++ b/mods/tuxemon/db/technique/font.json
@@ -3,8 +3,8 @@
   "accuracy": 0.75,
   "animation": "waterspurt",
   "effects": [
-    "damage",
-    "recover"
+    "damage 100",
+    "recover all"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/frostbite.json
+++ b/mods/tuxemon/db/technique/frostbite.json
@@ -3,8 +3,8 @@
   "accuracy": 0.8,
   "animation": "lance_ice",
   "effects": [
-    "poison",
-    "damage"
+    "poison target",
+    "damage 100"
   ],
   "flip_axes": "xy",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/give_all.json
+++ b/mods/tuxemon/db/technique/give_all.json
@@ -3,7 +3,7 @@
   "accuracy": 1,
   "animation": "firelion_front",
   "effects": [
-    "damage",
+    "damage 100",
     "exhausted user"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/goad.json
+++ b/mods/tuxemon/db/technique/goad.json
@@ -3,7 +3,7 @@
   "accuracy": 0.8,
   "animation": "buff_rage",
   "effects": [
-    "damage",
+    "damage 100",
     "enraged target"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/headbutt.json
+++ b/mods/tuxemon/db/technique/headbutt.json
@@ -3,7 +3,7 @@
   "accuracy": 1,
   "animation": "slash_power",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "x",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/ice_claw.json
+++ b/mods/tuxemon/db/technique/ice_claw.json
@@ -3,7 +3,7 @@
   "accuracy": 0.8,
   "animation": "icetacle",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/icicle_spear.json
+++ b/mods/tuxemon/db/technique/icicle_spear.json
@@ -3,7 +3,7 @@
   "accuracy": 0.75,
   "animation": "lance_ice",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "xy",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/invictus.json
+++ b/mods/tuxemon/db/technique/invictus.json
@@ -3,7 +3,7 @@
   "accuracy": 0.75,
   "animation": "triforce",
   "effects": [
-    "damage",
+    "damage 100",
     "enraged user"
   ],
   "flip_axes": "xy",

--- a/mods/tuxemon/db/technique/kindling_flame.json
+++ b/mods/tuxemon/db/technique/kindling_flame.json
@@ -3,7 +3,7 @@
   "accuracy": 0.8,
   "animation": "constantburn",
   "effects": [
-    "damage",
+    "damage 100",
     "enraged user"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/midnight_mantle.json
+++ b/mods/tuxemon/db/technique/midnight_mantle.json
@@ -3,7 +3,7 @@
   "accuracy": 0.7,
   "animation": "claw_blue",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "x",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/muddle.json
+++ b/mods/tuxemon/db/technique/muddle.json
@@ -3,7 +3,7 @@
   "accuracy": 0.75,
   "animation": "sparks_white",
   "effects": [
-    "damage",
+    "damage 100",
     "focused target",
     "focused user"
   ],

--- a/mods/tuxemon/db/technique/mudslide.json
+++ b/mods/tuxemon/db/technique/mudslide.json
@@ -3,7 +3,7 @@
   "accuracy": 0.8,
   "animation": "spikes_rock",
   "effects": [
-    "damage",
+    "damage 100",
     "softened target"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/one_two.json
+++ b/mods/tuxemon/db/technique/one_two.json
@@ -3,7 +3,7 @@
   "accuracy": 1,
   "animation": "triple_whammy_80",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/overfeed.json
+++ b/mods/tuxemon/db/technique/overfeed.json
@@ -4,7 +4,7 @@
   "animation": "drip_green",
   "can_apply_status": true,
   "effects": [
-    "statchange"
+    "statchange all"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/overgrowth.json
+++ b/mods/tuxemon/db/technique/overgrowth.json
@@ -3,7 +3,7 @@
   "accuracy": 0.8,
   "animation": null,
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/peck.json
+++ b/mods/tuxemon/db/technique/peck.json
@@ -3,7 +3,7 @@
   "accuracy": 1,
   "animation": "pound",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/peregrine.json
+++ b/mods/tuxemon/db/technique/peregrine.json
@@ -3,7 +3,7 @@
   "accuracy": 0.8,
   "animation": "smash",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/perfect_cut.json
+++ b/mods/tuxemon/db/technique/perfect_cut.json
@@ -3,7 +3,7 @@
   "accuracy": 0.8,
   "animation": "slash_power",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "x",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/probiscus.json
+++ b/mods/tuxemon/db/technique/probiscus.json
@@ -3,8 +3,8 @@
   "accuracy": 0.8,
   "animation": "lance_ice",
   "effects": [
-    "damage",
-    "lifeleech"
+    "damage 100",
+    "lifeleech all"
   ],
   "flip_axes": "xy",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/pseudopod.json
+++ b/mods/tuxemon/db/technique/pseudopod.json
@@ -3,7 +3,7 @@
   "accuracy": 1,
   "animation": "snake_right",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "x",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/quicksand.json
+++ b/mods/tuxemon/db/technique/quicksand.json
@@ -3,7 +3,7 @@
   "accuracy": 0.8,
   "animation": "spikes_rock",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/ram.json
+++ b/mods/tuxemon/db/technique/ram.json
@@ -3,7 +3,7 @@
   "accuracy": 1,
   "animation": "pound",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/refresh.json
+++ b/mods/tuxemon/db/technique/refresh.json
@@ -3,7 +3,7 @@
   "accuracy": 1,
   "animation": "heal_burst_120",
   "effects": [
-    "recover"
+    "recover all"
   ],
   "flip_axes": "",
   "healing_power": 4.0,

--- a/mods/tuxemon/db/technique/rock.json
+++ b/mods/tuxemon/db/technique/rock.json
@@ -3,7 +3,7 @@
   "accuracy": 1,
   "animation": "crushingball",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/rot.json
+++ b/mods/tuxemon/db/technique/rot.json
@@ -3,7 +3,7 @@
   "accuracy": 1,
   "animation": "drip_green",
   "effects": [
-    "poison"
+    "poison target"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/rust_bomb.json
+++ b/mods/tuxemon/db/technique/rust_bomb.json
@@ -3,8 +3,8 @@
   "accuracy": 0.5,
   "animation": "puff",
   "effects": [
-    "poison",
-    "damage"
+    "poison target",
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/salamander.json
+++ b/mods/tuxemon/db/technique/salamander.json
@@ -3,8 +3,8 @@
   "accuracy": 0.8,
   "animation": "fire enemy death 1",
   "effects": [
-    "poison",
-    "damage"
+    "poison target",
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/sand_spray.json
+++ b/mods/tuxemon/db/technique/sand_spray.json
@@ -4,7 +4,7 @@
   "animation": "explosion_dusty_96",
   "effects": [
     "blinded target",
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/shadow_boxing.json
+++ b/mods/tuxemon/db/technique/shadow_boxing.json
@@ -3,7 +3,7 @@
   "accuracy": 1,
   "animation": "triple_whammy_80",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/shrapnel.json
+++ b/mods/tuxemon/db/technique/shrapnel.json
@@ -3,7 +3,7 @@
   "accuracy": 0.5,
   "animation": "explosion_small",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/shuriken.json
+++ b/mods/tuxemon/db/technique/shuriken.json
@@ -3,7 +3,7 @@
   "accuracy": 0.75,
   "animation": "explosion_small",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/sleep_bomb.json
+++ b/mods/tuxemon/db/technique/sleep_bomb.json
@@ -3,7 +3,7 @@
   "accuracy": 0.75,
   "animation": "sparks_white",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/snowstorm.json
+++ b/mods/tuxemon/db/technique/snowstorm.json
@@ -3,7 +3,7 @@
   "accuracy": 0.5,
   "animation": "ice blast",
   "effects": [
-    "damage",
+    "damage 100",
     "exhausted target"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/splinter.json
+++ b/mods/tuxemon/db/technique/splinter.json
@@ -4,7 +4,7 @@
   "animation": "snake_right",
   "effects": [
     "blinded target",
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "x",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/spray.json
+++ b/mods/tuxemon/db/technique/spray.json
@@ -3,8 +3,8 @@
   "accuracy": 0.8,
   "animation": null,
   "effects": [
-    "poison",
-    "damage"
+    "poison target",
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/stampede.json
+++ b/mods/tuxemon/db/technique/stampede.json
@@ -3,7 +3,7 @@
   "accuracy": 1,
   "animation": "explosion_dusty_96",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/starfall.json
+++ b/mods/tuxemon/db/technique/starfall.json
@@ -3,7 +3,7 @@
   "accuracy": 0.7,
   "animation": "bolt",
   "effects": [
-    "damage",
+    "damage 100",
     "focused user"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/status_blinded.json
+++ b/mods/tuxemon/db/technique/status_blinded.json
@@ -2,7 +2,7 @@
   "animation": "drip_green",
   "category": "negative",
   "effects": [
-    "statchange"
+    "statchange all"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_blinded.png",

--- a/mods/tuxemon/db/technique/status_chargedup.json
+++ b/mods/tuxemon/db/technique/status_chargedup.json
@@ -2,7 +2,7 @@
   "animation": "drip_green",
   "category": "positive",
   "effects": [
-    "statchange"
+    "statchange all"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_chargedup.png",

--- a/mods/tuxemon/db/technique/status_enraged.json
+++ b/mods/tuxemon/db/technique/status_enraged.json
@@ -2,7 +2,7 @@
   "animation": "drip_green",
   "category": "positive",
   "effects": [
-    "statchange"
+    "statchange all"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_enraged.png",

--- a/mods/tuxemon/db/technique/status_exhausted.json
+++ b/mods/tuxemon/db/technique/status_exhausted.json
@@ -2,7 +2,7 @@
   "animation": "drip_green",
   "category": "negative",
   "effects": [
-    "statchange"
+    "statchange all"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_exhausted.png",

--- a/mods/tuxemon/db/technique/status_focused.json
+++ b/mods/tuxemon/db/technique/status_focused.json
@@ -2,7 +2,7 @@
   "animation": "drip_green",
   "category": "positive",
   "effects": [
-    "statchange"
+    "statchange all"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_focused.png",

--- a/mods/tuxemon/db/technique/status_hardshell.json
+++ b/mods/tuxemon/db/technique/status_hardshell.json
@@ -2,7 +2,7 @@
   "animation": "drip_green",
   "category": "positive",
   "effects": [
-    "statchange"
+    "statchange all"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_hardshell.png",

--- a/mods/tuxemon/db/technique/status_lifeleech.json
+++ b/mods/tuxemon/db/technique/status_lifeleech.json
@@ -2,7 +2,7 @@
   "animation": "drip_green",
   "category": "negative",
   "effects": [
-    "lifeleech"
+    "lifeleech all"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_lifeleech.png",

--- a/mods/tuxemon/db/technique/status_poison.json
+++ b/mods/tuxemon/db/technique/status_poison.json
@@ -2,7 +2,7 @@
   "animation": "drip_green",
   "category": "negative",
   "effects": [
-    "poison"
+    "poison target"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_poison.png",

--- a/mods/tuxemon/db/technique/status_recover.json
+++ b/mods/tuxemon/db/technique/status_recover.json
@@ -2,7 +2,7 @@
   "animation": "drip_green",
   "category": "positive",
   "effects": [
-    "recover"
+    "recover all"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_recover.png",

--- a/mods/tuxemon/db/technique/status_sniping.json
+++ b/mods/tuxemon/db/technique/status_sniping.json
@@ -2,7 +2,7 @@
   "animation": "drip_green",
   "category": "positive",
   "effects": [
-    "statchange"
+    "statchange all"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_sniping.png",

--- a/mods/tuxemon/db/technique/status_softened.json
+++ b/mods/tuxemon/db/technique/status_softened.json
@@ -2,7 +2,7 @@
   "animation": "drip_green",
   "category": "negative",
   "effects": [
-    "statchange"
+    "statchange all"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_softened.png",

--- a/mods/tuxemon/db/technique/sting.json
+++ b/mods/tuxemon/db/technique/sting.json
@@ -3,8 +3,8 @@
   "accuracy": 0.8,
   "animation": "pound",
   "effects": [
-    "poison",
-    "damage"
+    "poison target",
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/stone_rot.json
+++ b/mods/tuxemon/db/technique/stone_rot.json
@@ -3,7 +3,7 @@
   "accuracy": 1,
   "animation": "drip_green",
   "effects": [
-    "poison"
+    "poison target"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/strike.json
+++ b/mods/tuxemon/db/technique/strike.json
@@ -3,7 +3,7 @@
   "accuracy": 1,
   "animation": "slash_power",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "x",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/suck_poison.json
+++ b/mods/tuxemon/db/technique/suck_poison.json
@@ -3,8 +3,8 @@
   "accuracy": 0.8,
   "animation": "drip_green",
   "effects": [
-    "poison",
-    "damage",
+    "poison target",
+    "damage 100",
     "focused user"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/sudden_glow.json
+++ b/mods/tuxemon/db/technique/sudden_glow.json
@@ -4,7 +4,7 @@
   "animation": "heal_burst_120",
   "effects": [
     "focused target",
-    "recover"
+    "recover all"
   ],
   "flip_axes": "",
   "healing_power": 2.0,

--- a/mods/tuxemon/db/technique/supernova.json
+++ b/mods/tuxemon/db/technique/supernova.json
@@ -3,7 +3,7 @@
   "accuracy": 0.75,
   "animation": "fireball_114",
   "effects": [
-    "damage",
+    "damage 100",
     "chargedup target"
   ],
   "flip_axes": "x",

--- a/mods/tuxemon/db/technique/surge.json
+++ b/mods/tuxemon/db/technique/surge.json
@@ -3,7 +3,7 @@
   "accuracy": 0.75,
   "animation": "bolt",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/swap.json
+++ b/mods/tuxemon/db/technique/swap.json
@@ -1,7 +1,7 @@
 {
 	"animation": null,
 	"effects": [
-		"swap"
+		"swap all"
 	],
 	"flip_axes": "",
 	"icon": "",

--- a/mods/tuxemon/db/technique/thunderball.json
+++ b/mods/tuxemon/db/technique/thunderball.json
@@ -3,7 +3,7 @@
   "accuracy": 1,
   "animation": "pound",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/thunderclap.json
+++ b/mods/tuxemon/db/technique/thunderclap.json
@@ -3,7 +3,7 @@
   "accuracy": 0.75,
   "animation": "thunderstrike",
   "effects": [
-    "damage",
+    "damage 100",
     "exhausted target"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/tonguespear.json
+++ b/mods/tuxemon/db/technique/tonguespear.json
@@ -3,8 +3,8 @@
   "accuracy": 0.8,
   "animation": "lance_ice",
   "effects": [
-    "damage",
-    "lifeleech"
+    "damage 100",
+    "lifeleech all"
   ],
   "flip_axes": "xy",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/venomous_tentacle.json
+++ b/mods/tuxemon/db/technique/venomous_tentacle.json
@@ -3,8 +3,8 @@
   "accuracy": 0.8,
   "animation": "torrentacle",
   "effects": [
-    "poison",
-    "damage"
+    "poison target",
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/wall_of_steel.json
+++ b/mods/tuxemon/db/technique/wall_of_steel.json
@@ -4,7 +4,7 @@
   "animation": "screen",
   "effects": [
     "hardshell user",
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "x",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/web.json
+++ b/mods/tuxemon/db/technique/web.json
@@ -3,7 +3,7 @@
   "accuracy": 0.75,
   "animation": "snake_right",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "x",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/whirlwind.json
+++ b/mods/tuxemon/db/technique/whirlwind.json
@@ -3,7 +3,7 @@
   "accuracy": 1,
   "animation": "whirlwind",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/wing_tip.json
+++ b/mods/tuxemon/db/technique/wing_tip.json
@@ -3,7 +3,7 @@
   "accuracy": 0.8,
   "animation": "pound",
   "effects": [
-    "damage"
+    "damage 100"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/tuxemon/technique/effects/blinded.py
+++ b/tuxemon/technique/effects/blinded.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import random
-from typing import NamedTuple, Optional
+from dataclasses import dataclass
+from typing import Optional
 
 from tuxemon.monster import Monster
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
@@ -14,21 +15,20 @@ class BlindedEffectResult(TechEffectResult):
     status: Optional[Technique]
 
 
-class BlindedEffectParameters(NamedTuple):
-    objective: str
-
-
-class BlindedEffect(TechEffect[BlindedEffectParameters]):
+@dataclass
+class BlindedEffect(TechEffect):
     """
     This effect has a chance to apply the blinded status effect.
     """
 
     name = "blinded"
-    param_class = BlindedEffectParameters
+    objective: str
 
-    def apply(self, user: Monster, target: Monster) -> BlindedEffectResult:
-        obj = self.parameters.objective
-        success = self.move.potency >= random.random()
+    def apply(
+        self, tech: Technique, user: Monster, target: Monster
+    ) -> BlindedEffectResult:
+        obj = self.objective
+        success = tech.potency >= random.random()
         if success:
             tech = Technique("status_blinded")
             if obj == "user":

--- a/tuxemon/technique/effects/chargedup.py
+++ b/tuxemon/technique/effects/chargedup.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import random
-from typing import NamedTuple, Optional
+from dataclasses import dataclass
+from typing import Optional
 
 from tuxemon.monster import Monster
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
@@ -14,21 +15,20 @@ class ChargedUpEffectResult(TechEffectResult):
     status: Optional[Technique]
 
 
-class ChargedUpEffectParameters(NamedTuple):
-    objective: str
-
-
-class ChargedUpEffect(TechEffect[ChargedUpEffectParameters]):
+@dataclass
+class ChargedUpEffect(TechEffect):
     """
     This effect has a chance to apply the charged up status effect.
     """
 
     name = "chargedup"
-    param_class = ChargedUpEffectParameters
+    objective: str
 
-    def apply(self, user: Monster, target: Monster) -> ChargedUpEffectResult:
-        obj = self.parameters.objective
-        success = self.move.potency >= random.random()
+    def apply(
+        self, tech: Technique, user: Monster, target: Monster
+    ) -> ChargedUpEffectResult:
+        obj = self.objective
+        success = tech.potency >= random.random()
         if success:
             tech = Technique("status_chargedup")
             if obj == "user":

--- a/tuxemon/technique/effects/damage.py
+++ b/tuxemon/technique/effects/damage.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import random
-from typing import NamedTuple
+from dataclasses import dataclass
 
 from tuxemon import formula
 from tuxemon.monster import Monster
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
+from tuxemon.technique.technique import Technique
 
 
 class DamageEffectResult(TechEffectResult):
@@ -14,11 +15,8 @@ class DamageEffectResult(TechEffectResult):
     should_tackle: bool
 
 
-class DamageEffectParameters(NamedTuple):
-    pass
-
-
-class DamageEffect(TechEffect[DamageEffectParameters]):
+@dataclass
+class DamageEffect(TechEffect):
     """
     Apply damage.
 
@@ -36,15 +34,15 @@ class DamageEffect(TechEffect[DamageEffectParameters]):
     """
 
     name = "damage"
-    param_class = DamageEffectParameters
+    objective: int
 
-    def apply(self, user: Monster, target: Monster) -> DamageEffectResult:
-        hit = self.move.accuracy >= random.random()
-        if hit or self.move.is_area:
-            self.move.can_apply_status = True
-            damage, mult = formula.simple_damage_calculate(
-                self.move, user, target
-            )
+    def apply(
+        self, tech: Technique, user: Monster, target: Monster
+    ) -> DamageEffectResult:
+        hit = tech.accuracy >= random.random()
+        if hit or tech.is_area:
+            tech.can_apply_status = True
+            damage, mult = formula.simple_damage_calculate(tech, user, target)
             if not hit:
                 damage //= 2
             target.current_hp -= damage

--- a/tuxemon/technique/effects/enraged.py
+++ b/tuxemon/technique/effects/enraged.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import random
-from typing import NamedTuple, Optional
+from dataclasses import dataclass
+from typing import Optional
 
 from tuxemon.monster import Monster
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
@@ -14,21 +15,20 @@ class EnragedEffectResult(TechEffectResult):
     status: Optional[Technique]
 
 
-class EnragedEffectParameters(NamedTuple):
-    objective: str
-
-
-class EnragedEffect(TechEffect[EnragedEffectParameters]):
+@dataclass
+class EnragedEffect(TechEffect):
     """
     This effect has a chance to apply the enraged status effect.
     """
 
     name = "enraged"
-    param_class = EnragedEffectParameters
+    objective: str
 
-    def apply(self, user: Monster, target: Monster) -> EnragedEffectResult:
-        obj = self.parameters.objective
-        success = self.move.potency >= random.random()
+    def apply(
+        self, tech: Technique, user: Monster, target: Monster
+    ) -> EnragedEffectResult:
+        obj = self.objective
+        success = tech.potency >= random.random()
         if success:
             tech = Technique("status_enraged")
             if obj == "user":

--- a/tuxemon/technique/effects/exhausted.py
+++ b/tuxemon/technique/effects/exhausted.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import random
-from typing import NamedTuple, Optional
+from dataclasses import dataclass
+from typing import Optional
 
 from tuxemon.monster import Monster
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
@@ -14,21 +15,20 @@ class ExhaustedEffectResult(TechEffectResult):
     status: Optional[Technique]
 
 
-class ExhaustedEffectParameters(NamedTuple):
-    objective: str
-
-
-class ExhaustedEffect(TechEffect[ExhaustedEffectParameters]):
+@dataclass
+class ExhaustedEffect(TechEffect):
     """
     This effect has a chance to apply the exhausted status effect.
     """
 
     name = "exhausted"
-    param_class = ExhaustedEffectParameters
+    objective: str
 
-    def apply(self, user: Monster, target: Monster) -> ExhaustedEffectResult:
-        obj = self.parameters.objective
-        success = self.move.potency >= random.random()
+    def apply(
+        self, tech: Technique, user: Monster, target: Monster
+    ) -> ExhaustedEffectResult:
+        obj = self.objective
+        success = tech.potency >= random.random()
         if success:
             tech = Technique("status_exhausted")
             if obj == "user":

--- a/tuxemon/technique/effects/focused.py
+++ b/tuxemon/technique/effects/focused.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import random
-from typing import NamedTuple, Optional
+from dataclasses import dataclass
+from typing import Optional
 
 from tuxemon.monster import Monster
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
@@ -14,21 +15,20 @@ class FocusedEffectResult(TechEffectResult):
     status: Optional[Technique]
 
 
-class FocusedEffectParameters(NamedTuple):
-    objective: str
-
-
-class FocusedEffect(TechEffect[FocusedEffectParameters]):
+@dataclass
+class FocusedEffect(TechEffect):
     """
     This effect has a chance to apply the focused status effect.
     """
 
     name = "focused"
-    param_class = FocusedEffectParameters
+    objective: str
 
-    def apply(self, user: Monster, target: Monster) -> FocusedEffectResult:
-        obj = self.parameters.objective
-        success = self.move.potency >= random.random()
+    def apply(
+        self, tech: Technique, user: Monster, target: Monster
+    ) -> FocusedEffectResult:
+        obj = self.objective
+        success = tech.potency >= random.random()
         if success:
             tech = Technique("status_focused")
             if obj == "user":

--- a/tuxemon/technique/effects/hardshell.py
+++ b/tuxemon/technique/effects/hardshell.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import random
-from typing import NamedTuple, Optional
+from dataclasses import dataclass
+from typing import Optional
 
 from tuxemon.monster import Monster
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
@@ -14,21 +15,20 @@ class HardShellEffectResult(TechEffectResult):
     status: Optional[Technique]
 
 
-class HardShellEffectParameters(NamedTuple):
-    objective: str
-
-
-class HardShellEffect(TechEffect[HardShellEffectParameters]):
+@dataclass
+class HardShellEffect(TechEffect):
     """
     This effect has a chance to apply the hard shell status effect.
     """
 
     name = "hardshell"
-    param_class = HardShellEffectParameters
+    objective: str
 
-    def apply(self, user: Monster, target: Monster) -> HardShellEffectResult:
-        obj = self.parameters.objective
-        success = self.move.potency >= random.random()
+    def apply(
+        self, tech: Technique, user: Monster, target: Monster
+    ) -> HardShellEffectResult:
+        obj = self.objective
+        success = tech.potency >= random.random()
         if success:
             tech = Technique("status_hardshell")
             if obj == "user":

--- a/tuxemon/technique/effects/sniping.py
+++ b/tuxemon/technique/effects/sniping.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import random
-from typing import NamedTuple, Optional
+from dataclasses import dataclass
+from typing import Optional
 
 from tuxemon.monster import Monster
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
@@ -14,21 +15,20 @@ class SnipingEffectResult(TechEffectResult):
     status: Optional[Technique]
 
 
-class SnipingEffectParameters(NamedTuple):
-    objective: str
-
-
-class SnipingEffect(TechEffect[SnipingEffectParameters]):
+@dataclass
+class SnipingEffect(TechEffect):
     """
     This effect has a chance to apply the sniping status effect.
     """
 
     name = "sniping"
-    param_class = SnipingEffectParameters
+    objective: str
 
-    def apply(self, user: Monster, target: Monster) -> SnipingEffectResult:
-        obj = self.parameters.objective
-        success = self.move.potency >= random.random()
+    def apply(
+        sself, tech: Technique, user: Monster, target: Monster
+    ) -> SnipingEffectResult:
+        obj = self.objective
+        success = tech.potency >= random.random()
         if success:
             tech = Technique("status_sniping")
             if obj == "user":

--- a/tuxemon/technique/effects/softened.py
+++ b/tuxemon/technique/effects/softened.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import random
-from typing import NamedTuple, Optional
+from dataclasses import dataclass
+from typing import Optional
 
 from tuxemon.monster import Monster
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
@@ -14,21 +15,20 @@ class SoftenedEffectResult(TechEffectResult):
     status: Optional[Technique]
 
 
-class SoftenedEffectParameters(NamedTuple):
-    objective: str
-
-
-class SoftenedEffect(TechEffect[SoftenedEffectParameters]):
+@dataclass
+class SoftenedEffect(TechEffect):
     """
     This effect has a chance to apply the softened status effect.
     """
 
     name = "softened"
-    param_class = SoftenedEffectParameters
+    objective: str
 
-    def apply(self, user: Monster, target: Monster) -> SoftenedEffectResult:
-        obj = self.parameters.objective
-        success = self.move.potency >= random.random()
+    def apply(
+        self, tech: Technique, user: Monster, target: Monster
+    ) -> SoftenedEffectResult:
+        obj = self.objective
+        success = tech.potency >= random.random()
         if success:
             tech = Technique("status_softened")
             if obj == "user":

--- a/tuxemon/technique/effects/statchange.py
+++ b/tuxemon/technique/effects/statchange.py
@@ -2,21 +2,19 @@ from __future__ import annotations
 
 import operator
 import random
-from typing import NamedTuple
+from dataclasses import dataclass
 
 from tuxemon.monster import Monster
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
+from tuxemon.technique.technique import Technique
 
 
 class StatChangeEffectResult(TechEffectResult):
     pass
 
 
-class StatChangeEffectParameters(NamedTuple):
-    pass
-
-
-class StatChangeEffect(TechEffect[StatChangeEffectParameters]):
+@dataclass
+class StatChangeEffect(TechEffect):
     """
     Change combat stats.
 
@@ -33,16 +31,18 @@ class StatChangeEffect(TechEffect[StatChangeEffectParameters]):
     """
 
     name = "statchange"
-    param_class = StatChangeEffectParameters
+    objective: str
 
-    def apply(self, user: Monster, target: Monster) -> StatChangeEffectResult:
+    def apply(
+        self, tech: Technique, user: Monster, target: Monster
+    ) -> StatChangeEffectResult:
         statsmaster = [
-            self.move.statspeed,
-            self.move.stathp,
-            self.move.statarmour,
-            self.move.statmelee,
-            self.move.statranged,
-            self.move.statdodge,
+            tech.statspeed,
+            tech.stathp,
+            tech.statarmour,
+            tech.statmelee,
+            tech.statranged,
+            tech.statdodge,
         ]
         statslugs = [
             "speed",

--- a/tuxemon/technique/effects/swap.py
+++ b/tuxemon/technique/effects/swap.py
@@ -1,20 +1,18 @@
 from __future__ import annotations
 
-from typing import NamedTuple
+from dataclasses import dataclass
 
 from tuxemon.monster import Monster
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
+from tuxemon.technique.technique import Technique
 
 
 class SwapEffectResult(TechEffectResult):
     should_tackle: bool
 
 
-class SwapEffectParameters(NamedTuple):
-    pass
-
-
-class SwapEffect(TechEffect[SwapEffectParameters]):
+@dataclass
+class SwapEffect(TechEffect):
     """
     Used just for combat: change order of monsters.
 
@@ -26,17 +24,19 @@ class SwapEffect(TechEffect[SwapEffectParameters]):
     """
 
     name = "swap"
-    param_class = SwapEffectParameters
+    objective: str
 
-    def apply(self, user: Monster, target: Monster) -> SwapEffectResult:
+    def apply(
+        self, tech: Technique, user: Monster, target: Monster
+    ) -> SwapEffectResult:
         # TODO: implement actions as events, so that combat state can find them
         # TODO: relies on setting "combat_state" attribute.  maybe clear it up
         # later
         # TODO: these values are set in combat_menus.py
 
-        assert self.move.combat_state
+        assert tech.combat_state
         # TODO: find a way to pass values. this will only work for SP games with one monster party
-        combat_state = self.move.combat_state
+        combat_state = tech.combat_state
 
         def swap_add() -> None:
             # TODO: make accommodations for battlefield positions

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -195,7 +195,7 @@ class Technique:
             except KeyError:
                 logger.error(f'Error: TechEffect "{name}" not implemented')
             else:
-                ret.append(effect(self, self.link or self.carrier, params))
+                ret.append(effect(*params))
 
         return ret
 
@@ -268,7 +268,7 @@ class Technique:
 
         # Loop through all the effects of this technique and execute the effect's function.
         for effect in self.effects:
-            result = effect.apply(user, target)
+            result = effect.apply(self, user, target)
             meta_result.update(result)
 
         self.next_use = self.recharge_length


### PR DESCRIPTION
Technique turn, after #1418, following #1385

PR addresses the removal of namedtuple from tech (effects), now the attributes are on the class:
- edited effect files;
- added the param "amount int" to damage and fixed JSONs;
- added the param "all str" to poison and fixed JSONs;
- added the param "all str" to recover and fixed JSONs;
- added the param "all str" to statchange and fixed JSONs;
- added the param "all str" to lifeleech and fixed JSONs;
- added the param to swap, there is no JSON to fix;

The previous loading crash has been solved by the actions above (addition of params), now the game load, it can start a battle without a battle, but there is a crash when switching -> issue solved.

Testing all the status with statchange: no problem.
Testing poison: no problem.
Testing recover: no problem.
Testing lifeleech: no problem.