### PR TITLE
text input

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -334,6 +334,9 @@ msgstr "Gotcha!"
 msgid "not_implemented"
 msgstr "This feature is not yet implemented."
 
+msgid "alert_text"
+msgstr "Text too long!"
+
 msgid "receive_happiness"
 msgstr "Received 5 Capture Devices!"
 

--- a/tuxemon/menu/input.py
+++ b/tuxemon/menu/input.py
@@ -194,7 +194,7 @@ class InputMenu(Menu[InputMenuObj]):
             self.input_string += char
             self.update_text_area()
         else:
-            self.text_area.text = "Please choose a shorter name!"
+            self.text_area.text = T.translate("alert_text")
 
     def update_text_area(self) -> None:
         self.text_area.text = self.input_string


### PR DESCRIPTION
PR adds a new msgid to the PO and changes the text.

The text appears if someone writes a name too long.

new msgid because "Please choose a shorter name!" wasn't translatable.
new text, more generic, because "Please choose a shorter name!" was referred to the name, let's say someone wants to enter something else and not a name, etc.

Question: isn't too much 30 characters as limit for a name?

PLAYER_NAME_LIMIT = 30