### PR TITLE
setcode action

### DIFF
--- a/tuxemon/event/actions/set_code.py
+++ b/tuxemon/event/actions/set_code.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import final
+
+from tuxemon.event.eventaction import EventAction
+from tuxemon.locale import T
+from tuxemon.menu.input import InputMenu
+
+
+@final
+@dataclass
+class SetCodeAction(EventAction):
+    """
+    Set a code and checks if it's correct or not.
+    Case Sensitive:
+    ATTENTION and AtTenTION are two different words.
+
+    Script usage:
+        .. code-block::
+
+            set_code <question>,<answer>,<variable>
+
+    Script parameters:
+        question: The question the player needs to reply.
+                  (eg. "access_code")
+                  then you create the msgid "access_code"
+                  inside the English PO file, as follows:
+                  msgid "access_code"
+                  msgstr "Here the actual question?"
+        answer: The right answer to the question.
+        variable: Where the result (right/wrong) is saved.
+
+    """
+
+    name = "set_code"
+    question: str
+    answer: str
+    variable: str
+
+    def check_setcode(self, name: str) -> None:
+        player = self.session.player
+        if self.answer == name:
+            player.game_variables[self.variable] = "right"
+        else:
+            player.game_variables[self.variable] = "wrong"
+
+    def start(self) -> None:
+        self.session.client.push_state(
+            state_name=InputMenu,
+            prompt=T.translate(self.question),
+            callback=self.check_setcode,
+            escape_key_exits=False,
+            char_limit=len(self.answer),
+        )
+
+    def update(self) -> None:
+        try:
+            self.session.client.get_state_by_name(InputMenu)
+        except ValueError:
+            self.stop()


### PR DESCRIPTION
PR addresses the creation of the set_code action (already structured for #1385) as well as adds three msgid PO.

(I have the other version with params, so it's not a problem to reverse)

Reason? Modders, modders can define a code (numeric or alphabetical or mixed) to access, open a door, receive or trigger something.

It's composed by three parameters:
- code (the actual code);
- characters (characters of the code; eg. code is "1234", then 4 characters;
- variable: the variable that if the code is correct will be set on "on", if not will be set on "off";

eg: **property name="act2" value="set_code lepeletier,10,revolution"**

The variable will help modders with the following actions (a scenario if it's correct, another if it's wrong); above the player has to guess "rockitten". It'll be created the variable prize, so if it's correct the value will be "on", otherwise "off". 

Question: is it ok case sensible? Too complicated? Do we need all upper or lowercase? Let me know. At the end the modders can play on the difficulty of the word too (or sequence of numbers or both).

The input:
![Screenshot from 2022-11-06 08-14-34](https://user-images.githubusercontent.com/64643719/200158887-bf2cb88d-a576-4cc9-aa9e-8b39f919ad24.png)
The message, if it's correct, then it'll be correct.
![Screenshot from 2022-11-06 08-14-47](https://user-images.githubusercontent.com/64643719/200158903-fa95b0ce-dffd-42e4-b9ef-931caefc85e0.png)
