### PR TITLE
fix crash escape

### DIFF
--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -428,7 +428,6 @@ class CombatState(CombatAnimations):
             self.players[0].set_party_status()
             var = self.players[0].game_variables
             var["battle_last_result"] = "ran"
-            var["run_attempts"] += 1
             self.alert(T.translate("combat_player_run"))
 
             # after 3 seconds, push a state that blocks until enter is pressed

--- a/tuxemon/states/combat/combat_menus.py
+++ b/tuxemon/states/combat/combat_menus.py
@@ -119,12 +119,15 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
         player = combat_state.monsters_in_play[combat_state.players[0]][0]
         target = combat_state.monsters_in_play[combat_state.players[1]][0]
         var = combat_state.players[0].game_variables
-        var["run_attempts"] = 0
+        # if the variable doesn't exist
+        if "run_attempts" not in var:
+            var["run_attempts"] = 0
         if (
             formula.escape(player.level, target.level, var["run_attempts"])
             and combat_state._run == "on"
         ):
             combat_state.trigger_player_run(combat_state.players[0])
+            var["run_attempts"] += 1
         else:
 
             def open_menu() -> None:


### PR DESCRIPTION
PR addresses the crash of escape (attempt of running from a wild encounter).

```
  File "/home/robespierre/Tuxemon/tuxemon/states/combat/combat.py", line 431, in transition_phase
    var["run_attempts"] += 1
KeyError: 'run_attempts'
```
var["run_attempts"] += 1 was in the wrong spot
Then I add the check if the variable exists.
