### PR TITLE
output and update battle_history

### DIFF
--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -93,6 +93,14 @@ class ItemType(str, Enum):
     key_item = "KeyItem"
 
 
+class OutputBattle(str, Enum):
+    won = "won"
+    lost = "lost"
+    draw = "draw"
+    ran = "ran"
+    forfeit = "forfeit"
+
+
 # ItemBattleMenu is which menu you want to use to choose the target.
 class ItemBattleMenu(str, Enum):
     monster = "monster"

--- a/tuxemon/event/actions/battles_print.py
+++ b/tuxemon/event/actions/battles_print.py
@@ -59,16 +59,16 @@ class BattlesAction(EventAction[BattlesPrintActionParameters]):
 
     def start(self) -> None:
         player = self.session.player
+        character = self.parameters.character
+        result = self.parameters.result
         today = dt.date.today().toordinal()
 
-        value = (self.parameters.character, self.parameters.result)
-        if self.parameters.result:
-            if value[0] in player.battle_history:
-                battle_date = player.battle_history.get(value)
-                print(
-                    f"{value[1]} against {value[0]} {today - battle_date} days ago"
-                )
+        if character in player.battle_history:
+            output, battle_date = player.battle_history[character]
+            diff_date = today - battle_date
+            if result == output:
+                print(f"{result} against {character} {diff_date} days ago")
             else:
-                print(f"Never {value[1]} against {value[0]}")
+                print(f"Never {result} against {character}")
         else:
             print(player.battle_history)

--- a/tuxemon/event/actions/battles_print.py
+++ b/tuxemon/event/actions/battles_print.py
@@ -21,6 +21,7 @@
 
 from __future__ import annotations
 
+import datetime as dt
 import logging
 from typing import NamedTuple, Optional, final
 
@@ -30,7 +31,8 @@ logger = logging.getLogger(__name__)
 
 
 class BattlesPrintActionParameters(NamedTuple):
-    variable: Optional[str]
+    character: Optional[str]
+    result: Optional[str]
 
 
 @final
@@ -44,10 +46,11 @@ class BattlesAction(EventAction[BattlesPrintActionParameters]):
         .. code-block::
 
             battles_print
-            battles_print <variable>
+            battles_print [<character>,<result>]
 
         Script parameters:
-            variable: Optional, prints out the value of this variable.
+            character: Npc slug name (e.g. "npc_maple").
+            result: One among "won", "lost" or "draw"
 
     """
 
@@ -56,12 +59,16 @@ class BattlesAction(EventAction[BattlesPrintActionParameters]):
 
     def start(self) -> None:
         player = self.session.player
+        today = dt.date.today().toordinal()
 
-        variable = self.parameters.variable
-        if variable:
-            if variable in player.battle_history:
-                print(f"{variable}: {player.battle_history[variable]}")
+        value = (self.parameters.character, self.parameters.result)
+        if self.parameters.result:
+            if value[0] in player.battle_history:
+                battle_date = player.battle_history.get(value)
+                print(
+                    f"{value[1]} against {value[0]} {today - battle_date} days ago"
+                )
             else:
-                print(f"'{variable}' has not been set yet.")
+                print(f"Never {value[1]} against {value[0]}")
         else:
             print(player.battle_history)

--- a/tuxemon/event/actions/set_battle.py
+++ b/tuxemon/event/actions/set_battle.py
@@ -21,6 +21,7 @@
 
 from __future__ import annotations
 
+import datetime as dt
 from typing import NamedTuple, final
 
 from tuxemon.event.eventaction import EventAction
@@ -57,5 +58,7 @@ class SetBattleAction(EventAction[SetBattleActionParameters]):
         battle_key = str(battle_list[0])
         battle_value = str(battle_list[1])
 
-        # Append the battle_history dictionary with the key: value pair
-        player.battle_history[battle_key] = battle_value
+        # Append the battle_history dict tuple with the key: value pair
+        player.battle_history[
+            battle_key, battle_value
+        ] = dt.date.today().toordinal()

--- a/tuxemon/event/actions/set_battle.py
+++ b/tuxemon/event/actions/set_battle.py
@@ -58,7 +58,8 @@ class SetBattleAction(EventAction[SetBattleActionParameters]):
         battle_key = str(battle_list[0])
         battle_value = str(battle_list[1])
 
-        # Append the battle_history dict tuple with the key: value pair
-        player.battle_history[
-            battle_key, battle_value
-        ] = dt.date.today().toordinal()
+        # set the value in battle history
+        player.battle_history[battle_key] = (
+            battle_value,
+            dt.date.today().toordinal(),
+        )

--- a/tuxemon/event/conditions/battle_is.py
+++ b/tuxemon/event/conditions/battle_is.py
@@ -60,9 +60,11 @@ class BattleIsCondition(EventCondition):
         character = condition.parameters[0]
         result = condition.parameters[1]
 
-        key_value = (character, result)
-
-        if key_value in player.battle_history:
-            return True
+        if character in player.battle_history:
+            output, date = player.battle_history[character]
+            if result == output:
+                return True
+            else:
+                return False
         else:
             return False

--- a/tuxemon/event/conditions/battle_is.py
+++ b/tuxemon/event/conditions/battle_is.py
@@ -60,10 +60,9 @@ class BattleIsCondition(EventCondition):
         character = condition.parameters[0]
         result = condition.parameters[1]
 
-        if character in player.battle_history:
-            if player.battle_history[character] == result:
-                return True
-            else:
-                return False
+        key_value = (character, result)
+
+        if key_value in player.battle_history:
+            return True
         else:
             return False

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING, NamedTuple, Optional, Sequence, Tuple
 
 if TYPE_CHECKING:
     from tuxemon.monster import Monster
+    from tuxemon.npc import NPC
     from tuxemon.technique.technique import Technique
 
 logger = logging.getLogger(__name__)
@@ -211,3 +212,22 @@ def escape(level_user: int, level_target: int, attempts: int) -> bool:
         return True
     else:
         return False
+
+
+def battle_math(player: NPC, output: str) -> None:
+    player = player.game_variables
+    if output == "won":
+        player["battle_won"] += 1
+        player["percent_win"] = round(
+            (player["battle_won"] / player["battle_total"]) * 100
+        )
+    elif output == "lost":
+        player["battle_lost"] += 1
+        player["percent_lose"] = round(
+            (player["battle_lost"] / player["battle_total"]) * 100
+        )
+    elif output == "draw":
+        player["battle_draw"] += 1
+        player["percent_draw"] = round(
+            (player["battle_draw"] / player["battle_total"]) * 100
+        )

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -216,6 +216,12 @@ def escape(level_user: int, level_target: int, attempts: int) -> bool:
 
 def battle_math(player: NPC, output: str) -> None:
     player = player.game_variables
+    if "battle_total" not in player:
+        player["battle_total"] = 0
+        player["battle_won"] = 0
+        player["battle_lost"] = 0
+        player["battle_draw"] = 0
+    player["battle_total"] += 1
     if output == "won":
         player["battle_won"] += 1
         player["percent_win"] = round(

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -93,7 +93,7 @@ class NPCState(TypedDict):
     current_map: str
     facing: Direction
     game_variables: Dict[str, Any]
-    battle_history: Dict[Tuple[str, OutputBattle], int]
+    battle_history: Dict[str, Tuple[OutputBattle, int]]
     tuxepedia: Dict[str, SeenStatus]
     money: Dict[str, int]
     inventory: Mapping[str, Optional[int]]
@@ -173,7 +173,7 @@ class NPC(Entity[NPCState]):
         self.behavior: Optional[str] = "wander"  # not used for now
         self.game_variables: Dict[str, Any] = {}  # Tracks the game state
         self.battle_history: Dict[
-            Tuple[str, OutputBattle], int
+            str, Tuple[OutputBattle, int]
         ] = {}  # Tracks the battles
         # Tracks Tuxepedia (monster seen or caught)
         self.tuxepedia: Dict[str, SeenStatus] = {}

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -51,7 +51,7 @@ from typing import (
 from tuxemon import surfanim
 from tuxemon.ai import AI
 from tuxemon.compat import Rect
-from tuxemon.db import SeenStatus, db
+from tuxemon.db import OutputBattle, SeenStatus, db
 from tuxemon.entity import Entity
 from tuxemon.graphics import load_and_scale
 from tuxemon.item.item import (
@@ -93,7 +93,7 @@ class NPCState(TypedDict):
     current_map: str
     facing: Direction
     game_variables: Dict[str, Any]
-    battle_history: Dict[str, Any]
+    battle_history: Dict[Tuple[str, OutputBattle], int]
     tuxepedia: Dict[str, SeenStatus]
     money: Dict[str, int]
     inventory: Mapping[str, Optional[int]]
@@ -172,7 +172,9 @@ class NPC(Entity[NPCState]):
         # general
         self.behavior: Optional[str] = "wander"  # not used for now
         self.game_variables: Dict[str, Any] = {}  # Tracks the game state
-        self.battle_history: Dict[str, Any] = {}  # Tracks the battles
+        self.battle_history: Dict[
+            Tuple[str, OutputBattle], int
+        ] = {}  # Tracks the battles
         # Tracks Tuxepedia (monster seen or caught)
         self.tuxepedia: Dict[str, SeenStatus] = {}
         self.money: Dict[str, int] = {}  # Tracks money

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -493,7 +493,7 @@ class CombatState(CombatAnimations):
                     var["battle_last_trainer"] = self.players[1].slug
                     # track battles against NPC
                     self.players[0].battle_history[self.players[1].slug] = (
-                        OutputBattle.won,
+                        OutputBattle.lost,
                         dt.date.today().toordinal(),
                     )
 

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -29,6 +29,7 @@
 #
 from __future__ import annotations
 
+import datetime as dt
 import logging
 from collections import defaultdict
 from functools import partial
@@ -53,10 +54,10 @@ from typing import (
 import pygame
 from pygame.rect import Rect
 
-from tuxemon import audio, graphics, state, tools
+from tuxemon import audio, formula, graphics, state, tools
 from tuxemon.animation import Task
 from tuxemon.combat import check_status, defeated, fainted, get_awake_monsters
-from tuxemon.db import SeenStatus
+from tuxemon.db import OutputBattle, SeenStatus
 from tuxemon.item.item import Item
 from tuxemon.locale import T
 from tuxemon.menu.interface import MenuItem
@@ -422,12 +423,12 @@ class CombatState(CombatAnimations):
             # update battle_total only once after each battle
             if self.is_trainer_battle:
                 var = self.players[0].game_variables
-                var["battle_total"] = +1
+                var["battle_total"] += 1
 
         elif phase == "ran away":
             self.players[0].set_party_status()
             var = self.players[0].game_variables
-            var["battle_last_result"] = "ran"
+            var["battle_last_result"] = OutputBattle.ran
             var["run_attempts"] += 1
             self.alert(T.translate("combat_player_run"))
 
@@ -440,15 +441,14 @@ class CombatState(CombatAnimations):
         elif phase == "draw match":
             self.players[0].set_party_status()
             var = self.players[0].game_variables
-            var["battle_last_result"] = "draw"
+            var["battle_last_result"] = OutputBattle.draw
             if self.is_trainer_battle:
+                formula.battle_math(self.players[0], OutputBattle.draw)
                 var["battle_last_trainer"] = self.players[1].slug
-                var["battle_draw"] = +1
-                var["percent_draw"] = round(
-                    (var["battle_draw"] / var["battle_total"]) * 100
-                )
                 # track battles against NPC
-                self.players[0].battle_history[self.players[1].slug] = "draw"
+                self.players[0].battle_history[
+                    self.players[1].slug, OutputBattle.draw
+                ] = dt.date.today().toordinal()
 
             # it is a draw match; both players were defeated in same round
             self.alert(T.translate("combat_draw"))
@@ -464,7 +464,7 @@ class CombatState(CombatAnimations):
             self.players[0].set_party_status()
             var = self.players[0].game_variables
             if self.remaining_players[0] == self.players[0]:
-                var["battle_last_result"] = "won"
+                var["battle_last_result"] = OutputBattle.won
                 if self.is_trainer_battle:
                     self.alert(
                         T.format(
@@ -478,31 +478,25 @@ class CombatState(CombatAnimations):
                     )
                     self.players[0].give_money(self._prize)
                     var["battle_last_trainer"] = self.players[1].slug
-                    var["battle_won"] = +1
-                    var["percent_win"] = round(
-                        (var["battle_won"] / var["battle_total"]) * 100
-                    )
                     # track battles against NPC
+                    formula.battle_math(self.players[0], OutputBattle.won)
                     self.players[0].battle_history[
-                        self.players[1].slug
-                    ] = "won"
+                        self.players[1].slug, OutputBattle.won
+                    ] = dt.date.today().toordinal()
                 else:
                     self.alert(T.translate("combat_victory"))
 
             else:
-                var["battle_last_result"] = "lost"
+                var["battle_last_result"] = OutputBattle.lost
                 var["battle_lost_faint"] = "true"
                 self.alert(T.translate("combat_defeat"))
                 if self.is_trainer_battle:
+                    formula.battle_math(self.players[0], OutputBattle.lost)
                     var["battle_last_trainer"] = self.players[1].slug
-                    var["battle_lost"] = +1
-                    var["percent_lose"] = round(
-                        (var["battle_lost"] / var["battle_total"]) * 100
-                    )
                     # track battles against NPC
                     self.players[0].battle_history[
-                        self.players[1].slug
-                    ] = "lost"
+                        self.players[1].slug, OutputBattle.lost
+                    ] = dt.date.today().toordinal()
 
             # after 3 seconds, push a state that blocks until enter is pressed
             # after the state is popped, the combat state will clean up and close

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -420,16 +420,12 @@ class CombatState(CombatAnimations):
                     monster.set_stats()
 
         elif phase == "resolve match":
-            # update battle_total only once after each battle
-            if self.is_trainer_battle:
-                var = self.players[0].game_variables
-                var["battle_total"] += 1
+            pass
 
         elif phase == "ran away":
             self.players[0].set_party_status()
             var = self.players[0].game_variables
             var["battle_last_result"] = OutputBattle.ran
-            var["battle_last_result"] = "ran"
             self.alert(T.translate("combat_player_run"))
 
             # after 3 seconds, push a state that blocks until enter is pressed
@@ -446,9 +442,10 @@ class CombatState(CombatAnimations):
                 formula.battle_math(self.players[0], OutputBattle.draw)
                 var["battle_last_trainer"] = self.players[1].slug
                 # track battles against NPC
-                self.players[0].battle_history[
-                    self.players[1].slug, OutputBattle.draw
-                ] = dt.date.today().toordinal()
+                self.players[0].battle_history[self.players[1].slug] = (
+                    OutputBattle.draw,
+                    dt.date.today().toordinal(),
+                )
 
             # it is a draw match; both players were defeated in same round
             self.alert(T.translate("combat_draw"))
@@ -480,9 +477,10 @@ class CombatState(CombatAnimations):
                     var["battle_last_trainer"] = self.players[1].slug
                     # track battles against NPC
                     formula.battle_math(self.players[0], OutputBattle.won)
-                    self.players[0].battle_history[
-                        self.players[1].slug, OutputBattle.won
-                    ] = dt.date.today().toordinal()
+                    self.players[0].battle_history[self.players[1].slug] = (
+                        OutputBattle.won,
+                        dt.date.today().toordinal(),
+                    )
                 else:
                     self.alert(T.translate("combat_victory"))
 
@@ -494,9 +492,10 @@ class CombatState(CombatAnimations):
                     formula.battle_math(self.players[0], OutputBattle.lost)
                     var["battle_last_trainer"] = self.players[1].slug
                     # track battles against NPC
-                    self.players[0].battle_history[
-                        self.players[1].slug, OutputBattle.lost
-                    ] = dt.date.today().toordinal()
+                    self.players[0].battle_history[self.players[1].slug] = (
+                        OutputBattle.won,
+                        dt.date.today().toordinal(),
+                    )
 
             # after 3 seconds, push a state that blocks until enter is pressed
             # after the state is popped, the combat state will clean up and close


### PR DESCRIPTION
PR addresses the following points:

1. added str enum in db.py
2. update of battle_history
3. moved the rounds and variables from combat.py to formula.py

- **added str enum in db.py**

```
class OutputBattle(str, Enum):
    won = "won"
    lost = "lost"
    draw = "draw"
    ran = "ran"
    forfeit = "forfeit"
```
I wasn't satisfied with the original "won", "lost", etc. I prefer to centralize like SeenStatus.

- **update of battle_history**

~~**battle_history: Dict[Tuple[str, OutputBattle], int]** -> npc_slug, (won/draw/lost), date~~
**Dict[str, Tuple[OutputBattle, int]]**
**changed, now the tuple is inside the value, not anymore in the key, I fixed all the other files. Why? Because when I tried to save the filegame, it crashed. Unable to save a tuple as key in JSON**

so if you are going to lose or win or draw against the same NPC, it updates the date, it gaves us the possibility to know xx days ago.

The missing variable was time (when the battle was fought?). Initially I wasn't able to include the variable, but now I can. The discover of ordinal, as well as working on other PRs, gave me the possibility to discover toordinal, the perfect value (all int) to indicate the date. So it's possible, easily, to understand when it was fought the last battle.

Now, for instance, battles_print gives (when you look for npc and output):
**won against spyder_route2_billie 0 days ago**

- **moved the rounds and variables from combat.py to formula.py**

The reason is order and cleanness, combat.py results a bit less chaotic and all the math ops are in formula.

As usual tested and black.