### PR TITLE
removal of levelrange

### DIFF
--- a/mods/tuxemon/db/encounter/37707_town.json
+++ b/mods/tuxemon/db/encounter/37707_town.json
@@ -3,34 +3,18 @@
     "monsters":[
         {
             "encounter_rate": 0.5,
-            "level_range": [
-                1,
-                10
-            ],
             "monster": "fruitera"
         },
         {
             "encounter_rate": 0.5,
-            "level_range": [
-                1,
-                10
-            ],
             "monster": "dollfin"
         },
         {
             "encounter_rate": 0.5,
-            "level_range": [
-                1,
-                10
-            ],
             "monster": "legko"
         },
         {
             "encounter_rate": 0.5,
-            "level_range": [
-                1,
-                10
-            ],
             "monster": "rockitten"
         }
     ]

--- a/mods/tuxemon/db/encounter/37707_town_missing.json
+++ b/mods/tuxemon/db/encounter/37707_town_missing.json
@@ -3,32 +3,18 @@
     "monsters":[
         {
             "encounter_rate": 0.5,
-            "level_range": [
-                1,
-                999
-            ],
             "monster": "f7u1t3ra"
         },
         {
             "encounter_rate": 0.5,
-            "level_range": [
-                1
-            ],
             "monster": "d0llf1n"
         },
         {
             "encounter_rate": 0.5,
-            "level_range": [
-                666
-            ],
             "monster": "l3gk0"
         },
         {
             "encounter_rate": 0.5,
-            "level_range": [
-                13,
-                37
-            ],
             "monster": "r0ck1tt3n"
         }
     ]

--- a/mods/tuxemon/db/encounter/citypark.json
+++ b/mods/tuxemon/db/encounter/citypark.json
@@ -3,67 +3,35 @@
   "monsters": [
     {
       "monster": "cardiling",
-      "encounter_rate": 3,
-      "level_range": [
-        5,
-        8
-      ]
+      "encounter_rate": 3
     },
     {
       "monster": "cardiwing",
-      "encounter_rate": 1,
-      "level_range": [
-        8,
-        11
-      ]
+      "encounter_rate": 1
     },
     {
       "monster": "cataspike",
-      "encounter_rate": 3,
-      "level_range": [
-        6,
-        9
-      ]
+      "encounter_rate": 3
     },
     {
       "monster": "eyenemy",
-      "encounter_rate": 3,
-      "level_range": [
-        5,
-        8
-      ]
+      "encounter_rate": 3
     },
     {
       "monster": "axylightl",
-      "encounter_rate": 3,
-      "level_range": [
-        5,
-        8
-      ]
+      "encounter_rate": 3
     },
     {
       "monster": "tourbidi",
-      "encounter_rate": 1,
-      "level_range": [
-        6,
-        9
-      ]
+      "encounter_rate": 1
     },
     {
       "monster": "squabbit",
-      "encounter_rate": 3,
-      "level_range": [
-        5,
-        8
-      ]
+      "encounter_rate": 3
     },
     {
       "monster": "puparmor",
-      "encounter_rate": 1,
-      "level_range": [
-        8,
-        11
-      ]
+      "encounter_rate": 1
     }
   ]
 }

--- a/mods/tuxemon/db/encounter/default_encounter.json
+++ b/mods/tuxemon/db/encounter/default_encounter.json
@@ -3,82 +3,42 @@
    "monsters": [
       {
          "encounter_rate": 0.5,
-         "level_range": [
-            2,
-            4
-         ],
          "monster": "eyenemy"
       },
       {
          "encounter_rate": 0.5,
-         "level_range": [
-            2,
-            4
-         ],
          "monster": "dandicub"
       },
       {
          "encounter_rate": 0.5,
-         "level_range": [
-            2,
-            4
-         ],
          "monster": "cardiling"
       },
       {
          "encounter_rate": 0.5,
-         "level_range": [
-            2,
-            4
-         ],
          "monster": "budaye"
       },
       {
          "encounter_rate": 0.5,
-         "level_range": [
-            2,
-            4
-         ],
          "monster": "cataspike"
       },
       {
          "encounter_rate": 0.5,
-         "level_range": [
-            2,
-            4
-         ],
          "monster": "elofly"
       },
       {
          "encounter_rate": 0.5,
-         "level_range": [
-            2,
-            4
-         ],
          "monster": "aardorn"
       },
       {
          "encounter_rate": 0.5,
-         "level_range": [
-            2,
-            4
-         ],
          "monster": "nut"
       },
       {
          "encounter_rate": 0.5,
-         "level_range": [
-            2,
-            4
-         ],
          "monster": "grimachin"
       },
       {
          "encounter_rate": 0.5,
-         "level_range": [
-            2,
-            4
-         ],
          "monster": "spighter"
       }
    ]

--- a/mods/tuxemon/db/encounter/dragonscave.json
+++ b/mods/tuxemon/db/encounter/dragonscave.json
@@ -3,35 +3,19 @@
   "monsters": [
     {
       "monster": "agnite",
-      "encounter_rate": 3,
-      "level_range": [
-        25,
-        28
-      ]
+      "encounter_rate": 3
     },
     {
       "monster": "agnidon",
-      "encounter_rate": 1,
-      "level_range": [
-        20,
-        25
-      ]
+      "encounter_rate": 1
     },
     {
       "monster": "embra",
-      "encounter_rate": 3,
-      "level_range": [
-        25,
-        28
-      ]
+      "encounter_rate": 3
     },
     {
       "monster": "ruption",
-      "encounter_rate": 1,
-      "level_range": [
-        20,
-        25
-      ]
+      "encounter_rate": 1
     }
   ]
 }

--- a/mods/tuxemon/db/encounter/dryadsgrove.json
+++ b/mods/tuxemon/db/encounter/dryadsgrove.json
@@ -3,51 +3,27 @@
   "monsters": [
     {
       "monster": "coleorus",
-      "encounter_rate": 1,
-      "level_range": [
-        25,
-        28
-      ]
+      "encounter_rate": 1
     },
     {
       "monster": "tourbidi",
-      "encounter_rate": 1,
-      "level_range": [
-        20,
-        25
-      ]
+      "encounter_rate": 1
     },
     {
       "monster": "shybulb",
-      "encounter_rate": 3,
-      "level_range": [
-        25,
-        28
-      ]
+      "encounter_rate": 3
     },
     {
       "monster": "narcileaf",
-      "encounter_rate": 3,
-      "level_range": [
-        20,
-        25
-      ]
+      "encounter_rate": 3
     },
     {
       "monster": "sapsnap",
-      "encounter_rate": 3,
-      "level_range": [
-        25,
-        28
-      ]
+      "encounter_rate": 3
     },
     {
       "monster": "lambert",
-      "encounter_rate": 1,
-      "level_range": [
-        20,
-        25
-      ]
+      "encounter_rate": 1
     }
   ]
 }

--- a/mods/tuxemon/db/encounter/greenwash.json
+++ b/mods/tuxemon/db/encounter/greenwash.json
@@ -3,43 +3,23 @@
   "monsters": [
     {
       "monster": "cochini",
-      "encounter_rate": 5,
-      "level_range": [
-        15,
-        25
-      ]
+      "encounter_rate": 5
     },
     {
       "monster": "cateye",
-      "encounter_rate": 5,
-      "level_range": [
-        15,
-        25
-      ]
+      "encounter_rate": 5
     },
     {
       "monster": "sclairus",
-      "encounter_rate": 5,
-      "level_range": [
-        15,
-        25
-      ]
+      "encounter_rate": 5
     },
     {
       "monster": "bursa",
-      "encounter_rate": 5,
-      "level_range": [
-        15,
-        25
-      ]
+      "encounter_rate": 5
     },
     {
       "monster": "nut",
-      "encounter_rate": 5,
-      "level_range": [
-        15,
-        25
-      ]
+      "encounter_rate": 5
     }
   ]
 }

--- a/mods/tuxemon/db/encounter/mansion.json
+++ b/mods/tuxemon/db/encounter/mansion.json
@@ -3,35 +3,19 @@
   "monsters": [
     {
       "monster": "cairfrey",
-      "encounter_rate": 3,
-      "level_range": [
-        13,
-        16
-      ]
+      "encounter_rate": 3
     },
     {
       "monster": "polyrock",
-      "encounter_rate": 3,
-      "level_range": [
-        13,
-        16
-      ]
+      "encounter_rate": 3
     },
     {
       "monster": "djinnbo",
-      "encounter_rate": 1,
-      "level_range": [
-        14,
-        17
-      ]
+      "encounter_rate": 1
     },
     {
       "monster": "pigabyte",
-      "encounter_rate": 3,
-      "level_range": [
-        13,
-        16
-      ]
+      "encounter_rate": 3
     }
   ]
 }

--- a/mods/tuxemon/db/encounter/new_txmn.json
+++ b/mods/tuxemon/db/encounter/new_txmn.json
@@ -3,42 +3,22 @@
     "monsters":[
         {
             "encounter_rate":0.5,
-            "level_range":[
-                2,
-                4
-            ],
             "monster":"chloragon"
         },
         {
             "encounter_rate":0.5,
-            "level_range":[
-                2,
-                4
-            ],
             "monster":"chillimp"
         },
         {
             "encounter_rate":0.5,
-            "level_range":[
-                2,
-                4
-            ],
             "monster":"coproblight"
         },
         {
             "encounter_rate":0.5,
-            "level_range":[
-                2,
-                4
-            ],
             "monster":"pilthropus"
         },
         {
             "encounter_rate":0.5,
-            "level_range":[
-                2,
-                4
-            ],
             "monster":"teddisun"
         }
     ]

--- a/mods/tuxemon/db/encounter/propellercat.json
+++ b/mods/tuxemon/db/encounter/propellercat.json
@@ -3,11 +3,7 @@
    "monsters": [
       {
          "monster": "propellercat",
-         "encounter_rate": 1,
-         "level_range": [
-            2,
-            64
-         ]
+         "encounter_rate": 1
       }
    ]
 }

--- a/mods/tuxemon/db/encounter/rare_txmn.json
+++ b/mods/tuxemon/db/encounter/rare_txmn.json
@@ -3,162 +3,82 @@
     "monsters":[
         {
             "encounter_rate":0.5,
-            "level_range":[
-                18,
-                35
-            ],
             "monster":"legko"
         },
         {
             "encounter_rate":0.5,
-            "level_range":[
-                36,
-                50
-            ],
             "monster":"moloch"
         },
         {
             "encounter_rate":0.5,
-            "level_range":[
-                18,
-                35
-            ],
             "monster":"heronquak"
         },
         {
             "encounter_rate":0.5,
-            "level_range":[
-                36,
-                50
-            ],
             "monster":"eaglace"
         },
         {
             "encounter_rate":0.5,
-            "level_range":[
-                18,
-                35
-            ],
             "monster":"sapragon"
         },
         {
             "encounter_rate":0.5,
-            "level_range":[
-                36,
-                50
-            ],
             "monster":"dragarbor"
         },
         {
             "encounter_rate":0.5,
-            "level_range":[
-                18,
-                35
-            ],
             "monster":"gectile"
         },
         {
             "encounter_rate":0.5,
-            "level_range":[
-                36,
-                50
-            ],
             "monster":"velocitile"
         },
         {
             "encounter_rate":0.5,
-            "level_range":[
-                18,
-                35
-            ],
             "monster":"allagon"
         },
         {
             "encounter_rate":0.5,
-            "level_range":[
-                10,
-                30
-            ],
             "monster":"aardart"
         },
         {
             "encounter_rate":0.5,
-            "level_range":[
-                18,
-                35
-            ],
             "monster":"agnidon"
         },
         {
             "encounter_rate":0.5,
-            "level_range":[
-                36,
-                50
-            ],
             "monster":"agnigon"
         },
         {
             "encounter_rate":0.5,
-            "level_range":[
-                18,
-                35
-            ],
             "monster":"cardiwing"
         },
         {
             "encounter_rate":0.5,
-            "level_range":[
-                36,
-                50
-            ],
             "monster":"cardinale"
         },
         {
             "encounter_rate":0.5,
-            "level_range":[
-                10,
-                30
-            ],
             "monster":"corvix"
         },
         {
             "encounter_rate":0.5,
-            "level_range":[
-                18,
-                35
-            ],
             "monster":"dracune"
         },
         {
             "encounter_rate":0.5,
-            "level_range":[
-                36,
-                50
-            ],
             "monster":"fluttaflap"
         },
         {
             "encounter_rate":0.5,
-            "level_range":[
-                10,
-                30
-            ],
             "monster":"noctalo"
         },
         {
             "encounter_rate":0.5,
-            "level_range":[
-                10,
-                30
-            ],
             "monster":"possessun"
         },
         {
             "encounter_rate":0.5,
-            "level_range":[
-                10,
-                30
-            ],
             "monster":"sharpfin"
         }
     ]

--- a/mods/tuxemon/db/encounter/route1.json
+++ b/mods/tuxemon/db/encounter/route1.json
@@ -3,27 +3,15 @@
   "monsters": [
     {
       "monster": "pairagrin",
-      "encounter_rate": 3.5,
-      "level_range": [
-        1,
-        4
-      ]
+      "encounter_rate": 3.5
     },
     {
       "monster": "aardorn",
-      "encounter_rate": 3.5,
-      "level_range": [
-        1,
-        4
-      ]
+      "encounter_rate": 3.5
     },
     {
       "monster": "cataspike",
-      "encounter_rate": 3.5,
-      "level_range": [
-        1,
-        4
-      ]
+      "encounter_rate": 3.5
     }
   ]
 }

--- a/mods/tuxemon/db/encounter/route2.json
+++ b/mods/tuxemon/db/encounter/route2.json
@@ -3,43 +3,23 @@
   "monsters": [
     {
       "monster": "cardiling",
-      "encounter_rate": 2.5,
-      "level_range": [
-        3,
-        6
-      ]
+      "encounter_rate": 2.5
     },
     {
       "monster": "aardorn",
-      "encounter_rate": 2.5,
-      "level_range": [
-        3,
-        6
-      ]
+      "encounter_rate": 2.5
     },
     {
       "monster": "eyenemy",
-      "encounter_rate": 2.5,
-      "level_range": [
-        3,
-        6
-      ]
+      "encounter_rate": 2.5
     },
     {
       "monster": "axylightl",
-      "encounter_rate": 1,
-      "level_range": [
-        4,
-        7
-      ]
+      "encounter_rate": 1
     },
     {
       "monster": "cataspike",
-      "encounter_rate": 2.5,
-      "level_range": [
-        3,
-        6
-      ]
+      "encounter_rate": 2.5
     }
   ]
 }

--- a/mods/tuxemon/db/encounter/route3.json
+++ b/mods/tuxemon/db/encounter/route3.json
@@ -3,35 +3,19 @@
   "monsters": [
     {
       "monster": "cardiling",
-      "encounter_rate": 3,
-      "level_range": [
-        7,
-        10
-      ]
+      "encounter_rate": 3
     },
     {
       "monster": "elofly",
-      "encounter_rate": 3,
-      "level_range": [
-        7,
-        10
-      ]
+      "encounter_rate": 3
     },
     {
       "monster": "squabbit",
-      "encounter_rate": 1,
-      "level_range": [
-        8,
-        11
-      ]
+      "encounter_rate": 1
     },
     {
       "monster": "shybulb",
-      "encounter_rate": 3,
-      "level_range": [
-        7,
-        10
-      ]
+      "encounter_rate": 3
     }
   ]
 }

--- a/mods/tuxemon/db/encounter/route4.json
+++ b/mods/tuxemon/db/encounter/route4.json
@@ -3,35 +3,19 @@
   "monsters": [
     {
       "monster": "elofly",
-      "encounter_rate": 3,
-      "level_range": [
-        11,
-        14
-      ]
+      "encounter_rate": 3
     },
     {
       "monster": "sapsnap",
-      "encounter_rate": 1,
-      "level_range": [
-        12,
-        15
-      ]
+      "encounter_rate": 1
     },
     {
       "monster": "aardorn",
-      "encounter_rate": 3,
-      "level_range": [
-        11,
-        14
-      ]
+      "encounter_rate": 3
     },
     {
       "monster": "katapill",
-      "encounter_rate": 3,
-      "level_range": [
-        11,
-        14
-      ]
+      "encounter_rate": 3
     }
   ]
 }

--- a/mods/tuxemon/db/encounter/route5.json
+++ b/mods/tuxemon/db/encounter/route5.json
@@ -3,43 +3,23 @@
   "monsters": [
     {
       "monster": "foofle",
-      "encounter_rate": 3,
-      "level_range": [
-        19,
-        23
-      ]
+      "encounter_rate": 3
     },
     {
       "monster": "vamporm",
-      "encounter_rate": 3,
-      "level_range": [
-        16,
-        20
-      ]
+      "encounter_rate": 3
     },
     {
       "monster": "dracune",
-      "encounter_rate": 1,
-      "level_range": [
-        18,
-        22
-      ]
+      "encounter_rate": 1
     },
     {
       "monster": "anoleaf",
-      "encounter_rate": 3,
-      "level_range": [
-        16,
-        20
-      ]
+      "encounter_rate": 3
     },
     {
       "monster": "gectile",
-      "encounter_rate": 1,
-      "level_range": [
-        20,
-        24
-      ]
+      "encounter_rate": 1
     }
   ]
 }

--- a/mods/tuxemon/db/encounter/route6.json
+++ b/mods/tuxemon/db/encounter/route6.json
@@ -3,27 +3,15 @@
   "monsters": [
     {
       "monster": "dandicub",
-      "encounter_rate": 10,
-      "level_range": [
-        19,
-        20
-      ]
+      "encounter_rate": 10
     },
     {
       "monster": "dandylion",
-      "encounter_rate": 5,
-      "level_range": [
-        21,
-        23
-      ]
+      "encounter_rate": 5
     },
     {
       "monster": "capiti",
-      "encounter_rate": 10,
-      "level_range": [
-        19,
-        22
-      ]
+      "encounter_rate": 10
     }
   ]
 }

--- a/mods/tuxemon/db/encounter/routea.json
+++ b/mods/tuxemon/db/encounter/routea.json
@@ -3,35 +3,19 @@
   "monsters": [
     {
       "monster": "shybulb",
-      "encounter_rate": 3.5,
-      "level_range": [
-        12,
-        15
-      ]
+      "encounter_rate": 3.5
     },
     {
       "monster": "katapill",
-      "encounter_rate": 3.5,
-      "level_range": [
-        12,
-        15
-      ]
+      "encounter_rate": 3.5
     },
     {
       "monster": "vamporm",
-      "encounter_rate": 1.5,
-      "level_range": [
-        12,
-        16
-      ]
+      "encounter_rate": 1.5
     },
     {
       "monster": "anoleaf",
-      "encounter_rate": 1.5,
-      "level_range": [
-        12,
-        15
-      ]
+      "encounter_rate": 1.5
     }
   ]
 }

--- a/mods/tuxemon/db/encounter/routeb.json
+++ b/mods/tuxemon/db/encounter/routeb.json
@@ -3,67 +3,35 @@
   "monsters": [
     {
       "monster": "toufigel",
-      "encounter_rate": 3,
-      "level_range": [
-        25,
-        28
-      ]
+      "encounter_rate": 3
     },
     {
       "monster": "pipis",
-      "encounter_rate": 3,
-      "level_range": [
-        20,
-        25
-      ]
+      "encounter_rate": 3
     },
     {
       "monster": "strella",
-      "encounter_rate": 1,
-      "level_range": [
-        25,
-        28
-      ]
+      "encounter_rate": 1
     },
     {
       "monster": "noctula",
-      "encounter_rate": 3,
-      "level_range": [
-        20,
-        25
-      ]
+      "encounter_rate": 3
     },
     {
       "monster": "noctalo",
-      "encounter_rate": 1,
-      "level_range": [
-        25,
-        28
-      ]
+      "encounter_rate": 1
     },
     {
       "monster": "cairfrey",
-      "encounter_rate": 3,
-      "level_range": [
-        20,
-        25
-      ]
+      "encounter_rate": 3
     },
     {
       "monster": "possessun",
-      "encounter_rate": 1,
-      "level_range": [
-        25,
-        28
-      ]
+      "encounter_rate": 1
     },
     {
       "monster": "rockitten",
-      "encounter_rate": 1,
-      "level_range": [
-        20,
-        22
-      ]
+      "encounter_rate": 1
     }
   ]
 }

--- a/mods/tuxemon/db/encounter/spyder_cochini.json
+++ b/mods/tuxemon/db/encounter/spyder_cochini.json
@@ -3,11 +3,7 @@
   "monsters": [
     {
       "monster": "cochini",
-      "encounter_rate": 1,
-      "level_range": [
-        30,
-        31
-      ]
+      "encounter_rate": 1
     }
   ]
 }

--- a/mods/tuxemon/db/encounter/spyder_drokoro.json
+++ b/mods/tuxemon/db/encounter/spyder_drokoro.json
@@ -3,11 +3,7 @@
   "monsters": [
     {
       "monster": "drokoro",
-      "encounter_rate": 100,
-      "level_range": [
-        50,
-        51
-      ]
+      "encounter_rate": 100
     }
   ]
 }

--- a/mods/tuxemon/db/encounter/spyder_landrace.json
+++ b/mods/tuxemon/db/encounter/spyder_landrace.json
@@ -3,11 +3,7 @@
   "monsters": [
     {
       "monster": "sludgehog",
-      "encounter_rate": 100,
-      "level_range": [
-        40,
-        41
-      ]
+      "encounter_rate": 100
     }
   ]
 }

--- a/mods/tuxemon/db/encounter/spyder_lapinou.json
+++ b/mods/tuxemon/db/encounter/spyder_lapinou.json
@@ -3,11 +3,7 @@
   "monsters": [
     {
       "monster": "lapinou",
-      "encounter_rate": 1,
-      "level_range": [
-        30,
-        31
-      ]
+      "encounter_rate": 1
     }
   ]
 }

--- a/mods/tuxemon/db/encounter/spyder_volcoli.json
+++ b/mods/tuxemon/db/encounter/spyder_volcoli.json
@@ -3,11 +3,7 @@
   "monsters": [
     {
       "monster": "volcoli",
-      "encounter_rate": 100,
-      "level_range": [
-        50,
-        51
-      ]
+      "encounter_rate": 100
     }
   ]
 }

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -506,9 +506,6 @@ class EnvironmentModel(BaseModel):
 class EncounterItemModel(BaseModel):
     monster: str = Field(..., description="Monster slug for this encounter")
     encounter_rate: float = Field(..., description="Rate of this encounter")
-    level_range: Sequence[int] = Field(
-        ..., description="Level range to encounter"
-    )
 
     @validator("monster")
     def monster_exists(cls, v):

--- a/tuxemon/event/actions/random_encounter.py
+++ b/tuxemon/event/actions/random_encounter.py
@@ -87,7 +87,7 @@ class RandomEncounterAction(EventAction[RandomEncounterActionParameters]):
             logger.info("Starting random encounter!")
 
             self.world = self.session.client.get_state_by_name(WorldState)
-            npc = _create_monster_npc(encounter, world=self.world)
+            npc = _create_monster_npc(player, encounter, world=self.world)
 
             # Lookup the environment
             env_slug = "grass"
@@ -160,19 +160,17 @@ def _choose_encounter(
 
 
 def _create_monster_npc(
+    player: NPC,
     encounter: EncounterItemModel,
     world: WorldState,
 ) -> NPC:
     current_monster = monster.Monster()
     current_monster.load_from_db(encounter.monster)
-    # Set the monster's level based on the specified level range
-    if len(encounter.level_range) > 1:
-        level = random.randrange(
-            encounter.level_range[0],
-            encounter.level_range[1],
-        )
-    else:
-        level = encounter.level_range[0]
+    # Set the monster's level based on the party level
+    level = random.randint(
+        player.game_variables["party_level_lowest"],
+        player.game_variables["party_level_highest"],
+    )
     # Set the monster's level
     current_monster.level = 1
     current_monster.set_level(level)


### PR DESCRIPTION
PR addresses:
- the removal of level_range from the JSON of encounters;
- the addition of the following code under random_encounters;

```
    # Set the monster's level based on the party level
    level = random.randint(
        player.game_variables["party_level_lowest"],
        player.game_variables["party_level_highest"],  --> we can use average instead of highest
    )
```
Reason? The random_encounters doesn't follow the development of the party. It's static, we have a range, but we are obliged to insert another field or JSON to mimic the party development.

The proposal is replace **level_range** with a random value that mimics the party. The range of the value is the **minimum** and the **maximum** level of the party. 

_For instance:
let's consider a party with 2 monsters, the weakest  lv 4, the strongest lv 12
the wild monster will be a random between 4 and 12
(if we use average, the random will be between 4 and 8)_

In this way we can remove a field from the JSON and centralizing the operation in the action file. For exceptions we can link the encounter_rate to the level, in some cases I saw 100, and the level range was 100, it takes nothing to add an exception (like if encounter_rate >= 50? only three cases or better == 100).

What do you think @Sanglorian ?

Pro? removing a field from the JSON, helping the player to level_up the new captured monsters
Cons? single monster party, very high level, like a single monster lv20, both value will be 20, but we can address it with counting the number of monsters in the party and setting the minimum to 1 (?).