### PR TITLE
combatwin message

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -174,7 +174,7 @@ msgid "combat_victory"
 msgstr "You have won!"
 
 msgid "combat_victory_trainer"
-msgstr "You have won against {npc} and you get {currency}{prize}!"
+msgstr "You have won against {npc}!\n You get {currency}{prize}!"
 
 msgid "combat_defeat"
 msgstr "You've been defeated!"


### PR DESCRIPTION
PR addresses the "combat_victory_trainer" in PO.

"combat_victory_trainer" is too long.
It gets cut when the NPC name is longer than usual.
Because of this it's not possible to see how much money the player won (the important part).

From: 
"You have won against {npc} and you get {currency}{prize}!"
To:
"You have won {currency}{prize}!"

Got rid of the NPC name, 20 characters saved (without considering the NPC name).