### PR TITLE
modify the setup.py conflict license version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setup(
     url="https://www.tuxemon.org",
     include_package_data=True,
     packages=modules,
-    license="GPLv3",
     long_description="https://github.com/Tuxemon/Tuxemon",
     install_requires=REQUIREMENTS,
     python_requires=">=3.8",


### PR DESCRIPTION
According to the official documentation of setuptools [1] it is not necessary to write the version of the license if it is mentioned in the classifiers.
Furthermore there is conflicting information about the license, in classifiers there is GPLv3 or GPLv3+ and in setup there is GPLv3.

[1] https://packaging.python.org/en/latest/guides/distributing- packages-using-setuptools/#license