### PR TITLE
katacoon and chromeye evolutions

### DIFF
--- a/mods/tuxemon/db/monster/chromeye.json
+++ b/mods/tuxemon/db/monster/chromeye.json
@@ -18,22 +18,22 @@
     ],
     "evolutions": [
         {
-            "path": "",
+            "path": "exception",
             "at_level": 20,
             "monster_slug": "angrito"
         },
         {
-            "path": "",
+            "path": "exception",
             "at_level": 20,
             "monster_slug": "happito"
         },
         {
-            "path": "",
+            "path": "exception",
             "at_level": 20,
             "monster_slug": "neutrito"
         },
         {
-            "path": "",
+            "path": "exception",
             "at_level": 20,
             "monster_slug": "sadito"
         }

--- a/mods/tuxemon/db/monster/katacoon.json
+++ b/mods/tuxemon/db/monster/katacoon.json
@@ -18,12 +18,12 @@
     ],
     "evolutions": [
         {
-            "path": "stat_melee",
+            "path": "exception",
             "at_level": 12,
             "monster_slug": "bugnin"
         },
         {
-            "path": "stat_armour",
+            "path": "exception",
             "at_level": 12,
             "monster_slug": "sumchon"
         }

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -218,6 +218,8 @@ class MonsterEvolutionItemModel(BaseModel):
     monster_slug: str = Field(
         ..., description="The monster slug that this evolution item applies to"
     )
+    # Optional parameters:
+    gender: Optional[GenderType] = Field("", description="Gender parameter")
 
     @validator("monster_slug")
     def monster_exists(cls, v):

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import logging
 import os
+import random
 import uuid
 from math import hypot
 from typing import (
@@ -795,6 +796,23 @@ class NPC(Entity[NPCState]):
             for old_flair in old_monster.flairs.values():
                 if new_flair.category == old_flair.category:
                     new_monster.flairs[new_flair.category] = old_flair
+
+    def evolve_exceptions(self, old_monster: Monster) -> Monster:
+        """
+        Deals with tricky cases of evolution.
+        """
+        if old_monster.slug == "katacoon":
+            if old_monster.melee > old_monster.armour:
+                evolution = "sumchon"
+            elif old_monster.melee < old_monster.armour:
+                evolution = "bugnin"
+            else:
+                options = ["sumchon", "bugnin"]
+                evolution = random.choice(options)
+        if old_monster.slug == "chromeye":
+            options = ["angrito", "happito", "neutrito", "sadito"]
+            evolution = random.choice(options)
+        self.evolve_monster(old_monster, evolution)
 
     def remove_monster_from_storage(self, monster: Monster) -> None:
         """

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -1204,14 +1204,18 @@ class CombatState(CombatAnimations):
                 # check the path field, path field signals evolution item based
                 if not evolution.path:
                     if evolution.at_level <= monster.level:
-                        logger.info(
-                            "{} evolved into {}!".format(
-                                monster.name, evolution.monster_slug
-                            )
-                        )
                         self.players[0].evolve_monster(
                             monster, evolution.monster_slug
                         )
+                elif evolution.path == "gender":
+                    if evolution.at_level <= monster.level:
+                        if evolution.gender == monster.gender:
+                            self.players[0].evolve_monster(
+                                monster, evolution.monster_slug
+                            )
+                elif evolution.path == "exception":
+                    if evolution.at_level <= monster.level:
+                        self.players[0].evolve_exceptions(monster)
 
     def end_combat(self) -> None:
         """End the combat."""


### PR DESCRIPTION
PR addresses two missing evolutions: **katacoon** and **chromeye**.
katacoon as described in wiki
chromeye random

I'm unable to act on others due to missing monster. 

Deleted all the proposals, these weren't considered.

@Sanglorian 