### PR TITLE
add slug and cardinal direction maps

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -702,6 +702,108 @@ msgstr "Whirlwind"
 msgid "wing_tip"
 msgstr "Wing Tip"
 
+## MAP ##
+
+msgid "candy_town"
+msgstr "Candy"
+
+msgid "citypark"
+msgstr "Citypark"
+
+msgid "cotton_town"
+msgstr "Cotton"
+
+msgid "dryadsgrove"
+msgstr "Dryadsgrove"
+
+msgid "flower_city"
+msgstr "Flower"
+
+msgid "leather_town"
+msgstr "Leather"
+
+msgid "paper_town"
+msgstr "Paper"
+
+msgid "route1"
+msgstr "Route 1"
+
+msgid "route1_sanglorian"
+msgstr "Sanglorian Avenue"
+
+msgid "route2"
+msgstr "Route 2"
+
+msgid "route3"
+msgstr "Route 3"
+
+msgid "route4"
+msgstr "Route 4"
+
+msgid "route5"
+msgstr "Route 5"
+
+msgid "route6"
+msgstr "Route 6"
+
+msgid "routea"
+msgstr "Route A"
+
+msgid "routec"
+msgstr "Route C"
+
+msgid "routed"
+msgstr "Route D"
+
+msgid "routee"
+msgstr "route E"
+
+msgid "taba_town"
+msgstr "Taba"
+
+msgid "timber_town"
+msgstr "Timber"
+
+msgid "tunnel"
+msgstr "Tunnel"
+
+## MAP DESCRIPTIONS TOWN / CITY ##
+
+msgid "candy_town_description"
+msgstr "Candy Town Slogan"
+
+msgid "cotton_town_description"
+msgstr "A growing force!"
+
+msgid "flower_city_description"
+msgstr "Uniforms that guard you while you sleep!"
+
+msgid "leather_town_description"
+msgstr "Proof that beauty and mining can co-exist!"
+
+msgid "paper_town_description"
+msgstr "The gateway to Fondent!"
+
+msgid "taba_town_description"
+msgstr "A peaceful refuge!"
+
+msgid "timber_town_description"
+msgstr "Breadbasket of Fondant!"
+
+## MAP SIGNS ##
+
+msgid "welcome_location_city"
+msgstr "Welcome to ${{map_name}} City: ${{map_desc}}\n"
+"North: ${{north}} / South: ${{south}} / West: ${{west}} / East: ${{east}}"
+
+msgid "welcome_location_route"
+msgstr "Welcome to ${{map_name}}: ${{map_desc}}\n"
+"North: ${{north}} / South: ${{south}} / West: ${{west}} / East: ${{east}}"
+
+msgid "welcome_location_town"
+msgstr "Welcome to ${{map_name}} Town: ${{map_desc}}\n"
+"North: ${{north}} / South: ${{south}} / West: ${{west}} / East: ${{east}}"
+
 ## MENU TRANSLATIONS ##
 
 msgid "menu_alphabet"
@@ -2683,10 +2785,6 @@ msgstr "Cathedral Center: We Live to Serve."
 
 msgid "Cotton_Mart"
 msgstr "Get the scoop at the Scoop Store!"
-
-msgid "Cotton_Town_Sign\n"
-msgstr "Welcome to Cotton Town: A Growing Force\n" 
-"↑ Cotton Town --- Route 1 ↓\n"
 
 msgid "column1"
 msgstr "A rare and ancient column. This used to be part of a temple."
@@ -4901,14 +4999,10 @@ msgid "_mk01alpha"
 msgstr "Mk01 Alpha"
 
 
-
 ## MESSAGE TRANSLATIONS ##
 # spyder messages
 msgid "spyder_multi_underrepairs"
 msgstr "The sign reads, 'Under repairs'"
-
-msgid "spyder_papertown_townsign"
-msgstr "Paper Town: The gateway to Fondent!"
 
 msgid "spyder_multi_martsign"
 msgstr "Buy things here"
@@ -4937,8 +5031,6 @@ msgstr "What's on TV? A prom queen is breaking her tiara into pieces and handing
 msgid "spyder_citypark_achievement"
 msgstr "Achievement Maniac's House: Closed."
 
-msgid "spyder_cottontown_townsign" 
-msgstr "Welcome to Cotton Town: A growing force." 
 msgid "spyder_route2_routesign" 
 msgstr "Welcome to Route 2: The historic path." 
 msgid "spyder_citypark_routesign" 
@@ -4973,8 +5065,6 @@ msgid "spyder_nimrod4_plaque"
 msgstr "But soon, tuxemon and humans may be rendered obsolete. \n Our corporate sponsors Nimrod are developing robot technology that could make war a bloodless affair. \n In the meantime, sign up for the Nimrod Enforcers for good pay, free education and a life of adventure."
 msgid "spyder_route3_sign"
 msgstr "Route 3: Rehabilitation will begin as soon as possible. \n Please stop nagging us."
-msgid "spyder_leathertown_sign"
-msgstr "Leather Town: Proof that beauty and mining can co-exist."
 msgid "spyder_shaft1_sign"
 msgstr "Shaft Headquarters: Mining Division"
 msgid "spyder_shaft2_sign"
@@ -4984,8 +5074,6 @@ msgstr "Open Air Cafe and Marketplace"
 msgid "spyder_leathercbd_sign"
 msgstr "Leather Town Business District"
 
-msgid "spyder_flower_sign"
-msgstr "Flower City: Uniforms that guard you while you sleep"
 msgid "spyder_route5_sign"
 msgstr "The memorial passage to Timber Town"
 msgid "spyder_leatherhouse1_radio"
@@ -5001,8 +5089,6 @@ msgstr "Haha, suckers - you'll never find me. \n It's on the Omnichannel CEO's l
 
 msgid "spyder_cottonhouse1_tvwatch"
 msgstr "It's the latest reality show: people and their tuxemon complete challenges on a remote island."
-msgid "spyder_timber_sign"
-msgstr "Timber Town: Breadbasket of Fondant."
 
 
 ## Item descriptions ##
@@ -5020,18 +5106,6 @@ msgid "sledgehammer_description"
 msgstr "Smash apart grey boulders."
 msgid "sledgehammer"
 msgstr "Sledgehammer"
-msgid "timber"
-msgstr "Timber Town"
-msgid "flower"
-msgstr "Flower City"
-msgid "paper"
-msgstr "Paper Town"
-msgid "candy"
-msgstr "Candy Town"
-msgid "cotton"
-msgstr "Cotton Town"
-msgid "leather"
-msgstr "Leather Town"
 
 msgid "cannot_use_item_monster"
 msgstr "This item cannot be used on this monster."
@@ -5166,8 +5240,6 @@ msgid "taba_town_sign_tuxemart"
 msgstr "Tuxemart - A place to buy and sell items"
 msgid "taba_town_sign_tuxecenter"
 msgstr "Tuxecenter - A place to heal your tuxemon"
-msgid "taba_town_sign"
-msgstr "Taba Town - A peaceful refuge"
 msgid "taba_town_route20"
 msgstr "Route 20"
 

--- a/mods/tuxemon/maps/candy_town.tmx
+++ b/mods/tuxemon/maps/candy_town.tmx
@@ -3,7 +3,9 @@
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="candy_town"/>
   <property name="town" type="bool" value="true"/>
+  <property name="south" value="route6"/>
  </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>

--- a/mods/tuxemon/maps/citypark.tmx
+++ b/mods/tuxemon/maps/citypark.tmx
@@ -2,6 +2,10 @@
 <map version="1.5" tiledversion="1.7.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="124">
  <properties>
   <property name="edges" value="clamped"/>
+  <property name="scenario" value="xero"/>
+  <property name="slug" value="citypark"/>
+  <property name="south" value="route2"/>
+  <property name="east" value="leather_town"/>
  </properties>
  <tileset firstgid="1" name="My_tuxemon_sheet" tilewidth="16" tileheight="16" tilecount="104" columns="8">
   <image source="../gfx/tilesets/My_tuxemon_sheet.png" width="128" height="208"/>
@@ -376,8 +380,7 @@
   </object>
   <object id="102" name="Sign: Leather Town" type="event" x="608" y="160" width="16" height="16">
    <properties>
-    <property name="act10" value="translated_dialog spyder_leathertown_sign"/>
-    <property name="act20" value="translated_dialog citypark_route_sign"/>
+    <property name="act10" value="translated_dialog citypark_route_sign"/>
     <property name="cond10" value="is player_facing_tile"/>
     <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>

--- a/mods/tuxemon/maps/cotton_cafe.tmx
+++ b/mods/tuxemon/maps/cotton_cafe.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="cotton_cafe"/>
  </properties>
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>

--- a/mods/tuxemon/maps/cotton_cathedral.tmx
+++ b/mods/tuxemon/maps/cotton_cathedral.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="cotton_cathedral"/>
  </properties>
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>

--- a/mods/tuxemon/maps/cotton_scoop.tmx
+++ b/mods/tuxemon/maps/cotton_scoop.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="cotton_scoop"/>
  </properties>
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>

--- a/mods/tuxemon/maps/cotton_town.tmx
+++ b/mods/tuxemon/maps/cotton_town.tmx
@@ -3,7 +3,11 @@
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="cotton_town"/>
   <property name="town" type="bool" value="true"/>
+  <property name="south" value="route1_sanglorian"/>
+  <property name="east" value="dryadsgrove"/>
+  <property name="west" value="route2"/>
  </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>
@@ -325,7 +329,7 @@
   </object>
   <object id="245" name="Sign: Cotton Town" type="event" x="240" y="608" width="16" height="16">
    <properties>
-    <property name="act10" value="translated_dialog Cotton_Town_Sign\n"/>
+    <property name="act10" value="translated_dialog welcome_location_town"/>
     <property name="cond10" value="is player_facing up"/>
     <property name="cond20" value="is button_pressed K_RETURN"/>
     <property name="cond30" value="is player_at"/>

--- a/mods/tuxemon/maps/daycare.tmx
+++ b/mods/tuxemon/maps/daycare.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="daycare"/>
  </properties>
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>

--- a/mods/tuxemon/maps/dojo1.tmx
+++ b/mods/tuxemon/maps/dojo1.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="dojo1"/>
  </properties>
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>

--- a/mods/tuxemon/maps/dojo2.tmx
+++ b/mods/tuxemon/maps/dojo2.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="dojo2"/>
  </properties>
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>

--- a/mods/tuxemon/maps/dojo3.tmx
+++ b/mods/tuxemon/maps/dojo3.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="dojo3"/>
  </properties>
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>

--- a/mods/tuxemon/maps/dragonscave.tmx
+++ b/mods/tuxemon/maps/dragonscave.tmx
@@ -4,6 +4,7 @@
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="dragonscave"/>
  </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>

--- a/mods/tuxemon/maps/dryadsgrove.tmx
+++ b/mods/tuxemon/maps/dryadsgrove.tmx
@@ -4,6 +4,8 @@
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="dryadsgrove"/>
+  <property name="west" value="cotton_town"/>
  </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>

--- a/mods/tuxemon/maps/flower_city.tmx
+++ b/mods/tuxemon/maps/flower_city.tmx
@@ -4,6 +4,10 @@
   <property name="edges" value="clamped"/>
   <property name="town" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="flower_city"/>
+  <property name="north" value="routea"/>
+  <property name="east" value="route5"/>
+  <property name="west" value="route4"/>
  </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>

--- a/mods/tuxemon/maps/healing_center.tmx
+++ b/mods/tuxemon/maps/healing_center.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="healing_center"/>
  </properties>
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>

--- a/mods/tuxemon/maps/leather_scoop.tmx
+++ b/mods/tuxemon/maps/leather_scoop.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="leather_scoop"/>
  </properties>
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>

--- a/mods/tuxemon/maps/leather_town.tmx
+++ b/mods/tuxemon/maps/leather_town.tmx
@@ -3,7 +3,10 @@
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="leather_town"/>
   <property name="town" type="bool" value="true"/>
+  <property name="north" value="route3"/>
+  <property name="west" value="citypark"/>
  </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>

--- a/mods/tuxemon/maps/mansion.tmx
+++ b/mods/tuxemon/maps/mansion.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="mansion"/>
  </properties>
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>

--- a/mods/tuxemon/maps/mansion_basement.tmx
+++ b/mods/tuxemon/maps/mansion_basement.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="mansion_basement"/>
  </properties>
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>

--- a/mods/tuxemon/maps/mansion_top.tmx
+++ b/mods/tuxemon/maps/mansion_top.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="mansion_top"/>
  </properties>
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>

--- a/mods/tuxemon/maps/maple_house.tmx
+++ b/mods/tuxemon/maps/maple_house.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="maple_house"/>
  </properties>
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>

--- a/mods/tuxemon/maps/omnichannel1.tmx
+++ b/mods/tuxemon/maps/omnichannel1.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="omnichannel1"/>
  </properties>
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>

--- a/mods/tuxemon/maps/omnichannel2.tmx
+++ b/mods/tuxemon/maps/omnichannel2.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="omnichannel2"/>
  </properties>
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>

--- a/mods/tuxemon/maps/omnichannel3.tmx
+++ b/mods/tuxemon/maps/omnichannel3.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="omnichannel3"/>
  </properties>
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>

--- a/mods/tuxemon/maps/omnichannel4.tmx
+++ b/mods/tuxemon/maps/omnichannel4.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="omnichannel4"/>
  </properties>
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>

--- a/mods/tuxemon/maps/player_house_bedroom.tmx
+++ b/mods/tuxemon/maps/player_house_bedroom.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="bedroom"/>
  </properties>
  <tileset firstgid="1" name="floors and walls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>

--- a/mods/tuxemon/maps/player_house_downstairs.tmx
+++ b/mods/tuxemon/maps/player_house_downstairs.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="downstairs"/>
  </properties>
  <tileset firstgid="1" name="floors and walls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>

--- a/mods/tuxemon/maps/professor_lab.tmx
+++ b/mods/tuxemon/maps/professor_lab.tmx
@@ -4,6 +4,7 @@
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="professor_lab"/>
  </properties>
  <tileset firstgid="1" name="furniture" tilewidth="16" tileheight="16" tilecount="72" columns="12">
   <image source="../gfx/tilesets/furniture.png" width="192" height="96"/>

--- a/mods/tuxemon/maps/route1.tmx
+++ b/mods/tuxemon/maps/route1.tmx
@@ -3,6 +3,9 @@
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="route1"/>
+  <property name="north" value="route1_sanglorian"/>
+  <property name="west" value="taba_town"/>
  </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>

--- a/mods/tuxemon/maps/route1_sanglorian.tmx
+++ b/mods/tuxemon/maps/route1_sanglorian.tmx
@@ -3,6 +3,9 @@
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="route1_sanglorian"/>
+  <property name="north" value="cotton_town"/>
+  <property name="south" value="route1"/>
  </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>

--- a/mods/tuxemon/maps/route2.tmx
+++ b/mods/tuxemon/maps/route2.tmx
@@ -3,6 +3,9 @@
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="route2"/>
+  <property name="north" value="citypark"/>
+  <property name="east" value="cotton_town"/>
  </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>

--- a/mods/tuxemon/maps/route3.tmx
+++ b/mods/tuxemon/maps/route3.tmx
@@ -3,6 +3,9 @@
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="route3"/>
+  <property name="north" value="route4"/>
+  <property name="south" value="leather_town"/>
  </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>

--- a/mods/tuxemon/maps/route4.tmx
+++ b/mods/tuxemon/maps/route4.tmx
@@ -3,6 +3,9 @@
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="route4"/>
+  <property name="south" value="route3"/>
+  <property name="east" value="flower_city"/>
  </properties>
  <tileset firstgid="1" name="My_tuxemon_sheet" tilewidth="16" tileheight="16" tilecount="104" columns="8">
   <image source="../gfx/tilesets/My_tuxemon_sheet.png" width="128" height="208"/>

--- a/mods/tuxemon/maps/route5.tmx
+++ b/mods/tuxemon/maps/route5.tmx
@@ -3,6 +3,9 @@
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="route5"/>
+  <property name="east" value="timber_town"/>
+  <property name="west" value="flower_city"/>
  </properties>
  <tileset firstgid="1" name="PastTheFuture_Grass_Sand_Snow" tilewidth="16" tileheight="16" tilecount="360" columns="24">
   <image source="../gfx/tilesets/PastTheFuture_Grass_Sand_Snow.png" width="384" height="240"/>

--- a/mods/tuxemon/maps/route6.tmx
+++ b/mods/tuxemon/maps/route6.tmx
@@ -3,6 +3,9 @@
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="route6"/>
+  <property name="north" value="candy_town"/>
+  <property name="east" value="tunnel"/>
  </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>

--- a/mods/tuxemon/maps/routea.tmx
+++ b/mods/tuxemon/maps/routea.tmx
@@ -3,6 +3,8 @@
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="routea"/>
+  <property name="south" value="flower_city"/>
  </properties>
  <tileset firstgid="1" name="PastTheFuture_Grass_Sand_Snow" tilewidth="16" tileheight="16" tilecount="360" columns="24">
   <image source="../gfx/tilesets/PastTheFuture_Grass_Sand_Snow.png" width="384" height="240"/>

--- a/mods/tuxemon/maps/routec.tmx
+++ b/mods/tuxemon/maps/routec.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="routec"/>
  </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>

--- a/mods/tuxemon/maps/scoop1.tmx
+++ b/mods/tuxemon/maps/scoop1.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="scoop1"/>
  </properties>
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>

--- a/mods/tuxemon/maps/scoop2.tmx
+++ b/mods/tuxemon/maps/scoop2.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="scoop2"/>
  </properties>
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>

--- a/mods/tuxemon/maps/scoop3.tmx
+++ b/mods/tuxemon/maps/scoop3.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="scoop3"/>
  </properties>
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>

--- a/mods/tuxemon/maps/scoop4.tmx
+++ b/mods/tuxemon/maps/scoop4.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="scoop4"/>
  </properties>
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>

--- a/mods/tuxemon/maps/spyder_bedroom.tmx
+++ b/mods/tuxemon/maps/spyder_bedroom.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="bedroom"/>
  </properties>
  <tileset firstgid="1" name="floors and walls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>

--- a/mods/tuxemon/maps/spyder_candy_center.tmx
+++ b/mods/tuxemon/maps/spyder_candy_center.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="candy_center"/>
  </properties>
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>

--- a/mods/tuxemon/maps/spyder_candy_house1.tmx
+++ b/mods/tuxemon/maps/spyder_candy_house1.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="candy_house1"/>
  </properties>
  <tileset firstgid="1" name="floors and walls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>

--- a/mods/tuxemon/maps/spyder_candy_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_candy_scoop.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="candy_scoop"/>
  </properties>
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>

--- a/mods/tuxemon/maps/spyder_candy_town.tmx
+++ b/mods/tuxemon/maps/spyder_candy_town.tmx
@@ -3,7 +3,10 @@
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="candy_town"/>
   <property name="town" type="bool" value="true"/>
+  <property name="north" value="route6"/>
+  <property name="east" value="routec"/>
  </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>

--- a/mods/tuxemon/maps/spyder_citypark.tmx
+++ b/mods/tuxemon/maps/spyder_citypark.tmx
@@ -3,6 +3,9 @@
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="citypark"/>
+  <property name="south" value="route2"/>
+  <property name="east" value="leather_town"/>
  </properties>
  <tileset firstgid="1" name="My_tuxemon_sheet" tilewidth="16" tileheight="16" tilecount="104" columns="8">
   <image source="../gfx/tilesets/My_tuxemon_sheet.png" width="128" height="208"/>
@@ -251,7 +254,7 @@
   </object>
   <object id="102" name="Sign: Leather Town" type="event" x="16" y="192" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_leathertown_sign"/>
+    <property name="act1" value="translated_dialog spyder_citypark_routesign"/>
     <property name="cond1" value="is player_facing_tile"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_cotton_artshop.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_artshop.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="cotton_artshop"/>
  </properties>
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>

--- a/mods/tuxemon/maps/spyder_cotton_cafe.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_cafe.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="cotton_cafe"/>
  </properties>
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>

--- a/mods/tuxemon/maps/spyder_cotton_house1.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_house1.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="cotton_house1"/>
  </properties>
  <tileset firstgid="1" name="floors and walls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>

--- a/mods/tuxemon/maps/spyder_cotton_house2.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_house2.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="cotton_house2"/>
  </properties>
  <tileset firstgid="1" name="floors and walls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>

--- a/mods/tuxemon/maps/spyder_cotton_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_scoop.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="cotton_scoop"/>
  </properties>
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>

--- a/mods/tuxemon/maps/spyder_cotton_town.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_town.tmx
@@ -3,7 +3,11 @@
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="cotton_town"/>
   <property name="town" type="bool" value="true"/>
+  <property name="south" value="route1"/>
+  <property name="east" value="dryadsgrove"/>
+  <property name="west" value="route2"/>
  </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>
@@ -390,7 +394,7 @@
   </object>
   <object id="561" name="Sign: Cotton Town" type="event" x="384" y="592" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_cottontown_townsign"/>
+    <property name="act1" value="translated_dialog welcome_location_town"/>
     <property name="cond1" value="is player_facing_tile"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_cotton_tunnel.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_tunnel.tmx
@@ -4,6 +4,7 @@
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="cotton_tunnel"/>
  </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>

--- a/mods/tuxemon/maps/spyder_daycare.tmx
+++ b/mods/tuxemon/maps/spyder_daycare.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="daycare"/>
  </properties>
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>

--- a/mods/tuxemon/maps/spyder_dojo1.tmx
+++ b/mods/tuxemon/maps/spyder_dojo1.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="dojo1"/>
  </properties>
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>

--- a/mods/tuxemon/maps/spyder_dojo2.tmx
+++ b/mods/tuxemon/maps/spyder_dojo2.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="dojo2"/>
  </properties>
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>

--- a/mods/tuxemon/maps/spyder_dojo3.tmx
+++ b/mods/tuxemon/maps/spyder_dojo3.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="dojo3"/>
  </properties>
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>

--- a/mods/tuxemon/maps/spyder_downstairs.tmx
+++ b/mods/tuxemon/maps/spyder_downstairs.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="downstairs"/>
  </properties>
  <tileset firstgid="1" name="floors and walls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>

--- a/mods/tuxemon/maps/spyder_dragonscave.tmx
+++ b/mods/tuxemon/maps/spyder_dragonscave.tmx
@@ -4,6 +4,7 @@
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="dragonscave"/>
  </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>

--- a/mods/tuxemon/maps/spyder_dryadsgrove.tmx
+++ b/mods/tuxemon/maps/spyder_dryadsgrove.tmx
@@ -4,6 +4,8 @@
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="dryadsgrove"/>
+  <property name="west" value="cotton_town"/>
  </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>

--- a/mods/tuxemon/maps/spyder_flower_center.tmx
+++ b/mods/tuxemon/maps/spyder_flower_center.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="flower_center"/>
  </properties>
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>

--- a/mods/tuxemon/maps/spyder_flower_city.tmx
+++ b/mods/tuxemon/maps/spyder_flower_city.tmx
@@ -3,7 +3,11 @@
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="flower_city"/>
   <property name="town" type="bool" value="true"/>
+  <property name="north" value="routea"/>
+  <property name="east" value="route5"/>
+  <property name="west" value="route4"/>
  </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>
@@ -285,7 +289,7 @@
   </object>
   <object id="410" name="Sign: Flower City" type="event" x="576" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_flower_sign"/>
+    <property name="act1" value="translated_dialog welcome_location_city"/>
     <property name="cond1" value="is player_facing_tile"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_flower_house1.tmx
+++ b/mods/tuxemon/maps/spyder_flower_house1.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="flower_house1"/>
  </properties>
  <tileset firstgid="1" name="floors and walls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>

--- a/mods/tuxemon/maps/spyder_flower_house2.tmx
+++ b/mods/tuxemon/maps/spyder_flower_house2.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="flower_house2"/>
  </properties>
  <tileset firstgid="1" name="floors and walls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>

--- a/mods/tuxemon/maps/spyder_flower_petshop.tmx
+++ b/mods/tuxemon/maps/spyder_flower_petshop.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="flower_petshop"/>
  </properties>
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>

--- a/mods/tuxemon/maps/spyder_flower_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_flower_scoop.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="flower_scoop"/>
  </properties>
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>

--- a/mods/tuxemon/maps/spyder_greenwash.tmx
+++ b/mods/tuxemon/maps/spyder_greenwash.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="greenwash"/>
  </properties>
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>

--- a/mods/tuxemon/maps/spyder_greenwash_greenhouse.tmx
+++ b/mods/tuxemon/maps/spyder_greenwash_greenhouse.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="greenwash_greenhouse"/>
  </properties>
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>

--- a/mods/tuxemon/maps/spyder_greenwash_level2.tmx
+++ b/mods/tuxemon/maps/spyder_greenwash_level2.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="greenwash_level2"/>
  </properties>
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>

--- a/mods/tuxemon/maps/spyder_healing_center.tmx
+++ b/mods/tuxemon/maps/spyder_healing_center.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="healing_center"/>
  </properties>
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>

--- a/mods/tuxemon/maps/spyder_hospital.tmx
+++ b/mods/tuxemon/maps/spyder_hospital.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="hospital"/>
  </properties>
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>

--- a/mods/tuxemon/maps/spyder_hospital_alt.tmx
+++ b/mods/tuxemon/maps/spyder_hospital_alt.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="hospital_alt"/>
  </properties>
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>

--- a/mods/tuxemon/maps/spyder_house5.tmx
+++ b/mods/tuxemon/maps/spyder_house5.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="house5"/>
  </properties>
  <tileset firstgid="1" name="floors and walls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>

--- a/mods/tuxemon/maps/spyder_house6.tmx
+++ b/mods/tuxemon/maps/spyder_house6.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="house6"/>
  </properties>
  <tileset firstgid="1" name="floors and walls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>

--- a/mods/tuxemon/maps/spyder_leather_center.tmx
+++ b/mods/tuxemon/maps/spyder_leather_center.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="leather_center"/>
  </properties>
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>

--- a/mods/tuxemon/maps/spyder_leather_house1.tmx
+++ b/mods/tuxemon/maps/spyder_leather_house1.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="leather_house1"/>
  </properties>
  <tileset firstgid="1" name="floors and walls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>

--- a/mods/tuxemon/maps/spyder_leather_house2.tmx
+++ b/mods/tuxemon/maps/spyder_leather_house2.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="leather_house2"/>
  </properties>
  <tileset firstgid="1" name="floors and walls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>

--- a/mods/tuxemon/maps/spyder_leather_museum.tmx
+++ b/mods/tuxemon/maps/spyder_leather_museum.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="leather_museum"/>
  </properties>
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>

--- a/mods/tuxemon/maps/spyder_leather_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_leather_scoop.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="leather_scoop"/>
  </properties>
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>

--- a/mods/tuxemon/maps/spyder_leather_town.tmx
+++ b/mods/tuxemon/maps/spyder_leather_town.tmx
@@ -4,6 +4,9 @@
   <property name="edges" value="clamped"/>
   <property name="town" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="leather_town"/>
+  <property name="north" value="route3"/>
+  <property name="west" value="citypark"/>
  </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>
@@ -228,7 +231,7 @@
   </object>
   <object id="269" name="Sign: Leather Town" type="event" x="576" y="480" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_leathertown_sign"/>
+    <property name="act1" value="translated_dialog welcome_location_town"/>
     <property name="cond1" value="is player_facing_tile"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_mansion.tmx
+++ b/mods/tuxemon/maps/spyder_mansion.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="mansion"/>
  </properties>
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>

--- a/mods/tuxemon/maps/spyder_mansion_basement.tmx
+++ b/mods/tuxemon/maps/spyder_mansion_basement.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="mansion_basement"/>
  </properties>
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>

--- a/mods/tuxemon/maps/spyder_mansion_top.tmx
+++ b/mods/tuxemon/maps/spyder_mansion_top.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="mansion_top"/>
  </properties>
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>

--- a/mods/tuxemon/maps/spyder_nimrod_bottom.tmx
+++ b/mods/tuxemon/maps/spyder_nimrod_bottom.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="nimrod_bottom"/>
  </properties>
  <tileset firstgid="1" name="factory" tilewidth="16" tileheight="16" tilecount="32" columns="8">
   <image source="../gfx/tilesets/factory.png" width="128" height="64"/>

--- a/mods/tuxemon/maps/spyder_nimrod_middle.tmx
+++ b/mods/tuxemon/maps/spyder_nimrod_middle.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="nimrod_middle"/>
  </properties>
  <tileset firstgid="1" name="factory" tilewidth="16" tileheight="16" tilecount="32" columns="8">
   <image source="../gfx/tilesets/factory.png" width="128" height="64"/>

--- a/mods/tuxemon/maps/spyder_nimrod_top.tmx
+++ b/mods/tuxemon/maps/spyder_nimrod_top.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="nimrod_top"/>
  </properties>
  <tileset firstgid="1" name="factory" tilewidth="16" tileheight="16" tilecount="32" columns="8">
   <image source="../gfx/tilesets/factory.png" width="128" height="64"/>

--- a/mods/tuxemon/maps/spyder_omnichannel1.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel1.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="omnichannel1"/>
  </properties>
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>

--- a/mods/tuxemon/maps/spyder_omnichannel2.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel2.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="omnichannel2"/>
  </properties>
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>

--- a/mods/tuxemon/maps/spyder_omnichannel3.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel3.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="omnichannel3"/>
  </properties>
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>

--- a/mods/tuxemon/maps/spyder_omnichannel4.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel4.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="omnichannel4"/>
  </properties>
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>

--- a/mods/tuxemon/maps/spyder_paper_mart.tmx
+++ b/mods/tuxemon/maps/spyder_paper_mart.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="paper_mart"/>
  </properties>
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>

--- a/mods/tuxemon/maps/spyder_paper_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_paper_scoop.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="paper_scoop"/>
  </properties>
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>

--- a/mods/tuxemon/maps/spyder_paper_town.tmx
+++ b/mods/tuxemon/maps/spyder_paper_town.tmx
@@ -3,7 +3,10 @@
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="paper_town"/>
   <property name="town" type="bool" value="true"/>
+  <property name="north" value="route1"/>
+  <property name="west" value="routec"/>
  </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>
@@ -235,7 +238,7 @@
   </object>
   <object id="339" name="Paper Town Sign" type="event" x="192" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_papertown_townsign"/>
+    <property name="act1" value="translated_dialog welcome_location_town"/>
     <property name="cond1" value="is player_facing_tile"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_radiotower.tmx
+++ b/mods/tuxemon/maps/spyder_radiotower.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="radiotower"/>
  </properties>
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>

--- a/mods/tuxemon/maps/spyder_route1.tmx
+++ b/mods/tuxemon/maps/spyder_route1.tmx
@@ -3,6 +3,9 @@
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="route1"/>
+  <property name="north" value="cotton_town"/>
+  <property name="south" value="paper_town"/>
  </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>

--- a/mods/tuxemon/maps/spyder_route2.tmx
+++ b/mods/tuxemon/maps/spyder_route2.tmx
@@ -3,6 +3,9 @@
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="route2"/>
+  <property name="north" value="citypark"/>
+  <property name="east" value="cotton_town"/>
  </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>

--- a/mods/tuxemon/maps/spyder_route3.tmx
+++ b/mods/tuxemon/maps/spyder_route3.tmx
@@ -3,6 +3,9 @@
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="route3"/>
+  <property name="south" value="leather_town"/>
+  <property name="east" value="route4"/>
  </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>

--- a/mods/tuxemon/maps/spyder_route4.tmx
+++ b/mods/tuxemon/maps/spyder_route4.tmx
@@ -3,6 +3,9 @@
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="route4"/>
+  <property name="east" value="flower_city"/>
+  <property name="west" value="route3"/>
  </properties>
  <tileset firstgid="1" name="My_tuxemon_sheet" tilewidth="16" tileheight="16" tilecount="104" columns="8">
   <image source="../gfx/tilesets/My_tuxemon_sheet.png" width="128" height="208"/>

--- a/mods/tuxemon/maps/spyder_route5.tmx
+++ b/mods/tuxemon/maps/spyder_route5.tmx
@@ -3,6 +3,9 @@
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="route5"/>
+  <property name="south" value="timber_town"/>
+  <property name="west" value="flower_city"/>
  </properties>
  <tileset firstgid="1" name="PastTheFuture_Grass_Sand_Snow" tilewidth="16" tileheight="16" tilecount="360" columns="24">
   <image source="../gfx/tilesets/PastTheFuture_Grass_Sand_Snow.png" width="384" height="240"/>

--- a/mods/tuxemon/maps/spyder_route6.tmx
+++ b/mods/tuxemon/maps/spyder_route6.tmx
@@ -3,6 +3,9 @@
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="route6"/>
+  <property name="south" value="candy_town"/>
+  <property name="east" value="tunnel"/>
  </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>

--- a/mods/tuxemon/maps/spyder_routea.tmx
+++ b/mods/tuxemon/maps/spyder_routea.tmx
@@ -3,6 +3,8 @@
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="routea"/>
+  <property name="south" value="flower_city"/>
  </properties>
  <tileset firstgid="1" name="PastTheFuture_Grass_Sand_Snow" tilewidth="16" tileheight="16" tilecount="360" columns="24">
   <image source="../gfx/tilesets/PastTheFuture_Grass_Sand_Snow.png" width="384" height="240"/>

--- a/mods/tuxemon/maps/spyder_routec.tmx
+++ b/mods/tuxemon/maps/spyder_routec.tmx
@@ -3,6 +3,9 @@
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="routec"/>
+  <property name="east" value="paper_town"/>
+  <property name="west" value="candy_town"/>
  </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>

--- a/mods/tuxemon/maps/spyder_routed.tmx
+++ b/mods/tuxemon/maps/spyder_routed.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="routed"/>
  </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>

--- a/mods/tuxemon/maps/spyder_routee.tmx
+++ b/mods/tuxemon/maps/spyder_routee.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="routee"/>
  </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>

--- a/mods/tuxemon/maps/spyder_scoop1.tmx
+++ b/mods/tuxemon/maps/spyder_scoop1.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="scoop1"/>
  </properties>
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>

--- a/mods/tuxemon/maps/spyder_scoop2.tmx
+++ b/mods/tuxemon/maps/spyder_scoop2.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="scoop2"/>
  </properties>
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>

--- a/mods/tuxemon/maps/spyder_scoop3.tmx
+++ b/mods/tuxemon/maps/spyder_scoop3.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="scoop3"/>
  </properties>
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>

--- a/mods/tuxemon/maps/spyder_scoop4.tmx
+++ b/mods/tuxemon/maps/spyder_scoop4.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="scoop4"/>
  </properties>
  <tileset firstgid="1" name="Pacheesi Tiles" tilewidth="16" tileheight="16" tilecount="21" columns="7">
   <image source="../gfx/tilesets/Pacheesi Tiles.png" width="112" height="48"/>

--- a/mods/tuxemon/maps/spyder_timber_center.tmx
+++ b/mods/tuxemon/maps/spyder_timber_center.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="timber_center"/>
  </properties>
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>

--- a/mods/tuxemon/maps/spyder_timber_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_timber_scoop.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="timber_scoop"/>
  </properties>
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>

--- a/mods/tuxemon/maps/spyder_timber_town.tmx
+++ b/mods/tuxemon/maps/spyder_timber_town.tmx
@@ -4,6 +4,9 @@
   <property name="edges" value="clamped"/>
   <property name="town" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="timber_town"/>
+  <property name="north" value="route5"/>
+  <property name="south" value="tunnel"/>
  </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>
@@ -332,7 +335,7 @@
   </object>
   <object id="351" name="Sign: Timber Town" type="event" x="96" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_timber_sign"/>
+    <property name="act1" value="translated_dialog welcome_location_town"/>
     <property name="cond1" value="is player_facing_tile"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_tunnel.tmx
+++ b/mods/tuxemon/maps/spyder_tunnel.tmx
@@ -2,8 +2,10 @@
 <map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="343">
  <properties>
   <property name="edges" value="clamped"/>
-  <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="tunnel"/>
+  <property name="north" value="timber_town"/>
+  <property name="west" value="route6"/>
  </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>

--- a/mods/tuxemon/maps/spyder_tunnel_below.tmx
+++ b/mods/tuxemon/maps/spyder_tunnel_below.tmx
@@ -4,6 +4,7 @@
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="tunnel_below"/>
  </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>

--- a/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
+++ b/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="wayfarer_inn1"/>
  </properties>
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>

--- a/mods/tuxemon/maps/spyder_wayfarer_inn2.tmx
+++ b/mods/tuxemon/maps/spyder_wayfarer_inn2.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
+  <property name="slug" value="wayfarer_inn2"/>
  </properties>
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>

--- a/mods/tuxemon/maps/taba_town.tmx
+++ b/mods/tuxemon/maps/taba_town.tmx
@@ -3,7 +3,9 @@
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="taba_town"/>
   <property name="town" type="bool" value="true"/>
+  <property name="east" value="route1"/>
  </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>
@@ -360,7 +362,7 @@
   </object>
   <object id="112" name="Startup Town Sign" type="event" x="624" y="640" width="16" height="16">
    <properties>
-    <property name="act10" value="translated_dialog taba_town_sign"/>
+    <property name="act10" value="translated_dialog welcome_location_town"/>
     <property name="cond10" value="is player_facing_tile"/>
     <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>

--- a/mods/tuxemon/maps/timber_town.tmx
+++ b/mods/tuxemon/maps/timber_town.tmx
@@ -3,7 +3,10 @@
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="timber_town"/>
   <property name="town" type="bool" value="true"/>
+  <property name="north" value="tunnel"/>
+  <property name="west" value="route5"/>
  </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>

--- a/mods/tuxemon/maps/tunnel.tmx
+++ b/mods/tuxemon/maps/tunnel.tmx
@@ -2,8 +2,10 @@
 <map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="103">
  <properties>
   <property name="edges" value="clamped"/>
-  <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="tunnel"/>
+  <property name="south" value="timber_town"/>
+  <property name="west" value="route6"/>
  </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>

--- a/mods/tuxemon/maps/tunnel_below.tmx
+++ b/mods/tuxemon/maps/tunnel_below.tmx
@@ -4,6 +4,7 @@
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="tunnel_below"/>
  </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>

--- a/mods/tuxemon/maps/tuxe_mart_taba.tmx
+++ b/mods/tuxemon/maps/tuxe_mart_taba.tmx
@@ -4,6 +4,7 @@
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="tuxe_mart_taba"/>
  </properties>
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>

--- a/mods/tuxemon/maps/wayfarer_inn1.tmx
+++ b/mods/tuxemon/maps/wayfarer_inn1.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="wayfarer_inn1"/>
  </properties>
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>

--- a/mods/tuxemon/maps/wayfarer_inn2.tmx
+++ b/mods/tuxemon/maps/wayfarer_inn2.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
+  <property name="slug" value="wayfarer_inn2"/>
  </properties>
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>

--- a/tuxemon/client.py
+++ b/tuxemon/client.py
@@ -184,6 +184,26 @@ class LocalPygameClient:
         self.event_engine.reset()
         self.event_engine.current_map = map_data
         self.maps = map_data.maps
+        self.map_name = map_data.name
+        self.map_desc = map_data.description
+
+        # Cardinal points
+        if map_data.north_trans is None:
+            self.map_north = str("-")
+        else:
+            self.map_north = map_data.north_trans
+        if map_data.south_trans is None:
+            self.map_south = str("-")
+        else:
+            self.map_south = map_data.south_trans
+        if map_data.east_trans is None:
+            self.map_east = str("-")
+        else:
+            self.map_east = map_data.east_trans
+        if map_data.west_trans is None:
+            self.map_west = str("-")
+        else:
+            self.map_west = map_data.west_trans
 
     def draw_event_debug(self) -> None:
         """

--- a/tuxemon/locale.py
+++ b/tuxemon/locale.py
@@ -248,6 +248,13 @@ def replace_text(session: Session, text: str) -> str:
     text = text.replace("${{currency}}", "$")
     text = text.replace(r"\n", "\n")
     text = text.replace("${{money}}", str(session.player.money["player"]))
+    # maps
+    text = text.replace("${{map_name}}", session.client.map_name)
+    text = text.replace("${{map_desc}}", session.client.map_desc)
+    text = text.replace("${{north}}", session.client.map_north)
+    text = text.replace("${{south}}", session.client.map_south)
+    text = text.replace("${{east}}", session.client.map_east)
+    text = text.replace("${{west}}", session.client.map_west)
 
     for i in range(len(session.player.monsters)):
         monster = session.player.monsters[i]

--- a/tuxemon/map.py
+++ b/tuxemon/map.py
@@ -55,6 +55,7 @@ from tuxemon import prepare
 from tuxemon.compat import ReadOnlyRect
 from tuxemon.event import EventObject
 from tuxemon.graphics import scaled_image_loader
+from tuxemon.locale import T
 from tuxemon.math import Vector2, Vector3
 from tuxemon.tools import round_to_divisible
 
@@ -447,6 +448,19 @@ class TuxemonMap:
         self.maps = maps
 
         # optional fields
+        self.slug = maps.get("slug")
+        self.name = T.translate(self.slug)
+        self.description = T.translate(f"{self.slug}_description")
+        # cardinal directions (towns + roads)
+        self.north = maps.get("north")
+        self.south = maps.get("south")
+        self.east = maps.get("east")
+        self.west = maps.get("west")
+        # translated cardinal directions (signs)
+        self.north_trans = T.translate(self.north)
+        self.south_trans = T.translate(self.south)
+        self.east_trans = T.translate(self.east)
+        self.west_trans = T.translate(self.west)
         # inside (true), outside (none)
         self.inside = bool(maps.get("inside"))
         # scenario: spyder, xero or none


### PR DESCRIPTION
PR addresses:
- addition of slug inside the tmx (Spyder and Xero);
- addition of cardinal direction inside the tmx (Spyder and Xero);
- fix a couple of error (previous PR);
- added some replacements in locale.py for the PO files;
- centralized the creation of town and city signs and deleted the duplicates;

about the slug, now we have the distinction (spyder/xero) inside the file, it's not necessary to specify spyder_ inside the file (important to develop a common vocabulary -> translations without duplicates);

about the cardinal direction, now through north/south/east/west we can orient ourselves (mostly scripting) without opening another file or creating a new JSON file

list to remember:
```
bedroom
candy_center
candy_house1
candy_scoop
candy_town
citypark
cotton_artshop
cotton_cafe
cotton_cathedral
cotton_house1
cotton_house2
cotton_scoop
cotton_town
cotton_tunnel
daycare
dojo1
dojo2
dojo3
downstairs
dragonscave
dryadsgrove
flower_center
flower_city
flower_house1
flower_house2
flower_petshop
flower_scoop
greenwash_greenhouse
greenwash_level2
greenwash
healing_center
hospital_alt
hospital
house5
house6
leather_center
leather_house1
leather_house2
leather_museum
leather_scoop
leather_town
mansion_basement
mansion_top
mansion
maple_house
nimrod_bottom
nimrod_middle
nimrod_top
omnichannel1
omnichannel2
omnichannel3
omnichannel4
paper_mart
paper_scoop
paper_town
professor_lab
radiotower
route1_sanglorian
route1
route2
route3
route4
route5
route6
routea
routec
routed
routee
scoop1
scoop2
scoop3
scoop4
taba_town
timber_center
timber_scoop
timber_town
tunnel_below
tunnel
tuxe_mart_taba
wayfarer_inn1
wayfarer_inn2
```