### PR TITLE
confirm evolution

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -733,6 +733,9 @@ msgstr "Are you sure you would like to release {name}?"
 msgid "tuxemon_released"
 msgstr "{name} has been released."
 
+msgid "evolution_confirmation"
+msgstr "Are you sure you would like to evolve {name}?"
+
 # Menu notifications
 msgid "log_off"
 msgstr "Log Off"

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -1201,6 +1201,28 @@ class CombatState(CombatAnimations):
     def evolve(self) -> None:
         for monster in self.players[0].monsters:
             for evolution in monster.evolutions:
+                if evolution.at_level <= monster.level:
+                    self.client.pop_state()
+                    tools.open_dialog(
+                        local_session,
+                        [
+                            T.format(
+                                "evolution_confirmation",
+                                {"name": monster.name},
+                            )
+                        ],
+                    )
+                    tools.open_choice_dialog(
+                        local_session,
+                        menu=(
+                            ("yes", T.translate("yes"), self.positive_answer),
+                            ("no", T.translate("no"), self.negative_answer),
+                        ),
+                    )
+
+    def positive_answer(self) -> None:
+        for monster in self.players[0].monsters:
+            for evolution in monster.evolutions:
                 # check the path field, path field signals evolution item based
                 if not evolution.path:
                     if evolution.at_level <= monster.level:
@@ -1212,6 +1234,12 @@ class CombatState(CombatAnimations):
                         self.players[0].evolve_monster(
                             monster, evolution.monster_slug
                         )
+        self.client.pop_state()
+        self.client.pop_state()
+
+    def negative_answer(self) -> None:
+        self.client.pop_state()
+        self.client.pop_state()
 
     def end_combat(self) -> None:
         """End the combat."""


### PR DESCRIPTION
PR addresses the introduction of the choice for evolution.

Right now the monsters evolve (the ones without path aka conditions) as soon as the battle is ended.

With this PR, it'll appear (after the last message of the trainer) the following menu:
![Screenshot from 2022-11-13 15-53-09](https://user-images.githubusercontent.com/64643719/201528306-839242d2-de92-4e30-8340-a1d5c922b1f3.png)
