### PR TITLE
time: seasons

### DIFF
--- a/tuxemon/config.py
+++ b/tuxemon/config.py
@@ -96,6 +96,7 @@ class TuxemonConfig:
             "net_controller_enabled",
         )
         self.locale = cfg.get("game", "locale")
+        self.hemisphere = cfg.get("game", "hemisphere")
         self.dev_tools = cfg.getboolean("game", "dev_tools")
         self.recompile_translations = cfg.getboolean(
             "game",
@@ -275,6 +276,7 @@ def get_defaults() -> Mapping[str, Any]:
                         ("cli_enabled", False),
                         ("net_controller_enabled", False),
                         ("locale", "en_US"),
+                        ("hemisphere", "north"),
                         ("dev_tools", False),
                         ("recompile_translations", True),
                         ("compress_save", None),

--- a/tuxemon/player.py
+++ b/tuxemon/player.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import datetime as dt
 import logging
 
+from tuxemon import prepare
 from tuxemon.map import proj
 from tuxemon.npc import NPC
 from tuxemon.states.world.worldstate import WorldState
@@ -106,3 +107,27 @@ class Player(NPC):
             var["stage_of_day"] = "dusk"
         else:
             var["stage_of_day"] = "night"
+
+        # Seasons
+        if prepare.CONFIG.hemisphere == "north":
+            if int(var["day_of_year"]) < 81:
+                var["season"] = "winter"
+            elif 81 <= int(var["day_of_year"]) < 173:
+                var["season"] = "spring"
+            elif 173 <= int(var["day_of_year"]) < 265:
+                var["season"] = "summer"
+            elif 265 <= int(var["day_of_year"]) < 356:
+                var["season"] = "autumn"
+            else:
+                var["season"] = "winter"
+        else:
+            if int(var["day_of_year"]) < 81:
+                var["season"] = "summer"
+            elif 81 <= int(var["day_of_year"]) < 173:
+                var["season"] = "autumn"
+            elif 173 <= int(var["day_of_year"]) < 265:
+                var["season"] = "winter"
+            elif 265 <= int(var["day_of_year"]) < 356:
+                var["season"] = "spring"
+            else:
+                var["season"] = "summer"


### PR DESCRIPTION
PR addresses the addition of the **seasons** based on the day of the year (I'm aware of the leap year).

To be more interesting I added the field **hemisphere** in the **tuxemon.cfg** with the **"north/south"** options, exactly below locale (en_US), so our Tuxemon friends on the other side of the planet can enjoy an opposite and at the same time intriguing gaming experience.

Seasons can be an interesting variable for events, evolutions, as well as spawn of random monsters, etc. (as well as day/night cycle).

I'm unsure if I put **hemisphere** in the correct place (it's in the game sector). So if I need to move it in another section, just tell me. Next step, as soon as the other PR is merged, it's the metric / imperial config. So we can solve another issue.