### PR TITLE
status grabbed and stuck + conditions

### DIFF
--- a/mods/tuxemon/db/technique/bubble_trap.json
+++ b/mods/tuxemon/db/technique/bubble_trap.json
@@ -3,7 +3,9 @@
   "accuracy": 0.75,
   "animation": "bomb_bright",
   "effects": [
-    "damage 100"
+    "damage 100",
+    "grabbed target",
+    "grabbed user"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/clamp_on.json
+++ b/mods/tuxemon/db/technique/clamp_on.json
@@ -2,7 +2,9 @@
   "tech_id": 17,
   "accuracy": 1,
   "animation": "bite",
-  "effects": [],
+  "effects": [
+    "grabbed target"
+  ],
   "flip_axes": "",
   "healing_power": 0,
   "icon": "",

--- a/mods/tuxemon/db/technique/constrict.json
+++ b/mods/tuxemon/db/technique/constrict.json
@@ -3,7 +3,8 @@
   "accuracy": 0.75,
   "animation": "tentacle_metal",
   "effects": [
-    "damage 100"
+    "damage 100",
+    "grabbed target"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/invictus.json
+++ b/mods/tuxemon/db/technique/invictus.json
@@ -4,7 +4,8 @@
   "animation": "triforce",
   "effects": [
     "damage 100",
-    "enraged user"
+    "enraged user",
+    "grabbed target"
   ],
   "flip_axes": "xy",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/overgrowth.json
+++ b/mods/tuxemon/db/technique/overgrowth.json
@@ -3,7 +3,8 @@
   "accuracy": 0.8,
   "animation": null,
   "effects": [
-    "damage 100"
+    "damage 100",
+    "grabbed target"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/quicksand.json
+++ b/mods/tuxemon/db/technique/quicksand.json
@@ -3,7 +3,8 @@
   "accuracy": 0.8,
   "animation": "spikes_rock",
   "effects": [
-    "damage 100"
+    "damage 100",
+    "stuck target"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/run.json
+++ b/mods/tuxemon/db/technique/run.json
@@ -1,5 +1,9 @@
 {
 	"animation": null,
+	"conditions": [
+	  	"status target,status_grabbed",
+	  	"status target,status_stuck"
+	],
 	"effects": [],
 	"flip_axes": "",
 	"icon": "",

--- a/mods/tuxemon/db/technique/status_grabbed.json
+++ b/mods/tuxemon/db/technique/status_grabbed.json
@@ -1,7 +1,9 @@
 {
   "animation": "drip_green",
   "category": "negative",
-  "effects": [],
+  "effects": [
+    "grabbed all"
+  ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_grabbed.png",
   "range": "special",

--- a/mods/tuxemon/db/technique/status_stuck.json
+++ b/mods/tuxemon/db/technique/status_stuck.json
@@ -1,7 +1,9 @@
 {
   "animation": "drip_green",
   "category": "negative",
-  "effects": [],
+  "effects": [
+    "stuck all"
+  ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_stuck.png",
   "range": "special",

--- a/mods/tuxemon/db/technique/swap.json
+++ b/mods/tuxemon/db/technique/swap.json
@@ -1,5 +1,9 @@
 {
 	"animation": null,
+	"conditions": [
+	  	"status target,status_grabbed",
+	  	"status target,status_stuck"
+	],
 	"effects": [
 		"swap all"
 	],

--- a/mods/tuxemon/db/technique/web.json
+++ b/mods/tuxemon/db/technique/web.json
@@ -3,7 +3,8 @@
   "accuracy": 0.75,
   "animation": "snake_right",
   "effects": [
-    "damage 100"
+    "damage 100",
+    "grabbed target"
   ],
   "flip_axes": "x",
   "healing_power": 0,

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -131,6 +131,18 @@ msgstr "Can't run!"
 msgid "combat_player_run"
 msgstr "You have run away!"
 
+msgid "combat_player_run_status"
+msgstr "Can't escape.\n{monster} is {status}!"
+
+msgid "combat_player_forfeit_status"
+msgstr "Can't forfeit the match.\n{monster} is {status}!"
+
+msgid "combat_player_swap_status"
+msgstr "Can't switch monsters.\n{monster} is {status}!"
+
+msgid "cannot_use_tech_monster"
+msgstr "{name} can't be used."
+
 msgid "combat_used_x"
 msgstr "{user} used {name}!"
 

--- a/tuxemon/constants/paths.py
+++ b/tuxemon/constants/paths.py
@@ -82,5 +82,6 @@ ACTIONS_PATH = os.path.join(LIBDIR, "event/actions")
 ITEM_EFFECT_PATH = os.path.join(LIBDIR, "item/effects")
 ITEM_CONDITION_PATH = os.path.join(LIBDIR, "item/conditions")
 
-# technique effects
+# technique effects/conditions
 TECH_EFFECT_PATH = os.path.join(LIBDIR, "technique/effects")
+TECH_CONDITION_PATH = os.path.join(LIBDIR, "technique/conditions")

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -350,6 +350,9 @@ class TechniqueModel(BaseModel):
     slug: str = Field(..., description="The slug of the technique")
     sort: TechSort = Field(..., description="The sort of technique this is")
     icon: str = Field(..., description="The icon to use for the technique")
+    conditions: Sequence[str] = Field(
+        [], description="Conditions that must be met"
+    )
     effects: Sequence[str] = Field(
         [], description="Effects this technique uses"
     )

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -206,6 +206,26 @@ def simple_overfeed(
     return speed
 
 
+def simple_grabbed(monster: Monster) -> None:
+    for move in monster.moves:
+        if move.range.ranged:
+            move.potency = move.default_potency * 0.5
+            move.power = move.default_power * 0.5
+        elif move.range.reach:
+            move.potency = move.default_potency * 0.5
+            move.power = move.default_power * 0.5
+
+
+def simple_stuck(monster: Monster) -> None:
+    for move in monster.moves:
+        if move.range.melee:
+            move.potency = move.default_potency * 0.5
+            move.power = move.default_power * 0.5
+        elif move.range.touch:
+            move.potency = move.default_potency * 0.5
+            move.power = move.default_power * 0.5
+
+
 def escape(level_user: int, level_target: int, attempts: int) -> bool:
     escape = 0.4 + (0.15 * (attempts + level_user - level_target))
     if random.random() <= escape:

--- a/tuxemon/plugin.py
+++ b/tuxemon/plugin.py
@@ -97,6 +97,7 @@ class PluginManager:
             "item.effects",
             "item.conditions",
             "technique.effects",
+            "technique.conditions",
         ]
 
     def setPluginPlaces(self, plugin_folders: Sequence[str]) -> None:

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -1215,6 +1215,9 @@ class CombatState(CombatAnimations):
                 # reset status stats
                 mon.set_stats()
                 mon.end_combat()
+                # reset technique stats
+                for tech in mon.moves:
+                    tech.set_stats()
 
         # clear action queue
         self._action_queue = list()

--- a/tuxemon/technique/conditions/current_hp.py
+++ b/tuxemon/technique/conditions/current_hp.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from operator import eq, ge, gt, le, lt
+from typing import Callable, Mapping, Optional, Union
+
+from tuxemon.monster import Monster
+from tuxemon.technique.techcondition import TechCondition
+
+cmp_dict: Mapping[Optional[str], Callable[[float, float], bool]] = {
+    None: ge,
+    "<": lt,
+    "<=": le,
+    ">": gt,
+    ">=": ge,
+    "==": eq,
+    "=": eq,
+}
+
+
+@dataclass
+class CurrentHitPointsCondition(TechCondition):
+    """
+    Compares the Monster's current hitpoints against the given value.
+
+    If an integer is passed, it will compare against the number directly, if a
+    decimal between 0.0 and 1.0 is passed it will compare the current hp
+    against the total hp.
+
+    Example:
+    "conditions": [
+        "current_hp target,<,1.0",
+    ],
+
+    """
+
+    name = "current_hp"
+    comparison: str
+    value: Union[int, float]
+
+    def test(self, target: Monster) -> bool:
+        lhs = target.current_hp
+        op = cmp_dict[self.comparison]
+        if type(self.value) is float:
+            rhs = target.hp * self.value
+        else:
+            rhs = self.value
+
+        return op(lhs, rhs)

--- a/tuxemon/technique/conditions/status.py
+++ b/tuxemon/technique/conditions/status.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tuxemon.monster import Monster
+from tuxemon.technique.techcondition import TechCondition
+
+
+@dataclass
+class StatusCondition(TechCondition):
+    """
+    Checks against the creature's current statuses.
+
+    Parameters:
+    status: Slug of the status
+
+    Example:
+    "conditions": [
+        "status target,status_xxx"
+    ],
+
+    """
+
+    name = "status"
+    status: str
+
+    def test(self, target: Monster) -> bool:
+        return self.status in [
+            x.slug for x in target.status if hasattr(x, "slug")
+        ]

--- a/tuxemon/technique/effects/grabbed.py
+++ b/tuxemon/technique/effects/grabbed.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Optional
+
+from tuxemon import formula
+from tuxemon.monster import Monster
+from tuxemon.technique.techeffect import TechEffect, TechEffectResult
+from tuxemon.technique.technique import Technique
+
+
+class GrabbedEffectResult(TechEffectResult):
+    damage: int
+    should_tackle: bool
+    status: Optional[Technique]
+
+
+@dataclass
+class GrabbedEffect(TechEffect):
+    """
+    This effect has a chance to apply the grabbed status effect.
+    """
+
+    name = "grabbed"
+    objective: str
+
+    def apply(
+        self, tech: Technique, user: Monster, target: Monster
+    ) -> GrabbedEffectResult:
+        obj = self.objective
+        success = tech.potency >= random.random()
+        if success:
+            tech = Technique("status_grabbed")
+            if obj == "user":
+                user.apply_status(tech)
+                formula.simple_grabbed(user)
+            elif obj == "target":
+                target.apply_status(tech)
+                formula.simple_grabbed(target)
+            else:
+                return
+            return {"status": tech}
+
+        return {"damage": 0, "should_tackle": False, "success": False}

--- a/tuxemon/technique/effects/stuck.py
+++ b/tuxemon/technique/effects/stuck.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Optional
+
+from tuxemon import formula
+from tuxemon.monster import Monster
+from tuxemon.technique.techeffect import TechEffect, TechEffectResult
+from tuxemon.technique.technique import Technique
+
+
+class StuckEffectResult(TechEffectResult):
+    damage: int
+    should_tackle: bool
+    status: Optional[Technique]
+
+
+@dataclass
+class StuckEffect(TechEffect):
+    """
+    This effect has a chance to apply the stuck status effect.
+    """
+
+    name = "stuck"
+    objective: str
+
+    def apply(
+        self, tech: Technique, user: Monster, target: Monster
+    ) -> StuckEffectResult:
+        obj = self.objective
+        success = tech.potency >= random.random()
+        if success:
+            tech = Technique("status_stuck")
+            if obj == "user":
+                user.apply_status(tech)
+                formula.simple_stuck(user)
+            elif obj == "target":
+                target.apply_status(tech)
+                formula.simple_stuck(target)
+            else:
+                return
+            return {"status": tech}
+
+        return {"damage": 0, "should_tackle": False, "success": False}

--- a/tuxemon/technique/techcondition.py
+++ b/tuxemon/technique/techcondition.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, ClassVar
+
+from tuxemon.session import Session, local_session
+from tuxemon.tools import cast_dataclass_parameters
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TechCondition:
+    """
+    TechConditions are evaluated by techniques.
+
+    TechCondition subclasses implement "conditions" defined in Tuxemon techniques.
+    All subclasses, at minimum, must implement the following:
+
+    * The TechCondition.test() method
+    * A meaningful name, which must match the name in technique file effects
+
+    By populating the "valid_parameters" class attribute, subclasses
+    will be assigned a "parameters" instance attribute that holds the
+    parameters passed to the condition in the technique file.  It is also used
+    to check the syntax of conditions, by verifying the correct type and
+    number of parameters passed.
+
+    Parameters
+    ==========
+
+    Tuxemon supports type-checking of the parameters defined in the techniques.
+
+    valid_parameters may be the following format (may change):
+
+    (type, name)
+
+    * the type may be any valid python type, or even a python class or function
+    * type may be a single type, or a tuple of types
+    * type, if a tuple, may include None is indicate the parameter is optional
+    * name must be a valid python string
+
+    After parsing the parameters of the Tech, the parameter's value
+    will be passed to the type constructor.
+
+    Example types: str, int, float, Monster, NPC
+
+    (int, "level")                => level must be an int
+    ((int, float), "level")       => can be an int or float
+    ((int, float, None), "level") => is optional
+
+    (Monster, "monster_slug")   => a Monster instance will be created
+    """
+
+    name: ClassVar[str]
+    session: Session = field(init=False, repr=False)
+    _done: bool = field(default=False, init=False)
+
+    def __post_init__(self):
+        self.session = local_session
+        self.player = local_session.player
+        cast_dataclass_parameters(self)
+
+    def test(self, target: Monster) -> bool:
+        """
+        Return True if satisfied, or False if not.
+
+        """
+        return True


### PR DESCRIPTION
PR addresses some of the missing status and add conditions:
- created the values default_power and default_potency, so there no risk of getting half value each time a move is used;
- player with a grabbed or stuck monster is unable to switch monster as well as run (forfeit too) from wild monsters;
- added status.py and current_hp.py under tech conditions, the first one because of grabbed and stuck, the other mostly for testing, I left because it's useful for **diehard** status (conditions can simplify a lot the implementation of the missing statuses).

Big improvement since September, back then only 3 out of 22, now we are at 13 out of 22.
And this for only one campaign!

Tested + black.

Source: https://wiki.tuxemon.org/index.php?title=Category:Condition

Remember missing:
```
grabbed user: Bubble Trap
grabbed target: Bubble Trap, Clamp On, Constrict, Invictus, Overgrowth, Web
stuck user: Quicksand
stuck target: -


diehard user: Clamp On, Shuriken
diehard target: -
dozing user: -
dozing target: Petrify
noddingoff user: Hibernate, Sleep Bomb
noddingoff target: Sleep Bomb, Sleeping Powder
tired user: -
tired target: Feint, Starfall
charging user: Energy Field, Stampede, Surge
charging target: -
```