### PR TITLE
rematch

### DIFF
--- a/tuxemon/event/actions/start_battle.py
+++ b/tuxemon/event/actions/start_battle.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import logging
 from typing import NamedTuple, final
 
+from tuxemon import formula
 from tuxemon.combat import check_battle_legal
 from tuxemon.db import db
 from tuxemon.event.eventaction import EventAction
@@ -72,6 +73,12 @@ class StartBattleAction(EventAction[StartBattleActionParameters]):
                 f"npc '{self.parameters.npc_slug}' has no monsters, won't start trainer battle."
             )
             return
+
+        # Rematch
+        if self.parameters.npc_slug in player.battle_history:
+            rematch = player.battle_history[self.parameters.npc_slug]
+            for mon in npc.monsters:
+                formula.rematch(player, npc, mon, rematch[1])
 
         # Lookup the environment
         env_slug = player.game_variables.get("environment", "grass")

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -28,6 +28,7 @@
 
 from __future__ import annotations
 
+import datetime as dt
 import logging
 import random
 from typing import TYPE_CHECKING, NamedTuple, Optional, Sequence, Tuple
@@ -237,3 +238,33 @@ def battle_math(player: NPC, output: str) -> None:
         player["percent_draw"] = round(
             (player["battle_draw"] / player["battle_total"]) * 100
         )
+
+
+def rematch(
+    player: NPC,
+    opponent: NPC,
+    monster: Monster,
+    date: int,
+) -> None:
+    today = dt.date.today().toordinal()
+    diff_date = today - date
+    low = player.game_variables["party_level_highest"]
+    high = 0
+    # nr days between match and rematch
+    if diff_date == 0:
+        high = low + 1
+    elif diff_date < 10:
+        high = low + 2
+    elif diff_date < 50:
+        high = low + 3
+    else:
+        high = low + 5
+    monster.level = random.randint(low, high)
+    # check if evolves
+    for evo in monster.evolutions:
+        if evo.path == "":
+            if evo.at_level <= monster.level:
+                opponent.evolve_monster(monster, evo.monster_slug)
+    # restore hp evolved monsters
+    for mon in opponent.monsters:
+        mon.current_hp = mon.hp


### PR DESCRIPTION
PR addresses the implementation of rematch: #1429 was a first step in this direction.

The situation now:
you fight against Trainer X (Rockitten lv5) in Route 2, it's done, you'll never meet Trainer X again.

This system obliges modders to create a ton of NPCs. The goal is making possible to fight again the NPC in another map later in the game (possibly with more powerful monster).

This situation tomorrow:
you fight against Trainer X (Rockitten lv5) in Route 2;
you fight against Trainer X (Rockitten lv32) - or the evolved version - in Route 6;

Why? Because creating new NPCs require a lot of work, especially choosing the monsters, if we can utilize again the "old" ones (that we meet at the beginning) later in the game, then that's a win win. We can easily double down the trainer battles.

This will be the string to put inside the maps to trigger the creation of the same NPC later (in other maps):
`    <property name="cond1" value="is battle_is NPC_SLUG,won"/>`
so if you don't fight it, it'll never create the NPC later.

Tested + black, it works.

Doubts about the parameters (values): average better? lowest? opponent monster level?
```
let's say you fight the same day TRAINER X, single monster, lv 10
diff_date = 0
high = low + 1

low = highest level of the party

let's say out of 3 monster (party), the strongest is 15
it means:
high = 15 + 1
high = 16

so when you fight again, the monsters will be in this range randint(15,16)
```