### PR TITLE
implementation of forfeit

### DIFF
--- a/mods/tuxemon/db/technique/forfeit.json
+++ b/mods/tuxemon/db/technique/forfeit.json
@@ -1,0 +1,28 @@
+{
+	"animation": null,
+	"conditions": [
+	  	"status target,status_grabbed",
+	  	"status target,status_stuck"
+	],
+	"effects": [],
+	"flip_axes": "",
+	"icon": "",
+	"power": 50,
+	"range": "special",
+	"sfx": "sfx_blaster",
+	"slug": "menu_forfeit",
+	"sort": "meta",
+	"target": {
+		"enemy monster": 0,
+		"enemy team": 0,
+		"enemy trainer": 0,
+		"own monster": 0,
+		"own team": 0,
+		"own trainer": 0,
+		"item": 0
+	},
+	"tech_id": 117,
+	"use_failure": "generic_failure",
+	"use_success": "generic_success",
+	"use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -123,7 +123,7 @@ msgid "combat_miss"
 msgstr "It missed..."
 
 msgid "combat_forfeit"
-msgstr "You have forfeited!"
+msgstr "You have forfeited!\n{npc} is disappointed."
 
 msgid "combat_can't_run_from_trainer"
 msgstr "Can't run!"

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -425,8 +425,19 @@ class CombatState(CombatAnimations):
         elif phase == "ran away":
             self.players[0].set_party_status()
             var = self.players[0].game_variables
-            var["battle_last_result"] = OutputBattle.ran
-            self.alert(T.translate("combat_player_run"))
+            if self.is_trainer_battle:
+                var["battle_last_result"] = OutputBattle.lost
+                self.alert(
+                    T.format(
+                        "combat_forfeit",
+                        {
+                            "npc": self.players[1].name,
+                        },
+                    )
+                )
+            else:
+                var["battle_last_result"] = OutputBattle.ran
+                self.alert(T.translate("combat_player_run"))
 
             # after 3 seconds, push a state that blocks until enter is pressed
             # after the state is popped, the combat state will clean up and close
@@ -1176,21 +1187,6 @@ class CombatState(CombatAnimations):
         # TODO: perhaps change this to remaining "parties", or "teams",
         # instead of player/trainer
         return [p for p in self.players if not defeated(p)]
-
-    def trigger_player_run(self, player: NPC) -> None:
-        """
-        WIP.  make player run from battle.
-
-        This is a temporary fix for now. Expected to be called by the
-        command menu.
-
-        Parameters:
-            player: The player leaving combat.
-
-        """
-        # TODO: non SP things
-        del self.monsters_in_play[player]
-        self.players.remove(player)
 
     def evolve(self) -> None:
         self.client.pop_state()


### PR DESCRIPTION
PR addresses the implementation of forfeit:
- creation of the technique forfeit (exactly like run.json);
- deleted the **trigger_player_run** in combat.py and moved the two lines of actual code inside combat_menu.py
- forfeit would result in killing all the monster, so you can be teleported inside the centers;
- the result of the battle will be "LOST", because if not, there would be a problem with the auto-healing (auto-healing at the moment is triggered if the battle result is lost) -> this one will be changed later on, because it involves a mass replacement in the maps (yeah);
- forfeit respects the grabbed and stuck status, so if your monster is stuck, the player cannot forfeit;
- added the string (NPC is disappointed) to the message, because among true trainers forfeit isn't an option;

I forgot to quote the original request, 5th line: https://github.com/Tuxemon/Tuxemon/pull/1395#issuecomment-1279885841