### PR TITLE
Random AI, next_use and skip

### DIFF
--- a/mods/tuxemon/db/technique/skip.json
+++ b/mods/tuxemon/db/technique/skip.json
@@ -1,0 +1,25 @@
+{
+	"animation": null,
+	"effects": [],
+	"flip_axes": "",
+	"icon": "",
+	"power": 0,
+	"range": "special",
+	"sfx": "sfx_blaster",
+	"slug": "skip",
+	"sort": "meta",
+	"target": {
+		"enemy monster": 0,
+		"enemy team": 0,
+		"enemy trainer": 0,
+		"own monster": 2,
+		"own team": 0,
+		"own trainer": 0,
+		"item": 0
+	},
+	"tech_id": 118,
+	"types": [],
+	"use_failure": null,
+	"use_success": null,
+	"use_tech": "combat_skip"
+}

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -152,6 +152,9 @@ msgstr "{user} used {name} on {target}!"
 msgid "combat_swap"
 msgstr "{user} sent out {target}!"
 
+msgid "combat_skip"
+msgstr "{user} skips the turn!"
+
 msgid "combat_call_tuxemon"
 msgstr "Go {name}!"
 
@@ -1013,6 +1016,9 @@ msgstr "Hostname or IP?"
 
 msgid "swap"
 msgstr "Swap"
+
+msgid "skip"
+msgstr "Skip"
 
 ## MONSTER TRANSLATIONS ##
 # Monster details

--- a/tuxemon/ai.py
+++ b/tuxemon/ai.py
@@ -87,4 +87,12 @@ class RandomAI(AI):
         opponents: Sequence[Monster],
     ) -> Tuple[Technique, Monster]:
         # TODO: healing and whatnot
-        return choice(monster.moves), choice(opponents)
+        filter_moves = []
+        for mov in monster.moves:
+            if mov.next_use <= 0:
+                filter_moves.append(mov)
+        if not filter_moves:
+            skip = Technique("skip")
+            return skip, choice(opponents)
+        else:
+            return choice(filter_moves), choice(opponents)

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -407,6 +407,9 @@ class CombatState(CombatAnimations):
                     for monster in self.monsters_in_play[trainer]:
                         action = self.get_combat_decision_from_ai(monster)
                         self._action_queue.append(action)
+                        # recharge opponent moves
+                        for tech in monster.moves:
+                            tech.recharge()
 
         elif phase == "action phase":
             self.sort_action_queue()

--- a/tuxemon/states/combat/combat_menus.py
+++ b/tuxemon/states/combat/combat_menus.py
@@ -295,6 +295,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
             menu.shrink_to_items = True
 
             # add techniques to the menu
+            filter_moves = []
             for tech in self.monster.moves:
                 if tech.next_use <= 0:
                     image = self.shadow_text(tech.name)
@@ -303,6 +304,11 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                         "%s %d" % (tech.name, abs(tech.next_use)),
                         fg=self.unavailable_color,
                     )
+                    filter_moves.append(tech)
+                # add skip move if both grey
+                if len(filter_moves) == len(self.monster.moves):
+                    skip = Technique("skip")
+                    self.monster.moves.append(skip)
                 item = MenuItem(image, None, None, tech)
                 menu.add(item)
 
@@ -356,6 +362,9 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
             else:
                 combat_state = self.client.get_state_by_name(CombatState)
                 combat_state.enqueue_action(self.monster, technique, target)
+                # remove skip after using it
+                if technique.slug == "skip":
+                    self.monster.moves.pop()
 
                 # close all the open menus
                 self.client.pop_state()  # close target chooser


### PR DESCRIPTION
PR addresses a bug I discovered a while ago #1391, fixes it and introduces a feature.

Before a random monster as well as a trainer's monster could use the same move like 7 times in a row (could be more, but I stopped testing after 7).
_(note: five times in a row if the random choice granted the same move)_
The point is that they had the advantage of using moves without recharging.
So the most powerful ones (the ones which take sometime 3 turns to recharge) could be used many times more.
Uneven advantage.

The PR inserts the recharging as well as the mechanism that impedes of being utilized in a row like before. Now before using a techniques that takes 3 turns to recharge, they need to wait 3 turns before this one is again available in the random list.

This pushed me to create a new technique called **skip**.
Skip will be used automatically by the adversary monster, while it'll appear in the player menu due certain conditions and it'll disappear once used.

This solves also the issue that if you're in a battle against a trainer, if your last monster is without moves, then you are forced to close abruptly the windows since you are stuck (no other monsters, no swap and back then no forfeit).

I'm not convinced about the IFs in the ai.py, especially the subtraction, at the moment I don't see a better alternative, maybe someone can see a way to beautify it.
Black + tested

Here the message that will appear when a monster uses skip, in this case the enemy after using his both moves, it was forced to use skip.
![Screenshot from 2022-11-30 13-11-27](https://user-images.githubusercontent.com/64643719/204811392-fcd683d5-e169-47de-ba77-f5d9f4f747b5.png)

Where it'll appear skip in the monster menu:
![Screenshot from 2022-11-30 14-03-14](https://user-images.githubusercontent.com/64643719/204811401-094191ad-381e-431e-a2e1-df0d34e1499c.png)