### PR TITLE
add item NPC + random AI

### DIFF
--- a/tuxemon/ai.py
+++ b/tuxemon/ai.py
@@ -102,15 +102,15 @@ class RandomAI(AI):
         opponents: Sequence[Monster],
     ) -> Tuple[Union[Monster, NPC], Union[Item, Technique], Monster]:
         """
-        Trainers battles.
+        Trainer battles.
         """
         if self.check_strongest(user, monster):
             if len(user.inventory) > 0:
                 inventory = list(user.inventory)
-                for i in inventory:
-                    if user.is_item_sort(i, "potion"):
-                        if self.check_hp_potion(monster):
-                            item = self.item_healing(user, i)
+                for item_slug in inventory:
+                    if user.is_item_sort(item_slug, "potion"):
+                        if self.need_potion(monster):
+                            item = self.item_healing(user, item_slug)
                             return user, item, monster
         technique, target = self.track_next_use(monster, opponents)
         # send data
@@ -178,7 +178,7 @@ class RandomAI(AI):
         else:
             return False
 
-    def check_hp_potion(self, monster: Monster) -> bool:
+    def need_potion(self, monster: Monster) -> bool:
         """
         It checks if the current_hp are less than the 15%.
         """

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -895,6 +895,16 @@ class NPC(Entity[NPCState]):
     def has_item(self, item_slug: str) -> bool:
         return self.inventory.get(item_slug) is not None
 
+    def is_item_sort(self, item_slug: str, sort_slug: str) -> bool:
+        """
+        Is the item sort "sort" (eg. potion, etc.)
+        """
+        result = db.lookup(item_slug, table="item")
+        if result.sort == sort_slug:
+            return True
+        else:
+            return False
+
     def alter_item_quantity(
         self, session: Session, item_slug: str, amount: int
     ) -> bool:

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -526,8 +526,16 @@ class CombatState(CombatAnimations):
         """
         # TODO: parties/teams/etc to choose opponents
         opponents = self.monsters_in_play[self.players[0]]
-        technique, target = monster.ai.make_decision(monster, opponents)
-        return EnqueuedAction(monster, technique, target)
+        trainer = self.players[1]
+        if self.is_trainer_battle:
+            user, technique, target = monster.ai.make_decision_trainer(
+                trainer, monster, opponents
+            )
+        else:
+            user, technique, target = monster.ai.make_decision_wild(
+                trainer, monster, opponents
+            )
+        return EnqueuedAction(user, technique, target)
 
     def sort_action_queue(self) -> None:
         """Sort actions in the queue according to game rules.
@@ -546,7 +554,8 @@ class CombatState(CombatAnimations):
                 # all meta items sorted together
                 # use of 0 leads to undefined sort/probably random
                 return primary_order, 0
-
+            elif sort == "potion":
+                return primary_order, 0
             else:
                 # TODO: determine the secondary sort element,
                 # monster speed, trainer speed, etc

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -714,8 +714,8 @@ class CombatState(CombatAnimations):
                 T.format(
                     "combat_swap",
                     {
-                        "user": monster.name.upper(),
-                        "target": player.name.upper(),
+                        "target": monster.name.upper(),
+                        "user": player.name.upper(),
                     },
                 )
             )


### PR DESCRIPTION
PR addresses the addition of the slug parameter to add_item. Until now it was possible to add items only to player, now to NPCs too.

I got curious, so I added and I resorted some things in random AI:
- a couple of functions to individuate the strongest and weakest monster in the NPC's party;
- create **is_item_sort** in npc.py, a simple bool, so we can check if an item is in a certain category (sort);
- doubled **make_decision** in **make_decision_wild** and **make_decision_trainer**, so I can avoid to import combatstate inside ai (creating problem of circular importation -> Monster, test_monster and test_catch_monster); in this way we can define specific behavior for wild monsters (for which I have an idea); technically I could use random_dummy slug to define it, but it would be resulted as hardcoding, this way is more fluid.

I set the 15% as trigger for the potion, it can be changed.
At the end (if approved the item to NPC), modders can choose to spice up fights against NPCs by giving more items to them.
I tested a fight against a trainer with potions, and that's really another level, it can be handy for bosses, etc.. 

`<property name="act4" value="add_item ITEM,QUANTITY,NPC"/>`

Tested + black


Update:
added a fix about target/user, I noticed only now that when an NPC sent out a monster was:
MONSTER sent out NPC
now it's correct:
NPC sent out MONSTER