### PR TITLE
item location

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -78,6 +78,32 @@ msgstr "Capture Device"
 msgid "capture_device_description"
 msgstr "Captures a monster."
 
+# Map Types:
+
+msgid "no_type"
+msgstr "no type"
+
+msgid "town"
+msgstr "town"
+
+msgid "route"
+msgstr "route"
+
+msgid "dungeon"
+msgstr "dungeon"
+
+msgid "center"
+msgstr "center"
+
+msgid "shop"
+msgstr "shop"
+
+msgid "inside"
+msgstr "inside"
+
+msgid "outside"
+msgstr "outside"
+
 # TMs
 msgid "tm_avalanche"
 msgstr "TM: Avalanche"
@@ -93,6 +119,12 @@ msgstr "Technique Manual that teaches a Wood Tuxemon the Blossom technique."
 
 msgid "item_cannot_use_here"
 msgstr "{name} cannot be used here!"
+
+msgid "item_used_wrong_location_inside"
+msgstr "{name} can only be used {here}!"
+
+msgid "item_used_wrong_location_type"
+msgstr "{name} can only be used in a {here}!"
 
 msgid "item_no_available_target"
 msgstr "{name} cannot be used on any of your Tuxemon right now."

--- a/mods/tuxemon/maps/candy_town.tmx
+++ b/mods/tuxemon/maps/candy_town.tmx
@@ -5,7 +5,7 @@
   <property name="scenario" value="xero"/>
   <property name="slug" value="candy_town"/>
   <property name="south" value="route6"/>
-  <property name="town" type="bool" value="true"/>
+  <property name="types" value="town"/>
  </properties>
  <tileset firstgid="1" name="Outdoor_Tiles_-_City_and_Country_-_by_ArMM1998" tilewidth="16" tileheight="16" tilecount="1440" columns="40">
   <image source="../gfx/tilesets/Outdoor_Tiles_-_City_and_Country_-_by_ArMM1998.png" width="640" height="576"/>

--- a/mods/tuxemon/maps/citypark.tmx
+++ b/mods/tuxemon/maps/citypark.tmx
@@ -6,6 +6,7 @@
   <property name="scenario" value="xero"/>
   <property name="slug" value="citypark"/>
   <property name="south" value="route2"/>
+  <property name="types" value="route"/>
  </properties>
  <tileset firstgid="1" name="My_tuxemon_sheet" tilewidth="16" tileheight="16" tilecount="104" columns="8">
   <image source="../gfx/tilesets/My_tuxemon_sheet.png" width="128" height="208"/>

--- a/mods/tuxemon/maps/cotton_cafe.tmx
+++ b/mods/tuxemon/maps/cotton_cafe.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="cotton_cafe"/>
+  <property name="types" value="notype"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_walls" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_walls.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/cotton_cathedral.tmx
+++ b/mods/tuxemon/maps/cotton_cathedral.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="cotton_cathedral"/>
+  <property name="types" value="center"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_walls" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_walls.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/cotton_scoop.tmx
+++ b/mods/tuxemon/maps/cotton_scoop.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="cotton_scoop"/>
+  <property name="types" value="shop"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_walls" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_walls.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/cotton_town.tmx
+++ b/mods/tuxemon/maps/cotton_town.tmx
@@ -6,7 +6,7 @@
   <property name="scenario" value="xero"/>
   <property name="slug" value="cotton_town"/>
   <property name="south" value="route1_sanglorian"/>
-  <property name="town" type="bool" value="true"/>
+  <property name="types" value="town"/>
   <property name="west" value="route2"/>
  </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">

--- a/mods/tuxemon/maps/daycare.tmx
+++ b/mods/tuxemon/maps/daycare.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="daycare"/>
+  <property name="types" value="notype"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_floors" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_floors.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/dojo1.tmx
+++ b/mods/tuxemon/maps/dojo1.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="dojo1"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Interior_Walls_by_George" tilewidth="16" tileheight="16" tilecount="210" columns="15">
   <image source="../gfx/tilesets/Interior_Walls_by_George.png" width="240" height="224"/>

--- a/mods/tuxemon/maps/dojo2.tmx
+++ b/mods/tuxemon/maps/dojo2.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="dojo2"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Interior_Walls_by_George" tilewidth="16" tileheight="16" tilecount="210" columns="15">
   <image source="../gfx/tilesets/Interior_Walls_by_George.png" width="240" height="224"/>

--- a/mods/tuxemon/maps/dojo3.tmx
+++ b/mods/tuxemon/maps/dojo3.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="dojo3"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Interior_Walls_by_George" tilewidth="16" tileheight="16" tilecount="210" columns="15">
   <image source="../gfx/tilesets/Interior_Walls_by_George.png" width="240" height="224"/>

--- a/mods/tuxemon/maps/dragonscave.tmx
+++ b/mods/tuxemon/maps/dragonscave.tmx
@@ -5,6 +5,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="dragonscave"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="160" columns="16">
   <image source="../gfx/tilesets/Cave_Tiles_by_ArMM1998_(Tuxemon_Style).png" width="256" height="160"/>

--- a/mods/tuxemon/maps/dryadsgrove.tmx
+++ b/mods/tuxemon/maps/dryadsgrove.tmx
@@ -2,10 +2,10 @@
 <map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="40">
  <properties>
   <property name="edges" value="clamped"/>
-  <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="dryadsgrove"/>
   <property name="west" value="cotton_town"/>
+  <property name="types" value="route"/>
  </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>

--- a/mods/tuxemon/maps/flower_city.tmx
+++ b/mods/tuxemon/maps/flower_city.tmx
@@ -6,7 +6,7 @@
   <property name="north" value="routea"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="flower_city"/>
-  <property name="town" type="bool" value="true"/>
+  <property name="types" value="town"/>
   <property name="west" value="route4"/>
  </properties>
  <tileset firstgid="1" name="PastTheFuture_Grass_Sand_Snow" tilewidth="16" tileheight="16" tilecount="360" columns="24">

--- a/mods/tuxemon/maps/healing_center.tmx
+++ b/mods/tuxemon/maps/healing_center.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="healing_center"/>
+  <property name="types" value="center"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_walls" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_walls.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/leather_scoop.tmx
+++ b/mods/tuxemon/maps/leather_scoop.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="leather_scoop"/>
+  <property name="types" value="shop"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_walls" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_walls.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/leather_town.tmx
+++ b/mods/tuxemon/maps/leather_town.tmx
@@ -5,7 +5,7 @@
   <property name="north" value="route3"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="leather_town"/>
-  <property name="town" type="bool" value="true"/>
+  <property name="types" value="town"/>
   <property name="west" value="citypark"/>
  </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">

--- a/mods/tuxemon/maps/mansion.tmx
+++ b/mods/tuxemon/maps/mansion.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="mansion"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Interior_Walls_by_George" tilewidth="16" tileheight="16" tilecount="210" columns="15">
   <image source="../gfx/tilesets/Interior_Walls_by_George.png" width="240" height="224"/>

--- a/mods/tuxemon/maps/mansion_basement.tmx
+++ b/mods/tuxemon/maps/mansion_basement.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="mansion_basement"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Interior_Walls_by_George" tilewidth="16" tileheight="16" tilecount="210" columns="15">
   <image source="../gfx/tilesets/Interior_Walls_by_George.png" width="240" height="224"/>

--- a/mods/tuxemon/maps/mansion_top.tmx
+++ b/mods/tuxemon/maps/mansion_top.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="mansion_top"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Interior_Walls_by_George" tilewidth="16" tileheight="16" tilecount="210" columns="15">
   <image source="../gfx/tilesets/Interior_Walls_by_George.png" width="240" height="224"/>

--- a/mods/tuxemon/maps/maple_house.tmx
+++ b/mods/tuxemon/maps/maple_house.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="maple_house"/>
+  <property name="types" value="notype"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_floors" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_floors.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/omnichannel1.tmx
+++ b/mods/tuxemon/maps/omnichannel1.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="omnichannel1"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Interior_Walls_by_George" tilewidth="16" tileheight="16" tilecount="210" columns="15">
   <image source="../gfx/tilesets/Interior_Walls_by_George.png" width="240" height="224"/>

--- a/mods/tuxemon/maps/omnichannel2.tmx
+++ b/mods/tuxemon/maps/omnichannel2.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="omnichannel2"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Interior_Walls_by_George" tilewidth="16" tileheight="16" tilecount="210" columns="15">
   <image source="../gfx/tilesets/Interior_Walls_by_George.png" width="240" height="224"/>

--- a/mods/tuxemon/maps/omnichannel3.tmx
+++ b/mods/tuxemon/maps/omnichannel3.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="omnichannel3"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Interior_Walls_by_George" tilewidth="16" tileheight="16" tilecount="210" columns="15">
   <image source="../gfx/tilesets/Interior_Walls_by_George.png" width="240" height="224"/>

--- a/mods/tuxemon/maps/omnichannel4.tmx
+++ b/mods/tuxemon/maps/omnichannel4.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="omnichannel4"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Interior_Walls_by_George" tilewidth="16" tileheight="16" tilecount="210" columns="15">
   <image source="../gfx/tilesets/Interior_Walls_by_George.png" width="240" height="224"/>

--- a/mods/tuxemon/maps/player_house_bedroom.tmx
+++ b/mods/tuxemon/maps/player_house_bedroom.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="bedroom"/>
+  <property name="types" value="notype"/>
  </properties>
  <tileset firstgid="1" name="floors and walls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>

--- a/mods/tuxemon/maps/player_house_downstairs.tmx
+++ b/mods/tuxemon/maps/player_house_downstairs.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="downstairs"/>
+  <property name="types" value="notype"/>
  </properties>
  <tileset firstgid="1" name="floors and walls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>

--- a/mods/tuxemon/maps/professor_lab.tmx
+++ b/mods/tuxemon/maps/professor_lab.tmx
@@ -5,6 +5,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="professor_lab"/>
+  <property name="types" value="notype"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_floors" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_floors.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/route1.tmx
+++ b/mods/tuxemon/maps/route1.tmx
@@ -6,6 +6,7 @@
   <property name="slug" value="route1"/>
   <property name="north" value="route1_sanglorian"/>
   <property name="west" value="taba_town"/>
+  <property name="types" value="route"/>
  </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>

--- a/mods/tuxemon/maps/route1_sanglorian.tmx
+++ b/mods/tuxemon/maps/route1_sanglorian.tmx
@@ -6,6 +6,7 @@
   <property name="scenario" value="xero"/>
   <property name="slug" value="route1_sanglorian"/>
   <property name="south" value="route1"/>
+  <property name="types" value="route"/>
  </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>

--- a/mods/tuxemon/maps/route2.tmx
+++ b/mods/tuxemon/maps/route2.tmx
@@ -6,6 +6,7 @@
   <property name="north" value="citypark"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="route2"/>
+  <property name="types" value="route"/>
  </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>

--- a/mods/tuxemon/maps/route3.tmx
+++ b/mods/tuxemon/maps/route3.tmx
@@ -6,6 +6,7 @@
   <property name="scenario" value="xero"/>
   <property name="slug" value="route3"/>
   <property name="south" value="leather_town"/>
+  <property name="types" value="route"/>
  </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>

--- a/mods/tuxemon/maps/route4.tmx
+++ b/mods/tuxemon/maps/route4.tmx
@@ -6,6 +6,7 @@
   <property name="scenario" value="xero"/>
   <property name="slug" value="route4"/>
   <property name="south" value="route3"/>
+  <property name="types" value="route"/>
  </properties>
  <tileset firstgid="1" name="My_tuxemon_sheet" tilewidth="16" tileheight="16" tilecount="104" columns="8">
   <image source="../gfx/tilesets/My_tuxemon_sheet.png" width="128" height="208"/>

--- a/mods/tuxemon/maps/route5.tmx
+++ b/mods/tuxemon/maps/route5.tmx
@@ -6,6 +6,7 @@
   <property name="scenario" value="xero"/>
   <property name="slug" value="route5"/>
   <property name="west" value="flower_city"/>
+  <property name="types" value="route"/>
  </properties>
  <tileset firstgid="1" name="PastTheFuture_Grass_Sand_Snow" tilewidth="16" tileheight="16" tilecount="360" columns="24">
   <image source="../gfx/tilesets/PastTheFuture_Grass_Sand_Snow.png" width="384" height="240"/>

--- a/mods/tuxemon/maps/route6.tmx
+++ b/mods/tuxemon/maps/route6.tmx
@@ -6,6 +6,7 @@
   <property name="north" value="candy_town"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="route6"/>
+  <property name="types" value="route"/>
  </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>

--- a/mods/tuxemon/maps/routea.tmx
+++ b/mods/tuxemon/maps/routea.tmx
@@ -5,6 +5,7 @@
   <property name="scenario" value="xero"/>
   <property name="slug" value="routea"/>
   <property name="south" value="flower_city"/>
+  <property name="types" value="route"/>
  </properties>
  <tileset firstgid="1" name="PastTheFuture_Grass_Sand_Snow" tilewidth="16" tileheight="16" tilecount="360" columns="24">
   <image source="../gfx/tilesets/PastTheFuture_Grass_Sand_Snow.png" width="384" height="240"/>

--- a/mods/tuxemon/maps/routec.tmx
+++ b/mods/tuxemon/maps/routec.tmx
@@ -4,6 +4,7 @@
   <property name="edges" value="clamped"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="routec"/>
+  <property name="types" value="route"/>
  </properties>
  <tileset firstgid="1" name="Outdoor_Tiles_-_City_and_Country_-_by_ArMM1998" tilewidth="16" tileheight="16" tilecount="1440" columns="40">
   <image source="../gfx/tilesets/Outdoor_Tiles_-_City_and_Country_-_by_ArMM1998.png" width="640" height="576"/>

--- a/mods/tuxemon/maps/scoop1.tmx
+++ b/mods/tuxemon/maps/scoop1.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="scoop1"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>

--- a/mods/tuxemon/maps/scoop2.tmx
+++ b/mods/tuxemon/maps/scoop2.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="scoop2"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_floors" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_floors.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/scoop3.tmx
+++ b/mods/tuxemon/maps/scoop3.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="scoop3"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>

--- a/mods/tuxemon/maps/scoop4.tmx
+++ b/mods/tuxemon/maps/scoop4.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="scoop4"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="core_outdoor" tilewidth="16" tileheight="16" tilecount="2294" columns="37">
   <image source="../gfx/tilesets/core_outdoor.png" width="592" height="1000"/>

--- a/mods/tuxemon/maps/spyder_bedroom.tmx
+++ b/mods/tuxemon/maps/spyder_bedroom.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="bedroom"/>
+  <property name="types" value="notype"/>
  </properties>
  <tileset firstgid="1" name="floors and walls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>

--- a/mods/tuxemon/maps/spyder_candy_center.tmx
+++ b/mods/tuxemon/maps/spyder_candy_center.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="candy_center"/>
+  <property name="types" value="center"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_floors" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_floors.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/spyder_candy_house1.tmx
+++ b/mods/tuxemon/maps/spyder_candy_house1.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="candy_house1"/>
+  <property name="types" value="notype"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_walls" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_walls.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/spyder_candy_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_candy_scoop.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="candy_scoop"/>
+  <property name="types" value="shop"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_floors" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_floors.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/spyder_candy_town.tmx
+++ b/mods/tuxemon/maps/spyder_candy_town.tmx
@@ -6,7 +6,7 @@
   <property name="north" value="route6"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="candy_town"/>
-  <property name="town" type="bool" value="true"/>
+  <property name="types" value="town"/>
  </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>

--- a/mods/tuxemon/maps/spyder_citypark.tmx
+++ b/mods/tuxemon/maps/spyder_citypark.tmx
@@ -6,6 +6,7 @@
   <property name="scenario" value="spyder"/>
   <property name="slug" value="citypark"/>
   <property name="south" value="route2"/>
+  <property name="types" value="route"/>
  </properties>
  <tileset firstgid="1" name="Tileset" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>

--- a/mods/tuxemon/maps/spyder_cotton_artshop.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_artshop.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="cotton_artshop"/>
+  <property name="types" value="notype"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_floors" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_floors.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/spyder_cotton_cafe.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_cafe.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="cotton_cafe"/>
+  <property name="types" value="notype"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_floors" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_floors.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/spyder_cotton_house1.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_house1.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="cotton_house1"/>
+  <property name="types" value="notype"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_floors" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_floors.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/spyder_cotton_house2.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_house2.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="cotton_house2"/>
+  <property name="types" value="notype"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_walls" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_walls.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/spyder_cotton_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_scoop.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="cotton_scoop"/>
+  <property name="types" value="shop"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_walls" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_walls.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/spyder_cotton_town.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_town.tmx
@@ -6,7 +6,7 @@
   <property name="scenario" value="spyder"/>
   <property name="slug" value="cotton_town"/>
   <property name="south" value="route1"/>
-  <property name="town" type="bool" value="true"/>
+  <property name="types" value="town"/>
   <property name="west" value="route2"/>
  </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">

--- a/mods/tuxemon/maps/spyder_cotton_tunnel.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_tunnel.tmx
@@ -5,6 +5,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="cotton_tunnel"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="160" columns="16">
   <image source="../gfx/tilesets/Cave_Tiles_by_ArMM1998_(Tuxemon_Style).png" width="256" height="160"/>

--- a/mods/tuxemon/maps/spyder_daycare.tmx
+++ b/mods/tuxemon/maps/spyder_daycare.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="daycare"/>
+  <property name="types" value="notype"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_walls" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_walls.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/spyder_dojo1.tmx
+++ b/mods/tuxemon/maps/spyder_dojo1.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="dojo1"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Interior_Walls_by_George" tilewidth="16" tileheight="16" tilecount="210" columns="15">
   <image source="../gfx/tilesets/Interior_Walls_by_George.png" width="240" height="224"/>

--- a/mods/tuxemon/maps/spyder_dojo2.tmx
+++ b/mods/tuxemon/maps/spyder_dojo2.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="dojo2"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Interior_Walls_by_George" tilewidth="16" tileheight="16" tilecount="210" columns="15">
   <image source="../gfx/tilesets/Interior_Walls_by_George.png" width="240" height="224"/>

--- a/mods/tuxemon/maps/spyder_dojo3.tmx
+++ b/mods/tuxemon/maps/spyder_dojo3.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="dojo3"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Interior_Walls_by_George" tilewidth="16" tileheight="16" tilecount="210" columns="15">
   <image source="../gfx/tilesets/Interior_Walls_by_George.png" width="240" height="224"/>

--- a/mods/tuxemon/maps/spyder_downstairs.tmx
+++ b/mods/tuxemon/maps/spyder_downstairs.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="downstairs"/>
+  <property name="types" value="notype"/>
  </properties>
  <tileset firstgid="1" name="floors and walls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>

--- a/mods/tuxemon/maps/spyder_dragonscave.tmx
+++ b/mods/tuxemon/maps/spyder_dragonscave.tmx
@@ -5,6 +5,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="dragonscave"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="160" columns="16">
   <image source="../gfx/tilesets/Cave_Tiles_by_ArMM1998_(Tuxemon_Style).png" width="256" height="160"/>

--- a/mods/tuxemon/maps/spyder_dryadsgrove.tmx
+++ b/mods/tuxemon/maps/spyder_dryadsgrove.tmx
@@ -2,10 +2,10 @@
 <map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="225">
  <properties>
   <property name="edges" value="clamped"/>
-  <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="dryadsgrove"/>
   <property name="west" value="cotton_town"/>
+  <property name="types" value="route"/>
  </properties>
  <tileset firstgid="1" name="volcoli" tilewidth="16" tileheight="16" tilecount="4" columns="2">
   <image source="../gfx/tilesets/volcoli.png" width="32" height="32"/>

--- a/mods/tuxemon/maps/spyder_flower_center.tmx
+++ b/mods/tuxemon/maps/spyder_flower_center.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="flower_center"/>
+  <property name="types" value="center"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_walls" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_walls.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/spyder_flower_city.tmx
+++ b/mods/tuxemon/maps/spyder_flower_city.tmx
@@ -6,7 +6,7 @@
   <property name="north" value="routea"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="flower_city"/>
-  <property name="town" type="bool" value="true"/>
+  <property name="types" value="town"/>
   <property name="west" value="route4"/>
  </properties>
  <tileset firstgid="1" name="core_outdoor_nature" tilewidth="16" tileheight="16" tilecount="8192" columns="64">

--- a/mods/tuxemon/maps/spyder_flower_house1.tmx
+++ b/mods/tuxemon/maps/spyder_flower_house1.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="flower_house1"/>
+  <property name="types" value="notype"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_floors" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_floors.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/spyder_flower_house2.tmx
+++ b/mods/tuxemon/maps/spyder_flower_house2.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="flower_house2"/>
+  <property name="types" value="notype"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_floors" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_floors.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/spyder_flower_petshop.tmx
+++ b/mods/tuxemon/maps/spyder_flower_petshop.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="flower_petshop"/>
+  <property name="types" value="notype"/>
  </properties>
  <tileset firstgid="1" name="core_set pieces" tilewidth="16" tileheight="16" tilecount="961" columns="31">
   <image source="../gfx/tilesets/core_set pieces.png" width="496" height="640"/>

--- a/mods/tuxemon/maps/spyder_flower_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_flower_scoop.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="flower_scoop"/>
+  <property name="types" value="shop"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_floors" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_floors.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/spyder_greenwash.tmx
+++ b/mods/tuxemon/maps/spyder_greenwash.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="greenwash"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_floors" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_floors.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/spyder_greenwash_greenhouse.tmx
+++ b/mods/tuxemon/maps/spyder_greenwash_greenhouse.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="greenwash_greenhouse"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="core_outdoor" tilewidth="16" tileheight="16" tilecount="2294" columns="37">
   <image source="../gfx/tilesets/core_outdoor.png" width="592" height="1000"/>

--- a/mods/tuxemon/maps/spyder_greenwash_level2.tmx
+++ b/mods/tuxemon/maps/spyder_greenwash_level2.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="greenwash_level2"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_floors" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_floors.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/spyder_healing_center.tmx
+++ b/mods/tuxemon/maps/spyder_healing_center.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="healing_center"/>
+  <property name="types" value="center"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_walls" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_walls.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/spyder_hospital.tmx
+++ b/mods/tuxemon/maps/spyder_hospital.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="hospital"/>
+  <property name="types" value="notype"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_floors" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_floors.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/spyder_hospital_alt.tmx
+++ b/mods/tuxemon/maps/spyder_hospital_alt.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="hospital_alt"/>
+  <property name="types" value="notype"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_floors" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_floors.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/spyder_house5.tmx
+++ b/mods/tuxemon/maps/spyder_house5.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="house5"/>
+  <property name="types" value="notype"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_floors" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_floors.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/spyder_house6.tmx
+++ b/mods/tuxemon/maps/spyder_house6.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="house6"/>
+  <property name="types" value="notype"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_floors" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_floors.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/spyder_leather_center.tmx
+++ b/mods/tuxemon/maps/spyder_leather_center.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="leather_center"/>
+  <property name="types" value="center"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_walls" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_walls.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/spyder_leather_house1.tmx
+++ b/mods/tuxemon/maps/spyder_leather_house1.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="leather_house1"/>
+  <property name="types" value="notype"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_walls" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_walls.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/spyder_leather_house2.tmx
+++ b/mods/tuxemon/maps/spyder_leather_house2.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="leather_house2"/>
+  <property name="types" value="notype"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_floors" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_floors.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/spyder_leather_museum.tmx
+++ b/mods/tuxemon/maps/spyder_leather_museum.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="leather_museum"/>
+  <property name="types" value="notype"/>
  </properties>
  <tileset firstgid="1" name="Warmachine_black_and_yellow" tilewidth="16" tileheight="16" tilecount="70" columns="14">
   <image source="../gfx/tilesets/Warmachine_black_and_yellow.png" width="224" height="80"/>

--- a/mods/tuxemon/maps/spyder_leather_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_leather_scoop.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="leather_scoop"/>
+  <property name="types" value="shop"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_floors" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_floors.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/spyder_leather_town.tmx
+++ b/mods/tuxemon/maps/spyder_leather_town.tmx
@@ -5,7 +5,7 @@
   <property name="north" value="route3"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="leather_town"/>
-  <property name="town" type="bool" value="true"/>
+  <property name="types" value="town"/>
   <property name="west" value="citypark"/>
  </properties>
  <tileset firstgid="1" name="core_outdoor" tilewidth="16" tileheight="16" tilecount="2294" columns="37">

--- a/mods/tuxemon/maps/spyder_mansion.tmx
+++ b/mods/tuxemon/maps/spyder_mansion.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="mansion"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Interior_Walls_by_George" tilewidth="16" tileheight="16" tilecount="210" columns="15">
   <image source="../gfx/tilesets/Interior_Walls_by_George.png" width="240" height="224"/>

--- a/mods/tuxemon/maps/spyder_mansion_basement.tmx
+++ b/mods/tuxemon/maps/spyder_mansion_basement.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="mansion_basement"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Interior_Walls_by_George" tilewidth="16" tileheight="16" tilecount="210" columns="15">
   <image source="../gfx/tilesets/Interior_Walls_by_George.png" width="240" height="224"/>

--- a/mods/tuxemon/maps/spyder_mansion_top.tmx
+++ b/mods/tuxemon/maps/spyder_mansion_top.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="mansion_top"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Interior_Walls_by_George" tilewidth="16" tileheight="16" tilecount="210" columns="15">
   <image source="../gfx/tilesets/Interior_Walls_by_George.png" width="240" height="224"/>

--- a/mods/tuxemon/maps/spyder_nimrod_bottom.tmx
+++ b/mods/tuxemon/maps/spyder_nimrod_bottom.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="nimrod_bottom"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="factory" tilewidth="16" tileheight="16" tilecount="32" columns="8">
   <image source="../gfx/tilesets/factory.png" width="128" height="64"/>

--- a/mods/tuxemon/maps/spyder_nimrod_middle.tmx
+++ b/mods/tuxemon/maps/spyder_nimrod_middle.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="nimrod_middle"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Interior_Walls_by_George" tilewidth="16" tileheight="16" tilecount="210" columns="15">
   <image source="../gfx/tilesets/Interior_Walls_by_George.png" width="240" height="224"/>

--- a/mods/tuxemon/maps/spyder_nimrod_top.tmx
+++ b/mods/tuxemon/maps/spyder_nimrod_top.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="nimrod_top"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="factory" tilewidth="16" tileheight="16" tilecount="32" columns="8">
   <image source="../gfx/tilesets/factory.png" width="128" height="64"/>

--- a/mods/tuxemon/maps/spyder_omnichannel1.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel1.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="omnichannel1"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Interior_Walls_by_George" tilewidth="16" tileheight="16" tilecount="210" columns="15">
   <image source="../gfx/tilesets/Interior_Walls_by_George.png" width="240" height="224"/>

--- a/mods/tuxemon/maps/spyder_omnichannel2.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel2.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="omnichannel2"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Interior_Walls_by_George" tilewidth="16" tileheight="16" tilecount="210" columns="15">
   <image source="../gfx/tilesets/Interior_Walls_by_George.png" width="240" height="224"/>

--- a/mods/tuxemon/maps/spyder_omnichannel3.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel3.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="omnichannel3"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Interior_Tiles_by_ArMM1998" tilewidth="16" tileheight="16" tilecount="1000" columns="40">
   <image source="../gfx/tilesets/Interior_Tiles_by_ArMM1998.png" width="640" height="400"/>

--- a/mods/tuxemon/maps/spyder_omnichannel4.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel4.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="omnichannel4"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Interior_Walls_by_George" tilewidth="16" tileheight="16" tilecount="210" columns="15">
   <image source="../gfx/tilesets/Interior_Walls_by_George.png" width="240" height="224"/>

--- a/mods/tuxemon/maps/spyder_paper_mart.tmx
+++ b/mods/tuxemon/maps/spyder_paper_mart.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="paper_mart"/>
+  <property name="types" value="shop"/>
  </properties>
  <tileset firstgid="1" name="core_set pieces" tilewidth="16" tileheight="16" tilecount="961" columns="31">
   <image source="../gfx/tilesets/core_set pieces.png" width="496" height="640"/>

--- a/mods/tuxemon/maps/spyder_paper_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_paper_scoop.tmx
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="63">
- <properties>
-  <property name="inside" type="bool" value="true"/>
-  <property name="scenario" value="spyder"/>
-  <property name="slug" value="paper_scoop"/>
- </properties>
  <tileset firstgid="1" name="core_indoor_walls" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_walls.png" width="736" height="1344"/>
  </tileset>

--- a/mods/tuxemon/maps/spyder_paper_town.tmx
+++ b/mods/tuxemon/maps/spyder_paper_town.tmx
@@ -5,7 +5,7 @@
   <property name="north" value="route1"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="paper_town"/>
-  <property name="town" type="bool" value="true"/>
+  <property name="types" value="town"/>
   <property name="west" value="routec"/>
  </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">

--- a/mods/tuxemon/maps/spyder_radiotower.tmx
+++ b/mods/tuxemon/maps/spyder_radiotower.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="radiotower"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Interior_Tiles_by_ArMM1998" tilewidth="16" tileheight="16" tilecount="1000" columns="40">
   <image source="../gfx/tilesets/Interior_Tiles_by_ArMM1998.png" width="640" height="400"/>

--- a/mods/tuxemon/maps/spyder_route1.tmx
+++ b/mods/tuxemon/maps/spyder_route1.tmx
@@ -6,6 +6,7 @@
   <property name="scenario" value="spyder"/>
   <property name="slug" value="route1"/>
   <property name="south" value="paper_town"/>
+  <property name="types" value="route"/>
  </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>

--- a/mods/tuxemon/maps/spyder_route2.tmx
+++ b/mods/tuxemon/maps/spyder_route2.tmx
@@ -6,6 +6,7 @@
   <property name="north" value="citypark"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="route2"/>
+  <property name="types" value="route"/>
  </properties>
  <tileset firstgid="1" name="core_outdoor" tilewidth="16" tileheight="16" tilecount="2294" columns="37">
   <image source="../gfx/tilesets/core_outdoor.png" width="592" height="1000"/>

--- a/mods/tuxemon/maps/spyder_route3.tmx
+++ b/mods/tuxemon/maps/spyder_route3.tmx
@@ -6,6 +6,7 @@
   <property name="scenario" value="spyder"/>
   <property name="slug" value="route3"/>
   <property name="south" value="leather_town"/>
+  <property name="types" value="route"/>
  </properties>
  <tileset firstgid="1" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="160" columns="16">
   <image source="../gfx/tilesets/Cave_Tiles_by_ArMM1998_(Tuxemon_Style).png" width="256" height="160"/>

--- a/mods/tuxemon/maps/spyder_route4.tmx
+++ b/mods/tuxemon/maps/spyder_route4.tmx
@@ -6,6 +6,7 @@
   <property name="scenario" value="spyder"/>
   <property name="slug" value="route4"/>
   <property name="west" value="route3"/>
+  <property name="types" value="route"/>
  </properties>
  <tileset firstgid="1" name="Outdoor_Tiles_-_City_and_Country_-_by_ArMM1998" tilewidth="16" tileheight="16" tilecount="1440" columns="40">
   <image source="../gfx/tilesets/Outdoor_Tiles_-_City_and_Country_-_by_ArMM1998.png" width="640" height="576"/>

--- a/mods/tuxemon/maps/spyder_route5.tmx
+++ b/mods/tuxemon/maps/spyder_route5.tmx
@@ -6,6 +6,7 @@
   <property name="slug" value="route5"/>
   <property name="south" value="timber_town"/>
   <property name="west" value="flower_city"/>
+  <property name="types" value="route"/>
  </properties>
  <tileset firstgid="1" name="core_outdoor" tilewidth="16" tileheight="16" tilecount="2294" columns="37">
   <image source="../gfx/tilesets/core_outdoor.png" width="592" height="1000"/>

--- a/mods/tuxemon/maps/spyder_route6.tmx
+++ b/mods/tuxemon/maps/spyder_route6.tmx
@@ -6,6 +6,7 @@
   <property name="scenario" value="spyder"/>
   <property name="slug" value="route6"/>
   <property name="south" value="candy_town"/>
+  <property name="types" value="route"/>
  </properties>
  <tileset firstgid="1" name="Outdoor_Tiles_-_City_and_Country_-_by_ArMM1998" tilewidth="16" tileheight="16" tilecount="1440" columns="40">
   <image source="../gfx/tilesets/Outdoor_Tiles_-_City_and_Country_-_by_ArMM1998.png" width="640" height="576"/>

--- a/mods/tuxemon/maps/spyder_routea.tmx
+++ b/mods/tuxemon/maps/spyder_routea.tmx
@@ -5,6 +5,7 @@
   <property name="scenario" value="spyder"/>
   <property name="slug" value="routea"/>
   <property name="south" value="flower_city"/>
+  <property name="types" value="route"/>
  </properties>
  <tileset firstgid="1" name="PastTheFuture_Grass_Sand_Snow" tilewidth="16" tileheight="16" tilecount="360" columns="24">
   <image source="../gfx/tilesets/PastTheFuture_Grass_Sand_Snow.png" width="384" height="240"/>

--- a/mods/tuxemon/maps/spyder_routec.tmx
+++ b/mods/tuxemon/maps/spyder_routec.tmx
@@ -6,6 +6,7 @@
   <property name="scenario" value="spyder"/>
   <property name="slug" value="routec"/>
   <property name="west" value="candy_town"/>
+  <property name="types" value="route"/>
  </properties>
  <tileset firstgid="1" name="core_outdoor_water" tilewidth="16" tileheight="16" tilecount="8192" columns="64">
   <image source="../gfx/tilesets/core_outdoor_water.png" width="1024" height="2048"/>

--- a/mods/tuxemon/maps/spyder_routed.tmx
+++ b/mods/tuxemon/maps/spyder_routed.tmx
@@ -4,6 +4,7 @@
   <property name="edges" value="clamped"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="routed"/>
+  <property name="types" value="route"/>
  </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>

--- a/mods/tuxemon/maps/spyder_routee.tmx
+++ b/mods/tuxemon/maps/spyder_routee.tmx
@@ -4,6 +4,7 @@
   <property name="edges" value="clamped"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="routee"/>
+  <property name="types" value="route"/>
  </properties>
  <tileset firstgid="1" name="core_outdoor" tilewidth="16" tileheight="16" tilecount="2294" columns="37">
   <image source="../gfx/tilesets/core_outdoor.png" width="592" height="1000"/>

--- a/mods/tuxemon/maps/spyder_scoop1.tmx
+++ b/mods/tuxemon/maps/spyder_scoop1.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="scoop1"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>

--- a/mods/tuxemon/maps/spyder_scoop2.tmx
+++ b/mods/tuxemon/maps/spyder_scoop2.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="scoop2"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_walls" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_walls.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/spyder_scoop3.tmx
+++ b/mods/tuxemon/maps/spyder_scoop3.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="scoop3"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
   <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>

--- a/mods/tuxemon/maps/spyder_scoop4.tmx
+++ b/mods/tuxemon/maps/spyder_scoop4.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="scoop4"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_floors" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_floors.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/spyder_timber_center.tmx
+++ b/mods/tuxemon/maps/spyder_timber_center.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="timber_center"/>
+  <property name="types" value="center"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_walls" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_walls.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/spyder_timber_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_timber_scoop.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="timber_scoop"/>
+  <property name="types" value="shop"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_floors" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_floors.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/spyder_timber_town.tmx
+++ b/mods/tuxemon/maps/spyder_timber_town.tmx
@@ -6,7 +6,7 @@
   <property name="scenario" value="spyder"/>
   <property name="slug" value="timber_town"/>
   <property name="south" value="tunnel"/>
-  <property name="town" type="bool" value="true"/>
+  <property name="types" value="town"/>
  </properties>
  <tileset firstgid="1" name="core_outdoor_nature" tilewidth="16" tileheight="16" tilecount="8192" columns="64">
   <image source="../gfx/tilesets/core_outdoor_nature.png" width="1024" height="2048"/>

--- a/mods/tuxemon/maps/spyder_tunnel.tmx
+++ b/mods/tuxemon/maps/spyder_tunnel.tmx
@@ -6,6 +6,7 @@
   <property name="scenario" value="spyder"/>
   <property name="slug" value="tunnel"/>
   <property name="west" value="route6"/>
+  <property name="types" value="route"/>
  </properties>
  <tileset firstgid="1" name="core_outdoor" tilewidth="16" tileheight="16" tilecount="2294" columns="37">
   <image source="../gfx/tilesets/core_outdoor.png" width="592" height="1000"/>

--- a/mods/tuxemon/maps/spyder_tunnel_below.tmx
+++ b/mods/tuxemon/maps/spyder_tunnel_below.tmx
@@ -5,6 +5,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="tunnel_below"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="160" columns="16">
   <image source="../gfx/tilesets/Cave_Tiles_by_ArMM1998_(Tuxemon_Style).png" width="256" height="160"/>

--- a/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
+++ b/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="wayfarer_inn1"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Interior_Walls_by_George" tilewidth="16" tileheight="16" tilecount="210" columns="15">
   <image source="../gfx/tilesets/Interior_Walls_by_George.png" width="240" height="224"/>

--- a/mods/tuxemon/maps/spyder_wayfarer_inn2.tmx
+++ b/mods/tuxemon/maps/spyder_wayfarer_inn2.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="wayfarer_inn2"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Interior_Walls_by_George" tilewidth="16" tileheight="16" tilecount="210" columns="15">
   <image source="../gfx/tilesets/Interior_Walls_by_George.png" width="240" height="224"/>

--- a/mods/tuxemon/maps/taba_town.tmx
+++ b/mods/tuxemon/maps/taba_town.tmx
@@ -5,7 +5,7 @@
   <property name="edges" value="clamped"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="taba_town"/>
-  <property name="town" type="bool" value="true"/>
+  <property name="types" value="town"/>
  </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">
   <image source="../gfx/tilesets/setPiecesTSR.png" width="671" height="512"/>

--- a/mods/tuxemon/maps/timber_town.tmx
+++ b/mods/tuxemon/maps/timber_town.tmx
@@ -5,7 +5,7 @@
   <property name="north" value="tunnel"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="timber_town"/>
-  <property name="town" type="bool" value="true"/>
+  <property name="types" value="town"/>
   <property name="west" value="route5"/>
  </properties>
  <tileset firstgid="1" name="setPiecesTSR" tilewidth="16" tileheight="16" tilecount="1312" columns="41">

--- a/mods/tuxemon/maps/tunnel.tmx
+++ b/mods/tuxemon/maps/tunnel.tmx
@@ -6,6 +6,7 @@
   <property name="slug" value="tunnel"/>
   <property name="south" value="timber_town"/>
   <property name="west" value="route6"/>
+  <property name="types" value="route"/>
  </properties>
  <tileset firstgid="1" name="Basic_Buch_Tiles_Compiled" tilewidth="16" tileheight="16" tilecount="448" columns="32">
   <image source="../gfx/tilesets/Basic_Buch_Tiles_Compiled.png" width="512" height="224"/>

--- a/mods/tuxemon/maps/tunnel_below.tmx
+++ b/mods/tuxemon/maps/tunnel_below.tmx
@@ -5,6 +5,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="tunnel_below"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Cave_Tiles_by_ArMM1998_(Tuxemon_Style)" tilewidth="16" tileheight="16" tilecount="160" columns="16">
   <image source="../gfx/tilesets/Cave_Tiles_by_ArMM1998_(Tuxemon_Style).png" width="256" height="160"/>

--- a/mods/tuxemon/maps/tuxe_mart_taba.tmx
+++ b/mods/tuxemon/maps/tuxe_mart_taba.tmx
@@ -5,6 +5,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="tuxe_mart_taba"/>
+  <property name="types" value="shop"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_walls" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_walls.png" width="736" height="1344"/>

--- a/mods/tuxemon/maps/wayfarer_inn1.tmx
+++ b/mods/tuxemon/maps/wayfarer_inn1.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="wayfarer_inn1"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Interior_Walls_by_George" tilewidth="16" tileheight="16" tilecount="210" columns="15">
   <image source="../gfx/tilesets/Interior_Walls_by_George.png" width="240" height="224"/>

--- a/mods/tuxemon/maps/wayfarer_inn2.tmx
+++ b/mods/tuxemon/maps/wayfarer_inn2.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="wayfarer_inn2"/>
+  <property name="types" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Set_Pieces_by_Kelvin_Shadewing" tilewidth="16" tileheight="16" tilecount="1440" columns="45">
   <image source="../gfx/tilesets/Set_Pieces_by_Kelvin_Shadewing.png" width="720" height="512"/>

--- a/tuxemon/client.py
+++ b/tuxemon/client.py
@@ -49,6 +49,7 @@ import pygame as pg
 from tuxemon import networking, rumble
 from tuxemon.cli.processor import CommandProcessor
 from tuxemon.config import TuxemonConfig
+from tuxemon.db import MapType
 from tuxemon.event import EventObject
 from tuxemon.event.eventengine import EventEngine
 from tuxemon.map import TuxemonMap
@@ -184,8 +185,19 @@ class LocalPygameClient:
         self.event_engine.reset()
         self.event_engine.current_map = map_data
         self.maps = map_data.maps
+
+        # Map properties
+        self.map_slug = map_data.slug
         self.map_name = map_data.name
         self.map_desc = map_data.description
+        self.map_inside = map_data.inside
+
+        # Check if the map type exists
+        types = [maps.value for maps in MapType]
+        if map_data.types in types:
+            self.map_type = map_data.types
+        else:
+            logger.error(f"The type '{map_data.types}' doesn't exist.")
 
         # Cardinal points
         if map_data.north_trans is None:

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -130,6 +130,15 @@ class SeenStatus(str, Enum):
     caught = "caught"
 
 
+class MapType(str, Enum):
+    notype = "notype"
+    town = "town"
+    route = "route"
+    center = "center"
+    shop = "shop"
+    dungeon = "dungeon"
+
+
 class EvolutionType(str, Enum):
     standard = "standard"
     item = "item"

--- a/tuxemon/item/conditions/has_path.py
+++ b/tuxemon/item/conditions/has_path.py
@@ -1,28 +1,3 @@
-#
-# Tuxemon
-# Copyright (c) 2014-2017 William Edwards <shadowapex@gmail.com>,
-#                         Benjamin Bean <superman2k5@gmail.com>
-#
-# This file is part of Tuxemon
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>.
-#
-# Contributor(s):
-#
-# Adam Chevalier <chevalieradam2@gmail.com>
-#
-
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/tuxemon/item/conditions/location_inside.py
+++ b/tuxemon/item/conditions/location_inside.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tuxemon.item.itemcondition import ItemCondition
+from tuxemon.monster import Monster
+
+
+@dataclass
+class LocationInsideCondition(ItemCondition):
+    """
+    Checks against the location type the player's in.
+
+    Accepts "inside" or "outside"
+
+    """
+
+    name = "location_inside"
+    location_inside: str
+
+    def test(self, target: Monster) -> bool:
+        if self.location_inside == "inside":
+            if self.session.client.map_inside:
+                return True
+            else:
+                return False
+        elif self.location_inside == "outside":
+            if self.session.client.map_inside:
+                return False
+            else:
+                return True

--- a/tuxemon/item/conditions/location_type.py
+++ b/tuxemon/item/conditions/location_type.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tuxemon.db import MapType
+from tuxemon.item.itemcondition import ItemCondition
+from tuxemon.monster import Monster
+
+
+@dataclass
+class LocationTypeCondition(ItemCondition):
+    """
+    Checks against the location type the player's in.
+
+    Shop, center, town, route, dungeon or notype.
+
+    """
+
+    name = "location_type"
+    location_type: str
+
+    def test(self, target: Monster) -> bool:
+        types = [maps.value for maps in MapType]
+        if self.location_type in types:
+            if self.session.client.map_type == self.location_type:
+                return True
+            else:
+                return False
+        else:
+            return False

--- a/tuxemon/map.py
+++ b/tuxemon/map.py
@@ -465,8 +465,8 @@ class TuxemonMap:
         self.inside = bool(maps.get("inside"))
         # scenario: spyder, xero or none
         self.scenario = maps.get("scenario")
-        # town (true), not town (none)
-        self.town = bool(maps.get("town"))
+        # check type of location
+        self.types = maps.get("types")
 
     def initialize_renderer(self) -> None:
         """

--- a/tuxemon/states/items/__init__.py
+++ b/tuxemon/states/items/__init__.py
@@ -155,6 +155,23 @@ class ItemMenuState(Menu[Item]):
             for m in local_session.player.monsters
         ):
             msg = T.format("item_no_available_target", {"name": item.name})
+            for i in menu_item.game_object.conditions:
+                if i.name == "location_inside":
+                    msg = T.format(
+                        "item_used_wrong_location_inside",
+                        {
+                            "name": item.name,
+                            "here": T.translate(i.__getattribute__("location_inside")),
+                        },
+                    )
+                elif i.name == "location_type":
+                    msg = T.format(
+                        "item_used_wrong_location_type",
+                        {
+                            "name": item.name,
+                            "here": T.translate(i.__getattribute__("location_type")),
+                        },
+                    )
             tools.open_dialog(local_session, [msg])
         elif State[state] not in item.usable_in:
             msg = T.format("item_cannot_use_here", {"name": item.name})


### PR DESCRIPTION
PR addresses the additions of two conditions for items:
- location_type target,(type of location: shop, center, town, route, dungeon or notype);
- location_inside, target,(inside or outside);
- creation of two strings in PO related to the condition;
- removed the boilerplate from has_path because I forgot (created the file);

```
  "conditions": [
    "location_type target,center",
    "location_inside target,inside"
  ],
```

We have already the distinction between battle and not battle; now we can have the distinction inside the world too by two conditions: type of map and inside/outside;

To do this I edited all the previous bool town in a simple "types" string, create a strenum in db, so there is the checking in client (as well as in the condition file) about the correctness of the string.

Why? Because of modders. It can be handy and I have a couple ideas on how to implement it.

```
class MapType(str, Enum):
    notype = "notype"
    town = "town"
    route = "route"
    center = "center"
    shop = "shop"
    dungeon = "dungeon"
```
If someone wants to add something to the MapType, feel free to add.

![Screenshot from 2022-12-04 11-08-42](https://user-images.githubusercontent.com/64643719/205485439-40267f62-5902-42a8-9230-a6acb87b11b3.png)
![Screenshot from 2022-12-04 11-11-28](https://user-images.githubusercontent.com/64643719/205485440-cb2a8c80-ff57-4c9d-8546-ea77aefbd802.png)
