### PR TITLE
breeding update

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -5204,7 +5204,7 @@ msgid "gotfivetuxeballs"
 msgstr "You got 5 Tuxeballs!"
 
 msgid "got_new_tuxemon"
-msgstr "You got a ${{monster_name}}!"
+msgstr "A new Tuxemon is born! Welcome {monster_name}!"
 
 msgid "spyder_greenwash_guard"
 msgstr "Alright, alright, nothing to see here."

--- a/mods/tuxemon/maps/daycare.tmx
+++ b/mods/tuxemon/maps/daycare.tmx
@@ -94,15 +94,16 @@
     <property name="cond10" value="is variable_set breeder_state:1"/>
     <property name="cond20" value="is to_talk cotton_breeder"/>
     <property name="cond30" value="not variable_set wannabreed"/>
+    <property name="cond40" value="is has_party_breeder"/>
    </properties>
   </object>
   <object id="23" name="breeder state 2a" type="event" x="144" y="48" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog cotton_breeder2a_1"/>
-    <property name="act15" value="get_player_monster breeding_mother"/>
+    <property name="act15" value="breeding female"/>
     <property name="act17" value="store_monster breeding_mother,cotton_breeder"/>
     <property name="act20" value="translated_dialog cotton_breeder2a_2"/>
-    <property name="act30" value="get_player_monster breeding_father"/>
+    <property name="act30" value="breeding male"/>
     <property name="act35" value="store_monster breeding_father,cotton_breeder"/>
     <property name="act40" value="set_variable breeder_state:3"/>
     <property name="act50" value="clear_variable wannabreed"/>

--- a/tuxemon/event/actions/breeding.py
+++ b/tuxemon/event/actions/breeding.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import NamedTuple, final
+
+from tuxemon.event.eventaction import EventAction
+from tuxemon.menu.interface import MenuItem
+from tuxemon.monster import Monster
+from tuxemon.states.monster import MonsterMenuState
+
+
+class BreedingActionParameters(NamedTuple):
+    gender: str
+
+
+@final
+class BreedingAction(EventAction[BreedingActionParameters]):
+    """
+    Select a monster in the player party filtered by gender and store its
+    id in a variables (breeding_father or breeding_mother)
+
+    Script usage:
+        .. code-block::
+
+            breeding <gender>
+
+    Script parameters:
+        gender: Gender (male or female).
+
+    """
+
+    name = "breeding"
+    param_class = BreedingActionParameters
+
+    def set_var(self, menu_item: MenuItem[Monster]) -> None:
+        if self.gender == "male":
+            if menu_item.game_object.gender == self.gender:
+                self.player.game_variables[
+                    "breeding_father"
+                ] = menu_item.game_object.instance_id.hex
+                self.session.client.pop_state()
+        elif self.gender == "female":
+            if menu_item.game_object.gender == self.gender:
+                self.player.game_variables[
+                    "breeding_mother"
+                ] = menu_item.game_object.instance_id.hex
+                self.session.client.pop_state()
+
+    def start(self) -> None:
+        self.player = self.session.player
+        self.gender = self.parameters.gender
+
+        # pull up the monster menu
+        menu = self.session.client.push_state(MonsterMenuState)
+        for t in self.player.monsters:
+            if t.gender == self.gender:
+                menu.on_menu_selection = self.set_var
+
+    def update(self) -> None:
+        try:
+            self.session.client.get_state_by_name(MonsterMenuState)
+        except ValueError:
+            self.stop()

--- a/tuxemon/event/conditions/has_party_breeder.py
+++ b/tuxemon/event/conditions/has_party_breeder.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from tuxemon.event import MapCondition
+from tuxemon.event.eventcondition import EventCondition
+from tuxemon.session import Session
+
+
+class HasPartyBreederCondition(EventCondition):
+    """
+    Check to see if the player has a male and female
+    monsters in the party.
+
+    Script usage:
+        .. code-block::
+
+            is has_party_breeder
+
+    """
+
+    name = "has_party_breeder"
+
+    def test(self, session: Session, condition: MapCondition) -> bool:
+        """
+        Check to see if the player has a technique in his party.
+
+        Parameters:
+            session: The session object
+            condition: The map condition object.
+
+        Returns:
+            Whether the player has a technique in his party.
+
+        """
+        player = session.player
+        if any(t for t in player.monsters if t.gender == "male"):
+            if any(t for t in player.monsters if t.gender == "female"):
+                return True
+        else:
+            return False

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -285,32 +285,6 @@ class Monster:
         self.set_stats()
         self.set_flairs()
 
-    def spawn(self, father: Monster) -> Monster:
-        """
-        Spawn a child monster.
-
-        Creates a new Monster, with this monster as the mother and the passed
-        in monster as father.
-
-        Parameters:
-            The monster.Monster to be father of this monsterous child.
-
-        Returns:
-            Child monster.
-
-        """
-        child = Monster()
-        child.load_from_db(self.slug)
-        child.set_level(5)
-
-        father_tech_count = len(father.moves)
-        tech_to_replace = random.randrange(0, 2)
-        child.moves[tech_to_replace] = father.moves[
-            random.randrange(0, father_tech_count - 1)
-        ]
-
-        return child
-
     def load_from_db(self, slug: str) -> None:
         """
         Loads and sets this monster's attributes from the monster.db database.


### PR DESCRIPTION
PR addresses breeding process:
- updated spawn_monster.py;
- deleted spawn in monster.py and centralized everything in spawn_monster.py (like random_ and add_monster);
- created a new condition for breeding, it returns true if there is a male and female in a party (important to avoid crashes);
- now without male and female monster in the player party, it's not possible to start the discussion about breeding;
- inserted matrix related to the type1, if the mother is FIRE and the father is WATER, the child will be FATHER based since WATER > FIRE (https://wiki.tuxemon.org/Category:Type);

No matter if Xero is still unplayable (daycare breeding dynamic is present only in Xero) and far from being complete, after introducing the gender mechanics it was necessary to update the process (now we have males and females). It can be handy if someone wants to introduce the same mechanics in another campaign.