### PR TITLE
fixing lifeleech status

### DIFF
--- a/tuxemon/combat.py
+++ b/tuxemon/combat.py
@@ -49,6 +49,17 @@ def check_status(monster: Monster, status_name: str) -> bool:
     return any(t for t in monster.status if t.slug == status_name)
 
 
+def check_status_connected(monster: Monster) -> bool:
+    """
+    Statuses connected are the ones where an effect is present only
+    if both monsters are alive (lifeleech, grabbed).
+    """
+    if check_status(monster, "status_grabbed"):
+        return True
+    elif check_status(monster, "status_lifeleech"):
+        return True
+
+
 def fainted(monster: Monster) -> bool:
     return check_status(monster, "status_faint") or monster.current_hp <= 0
 

--- a/tuxemon/combat.py
+++ b/tuxemon/combat.py
@@ -58,6 +58,8 @@ def check_status_connected(monster: Monster) -> bool:
         return True
     elif check_status(monster, "status_lifeleech"):
         return True
+    else:
+        return False
 
 
 def fainted(monster: Monster) -> bool:

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -141,7 +141,6 @@ def simple_damage_calculate(
 
 
 def simple_poison(
-    technique: Technique,
     target: Monster,
 ) -> int:
     """
@@ -160,7 +159,6 @@ def simple_poison(
 
 
 def simple_recover(
-    technique: Technique,
     target: Monster,
 ) -> int:
     """
@@ -179,7 +177,6 @@ def simple_recover(
 
 
 def simple_lifeleech(
-    technique: Technique,
     user: Monster,
     target: Monster,
 ) -> int:

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -56,7 +56,7 @@ from pygame.rect import Rect
 
 from tuxemon import audio, formula, graphics, state, tools
 from tuxemon.animation import Task
-from tuxemon.combat import check_status, defeated, fainted, get_awake_monsters
+from tuxemon.combat import check_status, defeated, fainted, get_awake_monsters, check_status_connected
 from tuxemon.db import OutputBattle, SeenStatus
 from tuxemon.item.item import Item
 from tuxemon.locale import T
@@ -691,6 +691,11 @@ class CombatState(CombatAnimations):
         self.animate_monster_release(player, monster)
         self.build_hud(self._layout[player]["hud"][0], monster)
         self.monsters_in_play[player].append(monster)
+
+        # remove "connected" status (eg. lifeleech, etc.)
+        for mon in self.monsters_in_play[self.players[0]]:
+            if check_status_connected(mon):
+                mon.status.clear()
 
         # TODO: not hardcode
         if player is self.players[0]:

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -56,7 +56,13 @@ from pygame.rect import Rect
 
 from tuxemon import audio, formula, graphics, state, tools
 from tuxemon.animation import Task
-from tuxemon.combat import check_status, defeated, fainted, get_awake_monsters, check_status_connected
+from tuxemon.combat import (
+    check_status,
+    check_status_connected,
+    defeated,
+    fainted,
+    get_awake_monsters,
+)
 from tuxemon.db import OutputBattle, SeenStatus
 from tuxemon.item.item import Item
 from tuxemon.locale import T

--- a/tuxemon/technique/effects/lifeleech.py
+++ b/tuxemon/technique/effects/lifeleech.py
@@ -50,11 +50,11 @@ class LifeLeechEffect(TechEffect):
         if user is None:
             user = tech.link
             assert user
-            damage = formula.simple_lifeleech(tech, user, target)
+            damage = formula.simple_lifeleech(user, target)
             target.current_hp -= damage
             user.current_hp += damage
         else:
-            damage = formula.simple_lifeleech(tech, user, target)
+            damage = formula.simple_lifeleech(user, target)
             target.current_hp -= damage
             user.current_hp += damage
 

--- a/tuxemon/technique/effects/poison.py
+++ b/tuxemon/technique/effects/poison.py
@@ -37,7 +37,7 @@ class PoisonEffect(TechEffect):
                 target.apply_status(tech)
             return {"status": tech}
 
-        damage = formula.simple_poison(tech, target)
+        damage = formula.simple_poison(target)
         target.current_hp -= damage
 
         return {

--- a/tuxemon/technique/effects/recover.py
+++ b/tuxemon/technique/effects/recover.py
@@ -38,10 +38,10 @@ class RecoverEffect(TechEffect):
         if user is None:
             user = tech.link
             assert user
-            heal = formula.simple_recover(tech, user)
+            heal = formula.simple_recover(user)
             user.current_hp += heal
         else:
-            heal = formula.simple_recover(tech, user)
+            heal = formula.simple_recover(user)
             user.current_hp += heal
 
         return {


### PR DESCRIPTION
Related to the recent  #1472 

Added check to the combat.py, so when the NPC monster faints, there is a check about the remaining monster of the PC (the one active in the battle);
if there is status_grabbed or status_lifeleech, then the status will be automatically cleaned up;

So we can solve 1 issue, 2 potential issues and cleaning up some unused parameters.

tested + black

update: moved most of the check in combat.py (no states) as check_status_connected, I want to avoid pointless ifs inside the other combat.py (states)