### PR TITLE
evolution stage

### DIFF
--- a/mods/tuxemon/db/monster/aardart.json
+++ b/mods/tuxemon/db/monster/aardart.json
@@ -22,6 +22,7 @@
     ],
     "evolutions": [],
     "shape": "varmint",
+    "stage": "stage1",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/aardorn.json
+++ b/mods/tuxemon/db/monster/aardorn.json
@@ -28,6 +28,7 @@
         }
     ],
     "shape": "varmint",
+    "stage": "basic",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/abesnaki.json
+++ b/mods/tuxemon/db/monster/abesnaki.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "serpent",
+    "stage": "standalone",
     "types": [
         "fire"
     ],

--- a/mods/tuxemon/db/monster/agnidon.json
+++ b/mods/tuxemon/db/monster/agnidon.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "dragon",
+    "stage": "stage1",
     "types": [
         "fire"
     ],

--- a/mods/tuxemon/db/monster/agnigon.json
+++ b/mods/tuxemon/db/monster/agnigon.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "dragon",
+    "stage": "stage2",
     "types": [
         "fire"
     ],

--- a/mods/tuxemon/db/monster/agnite.json
+++ b/mods/tuxemon/db/monster/agnite.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "dragon",
+    "stage": "basic",
     "types": [
         "fire"
     ],

--- a/mods/tuxemon/db/monster/allagon.json
+++ b/mods/tuxemon/db/monster/allagon.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "dragon",
+    "stage": "stage1",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/altie.json
+++ b/mods/tuxemon/db/monster/altie.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "humanoid",
+    "stage": "standalone",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/angrito.json
+++ b/mods/tuxemon/db/monster/angrito.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "blob",
+    "stage": "stage1",
     "types": [
         "fire",
         "metal"

--- a/mods/tuxemon/db/monster/anoleaf.json
+++ b/mods/tuxemon/db/monster/anoleaf.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "varmint",
+    "stage": "basic",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/anu.json
+++ b/mods/tuxemon/db/monster/anu.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "varmint",
+    "stage": "standalone",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/apeoro.json
+++ b/mods/tuxemon/db/monster/apeoro.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "humanoid",
+    "stage": "stage1",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/araignee.json
+++ b/mods/tuxemon/db/monster/araignee.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "grub",
+    "stage": "standalone",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/arthrobolt.json
+++ b/mods/tuxemon/db/monster/arthrobolt.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "humanoid",
+    "stage": "stage2",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/av8r.json
+++ b/mods/tuxemon/db/monster/av8r.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "flier",
+    "stage": "stage1",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/axylightl.json
+++ b/mods/tuxemon/db/monster/axylightl.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "polliwog",
+    "stage": "standalone",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/b_ver_1.json
+++ b/mods/tuxemon/db/monster/b_ver_1.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "varmint",
+    "stage": "stage1",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/bamboon.json
+++ b/mods/tuxemon/db/monster/bamboon.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "sprite",
+    "stage": "stage1",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/banling.json
+++ b/mods/tuxemon/db/monster/banling.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "brute",
+    "stage": "standalone",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/baobaraffe.json
+++ b/mods/tuxemon/db/monster/baobaraffe.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "landrace",
+    "stage": "stage1",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/baoby.json
+++ b/mods/tuxemon/db/monster/baoby.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "landrace",
+    "stage": "basic",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/beenstalker.json
+++ b/mods/tuxemon/db/monster/beenstalker.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "hunter",
+    "stage": "stage1",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/bigfin.json
+++ b/mods/tuxemon/db/monster/bigfin.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "leviathan",
+    "stage": "stage1",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/birb_robo.json
+++ b/mods/tuxemon/db/monster/birb_robo.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "flier",
+    "stage": "standalone",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/birdling.json
+++ b/mods/tuxemon/db/monster/birdling.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "flier",
+    "stage": "stage1",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/bolt.json
+++ b/mods/tuxemon/db/monster/bolt.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "blob",
+    "stage": "stage1",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/boltnu.json
+++ b/mods/tuxemon/db/monster/boltnu.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "blob",
+    "stage": "basic",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/botbot.json
+++ b/mods/tuxemon/db/monster/botbot.json
@@ -49,6 +49,7 @@
         }
     ],
     "shape": "grub",
+    "stage": "basic",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/boxali.json
+++ b/mods/tuxemon/db/monster/boxali.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "brute",
+    "stage": "standalone",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/brewdin.json
+++ b/mods/tuxemon/db/monster/brewdin.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "varmint",
+    "stage": "standalone",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/budaye.json
+++ b/mods/tuxemon/db/monster/budaye.json
@@ -43,6 +43,7 @@
         }
     ],
     "shape": "sprite",
+    "stage": "basic",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/bugnin.json
+++ b/mods/tuxemon/db/monster/bugnin.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "brute",
+    "stage": "stage2",
     "types": [
         "metal",
         "wood"

--- a/mods/tuxemon/db/monster/bumbulus.json
+++ b/mods/tuxemon/db/monster/bumbulus.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "blob",
+    "stage": "standalone",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/bursa.json
+++ b/mods/tuxemon/db/monster/bursa.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "humanoid",
+    "stage": "basic",
     "types": [
         "fire"
     ],

--- a/mods/tuxemon/db/monster/cairfrey.json
+++ b/mods/tuxemon/db/monster/cairfrey.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "blob",
+    "stage": "basic",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/capiti.json
+++ b/mods/tuxemon/db/monster/capiti.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "sprite",
+    "stage": "standalone",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/cardiling.json
+++ b/mods/tuxemon/db/monster/cardiling.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "flier",
+    "stage": "basic",
     "types": [
         "fire"
     ],

--- a/mods/tuxemon/db/monster/cardinale.json
+++ b/mods/tuxemon/db/monster/cardinale.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "flier",
+    "stage": "stage2",
     "types": [
         "fire"
     ],

--- a/mods/tuxemon/db/monster/cardiwing.json
+++ b/mods/tuxemon/db/monster/cardiwing.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "flier",
+    "stage": "stage1",
     "types": [
         "fire"
     ],

--- a/mods/tuxemon/db/monster/cataspike.json
+++ b/mods/tuxemon/db/monster/cataspike.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "grub",
+    "stage": "basic",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/cateye.json
+++ b/mods/tuxemon/db/monster/cateye.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "hunter",
+    "stage": "standalone",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/chenipode.json
+++ b/mods/tuxemon/db/monster/chenipode.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "grub",
+    "stage": "basic",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/chibiro.json
+++ b/mods/tuxemon/db/monster/chibiro.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "varmint",
+    "stage": "standalone",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/chillimp.json
+++ b/mods/tuxemon/db/monster/chillimp.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "brute",
+    "stage": "basic",
     "types": [
         "water",
         "earth"

--- a/mods/tuxemon/db/monster/chloragon.json
+++ b/mods/tuxemon/db/monster/chloragon.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "dragon",
+    "stage": "basic",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/chrome_robo.json
+++ b/mods/tuxemon/db/monster/chrome_robo.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "humanoid",
+    "stage": "standalone",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/chromeye.json
+++ b/mods/tuxemon/db/monster/chromeye.json
@@ -18,27 +18,32 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
+            "path": "mixed",
             "at_level": 20,
-            "monster_slug": "angrito"
+            "monster_slug": "angrito",
+            "mixed": "tobedefined"
         },
         {
-            "path": "standard",
+            "path": "mixed",
             "at_level": 20,
-            "monster_slug": "happito"
+            "monster_slug": "happito",
+            "mixed": "tobedefined"
         },
         {
-            "path": "standard",
+            "path": "mixed",
             "at_level": 20,
-            "monster_slug": "neutrito"
+            "monster_slug": "neutrito",
+            "mixed": "tobedefined"
         },
         {
-            "path": "standard",
+            "path": "mixed",
             "at_level": 20,
-            "monster_slug": "sadito"
+            "monster_slug": "sadito",
+            "mixed": "tobedefined"
         }
     ],
     "shape": "blob",
+    "stage": "basic",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/cochini.json
+++ b/mods/tuxemon/db/monster/cochini.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "varmint",
+    "stage": "standalone",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/coleorus.json
+++ b/mods/tuxemon/db/monster/coleorus.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "sprite",
+    "stage": "standalone",
     "types": [
         "wood",
         "earth"

--- a/mods/tuxemon/db/monster/conifrost.json
+++ b/mods/tuxemon/db/monster/conifrost.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "blob",
+    "stage": "standalone",
     "types": [
         "water",
         "wood"

--- a/mods/tuxemon/db/monster/conileaf.json
+++ b/mods/tuxemon/db/monster/conileaf.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "blob",
+    "stage": "standalone",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/coproblight.json
+++ b/mods/tuxemon/db/monster/coproblight.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "blob",
+    "stage": "standalone",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/corvix.json
+++ b/mods/tuxemon/db/monster/corvix.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "flier",
+    "stage": "stage1",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/cowpignon.json
+++ b/mods/tuxemon/db/monster/cowpignon.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "sprite",
+    "stage": "standalone",
     "types": [
         "wood",
         "earth"

--- a/mods/tuxemon/db/monster/criniotherme.json
+++ b/mods/tuxemon/db/monster/criniotherme.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "hunter",
+    "stage": "stage1",
     "types": [
         "fire"
     ],

--- a/mods/tuxemon/db/monster/d0llf1n.json
+++ b/mods/tuxemon/db/monster/d0llf1n.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "aquatic",
+    "stage": "standalone",
     "types": [
         "glitch",
         "water"

--- a/mods/tuxemon/db/monster/dandicub.json
+++ b/mods/tuxemon/db/monster/dandicub.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "blob",
+    "stage": "basic",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/dandylion.json
+++ b/mods/tuxemon/db/monster/dandylion.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "hunter",
+    "stage": "stage1",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/dark_robo.json
+++ b/mods/tuxemon/db/monster/dark_robo.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "humanoid",
+    "stage": "standalone",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/dinoflop.json
+++ b/mods/tuxemon/db/monster/dinoflop.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "dragon",
+    "stage": "standalone",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/djinnbo.json
+++ b/mods/tuxemon/db/monster/djinnbo.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "humanoid",
+    "stage": "standalone",
     "types": [
         "fire"
     ],

--- a/mods/tuxemon/db/monster/dollfin.json
+++ b/mods/tuxemon/db/monster/dollfin.json
@@ -43,6 +43,7 @@
         }
     ],
     "shape": "aquatic",
+    "stage": "basic",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/dracune.json
+++ b/mods/tuxemon/db/monster/dracune.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "blob",
+    "stage": "stage1",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/dragarbor.json
+++ b/mods/tuxemon/db/monster/dragarbor.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "dragon",
+    "stage": "stage2",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/drashimi.json
+++ b/mods/tuxemon/db/monster/drashimi.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "polliwog",
+    "stage": "basic",
     "types": [
         "water",
         "wood"

--- a/mods/tuxemon/db/monster/drokoro.json
+++ b/mods/tuxemon/db/monster/drokoro.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "dragon",
+    "stage": "standalone",
     "types": [
         "fire"
     ],

--- a/mods/tuxemon/db/monster/dune_pincher.json
+++ b/mods/tuxemon/db/monster/dune_pincher.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "grub",
+    "stage": "standalone",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/eaglace.json
+++ b/mods/tuxemon/db/monster/eaglace.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "flier",
+    "stage": "stage2",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/elofly.json
+++ b/mods/tuxemon/db/monster/elofly.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "flier",
+    "stage": "basic",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/elostorm.json
+++ b/mods/tuxemon/db/monster/elostorm.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "flier",
+    "stage": "stage2",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/elowind.json
+++ b/mods/tuxemon/db/monster/elowind.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "flier",
+    "stage": "stage1",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/embazook.json
+++ b/mods/tuxemon/db/monster/embazook.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "polliwog",
+    "stage": "stage1",
     "types": [
         "fire",
         "metal"

--- a/mods/tuxemon/db/monster/embra.json
+++ b/mods/tuxemon/db/monster/embra.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "blob",
+    "stage": "basic",
     "types": [
         "fire"
     ],

--- a/mods/tuxemon/db/monster/enduros.json
+++ b/mods/tuxemon/db/monster/enduros.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "brute",
+    "stage": "standalone",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/eruptibus.json
+++ b/mods/tuxemon/db/monster/eruptibus.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "landrace",
+    "stage": "stage1",
     "types": [
         "fire"
     ],

--- a/mods/tuxemon/db/monster/exapode.json
+++ b/mods/tuxemon/db/monster/exapode.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "grub",
+    "stage": "stage1",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/exclawvate.json
+++ b/mods/tuxemon/db/monster/exclawvate.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "dragon",
+    "stage": "stage1",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/eyenemy.json
+++ b/mods/tuxemon/db/monster/eyenemy.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "serpent",
+    "stage": "basic",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/eyesore.json
+++ b/mods/tuxemon/db/monster/eyesore.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "serpent",
+    "stage": "stage1",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/f7u1t3ra.json
+++ b/mods/tuxemon/db/monster/f7u1t3ra.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "flier",
+    "stage": "standalone",
     "types": [
         "glitch",
         "wood"

--- a/mods/tuxemon/db/monster/fancair.json
+++ b/mods/tuxemon/db/monster/fancair.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "sprite",
+    "stage": "basic",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/ferricran.json
+++ b/mods/tuxemon/db/monster/ferricran.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "dragon",
+    "stage": "stage2",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/flacono.json
+++ b/mods/tuxemon/db/monster/flacono.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "flier",
+    "stage": "basic",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/flambear.json
+++ b/mods/tuxemon/db/monster/flambear.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "brute",
+    "stage": "stage1",
     "types": [
         "fire"
     ],

--- a/mods/tuxemon/db/monster/fluoresfin.json
+++ b/mods/tuxemon/db/monster/fluoresfin.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "aquatic",
+    "stage": "basic",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/fluttaflap.json
+++ b/mods/tuxemon/db/monster/fluttaflap.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "grub",
+    "stage": "stage2",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/foofle.json
+++ b/mods/tuxemon/db/monster/foofle.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "varmint",
+    "stage": "standalone",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/fordin.json
+++ b/mods/tuxemon/db/monster/fordin.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "leviathan",
+    "stage": "standalone",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/forturtle.json
+++ b/mods/tuxemon/db/monster/forturtle.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "humanoid",
+    "stage": "basic",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/foxfire.json
+++ b/mods/tuxemon/db/monster/foxfire.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "varmint",
+    "stage": "standalone",
     "types": [
         "fire"
     ],

--- a/mods/tuxemon/db/monster/frondly.json
+++ b/mods/tuxemon/db/monster/frondly.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "sprite",
+    "stage": "stage1",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/fruitera.json
+++ b/mods/tuxemon/db/monster/fruitera.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "flier",
+    "stage": "standalone",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/furnursus.json
+++ b/mods/tuxemon/db/monster/furnursus.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "humanoid",
+    "stage": "basic",
     "types": [
         "fire"
     ],

--- a/mods/tuxemon/db/monster/galnec.json
+++ b/mods/tuxemon/db/monster/galnec.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "hunter",
+    "stage": "standalone",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/gectile.json
+++ b/mods/tuxemon/db/monster/gectile.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "humanoid",
+    "stage": "stage1",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/ghosteeth.json
+++ b/mods/tuxemon/db/monster/ghosteeth.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "blob",
+    "stage": "standalone",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/graffiki.json
+++ b/mods/tuxemon/db/monster/graffiki.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "humanoid",
+    "stage": "standalone",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/grimachin.json
+++ b/mods/tuxemon/db/monster/grimachin.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "hunter",
+    "stage": "basic",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/grinflare.json
+++ b/mods/tuxemon/db/monster/grinflare.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "brute",
+    "stage": "stage1",
     "types": [
         "earth",
         "fire"

--- a/mods/tuxemon/db/monster/grintot.json
+++ b/mods/tuxemon/db/monster/grintot.json
@@ -43,6 +43,7 @@
         }
     ],
     "shape": "brute",
+    "stage": "basic",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/grintrock.json
+++ b/mods/tuxemon/db/monster/grintrock.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "brute",
+    "stage": "stage1",
     "types": [
         "earth",
         "metal"

--- a/mods/tuxemon/db/monster/grumpi.json
+++ b/mods/tuxemon/db/monster/grumpi.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "brute",
+    "stage": "standalone",
     "types": [
         "earth",
         "water"

--- a/mods/tuxemon/db/monster/gryfix.json
+++ b/mods/tuxemon/db/monster/gryfix.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "flier",
+    "stage": "stage2",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/hampotamos.json
+++ b/mods/tuxemon/db/monster/hampotamos.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "landrace",
+    "stage": "standalone",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/happito.json
+++ b/mods/tuxemon/db/monster/happito.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "blob",
+    "stage": "stage1",
     "types": [
         "earth",
         "metal"

--- a/mods/tuxemon/db/monster/hatchling.json
+++ b/mods/tuxemon/db/monster/hatchling.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "flier",
+    "stage": "basic",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/heronquak.json
+++ b/mods/tuxemon/db/monster/heronquak.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "flier",
+    "stage": "stage1",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/hydrone.json
+++ b/mods/tuxemon/db/monster/hydrone.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "humanoid",
+    "stage": "standalone",
     "types": [
         "metal",
         "water"

--- a/mods/tuxemon/db/monster/ignibus.json
+++ b/mods/tuxemon/db/monster/ignibus.json
@@ -43,6 +43,7 @@
         }
     ],
     "shape": "polliwog",
+    "stage": "basic",
     "types": [
         "fire"
     ],

--- a/mods/tuxemon/db/monster/incandesfin.json
+++ b/mods/tuxemon/db/monster/incandesfin.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "aquatic",
+    "stage": "stage1",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/jelillow.json
+++ b/mods/tuxemon/db/monster/jelillow.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "blob",
+    "stage": "standalone",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/jemuar.json
+++ b/mods/tuxemon/db/monster/jemuar.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "hunter",
+    "stage": "stage2",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/k9.json
+++ b/mods/tuxemon/db/monster/k9.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "hunter",
+    "stage": "stage1",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/katacoon.json
+++ b/mods/tuxemon/db/monster/katacoon.json
@@ -31,6 +31,7 @@
         }
     ],
     "shape": "grub",
+    "stage": "stage1",
     "types": [
         "metal",
         "wood"

--- a/mods/tuxemon/db/monster/katapill.json
+++ b/mods/tuxemon/db/monster/katapill.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "grub",
+    "stage": "basic",
     "types": [
         "metal",
         "wood"

--- a/mods/tuxemon/db/monster/komodraw.json
+++ b/mods/tuxemon/db/monster/komodraw.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "humanoid",
+    "stage": "standalone",
     "types": [
         "fire"
     ],

--- a/mods/tuxemon/db/monster/l3gk0.json
+++ b/mods/tuxemon/db/monster/l3gk0.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "serpent",
+    "stage": "standalone",
     "types": [
         "glitch",
         "wood"

--- a/mods/tuxemon/db/monster/lambert.json
+++ b/mods/tuxemon/db/monster/lambert.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "sprite",
+    "stage": "basic",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/lapinou.json
+++ b/mods/tuxemon/db/monster/lapinou.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "varmint",
+    "stage": "standalone",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/legko.json
+++ b/mods/tuxemon/db/monster/legko.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "serpent",
+    "stage": "stage1",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/lightmare.json
+++ b/mods/tuxemon/db/monster/lightmare.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "leviathan",
+    "stage": "stage2",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/loliferno.json
+++ b/mods/tuxemon/db/monster/loliferno.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "blob",
+    "stage": "stage1",
     "types": [
         "fire"
     ],

--- a/mods/tuxemon/db/monster/lunight.json
+++ b/mods/tuxemon/db/monster/lunight.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "sprite",
+    "stage": "standalone",
     "types": [
         "metal",
         "water"

--- a/mods/tuxemon/db/monster/manosting.json
+++ b/mods/tuxemon/db/monster/manosting.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "blob",
+    "stage": "standalone",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/masknake.json
+++ b/mods/tuxemon/db/monster/masknake.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "serpent",
+    "stage": "standalone",
     "types": [
         "fire"
     ],

--- a/mods/tuxemon/db/monster/medushock.json
+++ b/mods/tuxemon/db/monster/medushock.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "blob",
+    "stage": "standalone",
     "types": [
         "fire",
         "water"

--- a/mods/tuxemon/db/monster/memnomnom.json
+++ b/mods/tuxemon/db/monster/memnomnom.json
@@ -43,6 +43,7 @@
         }
     ],
     "shape": "hunter",
+    "stage": "basic",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/merlicun.json
+++ b/mods/tuxemon/db/monster/merlicun.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "varmint",
+    "stage": "standalone",
     "types": [
         "fire"
     ],

--- a/mods/tuxemon/db/monster/metesaur.json
+++ b/mods/tuxemon/db/monster/metesaur.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "flier",
+    "stage": "basic",
     "types": [
         "earth",
         "fire"

--- a/mods/tuxemon/db/monster/miaownolith.json
+++ b/mods/tuxemon/db/monster/miaownolith.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "hunter",
+    "stage": "stage1",
     "types": [
         "metal",
         "earth"

--- a/mods/tuxemon/db/monster/mk01_alpha.json
+++ b/mods/tuxemon/db/monster/mk01_alpha.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "dragon",
+    "stage": "standalone",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/mk01_beta.json
+++ b/mods/tuxemon/db/monster/mk01_beta.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "dragon",
+    "stage": "standalone",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/moloch.json
+++ b/mods/tuxemon/db/monster/moloch.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "brute",
+    "stage": "stage2",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/mrmoswitch.json
+++ b/mods/tuxemon/db/monster/mrmoswitch.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "sprite",
+    "stage": "stage1",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/mystikapi.json
+++ b/mods/tuxemon/db/monster/mystikapi.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "landrace",
+    "stage": "standalone",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/narcileaf.json
+++ b/mods/tuxemon/db/monster/narcileaf.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "blob",
+    "stage": "stage1",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/neutrito.json
+++ b/mods/tuxemon/db/monster/neutrito.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "blob",
+    "stage": "stage1",
     "types": [
         "metal",
         "wood"

--- a/mods/tuxemon/db/monster/noctalo.json
+++ b/mods/tuxemon/db/monster/noctalo.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "flier",
+    "stage": "stage1",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/noctula.json
+++ b/mods/tuxemon/db/monster/noctula.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "flier",
+    "stage": "basic",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/nostray.json
+++ b/mods/tuxemon/db/monster/nostray.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "aquatic",
+    "stage": "basic",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/nudiflot_female.json
+++ b/mods/tuxemon/db/monster/nudiflot_female.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "polliwog",
+    "stage": "basic",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/nudiflot_male.json
+++ b/mods/tuxemon/db/monster/nudiflot_male.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "polliwog",
+    "stage": "basic",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/nudikill.json
+++ b/mods/tuxemon/db/monster/nudikill.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "polliwog",
+    "stage": "stage1",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/nudimind.json
+++ b/mods/tuxemon/db/monster/nudimind.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "polliwog",
+    "stage": "stage1",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/nuenflu.json
+++ b/mods/tuxemon/db/monster/nuenflu.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "varmint",
+    "stage": "standalone",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/nut.json
+++ b/mods/tuxemon/db/monster/nut.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "blob",
+    "stage": "basic",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/octabode.json
+++ b/mods/tuxemon/db/monster/octabode.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "polliwog",
+    "stage": "stage1",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/ouroboutlet.json
+++ b/mods/tuxemon/db/monster/ouroboutlet.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "serpent",
+    "stage": "stage1",
     "types": [
         "metal",
         "fire"

--- a/mods/tuxemon/db/monster/pairagrim.json
+++ b/mods/tuxemon/db/monster/pairagrim.json
@@ -22,6 +22,7 @@
     ],
     "evolutions": [],
     "shape": "flier",
+    "stage": "stage1",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/pairagrin.json
+++ b/mods/tuxemon/db/monster/pairagrin.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "flier",
+    "stage": "basic",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/pantherafira.json
+++ b/mods/tuxemon/db/monster/pantherafira.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "hunter",
+    "stage": "basic",
     "types": [
         "fire"
     ],

--- a/mods/tuxemon/db/monster/pharfan.json
+++ b/mods/tuxemon/db/monster/pharfan.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "landrace",
+    "stage": "standalone",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/picc.json
+++ b/mods/tuxemon/db/monster/picc.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "aquatic",
+    "stage": "stage1",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/pigabyte.json
+++ b/mods/tuxemon/db/monster/pigabyte.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "blob",
+    "stage": "standalone",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/pilthropus.json
+++ b/mods/tuxemon/db/monster/pilthropus.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "humanoid",
+    "stage": "standalone",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/pipis.json
+++ b/mods/tuxemon/db/monster/pipis.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "flier",
+    "stage": "basic",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/poinchin.json
+++ b/mods/tuxemon/db/monster/poinchin.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "grub",
+    "stage": "basic",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/polyrock.json
+++ b/mods/tuxemon/db/monster/polyrock.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "brute",
+    "stage": "standalone",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/possessun.json
+++ b/mods/tuxemon/db/monster/possessun.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "blob",
+    "stage": "stage1",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/propellercat.json
+++ b/mods/tuxemon/db/monster/propellercat.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "flier",
+    "stage": "standalone",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/prophetoise.json
+++ b/mods/tuxemon/db/monster/prophetoise.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "humanoid",
+    "stage": "stage1",
     "types": [
         "fire"
     ],

--- a/mods/tuxemon/db/monster/puparmor.json
+++ b/mods/tuxemon/db/monster/puparmor.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "blob",
+    "stage": "stage1",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/pyraminx.json
+++ b/mods/tuxemon/db/monster/pyraminx.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "hunter",
+    "stage": "stage1",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/pythock.json
+++ b/mods/tuxemon/db/monster/pythock.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "serpent",
+    "stage": "stage1",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/pythwire.json
+++ b/mods/tuxemon/db/monster/pythwire.json
@@ -31,6 +31,7 @@
         }
     ],
     "shape": "serpent",
+    "stage": "basic",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/qetzlrokilus.json
+++ b/mods/tuxemon/db/monster/qetzlrokilus.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "flier",
+    "stage": "stage1",
     "types": [
         "earth",
         "fire"

--- a/mods/tuxemon/db/monster/r0ck1tt3n.json
+++ b/mods/tuxemon/db/monster/r0ck1tt3n.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "hunter",
+    "stage": "standalone",
     "types": [
         "glitch",
         "earth"

--- a/mods/tuxemon/db/monster/rabbitosaur.json
+++ b/mods/tuxemon/db/monster/rabbitosaur.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "varmint",
+    "stage": "stage1",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/rhincus.json
+++ b/mods/tuxemon/db/monster/rhincus.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "flier",
+    "stage": "standalone",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/rockat.json
+++ b/mods/tuxemon/db/monster/rockat.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "hunter",
+    "stage": "stage1",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/rockitten.json
+++ b/mods/tuxemon/db/monster/rockitten.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "hunter",
+    "stage": "basic",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/rosarin.json
+++ b/mods/tuxemon/db/monster/rosarin.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "humanoid",
+    "stage": "standalone",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/ruption.json
+++ b/mods/tuxemon/db/monster/ruption.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "brute",
+    "stage": "stage1",
     "types": [
         "fire"
     ],

--- a/mods/tuxemon/db/monster/sadito.json
+++ b/mods/tuxemon/db/monster/sadito.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "blob",
+    "stage": "stage1",
     "types": [
         "metal",
         "water"

--- a/mods/tuxemon/db/monster/sampsack.json
+++ b/mods/tuxemon/db/monster/sampsack.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "brute",
+    "stage": "standalone",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/sampsage.json
+++ b/mods/tuxemon/db/monster/sampsage.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "humanoid",
+    "stage": "standalone",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/sapragon.json
+++ b/mods/tuxemon/db/monster/sapragon.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "dragon",
+    "stage": "stage1",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/sapsnap.json
+++ b/mods/tuxemon/db/monster/sapsnap.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "brute",
+    "stage": "stage1",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/saurchin.json
+++ b/mods/tuxemon/db/monster/saurchin.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "dragon",
+    "stage": "stage1",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/sclairus.json
+++ b/mods/tuxemon/db/monster/sclairus.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "blob",
+    "stage": "standalone",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/seirein.json
+++ b/mods/tuxemon/db/monster/seirein.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "blob",
+    "stage": "basic",
     "types": [
         "fire",
         "water"

--- a/mods/tuxemon/db/monster/selket.json
+++ b/mods/tuxemon/db/monster/selket.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "grub",
+    "stage": "basic",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/selmatek.json
+++ b/mods/tuxemon/db/monster/selmatek.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "grub",
+    "stage": "stage1",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/shammer.json
+++ b/mods/tuxemon/db/monster/shammer.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "hunter",
+    "stage": "standalone",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/sharpfin.json
+++ b/mods/tuxemon/db/monster/sharpfin.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "aquatic",
+    "stage": "stage1",
     "types": [
         "water",
         "wood"

--- a/mods/tuxemon/db/monster/shelagu.json
+++ b/mods/tuxemon/db/monster/shelagu.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "polliwog",
+    "stage": "standalone",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/shnark.json
+++ b/mods/tuxemon/db/monster/shnark.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "aquatic",
+    "stage": "stage1",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/shybulb.json
+++ b/mods/tuxemon/db/monster/shybulb.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "sprite",
+    "stage": "basic",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/skwib.json
+++ b/mods/tuxemon/db/monster/skwib.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "polliwog",
+    "stage": "basic",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/sludgehog.json
+++ b/mods/tuxemon/db/monster/sludgehog.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "landrace",
+    "stage": "standalone",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/snaki.json
+++ b/mods/tuxemon/db/monster/snaki.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "serpent",
+    "stage": "basic",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/snarlon.json
+++ b/mods/tuxemon/db/monster/snarlon.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "hunter",
+    "stage": "standalone",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/snock.json
+++ b/mods/tuxemon/db/monster/snock.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "serpent",
+    "stage": "basic",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/snokari.json
+++ b/mods/tuxemon/db/monster/snokari.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "serpent",
+    "stage": "stage1",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/snowrilla.json
+++ b/mods/tuxemon/db/monster/snowrilla.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "brute",
+    "stage": "stage1",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/sockeserp.json
+++ b/mods/tuxemon/db/monster/sockeserp.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "serpent",
+    "stage": "stage1",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/solight.json
+++ b/mods/tuxemon/db/monster/solight.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "sprite",
+    "stage": "standalone",
     "types": [
         "fire",
         "metal"

--- a/mods/tuxemon/db/monster/spighter.json
+++ b/mods/tuxemon/db/monster/spighter.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "grub",
+    "stage": "standalone",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/spoilurm.json
+++ b/mods/tuxemon/db/monster/spoilurm.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "serpent",
+    "stage": "standalone",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/spycozeus.json
+++ b/mods/tuxemon/db/monster/spycozeus.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "varmint",
+    "stage": "standalone",
     "types": [
         "metal",
         "wood"

--- a/mods/tuxemon/db/monster/squabbit.json
+++ b/mods/tuxemon/db/monster/squabbit.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "varmint",
+    "stage": "basic",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/statursus.json
+++ b/mods/tuxemon/db/monster/statursus.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "humanoid",
+    "stage": "stage1",
     "types": [
         "fire"
     ],

--- a/mods/tuxemon/db/monster/strella.json
+++ b/mods/tuxemon/db/monster/strella.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "flier",
+    "stage": "stage1",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/sumchon.json
+++ b/mods/tuxemon/db/monster/sumchon.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "brute",
+    "stage": "stage2",
     "types": [
         "metal",
         "wood"

--- a/mods/tuxemon/db/monster/tarpeur.json
+++ b/mods/tuxemon/db/monster/tarpeur.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "grub",
+    "stage": "basic",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/taupypus.json
+++ b/mods/tuxemon/db/monster/taupypus.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "varmint",
+    "stage": "standalone",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/teddisun.json
+++ b/mods/tuxemon/db/monster/teddisun.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "humanoid",
+    "stage": "standalone",
     "types": [
         "fire"
     ],

--- a/mods/tuxemon/db/monster/tetrchimp.json
+++ b/mods/tuxemon/db/monster/tetrchimp.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "humanoid",
+    "stage": "basic",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/tigrock.json
+++ b/mods/tuxemon/db/monster/tigrock.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "hunter",
+    "stage": "stage1",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/tikoal.json
+++ b/mods/tuxemon/db/monster/tikoal.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "blob",
+    "stage": "basic",
     "types": [
         "fire",
         "wood"

--- a/mods/tuxemon/db/monster/tikorch.json
+++ b/mods/tuxemon/db/monster/tikorch.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "blob",
+    "stage": "stage1",
     "types": [
         "fire",
         "wood"

--- a/mods/tuxemon/db/monster/tobishimi.json
+++ b/mods/tuxemon/db/monster/tobishimi.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "dragon",
+    "stage": "stage2",
     "types": [
         "water",
         "wood"

--- a/mods/tuxemon/db/monster/toufigel.json
+++ b/mods/tuxemon/db/monster/toufigel.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "varmint",
+    "stage": "standalone",
     "types": [
         "earth",
         "water"

--- a/mods/tuxemon/db/monster/tourbidi.json
+++ b/mods/tuxemon/db/monster/tourbidi.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "humanoid",
+    "stage": "standalone",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/trapsnap.json
+++ b/mods/tuxemon/db/monster/trapsnap.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "brute",
+    "stage": "basic",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/tsushimi.json
+++ b/mods/tuxemon/db/monster/tsushimi.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "dragon",
+    "stage": "stage1",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/tumblebee.json
+++ b/mods/tuxemon/db/monster/tumblebee.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "flier",
+    "stage": "stage1",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/tumblequill.json
+++ b/mods/tuxemon/db/monster/tumblequill.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "varmint",
+    "stage": "standalone",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/tumbleworm.json
+++ b/mods/tuxemon/db/monster/tumbleworm.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "grub",
+    "stage": "basic",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/turnipper.json
+++ b/mods/tuxemon/db/monster/turnipper.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "hunter",
+    "stage": "basic",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/tweesher.json
+++ b/mods/tuxemon/db/monster/tweesher.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "flier",
+    "stage": "basic",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/urcine.json
+++ b/mods/tuxemon/db/monster/urcine.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "brute",
+    "stage": "standalone",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/vamporm.json
+++ b/mods/tuxemon/db/monster/vamporm.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "grub",
+    "stage": "basic",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/velocitile.json
+++ b/mods/tuxemon/db/monster/velocitile.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "humanoid",
+    "stage": "stage2",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/vigueur.json
+++ b/mods/tuxemon/db/monster/vigueur.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "brute",
+    "stage": "stage1",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/vivicinder.json
+++ b/mods/tuxemon/db/monster/vivicinder.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "serpent",
+    "stage": "stage1",
     "types": [
         "fire"
     ],

--- a/mods/tuxemon/db/monster/vividactil.json
+++ b/mods/tuxemon/db/monster/vividactil.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "flier",
+    "stage": "stage1",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/vivipere.json
+++ b/mods/tuxemon/db/monster/vivipere.json
@@ -18,24 +18,26 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
-            "at_level": 25,
-            "monster_slug": "vivicinder"
+            "path": "mixed",
+            "at_level": 0,
+            "monster_slug": "vivicinder",
+            "mixed": "inside"
         },
         {
-            "path": "standard",
-            "at_level": 25,
-            "monster_slug": "viviphyta"
+            "path": "mixed",
+            "at_level": 0,
+            "monster_slug": "viviphyta",
+            "mixed": "wood"
         },
         {
-            "path": "standard",
+            "path": "gender",
             "at_level": 24,
             "monster_slug": "viviteel",
             "gender": "female"
         },
         {
             "path": "standard",
-            "at_level": 25,
+            "at_level": 0,
             "monster_slug": "vivitrans"
         },
         {
@@ -44,19 +46,20 @@
             "monster_slug": "vivitron"
         },
         {
-            "path": "standard",
-            "at_level": 24,
+            "path": "item",
+            "at_level": 0,
             "monster_slug": "vividactil",
             "item": "fossil"
         },
         {
-            "path": "standard",
+            "path": "gender",
             "at_level": 24,
             "monster_slug": "vivisource",
             "gender": "male"
         }
     ],
     "shape": "serpent",
+    "stage": "basic",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/viviphyta.json
+++ b/mods/tuxemon/db/monster/viviphyta.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "serpent",
+    "stage": "stage1",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/vivisource.json
+++ b/mods/tuxemon/db/monster/vivisource.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "serpent",
+    "stage": "stage1",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/viviteel.json
+++ b/mods/tuxemon/db/monster/viviteel.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "serpent",
+    "stage": "stage1",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/vivitrans.json
+++ b/mods/tuxemon/db/monster/vivitrans.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "serpent",
+    "stage": "stage1",
     "types": [
         "metal",
         "water"

--- a/mods/tuxemon/db/monster/vivitron.json
+++ b/mods/tuxemon/db/monster/vivitron.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "serpent",
+    "stage": "stage1",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/volcoli.json
+++ b/mods/tuxemon/db/monster/volcoli.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "humanoid",
+    "stage": "standalone",
     "types": [
         "fire"
     ],

--- a/mods/tuxemon/db/monster/weavifly.json
+++ b/mods/tuxemon/db/monster/weavifly.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "grub",
+    "stage": "stage2",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/windeye.json
+++ b/mods/tuxemon/db/monster/windeye.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "humanoid",
+    "stage": "stage1",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/wrougon.json
+++ b/mods/tuxemon/db/monster/wrougon.json
@@ -24,6 +24,7 @@
         }
     ],
     "shape": "dragon",
+    "stage": "basic",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/xeon.json
+++ b/mods/tuxemon/db/monster/xeon.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "humanoid",
+    "stage": "standalone",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/xeon_2.json
+++ b/mods/tuxemon/db/monster/xeon_2.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "humanoid",
+    "stage": "standalone",
     "types": [
         "metal"
     ],

--- a/mods/tuxemon/db/monster/yiinaang.json
+++ b/mods/tuxemon/db/monster/yiinaang.json
@@ -18,11 +18,12 @@
     ],
     "evolutions": [],
     "shape": "blob",
+    "stage": "standalone",
     "types": [
         "fire",
         "water"
     ],
-    "possible_genders": ["male", "female"],
+    "possible_genders": ["neuter"],
     "txmn_id": 142,
     "height": 200,
     "weight": 0,

--- a/mods/tuxemon/db/monster/zunna.json
+++ b/mods/tuxemon/db/monster/zunna.json
@@ -18,6 +18,7 @@
     ],
     "evolutions": [],
     "shape": "blob",
+    "stage": "standalone",
     "types": [
         "metal"
     ],

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -146,6 +146,13 @@ class EvolutionType(str, Enum):
     mixed = "mixed"
 
 
+class EvolutionStage(str, Enum):
+    standalone = "standalone"
+    basic = "basic"
+    stage1 = "stage1"
+    stage2 = "stage2"
+
+
 # TODO: Automatically generate state enum through discovery
 State = Enum(
     "State",
@@ -289,6 +296,9 @@ class MonsterModel(BaseModel):
     txmn_id: int = Field(..., description="The id of the monster")
     height: float = Field(..., description="The height of the monster")
     weight: float = Field(..., description="The weight of the monster")
+    stage: EvolutionStage = Field(
+        ..., description="The evolution stage of the monster"
+    )
 
     # Optional fields
     sprites: Optional[MonsterSpritesModel]

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -38,6 +38,7 @@ from tuxemon import ai, formula, fusion, graphics
 from tuxemon.config import TuxemonConfig
 from tuxemon.db import (
     ElementType,
+    EvolutionStage,
     GenderType,
     MonsterEvolutionItemModel,
     MonsterMovesetItemModel,
@@ -228,6 +229,7 @@ class Monster:
         self.moves: List[Technique] = []
         self.moveset: List[MonsterMovesetItemModel] = []
         self.evolutions: List[MonsterEvolutionItemModel] = []
+        self.stage = EvolutionStage.standalone
         self.flairs: Dict[str, Flair] = {}
         self.battle_cry = ""
         self.faint_cry = ""
@@ -307,6 +309,7 @@ class Monster:
         self.description = T.translate(f"{results.slug}_description")
         self.category = T.translate(results.category)
         self.shape = results.shape or MonsterShape.landrace
+        self.stage = results.stage or EvolutionStage.standalone
         types = results.types
         if types:
             self.type1 = results.types[0]


### PR DESCRIPTION
PR addresses the insertion of "stage" inside the monster.json; it completes the db giving an important piece of information.
Fixed the last genders;
Fixed structure evolution vivipere and chromeye;

it helps to filter out easily the monsters based on the stage:
- 81 standalone (no evolutionary line)
- 62 basic (eg rockitten)
- 81 stage1 (eg rockat)
- 17 stage2 (eg jemuar)