### PR TITLE
fix txmn_id

### DIFF
--- a/mods/tuxemon/db/monster/aardart.json
+++ b/mods/tuxemon/db/monster/aardart.json
@@ -27,7 +27,7 @@
         "earth"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 42,
+    "txmn_id": 43,
     "height": 185,
     "weight": 45,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/aardorn.json
+++ b/mods/tuxemon/db/monster/aardorn.json
@@ -33,7 +33,7 @@
         "earth"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 41,
+    "txmn_id": 42,
     "height": 40,
     "weight": 18,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/abesnaki.json
+++ b/mods/tuxemon/db/monster/abesnaki.json
@@ -23,7 +23,7 @@
         "fire"
     ],
     "possible_genders": ["neuter"],
-    "txmn_id": 98,
+    "txmn_id": 99,
     "height": 0,
     "weight": 0,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/allagon.json
+++ b/mods/tuxemon/db/monster/allagon.json
@@ -29,7 +29,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 153,
+    "txmn_id": 160,
     "height": 0,
     "weight": 0,
     "catch_rate": 3.0,

--- a/mods/tuxemon/db/monster/altie.json
+++ b/mods/tuxemon/db/monster/altie.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 201,
     "height": 130,
     "weight": 30,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/angrito.json
+++ b/mods/tuxemon/db/monster/angrito.json
@@ -24,7 +24,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 166,
+    "txmn_id": 175,
     "height": 90,
     "weight": 55,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/anoleaf.json
+++ b/mods/tuxemon/db/monster/anoleaf.json
@@ -29,7 +29,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 64,
+    "txmn_id": 65,
     "height": 0,
     "weight": 0,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/anu.json
+++ b/mods/tuxemon/db/monster/anu.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 162,
+    "txmn_id": 171,
     "height": 100,
     "weight": 10,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/apeoro.json
+++ b/mods/tuxemon/db/monster/apeoro.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 197,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/araignee.json
+++ b/mods/tuxemon/db/monster/araignee.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 99,
+    "txmn_id": 100,
     "height": 0,
     "weight": 0,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/av8r.json
+++ b/mods/tuxemon/db/monster/av8r.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["neuter"],
-    "txmn_id": 125,
+    "txmn_id": 126,
     "height": 0,
     "weight": 0,
     "sounds": {

--- a/mods/tuxemon/db/monster/axylightl.json
+++ b/mods/tuxemon/db/monster/axylightl.json
@@ -23,7 +23,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 100,
+    "txmn_id": 101,
     "height": 80,
     "weight": 15,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/b_ver_1.json
+++ b/mods/tuxemon/db/monster/b_ver_1.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["neuter"],
-    "txmn_id": 0,
+    "txmn_id": 130,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/bamboon.json
+++ b/mods/tuxemon/db/monster/bamboon.json
@@ -23,7 +23,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 27,
+    "txmn_id": 28,
     "height": 120,
     "weight": 40,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/banling.json
+++ b/mods/tuxemon/db/monster/banling.json
@@ -23,7 +23,7 @@
         "wood"
     ],
     "possible_genders": ["neuter"],
-    "txmn_id": 0,
+    "txmn_id": 200,
     "height": 120,
     "weight": 180,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/baobaraffe.json
+++ b/mods/tuxemon/db/monster/baobaraffe.json
@@ -23,7 +23,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 193,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/baoby.json
+++ b/mods/tuxemon/db/monster/baoby.json
@@ -29,7 +29,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 192,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/beenstalker.json
+++ b/mods/tuxemon/db/monster/beenstalker.json
@@ -23,7 +23,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 199,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/bigfin.json
+++ b/mods/tuxemon/db/monster/bigfin.json
@@ -23,7 +23,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 24,
+    "txmn_id": 25,
     "height": 1200,
     "weight": 50000,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/birdling.json
+++ b/mods/tuxemon/db/monster/birdling.json
@@ -23,7 +23,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 81,
+    "txmn_id": 82,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/boltnu.json
+++ b/mods/tuxemon/db/monster/boltnu.json
@@ -29,7 +29,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 194,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/botbot.json
+++ b/mods/tuxemon/db/monster/botbot.json
@@ -54,7 +54,7 @@
         "metal"
     ],
     "possible_genders": ["neuter"],
-    "txmn_id": 124,
+    "txmn_id": 125,
     "height": 0,
     "weight": 0,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/boxali.json
+++ b/mods/tuxemon/db/monster/boxali.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 213,
     "height": 180,
     "weight": 90,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/brewdin.json
+++ b/mods/tuxemon/db/monster/brewdin.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 215,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/budaye.json
+++ b/mods/tuxemon/db/monster/budaye.json
@@ -48,7 +48,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 26,
+    "txmn_id": 27,
     "height": 0,
     "weight": 0,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/bugnin.json
+++ b/mods/tuxemon/db/monster/bugnin.json
@@ -24,7 +24,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 57,
+    "txmn_id": 58,
     "height": 150,
     "weight": 52,
     "catch_rate": 3.0,

--- a/mods/tuxemon/db/monster/bumbulus.json
+++ b/mods/tuxemon/db/monster/bumbulus.json
@@ -23,7 +23,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 210,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/bursa.json
+++ b/mods/tuxemon/db/monster/bursa.json
@@ -29,7 +29,7 @@
         "fire"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 82,
+    "txmn_id": 83,
     "height": 180,
     "weight": 110,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/cairfrey.json
+++ b/mods/tuxemon/db/monster/cairfrey.json
@@ -29,7 +29,7 @@
         "earth"
     ],
     "possible_genders": ["neuter"],
-    "txmn_id": 70,
+    "txmn_id": 71,
     "height": 0,
     "weight": 0,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/capiti.json
+++ b/mods/tuxemon/db/monster/capiti.json
@@ -23,7 +23,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 101,
+    "txmn_id": 102,
     "height": 100,
     "weight": 20,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/cardiling.json
+++ b/mods/tuxemon/db/monster/cardiling.json
@@ -29,7 +29,7 @@
         "fire"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 61,
+    "txmn_id": 62,
     "height": 0,
     "weight": 0,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/cardinale.json
+++ b/mods/tuxemon/db/monster/cardinale.json
@@ -23,7 +23,7 @@
         "fire"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 63,
+    "txmn_id": 64,
     "height": 0,
     "weight": 0,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/cardiwing.json
+++ b/mods/tuxemon/db/monster/cardiwing.json
@@ -29,7 +29,7 @@
         "fire"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 62,
+    "txmn_id": 63,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/cataspike.json
+++ b/mods/tuxemon/db/monster/cataspike.json
@@ -29,7 +29,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 32,
+    "txmn_id": 33,
     "height": 12,
     "weight": 1,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/cateye.json
+++ b/mods/tuxemon/db/monster/cateye.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 102,
+    "txmn_id": 103,
     "height": 0,
     "weight": 0,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/chenipode.json
+++ b/mods/tuxemon/db/monster/chenipode.json
@@ -29,7 +29,7 @@
         "earth"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 59,
+    "txmn_id": 60,
     "height": 15,
     "weight": 0.5,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/chibiro.json
+++ b/mods/tuxemon/db/monster/chibiro.json
@@ -23,7 +23,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 212,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/chillimp.json
+++ b/mods/tuxemon/db/monster/chillimp.json
@@ -30,7 +30,7 @@
         "earth"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 149,
+    "txmn_id": 154,
     "height": 0,
     "weight": 0,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/chloragon.json
+++ b/mods/tuxemon/db/monster/chloragon.json
@@ -29,7 +29,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 136,
+    "txmn_id": 140,
     "height": 0,
     "weight": 0,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/chromeye.json
+++ b/mods/tuxemon/db/monster/chromeye.json
@@ -48,7 +48,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 165,
+    "txmn_id": 174,
     "height": 38,
     "weight": 3.5,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/cochini.json
+++ b/mods/tuxemon/db/monster/cochini.json
@@ -23,7 +23,7 @@
         "earth"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 103,
+    "txmn_id": 104,
     "height": 80,
     "weight": 15,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/coleorus.json
+++ b/mods/tuxemon/db/monster/coleorus.json
@@ -24,7 +24,7 @@
         "earth"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 104,
+    "txmn_id": 105,
     "height": 0,
     "weight": 0,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/conifrost.json
+++ b/mods/tuxemon/db/monster/conifrost.json
@@ -24,7 +24,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 105,
+    "txmn_id": 106,
     "height": 250,
     "weight": 371,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/conileaf.json
+++ b/mods/tuxemon/db/monster/conileaf.json
@@ -23,7 +23,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 144,
+    "txmn_id": 148,
     "height": 0,
     "weight": 0,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/coproblight.json
+++ b/mods/tuxemon/db/monster/coproblight.json
@@ -23,7 +23,7 @@
         "earth"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 164,
+    "txmn_id": 173,
     "height": 0,
     "weight": 1,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/corvix.json
+++ b/mods/tuxemon/db/monster/corvix.json
@@ -29,7 +29,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 151,
+    "txmn_id": 157,
     "height": 0,
     "weight": 0,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/cowpignon.json
+++ b/mods/tuxemon/db/monster/cowpignon.json
@@ -24,7 +24,7 @@
         "earth"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 106,
+    "txmn_id": 107,
     "height": 30.48,
     "weight": 2,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/criniotherme.json
+++ b/mods/tuxemon/db/monster/criniotherme.json
@@ -23,7 +23,7 @@
         "fire"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 20,
+    "txmn_id": 23,
     "height": 210,
     "weight": 170,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/dandicub.json
+++ b/mods/tuxemon/db/monster/dandicub.json
@@ -29,7 +29,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 72,
+    "txmn_id": 73,
     "height": 0,
     "weight": 0,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/dandylion.json
+++ b/mods/tuxemon/db/monster/dandylion.json
@@ -23,7 +23,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 73,
+    "txmn_id": 74,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/dinoflop.json
+++ b/mods/tuxemon/db/monster/dinoflop.json
@@ -23,7 +23,7 @@
         "earth"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 157,
+    "txmn_id": 166,
     "height": 120,
     "weight": 120,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/djinnbo.json
+++ b/mods/tuxemon/db/monster/djinnbo.json
@@ -23,7 +23,7 @@
         "fire"
     ],
     "possible_genders": ["neuter"],
-    "txmn_id": 107,
+    "txmn_id": 108,
     "height": 160,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/dollfin.json
+++ b/mods/tuxemon/db/monster/dollfin.json
@@ -48,7 +48,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 23,	
+    "txmn_id": 24,	
     "height": 250,
     "weight": 190,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/dracune.json
+++ b/mods/tuxemon/db/monster/dracune.json
@@ -29,7 +29,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 36,
+    "txmn_id": 37,
     "height": 0,
     "weight": 0,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/dragarbor.json
+++ b/mods/tuxemon/db/monster/dragarbor.json
@@ -23,7 +23,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 138,
+    "txmn_id": 142,
     "height": 0,
     "weight": 0,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/drashimi.json
+++ b/mods/tuxemon/db/monster/drashimi.json
@@ -30,7 +30,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 185,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/drokoro.json
+++ b/mods/tuxemon/db/monster/drokoro.json
@@ -23,7 +23,7 @@
         "fire"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 141,
+    "txmn_id": 145,
     "height": 1200,
     "weight": 10000,
     "catch_rate": 3.0,

--- a/mods/tuxemon/db/monster/dune_pincher.json
+++ b/mods/tuxemon/db/monster/dune_pincher.json
@@ -23,7 +23,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 108,
+    "txmn_id": 109,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/elofly.json
+++ b/mods/tuxemon/db/monster/elofly.json
@@ -29,7 +29,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 38,
+    "txmn_id": 39,
     "height": 0,
     "weight": 0,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/elostorm.json
+++ b/mods/tuxemon/db/monster/elostorm.json
@@ -23,7 +23,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 40,
+    "txmn_id": 41,
     "height": 0,
     "weight": 0,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/elowind.json
+++ b/mods/tuxemon/db/monster/elowind.json
@@ -29,7 +29,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 39,
+    "txmn_id": 40,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/embazook.json
+++ b/mods/tuxemon/db/monster/embazook.json
@@ -24,7 +24,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 30,
+    "txmn_id": 31,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/embra.json
+++ b/mods/tuxemon/db/monster/embra.json
@@ -29,7 +29,7 @@
         "fire"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 74,
+    "txmn_id": 75,
     "height": 0,
     "weight": 0,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/enduros.json
+++ b/mods/tuxemon/db/monster/enduros.json
@@ -23,7 +23,7 @@
         "earth"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 158,
+    "txmn_id": 167,
     "height": 170,
     "weight": 65,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/eruptibus.json
+++ b/mods/tuxemon/db/monster/eruptibus.json
@@ -23,7 +23,7 @@
         "fire"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 31,
+    "txmn_id": 32,
     "height": 600,
     "weight": 12000,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/exapode.json
+++ b/mods/tuxemon/db/monster/exapode.json
@@ -23,7 +23,7 @@
         "earth"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 60,
+    "txmn_id": 61,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/exclawvate.json
+++ b/mods/tuxemon/db/monster/exclawvate.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 195,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/eyenemy.json
+++ b/mods/tuxemon/db/monster/eyenemy.json
@@ -29,7 +29,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 45,
+    "txmn_id": 46,
     "height": 0,
     "weight": 0,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/eyesore.json
+++ b/mods/tuxemon/db/monster/eyesore.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 46,
+    "txmn_id": 47,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/fancair.json
+++ b/mods/tuxemon/db/monster/fancair.json
@@ -29,7 +29,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 170,
+    "txmn_id": 179,
     "height": 45,
     "weight": 18,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/ferricran.json
+++ b/mods/tuxemon/db/monster/ferricran.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 161,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/flacono.json
+++ b/mods/tuxemon/db/monster/flacono.json
@@ -29,7 +29,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 150,
+    "txmn_id": 156,
     "height": 70,
     "weight": 6,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/flambear.json
+++ b/mods/tuxemon/db/monster/flambear.json
@@ -23,7 +23,7 @@
         "fire"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 83,
+    "txmn_id": 84,
     "height": 250,
     "weight": 500,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/fluoresfin.json
+++ b/mods/tuxemon/db/monster/fluoresfin.json
@@ -29,7 +29,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 67,
+    "txmn_id": 68,
     "height": 80,
     "weight": 11,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/fluttaflap.json
+++ b/mods/tuxemon/db/monster/fluttaflap.json
@@ -23,7 +23,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 37,
+    "txmn_id": 38,
     "height": 0,
     "weight": 0,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/foofle.json
+++ b/mods/tuxemon/db/monster/foofle.json
@@ -23,7 +23,7 @@
         "earth"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 109,
+    "txmn_id": 110,
     "height": 0,
     "weight": 0,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/fordin.json
+++ b/mods/tuxemon/db/monster/fordin.json
@@ -23,7 +23,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 211,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/forturtle.json
+++ b/mods/tuxemon/db/monster/forturtle.json
@@ -29,7 +29,7 @@
         "earth"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 86,
+    "txmn_id": 87,
     "height": 0,
     "weight": 0,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/foxfire.json
+++ b/mods/tuxemon/db/monster/foxfire.json
@@ -23,7 +23,7 @@
         "fire"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 145,
+    "txmn_id": 149,
     "height": 0,
     "weight": 0,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/frondly.json
+++ b/mods/tuxemon/db/monster/frondly.json
@@ -23,7 +23,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 28,
+    "txmn_id": 29,
     "height": 0,
     "weight": 0,
     "catch_rate": 3.0,

--- a/mods/tuxemon/db/monster/fruitera.json
+++ b/mods/tuxemon/db/monster/fruitera.json
@@ -23,7 +23,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 160,
+    "txmn_id": 169,
     "height": 30,
     "weight": 2,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/furnursus.json
+++ b/mods/tuxemon/db/monster/furnursus.json
@@ -29,7 +29,7 @@
         "fire"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 190,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/galnec.json
+++ b/mods/tuxemon/db/monster/galnec.json
@@ -23,7 +23,7 @@
         "earth"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 159,
+    "txmn_id": 168,
     "height": 40,
     "weight": 6,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/gectile.json
+++ b/mods/tuxemon/db/monster/gectile.json
@@ -29,7 +29,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 65,
+    "txmn_id": 66,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/ghosteeth.json
+++ b/mods/tuxemon/db/monster/ghosteeth.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["neuter"],
-    "txmn_id": 110,
+    "txmn_id": 111,
     "height": 70,
     "weight": 0,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/graffiki.json
+++ b/mods/tuxemon/db/monster/graffiki.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 205,
     "height": 65,
     "weight": 13,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/grimachin.json
+++ b/mods/tuxemon/db/monster/grimachin.json
@@ -29,7 +29,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 92,
+    "txmn_id": 93,
     "height": 45,
     "weight": 3,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/grumpi.json
+++ b/mods/tuxemon/db/monster/grumpi.json
@@ -24,7 +24,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 206,
     "height": 150,
     "weight": 160,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/gryfix.json
+++ b/mods/tuxemon/db/monster/gryfix.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 158,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/hampotamos.json
+++ b/mods/tuxemon/db/monster/hampotamos.json
@@ -23,7 +23,7 @@
         "earth"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 146,
+    "txmn_id": 150,
     "height": 150,
     "weight": 180,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/happito.json
+++ b/mods/tuxemon/db/monster/happito.json
@@ -24,7 +24,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 167,
+    "txmn_id": 176,
     "height": 90,
     "weight": 55,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/hatchling.json
+++ b/mods/tuxemon/db/monster/hatchling.json
@@ -29,7 +29,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 80,
+    "txmn_id": 81,
     "height": 0,
     "weight": 0,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/hydrone.json
+++ b/mods/tuxemon/db/monster/hydrone.json
@@ -24,7 +24,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 111,
+    "txmn_id": 112,
     "height": 155,
     "weight": 200,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/ignibus.json
+++ b/mods/tuxemon/db/monster/ignibus.json
@@ -48,7 +48,7 @@
         "fire"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 29,
+    "txmn_id": 30,
     "height": 0,
     "weight": 0,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/incandesfin.json
+++ b/mods/tuxemon/db/monster/incandesfin.json
@@ -29,7 +29,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 68,
+    "txmn_id": 69,
     "height": 250,
     "weight": 150,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/jelillow.json
+++ b/mods/tuxemon/db/monster/jelillow.json
@@ -23,7 +23,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 207,
     "height": 66,
     "weight": 9.6,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/k9.json
+++ b/mods/tuxemon/db/monster/k9.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["neuter"],
-    "txmn_id": 128,
+    "txmn_id": 129,
     "height": 60,
     "weight": 5,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/katacoon.json
+++ b/mods/tuxemon/db/monster/katacoon.json
@@ -37,7 +37,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 56,
+    "txmn_id": 57,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/katapill.json
+++ b/mods/tuxemon/db/monster/katapill.json
@@ -30,7 +30,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 55,
+    "txmn_id": 56,
     "height": 0,
     "weight": 0,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/komodraw.json
+++ b/mods/tuxemon/db/monster/komodraw.json
@@ -23,7 +23,7 @@
         "fire"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 91,
+    "txmn_id": 92,
     "height": 155,
     "weight": 55,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/lapinou.json
+++ b/mods/tuxemon/db/monster/lapinou.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 112,
+    "txmn_id": 113,
     "height": 60,
     "weight": 8,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/lightmare.json
+++ b/mods/tuxemon/db/monster/lightmare.json
@@ -23,7 +23,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 69,
+    "txmn_id": 70,
     "height": 300,
     "weight": 200,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/loliferno.json
+++ b/mods/tuxemon/db/monster/loliferno.json
@@ -23,7 +23,7 @@
         "fire"
     ],
     "possible_genders": ["neuter"],
-    "txmn_id": 0,
+    "txmn_id": 163,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/lunight.json
+++ b/mods/tuxemon/db/monster/lunight.json
@@ -24,7 +24,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 214,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/manosting.json
+++ b/mods/tuxemon/db/monster/manosting.json
@@ -23,7 +23,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 113,
+    "txmn_id": 114,
     "height": 180,
     "weight": 0,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/masknake.json
+++ b/mods/tuxemon/db/monster/masknake.json
@@ -23,7 +23,7 @@
         "fire"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 114,
+    "txmn_id": 115,
     "height": 0,
     "weight": 0,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/medushock.json
+++ b/mods/tuxemon/db/monster/medushock.json
@@ -24,7 +24,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 208,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/merlicun.json
+++ b/mods/tuxemon/db/monster/merlicun.json
@@ -23,7 +23,7 @@
         "fire"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 209,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/metesaur.json
+++ b/mods/tuxemon/db/monster/metesaur.json
@@ -30,7 +30,7 @@
         "fire"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 202,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/miaownolith.json
+++ b/mods/tuxemon/db/monster/miaownolith.json
@@ -24,7 +24,7 @@
         "earth"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 21,
+    "txmn_id": 20,
     "height": 210,
     "weight": 255,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/mrmoswitch.json
+++ b/mods/tuxemon/db/monster/mrmoswitch.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["neuter"],
-    "txmn_id": 127,
+    "txmn_id": 128,
     "height": 0,
     "weight": 0,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/mystikapi.json
+++ b/mods/tuxemon/db/monster/mystikapi.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 223,
     "height": 160,
     "weight": 250,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/narcileaf.json
+++ b/mods/tuxemon/db/monster/narcileaf.json
@@ -23,7 +23,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 77,
+    "txmn_id": 78,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/neutrito.json
+++ b/mods/tuxemon/db/monster/neutrito.json
@@ -24,7 +24,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 168,
+    "txmn_id": 177,
     "height": 90,
     "weight": 55,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/noctalo.json
+++ b/mods/tuxemon/db/monster/noctalo.json
@@ -23,7 +23,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 50,
+    "txmn_id": 51,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/noctula.json
+++ b/mods/tuxemon/db/monster/noctula.json
@@ -29,7 +29,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 49,
+    "txmn_id": 50,
     "height": 0,
     "weight": 0,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/nostray.json
+++ b/mods/tuxemon/db/monster/nostray.json
@@ -29,7 +29,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 148,
+    "txmn_id": 152,
     "height": 120,
     "weight": 30,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/nudiflot_female.json
+++ b/mods/tuxemon/db/monster/nudiflot_female.json
@@ -29,7 +29,7 @@
         "water"
     ],
     "possible_genders": ["female"],
-    "txmn_id": 53,
+    "txmn_id": 54,
     "height": 0,
     "weight": 0,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/nudiflot_male.json
+++ b/mods/tuxemon/db/monster/nudiflot_male.json
@@ -29,7 +29,7 @@
         "water"
     ],
     "possible_genders": ["male"],
-    "txmn_id": 51,
+    "txmn_id": 52,
     "height": 36,
     "weight": 3,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/nudikill.json
+++ b/mods/tuxemon/db/monster/nudikill.json
@@ -23,7 +23,7 @@
         "water"
     ],
     "possible_genders": ["male"],
-    "txmn_id": 52,
+    "txmn_id": 53,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/nudimind.json
+++ b/mods/tuxemon/db/monster/nudimind.json
@@ -23,7 +23,7 @@
         "water"
     ],
     "possible_genders": ["female"],
-    "txmn_id": 54,
+    "txmn_id": 55,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/nuenflu.json
+++ b/mods/tuxemon/db/monster/nuenflu.json
@@ -23,7 +23,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 224,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/octabode.json
+++ b/mods/tuxemon/db/monster/octabode.json
@@ -23,7 +23,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 184,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/ouroboutlet.json
+++ b/mods/tuxemon/db/monster/ouroboutlet.json
@@ -24,7 +24,7 @@
         "fire"
     ],
     "possible_genders": ["neuter"],
-    "txmn_id": 89,
+    "txmn_id": 90,
     "height": 62,
     "weight": 4,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/pairagrim.json
+++ b/mods/tuxemon/db/monster/pairagrim.json
@@ -27,7 +27,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 173,
+    "txmn_id": 182,
     "height": 0,
     "weight": 10,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/pairagrin.json
+++ b/mods/tuxemon/db/monster/pairagrin.json
@@ -29,7 +29,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 172,
+    "txmn_id": 181,
     "height": 70,
     "weight": 4,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/pantherafira.json
+++ b/mods/tuxemon/db/monster/pantherafira.json
@@ -29,7 +29,7 @@
         "fire"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 22,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/pharfan.json
+++ b/mods/tuxemon/db/monster/pharfan.json
@@ -23,7 +23,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 147,
+    "txmn_id": 151,
     "height": 200,
     "weight": 500,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/picc.json
+++ b/mods/tuxemon/db/monster/picc.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["neuter"],
-    "txmn_id": 126,
+    "txmn_id": 127,
     "height": 55,
     "weight": 4,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/pigabyte.json
+++ b/mods/tuxemon/db/monster/pigabyte.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 115,
+    "txmn_id": 116,
     "height": 155,
     "weight": 180,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/pilthropus.json
+++ b/mods/tuxemon/db/monster/pilthropus.json
@@ -23,7 +23,7 @@
         "earth"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 163,
+    "txmn_id": 172,
     "height": 0,
     "weight": 50,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/pipis.json
+++ b/mods/tuxemon/db/monster/pipis.json
@@ -29,7 +29,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 47,
+    "txmn_id": 48,
     "height": 0,
     "weight": 0,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/poinchin.json
+++ b/mods/tuxemon/db/monster/poinchin.json
@@ -29,7 +29,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 155,
+    "txmn_id": 164,
     "height": 30,
     "weight": 6,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/polyrock.json
+++ b/mods/tuxemon/db/monster/polyrock.json
@@ -23,7 +23,7 @@
         "earth"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 116,
+    "txmn_id": 117,
     "height": 0,
     "weight": 0,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/possessun.json
+++ b/mods/tuxemon/db/monster/possessun.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["neuter"],
-    "txmn_id": 71,
+    "txmn_id": 72,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/propellercat.json
+++ b/mods/tuxemon/db/monster/propellercat.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 117,
+    "txmn_id": 118,
     "height": 55,
     "weight": 6,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/prophetoise.json
+++ b/mods/tuxemon/db/monster/prophetoise.json
@@ -23,7 +23,7 @@
         "fire"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 87,
+    "txmn_id": 88,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/puparmor.json
+++ b/mods/tuxemon/db/monster/puparmor.json
@@ -29,7 +29,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 33,
+    "txmn_id": 34,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/pyraminx.json
+++ b/mods/tuxemon/db/monster/pyraminx.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 22,
+    "txmn_id": 21,
     "height": 210,
     "weight": 190,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/pythock.json
+++ b/mods/tuxemon/db/monster/pythock.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 226,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/pythwire.json
+++ b/mods/tuxemon/db/monster/pythwire.json
@@ -36,7 +36,7 @@
         "metal"
     ],
     "possible_genders": ["neuter"],
-    "txmn_id": 88,
+    "txmn_id": 89,
     "height": 200,
     "weight": 4,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/qetzlrokilus.json
+++ b/mods/tuxemon/db/monster/qetzlrokilus.json
@@ -24,7 +24,7 @@
         "fire"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 203,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/rabbitosaur.json
+++ b/mods/tuxemon/db/monster/rabbitosaur.json
@@ -23,7 +23,7 @@
         "earth"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 44,
+    "txmn_id": 45,
     "height": 120,
     "weight": 80,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/rhincus.json
+++ b/mods/tuxemon/db/monster/rhincus.json
@@ -23,7 +23,7 @@
         "earth"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 139,
+    "txmn_id": 143,
     "height": 0,
     "weight": 0,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/rosarin.json
+++ b/mods/tuxemon/db/monster/rosarin.json
@@ -23,7 +23,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 204,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/ruption.json
+++ b/mods/tuxemon/db/monster/ruption.json
@@ -23,7 +23,7 @@
         "fire"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 75,
+    "txmn_id": 76,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/sadito.json
+++ b/mods/tuxemon/db/monster/sadito.json
@@ -24,7 +24,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 169,
+    "txmn_id": 178,
     "height": 90,
     "weight": 55,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/sampsack.json
+++ b/mods/tuxemon/db/monster/sampsack.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 96,
+    "txmn_id": 97,
     "height": 225,
     "weight": 235,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/sampsage.json
+++ b/mods/tuxemon/db/monster/sampsage.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 97,
+    "txmn_id": 98,
     "height": 0,
     "weight": 0,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/sapragon.json
+++ b/mods/tuxemon/db/monster/sapragon.json
@@ -29,7 +29,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 137,
+    "txmn_id": 141,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/sapsnap.json
+++ b/mods/tuxemon/db/monster/sapsnap.json
@@ -23,7 +23,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 85,
+    "txmn_id": 86,
     "height": 210,
     "weight": 125,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/saurchin.json
+++ b/mods/tuxemon/db/monster/saurchin.json
@@ -23,7 +23,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 156,
+    "txmn_id": 165,
     "height": 800,
     "weight": 3000,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/sclairus.json
+++ b/mods/tuxemon/db/monster/sclairus.json
@@ -23,7 +23,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 118,
+    "txmn_id": 119,
     "height": 0,
     "weight": 0,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/seirein.json
+++ b/mods/tuxemon/db/monster/seirein.json
@@ -30,7 +30,7 @@
         "water"
     ],
     "possible_genders": ["neuter"],
-    "txmn_id": 154,
+    "txmn_id": 162,
     "height": 0,
     "weight": 0,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/selket.json
+++ b/mods/tuxemon/db/monster/selket.json
@@ -29,7 +29,7 @@
         "earth"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 188,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/selmatek.json
+++ b/mods/tuxemon/db/monster/selmatek.json
@@ -23,7 +23,7 @@
         "earth"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 189,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/shammer.json
+++ b/mods/tuxemon/db/monster/shammer.json
@@ -23,7 +23,7 @@
         "earth"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 140,
+    "txmn_id": 144,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/sharpfin.json
+++ b/mods/tuxemon/db/monster/sharpfin.json
@@ -24,7 +24,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 25,
+    "txmn_id": 26,
     "height": 300,
     "weight": 200,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/shelagu.json
+++ b/mods/tuxemon/db/monster/shelagu.json
@@ -23,7 +23,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 221,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/shnark.json
+++ b/mods/tuxemon/db/monster/shnark.json
@@ -23,7 +23,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 153,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/shybulb.json
+++ b/mods/tuxemon/db/monster/shybulb.json
@@ -29,7 +29,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 76,
+    "txmn_id": 77,
     "height": 0,
     "weight": 0,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/skwib.json
+++ b/mods/tuxemon/db/monster/skwib.json
@@ -29,7 +29,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 174,
+    "txmn_id": 183,
     "height": 30,
     "weight": 9,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/sludgehog.json
+++ b/mods/tuxemon/db/monster/sludgehog.json
@@ -23,7 +23,7 @@
         "earth"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 119,
+    "txmn_id": 120,
     "height": 125,
     "weight": 95,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/snaki.json
+++ b/mods/tuxemon/db/monster/snaki.json
@@ -29,7 +29,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 227,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/snarlon.json
+++ b/mods/tuxemon/db/monster/snarlon.json
@@ -23,7 +23,7 @@
         "earth"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 143,
+    "txmn_id": 147,
     "height": 160,
     "weight": 130,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/snock.json
+++ b/mods/tuxemon/db/monster/snock.json
@@ -29,7 +29,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 225,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/snokari.json
+++ b/mods/tuxemon/db/monster/snokari.json
@@ -23,7 +23,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 228,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/snowrilla.json
+++ b/mods/tuxemon/db/monster/snowrilla.json
@@ -23,7 +23,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 155,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/sockeserp.json
+++ b/mods/tuxemon/db/monster/sockeserp.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["neuter"],
-    "txmn_id": 90,
+    "txmn_id": 91,
     "height": 100,
     "weight": 1,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/solight.json
+++ b/mods/tuxemon/db/monster/solight.json
@@ -24,7 +24,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 229,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/spighter.json
+++ b/mods/tuxemon/db/monster/spighter.json
@@ -23,7 +23,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 120,
+    "txmn_id": 121,
     "height": 30,
     "weight": 2,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/spoilurm.json
+++ b/mods/tuxemon/db/monster/spoilurm.json
@@ -23,7 +23,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 230,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/spycozeus.json
+++ b/mods/tuxemon/db/monster/spycozeus.json
@@ -24,7 +24,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 222,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/squabbit.json
+++ b/mods/tuxemon/db/monster/squabbit.json
@@ -29,7 +29,7 @@
         "earth"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 43,
+    "txmn_id": 44,
     "height": 60,
     "weight": 10,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/statursus.json
+++ b/mods/tuxemon/db/monster/statursus.json
@@ -23,7 +23,7 @@
         "fire"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 191,
     "height": 190,
     "weight": 160,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/strella.json
+++ b/mods/tuxemon/db/monster/strella.json
@@ -23,7 +23,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 48,
+    "txmn_id": 49,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/sumchon.json
+++ b/mods/tuxemon/db/monster/sumchon.json
@@ -24,7 +24,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 58,
+    "txmn_id": 59,
     "height": 150,
     "weight": 125,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/tarpeur.json
+++ b/mods/tuxemon/db/monster/tarpeur.json
@@ -29,7 +29,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 217,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/taupypus.json
+++ b/mods/tuxemon/db/monster/taupypus.json
@@ -23,7 +23,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 219,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/teddisun.json
+++ b/mods/tuxemon/db/monster/teddisun.json
@@ -23,7 +23,7 @@
         "fire"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 161,
+    "txmn_id": 170,
     "height": 0,
     "weight": 60,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/tetrchimp.json
+++ b/mods/tuxemon/db/monster/tetrchimp.json
@@ -29,7 +29,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 196,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/tigrock.json
+++ b/mods/tuxemon/db/monster/tigrock.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 93,
+    "txmn_id": 94,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/tikoal.json
+++ b/mods/tuxemon/db/monster/tikoal.json
@@ -30,7 +30,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 78,
+    "txmn_id": 79,
     "height": 0,
     "weight": 0,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/tikorch.json
+++ b/mods/tuxemon/db/monster/tikorch.json
@@ -24,7 +24,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 79,
+    "txmn_id": 80,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/tobishimi.json
+++ b/mods/tuxemon/db/monster/tobishimi.json
@@ -24,7 +24,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 187,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/toufigel.json
+++ b/mods/tuxemon/db/monster/toufigel.json
@@ -24,7 +24,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 121,
+    "txmn_id": 122,
     "height": 40,
     "weight": 3,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/tourbidi.json
+++ b/mods/tuxemon/db/monster/tourbidi.json
@@ -23,7 +23,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 122,
+    "txmn_id": 123,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/trapsnap.json
+++ b/mods/tuxemon/db/monster/trapsnap.json
@@ -29,7 +29,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 84,
+    "txmn_id": 85,
     "height": 120,
     "weight": 60,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/tsushimi.json
+++ b/mods/tuxemon/db/monster/tsushimi.json
@@ -29,7 +29,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 186,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/tumblebee.json
+++ b/mods/tuxemon/db/monster/tumblebee.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 95,
+    "txmn_id": 96,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/tumblequill.json
+++ b/mods/tuxemon/db/monster/tumblequill.json
@@ -23,7 +23,7 @@
         "earth"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 220,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/tumbleworm.json
+++ b/mods/tuxemon/db/monster/tumbleworm.json
@@ -29,7 +29,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 94,
+    "txmn_id": 95,
     "height": 0,
     "weight": 0,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/turnipper.json
+++ b/mods/tuxemon/db/monster/turnipper.json
@@ -29,7 +29,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 198,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/urcine.json
+++ b/mods/tuxemon/db/monster/urcine.json
@@ -23,7 +23,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 216,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/vamporm.json
+++ b/mods/tuxemon/db/monster/vamporm.json
@@ -29,7 +29,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 35,
+    "txmn_id": 36,
     "height": 0,
     "weight": 0,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/velocitile.json
+++ b/mods/tuxemon/db/monster/velocitile.json
@@ -23,7 +23,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 66,
+    "txmn_id": 67,
     "height": 0,
     "weight": 0,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/vigueur.json
+++ b/mods/tuxemon/db/monster/vigueur.json
@@ -23,7 +23,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 218,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/vivicinder.json
+++ b/mods/tuxemon/db/monster/vivicinder.json
@@ -23,7 +23,7 @@
         "fire"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 131,
+    "txmn_id": 133,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/vividactil.json
+++ b/mods/tuxemon/db/monster/vividactil.json
@@ -23,7 +23,7 @@
         "earth"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 0,
+    "txmn_id": 138,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/vivipere.json
+++ b/mods/tuxemon/db/monster/vivipere.json
@@ -64,7 +64,7 @@
         "earth"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 130,
+    "txmn_id": 132,
     "height": 0,
     "weight": 0,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/viviphyta.json
+++ b/mods/tuxemon/db/monster/viviphyta.json
@@ -23,7 +23,7 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 132,
+    "txmn_id": 134,
     "height": 0,
     "weight": 0,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/vivisource.json
+++ b/mods/tuxemon/db/monster/vivisource.json
@@ -23,7 +23,7 @@
         "water"
     ],
     "possible_genders": ["male"],
-    "txmn_id": 0,
+    "txmn_id": 139,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/viviteel.json
+++ b/mods/tuxemon/db/monster/viviteel.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["female"],
-    "txmn_id": 133,
+    "txmn_id": 135,
     "height": 0,
     "weight": 0,
     "catch_rate": 170.0,

--- a/mods/tuxemon/db/monster/vivitrans.json
+++ b/mods/tuxemon/db/monster/vivitrans.json
@@ -24,7 +24,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 134,
+    "txmn_id": 136,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/vivitron.json
+++ b/mods/tuxemon/db/monster/vivitron.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 135,
+    "txmn_id": 137,
     "height": 0,
     "weight": 0,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/volcoli.json
+++ b/mods/tuxemon/db/monster/volcoli.json
@@ -23,7 +23,7 @@
         "fire"
     ],
     "possible_genders": ["neuter"],
-    "txmn_id": 123,
+    "txmn_id": 124,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/weavifly.json
+++ b/mods/tuxemon/db/monster/weavifly.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 34,
+    "txmn_id": 35,
     "height": 0,
     "weight": 0,
     "catch_rate": 85.0,

--- a/mods/tuxemon/db/monster/windeye.json
+++ b/mods/tuxemon/db/monster/windeye.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 171,
+    "txmn_id": 180,
     "height": 300,
     "weight": 600,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/wrougon.json
+++ b/mods/tuxemon/db/monster/wrougon.json
@@ -29,7 +29,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 152,
+    "txmn_id": 159,
     "height": 0,
     "weight": 0,
     "catch_rate": 45.0,

--- a/mods/tuxemon/db/monster/yiinaang.json
+++ b/mods/tuxemon/db/monster/yiinaang.json
@@ -24,7 +24,7 @@
         "water"
     ],
     "possible_genders": ["neuter"],
-    "txmn_id": 142,
+    "txmn_id": 146,
     "height": 200,
     "weight": 0,
     "catch_rate": 120.0,

--- a/mods/tuxemon/db/monster/zunna.json
+++ b/mods/tuxemon/db/monster/zunna.json
@@ -23,7 +23,7 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 129,
+    "txmn_id": 131,
     "height": 90,
     "weight": 2,
     "catch_rate": 120.0,


### PR DESCRIPTION
@Sanglorian the update related to the txmn_ids as follows, let me know if you're ok.

Summary:
- Pantherafira got number 20, because it evolves in Criniotherme; => edited as per Sanglorian request.
- B-ver.1 got number 130, because it's a Botbot evolution;
- Vividactil got number 138, because it's a Vivipere evolution; 
- Vivisource got number 139, because it's a Vivipere evolution;
- Shnark got number 153, because it's Nostray evolution;
- Snowrilla got number 155, because it's Chillimp evolution;
- Gryfix got number 158,  because it's Corvix evolution;
- Ferricran got number 161, because it's the last stage of Wrougon/Allagon;
- Octabode got number 184, after this there are all the others.

Evolution lines are together, like Drashimi, Tsushimi and Tobishimi, etc.

File: [txmn_ids.ods](https://github.com/Tuxemon/Tuxemon/files/10245570/txmn_ids.ods) (updated)
