### PR TITLE
fix shop

### DIFF
--- a/mods/tuxemon/maps/spyder_paper_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_paper_scoop.tmx
@@ -4,6 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="paper_scoop"/>
+  <property name="types" value="shop"/>
  </properties>
  <tileset firstgid="1" name="floorsandwalls" tilewidth="16" tileheight="16" tilecount="88" columns="11">
   <image source="../gfx/tilesets/floorsandwalls.png" width="176" height="128"/>


### PR DESCRIPTION
PR addresses the following log:
`2022-12-16 17:34:30,406 - tuxemon.client - ERROR - The type 'None' doesn't exist.`
The previous crash was caused by the missing slug, the message above was caused by the missing types (when entering the scoop in Paper Town).
Now it's completely fixed.