### PR TITLE
fix weight height monsters

### DIFF
--- a/mods/tuxemon/db/monster/abesnaki.json
+++ b/mods/tuxemon/db/monster/abesnaki.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["neuter"],
     "txmn_id": 99,
-    "height": 0,
-    "weight": 0,
+    "height": 104,
+    "weight": 14,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/allagon.json
+++ b/mods/tuxemon/db/monster/allagon.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 160,
-    "height": 0,
-    "weight": 0,
+    "height": 162,
+    "weight": 145,
     "catch_rate": 3.0,
     "lower_catch_resistance": 0.8,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/anoleaf.json
+++ b/mods/tuxemon/db/monster/anoleaf.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 65,
-    "height": 0,
-    "weight": 0,
+    "height": 33,
+    "weight": 2,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/apeoro.json
+++ b/mods/tuxemon/db/monster/apeoro.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 197,
-    "height": 0,
-    "weight": 0,
+    "height": 197,
+    "weight": 145,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/araignee.json
+++ b/mods/tuxemon/db/monster/araignee.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 100,
-    "height": 0,
-    "weight": 0,
+    "height": 68,
+    "weight": 7,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/av8r.json
+++ b/mods/tuxemon/db/monster/av8r.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["neuter"],
     "txmn_id": 126,
-    "height": 0,
-    "weight": 0,
+    "height": 45,
+    "weight": 6,
     "sounds": {
         "combat_call": "sound_av8r",
         "faint_call": "sound_av8r_faint"

--- a/mods/tuxemon/db/monster/b_ver_1.json
+++ b/mods/tuxemon/db/monster/b_ver_1.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["neuter"],
     "txmn_id": 130,
-    "height": 0,
-    "weight": 0,
+    "height": 100,
+    "weight": 50,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/baobaraffe.json
+++ b/mods/tuxemon/db/monster/baobaraffe.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 193,
-    "height": 0,
-    "weight": 0,
+    "height": 320,
+    "weight": 302,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/baoby.json
+++ b/mods/tuxemon/db/monster/baoby.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 192,
-    "height": 0,
-    "weight": 0,
+    "height": 54,
+    "weight": 23,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/beenstalker.json
+++ b/mods/tuxemon/db/monster/beenstalker.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 199,
-    "height": 0,
-    "weight": 0,
+    "height": 98,
+    "weight": 41,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/birdling.json
+++ b/mods/tuxemon/db/monster/birdling.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 82,
-    "height": 0,
-    "weight": 0,
+    "height": 40,
+    "weight": 8,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/bolt.json
+++ b/mods/tuxemon/db/monster/bolt.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 5,
-    "height": 0,
-    "weight": 0,
+    "height": 90,
+    "weight": 15.6,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/boltnu.json
+++ b/mods/tuxemon/db/monster/boltnu.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 194,
-    "height": 0,
-    "weight": 0,
+    "height": 47,
+    "weight": 8,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/botbot.json
+++ b/mods/tuxemon/db/monster/botbot.json
@@ -55,8 +55,8 @@
     ],
     "possible_genders": ["neuter"],
     "txmn_id": 125,
-    "height": 0,
-    "weight": 0,
+    "height": 40,
+    "weight": 4,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/brewdin.json
+++ b/mods/tuxemon/db/monster/brewdin.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 215,
-    "height": 0,
-    "weight": 0,
+    "height": 22,
+    "weight": 1,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/budaye.json
+++ b/mods/tuxemon/db/monster/budaye.json
@@ -49,8 +49,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 27,
-    "height": 0,
-    "weight": 0,
+    "height": 80,
+    "weight": 20,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/bumbulus.json
+++ b/mods/tuxemon/db/monster/bumbulus.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 210,
-    "height": 0,
-    "weight": 0,
+    "height": 78,
+    "weight": 1,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/cairfrey.json
+++ b/mods/tuxemon/db/monster/cairfrey.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["neuter"],
     "txmn_id": 71,
-    "height": 0,
-    "weight": 0,
+    "height": 54,
+    "weight": 10,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/cardiling.json
+++ b/mods/tuxemon/db/monster/cardiling.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 62,
-    "height": 0,
-    "weight": 0,
+    "height": 30,
+    "weight": 2,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/cardinale.json
+++ b/mods/tuxemon/db/monster/cardinale.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 64,
-    "height": 0,
-    "weight": 0,
+    "height": 60,
+    "weight": 8,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/cardiwing.json
+++ b/mods/tuxemon/db/monster/cardiwing.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 63,
-    "height": 0,
-    "weight": 0,
+    "height": 45,
+    "weight": 5,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/cateye.json
+++ b/mods/tuxemon/db/monster/cateye.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 103,
-    "height": 0,
-    "weight": 0,
+    "height": 45,
+    "weight": 19,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/chibiro.json
+++ b/mods/tuxemon/db/monster/chibiro.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 212,
-    "height": 0,
-    "weight": 0,
+    "height": 36,
+    "weight": 3,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/chillimp.json
+++ b/mods/tuxemon/db/monster/chillimp.json
@@ -31,8 +31,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 154,
-    "height": 0,
-    "weight": 0,
+    "height": 115,
+    "weight": 54,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/chloragon.json
+++ b/mods/tuxemon/db/monster/chloragon.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 140,
-    "height": 0,
-    "weight": 0,
+    "height": 102,
+    "weight": 85,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/coleorus.json
+++ b/mods/tuxemon/db/monster/coleorus.json
@@ -25,8 +25,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 105,
-    "height": 0,
-    "weight": 0,
+    "height": 39,
+    "weight": 6,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/conileaf.json
+++ b/mods/tuxemon/db/monster/conileaf.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 148,
-    "height": 0,
-    "weight": 0,
+    "height": 45,
+    "weight": 3,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/coproblight.json
+++ b/mods/tuxemon/db/monster/coproblight.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 173,
-    "height": 0,
-    "weight": 1,
+    "height": 45,
+    "weight": 8,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/corvix.json
+++ b/mods/tuxemon/db/monster/corvix.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 157,
-    "height": 0,
-    "weight": 0,
+    "height": 55,
+    "weight": 4,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/dandicub.json
+++ b/mods/tuxemon/db/monster/dandicub.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 73,
-    "height": 0,
-    "weight": 0,
+    "height": 46,
+    "weight": 2,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/dandylion.json
+++ b/mods/tuxemon/db/monster/dandylion.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 74,
-    "height": 0,
-    "weight": 0,
+    "height": 138,
+    "weight": 45,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/dracune.json
+++ b/mods/tuxemon/db/monster/dracune.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 37,
-    "height": 0,
-    "weight": 0,
+    "height": 35,
+    "weight": 3.5,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/dragarbor.json
+++ b/mods/tuxemon/db/monster/dragarbor.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 142,
-    "height": 0,
-    "weight": 0,
+    "height": 397,
+    "weight": 336,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/drashimi.json
+++ b/mods/tuxemon/db/monster/drashimi.json
@@ -31,8 +31,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 185,
-    "height": 0,
-    "weight": 0,
+    "height": 38,
+    "weight": 12,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/dune_pincher.json
+++ b/mods/tuxemon/db/monster/dune_pincher.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 109,
-    "height": 0,
-    "weight": 0,
+    "height": 37,
+    "weight": 7,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/elofly.json
+++ b/mods/tuxemon/db/monster/elofly.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 39,
-    "height": 0,
-    "weight": 0,
+    "height": 75,
+    "weight": 3,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/elostorm.json
+++ b/mods/tuxemon/db/monster/elostorm.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 41,
-    "height": 0,
-    "weight": 0,
+    "height": 144,
+    "weight": 25,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/elowind.json
+++ b/mods/tuxemon/db/monster/elowind.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 40,
-    "height": 0,
-    "weight": 0,
+    "height": 115,
+    "weight": 15,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/embazook.json
+++ b/mods/tuxemon/db/monster/embazook.json
@@ -25,8 +25,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 31,
-    "height": 0,
-    "weight": 0,
+    "height": 137,
+    "weight": 502,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/embra.json
+++ b/mods/tuxemon/db/monster/embra.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 75,
-    "height": 0,
-    "weight": 0,
+    "height": 48,
+    "weight": 2,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/exapode.json
+++ b/mods/tuxemon/db/monster/exapode.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 61,
-    "height": 0,
-    "weight": 0,
+    "height": 44,
+    "weight": 5,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/exclawvate.json
+++ b/mods/tuxemon/db/monster/exclawvate.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 195,
-    "height": 0,
-    "weight": 0,
+    "height": 213,
+    "weight": 1000,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/eyenemy.json
+++ b/mods/tuxemon/db/monster/eyenemy.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 46,
-    "height": 0,
-    "weight": 0,
+    "height": 104,
+    "weight": 2,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/eyesore.json
+++ b/mods/tuxemon/db/monster/eyesore.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 47,
-    "height": 0,
-    "weight": 0,
+    "height": 135,
+    "weight": 4,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/ferricran.json
+++ b/mods/tuxemon/db/monster/ferricran.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 161,
-    "height": 0,
-    "weight": 0,
+    "height": 230,
+    "weight": 214,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/fluttaflap.json
+++ b/mods/tuxemon/db/monster/fluttaflap.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 38,
-    "height": 0,
-    "weight": 0,
+    "height": 47,
+    "weight": 7,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/foofle.json
+++ b/mods/tuxemon/db/monster/foofle.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 110,
-    "height": 0,
-    "weight": 0,
+    "height": 53,
+    "weight": 8,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/fordin.json
+++ b/mods/tuxemon/db/monster/fordin.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 211,
-    "height": 0,
-    "weight": 0,
+    "height": 56,
+    "weight": 19,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/forturtle.json
+++ b/mods/tuxemon/db/monster/forturtle.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 87,
-    "height": 0,
-    "weight": 0,
+    "height": 85,
+    "weight": 55,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/foxfire.json
+++ b/mods/tuxemon/db/monster/foxfire.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 149,
-    "height": 0,
-    "weight": 0,
+    "height": 41,
+    "weight": 2,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/frondly.json
+++ b/mods/tuxemon/db/monster/frondly.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 29,
-    "height": 0,
-    "weight": 0,
+    "height": 160,
+    "weight": 60,
     "catch_rate": 3.0,
     "lower_catch_resistance": 0.8,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/furnursus.json
+++ b/mods/tuxemon/db/monster/furnursus.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 190,
-    "height": 0,
-    "weight": 0,
+    "height": 110,
+    "weight": 47,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/gectile.json
+++ b/mods/tuxemon/db/monster/gectile.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 66,
-    "height": 0,
-    "weight": 0,
+    "height": 54,
+    "weight": 7,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/gryfix.json
+++ b/mods/tuxemon/db/monster/gryfix.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 158,
-    "height": 0,
-    "weight": 0,
+    "height": 180,
+    "weight": 31,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/hatchling.json
+++ b/mods/tuxemon/db/monster/hatchling.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 81,
-    "height": 0,
-    "weight": 0,
+    "height": 20,
+    "weight": 1,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/ignibus.json
+++ b/mods/tuxemon/db/monster/ignibus.json
@@ -49,8 +49,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 30,
-    "height": 0,
-    "weight": 0,
+    "height": 68,
+    "weight": 27,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/jelillow.json
+++ b/mods/tuxemon/db/monster/jelillow.json
@@ -25,7 +25,7 @@
     "possible_genders": ["male", "female"],
     "txmn_id": 207,
     "height": 66,
-    "weight": 9.6,
+    "weight": 10,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/katacoon.json
+++ b/mods/tuxemon/db/monster/katacoon.json
@@ -38,8 +38,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 57,
-    "height": 0,
-    "weight": 0,
+    "height": 58,
+    "weight": 12,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/katapill.json
+++ b/mods/tuxemon/db/monster/katapill.json
@@ -31,8 +31,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 56,
-    "height": 0,
-    "weight": 0,
+    "height": 32,
+    "weight": 3,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/lambert.json
+++ b/mods/tuxemon/db/monster/lambert.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 10,
-    "height": 0,
-    "weight": 0,
+    "height": 69,
+    "weight": 37,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/legko.json
+++ b/mods/tuxemon/db/monster/legko.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 11,
-    "height": 0,
-    "weight": 0,
+    "height": 123,
+    "weight": 52,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/loliferno.json
+++ b/mods/tuxemon/db/monster/loliferno.json
@@ -24,7 +24,7 @@
     ],
     "possible_genders": ["neuter"],
     "txmn_id": 163,
-    "height": 0,
+    "height": 60,
     "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/lunight.json
+++ b/mods/tuxemon/db/monster/lunight.json
@@ -24,9 +24,9 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 214,
-    "height": 0,
-    "weight": 0,
+    "txmn_id": 229,
+    "height": 55,
+    "weight": 17,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/masknake.json
+++ b/mods/tuxemon/db/monster/masknake.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 115,
-    "height": 0,
-    "weight": 0,
+    "height": 112,
+    "weight": 8,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/medushock.json
+++ b/mods/tuxemon/db/monster/medushock.json
@@ -25,8 +25,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 208,
-    "height": 0,
-    "weight": 0,
+    "height": 133,
+    "weight": 3,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/merlicun.json
+++ b/mods/tuxemon/db/monster/merlicun.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 209,
-    "height": 0,
-    "weight": 0,
+    "height": 28,
+    "weight": 3,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/metesaur.json
+++ b/mods/tuxemon/db/monster/metesaur.json
@@ -31,8 +31,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 202,
-    "height": 0,
-    "weight": 0,
+    "height": 95,
+    "weight": 10,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/mrmoswitch.json
+++ b/mods/tuxemon/db/monster/mrmoswitch.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["neuter"],
     "txmn_id": 128,
-    "height": 0,
-    "weight": 0,
+    "height": 56,
+    "weight": 4,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/narcileaf.json
+++ b/mods/tuxemon/db/monster/narcileaf.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 78,
-    "height": 0,
-    "weight": 0,
+    "height": 42,
+    "weight": 4,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/noctalo.json
+++ b/mods/tuxemon/db/monster/noctalo.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 51,
-    "height": 0,
-    "weight": 0,
+    "height": 100,
+    "weight": 12,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/noctula.json
+++ b/mods/tuxemon/db/monster/noctula.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 50,
-    "height": 0,
-    "weight": 0,
+    "height": 50,
+    "weight": 3,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/nudiflot_female.json
+++ b/mods/tuxemon/db/monster/nudiflot_female.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["female"],
     "txmn_id": 54,
-    "height": 0,
-    "weight": 0,
+    "height": 29,
+    "weight": 3,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/nudikill.json
+++ b/mods/tuxemon/db/monster/nudikill.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male"],
     "txmn_id": 53,
-    "height": 0,
-    "weight": 0,
+    "height": 122,
+    "weight": 35,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/nudimind.json
+++ b/mods/tuxemon/db/monster/nudimind.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["female"],
     "txmn_id": 55,
-    "height": 0,
-    "weight": 0,
+    "height": 98,
+    "weight": 34,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/nuenflu.json
+++ b/mods/tuxemon/db/monster/nuenflu.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 224,
-    "height": 0,
-    "weight": 0,
+    "height": 75,
+    "weight": 21,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/octabode.json
+++ b/mods/tuxemon/db/monster/octabode.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 184,
-    "height": 0,
-    "weight": 0,
+    "height": 44,
+    "weight": 19,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/pairagrim.json
+++ b/mods/tuxemon/db/monster/pairagrim.json
@@ -28,7 +28,7 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 182,
-    "height": 0,
+    "height": 110,
     "weight": 10,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/pantherafira.json
+++ b/mods/tuxemon/db/monster/pantherafira.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 22,
-    "height": 0,
-    "weight": 0,
+    "height": 90,
+    "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/pilthropus.json
+++ b/mods/tuxemon/db/monster/pilthropus.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 172,
-    "height": 0,
-    "weight": 50,
+    "height": 154,
+    "weight": 82,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/pipis.json
+++ b/mods/tuxemon/db/monster/pipis.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 48,
-    "height": 0,
-    "weight": 0,
+    "height": 40,
+    "weight": 2,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/polyrock.json
+++ b/mods/tuxemon/db/monster/polyrock.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 117,
-    "height": 0,
-    "weight": 0,
+    "height": 133,
+    "weight": 66,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/possessun.json
+++ b/mods/tuxemon/db/monster/possessun.json
@@ -24,7 +24,7 @@
     ],
     "possible_genders": ["neuter"],
     "txmn_id": 72,
-    "height": 0,
+    "height": 69,
     "weight": 0,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/prophetoise.json
+++ b/mods/tuxemon/db/monster/prophetoise.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 88,
-    "height": 0,
-    "weight": 0,
+    "height": 108,
+    "weight": 88,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/puparmor.json
+++ b/mods/tuxemon/db/monster/puparmor.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 34,
-    "height": 0,
-    "weight": 0,
+    "height": 35,
+    "weight": 8.5,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/pythock.json
+++ b/mods/tuxemon/db/monster/pythock.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 226,
-    "height": 0,
-    "weight": 0,
+    "height": 154,
+    "weight": 32,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/qetzlrokilus.json
+++ b/mods/tuxemon/db/monster/qetzlrokilus.json
@@ -25,8 +25,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 203,
-    "height": 0,
-    "weight": 0,
+    "height": 183,
+    "weight": 41,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/rhincus.json
+++ b/mods/tuxemon/db/monster/rhincus.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 143,
-    "height": 0,
-    "weight": 0,
+    "height": 92,
+    "weight": 17,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/rockat.json
+++ b/mods/tuxemon/db/monster/rockat.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 2,
-    "height": 0,
-    "weight": 0,
+    "height": 120,
+    "weight": 60,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/rosarin.json
+++ b/mods/tuxemon/db/monster/rosarin.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 204,
-    "height": 0,
-    "weight": 0,
+    "height": 48,
+    "weight": 14,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/ruption.json
+++ b/mods/tuxemon/db/monster/ruption.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 76,
-    "height": 0,
-    "weight": 0,
+    "height": 169,
+    "weight": 16,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/sampsage.json
+++ b/mods/tuxemon/db/monster/sampsage.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 98,
-    "height": 0,
-    "weight": 0,
+    "height": 180,
+    "weight": 122,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/sapragon.json
+++ b/mods/tuxemon/db/monster/sapragon.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 141,
-    "height": 0,
-    "weight": 0,
+    "height": 122,
+    "weight": 115,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/sclairus.json
+++ b/mods/tuxemon/db/monster/sclairus.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 119,
-    "height": 0,
-    "weight": 0,
+    "height": 85,
+    "weight": 3,
     "catch_rate": 120.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05

--- a/mods/tuxemon/db/monster/seirein.json
+++ b/mods/tuxemon/db/monster/seirein.json
@@ -31,7 +31,7 @@
     ],
     "possible_genders": ["neuter"],
     "txmn_id": 162,
-    "height": 0,
+    "height": 30,
     "weight": 0,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,

--- a/mods/tuxemon/db/monster/selket.json
+++ b/mods/tuxemon/db/monster/selket.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 188,
-    "height": 0,
-    "weight": 0,
+    "height": 17,
+    "weight": 10,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/selmatek.json
+++ b/mods/tuxemon/db/monster/selmatek.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 189,
-    "height": 0,
-    "weight": 0,
+    "height": 155,
+    "weight": 80,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/shammer.json
+++ b/mods/tuxemon/db/monster/shammer.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 144,
-    "height": 0,
-    "weight": 0,
+    "height": 80,
+    "weight": 40,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/shelagu.json
+++ b/mods/tuxemon/db/monster/shelagu.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 221,
-    "height": 0,
-    "weight": 0,
+    "height": 60,
+    "weight": 4,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/shnark.json
+++ b/mods/tuxemon/db/monster/shnark.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 153,
-    "height": 0,
-    "weight": 0,
+    "height": 205,
+    "weight": 120,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/shybulb.json
+++ b/mods/tuxemon/db/monster/shybulb.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 77,
-    "height": 0,
-    "weight": 0,
+    "height": 29,
+    "weight": 2,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/snaki.json
+++ b/mods/tuxemon/db/monster/snaki.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 227,
-    "height": 0,
-    "weight": 0,
+    "height": 70,
+    "weight": 15,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/snock.json
+++ b/mods/tuxemon/db/monster/snock.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 225,
-    "height": 0,
-    "weight": 0,
+    "height": 30,
+    "weight": 1,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/snokari.json
+++ b/mods/tuxemon/db/monster/snokari.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 228,
-    "height": 0,
-    "weight": 0,
+    "height": 145,
+    "weight": 45,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/snowrilla.json
+++ b/mods/tuxemon/db/monster/snowrilla.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 155,
-    "height": 0,
-    "weight": 0,
+    "height": 192,
+    "weight": 112,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/solight.json
+++ b/mods/tuxemon/db/monster/solight.json
@@ -24,9 +24,9 @@
         "metal"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 229,
-    "height": 0,
-    "weight": 0,
+    "txmn_id": 230,
+    "height": 55,
+    "weight": 17,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/spoilurm.json
+++ b/mods/tuxemon/db/monster/spoilurm.json
@@ -23,9 +23,9 @@
         "wood"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 230,
-    "height": 0,
-    "weight": 0,
+    "txmn_id": 214,
+    "height": 41,
+    "weight": 4,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/spycozeus.json
+++ b/mods/tuxemon/db/monster/spycozeus.json
@@ -25,8 +25,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 222,
-    "height": 0,
-    "weight": 0,
+    "height": 60,
+    "weight": 18,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/strella.json
+++ b/mods/tuxemon/db/monster/strella.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 49,
-    "height": 0,
-    "weight": 0,
+    "height": 80,
+    "weight": 8,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/tarpeur.json
+++ b/mods/tuxemon/db/monster/tarpeur.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 217,
-    "height": 0,
-    "weight": 0,
+    "height": 19,
+    "weight": 1,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/taupypus.json
+++ b/mods/tuxemon/db/monster/taupypus.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 219,
-    "height": 0,
-    "weight": 0,
+    "height": 60,
+    "weight": 3,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/teddisun.json
+++ b/mods/tuxemon/db/monster/teddisun.json
@@ -24,7 +24,7 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 170,
-    "height": 0,
+    "height": 110,
     "weight": 60,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/tetrchimp.json
+++ b/mods/tuxemon/db/monster/tetrchimp.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 196,
-    "height": 0,
-    "weight": 0,
+    "height": 45,
+    "weight": 4,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/tigrock.json
+++ b/mods/tuxemon/db/monster/tigrock.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 94,
-    "height": 0,
-    "weight": 0,
+    "height": 200,
+    "weight": 220,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/tikoal.json
+++ b/mods/tuxemon/db/monster/tikoal.json
@@ -31,8 +31,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 79,
-    "height": 0,
-    "weight": 0,
+    "height": 68,
+    "weight": 11,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/tikorch.json
+++ b/mods/tuxemon/db/monster/tikorch.json
@@ -25,8 +25,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 80,
-    "height": 0,
-    "weight": 0,
+    "height": 136,
+    "weight": 44,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/tobishimi.json
+++ b/mods/tuxemon/db/monster/tobishimi.json
@@ -25,8 +25,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 187,
-    "height": 0,
-    "weight": 0,
+    "height": 180,
+    "weight": 169,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/tourbidi.json
+++ b/mods/tuxemon/db/monster/tourbidi.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 123,
-    "height": 0,
-    "weight": 0,
+    "height": 42,
+    "weight": 14,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/tsushimi.json
+++ b/mods/tuxemon/db/monster/tsushimi.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 186,
-    "height": 0,
-    "weight": 0,
+    "height": 136,
+    "weight": 85,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/tumblebee.json
+++ b/mods/tuxemon/db/monster/tumblebee.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 96,
-    "height": 0,
-    "weight": 0,
+    "height": 66,
+    "weight": 23,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/tumblequill.json
+++ b/mods/tuxemon/db/monster/tumblequill.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 220,
-    "height": 0,
-    "weight": 0,
+    "height": 27,
+    "weight": 2,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/tumbleworm.json
+++ b/mods/tuxemon/db/monster/tumbleworm.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 95,
-    "height": 0,
-    "weight": 0,
+    "height": 21,
+    "weight": 5,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/turnipper.json
+++ b/mods/tuxemon/db/monster/turnipper.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 198,
-    "height": 0,
-    "weight": 0,
+    "height": 65,
+    "weight": 25,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/urcine.json
+++ b/mods/tuxemon/db/monster/urcine.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 216,
-    "height": 0,
-    "weight": 0,
+    "height": 115,
+    "weight": 45,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/vamporm.json
+++ b/mods/tuxemon/db/monster/vamporm.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 36,
-    "height": 0,
-    "weight": 0,
+    "height": 17,
+    "weight": 1,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/velocitile.json
+++ b/mods/tuxemon/db/monster/velocitile.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 67,
-    "height": 0,
-    "weight": 0,
+    "height": 150,
+    "weight": 75,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/vigueur.json
+++ b/mods/tuxemon/db/monster/vigueur.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 218,
-    "height": 0,
-    "weight": 0,
+    "height": 38,
+    "weight": 4,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/vivicinder.json
+++ b/mods/tuxemon/db/monster/vivicinder.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 133,
-    "height": 0,
-    "weight": 0,
+    "height": 95,
+    "weight": 6,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/vividactil.json
+++ b/mods/tuxemon/db/monster/vividactil.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 138,
-    "height": 0,
-    "weight": 0,
+    "height": 97,
+    "weight": 10,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/vivipere.json
+++ b/mods/tuxemon/db/monster/vivipere.json
@@ -65,8 +65,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 132,
-    "height": 0,
-    "weight": 0,
+    "height": 85,
+    "weight": 8,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/viviphyta.json
+++ b/mods/tuxemon/db/monster/viviphyta.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 134,
-    "height": 0,
-    "weight": 0,
+    "height": 87,
+    "weight": 9,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/vivisource.json
+++ b/mods/tuxemon/db/monster/vivisource.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male"],
     "txmn_id": 139,
-    "height": 0,
-    "weight": 0,
+    "height": 107,
+    "weight": 9,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/viviteel.json
+++ b/mods/tuxemon/db/monster/viviteel.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["female"],
     "txmn_id": 135,
-    "height": 0,
-    "weight": 0,
+    "height": 102,
+    "weight": 18,
     "catch_rate": 170.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25

--- a/mods/tuxemon/db/monster/vivitrans.json
+++ b/mods/tuxemon/db/monster/vivitrans.json
@@ -25,8 +25,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 136,
-    "height": 0,
-    "weight": 0,
+    "height": 98,
+    "weight": 11,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/vivitron.json
+++ b/mods/tuxemon/db/monster/vivitron.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 137,
-    "height": 0,
-    "weight": 0,
+    "height": 92,
+    "weight": 12,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1

--- a/mods/tuxemon/db/monster/volcoli.json
+++ b/mods/tuxemon/db/monster/volcoli.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["neuter"],
     "txmn_id": 124,
-    "height": 0,
-    "weight": 0,
+    "height": 53,
+    "weight": 18,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/weavifly.json
+++ b/mods/tuxemon/db/monster/weavifly.json
@@ -24,8 +24,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 35,
-    "height": 0,
-    "weight": 0,
+    "height": 52,
+    "weight": 17,
     "catch_rate": 85.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15

--- a/mods/tuxemon/db/monster/wrougon.json
+++ b/mods/tuxemon/db/monster/wrougon.json
@@ -30,8 +30,8 @@
     ],
     "possible_genders": ["male", "female"],
     "txmn_id": 159,
-    "height": 0,
-    "weight": 0,
+    "height": 120,
+    "weight": 96,
     "catch_rate": 45.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1


### PR DESCRIPTION
Hi @sanglorian
Here the complete weight and height for all the 230 monsters, let me know what do you think.

I followed the same pattern as per the moves, I looked in a common value among the shape + type (eg earth + hunter), if the combination wasn't present, then I looked only the shape (eg hunter).

Where there was an evolutionary line (basic + stage1 or stage2, eg rockitten evolutionary line), I took into consideration the BMI (relationship between weight and double height); it was handy because considering the increment of the weight, I got a realistic height.