### PR TITLE
economy & inventory

### DIFF
--- a/mods/tuxemon/db/economy/spyder_candy_scoop.json
+++ b/mods/tuxemon/db/economy/spyder_candy_scoop.json
@@ -1,0 +1,20 @@
+{
+  "slug": "spyder_candy_scoop",
+  "items": [
+    {
+      "item_name": "potion",
+      "price": 20,
+      "cost": 5
+    },
+    {
+      "item_name": "revive",
+      "price": 100,
+      "cost": 20
+    },
+    {
+      "item_name": "capture_device",
+      "price": 50,
+      "cost": 10
+    }
+  ]
+}

--- a/mods/tuxemon/db/economy/spyder_cotton_scoop.json
+++ b/mods/tuxemon/db/economy/spyder_cotton_scoop.json
@@ -1,0 +1,30 @@
+{
+  "slug": "spyder_cotton_scoop",
+  "items": [
+    {
+      "item_name": "potion",
+      "price": 20,
+      "cost": 5
+    },
+    {
+      "item_name": "revive",
+      "price": 100,
+      "cost": 20
+    },
+    {
+      "item_name": "tm_avalanche",
+      "price": 2000,
+      "cost": 400
+    },
+    {
+      "item_name": "tm_blossom",
+      "price": 1000,
+      "cost": 200
+    },
+    {
+      "item_name": "capture_device",
+      "price": 50,
+      "cost": 10
+    }
+  ]
+}

--- a/mods/tuxemon/db/economy/spyder_flower_scoop.json
+++ b/mods/tuxemon/db/economy/spyder_flower_scoop.json
@@ -1,0 +1,20 @@
+{
+  "slug": "spyder_flower_scoop",
+  "items": [
+    {
+      "item_name": "potion",
+      "price": 20,
+      "cost": 5
+    },
+    {
+      "item_name": "revive",
+      "price": 100,
+      "cost": 20
+    },
+    {
+      "item_name": "capture_device",
+      "price": 50,
+      "cost": 10
+    }
+  ]
+}

--- a/mods/tuxemon/db/economy/spyder_leather_scoop.json
+++ b/mods/tuxemon/db/economy/spyder_leather_scoop.json
@@ -1,0 +1,20 @@
+{
+  "slug": "spyder_leather_scoop",
+  "items": [
+    {
+      "item_name": "potion",
+      "price": 20,
+      "cost": 5
+    },
+    {
+      "item_name": "revive",
+      "price": 100,
+      "cost": 20
+    },
+    {
+      "item_name": "capture_device",
+      "price": 50,
+      "cost": 10
+    }
+  ]
+}

--- a/mods/tuxemon/db/economy/spyder_paper_mart.json
+++ b/mods/tuxemon/db/economy/spyder_paper_mart.json
@@ -1,5 +1,5 @@
 {
-  "slug": "default",
+  "slug": "spyder_paper_mart",
   "items": [
     {
       "item_name": "potion",
@@ -12,20 +12,9 @@
       "cost": 20
     },
     {
-      "item_name": "tm_avalanche",
-      "price": 2000,
-      "cost": 400
-    },
-    {
-      "item_name": "tm_blossom",
-      "price": 1000,
-      "cost": 200
-    },
-    {
       "item_name": "capture_device",
       "price": 50,
       "cost": 10
     }
   ]
 }
-

--- a/mods/tuxemon/db/economy/spyder_timber_scoop.json
+++ b/mods/tuxemon/db/economy/spyder_timber_scoop.json
@@ -1,0 +1,20 @@
+{
+  "slug": "spyder_timber_scoop",
+  "items": [
+    {
+      "item_name": "potion",
+      "price": 20,
+      "cost": 5
+    },
+    {
+      "item_name": "revive",
+      "price": 100,
+      "cost": 20
+    },
+    {
+      "item_name": "capture_device",
+      "price": 50,
+      "cost": 10
+    }
+  ]
+}

--- a/mods/tuxemon/db/economy/tuxe_mart_taba.json
+++ b/mods/tuxemon/db/economy/tuxe_mart_taba.json
@@ -1,0 +1,20 @@
+{
+  "slug": "tuxe_mart_taba",
+  "items": [
+    {
+      "item_name": "potion",
+      "price": 20,
+      "cost": 5
+    },
+    {
+      "item_name": "revive",
+      "price": 100,
+      "cost": 20
+    },
+    {
+      "item_name": "capture_device",
+      "price": 50,
+      "cost": 10
+    }
+  ]
+}

--- a/mods/tuxemon/db/inventory/spyder_candy_scoop.json
+++ b/mods/tuxemon/db/inventory/spyder_candy_scoop.json
@@ -1,0 +1,8 @@
+{
+  "slug": "spyder_candy_scoop",
+  "inventory": {
+    "capture_device": null,
+    "potion": 20,
+    "revive": 3
+  }
+}

--- a/mods/tuxemon/db/inventory/spyder_cotton_scoop.json
+++ b/mods/tuxemon/db/inventory/spyder_cotton_scoop.json
@@ -1,5 +1,5 @@
 {
-  "slug": "inv_basic_store",
+  "slug": "spyder_cotton_scoop",
   "inventory": {
     "capture_device": null,
     "potion": 20,
@@ -8,4 +8,3 @@
     "tm_blossom": 1
   }
 }
-

--- a/mods/tuxemon/db/inventory/spyder_flower_scoop.json
+++ b/mods/tuxemon/db/inventory/spyder_flower_scoop.json
@@ -1,0 +1,8 @@
+{
+  "slug": "spyder_flower_scoop",
+  "inventory": {
+    "capture_device": null,
+    "potion": 20,
+    "revive": 3
+  }
+}

--- a/mods/tuxemon/db/inventory/spyder_leather_scoop.json
+++ b/mods/tuxemon/db/inventory/spyder_leather_scoop.json
@@ -1,0 +1,8 @@
+{
+  "slug": "spyder_leather_scoop",
+  "inventory": {
+    "capture_device": null,
+    "potion": 20,
+    "revive": 3
+  }
+}

--- a/mods/tuxemon/db/inventory/spyder_paper_mart.json
+++ b/mods/tuxemon/db/inventory/spyder_paper_mart.json
@@ -1,0 +1,8 @@
+{
+  "slug": "spyder_paper_mart",
+  "inventory": {
+    "capture_device": null,
+    "potion": 20,
+    "revive": 3
+  }
+}

--- a/mods/tuxemon/db/inventory/spyder_timber_scoop.json
+++ b/mods/tuxemon/db/inventory/spyder_timber_scoop.json
@@ -1,0 +1,8 @@
+{
+  "slug": "spyder_timber_scoop",
+  "inventory": {
+    "capture_device": null,
+    "potion": 20,
+    "revive": 3
+  }
+}

--- a/mods/tuxemon/db/inventory/tuxe_mart_taba.json
+++ b/mods/tuxemon/db/inventory/tuxe_mart_taba.json
@@ -1,0 +1,8 @@
+{
+  "slug": "tuxe_mart_taba",
+  "inventory": {
+    "capture_device": null,
+    "potion": 20,
+    "revive": 3
+  }
+}

--- a/mods/tuxemon/maps/spyder_candy_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_candy_scoop.tmx
@@ -83,7 +83,8 @@
    <properties>
     <property name="act1" value="create_npc spyder_shopkeeper,1,6"/>
     <property name="act2" value="npc_face spyder_shopkeeper,right"/>
-    <property name="act20" value="set_inventory spyder_shopkeeper,inv_basic_store"/>
+    <property name="act20" value="set_inventory spyder_shopkeeper,spyder_candy_scoop"/>
+    <property name="act30" value="set_economy spyder_shopkeeper,spyder_candy_scoop"/>
     <property name="cond1" value="not npc_exists spyder_shopkeeper"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_cotton_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_scoop.tmx
@@ -84,7 +84,8 @@
    <properties>
     <property name="act1" value="create_npc spyder_shopkeeper,1,6"/>
     <property name="act2" value="npc_face spyder_shopkeeper,right"/>
-    <property name="act20" value="set_inventory spyder_shopkeeper,inv_basic_store"/>
+    <property name="act20" value="set_inventory spyder_shopkeeper,spyder_cotton_scoop"/>
+    <property name="act30" value="set_economy spyder_shopkeeper,spyder_cotton_scoop"/>
     <property name="cond1" value="not npc_exists spyder_shopkeeper"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_flower_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_flower_scoop.tmx
@@ -83,7 +83,8 @@
    <properties>
     <property name="act1" value="create_npc spyder_shopkeeper,1,6"/>
     <property name="act2" value="npc_face spyder_shopkeeper,right"/>
-    <property name="act20" value="set_inventory spyder_shopkeeper,inv_basic_store"/>
+    <property name="act20" value="set_inventory spyder_shopkeeper,spyder_flower_scoop"/>
+    <property name="act30" value="set_economy spyder_shopkeeper,spyder_flower_scoop"/>
     <property name="cond1" value="not npc_exists spyder_shopkeeper"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_leather_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_leather_scoop.tmx
@@ -107,7 +107,8 @@
    <properties>
     <property name="act1" value="create_npc spyder_shopkeeper,1,6"/>
     <property name="act2" value="npc_face spyder_shopkeeper,right"/>
-    <property name="act20" value="set_inventory spyder_shopkeeper,inv_basic_store"/>
+    <property name="act20" value="set_inventory spyder_shopkeeper,spyder_leather_scoop"/>
+    <property name="act30" value="set_economy spyder_shopkeeper,spyder_leather_scoop"/>
     <property name="cond1" value="not npc_exists spyder_shopkeeper"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_paper_mart.tmx
+++ b/mods/tuxemon/maps/spyder_paper_mart.tmx
@@ -132,7 +132,8 @@
    <properties>
     <property name="act1" value="create_npc tuxemart_keeper,2,7,tuxemartemployee,stand"/>
     <property name="act2" value="npc_face tuxemart_keeper,right"/>
-    <property name="act3" value="set_inventory tuxemart_keeper,inv_basic_store"/>
+    <property name="act3" value="set_inventory tuxemart_keeper,spyder_paper_mart"/>
+    <property name="act4" value="set_economy tuxemart_keeper,spyder_paper_mart"/>
     <property name="cond1" value="not npc_exists tuxemart_keeper"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_timber_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_timber_scoop.tmx
@@ -83,7 +83,8 @@
    <properties>
     <property name="act1" value="create_npc spyder_shopkeeper,1,6"/>
     <property name="act2" value="npc_face spyder_shopkeeper,right"/>
-    <property name="act20" value="set_inventory spyder_shopkeeper,inv_basic_store"/>
+    <property name="act20" value="set_inventory spyder_shopkeeper,spyder_timber_scoop"/>
+    <property name="act30" value="set_economy spyder_shopkeeper,spyder_timber_scoop"/>
     <property name="cond1" value="not npc_exists spyder_shopkeeper"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/tuxe_mart.tmx
+++ b/mods/tuxemon/maps/tuxe_mart.tmx
@@ -125,7 +125,8 @@
    <properties>
     <property name="act10" value="create_npc tuxemart_keeper,2,7,tuxemartemployee,stand"/>
     <property name="act20" value="npc_face tuxemart_keeper,right"/>
-    <property name="act30" value="set_inventory tuxemart_keeper,inv_basic_store"/>
+    <property name="act30" value="set_inventory tuxemart_keeper,tuxe_mart_taba"/>
+    <property name="act40" value="set_economy tuxemart_keeper,tuxe_mart_taba"/>
     <property name="cond10" value="not npc_exists tuxemart_keeper"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/tuxe_mart_taba.tmx
+++ b/mods/tuxemon/maps/tuxe_mart_taba.tmx
@@ -70,7 +70,8 @@
    <properties>
     <property name="act10" value="create_npc tuxemart_keeper,2,7,,stand"/>
     <property name="act20" value="npc_face tuxemart_keeper,right"/>
-    <property name="act30" value="set_inventory tuxemart_keeper,inv_basic_store"/>
+    <property name="act30" value="set_inventory tuxemart_keeper,tuxe_mart_taba"/>
+    <property name="act40" value="set_economy tuxemart_keeper,tuxe_mart_taba"/>
     <property name="cond10" value="not npc_exists tuxemart_keeper"/>
    </properties>
   </object>


### PR DESCRIPTION
PR addresses economies and inventories (shops related):
- added the inventory of the other scoops;
- added the economy of the other scoops;
- prices and costs unchanged;
- items displayed similar, other scoops without the TMs (only Cotton has both);

At the moment 7 scoops: 6 Spyder and 1 Xero

Just a structural change + maps edits (it was missing the set_economy action, now there is and it mimics the set_inventory).

First step to start in diversifying objects and items around the scenarios;
