### PR TITLE
open dialog choice

### DIFF
--- a/tuxemon/event/actions/open_shop.py
+++ b/tuxemon/event/actions/open_shop.py
@@ -26,9 +26,8 @@ from typing import NamedTuple, Optional, final
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.item.economy import Economy
-from tuxemon.states.choice import ChoiceState
 from tuxemon.states.items import ShopBuyMenuState, ShopSellMenuState
-from tuxemon.tools import assert_never
+from tuxemon.tools import assert_never, open_choice_dialog
 
 
 class OpenShopActionParameters(NamedTuple):
@@ -96,8 +95,8 @@ class OpenShopAction(EventAction[OpenShopActionParameters]):
                 ("Sell", "Sell", sell_menu),
             ]
 
-            self.session.client.push_state(
-                ChoiceState,
+            open_choice_dialog(
+                self.session,
                 menu=var_menu,
                 escape_key_exits=True,
             )

--- a/tuxemon/event/actions/translated_dialog_choice.py
+++ b/tuxemon/event/actions/translated_dialog_choice.py
@@ -23,13 +23,13 @@ from __future__ import annotations
 
 import logging
 from functools import partial
-from typing import Callable, NamedTuple, Sequence, Tuple, final
+from typing import NamedTuple, final
 
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.locale import T, replace_text
-from tuxemon.session import Session
 from tuxemon.states.choice import ChoiceState
+from tuxemon.tools import open_choice_dialog
 
 logger = logging.getLogger(__name__)
 
@@ -80,18 +80,13 @@ class TranslatedDialogChoiceAction(
             text = T.translate(val)
             var_menu.append((text, text, partial(set_variable, val)))
 
-        self.open_choice_dialog(self.session, var_menu)
+        open_choice_dialog(
+            self.session,
+            menu=var_menu,
+        )
 
     def update(self) -> None:
         try:
             self.session.client.get_state_by_name(ChoiceState)
         except ValueError:
             self.stop()
-
-    def open_choice_dialog(
-        self,
-        session: Session,
-        menu: Sequence[Tuple[str, str, Callable[[], None]]],
-    ) -> ChoiceState:
-        logger.info("Opening choice window")
-        return session.client.push_state(ChoiceState, menu=menu)

--- a/tuxemon/states/world/world_menus.py
+++ b/tuxemon/states/world/world_menus.py
@@ -40,8 +40,7 @@ from tuxemon.locale import T
 from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.session import local_session
-from tuxemon.states.choice import ChoiceState
-from tuxemon.tools import open_dialog
+from tuxemon.tools import open_choice_dialog, open_dialog
 
 logger = logging.getLogger(__name__)
 
@@ -229,8 +228,8 @@ class WorldMenuState(PygameMenuState):
                 local_session,
                 [T.format("release_confirmation", {"name": monster.name})],
             )
-            self.client.push_state(
-                ChoiceState,
+            open_choice_dialog(
+                local_session,
                 menu=(
                     ("no", T.translate("no"), negative_answer),
                     ("yes", T.translate("yes"), positive_answer),

--- a/tuxemon/tools.py
+++ b/tuxemon/tools.py
@@ -214,6 +214,7 @@ def open_dialog(
 def open_choice_dialog(
     session: Session,
     menu: Sequence[Tuple[str, str, Callable[[], None]]],
+    escape_key_exits: bool = False,
 ) -> State:
     """
     Open a dialog choice with the standard window size.
@@ -231,6 +232,7 @@ def open_choice_dialog(
     return session.client.push_state(
         ChoiceState,
         menu=menu,
+        escape_key_exits=escape_key_exits,
     )
 
 


### PR DESCRIPTION
PR addresses the replacement of the old open_dialog_choice.

A month ago we implemented the open_dialog_choice inside tools, until now we had still some parts of the code where the function was still based on importing ChoiceState. This wasn't necessary, so I removed it where it was possible. I added the escape_key_exits to the open_dialog_choice, this makes it complete (it was necessary for the open_shop)

Tested + black

the release choice works without issues, as well as the multiple choice based on the action (tested on the first monster choice) and the open shop.