### PR TITLE
action "remove technique" + NPC

### DIFF
--- a/tuxemon/event/actions/removing_move.py
+++ b/tuxemon/event/actions/removing_move.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import logging
+import uuid
+from functools import partial
+from typing import NamedTuple, Optional, Union, final
+
+from tuxemon.event import get_npc
+from tuxemon.event.eventaction import EventAction
+from tuxemon.locale import T
+from tuxemon.npc import NPC
+from tuxemon.states.dialog import ChoiceState
+from tuxemon.tools import open_choice_dialog
+
+logger = logging.getLogger(__name__)
+
+
+class RemovingMoveActionParameters(NamedTuple):
+    npc_slug: Union[str, None]
+
+
+# noinspection PyAttributeOutsideInit
+@final
+class RemovingMoveAction(EventAction[RemovingMoveActionParameters]):
+    """
+    It removes a chosen technique from the monster moves.
+
+    Script usage:
+        .. code-block::
+
+            removing_move [npc_slug]
+
+    Script parameters:
+        npc_slug: Either "player" or npc slug name (e.g. "npc_maple").
+
+    """
+
+    name = "removing_move"
+    param_class = RemovingMoveActionParameters
+
+    def start(self) -> None:
+        def set_variable(var_value: str) -> None:
+            if len(mon.moves) > 1:
+                mon.moves.remove(var_value)
+                self.session.client.pop_state()
+            else:
+                self.session.client.pop_state()
+
+        npc_slug = self.parameters.npc_slug
+
+        trainer: Optional[NPC]
+        if npc_slug is None:
+            trainer = self.session.player
+        else:
+            trainer = get_npc(self.session, npc_slug)
+
+        assert trainer, "No Trainer found with slug '{}'".format(
+            npc_slug or "player"
+        )
+
+        monster_id = uuid.UUID(trainer.game_variables["monster_remove_moves"])
+
+        mon = trainer.find_monster_by_id(monster_id)
+        if mon is None:
+            logger.debug(
+                "Monster not found in party, searching storage boxes."
+            )
+            mon = trainer.find_monster_in_storage(monster_id)
+
+        if mon is None:
+            logger.error(
+                f"Could not find the monster with instance id {monster_id}"
+            )
+            return
+
+        var_list = mon.moves
+        var_menu = list()
+
+        for val in var_list:
+            text = T.translate(val.slug)
+            var_menu.append((text, text, partial(set_variable, val)))
+
+        open_choice_dialog(
+            self.session,
+            menu=var_menu,
+            escape_key_exits=True,
+        )
+
+    def update(self) -> None:
+        try:
+            self.session.client.get_state_by_name(ChoiceState)
+        except ValueError:
+            self.stop()

--- a/tuxemon/event/actions/replacing_move.py
+++ b/tuxemon/event/actions/replacing_move.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import NamedTuple, final
+
+from tuxemon.event.eventaction import EventAction
+from tuxemon.menu.interface import MenuItem
+from tuxemon.monster import Monster
+from tuxemon.states.monster import MonsterMenuState
+
+
+class ReplacingMoveActionParameters(NamedTuple):
+    pass
+
+
+@final
+class ReplacingMoveAction(EventAction[ReplacingMoveActionParameters]):
+    """
+    Select a monster in the player party for forgetting a move.
+
+    Script usage:
+        .. code-block::
+
+            replacing_move
+
+    """
+
+    name = "replacing_move"
+    param_class = ReplacingMoveActionParameters
+
+    def set_var(self, menu_item: MenuItem[Monster]) -> None:
+        if len(menu_item.game_object.moves) > 1:
+            self.player.game_variables[
+                "monster_remove_moves"
+            ] = menu_item.game_object.instance_id.hex
+            self.session.client.pop_state()
+
+    def start(self) -> None:
+        self.player = self.session.player
+
+        # pull up the monster menu
+        menu = self.session.client.push_state(MonsterMenuState)
+        for t in self.player.monsters:
+            if len(t.moves) > 1:
+                menu.on_menu_selection = self.set_var
+
+    def update(self) -> None:
+        try:
+            self.session.client.get_state_by_name(MonsterMenuState)
+        except ValueError:
+            self.stop()


### PR DESCRIPTION
PR addresses and solves a problem related to #1496 

Still isn't clear of the number max of moves for monster, at the moment the rule is 3 moves per monster, the max can easily be 4, 5 or 6, but no more than 7, because if not the list inside the combat menu becomes a mess.

This requires a series of way to forget moves. In #1496 there is a pill that makes forget a random move, here there is a NPC called Mr Lethe (the guy of the pill) that you can easily find inside scoops.

There are two action:
- **replacing** where you choose the monster, only the monsters with more than 1 move can be selected;
- **removing** where it opens up a choice menu (screenshot below) and you choose what technique do you want to forget (same principle here, you are unable to forget the last technique);

The dialogue is the first thing that came up. If someone has suggestions, feel free to suggest.

@Sanglorian are you ok if I populate certain scoops with Mr Lethe and company? It's another way to forget moves.