### PR TITLE
moves monster

### DIFF
--- a/mods/tuxemon/db/monster/aardart.json
+++ b/mods/tuxemon/db/monster/aardart.json
@@ -4,7 +4,7 @@
     "ai": "RandomAI",
     "moveset": [
         {
-            "level_learned": 1,
+            "level_learned": 2,
             "technique": "tonguespear"
         },
         {
@@ -16,8 +16,16 @@
             "technique": "stampede"
         },
 	    {
-            "level_learned": 17,
+            "level_learned": 24,
             "technique": "feint"
+        },
+	    {
+            "level_learned": 28,
+            "technique": "sand_spray"
+        },
+	    {
+            "level_learned": 32,
+            "technique": "mudslide"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/aardorn.json
+++ b/mods/tuxemon/db/monster/aardorn.json
@@ -4,7 +4,7 @@
     "ai": "RandomAI",
     "moveset": [
         {
-            "level_learned": 1,
+            "level_learned": 2,
             "technique": "tonguespear"
         },
         {
@@ -14,16 +14,12 @@
         {
             "level_learned": 8,
             "technique": "stampede"
-        },
-	    {
-            "level_learned": 17,
-            "technique": "feint"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 20,
+            "at_level": 18,
             "monster_slug": "aardart"
         }
     ],

--- a/mods/tuxemon/db/monster/abesnaki.json
+++ b/mods/tuxemon/db/monster/abesnaki.json
@@ -12,7 +12,7 @@
             "technique": "pseudopod"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "sleep_bomb"
         }
     ],

--- a/mods/tuxemon/db/monster/agnidon.json
+++ b/mods/tuxemon/db/monster/agnidon.json
@@ -9,11 +9,23 @@
         },
         {
             "level_learned": 2,
+            "technique": "fire_ball"
+        },
+        {
+            "level_learned": 12,
+            "technique": "fume"
+        },
+        {
+            "level_learned": 28,
             "technique": "kindling_flame"
         },
         {
-            "level_learned": 2,
+            "level_learned": 32,
             "technique": "energy_claws"
+        },
+        {
+            "level_learned": 34,
+            "technique": "breathe_fire"
         }
     ],
     "evolutions": [

--- a/mods/tuxemon/db/monster/agnigon.json
+++ b/mods/tuxemon/db/monster/agnigon.json
@@ -12,8 +12,32 @@
             "technique": "fire_ball"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
+            "technique": "fume"
+        },
+        {
+            "level_learned": 28,
+            "technique": "kindling_flame"
+        },
+        {
+            "level_learned": 32,
+            "technique": "energy_claws"
+        },
+        {
+            "level_learned": 34,
+            "technique": "breathe_fire"
+        },
+        {
+            "level_learned": 44,
             "technique": "take_cover"
+        },
+        {
+            "level_learned": 48,
+            "technique": "muddle"
+        },
+        {
+            "level_learned": 52,
+            "technique": "supernova"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/agnite.json
+++ b/mods/tuxemon/db/monster/agnite.json
@@ -12,7 +12,7 @@
             "technique": "fire_ball"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "fume"
         }
     ],

--- a/mods/tuxemon/db/monster/allagon.json
+++ b/mods/tuxemon/db/monster/allagon.json
@@ -12,14 +12,26 @@
             "technique": "shrapnel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 16,
+            "technique": "strike"
+        },
+        {
+            "level_learned": 40,
             "technique": "rust_bomb"
+        },
+        {
+            "level_learned": 44,
+            "technique": "shuriken"
+        },
+        {
+            "level_learned": 48,
+            "technique": "wall_of_steel"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 55,
+            "at_level": 54,
             "monster_slug": "ferricran"
         }
     ],

--- a/mods/tuxemon/db/monster/altie.json
+++ b/mods/tuxemon/db/monster/altie.json
@@ -12,7 +12,7 @@
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "strike"
         }
     ],

--- a/mods/tuxemon/db/monster/angrito.json
+++ b/mods/tuxemon/db/monster/angrito.json
@@ -5,14 +5,26 @@
     "moveset": [
         {
             "level_learned": 2,
+            "technique": "perfect_cut"
+        },
+        {
+            "level_learned": 2,
+            "technique": "shrapnel"
+        },
+        {
+            "level_learned": 12,
+            "technique": "wall_of_steel"
+        },
+        {
+            "level_learned": 24,
             "technique": "fire_ball"
         },
         {
-            "level_learned": 2,
+            "level_learned": 28,
             "technique": "fire_claw"
         },
         {
-            "level_learned": 2,
+            "level_learned": 32,
             "technique": "flamethrower"
         }
     ],

--- a/mods/tuxemon/db/monster/anoleaf.json
+++ b/mods/tuxemon/db/monster/anoleaf.json
@@ -12,7 +12,7 @@
             "technique": "feint"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "whirlwind"
         }
     ],

--- a/mods/tuxemon/db/monster/anu.json
+++ b/mods/tuxemon/db/monster/anu.json
@@ -12,7 +12,7 @@
             "technique": "shrapnel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "wall_of_steel"
         }
     ],

--- a/mods/tuxemon/db/monster/apeoro.json
+++ b/mods/tuxemon/db/monster/apeoro.json
@@ -5,14 +5,26 @@
     "moveset": [
         {
             "level_learned": 2,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 2,
             "technique": "sleep_bomb"
         },
         {
             "level_learned": 2,
+            "technique": "shrapnel"
+        },
+        {
+            "level_learned": 12,
+            "technique": "bubble_trap"
+        },
+        {
+            "level_learned": 20,
+            "technique": "strike"
+        },
+        {
+            "level_learned": 24,
+            "technique": "constrict"
+        },
+        {
+            "level_learned": 28,
             "technique": "wall_of_steel"
         }
     ],

--- a/mods/tuxemon/db/monster/araignee.json
+++ b/mods/tuxemon/db/monster/araignee.json
@@ -12,7 +12,7 @@
             "technique": "petrify"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "shrapnel"
         }
     ],

--- a/mods/tuxemon/db/monster/arthrobolt.json
+++ b/mods/tuxemon/db/monster/arthrobolt.json
@@ -5,14 +5,38 @@
     "moveset": [
         {
             "level_learned": 2,
+            "technique": "bullet"
+        },
+        {
+            "level_learned": 2,
+            "technique": "static_field"
+        },
+        {
+            "level_learned": 4,
+            "technique": "shuriken"
+        },
+        {
+            "level_learned": 6,
+            "technique": "clamp_on"
+        },
+        {
+            "level_learned": 8,
+            "technique": "muddle"
+        },
+        {
+            "level_learned": 10,
+            "technique": "bubble_trap"
+        },
+        {
+            "level_learned": 16,
             "technique": "beam"
         },
         {
-            "level_learned": 2,
+            "level_learned": 20,
             "technique": "surge"
         },
         {
-            "level_learned": 2,
+            "level_learned": 24,
             "technique": "thunderclap"
         }
     ],

--- a/mods/tuxemon/db/monster/av8r.json
+++ b/mods/tuxemon/db/monster/av8r.json
@@ -5,15 +5,27 @@
     "moveset": [
         {
             "level_learned": 2,
+            "technique": "beam"
+        },
+        {
+            "level_learned": 2,
+            "technique": "levitate"
+        },
+        {
+            "level_learned": 12,
+            "technique": "battery_discharge"
+        },
+        {
+            "level_learned": 16,
             "technique": "wing_tip"
         },
         {
-            "level_learned": 2,
+            "level_learned": 20,
             "technique": "glower"
         },
         {
-            "level_learned": 2,
-            "technique": "battery_discharge"
+            "level_learned": 24,
+            "technique": "shrapnel"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/axylightl.json
+++ b/mods/tuxemon/db/monster/axylightl.json
@@ -12,7 +12,7 @@
             "technique": "midnight_mantle"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "beam"
         }
     ],

--- a/mods/tuxemon/db/monster/b_ver_1.json
+++ b/mods/tuxemon/db/monster/b_ver_1.json
@@ -5,15 +5,27 @@
     "moveset": [
         {
             "level_learned": 2,
+            "technique": "beam"
+        },
+        {
+            "level_learned": 2,
+            "technique": "levitate"
+        },
+        {
+            "level_learned": 12,
+            "technique": "battery_discharge"
+        },
+        {
+            "level_learned": 16,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 20,
             "technique": "glower"
         },
         {
-            "level_learned": 2,
-            "technique": "battery_discharge"
+            "level_learned": 24,
+            "technique": "shrapnel"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/bamboon.json
+++ b/mods/tuxemon/db/monster/bamboon.json
@@ -5,15 +5,27 @@
     "moveset": [
         {
             "level_learned": 2,
-            "technique": "blade"
+            "technique": "muddle"
         },
         {
             "level_learned": 2,
             "technique": "clamp_on"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "ram"
+        },
+        {
+            "level_learned": 20,
+            "technique": "blade"
+        },
+        {
+            "level_learned": 24,
+            "technique": "peck"
+        },
+        {
+            "level_learned": 28,
+            "technique": "splinter"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/banling.json
+++ b/mods/tuxemon/db/monster/banling.json
@@ -12,7 +12,7 @@
             "technique": "overgrowth"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "shadow_boxing"
         }
     ],

--- a/mods/tuxemon/db/monster/baobaraffe.json
+++ b/mods/tuxemon/db/monster/baobaraffe.json
@@ -5,15 +5,27 @@
     "moveset": [
         {
             "level_learned": 2,
+            "technique": "peregrine"
+        },
+        {
+            "level_learned": 2,
+            "technique": "sting"
+        },
+        {
+            "level_learned": 16,
             "technique": "invictus"
         },
         {
-            "level_learned": 2,
+            "level_learned": 20,
             "technique": "fluff_up"
         },
         {
-            "level_learned": 2,
+            "level_learned": 24,
             "technique": "blossom"
+        },
+        {
+            "level_learned": 28,
+            "technique": "pseudopod"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/baoby.json
+++ b/mods/tuxemon/db/monster/baoby.json
@@ -12,14 +12,14 @@
             "technique": "sting"
         },
         {
-            "level_learned": 2,
+            "level_learned": 16,
             "technique": "invictus"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 20,
+            "at_level": 18,
             "monster_slug": "baobaraffe"
         }
     ],

--- a/mods/tuxemon/db/monster/beenstalker.json
+++ b/mods/tuxemon/db/monster/beenstalker.json
@@ -5,14 +5,26 @@
     "moveset": [
         {
             "level_learned": 2,
+            "technique": "peregrine"
+        },
+        {
+            "level_learned": 2,
+            "technique": "fester"
+        },
+        {
+            "level_learned": 12,
+            "technique": "one_two"
+        },
+        {
+            "level_learned": 24,
             "technique": "sting"
         },
         {
-            "level_learned": 2,
+            "level_learned": 28,
             "technique": "invictus"
         },
         {
-            "level_learned": 2,
+            "level_learned": 32,
             "technique": "fluff_up"
         }
     ],

--- a/mods/tuxemon/db/monster/bigfin.json
+++ b/mods/tuxemon/db/monster/bigfin.json
@@ -5,15 +5,27 @@
     "moveset": [
         {
             "level_learned": 2,
-            "technique": "refresh"
+            "technique": "goad"
         },
         {
             "level_learned": 2,
             "technique": "flood"
         },
         {
-            "level_learned": 2,
-            "technique": "goad"
+            "level_learned": 12,
+            "technique": "flow"
+        },
+        {
+            "level_learned": 16,
+            "technique": "refresh"
+        },
+        {
+            "level_learned": 20,
+            "technique": "font"
+        },
+        {
+            "level_learned": 24,
+            "technique": "starfall"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/birb_robo.json
+++ b/mods/tuxemon/db/monster/birb_robo.json
@@ -12,7 +12,7 @@
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "shrapnel"
         }
     ],

--- a/mods/tuxemon/db/monster/birdling.json
+++ b/mods/tuxemon/db/monster/birdling.json
@@ -12,8 +12,20 @@
             "technique": "peck"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
+            "technique": "fluff_up"
+        },
+        {
+            "level_learned": 24,
             "technique": "peregrine"
+        },
+        {
+            "level_learned": 28,
+            "technique": "whirlwind"
+        },
+        {
+            "level_learned": 32,
+            "technique": "one_two"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/bolt.json
+++ b/mods/tuxemon/db/monster/bolt.json
@@ -12,8 +12,20 @@
             "technique": "static_field"
         },
         {
-            "level_learned": 2,
+            "level_learned": 4,
+            "technique": "shuriken"
+        },
+        {
+            "level_learned": 6,
             "technique": "clamp_on"
+        },
+        {
+            "level_learned": 8,
+            "technique": "muddle"
+        },
+        {
+            "level_learned": 10,
+            "technique": "bubble_trap"
         }
     ],
     "evolutions": [

--- a/mods/tuxemon/db/monster/boltnu.json
+++ b/mods/tuxemon/db/monster/boltnu.json
@@ -12,14 +12,14 @@
             "technique": "strike"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "shrapnel"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 20,
+            "at_level": 18,
             "monster_slug": "exclawvate"
         }
     ],

--- a/mods/tuxemon/db/monster/botbot.json
+++ b/mods/tuxemon/db/monster/botbot.json
@@ -12,7 +12,7 @@
             "technique": "levitate"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "battery_discharge"
         }
     ],

--- a/mods/tuxemon/db/monster/boxali.json
+++ b/mods/tuxemon/db/monster/boxali.json
@@ -12,7 +12,7 @@
             "technique": "blade"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "wall_of_steel"
         }
     ],

--- a/mods/tuxemon/db/monster/brewdin.json
+++ b/mods/tuxemon/db/monster/brewdin.json
@@ -12,7 +12,7 @@
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "wall_of_steel"
         }
     ],

--- a/mods/tuxemon/db/monster/budaye.json
+++ b/mods/tuxemon/db/monster/budaye.json
@@ -12,7 +12,7 @@
             "technique": "clamp_on"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "ram"
         }
     ],

--- a/mods/tuxemon/db/monster/bugnin.json
+++ b/mods/tuxemon/db/monster/bugnin.json
@@ -9,11 +9,35 @@
         },
         {
             "level_learned": 2,
+            "technique": "shrapnel"
+        },
+        {
+            "level_learned": 4,
+            "technique": "splinter"
+        },
+        {
+            "level_learned": 6,
+            "technique": "font"
+        },
+        {
+            "level_learned": 8,
+            "technique": "peregrine"
+        },
+        {
+            "level_learned": 10,
+            "technique": "sting"
+        },
+        {
+            "level_learned": 20,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 2,
+            "level_learned": 24,
             "technique": "blade"
+        },
+        {
+            "level_learned": 28,
+            "technique": "sleep_bomb"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/bumbulus.json
+++ b/mods/tuxemon/db/monster/bumbulus.json
@@ -12,7 +12,7 @@
             "technique": "whirlwind"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "venomous_tentacle"
         }
     ],

--- a/mods/tuxemon/db/monster/bursa.json
+++ b/mods/tuxemon/db/monster/bursa.json
@@ -12,7 +12,7 @@
             "technique": "amnesia"
         },
         {
-            "level_learned": 2,
+            "level_learned": 16,
             "technique": "fire_ball"
         }
     ],

--- a/mods/tuxemon/db/monster/cairfrey.json
+++ b/mods/tuxemon/db/monster/cairfrey.json
@@ -12,7 +12,7 @@
             "technique": "refresh"
         },
         {
-            "level_learned": 2,
+            "level_learned": 16,
             "technique": "muddle"
         }
     ],

--- a/mods/tuxemon/db/monster/capiti.json
+++ b/mods/tuxemon/db/monster/capiti.json
@@ -12,7 +12,7 @@
             "technique": "fluff_up"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "sting"
         }
     ],

--- a/mods/tuxemon/db/monster/cardiling.json
+++ b/mods/tuxemon/db/monster/cardiling.json
@@ -8,11 +8,11 @@
             "technique": "breathe_fire"
         },
         {
-            "level_learned": 1,
+            "level_learned": 2,
             "technique": "give_all"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "fire_claw"
         }
     ],

--- a/mods/tuxemon/db/monster/cardinale.json
+++ b/mods/tuxemon/db/monster/cardinale.json
@@ -9,11 +9,35 @@
         },
         {
             "level_learned": 2,
+            "technique": "give_all"
+        },
+        {
+            "level_learned": 12,
+            "technique": "fire_claw"
+        },
+        {
+            "level_learned": 24,
+            "technique": "kindling_flame"
+        },
+        {
+            "level_learned": 28,
+            "technique": "peregrine"
+        },
+        {
+            "level_learned": 28,
+            "technique": "salamander"
+        },
+        {
+            "level_learned": 40,
             "technique": "berserk"
         },
         {
-            "level_learned": 2,
-            "technique": "peregrine"
+            "level_learned": 44,
+            "technique": "all_in"
+        },
+        {
+            "level_learned": 48,
+            "technique": "flamethrower"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/cardiwing.json
+++ b/mods/tuxemon/db/monster/cardiwing.json
@@ -9,11 +9,23 @@
         },
         {
             "level_learned": 2,
+            "technique": "give_all"
+        },
+        {
+            "level_learned": 12,
+            "technique": "fire_claw"
+        },
+        {
+            "level_learned": 24,
             "technique": "kindling_flame"
         },
         {
-            "level_learned": 2,
+            "level_learned": 28,
             "technique": "peregrine"
+        },
+        {
+            "level_learned": 28,
+            "technique": "salamander"
         }
     ],
     "evolutions": [

--- a/mods/tuxemon/db/monster/cataspike.json
+++ b/mods/tuxemon/db/monster/cataspike.json
@@ -4,7 +4,7 @@
     "ai": "RandomAI",
     "moveset": [
         {
-            "level_learned": 1,
+            "level_learned": 2,
             "technique": "bullet"
         },
         {
@@ -12,7 +12,7 @@
             "technique": "shuriken"
         },
         {
-            "level_learned": 5,
+            "level_learned": 4,
             "technique": "wallow"
         }
     ],

--- a/mods/tuxemon/db/monster/cateye.json
+++ b/mods/tuxemon/db/monster/cateye.json
@@ -12,7 +12,7 @@
             "technique": "eyebite"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "flow"
         }
     ],

--- a/mods/tuxemon/db/monster/chenipode.json
+++ b/mods/tuxemon/db/monster/chenipode.json
@@ -12,14 +12,14 @@
             "technique": "clamp_on"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "take_cover"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 20,
+            "at_level": 18,
             "monster_slug": "exapode"
         }
     ],

--- a/mods/tuxemon/db/monster/chibiro.json
+++ b/mods/tuxemon/db/monster/chibiro.json
@@ -12,7 +12,7 @@
             "technique": "fluff_up"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "overgrowth"
         }
     ],

--- a/mods/tuxemon/db/monster/chillimp.json
+++ b/mods/tuxemon/db/monster/chillimp.json
@@ -12,14 +12,14 @@
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "snowstorm"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 20,
+            "at_level": 18,
             "monster_slug": "snowrilla"
         }
     ],

--- a/mods/tuxemon/db/monster/chloragon.json
+++ b/mods/tuxemon/db/monster/chloragon.json
@@ -12,7 +12,7 @@
             "technique": "web"
         },
         {
-            "level_learned": 2,
+            "level_learned": 16,
             "technique": "hibernate"
         }
     ],

--- a/mods/tuxemon/db/monster/chrome_robo.json
+++ b/mods/tuxemon/db/monster/chrome_robo.json
@@ -12,7 +12,7 @@
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "shrapnel"
         }
     ],

--- a/mods/tuxemon/db/monster/chromeye.json
+++ b/mods/tuxemon/db/monster/chromeye.json
@@ -12,32 +12,32 @@
             "technique": "shrapnel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "wall_of_steel"
         }
     ],
     "evolutions": [
         {
             "path": "mixed",
-            "at_level": 20,
+            "at_level": 18,
             "monster_slug": "angrito",
             "mixed": "tobedefined"
         },
         {
             "path": "mixed",
-            "at_level": 20,
+            "at_level": 18,
             "monster_slug": "happito",
             "mixed": "tobedefined"
         },
         {
             "path": "mixed",
-            "at_level": 20,
+            "at_level": 18,
             "monster_slug": "neutrito",
             "mixed": "tobedefined"
         },
         {
             "path": "mixed",
-            "at_level": 20,
+            "at_level": 18,
             "monster_slug": "sadito",
             "mixed": "tobedefined"
         }

--- a/mods/tuxemon/db/monster/cochini.json
+++ b/mods/tuxemon/db/monster/cochini.json
@@ -12,7 +12,7 @@
             "technique": "thunderball"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "headbutt"
         }
     ],

--- a/mods/tuxemon/db/monster/coleorus.json
+++ b/mods/tuxemon/db/monster/coleorus.json
@@ -12,7 +12,7 @@
             "technique": "peck"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "fluff_up"
         }
     ],

--- a/mods/tuxemon/db/monster/conifrost.json
+++ b/mods/tuxemon/db/monster/conifrost.json
@@ -12,7 +12,7 @@
             "technique": "chill_mist"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "whirlwind"
         }
     ],

--- a/mods/tuxemon/db/monster/conileaf.json
+++ b/mods/tuxemon/db/monster/conileaf.json
@@ -12,7 +12,7 @@
             "technique": "pseudopod"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "overgrowth"
         }
     ],

--- a/mods/tuxemon/db/monster/coproblight.json
+++ b/mods/tuxemon/db/monster/coproblight.json
@@ -4,15 +4,15 @@
     "ai": "RandomAI",
     "moveset": [
         {
-            "level_learned": 1,
+            "level_learned": 2,
             "technique": "fester"
         },
         {
-            "level_learned": 1,
+            "level_learned": 2,
             "technique": "fume"
         },
         {
-            "level_learned": 1,
+            "level_learned": 12,
             "technique": "suck_poison"
         }
     ],

--- a/mods/tuxemon/db/monster/corvix.json
+++ b/mods/tuxemon/db/monster/corvix.json
@@ -12,7 +12,19 @@
             "technique": "berserk"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
+            "technique": "one_two"
+        },
+        {
+            "level_learned": 24,
+            "technique": "amnesia"
+        },
+        {
+            "level_learned": 28,
+            "technique": "rust_bomb"
+        },
+        {
+            "level_learned": 32,
             "technique": "all_in"
         }
     ],

--- a/mods/tuxemon/db/monster/cowpignon.json
+++ b/mods/tuxemon/db/monster/cowpignon.json
@@ -12,7 +12,7 @@
             "technique": "invictus"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "petrify"
         }
     ],

--- a/mods/tuxemon/db/monster/criniotherme.json
+++ b/mods/tuxemon/db/monster/criniotherme.json
@@ -5,15 +5,27 @@
     "moveset": [
         {
             "level_learned": 2,
-            "technique": "eyebite"
-        },
-        {
-            "level_learned": 2,
-            "technique": "glower"
+            "technique": "one_two"
         },
         {
             "level_learned": 2,
             "technique": "fire_claw"
+        },
+        {
+            "level_learned": 12,
+            "technique": "all_in"
+        },
+        {
+            "level_learned": 24,
+            "technique": "eyebite"
+        },
+        {
+            "level_learned": 28,
+            "technique": "glower"
+        },
+        {
+            "level_learned": 32,
+            "technique": "flamethrower"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/d0llf1n.json
+++ b/mods/tuxemon/db/monster/d0llf1n.json
@@ -12,7 +12,7 @@
             "technique": "flood"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "flow"
         }
     ],

--- a/mods/tuxemon/db/monster/dandicub.json
+++ b/mods/tuxemon/db/monster/dandicub.json
@@ -12,14 +12,14 @@
             "technique": "overgrowth"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "sleeping_powder"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 20,
+            "at_level": 18,
             "monster_slug": "dandylion"
         }
     ],

--- a/mods/tuxemon/db/monster/dandylion.json
+++ b/mods/tuxemon/db/monster/dandylion.json
@@ -5,15 +5,27 @@
     "moveset": [
         {
             "level_learned": 2,
-            "technique": "energy_claws"
+            "technique": "pseudopod"
         },
         {
             "level_learned": 2,
             "technique": "overgrowth"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "sleeping_powder"
+        },
+        {
+            "level_learned": 24,
+            "technique": "energy_claws"
+        },
+        {
+            "level_learned": 28,
+            "technique": "one_two"
+        },
+        {
+            "level_learned": 32,
+            "technique": "all_in"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/dark_robo.json
+++ b/mods/tuxemon/db/monster/dark_robo.json
@@ -12,7 +12,7 @@
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "shrapnel"
         }
     ],

--- a/mods/tuxemon/db/monster/dinoflop.json
+++ b/mods/tuxemon/db/monster/dinoflop.json
@@ -12,7 +12,7 @@
             "technique": "ram"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "rock"
         }
     ],

--- a/mods/tuxemon/db/monster/djinnbo.json
+++ b/mods/tuxemon/db/monster/djinnbo.json
@@ -12,7 +12,7 @@
             "technique": "give_all"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "flamethrower"
         }
     ],

--- a/mods/tuxemon/db/monster/dollfin.json
+++ b/mods/tuxemon/db/monster/dollfin.json
@@ -12,7 +12,7 @@
             "technique": "flood"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "flow"
         }
     ],

--- a/mods/tuxemon/db/monster/dracune.json
+++ b/mods/tuxemon/db/monster/dracune.json
@@ -9,11 +9,23 @@
         },
         {
             "level_learned": 2,
+            "technique": "spray"
+        },
+        {
+            "level_learned": 4,
+            "technique": "refresh"
+        },
+        {
+            "level_learned": 6,
             "technique": "font"
         },
         {
-            "level_learned": 2,
+            "level_learned": 8,
             "technique": "hibernate"
+        },
+        {
+            "level_learned": 10,
+            "technique": "goad"
         }
     ],
     "evolutions": [

--- a/mods/tuxemon/db/monster/dragarbor.json
+++ b/mods/tuxemon/db/monster/dragarbor.json
@@ -12,8 +12,32 @@
             "technique": "web"
         },
         {
-            "level_learned": 2,
+            "level_learned": 16,
+            "technique": "hibernate"
+        },
+        {
+            "level_learned": 32,
+            "technique": "sting"
+        },
+        {
+            "level_learned": 36,
+            "technique": "one_two"
+        },
+        {
+            "level_learned": 40,
+            "technique": "fluff_up"
+        },
+        {
+            "level_learned": 56,
             "technique": "whirlwind"
+        },
+        {
+            "level_learned": 60,
+            "technique": "wing_tip"
+        },
+        {
+            "level_learned": 64,
+            "technique": "shadow_boxing"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/drashimi.json
+++ b/mods/tuxemon/db/monster/drashimi.json
@@ -12,7 +12,7 @@
             "technique": "flow"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "flood"
         }
     ],

--- a/mods/tuxemon/db/monster/drokoro.json
+++ b/mods/tuxemon/db/monster/drokoro.json
@@ -12,7 +12,7 @@
             "technique": "berserk"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "breathe_fire"
         }
     ],

--- a/mods/tuxemon/db/monster/dune_pincher.json
+++ b/mods/tuxemon/db/monster/dune_pincher.json
@@ -12,7 +12,7 @@
             "technique": "avalanche"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "refresh"
         }
     ],

--- a/mods/tuxemon/db/monster/eaglace.json
+++ b/mods/tuxemon/db/monster/eaglace.json
@@ -5,14 +5,38 @@
     "moveset": [
         {
             "level_learned": 2,
+            "technique": "ice_claw"
+        },
+        {
+            "level_learned": 2,
+            "technique": "flow"
+        },
+        {
+            "level_learned": 12,
+            "technique": "energy_field"
+        },
+        {
+            "level_learned": 28,
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 2,
+            "level_learned": 32,
             "technique": "biting_winds"
         },
         {
-            "level_learned": 2,
+            "level_learned": 34,
+            "technique": "flood"
+        },
+        {
+            "level_learned": 44,
+            "technique": "font"
+        },
+        {
+            "level_learned": 48,
+            "technique": "chill_mist"
+        },
+        {
+            "level_learned": 52,
             "technique": "snowstorm"
         }
     ],

--- a/mods/tuxemon/db/monster/elofly.json
+++ b/mods/tuxemon/db/monster/elofly.json
@@ -12,7 +12,7 @@
             "technique": "biting_winds"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "fume"
         }
     ],

--- a/mods/tuxemon/db/monster/elostorm.json
+++ b/mods/tuxemon/db/monster/elostorm.json
@@ -9,11 +9,35 @@
         },
         {
             "level_learned": 2,
+            "technique": "biting_winds"
+        },
+        {
+            "level_learned": 12,
+            "technique": "fume"
+        },
+        {
+            "level_learned": 24,
+            "technique": "probiscus"
+        },
+        {
+            "level_learned": 28,
+            "technique": "flood"
+        },
+        {
+            "level_learned": 32,
+            "technique": "flow"
+        },
+        {
+            "level_learned": 44,
             "technique": "thunderclap"
         },
         {
-            "level_learned": 2,
-            "technique": "snowstorm"
+            "level_learned": 48,
+            "technique": "icicle_spear"
+        },
+        {
+            "level_learned": 52,
+            "technique": "chill_mist"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/elowind.json
+++ b/mods/tuxemon/db/monster/elowind.json
@@ -9,17 +9,29 @@
         },
         {
             "level_learned": 2,
-            "technique": "thunderclap"
+            "technique": "biting_winds"
         },
         {
-            "level_learned": 2,
-            "technique": "biting_winds"
+            "level_learned": 12,
+            "technique": "fume"
+        },
+        {
+            "level_learned": 24,
+            "technique": "probiscus"
+        },
+        {
+            "level_learned": 28,
+            "technique": "flood"
+        },
+        {
+            "level_learned": 32,
+            "technique": "flow"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 38,
+            "at_level": 42,
             "monster_slug": "elostorm"
         }
     ],

--- a/mods/tuxemon/db/monster/embazook.json
+++ b/mods/tuxemon/db/monster/embazook.json
@@ -9,11 +9,23 @@
         },
         {
             "level_learned": 2,
+            "technique": "boulder"
+        },
+        {
+            "level_learned": 12,
+            "technique": "static_field"
+        },
+        {
+            "level_learned": 16,
             "technique": "shuriken"
         },
         {
-            "level_learned": 2,
-            "technique": "static_field"
+            "level_learned": 20,
+            "technique": "kindling_flame"
+        },
+        {
+            "level_learned": 24,
+            "technique": "flamethrower"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/embra.json
+++ b/mods/tuxemon/db/monster/embra.json
@@ -12,7 +12,7 @@
             "technique": "refresh"
         },
         {
-            "level_learned": 2,
+            "level_learned": 16,
             "technique": "kindling_flame"
         }
     ],

--- a/mods/tuxemon/db/monster/enduros.json
+++ b/mods/tuxemon/db/monster/enduros.json
@@ -12,7 +12,7 @@
             "technique": "ram"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "rock"
         }
     ],

--- a/mods/tuxemon/db/monster/eruptibus.json
+++ b/mods/tuxemon/db/monster/eruptibus.json
@@ -5,14 +5,26 @@
     "moveset": [
         {
             "level_learned": 2,
+            "technique": "fire_ball"
+        },
+        {
+            "level_learned": 2,
+            "technique": "boulder"
+        },
+        {
+            "level_learned": 12,
+            "technique": "static_field"
+        },
+        {
+            "level_learned": 16,
             "technique": "berserk"
         },
         {
-            "level_learned": 2,
+            "level_learned": 20,
             "technique": "hibernate"
         },
         {
-            "level_learned": 2,
+            "level_learned": 24,
             "technique": "energy_field"
         }
     ],

--- a/mods/tuxemon/db/monster/exapode.json
+++ b/mods/tuxemon/db/monster/exapode.json
@@ -12,8 +12,20 @@
             "technique": "clamp_on"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
+            "technique": "take_cover"
+        },
+        {
+            "level_learned": 24,
             "technique": "avalanche"
+        },
+        {
+            "level_learned": 28,
+            "technique": "sand_spray"
+        },
+        {
+            "level_learned": 32,
+            "technique": "headbutt"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/exclawvate.json
+++ b/mods/tuxemon/db/monster/exclawvate.json
@@ -5,15 +5,27 @@
     "moveset": [
         {
             "level_learned": 2,
-            "technique": "electrical_storm"
-        },
-        {
-            "level_learned": 2,
-            "technique": "wall_of_steel"
+            "technique": "goad"
         },
         {
             "level_learned": 2,
             "technique": "strike"
+        },
+        {
+            "level_learned": 12,
+            "technique": "shrapnel"
+        },
+        {
+            "level_learned": 24,
+            "technique": "electrical_storm"
+        },
+        {
+            "level_learned": 28,
+            "technique": "muddle"
+        },
+        {
+            "level_learned": 32,
+            "technique": "wall_of_steel"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/eyenemy.json
+++ b/mods/tuxemon/db/monster/eyenemy.json
@@ -12,14 +12,14 @@
             "technique": "spray"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "glower"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 20,
+            "at_level": 18,
             "monster_slug": "eyesore"
         }
     ],

--- a/mods/tuxemon/db/monster/eyesore.json
+++ b/mods/tuxemon/db/monster/eyesore.json
@@ -12,8 +12,20 @@
             "technique": "spray"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
+            "technique": "glower"
+        },
+        {
+            "level_learned": 24,
             "technique": "eyebite"
+        },
+        {
+            "level_learned": 28,
+            "technique": "bullet"
+        },
+        {
+            "level_learned": 32,
+            "technique": "strike"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/f7u1t3ra.json
+++ b/mods/tuxemon/db/monster/f7u1t3ra.json
@@ -12,7 +12,7 @@
             "technique": "sting"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "splinter"
         }
     ],

--- a/mods/tuxemon/db/monster/fancair.json
+++ b/mods/tuxemon/db/monster/fancair.json
@@ -12,14 +12,14 @@
             "technique": "shrapnel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "wall_of_steel"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 20,
+            "at_level": 18,
             "monster_slug": "windeye"
         }
     ],

--- a/mods/tuxemon/db/monster/ferricran.json
+++ b/mods/tuxemon/db/monster/ferricran.json
@@ -5,15 +5,39 @@
     "moveset": [
         {
             "level_learned": 2,
-            "technique": "rust_bomb"
-        },
-        {
-            "level_learned": 2,
             "technique": "perfect_cut"
         },
         {
             "level_learned": 2,
+            "technique": "shrapnel"
+        },
+        {
+            "level_learned": 16,
+            "technique": "strike"
+        },
+        {
+            "level_learned": 40,
+            "technique": "rust_bomb"
+        },
+        {
+            "level_learned": 44,
+            "technique": "shuriken"
+        },
+        {
+            "level_learned": 48,
             "technique": "wall_of_steel"
+        },
+        {
+            "level_learned": 60,
+            "technique": "amnesia"
+        },
+        {
+            "level_learned": 64,
+            "technique": "muddle"
+        },
+        {
+            "level_learned": 68,
+            "technique": "bullet"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/flacono.json
+++ b/mods/tuxemon/db/monster/flacono.json
@@ -12,7 +12,7 @@
             "technique": "berserk"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "one_two"
         }
     ],

--- a/mods/tuxemon/db/monster/flambear.json
+++ b/mods/tuxemon/db/monster/flambear.json
@@ -9,11 +9,23 @@
         },
         {
             "level_learned": 2,
+            "technique": "amnesia"
+        },
+        {
+            "level_learned": 16,
+            "technique": "fire_ball"
+        },
+        {
+            "level_learned": 32,
             "technique": "all_in"
         },
         {
-            "level_learned": 2,
+            "level_learned": 36,
             "technique": "give_all"
+        },
+        {
+            "level_learned": 40,
+            "technique": "breathe_fire"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/fluoresfin.json
+++ b/mods/tuxemon/db/monster/fluoresfin.json
@@ -12,7 +12,7 @@
             "technique": "sudden_glow"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "glower"
         }
     ],

--- a/mods/tuxemon/db/monster/fluttaflap.json
+++ b/mods/tuxemon/db/monster/fluttaflap.json
@@ -12,8 +12,32 @@
             "technique": "spray"
         },
         {
-            "level_learned": 2,
+            "level_learned": 4,
+            "technique": "refresh"
+        },
+        {
+            "level_learned": 6,
+            "technique": "font"
+        },
+        {
+            "level_learned": 8,
+            "technique": "hibernate"
+        },
+        {
+            "level_learned": 10,
+            "technique": "goad"
+        },
+        {
+            "level_learned": 20,
             "technique": "sleeping_powder"
+        },
+        {
+            "level_learned": 24,
+            "technique": "venomous_tentacle"
+        },
+        {
+            "level_learned": 28,
+            "technique": "icicle_spear"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/foofle.json
+++ b/mods/tuxemon/db/monster/foofle.json
@@ -12,7 +12,7 @@
             "technique": "headbutt"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "refresh"
         }
     ],

--- a/mods/tuxemon/db/monster/fordin.json
+++ b/mods/tuxemon/db/monster/fordin.json
@@ -12,7 +12,7 @@
             "technique": "invictus"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "peregrine"
         }
     ],

--- a/mods/tuxemon/db/monster/forturtle.json
+++ b/mods/tuxemon/db/monster/forturtle.json
@@ -12,14 +12,14 @@
             "technique": "energy_field"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "sleep_bomb"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 20,
+            "at_level": 18,
             "monster_slug": "prophetoise"
         }
     ],

--- a/mods/tuxemon/db/monster/foxfire.json
+++ b/mods/tuxemon/db/monster/foxfire.json
@@ -12,7 +12,7 @@
             "technique": "fume"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "fluff_up"
         }
     ],

--- a/mods/tuxemon/db/monster/frondly.json
+++ b/mods/tuxemon/db/monster/frondly.json
@@ -9,11 +9,23 @@
         },
         {
             "level_learned": 2,
-            "technique": "blossom"
+            "technique": "clamp_on"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "ram"
+        },
+        {
+            "level_learned": 20,
+            "technique": "fester"
+        },
+        {
+            "level_learned": 24,
+            "technique": "splinter"
+        },
+        {
+            "level_learned": 28,
+            "technique": "blossom"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/fruitera.json
+++ b/mods/tuxemon/db/monster/fruitera.json
@@ -12,7 +12,7 @@
             "technique": "sting"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "splinter"
         }
     ],

--- a/mods/tuxemon/db/monster/furnursus.json
+++ b/mods/tuxemon/db/monster/furnursus.json
@@ -12,14 +12,14 @@
             "technique": "fire_ball"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "flamethrower"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 20,
+            "at_level": 18,
             "monster_slug": "statursus"
         }
     ],

--- a/mods/tuxemon/db/monster/galnec.json
+++ b/mods/tuxemon/db/monster/galnec.json
@@ -12,7 +12,7 @@
             "technique": "ram"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "rock"
         }
     ],

--- a/mods/tuxemon/db/monster/gectile.json
+++ b/mods/tuxemon/db/monster/gectile.json
@@ -5,15 +5,27 @@
     "moveset": [
         {
             "level_learned": 2,
+            "technique": "sting"
+        },
+        {
+            "level_learned": 2,
+            "technique": "feint"
+        },
+        {
+            "level_learned": 12,
+            "technique": "whirlwind"
+        },
+        {
+            "level_learned": 24,
             "technique": "splinter"
         },
         {
-            "level_learned": 2,
+            "level_learned": 28,
             "technique": "peregrine"
         },
         {
-            "level_learned": 2,
-            "technique": "whirlwind"
+            "level_learned": 32,
+            "technique": "pseudopod"
         }
     ],
     "evolutions": [

--- a/mods/tuxemon/db/monster/ghosteeth.json
+++ b/mods/tuxemon/db/monster/ghosteeth.json
@@ -12,7 +12,7 @@
             "technique": "blood_bond"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "chill_mist"
         }
     ],

--- a/mods/tuxemon/db/monster/graffiki.json
+++ b/mods/tuxemon/db/monster/graffiki.json
@@ -12,7 +12,7 @@
             "technique": "bubble_trap"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "wall_of_steel"
         }
     ],

--- a/mods/tuxemon/db/monster/grimachin.json
+++ b/mods/tuxemon/db/monster/grimachin.json
@@ -12,7 +12,7 @@
             "technique": "blade"
         },
         {
-            "level_learned": 2,
+            "level_learned": 16,
             "technique": "fume"
         }
     ],

--- a/mods/tuxemon/db/monster/grinflare.json
+++ b/mods/tuxemon/db/monster/grinflare.json
@@ -9,11 +9,23 @@
         },
         {
             "level_learned": 2,
+            "technique": "sand_spray"
+        },
+        {
+            "level_learned": 12,
+            "technique": "avalanche"
+        },
+        {
+            "level_learned": 16,
             "technique": "fire_claw"
         },
         {
-            "level_learned": 2,
+            "level_learned": 20,
             "technique": "give_all"
+        },
+        {
+            "level_learned": 24,
+            "technique": "flamethrower"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/grintot.json
+++ b/mods/tuxemon/db/monster/grintot.json
@@ -12,7 +12,7 @@
             "technique": "sand_spray"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "avalanche"
         }
     ],

--- a/mods/tuxemon/db/monster/grintrock.json
+++ b/mods/tuxemon/db/monster/grintrock.json
@@ -9,11 +9,23 @@
         },
         {
             "level_learned": 2,
+            "technique": "sand_spray"
+        },
+        {
+            "level_learned": 12,
+            "technique": "avalanche"
+        },
+        {
+            "level_learned": 16,
             "technique": "surge"
         },
         {
-            "level_learned": 2,
+            "level_learned": 20,
             "technique": "stampede"
+        },
+        {
+            "level_learned": 24,
+            "technique": "headbutt"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/grumpi.json
+++ b/mods/tuxemon/db/monster/grumpi.json
@@ -12,7 +12,7 @@
             "technique": "one_two"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "all_in"
         }
     ],

--- a/mods/tuxemon/db/monster/gryfix.json
+++ b/mods/tuxemon/db/monster/gryfix.json
@@ -5,15 +5,39 @@
     "moveset": [
         {
             "level_learned": 2,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 2,
             "technique": "wing_tip"
         },
         {
             "level_learned": 2,
+            "technique": "berserk"
+        },
+        {
+            "level_learned": 12,
             "technique": "one_two"
+        },
+        {
+            "level_learned": 24,
+            "technique": "amnesia"
+        },
+        {
+            "level_learned": 28,
+            "technique": "rust_bomb"
+        },
+        {
+            "level_learned": 32,
+            "technique": "all_in"
+        },
+        {
+            "level_learned": 40,
+            "technique": "strike"
+        },
+        {
+            "level_learned": 44,
+            "technique": "perfect_cut"
+        },
+        {
+            "level_learned": 48,
+            "technique": "blade"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/hampotamos.json
+++ b/mods/tuxemon/db/monster/hampotamos.json
@@ -12,7 +12,7 @@
             "technique": "mudslide"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "ram"
         }
     ],

--- a/mods/tuxemon/db/monster/happito.json
+++ b/mods/tuxemon/db/monster/happito.json
@@ -5,14 +5,26 @@
     "moveset": [
         {
             "level_learned": 2,
+            "technique": "perfect_cut"
+        },
+        {
+            "level_learned": 2,
+            "technique": "shrapnel"
+        },
+        {
+            "level_learned": 12,
+            "technique": "wall_of_steel"
+        },
+        {
+            "level_learned": 24,
             "technique": "mudslide"
         },
         {
-            "level_learned": 2,
+            "level_learned": 28,
             "technique": "ram"
         },
         {
-            "level_learned": 2,
+            "level_learned": 32,
             "technique": "rock"
         }
     ],

--- a/mods/tuxemon/db/monster/hatchling.json
+++ b/mods/tuxemon/db/monster/hatchling.json
@@ -12,14 +12,14 @@
             "technique": "peck"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "fluff_up"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 20,
+            "at_level": 18,
             "monster_slug": "birdling"
         }
     ],

--- a/mods/tuxemon/db/monster/heronquak.json
+++ b/mods/tuxemon/db/monster/heronquak.json
@@ -5,15 +5,27 @@
     "moveset": [
         {
             "level_learned": 2,
+            "technique": "ice_claw"
+        },
+        {
+            "level_learned": 2,
+            "technique": "flow"
+        },
+        {
+            "level_learned": 12,
+            "technique": "energy_field"
+        },
+        {
+            "level_learned": 28,
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 2,
+            "level_learned": 32,
             "technique": "biting_winds"
         },
         {
-            "level_learned": 2,
-            "technique": "energy_field"
+            "level_learned": 34,
+            "technique": "flood"
         }
     ],
     "evolutions": [

--- a/mods/tuxemon/db/monster/hydrone.json
+++ b/mods/tuxemon/db/monster/hydrone.json
@@ -12,7 +12,7 @@
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "shrapnel"
         }
     ],

--- a/mods/tuxemon/db/monster/ignibus.json
+++ b/mods/tuxemon/db/monster/ignibus.json
@@ -12,7 +12,7 @@
             "technique": "boulder"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "static_field"
         }
     ],

--- a/mods/tuxemon/db/monster/incandesfin.json
+++ b/mods/tuxemon/db/monster/incandesfin.json
@@ -12,8 +12,20 @@
             "technique": "sudden_glow"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
+            "technique": "glower"
+        },
+        {
+            "level_learned": 24,
+            "technique": "goad"
+        },
+        {
+            "level_learned": 28,
             "technique": "starfall"
+        },
+        {
+            "level_learned": 32,
+            "technique": "flood"
         }
     ],
     "evolutions": [

--- a/mods/tuxemon/db/monster/jelillow.json
+++ b/mods/tuxemon/db/monster/jelillow.json
@@ -12,7 +12,7 @@
             "technique": "hibernate"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "flood"
         }
     ],

--- a/mods/tuxemon/db/monster/jemuar.json
+++ b/mods/tuxemon/db/monster/jemuar.json
@@ -9,11 +9,35 @@
         },
         {
             "level_learned": 2,
+            "technique": "boulder"
+        },
+        {
+            "level_learned": 12,
+            "technique": "thunderball"
+        },
+        {
+            "level_learned": 28,
             "technique": "glower"
         },
         {
-            "level_learned": 2,
+            "level_learned": 32,
+            "technique": "ice_claw"
+        },
+        {
+            "level_learned": 34,
+            "technique": "surge"
+        },
+        {
+            "level_learned": 44,
             "technique": "stampede"
+        },
+        {
+            "level_learned": 48,
+            "technique": "mudslide"
+        },
+        {
+            "level_learned": 52,
+            "technique": "biting_winds"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/k9.json
+++ b/mods/tuxemon/db/monster/k9.json
@@ -5,15 +5,27 @@
     "moveset": [
         {
             "level_learned": 2,
+            "technique": "beam"
+        },
+        {
+            "level_learned": 2,
+            "technique": "levitate"
+        },
+        {
+            "level_learned": 12,
+            "technique": "battery_discharge"
+        },
+        {
+            "level_learned": 16,
             "technique": "constrict"
         },
         {
-            "level_learned": 2,
+            "level_learned": 20,
             "technique": "glower"
         },
         {
-            "level_learned": 2,
-            "technique": "battery_discharge"
+            "level_learned": 24,
+            "technique": "shrapnel"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/katacoon.json
+++ b/mods/tuxemon/db/monster/katacoon.json
@@ -12,8 +12,20 @@
             "technique": "shrapnel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 4,
+            "technique": "splinter"
+        },
+        {
+            "level_learned": 6,
             "technique": "font"
+        },
+        {
+            "level_learned": 8,
+            "technique": "peregrine"
+        },
+        {
+            "level_learned": 10,
+            "technique": "sting"
         }
     ],
     "evolutions": [

--- a/mods/tuxemon/db/monster/katapill.json
+++ b/mods/tuxemon/db/monster/katapill.json
@@ -12,7 +12,7 @@
             "technique": "shrapnel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 6,
             "technique": "splinter"
         }
     ],

--- a/mods/tuxemon/db/monster/komodraw.json
+++ b/mods/tuxemon/db/monster/komodraw.json
@@ -12,7 +12,7 @@
             "technique": "rock"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "sudden_glow"
         }
     ],

--- a/mods/tuxemon/db/monster/l3gk0.json
+++ b/mods/tuxemon/db/monster/l3gk0.json
@@ -12,7 +12,7 @@
             "technique": "blossom"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "boulder"
         }
     ],

--- a/mods/tuxemon/db/monster/lambert.json
+++ b/mods/tuxemon/db/monster/lambert.json
@@ -12,7 +12,7 @@
             "technique": "blossom"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "boulder"
         }
     ],

--- a/mods/tuxemon/db/monster/lapinou.json
+++ b/mods/tuxemon/db/monster/lapinou.json
@@ -12,7 +12,7 @@
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "perfect_cut"
         }
     ],

--- a/mods/tuxemon/db/monster/legko.json
+++ b/mods/tuxemon/db/monster/legko.json
@@ -5,15 +5,27 @@
     "moveset": [
         {
             "level_learned": 2,
-            "technique": "overgrowth"
+            "technique": "sting"
         },
         {
             "level_learned": 2,
             "technique": "blossom"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "boulder"
+        },
+        {
+            "level_learned": 28,
+            "technique": "overgrowth"
+        },
+        {
+            "level_learned": 32,
+            "technique": "peregrine"
+        },
+        {
+            "level_learned": 34,
+            "technique": "spray"
         }
     ],
     "evolutions": [

--- a/mods/tuxemon/db/monster/lightmare.json
+++ b/mods/tuxemon/db/monster/lightmare.json
@@ -5,15 +5,39 @@
     "moveset": [
         {
             "level_learned": 2,
-            "technique": "static_field"
+            "technique": "flow"
         },
         {
             "level_learned": 2,
             "technique": "sudden_glow"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
+            "technique": "glower"
+        },
+        {
+            "level_learned": 24,
+            "technique": "goad"
+        },
+        {
+            "level_learned": 28,
             "technique": "starfall"
+        },
+        {
+            "level_learned": 32,
+            "technique": "flood"
+        },
+        {
+            "level_learned": 40,
+            "technique": "static_field"
+        },
+        {
+            "level_learned": 44,
+            "technique": "icicle_spear"
+        },
+        {
+            "level_learned": 48,
+            "technique": "probiscus"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/loliferno.json
+++ b/mods/tuxemon/db/monster/loliferno.json
@@ -5,15 +5,27 @@
     "moveset": [
         {
             "level_learned": 2,
-            "technique": "flamethrower"
+            "technique": "supernova"
         },
         {
             "level_learned": 2,
             "technique": "chill_mist"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
+            "technique": "midnight_mantle"
+        },
+        {
+            "level_learned": 24,
+            "technique": "flamethrower"
+        },
+        {
+            "level_learned": 28,
             "technique": "rock"
+        },
+        {
+            "level_learned": 32,
+            "technique": "fire_ball"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/lunight.json
+++ b/mods/tuxemon/db/monster/lunight.json
@@ -12,7 +12,7 @@
             "technique": "fire_ball"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "shrapnel"
         }
     ],

--- a/mods/tuxemon/db/monster/manosting.json
+++ b/mods/tuxemon/db/monster/manosting.json
@@ -12,7 +12,7 @@
             "technique": "whirlwind"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "flood"
         }
     ],

--- a/mods/tuxemon/db/monster/masknake.json
+++ b/mods/tuxemon/db/monster/masknake.json
@@ -12,7 +12,7 @@
             "technique": "beam"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "supernova"
         }
     ],

--- a/mods/tuxemon/db/monster/medushock.json
+++ b/mods/tuxemon/db/monster/medushock.json
@@ -12,7 +12,7 @@
             "technique": "flood"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "midnight_mantle"
         }
     ],

--- a/mods/tuxemon/db/monster/memnomnom.json
+++ b/mods/tuxemon/db/monster/memnomnom.json
@@ -12,7 +12,7 @@
             "technique": "feint"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "sand_spray"
         }
     ],

--- a/mods/tuxemon/db/monster/merlicun.json
+++ b/mods/tuxemon/db/monster/merlicun.json
@@ -12,7 +12,7 @@
             "technique": "kindling_flame"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "muddle"
         }
     ],

--- a/mods/tuxemon/db/monster/metesaur.json
+++ b/mods/tuxemon/db/monster/metesaur.json
@@ -12,14 +12,14 @@
             "technique": "kindling_flame"
         },
         {
-            "level_learned": 2,
+            "level_learned": 20,
             "technique": "breathe_fire"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 40,
+            "at_level": 42,
             "monster_slug": "qetzlrokilus"
         }
     ],

--- a/mods/tuxemon/db/monster/miaownolith.json
+++ b/mods/tuxemon/db/monster/miaownolith.json
@@ -9,11 +9,23 @@
         },
         {
             "level_learned": 2,
+            "technique": "feint"
+        },
+        {
+            "level_learned": 12,
+            "technique": "sand_spray"
+        },
+        {
+            "level_learned": 20,
             "technique": "petrify"
         },
         {
-            "level_learned": 2,
-            "technique": "sand_spray"
+            "level_learned": 24,
+            "technique": "fluff_up"
+        },
+        {
+            "level_learned": 28,
+            "technique": "overgrowth"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/mk01_alpha.json
+++ b/mods/tuxemon/db/monster/mk01_alpha.json
@@ -12,7 +12,7 @@
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "shrapnel"
         }
     ],

--- a/mods/tuxemon/db/monster/mk01_beta.json
+++ b/mods/tuxemon/db/monster/mk01_beta.json
@@ -12,7 +12,7 @@
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "shrapnel"
         }
     ],

--- a/mods/tuxemon/db/monster/moloch.json
+++ b/mods/tuxemon/db/monster/moloch.json
@@ -5,15 +5,39 @@
     "moveset": [
         {
             "level_learned": 2,
+            "technique": "sting"
+        },
+        {
+            "level_learned": 2,
+            "technique": "blossom"
+        },
+        {
+            "level_learned": 12,
+            "technique": "boulder"
+        },
+        {
+            "level_learned": 28,
             "technique": "overgrowth"
         },
         {
-            "level_learned": 2,
+            "level_learned": 32,
+            "technique": "peregrine"
+        },
+        {
+            "level_learned": 34,
+            "technique": "spray"
+        },
+        {
+            "level_learned": 44,
             "technique": "thunderball"
         },
         {
-            "level_learned": 2,
-            "technique": "boulder"
+            "level_learned": 48,
+            "technique": "shadow_boxing"
+        },
+        {
+            "level_learned": 52,
+            "technique": "invictus"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/mrmoswitch.json
+++ b/mods/tuxemon/db/monster/mrmoswitch.json
@@ -5,15 +5,27 @@
     "moveset": [
         {
             "level_learned": 2,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 2,
             "technique": "beam"
         },
         {
             "level_learned": 2,
+            "technique": "levitate"
+        },
+        {
+            "level_learned": 12,
             "technique": "battery_discharge"
+        },
+        {
+            "level_learned": 16,
+            "technique": "wall_of_steel"
+        },
+        {
+            "level_learned": 20,
+            "technique": "shrapnel"
+        },
+        {
+            "level_learned": 24,
+            "technique": "glower"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/mystikapi.json
+++ b/mods/tuxemon/db/monster/mystikapi.json
@@ -12,7 +12,7 @@
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "muddle"
         }
     ],

--- a/mods/tuxemon/db/monster/narcileaf.json
+++ b/mods/tuxemon/db/monster/narcileaf.json
@@ -12,8 +12,20 @@
             "technique": "take_cover"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
+            "technique": "sting"
+        },
+        {
+            "level_learned": 24,
             "technique": "sleeping_powder"
+        },
+        {
+            "level_learned": 28,
+            "technique": "fester"
+        },
+        {
+            "level_learned": 32,
+            "technique": "whirlwind"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/neutrito.json
+++ b/mods/tuxemon/db/monster/neutrito.json
@@ -12,8 +12,20 @@
             "technique": "shrapnel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "wall_of_steel"
+        },
+        {
+            "level_learned": 20,
+            "technique": "amnesia"
+        },
+        {
+            "level_learned": 24,
+            "technique": "peregrine"
+        },
+        {
+            "level_learned": 28,
+            "technique": "whirlwind"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/noctalo.json
+++ b/mods/tuxemon/db/monster/noctalo.json
@@ -9,11 +9,23 @@
         },
         {
             "level_learned": 2,
+            "technique": "rot"
+        },
+        {
+            "level_learned": 12,
+            "technique": "take_cover"
+        },
+        {
+            "level_learned": 24,
             "technique": "starfall"
         },
         {
-            "level_learned": 2,
-            "technique": "take_cover"
+            "level_learned": 28,
+            "technique": "font"
+        },
+        {
+            "level_learned": 32,
+            "technique": "chill_mist"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/noctula.json
+++ b/mods/tuxemon/db/monster/noctula.json
@@ -12,14 +12,14 @@
             "technique": "rot"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "take_cover"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 20,
+            "at_level": 18,
             "monster_slug": "noctalo"
         }
     ],

--- a/mods/tuxemon/db/monster/nostray.json
+++ b/mods/tuxemon/db/monster/nostray.json
@@ -12,14 +12,14 @@
             "technique": "chill_mist"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "snowstorm"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 20,
+            "at_level": 18,
             "monster_slug": "shnark"
         }
     ],

--- a/mods/tuxemon/db/monster/nudiflot_female.json
+++ b/mods/tuxemon/db/monster/nudiflot_female.json
@@ -12,7 +12,7 @@
             "technique": "feint"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "flood"
         }
     ],

--- a/mods/tuxemon/db/monster/nudiflot_male.json
+++ b/mods/tuxemon/db/monster/nudiflot_male.json
@@ -12,7 +12,7 @@
             "technique": "feint"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "flood"
         }
     ],

--- a/mods/tuxemon/db/monster/nudikill.json
+++ b/mods/tuxemon/db/monster/nudikill.json
@@ -5,15 +5,27 @@
     "moveset": [
         {
             "level_learned": 2,
-            "technique": "rot"
+            "technique": "suck_poison"
         },
         {
             "level_learned": 2,
             "technique": "feint"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
+            "technique": "flood"
+        },
+        {
+            "level_learned": 20,
+            "technique": "rot"
+        },
+        {
+            "level_learned": 24,
             "technique": "bubble_trap"
+        },
+        {
+            "level_learned": 28,
+            "technique": "biting_winds"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/nudimind.json
+++ b/mods/tuxemon/db/monster/nudimind.json
@@ -12,8 +12,20 @@
             "technique": "feint"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
+            "technique": "flood"
+        },
+        {
+            "level_learned": 20,
             "technique": "sleep_bomb"
+        },
+        {
+            "level_learned": 24,
+            "technique": "bubble_trap"
+        },
+        {
+            "level_learned": 28,
+            "technique": "biting_winds"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/nuenflu.json
+++ b/mods/tuxemon/db/monster/nuenflu.json
@@ -12,7 +12,7 @@
             "technique": "starfall"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "blood_bond"
         }
     ],

--- a/mods/tuxemon/db/monster/nut.json
+++ b/mods/tuxemon/db/monster/nut.json
@@ -12,7 +12,7 @@
             "technique": "static_field"
         },
         {
-            "level_learned": 2,
+            "level_learned": 6,
             "technique": "shuriken"
         }
     ],

--- a/mods/tuxemon/db/monster/octabode.json
+++ b/mods/tuxemon/db/monster/octabode.json
@@ -5,15 +5,27 @@
     "moveset": [
         {
             "level_learned": 2,
-            "technique": "feint"
+            "technique": "flood"
         },
         {
             "level_learned": 2,
             "technique": "flow"
         },
         {
-            "level_learned": 2,
+            "level_learned": 16,
             "technique": "font"
+        },
+        {
+            "level_learned": 20,
+            "technique": "goad"
+        },
+        {
+            "level_learned": 24,
+            "technique": "feint"
+        },
+        {
+            "level_learned": 28,
+            "technique": "venomous_tentacle"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/ouroboutlet.json
+++ b/mods/tuxemon/db/monster/ouroboutlet.json
@@ -5,15 +5,27 @@
     "moveset": [
         {
             "level_learned": 2,
-            "technique": "electrical_storm"
+            "technique": "strike"
         },
         {
             "level_learned": 2,
             "technique": "surge"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "constrict"
+        },
+        {
+            "level_learned": 20,
+            "technique": "amnesia"
+        },
+        {
+            "level_learned": 24,
+            "technique": "shuriken"
+        },
+        {
+            "level_learned": 28,
+            "technique": "electrical_storm"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/pairagrim.json
+++ b/mods/tuxemon/db/monster/pairagrim.json
@@ -12,12 +12,20 @@
             "technique": "whirlwind"
         },
         {
-            "level_learned": 2,
+            "level_learned": 16,
             "technique": "wing_tip"
         },
         {
-            "level_learned": 2,
+            "level_learned": 32,
+            "technique": "fluff_up"
+        },
+        {
+            "level_learned": 36,
             "technique": "peregrine"
+        },
+        {
+            "level_learned": 40,
+            "technique": "one_two"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/pairagrin.json
+++ b/mods/tuxemon/db/monster/pairagrin.json
@@ -12,14 +12,14 @@
             "technique": "whirlwind"
         },
         {
-            "level_learned": 2,
+            "level_learned": 16,
             "technique": "wing_tip"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 26,
+            "at_level": 30,
             "monster_slug": "pairagrim"
         }
     ],

--- a/mods/tuxemon/db/monster/pantherafira.json
+++ b/mods/tuxemon/db/monster/pantherafira.json
@@ -12,14 +12,14 @@
             "technique": "fire_claw"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "all_in"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 20,
+            "at_level": 18,
             "monster_slug": "criniotherme"
         }
     ],

--- a/mods/tuxemon/db/monster/pharfan.json
+++ b/mods/tuxemon/db/monster/pharfan.json
@@ -12,7 +12,7 @@
             "technique": "flow"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "stampede"
         }
     ],

--- a/mods/tuxemon/db/monster/picc.json
+++ b/mods/tuxemon/db/monster/picc.json
@@ -5,15 +5,27 @@
     "moveset": [
         {
             "level_learned": 2,
+            "technique": "beam"
+        },
+        {
+            "level_learned": 2,
+            "technique": "levitate"
+        },
+        {
+            "level_learned": 12,
+            "technique": "battery_discharge"
+        },
+        {
+            "level_learned": 16,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 20,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 2,
-            "technique": "battery_discharge"
+            "level_learned": 24,
+            "technique": "constrict"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/pigabyte.json
+++ b/mods/tuxemon/db/monster/pigabyte.json
@@ -12,7 +12,7 @@
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "shrapnel"
         }
     ],

--- a/mods/tuxemon/db/monster/pilthropus.json
+++ b/mods/tuxemon/db/monster/pilthropus.json
@@ -4,15 +4,15 @@
     "ai": "RandomAI",
     "moveset": [
         {
-            "level_learned": 1,
+            "level_learned": 2,
             "technique": "strike"
         },
         {
-            "level_learned": 1,
+            "level_learned": 2,
             "technique": "eyebite"
         },
         {
-            "level_learned": 1,
+            "level_learned": 12,
             "technique": "blade"
         }
     ],

--- a/mods/tuxemon/db/monster/pipis.json
+++ b/mods/tuxemon/db/monster/pipis.json
@@ -12,14 +12,14 @@
             "technique": "splinter"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "take_cover"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 20,
+            "at_level": 18,
             "monster_slug": "strella"
         }
     ],

--- a/mods/tuxemon/db/monster/poinchin.json
+++ b/mods/tuxemon/db/monster/poinchin.json
@@ -12,14 +12,14 @@
             "technique": "flow"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "font"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 20,
+            "at_level": 18,
             "monster_slug": "saurchin"
         }
     ],

--- a/mods/tuxemon/db/monster/polyrock.json
+++ b/mods/tuxemon/db/monster/polyrock.json
@@ -12,7 +12,7 @@
             "technique": "all_in"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "one_two"
         }
     ],

--- a/mods/tuxemon/db/monster/possessun.json
+++ b/mods/tuxemon/db/monster/possessun.json
@@ -9,11 +9,23 @@
         },
         {
             "level_learned": 2,
+            "technique": "refresh"
+        },
+        {
+            "level_learned": 16,
+            "technique": "muddle"
+        },
+        {
+            "level_learned": 32,
             "technique": "amnesia"
         },
         {
-            "level_learned": 2,
-            "technique": "muddle"
+            "level_learned": 36,
+            "technique": "bubble_trap"
+        },
+        {
+            "level_learned": 40,
+            "technique": "constrict"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/propellercat.json
+++ b/mods/tuxemon/db/monster/propellercat.json
@@ -12,7 +12,7 @@
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "fluff_up"
         }
     ],

--- a/mods/tuxemon/db/monster/prophetoise.json
+++ b/mods/tuxemon/db/monster/prophetoise.json
@@ -5,15 +5,27 @@
     "moveset": [
         {
             "level_learned": 2,
-            "technique": "flamethrower"
-        },
-        {
-            "level_learned": 2,
             "technique": "rock"
         },
         {
             "level_learned": 2,
+            "technique": "energy_field"
+        },
+        {
+            "level_learned": 12,
             "technique": "sleep_bomb"
+        },
+        {
+            "level_learned": 20,
+            "technique": "thunderclap"
+        },
+        {
+            "level_learned": 24,
+            "technique": "shadow_boxing"
+        },
+        {
+            "level_learned": 28,
+            "technique": "flamethrower"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/puparmor.json
+++ b/mods/tuxemon/db/monster/puparmor.json
@@ -9,11 +9,23 @@
         },
         {
             "level_learned": 2,
+            "technique": "shuriken"
+        },
+        {
+            "level_learned": 4,
+            "technique": "wallow"
+        },
+        {
+            "level_learned": 6,
             "technique": "hibernate"
         },
         {
-            "level_learned": 2,
-            "technique": "wallow"
+            "level_learned": 8,
+            "technique": "perfect_cut"
+        },
+        {
+            "level_learned": 10,
+            "technique": "blade"
         }
     ],
     "evolutions": [

--- a/mods/tuxemon/db/monster/pyraminx.json
+++ b/mods/tuxemon/db/monster/pyraminx.json
@@ -9,11 +9,23 @@
         },
         {
             "level_learned": 2,
+            "technique": "feint"
+        },
+        {
+            "level_learned": 12,
+            "technique": "sand_spray"
+        },
+        {
+            "level_learned": 20,
             "technique": "rot"
         },
         {
-            "level_learned": 2,
+            "level_learned": 24,
             "technique": "blade"
+        },
+        {
+            "level_learned": 28,
+            "technique": "bullet"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/pythock.json
+++ b/mods/tuxemon/db/monster/pythock.json
@@ -5,15 +5,27 @@
     "moveset": [
         {
             "level_learned": 2,
-            "technique": "battery_acid"
+            "technique": "strike"
         },
         {
             "level_learned": 2,
+            "technique": "surge"
+        },
+        {
+            "level_learned": 16,
             "technique": "frostbite"
         },
         {
-            "level_learned": 2,
+            "level_learned": 24,
+            "technique": "battery_acid"
+        },
+        {
+            "level_learned": 28,
             "technique": "sudden_glow"
+        },
+        {
+            "level_learned": 32,
+            "technique": "shrapnel"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/pythwire.json
+++ b/mods/tuxemon/db/monster/pythwire.json
@@ -12,7 +12,7 @@
             "technique": "surge"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "constrict"
         }
     ],

--- a/mods/tuxemon/db/monster/qetzlrokilus.json
+++ b/mods/tuxemon/db/monster/qetzlrokilus.json
@@ -9,11 +9,23 @@
         },
         {
             "level_learned": 2,
+            "technique": "kindling_flame"
+        },
+        {
+            "level_learned": 20,
+            "technique": "breathe_fire"
+        },
+        {
+            "level_learned": 44,
             "technique": "peregrine"
         },
         {
-            "level_learned": 2,
-            "technique": "breathe_fire"
+            "level_learned": 48,
+            "technique": "all_in"
+        },
+        {
+            "level_learned": 52,
+            "technique": "flamethrower"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/r0ck1tt3n.json
+++ b/mods/tuxemon/db/monster/r0ck1tt3n.json
@@ -12,7 +12,7 @@
             "technique": "boulder"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "thunderball"
         }
     ],

--- a/mods/tuxemon/db/monster/rabbitosaur.json
+++ b/mods/tuxemon/db/monster/rabbitosaur.json
@@ -5,15 +5,27 @@
     "moveset": [
         {
             "level_learned": 2,
-            "technique": "stampede"
+            "technique": "thunderball"
         },
         {
             "level_learned": 2,
             "technique": "shadow_boxing"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "one_two"
+        },
+        {
+            "level_learned": 24,
+            "technique": "stampede"
+        },
+        {
+            "level_learned": 28,
+            "technique": "electrical_storm"
+        },
+        {
+            "level_learned": 32,
+            "technique": "snowstorm"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/rhincus.json
+++ b/mods/tuxemon/db/monster/rhincus.json
@@ -12,7 +12,7 @@
             "technique": "wing_tip"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "peck"
         }
     ],

--- a/mods/tuxemon/db/monster/rockat.json
+++ b/mods/tuxemon/db/monster/rockat.json
@@ -9,11 +9,23 @@
         },
         {
             "level_learned": 2,
+            "technique": "boulder"
+        },
+        {
+            "level_learned": 12,
+            "technique": "thunderball"
+        },
+        {
+            "level_learned": 28,
             "technique": "glower"
         },
         {
-            "level_learned": 2,
-            "technique": "thunderball"
+            "level_learned": 32,
+            "technique": "ice_claw"
+        },
+        {
+            "level_learned": 34,
+            "technique": "surge"
         }
     ],
     "evolutions": [

--- a/mods/tuxemon/db/monster/rockitten.json
+++ b/mods/tuxemon/db/monster/rockitten.json
@@ -12,7 +12,7 @@
             "technique": "boulder"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "thunderball"
         }
     ],

--- a/mods/tuxemon/db/monster/rosarin.json
+++ b/mods/tuxemon/db/monster/rosarin.json
@@ -12,7 +12,7 @@
             "technique": "fester"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "splinter"
         }
     ],

--- a/mods/tuxemon/db/monster/ruption.json
+++ b/mods/tuxemon/db/monster/ruption.json
@@ -5,15 +5,27 @@
     "moveset": [
         {
             "level_learned": 2,
+            "technique": "fire_ball"
+        },
+        {
+            "level_learned": 2,
+            "technique": "refresh"
+        },
+        {
+            "level_learned": 16,
+            "technique": "kindling_flame"
+        },
+        {
+            "level_learned": 32,
             "technique": "berserk"
         },
         {
-            "level_learned": 2,
+            "level_learned": 36,
             "technique": "fume"
         },
         {
-            "level_learned": 2,
-            "technique": "kindling_flame"
+            "level_learned": 40,
+            "technique": "flamethrower"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/sadito.json
+++ b/mods/tuxemon/db/monster/sadito.json
@@ -12,8 +12,20 @@
             "technique": "shrapnel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "wall_of_steel"
+        },
+        {
+            "level_learned": 20,
+            "technique": "shuriken"
+        },
+        {
+            "level_learned": 24,
+            "technique": "frostbite"
+        },
+        {
+            "level_learned": 28,
+            "technique": "flood"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/sampsack.json
+++ b/mods/tuxemon/db/monster/sampsack.json
@@ -12,7 +12,7 @@
             "technique": "all_in"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "strike"
         }
     ],

--- a/mods/tuxemon/db/monster/sampsage.json
+++ b/mods/tuxemon/db/monster/sampsage.json
@@ -12,7 +12,7 @@
             "technique": "bubble_trap"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "strike"
         }
     ],

--- a/mods/tuxemon/db/monster/sapragon.json
+++ b/mods/tuxemon/db/monster/sapragon.json
@@ -12,14 +12,26 @@
             "technique": "web"
         },
         {
-            "level_learned": 2,
+            "level_learned": 16,
+            "technique": "hibernate"
+        },
+        {
+            "level_learned": 32,
             "technique": "sting"
+        },
+        {
+            "level_learned": 36,
+            "technique": "one_two"
+        },
+        {
+            "level_learned": 40,
+            "technique": "fluff_up"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 55,
+            "at_level": 54,
             "monster_slug": "dragarbor"
         }
     ],

--- a/mods/tuxemon/db/monster/sapsnap.json
+++ b/mods/tuxemon/db/monster/sapsnap.json
@@ -9,11 +9,23 @@
         },
         {
             "level_learned": 2,
+            "technique": "headbutt"
+        },
+        {
+            "level_learned": 12,
+            "technique": "fluff_up"
+        },
+        {
+            "level_learned": 32,
             "technique": "one_two"
         },
         {
-            "level_learned": 2,
-            "technique": "fluff_up"
+            "level_learned": 36,
+            "technique": "all_in"
+        },
+        {
+            "level_learned": 40,
+            "technique": "sting"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/saurchin.json
+++ b/mods/tuxemon/db/monster/saurchin.json
@@ -12,8 +12,20 @@
             "technique": "flow"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "font"
+        },
+        {
+            "level_learned": 20,
+            "technique": "midnight_mantle"
+        },
+        {
+            "level_learned": 24,
+            "technique": "venomous_tentacle"
+        },
+        {
+            "level_learned": 28,
+            "technique": "chill_mist"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/sclairus.json
+++ b/mods/tuxemon/db/monster/sclairus.json
@@ -12,7 +12,7 @@
             "technique": "peck"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "blossom"
         }
     ],

--- a/mods/tuxemon/db/monster/seirein.json
+++ b/mods/tuxemon/db/monster/seirein.json
@@ -12,14 +12,14 @@
             "technique": "chill_mist"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "midnight_mantle"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 20,
+            "at_level": 18,
             "monster_slug": "loliferno"
         }
     ],

--- a/mods/tuxemon/db/monster/selket.json
+++ b/mods/tuxemon/db/monster/selket.json
@@ -12,14 +12,14 @@
             "technique": "rock"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "take_cover"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 20,
+            "at_level": 18,
             "monster_slug": "selmatek"
         }
     ],

--- a/mods/tuxemon/db/monster/selmatek.json
+++ b/mods/tuxemon/db/monster/selmatek.json
@@ -9,11 +9,23 @@
         },
         {
             "level_learned": 2,
-            "technique": "avalanche"
+            "technique": "rock"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "take_cover"
+        },
+        {
+            "level_learned": 24,
+            "technique": "quicksand"
+        },
+        {
+            "level_learned": 28,
+            "technique": "fester"
+        },
+        {
+            "level_learned": 32,
+            "technique": "avalanche"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/shammer.json
+++ b/mods/tuxemon/db/monster/shammer.json
@@ -12,7 +12,7 @@
             "technique": "mudslide"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "quicksand"
         }
     ],

--- a/mods/tuxemon/db/monster/sharpfin.json
+++ b/mods/tuxemon/db/monster/sharpfin.json
@@ -9,11 +9,23 @@
         },
         {
             "level_learned": 2,
+            "technique": "flood"
+        },
+        {
+            "level_learned": 12,
+            "technique": "flow"
+        },
+        {
+            "level_learned": 16,
             "technique": "splinter"
         },
         {
-            "level_learned": 2,
+            "level_learned": 20,
             "technique": "web"
+        },
+        {
+            "level_learned": 32,
+            "technique": "chill_mist"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/shelagu.json
+++ b/mods/tuxemon/db/monster/shelagu.json
@@ -12,7 +12,7 @@
             "technique": "midnight_mantle"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "flow"
         }
     ],

--- a/mods/tuxemon/db/monster/shnark.json
+++ b/mods/tuxemon/db/monster/shnark.json
@@ -5,15 +5,27 @@
     "moveset": [
         {
             "level_learned": 2,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 2,
             "technique": "probiscus"
         },
         {
             "level_learned": 2,
+            "technique": "chill_mist"
+        },
+        {
+            "level_learned": 12,
+            "technique": "snowstorm"
+        },
+        {
+            "level_learned": 24,
+            "technique": "flow"
+        },
+        {
+            "level_learned": 28,
             "technique": "goad"
+        },
+        {
+            "level_learned": 32,
+            "technique": "flood"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/shybulb.json
+++ b/mods/tuxemon/db/monster/shybulb.json
@@ -12,14 +12,14 @@
             "technique": "take_cover"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "sting"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 20,
+            "at_level": 18,
             "monster_slug": "narcileaf"
         }
     ],

--- a/mods/tuxemon/db/monster/skwib.json
+++ b/mods/tuxemon/db/monster/skwib.json
@@ -12,7 +12,7 @@
             "technique": "flow"
         },
         {
-            "level_learned": 2,
+            "level_learned": 16,
             "technique": "font"
         }
     ],

--- a/mods/tuxemon/db/monster/sludgehog.json
+++ b/mods/tuxemon/db/monster/sludgehog.json
@@ -12,7 +12,7 @@
             "technique": "venomous_tentacle"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "energy_claws"
         }
     ],

--- a/mods/tuxemon/db/monster/snaki.json
+++ b/mods/tuxemon/db/monster/snaki.json
@@ -12,14 +12,14 @@
             "technique": "biting_winds"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "midnight_mantle"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 20,
+            "at_level": 18,
             "monster_slug": "snokari"
         }
     ],

--- a/mods/tuxemon/db/monster/snarlon.json
+++ b/mods/tuxemon/db/monster/snarlon.json
@@ -12,7 +12,7 @@
             "technique": "energy_field"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "sand_spray"
         }
     ],

--- a/mods/tuxemon/db/monster/snock.json
+++ b/mods/tuxemon/db/monster/snock.json
@@ -12,14 +12,14 @@
             "technique": "surge"
         },
         {
-            "level_learned": 2,
+            "level_learned": 16,
             "technique": "frostbite"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 23,
+            "at_level": 24,
             "monster_slug": "pythock"
         }
     ],

--- a/mods/tuxemon/db/monster/snokari.json
+++ b/mods/tuxemon/db/monster/snokari.json
@@ -5,15 +5,27 @@
     "moveset": [
         {
             "level_learned": 2,
+            "technique": "venomous_tentacle"
+        },
+        {
+            "level_learned": 2,
+            "technique": "biting_winds"
+        },
+        {
+            "level_learned": 12,
             "technique": "midnight_mantle"
         },
         {
-            "level_learned": 2,
+            "level_learned": 24,
             "technique": "tonguespear"
         },
         {
-            "level_learned": 2,
+            "level_learned": 28,
             "technique": "icicle_spear"
+        },
+        {
+            "level_learned": 32,
+            "technique": "chill_mist"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/snowrilla.json
+++ b/mods/tuxemon/db/monster/snowrilla.json
@@ -5,15 +5,27 @@
     "moveset": [
         {
             "level_learned": 2,
+            "technique": "ice_claw"
+        },
+        {
+            "level_learned": 2,
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
+            "technique": "snowstorm"
+        },
+        {
+            "level_learned": 24,
             "technique": "flood"
         },
         {
-            "level_learned": 2,
+            "level_learned": 28,
             "technique": "chill_mist"
+        },
+        {
+            "level_learned": 32,
+            "technique": "frostbite"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/sockeserp.json
+++ b/mods/tuxemon/db/monster/sockeserp.json
@@ -5,15 +5,27 @@
     "moveset": [
         {
             "level_learned": 2,
-            "technique": "perfect_cut"
+            "technique": "strike"
         },
         {
             "level_learned": 2,
             "technique": "surge"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "constrict"
+        },
+        {
+            "level_learned": 20,
+            "technique": "perfect_cut"
+        },
+        {
+            "level_learned": 24,
+            "technique": "rust_bomb"
+        },
+        {
+            "level_learned": 28,
+            "technique": "blade"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/solight.json
+++ b/mods/tuxemon/db/monster/solight.json
@@ -12,7 +12,7 @@
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "shrapnel"
         }
     ],

--- a/mods/tuxemon/db/monster/spighter.json
+++ b/mods/tuxemon/db/monster/spighter.json
@@ -12,7 +12,7 @@
             "technique": "sting"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "splinter"
         }
     ],

--- a/mods/tuxemon/db/monster/spoilurm.json
+++ b/mods/tuxemon/db/monster/spoilurm.json
@@ -12,7 +12,7 @@
             "technique": "sting"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "web"
         }
     ],

--- a/mods/tuxemon/db/monster/spycozeus.json
+++ b/mods/tuxemon/db/monster/spycozeus.json
@@ -12,7 +12,7 @@
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "wall_of_steel"
         }
     ],

--- a/mods/tuxemon/db/monster/squabbit.json
+++ b/mods/tuxemon/db/monster/squabbit.json
@@ -12,14 +12,14 @@
             "technique": "shadow_boxing"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "one_two"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 20,
+            "at_level": 18,
             "monster_slug": "rabbitosaur"
         }
     ],

--- a/mods/tuxemon/db/monster/statursus.json
+++ b/mods/tuxemon/db/monster/statursus.json
@@ -5,15 +5,27 @@
     "moveset": [
         {
             "level_learned": 2,
+            "technique": "rock"
+        },
+        {
+            "level_learned": 2,
+            "technique": "fire_ball"
+        },
+        {
+            "level_learned": 12,
             "technique": "flamethrower"
         },
         {
-            "level_learned": 2,
+            "level_learned": 24,
             "technique": "give_all"
         },
         {
-            "level_learned": 2,
+            "level_learned": 28,
             "technique": "supernova"
+        },
+        {
+            "level_learned": 32,
+            "technique": "electrical_storm"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/strella.json
+++ b/mods/tuxemon/db/monster/strella.json
@@ -12,8 +12,20 @@
             "technique": "splinter"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
+            "technique": "take_cover"
+        },
+        {
+            "level_learned": 24,
             "technique": "all_in"
+        },
+        {
+            "level_learned": 28,
+            "technique": "blossom"
+        },
+        {
+            "level_learned": 32,
+            "technique": "peck"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/sumchon.json
+++ b/mods/tuxemon/db/monster/sumchon.json
@@ -5,14 +5,38 @@
     "moveset": [
         {
             "level_learned": 2,
+            "technique": "clamp_on"
+        },
+        {
+            "level_learned": 2,
+            "technique": "shrapnel"
+        },
+        {
+            "level_learned": 4,
+            "technique": "splinter"
+        },
+        {
+            "level_learned": 6,
+            "technique": "font"
+        },
+        {
+            "level_learned": 8,
+            "technique": "peregrine"
+        },
+        {
+            "level_learned": 10,
+            "technique": "sting"
+        },
+        {
+            "level_learned": 20,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 24,
             "technique": "invictus"
         },
         {
-            "level_learned": 2,
+            "level_learned": 28,
             "technique": "blade"
         }
     ],

--- a/mods/tuxemon/db/monster/tarpeur.json
+++ b/mods/tuxemon/db/monster/tarpeur.json
@@ -12,14 +12,14 @@
             "technique": "sting"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "fluff_up"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 20,
+            "at_level": 18,
             "monster_slug": "vigueur"
         }
     ],

--- a/mods/tuxemon/db/monster/taupypus.json
+++ b/mods/tuxemon/db/monster/taupypus.json
@@ -12,7 +12,7 @@
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "flood"
         }
     ],

--- a/mods/tuxemon/db/monster/teddisun.json
+++ b/mods/tuxemon/db/monster/teddisun.json
@@ -12,7 +12,7 @@
             "technique": "headbutt"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "supernova"
         }
     ],

--- a/mods/tuxemon/db/monster/tetrchimp.json
+++ b/mods/tuxemon/db/monster/tetrchimp.json
@@ -12,14 +12,14 @@
             "technique": "shrapnel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "bubble_trap"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 20,
+            "at_level": 18,
             "monster_slug": "apeoro"
         }
     ],

--- a/mods/tuxemon/db/monster/tigrock.json
+++ b/mods/tuxemon/db/monster/tigrock.json
@@ -9,11 +9,23 @@
         },
         {
             "level_learned": 2,
+            "technique": "blade"
+        },
+        {
+            "level_learned": 16,
+            "technique": "fume"
+        },
+        {
+            "level_learned": 32,
             "technique": "strike"
         },
         {
-            "level_learned": 2,
+            "level_learned": 36,
             "technique": "energy_field"
+        },
+        {
+            "level_learned": 40,
+            "technique": "shuriken"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/tikoal.json
+++ b/mods/tuxemon/db/monster/tikoal.json
@@ -12,7 +12,7 @@
             "technique": "blossom"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "petrify"
         }
     ],

--- a/mods/tuxemon/db/monster/tikorch.json
+++ b/mods/tuxemon/db/monster/tikorch.json
@@ -12,8 +12,20 @@
             "technique": "blossom"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
+            "technique": "petrify"
+        },
+        {
+            "level_learned": 32,
             "technique": "rock"
+        },
+        {
+            "level_learned": 36,
+            "technique": "berserk"
+        },
+        {
+            "level_learned": 40,
+            "technique": "flamethrower"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/tobishimi.json
+++ b/mods/tuxemon/db/monster/tobishimi.json
@@ -5,15 +5,39 @@
     "moveset": [
         {
             "level_learned": 2,
+            "technique": "suck_poison"
+        },
+        {
+            "level_learned": 2,
+            "technique": "flow"
+        },
+        {
+            "level_learned": 12,
             "technique": "flood"
         },
         {
-            "level_learned": 2,
+            "level_learned": 24,
+            "technique": "icicle_spear"
+        },
+        {
+            "level_learned": 28,
+            "technique": "font"
+        },
+        {
+            "level_learned": 32,
+            "technique": "starfall"
+        },
+        {
+            "level_learned": 40,
             "technique": "ice_claw"
         },
         {
-            "level_learned": 2,
+            "level_learned": 44,
             "technique": "chill_mist"
+        },
+        {
+            "level_learned": 48,
+            "technique": "frostbite"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/toufigel.json
+++ b/mods/tuxemon/db/monster/toufigel.json
@@ -12,7 +12,7 @@
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "snowstorm"
         }
     ],

--- a/mods/tuxemon/db/monster/tourbidi.json
+++ b/mods/tuxemon/db/monster/tourbidi.json
@@ -12,7 +12,7 @@
             "technique": "midnight_mantle"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "sleeping_powder"
         }
     ],

--- a/mods/tuxemon/db/monster/trapsnap.json
+++ b/mods/tuxemon/db/monster/trapsnap.json
@@ -12,7 +12,7 @@
             "technique": "headbutt"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "fluff_up"
         }
     ],

--- a/mods/tuxemon/db/monster/tsushimi.json
+++ b/mods/tuxemon/db/monster/tsushimi.json
@@ -5,14 +5,26 @@
     "moveset": [
         {
             "level_learned": 2,
+            "technique": "suck_poison"
+        },
+        {
+            "level_learned": 2,
+            "technique": "flow"
+        },
+        {
+            "level_learned": 12,
+            "technique": "flood"
+        },
+        {
+            "level_learned": 24,
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 2,
+            "level_learned": 28,
             "technique": "font"
         },
         {
-            "level_learned": 2,
+            "level_learned": 32,
             "technique": "starfall"
         }
     ],

--- a/mods/tuxemon/db/monster/tumblebee.json
+++ b/mods/tuxemon/db/monster/tumblebee.json
@@ -12,8 +12,20 @@
             "technique": "web"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
+            "technique": "constrict"
+        },
+        {
+            "level_learned": 24,
+            "technique": "amnesia"
+        },
+        {
+            "level_learned": 28,
             "technique": "overgrowth"
+        },
+        {
+            "level_learned": 32,
+            "technique": "whirlwind"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/tumblequill.json
+++ b/mods/tuxemon/db/monster/tumblequill.json
@@ -12,7 +12,7 @@
             "technique": "ice_claw"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "icicle_spear"
         }
     ],

--- a/mods/tuxemon/db/monster/tumbleworm.json
+++ b/mods/tuxemon/db/monster/tumbleworm.json
@@ -12,14 +12,14 @@
             "technique": "web"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "constrict"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 20,
+            "at_level": 18,
             "monster_slug": "tumblebee"
         }
     ],

--- a/mods/tuxemon/db/monster/turnipper.json
+++ b/mods/tuxemon/db/monster/turnipper.json
@@ -12,14 +12,14 @@
             "technique": "fester"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "one_two"
         }
     ],
     "evolutions": [
         {
             "path": "standard",
-            "at_level": 20,
+            "at_level": 18,
             "monster_slug": "beenstalker"
         }
     ],

--- a/mods/tuxemon/db/monster/tweesher.json
+++ b/mods/tuxemon/db/monster/tweesher.json
@@ -12,7 +12,7 @@
             "technique": "flow"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "energy_field"
         }
     ],

--- a/mods/tuxemon/db/monster/urcine.json
+++ b/mods/tuxemon/db/monster/urcine.json
@@ -12,7 +12,7 @@
             "technique": "boulder"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "shadow_boxing"
         }
     ],

--- a/mods/tuxemon/db/monster/vamporm.json
+++ b/mods/tuxemon/db/monster/vamporm.json
@@ -12,7 +12,7 @@
             "technique": "spray"
         },
         {
-            "level_learned": 2,
+            "level_learned": 6,
             "technique": "refresh"
         }
     ],

--- a/mods/tuxemon/db/monster/velocitile.json
+++ b/mods/tuxemon/db/monster/velocitile.json
@@ -5,15 +5,39 @@
     "moveset": [
         {
             "level_learned": 2,
+            "technique": "sting"
+        },
+        {
+            "level_learned": 2,
+            "technique": "feint"
+        },
+        {
+            "level_learned": 12,
+            "technique": "whirlwind"
+        },
+        {
+            "level_learned": 24,
             "technique": "splinter"
         },
         {
-            "level_learned": 2,
+            "level_learned": 28,
             "technique": "peregrine"
         },
         {
-            "level_learned": 2,
-            "technique": "whirlwind"
+            "level_learned": 32,
+            "technique": "pseudopod"
+        },
+        {
+            "level_learned": 40,
+            "technique": "wing_tip"
+        },
+        {
+            "level_learned": 44,
+            "technique": "all_in"
+        },
+        {
+            "level_learned": 48,
+            "technique": "invictus"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/vigueur.json
+++ b/mods/tuxemon/db/monster/vigueur.json
@@ -9,11 +9,23 @@
         },
         {
             "level_learned": 2,
+            "technique": "sting"
+        },
+        {
+            "level_learned": 12,
+            "technique": "fluff_up"
+        },
+        {
+            "level_learned": 24,
             "technique": "headbutt"
         },
         {
-            "level_learned": 2,
+            "level_learned": 28,
             "technique": "shadow_boxing"
+        },
+        {
+            "level_learned": 32,
+            "technique": "peregrine"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/vivicinder.json
+++ b/mods/tuxemon/db/monster/vivicinder.json
@@ -5,14 +5,26 @@
     "moveset": [
         {
             "level_learned": 2,
+            "technique": "stone_rot"
+        },
+        {
+            "level_learned": 2,
+            "technique": "headbutt"
+        },
+        {
+            "level_learned": 12,
+            "technique": "wallow"
+        },
+        {
+            "level_learned": 16,
             "technique": "salamander"
         },
         {
-            "level_learned": 2,
+            "level_learned": 20,
             "technique": "flamethrower"
         },
         {
-            "level_learned": 2,
+            "level_learned": 24,
             "technique": "refresh"
         }
     ],

--- a/mods/tuxemon/db/monster/vividactil.json
+++ b/mods/tuxemon/db/monster/vividactil.json
@@ -5,15 +5,27 @@
     "moveset": [
         {
             "level_learned": 2,
+            "technique": "stone_rot"
+        },
+        {
+            "level_learned": 2,
             "technique": "headbutt"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
+            "technique": "wallow"
+        },
+        {
+            "level_learned": 16,
             "technique": "wing_tip"
         },
         {
-            "level_learned": 2,
+            "level_learned": 20,
             "technique": "peck"
+        },
+        {
+            "level_learned": 24,
+            "technique": "frostbite"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/vivipere.json
+++ b/mods/tuxemon/db/monster/vivipere.json
@@ -12,7 +12,7 @@
             "technique": "headbutt"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "wallow"
         }
     ],
@@ -43,7 +43,7 @@
         },
         {
             "path": "standard",
-            "at_level": 25,
+            "at_level": 30,
             "monster_slug": "vivitron"
         },
         {

--- a/mods/tuxemon/db/monster/viviphyta.json
+++ b/mods/tuxemon/db/monster/viviphyta.json
@@ -5,14 +5,26 @@
     "moveset": [
         {
             "level_learned": 2,
+            "technique": "stone_rot"
+        },
+        {
+            "level_learned": 2,
+            "technique": "headbutt"
+        },
+        {
+            "level_learned": 12,
+            "technique": "wallow"
+        },
+        {
+            "level_learned": 16,
             "technique": "fester"
         },
         {
-            "level_learned": 2,
+            "level_learned": 20,
             "technique": "sting"
         },
         {
-            "level_learned": 2,
+            "level_learned": 24,
             "technique": "web"
         }
     ],

--- a/mods/tuxemon/db/monster/vivisource.json
+++ b/mods/tuxemon/db/monster/vivisource.json
@@ -5,15 +5,27 @@
     "moveset": [
         {
             "level_learned": 2,
+            "technique": "stone_rot"
+        },
+        {
+            "level_learned": 2,
+            "technique": "headbutt"
+        },
+        {
+            "level_learned": 12,
+            "technique": "wallow"
+        },
+        {
+            "level_learned": 16,
             "technique": "flood"
         },
         {
-            "level_learned": 2,
+            "level_learned": 20,
             "technique": "chill_mist"
         },
         {
-            "level_learned": 2,
-            "technique": "wallow"
+            "level_learned": 24,
+            "technique": "goad"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/viviteel.json
+++ b/mods/tuxemon/db/monster/viviteel.json
@@ -5,14 +5,26 @@
     "moveset": [
         {
             "level_learned": 2,
+            "technique": "stone_rot"
+        },
+        {
+            "level_learned": 2,
+            "technique": "headbutt"
+        },
+        {
+            "level_learned": 12,
+            "technique": "wallow"
+        },
+        {
+            "level_learned": 16,
             "technique": "rust_bomb"
         },
         {
-            "level_learned": 2,
+            "level_learned": 20,
             "technique": "constrict"
         },
         {
-            "level_learned": 2,
+            "level_learned": 24,
             "technique": "perfect_cut"
         }
     ],

--- a/mods/tuxemon/db/monster/vivitrans.json
+++ b/mods/tuxemon/db/monster/vivitrans.json
@@ -5,14 +5,26 @@
     "moveset": [
         {
             "level_learned": 2,
+            "technique": "stone_rot"
+        },
+        {
+            "level_learned": 2,
+            "technique": "headbutt"
+        },
+        {
+            "level_learned": 12,
+            "technique": "wallow"
+        },
+        {
+            "level_learned": 16,
             "technique": "chill_mist"
         },
         {
-            "level_learned": 2,
+            "level_learned": 20,
             "technique": "bubble_trap"
         },
         {
-            "level_learned": 2,
+            "level_learned": 24,
             "technique": "frostbite"
         }
     ],

--- a/mods/tuxemon/db/monster/vivitron.json
+++ b/mods/tuxemon/db/monster/vivitron.json
@@ -5,14 +5,26 @@
     "moveset": [
         {
             "level_learned": 2,
+            "technique": "stone_rot"
+        },
+        {
+            "level_learned": 2,
+            "technique": "headbutt"
+        },
+        {
+            "level_learned": 12,
+            "technique": "wallow"
+        },
+        {
+            "level_learned": 16,
             "technique": "electrical_storm"
         },
         {
-            "level_learned": 2,
+            "level_learned": 20,
             "technique": "sudden_glow"
         },
         {
-            "level_learned": 2,
+            "level_learned": 24,
             "technique": "battery_acid"
         }
     ],

--- a/mods/tuxemon/db/monster/volcoli.json
+++ b/mods/tuxemon/db/monster/volcoli.json
@@ -12,7 +12,7 @@
             "technique": "flamethrower"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "sudden_glow"
         }
     ],

--- a/mods/tuxemon/db/monster/weavifly.json
+++ b/mods/tuxemon/db/monster/weavifly.json
@@ -12,8 +12,32 @@
             "technique": "shuriken"
         },
         {
-            "level_learned": 2,
+            "level_learned": 4,
+            "technique": "wallow"
+        },
+        {
+            "level_learned": 6,
+            "technique": "hibernate"
+        },
+        {
+            "level_learned": 8,
+            "technique": "perfect_cut"
+        },
+        {
+            "level_learned": 10,
+            "technique": "blade"
+        },
+        {
+            "level_learned": 20,
+            "technique": "muddle"
+        },
+        {
+            "level_learned": 24,
             "technique": "eyebite"
+        },
+        {
+            "level_learned": 28,
+            "technique": "constrict"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/windeye.json
+++ b/mods/tuxemon/db/monster/windeye.json
@@ -12,8 +12,20 @@
             "technique": "shrapnel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "wall_of_steel"
+        },
+        {
+            "level_learned": 20,
+            "technique": "bubble_trap"
+        },
+        {
+            "level_learned": 24,
+            "technique": "rust_bomb"
+        },
+        {
+            "level_learned": 28,
+            "technique": "constrict"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/wrougon.json
+++ b/mods/tuxemon/db/monster/wrougon.json
@@ -12,7 +12,7 @@
             "technique": "shrapnel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 16,
             "technique": "strike"
         }
     ],

--- a/mods/tuxemon/db/monster/xeon.json
+++ b/mods/tuxemon/db/monster/xeon.json
@@ -12,7 +12,7 @@
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "shrapnel"
         }
     ],

--- a/mods/tuxemon/db/monster/xeon_2.json
+++ b/mods/tuxemon/db/monster/xeon_2.json
@@ -12,7 +12,7 @@
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "shrapnel"
         }
     ],

--- a/mods/tuxemon/db/monster/yiinaang.json
+++ b/mods/tuxemon/db/monster/yiinaang.json
@@ -12,7 +12,7 @@
             "technique": "midnight_mantle"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "electrical_storm"
         }
     ],

--- a/mods/tuxemon/db/monster/zunna.json
+++ b/mods/tuxemon/db/monster/zunna.json
@@ -12,7 +12,7 @@
             "technique": "goad"
         },
         {
-            "level_learned": 2,
+            "level_learned": 12,
             "technique": "strike"
         }
     ],


### PR DESCRIPTION
PR addresses monsters and moves.
This change involves only the structure.

@Sanglorian 
Since the addition of the last monsters and the fix of weight and height, I was working on this PR.
I share this after the max_moves (as you said in another PR, max 4), a mechanism of overwriting moves that it's really intriguing.

Example: **Rockitten** > **Rockat** > **Jemuar**

Situation at the moment, 
**Rockitten** moves: ram, boulder and thunderball
**Rockat** moves: ~~ram~~, glover and ~~thunderball~~
**Jemuar** moves: ~~ram~~, ~~glover~~ and stampede
**Evolutions**: **Rockitten** > lv 24 > **Rockat** > lv 36 > **Jemuar**
`Total potential moves without duplicates: 5`

After the PR:
**Rockitten** moves: ram, boulder and thunderball
**Rockat** moves: gover, ice_claw, surge
**Jemuar** moves: stampede, mudslide, biting_winds
**Evolutions**: **Rockitten** > lv 24 > **Rockat** > lv 42 > **Jemuar** (changed because the monster learns 3 moves every 4 level, then evolves, it's explained inside the file attached)
`Total potential moves without duplicates: 9`

Confrontation **Jemuar** JSON:
before:
```
2 lv - ram
2 lv - glower
2 lv - stampede
```
after:
```
2 lv - ram
2 lv - boulder
12 lv - thunderball
28 lv - glower
32 lv - ice_claw
36 lv - surge
44 lv - stampede
48 lv - mudslide
52 lv - biting_winds
```
The mechanism:
- basic and standalone (no evo) monsters (eg. rockitten is basic) have 3 moves;
- 1 stage (rockat) have 6 moves;
- 2 stage (jemuar) have 9 moves;

I added also a new validator called multiple to check both **level_learned** for techniques and **at_level** for evolutions. Technique learning is multiple of 2, while evolution level is multiple of 3, the will is having two ways, so we can reduce drastically the probability that someone needs to overwrite the technique immediately after an evolution.

Using the script for the missing move (the other PR) I generated the missing techniques based on type, everything related the moves is here: [moves.ods](https://github.com/Tuxemon/Tuxemon/files/10298760/moves.ods)
Everything related to the change of "at_level" involving evolutions is here: [at_level evolution.ods](https://github.com/Tuxemon/Tuxemon/files/10298761/at_level.evolution.ods)
Both files contain all the changes and additions I made.

Do you want also standalone monster with more techniques? We can generate easily, it doesn't take much time.
Do you think we need to use the 9 moves list (jemuar) also for rockitten and rockat? At the end someone can also refuse the evolution and keeping developing rockitten until the max level.

Let me know.

I think in the second case, considering overwriting and the maximum number of moves (4), it can be more challenging.
I already tested some mechanism and these are really interesting.