### PR TITLE
82 new techs

### DIFF
--- a/mods/tuxemon/db/technique/acid.json
+++ b/mods/tuxemon/db/technique/acid.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 119,
+  "accuracy": 0.4,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.9,
+  "power": 1.4,
+  "range": "reliable",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "acid",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "metal"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/adamantine.json
+++ b/mods/tuxemon/db/technique/adamantine.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 120,
+  "accuracy": 1,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.6,
+  "power": 1.4,
+  "range": "touch",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "adamantine",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "fire"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/air_chain.json
+++ b/mods/tuxemon/db/technique/air_chain.json
@@ -1,0 +1,36 @@
+{
+  "tech_id": 121,
+  "accuracy": 0.5,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.8,
+  "power": 2.2,
+  "range": "reach",
+  "recharge": 1,
+  "sfx": "sfx_blaster",
+  "slug": "air_chain",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "earth",
+    "wood"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/ants.json
+++ b/mods/tuxemon/db/technique/ants.json
@@ -1,0 +1,36 @@
+{
+  "tech_id": 131,
+  "accuracy": 0.6,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.3,
+  "power": 1.7,
+  "range": "melee",
+  "recharge": 1,
+  "sfx": "sfx_blaster",
+  "slug": "ants",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "wood",
+    "earth"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/arcane_eye.json
+++ b/mods/tuxemon/db/technique/arcane_eye.json
@@ -1,0 +1,36 @@
+{
+  "tech_id": 158,
+  "accuracy": 0.8,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.1,
+  "power": 2.9,
+  "range": "reliable",
+  "recharge": 1,
+  "sfx": "sfx_blaster",
+  "slug": "arcane_eye",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "metal",
+    "fire"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/assault.json
+++ b/mods/tuxemon/db/technique/assault.json
@@ -1,0 +1,36 @@
+{
+  "tech_id": 176,
+  "accuracy": 0.9,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.5,
+  "power": 1.7,
+  "range": "touch",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "assault",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "wood",
+    "earth"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/barking.json
+++ b/mods/tuxemon/db/technique/barking.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 194,
+  "accuracy": 0.1,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.6,
+  "power": 2.7,
+  "range": "ranged",
+  "recharge": 1,
+  "sfx": "sfx_blaster",
+  "slug": "barking",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "wood"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/blood_nets.json
+++ b/mods/tuxemon/db/technique/blood_nets.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 164,
+  "accuracy": 0.5,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.3,
+  "power": 1.7,
+  "range": "touch",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "blood_nets",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "earth"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/breath.json
+++ b/mods/tuxemon/db/technique/breath.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 122,
+  "accuracy": 0.8,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.2,
+  "power": 1.9,
+  "range": "reach",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "breath",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "earth"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/canine.json
+++ b/mods/tuxemon/db/technique/canine.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 123,
+  "accuracy": 0.3,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 1,
+  "power": 1,
+  "range": "reliable",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "canine",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "earth"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/cat_calling.json
+++ b/mods/tuxemon/db/technique/cat_calling.json
@@ -1,0 +1,36 @@
+{
+  "tech_id": 124,
+  "accuracy": 0.4,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.4,
+  "power": 1.9,
+  "range": "melee",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "cat_calling",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "wood",
+    "earth"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/cavity.json
+++ b/mods/tuxemon/db/technique/cavity.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 200,
+  "accuracy": 0.4,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.1,
+  "power": 2.9,
+  "range": "reliable",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "cavity",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "earth"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/chameleon.json
+++ b/mods/tuxemon/db/technique/chameleon.json
@@ -1,0 +1,36 @@
+{
+  "tech_id": 179,
+  "accuracy": 0.8,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.6,
+  "power": 1,
+  "range": "reach",
+  "recharge": 3,
+  "sfx": "sfx_blaster",
+  "slug": "chameleon",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "wood",
+    "fire"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/clairaudience.json
+++ b/mods/tuxemon/db/technique/clairaudience.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 125,
+  "accuracy": 0.3,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.8,
+  "power": 2.7,
+  "range": "reliable",
+  "recharge": 3,
+  "sfx": "sfx_blaster",
+  "slug": "clairaudience",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "wood"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/clock.json
+++ b/mods/tuxemon/db/technique/clock.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 187,
+  "accuracy": 0.2,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.1,
+  "power": 2,
+  "range": "reach",
+  "recharge": 1,
+  "sfx": "sfx_blaster",
+  "slug": "clock",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "wood"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/cloud_aether.json
+++ b/mods/tuxemon/db/technique/cloud_aether.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 126,
+  "accuracy": 0.2,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.6,
+  "power": 1.4,
+  "range": "ranged",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "cloud_aether",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "earth"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/conjurer.json
+++ b/mods/tuxemon/db/technique/conjurer.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 127,
+  "accuracy": 1,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.2,
+  "power": 1.4,
+  "range": "ranged",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "conjurer",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "fire"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/crystal.json
+++ b/mods/tuxemon/db/technique/crystal.json
@@ -1,0 +1,36 @@
+{
+  "tech_id": 128,
+  "accuracy": 0.7,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.9,
+  "power": 1,
+  "range": "reliable",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "crystal",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "earth",
+    "metal"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/demiurge.json
+++ b/mods/tuxemon/db/technique/demiurge.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 147,
+  "accuracy": 0.8,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.7,
+  "power": 1.3,
+  "range": "touch",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "demiurge",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "earth"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/earthquake.json
+++ b/mods/tuxemon/db/technique/earthquake.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 168,
+  "accuracy": 0.9,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.5,
+  "power": 2.9,
+  "range": "ranged",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "earthquake",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "earth"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/evasion.json
+++ b/mods/tuxemon/db/technique/evasion.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 198,
+  "accuracy": 0.5,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.3,
+  "power": 2.2,
+  "range": "melee",
+  "recharge": 1,
+  "sfx": "sfx_blaster",
+  "slug": "evasion",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "earth"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/feline.json
+++ b/mods/tuxemon/db/technique/feline.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 129,
+  "accuracy": 0.2,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.1,
+  "power": 2.8,
+  "range": "melee",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "feline",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "wood"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/fiery.json
+++ b/mods/tuxemon/db/technique/fiery.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 180,
+  "accuracy": 0.1,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.9,
+  "power": 2.4,
+  "range": "reliable",
+  "recharge": 1,
+  "sfx": "sfx_blaster",
+  "slug": "fiery",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "water"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/fire_shield.json
+++ b/mods/tuxemon/db/technique/fire_shield.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 167,
+  "accuracy": 0.1,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.3,
+  "power": 1.5,
+  "range": "reliable",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "fire_shield",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "fire"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/firestorm.json
+++ b/mods/tuxemon/db/technique/firestorm.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 166,
+  "accuracy": 0.6,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.4,
+  "power": 2.6,
+  "range": "reach",
+  "recharge": 3,
+  "sfx": "sfx_blaster",
+  "slug": "firestorm",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "fire"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/fledgling.json
+++ b/mods/tuxemon/db/technique/fledgling.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 199,
+  "accuracy": 0.2,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.6,
+  "power": 1.7,
+  "range": "reliable",
+  "recharge": 1,
+  "sfx": "sfx_blaster",
+  "slug": "fledgling",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "earth"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/gold_digger.json
+++ b/mods/tuxemon/db/technique/gold_digger.json
@@ -1,0 +1,36 @@
+{
+  "tech_id": 181,
+  "accuracy": 0.6,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.4,
+  "power": 2.8,
+  "range": "reach",
+  "recharge": 1,
+  "sfx": "sfx_blaster",
+  "slug": "gold_digger",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "metal",
+    "fire"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/grinding.json
+++ b/mods/tuxemon/db/technique/grinding.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 191,
+  "accuracy": 0.3,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.9,
+  "power": 2.2,
+  "range": "touch",
+  "recharge": 3,
+  "sfx": "sfx_blaster",
+  "slug": "grinding",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "water"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/gust.json
+++ b/mods/tuxemon/db/technique/gust.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 161,
+  "accuracy": 0.3,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.9,
+  "power": 1.5,
+  "range": "ranged",
+  "recharge": 3,
+  "sfx": "sfx_blaster",
+  "slug": "gust",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "fire"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/gyser.json
+++ b/mods/tuxemon/db/technique/gyser.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 173,
+  "accuracy": 0.1,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.2,
+  "power": 2.5,
+  "range": "ranged",
+  "recharge": 3,
+  "sfx": "sfx_blaster",
+  "slug": "gyser",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "water"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/hawk.json
+++ b/mods/tuxemon/db/technique/hawk.json
@@ -1,0 +1,36 @@
+{
+  "tech_id": 193,
+  "accuracy": 0.7,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.2,
+  "power": 1.5,
+  "range": "touch",
+  "recharge": 3,
+  "sfx": "sfx_blaster",
+  "slug": "hawk",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "wood",
+    "earth"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/ice_storm.json
+++ b/mods/tuxemon/db/technique/ice_storm.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 171,
+  "accuracy": 0.4,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.5,
+  "power": 2.2,
+  "range": "ranged",
+  "recharge": 3,
+  "sfx": "sfx_blaster",
+  "slug": "ice_storm",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "water"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/insanity.json
+++ b/mods/tuxemon/db/technique/insanity.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 130,
+  "accuracy": 0.8,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.5,
+  "power": 2.2,
+  "range": "touch",
+  "recharge": 3,
+  "sfx": "sfx_blaster",
+  "slug": "insanity",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "metal"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/kraken.json
+++ b/mods/tuxemon/db/technique/kraken.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 132,
+  "accuracy": 0.8,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 1,
+  "power": 1.7,
+  "range": "ranged",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "kraken",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "water"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/lantern.json
+++ b/mods/tuxemon/db/technique/lantern.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 133,
+  "accuracy": 0.4,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.1,
+  "power": 1.1,
+  "range": "reliable",
+  "recharge": 3,
+  "sfx": "sfx_blaster",
+  "slug": "lantern",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "earth"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/lava.json
+++ b/mods/tuxemon/db/technique/lava.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 134,
+  "accuracy": 0.4,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.4,
+  "power": 2.9,
+  "range": "touch",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "lava",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "fire"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/lightning_spheres.json
+++ b/mods/tuxemon/db/technique/lightning_spheres.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 163,
+  "accuracy": 0.8,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.4,
+  "power": 1.2,
+  "range": "melee",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "lightning_spheres",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "metal"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/lineage.json
+++ b/mods/tuxemon/db/technique/lineage.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 135,
+  "accuracy": 0.7,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.9,
+  "power": 1.3,
+  "range": "ranged",
+  "recharge": 3,
+  "sfx": "sfx_blaster",
+  "slug": "lineage",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "metal"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/lust.json
+++ b/mods/tuxemon/db/technique/lust.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 136,
+  "accuracy": 0.4,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.3,
+  "power": 2.8,
+  "range": "melee",
+  "recharge": 1,
+  "sfx": "sfx_blaster",
+  "slug": "lust",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "earth"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/magma.json
+++ b/mods/tuxemon/db/technique/magma.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 137,
+  "accuracy": 0.7,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.3,
+  "power": 1.4,
+  "range": "reach",
+  "recharge": 1,
+  "sfx": "sfx_blaster",
+  "slug": "magma",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "fire"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/maori.json
+++ b/mods/tuxemon/db/technique/maori.json
@@ -1,0 +1,36 @@
+{
+  "tech_id": 188,
+  "accuracy": 0.4,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.4,
+  "power": 3,
+  "range": "touch",
+  "recharge": 1,
+  "sfx": "sfx_blaster",
+  "slug": "maori",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "wood",
+    "earth"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/meltdown.json
+++ b/mods/tuxemon/db/technique/meltdown.json
@@ -1,0 +1,36 @@
+{
+  "tech_id": 185,
+  "accuracy": 0.3,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.1,
+  "power": 2.8,
+  "range": "reach",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "meltdown",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "earth",
+    "metal"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/mending.json
+++ b/mods/tuxemon/db/technique/mending.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 169,
+  "accuracy": 0.6,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.3,
+  "power": 2.3,
+  "range": "ranged",
+  "recharge": 1,
+  "sfx": "sfx_blaster",
+  "slug": "mending",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "earth"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/mobbing.json
+++ b/mods/tuxemon/db/technique/mobbing.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 197,
+  "accuracy": 0.7,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.1,
+  "power": 1.6,
+  "range": "touch",
+  "recharge": 3,
+  "sfx": "sfx_blaster",
+  "slug": "mobbing",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "water"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/muck.json
+++ b/mods/tuxemon/db/technique/muck.json
@@ -1,0 +1,36 @@
+{
+  "tech_id": 138,
+  "accuracy": 0.2,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.9,
+  "power": 2.4,
+  "range": "reach",
+  "recharge": 3,
+  "sfx": "sfx_blaster",
+  "slug": "muck",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "earth",
+    "water"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/mystic_blending.json
+++ b/mods/tuxemon/db/technique/mystic_blending.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 139,
+  "accuracy": 0.2,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.4,
+  "power": 1.2,
+  "range": "reliable",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "mystic_blending",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "earth"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/negation.json
+++ b/mods/tuxemon/db/technique/negation.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 140,
+  "accuracy": 0.8,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.7,
+  "power": 2.9,
+  "range": "ranged",
+  "recharge": 3,
+  "sfx": "sfx_blaster",
+  "slug": "negation",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "wood"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/nest.json
+++ b/mods/tuxemon/db/technique/nest.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 196,
+  "accuracy": 0.8,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.9,
+  "power": 1.6,
+  "range": "ranged",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "nest",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "fire"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/oedipus.json
+++ b/mods/tuxemon/db/technique/oedipus.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 182,
+  "accuracy": 0.5,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.8,
+  "power": 2.2,
+  "range": "reach",
+  "recharge": 3,
+  "sfx": "sfx_blaster",
+  "slug": "oedipus",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "metal"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/orbs.json
+++ b/mods/tuxemon/db/technique/orbs.json
@@ -1,0 +1,36 @@
+{
+  "tech_id": 141,
+  "accuracy": 0.7,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.7,
+  "power": 2.8,
+  "range": "melee",
+  "recharge": 3,
+  "sfx": "sfx_blaster",
+  "slug": "orbs",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "wood",
+    "water"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/phantasmal_force.json
+++ b/mods/tuxemon/db/technique/phantasmal_force.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 162,
+  "accuracy": 0.1,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.1,
+  "power": 1.6,
+  "range": "ranged",
+  "recharge": 1,
+  "sfx": "sfx_blaster",
+  "slug": "phantasmal_force",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "wood"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/pit.json
+++ b/mods/tuxemon/db/technique/pit.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 142,
+  "accuracy": 0.1,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.1,
+  "power": 1.1,
+  "range": "touch",
+  "recharge": 3,
+  "sfx": "sfx_blaster",
+  "slug": "pit",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "earth"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/platinum.json
+++ b/mods/tuxemon/db/technique/platinum.json
@@ -1,0 +1,36 @@
+{
+  "tech_id": 143,
+  "accuracy": 0.7,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.2,
+  "power": 1.7,
+  "range": "melee",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "platinum",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "metal",
+    "earth"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/poison_courtship.json
+++ b/mods/tuxemon/db/technique/poison_courtship.json
@@ -1,0 +1,36 @@
+{
+  "tech_id": 195,
+  "accuracy": 0.9,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.7,
+  "power": 2.1,
+  "range": "touch",
+  "recharge": 1,
+  "sfx": "sfx_blaster",
+  "slug": "poison_courtship",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "water",
+    "wood"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/radiance.json
+++ b/mods/tuxemon/db/technique/radiance.json
@@ -1,0 +1,36 @@
+{
+  "tech_id": 144,
+  "accuracy": 0.6,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.6,
+  "power": 1.6,
+  "range": "touch",
+  "recharge": 1,
+  "sfx": "sfx_blaster",
+  "slug": "radiance",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "wood",
+    "metal"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/ring.json
+++ b/mods/tuxemon/db/technique/ring.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 145,
+  "accuracy": 0.1,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.1,
+  "power": 2.4,
+  "range": "reach",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "ring",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "earth"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/ruby.json
+++ b/mods/tuxemon/db/technique/ruby.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 146,
+  "accuracy": 0.5,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.6,
+  "power": 3,
+  "range": "reach",
+  "recharge": 1,
+  "sfx": "sfx_blaster",
+  "slug": "ruby",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "metal"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/saber.json
+++ b/mods/tuxemon/db/technique/saber.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 184,
+  "accuracy": 0.3,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.9,
+  "power": 2.2,
+  "range": "ranged",
+  "recharge": 3,
+  "sfx": "sfx_blaster",
+  "slug": "saber",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "fire"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/shapechange.json
+++ b/mods/tuxemon/db/technique/shapechange.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 160,
+  "accuracy": 0.2,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.7,
+  "power": 1.1,
+  "range": "touch",
+  "recharge": 3,
+  "sfx": "sfx_blaster",
+  "slug": "shapechange",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "water"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/slime.json
+++ b/mods/tuxemon/db/technique/slime.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 178,
+  "accuracy": 0.3,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.1,
+  "power": 1.1,
+  "range": "reach",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "slime",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "earth"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/stabilo.json
+++ b/mods/tuxemon/db/technique/stabilo.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 190,
+  "accuracy": 0.6,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.9,
+  "power": 1.9,
+  "range": "reliable",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "stabilo",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "wood"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/stonehenge.json
+++ b/mods/tuxemon/db/technique/stonehenge.json
@@ -1,0 +1,36 @@
+{
+  "tech_id": 189,
+  "accuracy": 0.1,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.6,
+  "power": 1.2,
+  "range": "reach",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "stonehenge",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "earth",
+    "wood"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/strangulation.json
+++ b/mods/tuxemon/db/technique/strangulation.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 175,
+  "accuracy": 0.1,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.8,
+  "power": 1.2,
+  "range": "melee",
+  "recharge": 1,
+  "sfx": "sfx_blaster",
+  "slug": "strangulation",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "earth"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/sunburst.json
+++ b/mods/tuxemon/db/technique/sunburst.json
@@ -1,0 +1,36 @@
+{
+  "tech_id": 159,
+  "accuracy": 0.4,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.3,
+  "power": 1.5,
+  "range": "touch",
+  "recharge": 1,
+  "sfx": "sfx_blaster",
+  "slug": "sunburst",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "fire",
+    "metal"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/sword.json
+++ b/mods/tuxemon/db/technique/sword.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 183,
+  "accuracy": 0.7,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.7,
+  "power": 1.2,
+  "range": "melee",
+  "recharge": 3,
+  "sfx": "sfx_blaster",
+  "slug": "sword",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "metal"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/sylvan.json
+++ b/mods/tuxemon/db/technique/sylvan.json
@@ -1,0 +1,36 @@
+{
+  "tech_id": 148,
+  "accuracy": 0.5,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.4,
+  "power": 2.3,
+  "range": "melee",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "sylvan",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "wood",
+    "earth"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/terror.json
+++ b/mods/tuxemon/db/technique/terror.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 149,
+  "accuracy": 0.2,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.1,
+  "power": 2.9,
+  "range": "reach",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "terror",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "metal"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/time_crisis.json
+++ b/mods/tuxemon/db/technique/time_crisis.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 186,
+  "accuracy": 0.1,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.6,
+  "power": 1.3,
+  "range": "ranged",
+  "recharge": 3,
+  "sfx": "sfx_blaster",
+  "slug": "time_crisis",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "metal"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/tip.json
+++ b/mods/tuxemon/db/technique/tip.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 192,
+  "accuracy": 1,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.9,
+  "power": 1.5,
+  "range": "melee",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "tip",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "earth"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/torch.json
+++ b/mods/tuxemon/db/technique/torch.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 150,
+  "accuracy": 0.6,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.8,
+  "power": 1.4,
+  "range": "reach",
+  "recharge": 1,
+  "sfx": "sfx_blaster",
+  "slug": "torch",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "water"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/touch.json
+++ b/mods/tuxemon/db/technique/touch.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 151,
+  "accuracy": 0.7,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.9,
+  "power": 1.8,
+  "range": "melee",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "touch",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "earth"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/tsunami.json
+++ b/mods/tuxemon/db/technique/tsunami.json
@@ -1,0 +1,36 @@
+{
+  "tech_id": 170,
+  "accuracy": 0.4,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.6,
+  "power": 2.7,
+  "range": "reach",
+  "recharge": 3,
+  "sfx": "sfx_blaster",
+  "slug": "tsunami",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "water",
+    "earth"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/tux.json
+++ b/mods/tuxemon/db/technique/tux.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 174,
+  "accuracy": 0.3,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.1,
+  "power": 1.1,
+  "range": "touch",
+  "recharge": 1,
+  "sfx": "sfx_blaster",
+  "slug": "tux",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "wood"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/ubuntu.json
+++ b/mods/tuxemon/db/technique/ubuntu.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 177,
+  "accuracy": 0.4,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.6,
+  "power": 1.5,
+  "range": "reach",
+  "recharge": 1,
+  "sfx": "sfx_blaster",
+  "slug": "ubuntu",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "wood"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/undertaker.json
+++ b/mods/tuxemon/db/technique/undertaker.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 152,
+  "accuracy": 0.2,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.9,
+  "power": 1.4,
+  "range": "reach",
+  "recharge": 1,
+  "sfx": "sfx_blaster",
+  "slug": "undertaker",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "metal"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/venom.json
+++ b/mods/tuxemon/db/technique/venom.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 153,
+  "accuracy": 0.9,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.5,
+  "power": 2.2,
+  "range": "ranged",
+  "recharge": 3,
+  "sfx": "sfx_blaster",
+  "slug": "venom",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "wood"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/viper.json
+++ b/mods/tuxemon/db/technique/viper.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 154,
+  "accuracy": 0.6,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.4,
+  "power": 2.9,
+  "range": "reliable",
+  "recharge": 3,
+  "sfx": "sfx_blaster",
+  "slug": "viper",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "metal"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/vorpal.json
+++ b/mods/tuxemon/db/technique/vorpal.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 155,
+  "accuracy": 0.4,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.9,
+  "power": 2.7,
+  "range": "melee",
+  "recharge": 1,
+  "sfx": "sfx_blaster",
+  "slug": "vorpal",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "earth"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/wall_fire.json
+++ b/mods/tuxemon/db/technique/wall_fire.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 165,
+  "accuracy": 0.3,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.8,
+  "power": 1.9,
+  "range": "reach",
+  "recharge": 3,
+  "sfx": "sfx_blaster",
+  "slug": "wall_fire",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "fire"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/wall_ice.json
+++ b/mods/tuxemon/db/technique/wall_ice.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 172,
+  "accuracy": 0.3,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.8,
+  "power": 2.5,
+  "range": "reach",
+  "recharge": 3,
+  "sfx": "sfx_blaster",
+  "slug": "wall_ice",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "water"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/walls.json
+++ b/mods/tuxemon/db/technique/walls.json
@@ -1,0 +1,35 @@
+{
+  "tech_id": 156,
+  "accuracy": 0.1,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.2,
+  "power": 1,
+  "range": "ranged",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "walls",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "wood"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/db/technique/webs_wind.json
+++ b/mods/tuxemon/db/technique/webs_wind.json
@@ -1,0 +1,36 @@
+{
+  "tech_id": 157,
+  "accuracy": 0.3,
+  "animation": null,
+  "effects": [
+    "damage 100"
+  ],
+  "flip_axes": "",
+  "healing_power": 0,
+  "icon": "",
+  "is_area": false,
+  "is_fast": false,
+  "potency": 0.3,
+  "power": 1.8,
+  "range": "melee",
+  "recharge": 2,
+  "sfx": "sfx_blaster",
+  "slug": "webs_wind",
+  "sort": "damage",
+  "target": {
+    "enemy monster": 2,
+    "enemy team": 0,
+    "enemy trainer": 0,
+    "item": 0,
+    "own monster": 0,
+    "own team": 0,
+    "own trainer": 0
+  },
+  "types": [
+    "earth",
+    "wood"
+  ],
+  "use_failure": "combat_miss",
+  "use_success": null,
+  "use_tech": "combat_used_x"
+}

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -903,6 +903,252 @@ msgstr "Whirlwind"
 msgid "wing_tip"
 msgstr "Wing Tip"
 
+msgid "acid"
+msgstr "Acid"
+
+msgid "adamantine"
+msgstr "Adamantine"
+
+msgid "air_chain"
+msgstr "Air Chain"
+
+msgid "ants"
+msgstr "Ants"
+
+msgid "arcane_eye"
+msgstr "Arcane Eye"
+
+msgid "assault"
+msgstr "Assault"
+
+msgid "barking"
+msgstr "Barking"
+
+msgid "blood_nets"
+msgstr "Blood Nets"
+
+msgid "breath"
+msgstr "Breath"
+
+msgid "canine"
+msgstr "Canine"
+
+msgid "cat_calling"
+msgstr "Cat Calling"
+
+msgid "cavity"
+msgstr "Cavity"
+
+msgid "chameleon"
+msgstr "Chameleon"
+
+msgid "clairaudience"
+msgstr "Clairaudience"
+
+msgid "clock"
+msgstr "Clock"
+
+msgid "cloud_aether"
+msgstr "Cloud Aether"
+
+msgid "conjurer"
+msgstr "Conjurer"
+
+msgid "crystal"
+msgstr "Crystal"
+
+msgid "demiurge"
+msgstr "Demiurge"
+
+msgid "earthquake"
+msgstr "Earthquake"
+
+msgid "evasion"
+msgstr "Evasion"
+
+msgid "feline"
+msgstr "Feline"
+
+msgid "fiery"
+msgstr "Fiery"
+
+msgid "fire_shield"
+msgstr "Fire Shield"
+
+msgid "firestorm"
+msgstr "Firestorm"
+
+msgid "fledgling"
+msgstr "Fledgling"
+
+msgid "gold_digger"
+msgstr "Gold Digger"
+
+msgid "grinding"
+msgstr "Grinding"
+
+msgid "gust"
+msgstr "Gust"
+
+msgid "gyser"
+msgstr "Gyser"
+
+msgid "hawk"
+msgstr "Hawk"
+
+msgid "ice_storm"
+msgstr "Ice Storm"
+
+msgid "insanity"
+msgstr "Insanity"
+
+msgid "kraken"
+msgstr "Kraken"
+
+msgid "lantern"
+msgstr "Lantern"
+
+msgid "lava"
+msgstr "Lava"
+
+msgid "lightning_spheres"
+msgstr "Lightning Spheres"
+
+msgid "lineage"
+msgstr "Lineage"
+
+msgid "lust"
+msgstr "Lust"
+
+msgid "magma"
+msgstr "Magma"
+
+msgid "maori"
+msgstr "Maori"
+
+msgid "meltdown"
+msgstr "Meltdown"
+
+msgid "mending"
+msgstr "Mending"
+
+msgid "mobbing"
+msgstr "Mobbing"
+
+msgid "muck"
+msgstr "Muck"
+
+msgid "mystic_blending"
+msgstr "Mystic Blending"
+
+msgid "negation"
+msgstr "Negation"
+
+msgid "nest"
+msgstr "Nest"
+
+msgid "oedipus"
+msgstr "Oedipus"
+
+msgid "orbs"
+msgstr "Orbs"
+
+msgid "phantasmal_force"
+msgstr "Phantasmal Force"
+
+msgid "pit"
+msgstr "Pit"
+
+msgid "platinum"
+msgstr "Platinum"
+
+msgid "poison_courtship"
+msgstr "Poison Courtship"
+
+msgid "radiance"
+msgstr "Radiance"
+
+msgid "ring"
+msgstr "Ring"
+
+msgid "ruby"
+msgstr "Ruby"
+
+msgid "saber"
+msgstr "Saber"
+
+msgid "shapechange"
+msgstr "Shapechange"
+
+msgid "slime"
+msgstr "Slime"
+
+msgid "stabilo"
+msgstr "Stabilo"
+
+msgid "stonehenge"
+msgstr "Stonehenge"
+
+msgid "strangulation"
+msgstr "Strangulation"
+
+msgid "sunburst"
+msgstr "Sunburst"
+
+msgid "sword"
+msgstr "Sword"
+
+msgid "sylvan"
+msgstr "Sylvan"
+
+msgid "terror"
+msgstr "Terror"
+
+msgid "time_crisis"
+msgstr "Time Crisis"
+
+msgid "tip"
+msgstr "Tip"
+
+msgid "torch"
+msgstr "Torch"
+
+msgid "touch"
+msgstr "Touch"
+
+msgid "tsunami"
+msgstr "Tsunami"
+
+msgid "tux"
+msgstr "Tux"
+
+msgid "ubuntu"
+msgstr "Ubuntu"
+
+msgid "undertaker"
+msgstr "Undertaker"
+
+msgid "venom"
+msgstr "Venom"
+
+msgid "viper"
+msgstr "Viper"
+
+msgid "vorpal"
+msgstr "Vorpal"
+
+msgid "wall_fire"
+msgstr "Wall Fire"
+
+msgid "wall_ice"
+msgstr "Wall Ice"
+
+msgid "walls"
+msgstr "Walls"
+
+msgid "webs_wind"
+msgstr "Webs Wind"
+
 ## MAP ##
 
 msgid "candy_town"


### PR DESCRIPTION
@Sanglorian 

Since August, when I was inspired, I created a couple of techniques.
One after another, now I have accumulated 82 techniques. I stopped at the tech_id 200 (now we are at 118, statuses included)
Feel free to look at the file attached and share your feedback, if you want to modify something, etc.
Animation is null, because I have no clue what can be the right one.

At the end if we are going to introduce the overwriting (max 4 moves), some more techniques can help to vary the game.

Some numbers:
- 26 earth
- 11 fire
- 14 metal
- 11 water
- 20 wood

[techniques.ods](https://github.com/Tuxemon/Tuxemon/files/10299170/techniques.ods)
