### PR TITLE
standardization scoop maps

### DIFF
--- a/mods/tuxemon/db/economy/cotton_scoop.json
+++ b/mods/tuxemon/db/economy/cotton_scoop.json
@@ -1,0 +1,20 @@
+{
+  "slug": "cotton_scoop",
+  "items": [
+    {
+      "item_name": "potion",
+      "price": 20,
+      "cost": 5
+    },
+    {
+      "item_name": "revive",
+      "price": 100,
+      "cost": 20
+    },
+    {
+      "item_name": "capture_device",
+      "price": 50,
+      "cost": 10
+    }
+  ]
+}

--- a/mods/tuxemon/db/economy/leather_scoop.json
+++ b/mods/tuxemon/db/economy/leather_scoop.json
@@ -1,0 +1,20 @@
+{
+  "slug": "leather_scoop",
+  "items": [
+    {
+      "item_name": "potion",
+      "price": 20,
+      "cost": 5
+    },
+    {
+      "item_name": "revive",
+      "price": 100,
+      "cost": 20
+    },
+    {
+      "item_name": "capture_device",
+      "price": 50,
+      "cost": 10
+    }
+  ]
+}

--- a/mods/tuxemon/db/inventory/cotton_scoop.json
+++ b/mods/tuxemon/db/inventory/cotton_scoop.json
@@ -1,0 +1,8 @@
+{
+  "slug": "cotton_scoop",
+  "inventory": {
+    "capture_device": null,
+    "potion": 20,
+    "revive": 3
+  }
+}

--- a/mods/tuxemon/db/inventory/leather_scoop.json
+++ b/mods/tuxemon/db/inventory/leather_scoop.json
@@ -1,0 +1,8 @@
+{
+  "slug": "leather_scoop",
+  "inventory": {
+    "capture_device": null,
+    "potion": 20,
+    "revive": 3
+  }
+}

--- a/mods/tuxemon/maps/cotton_scoop.tmx
+++ b/mods/tuxemon/maps/cotton_scoop.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="17">
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="20">
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
@@ -58,11 +58,8 @@
   <object id="5" type="collision" x="0" y="160">
    <polygon points="0,0 16,0 16,16 0,16"/>
   </object>
-  <object id="8" type="collision" x="0" y="176" width="208" height="16"/>
-  <object id="9" type="collision" x="-16" y="0" width="16" height="176"/>
   <object id="10" type="collision" x="0" y="0" width="48" height="128"/>
   <object id="11" type="collision" x="48" y="0" width="160" height="48"/>
-  <object id="12" type="collision" x="208" y="48" width="16" height="128"/>
   <object id="14" type="collision" x="64" y="48" width="144" height="16"/>
  </objectgroup>
  <layer id="5" name="Above Player" width="13" height="11">
@@ -86,5 +83,28 @@
    </properties>
   </object>
   <object id="16" name="Player Spawn" type="event" x="80" y="128" width="16" height="16"/>
+  <object id="17" name="employee" type="event" x="16" y="80" width="16" height="16">
+   <properties>
+    <property name="act10" value="create_npc tuxemart_keeper,1,5,,stand"/>
+    <property name="act20" value="npc_face tuxemart_keeper,right"/>
+    <property name="act30" value="set_inventory tuxemart_keeper,cotton_scoop"/>
+    <property name="act40" value="set_economy tuxemart_keeper,cotton_scoop"/>
+    <property name="cond10" value="not npc_exists tuxemart_keeper"/>
+   </properties>
+  </object>
+  <object id="18" name="open shop" type="event" x="32" y="80" width="16" height="16">
+   <properties>
+    <property name="act10" value="open_shop tuxemart_keeper"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
+   </properties>
+  </object>
+  <object id="19" name="capture devices" type="event" x="32" y="96" width="16" height="16">
+   <properties>
+    <property name="act10" value="translated_dialog cash_register"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
+   </properties>
+  </object>
  </objectgroup>
 </map>

--- a/mods/tuxemon/maps/leather_scoop.tmx
+++ b/mods/tuxemon/maps/leather_scoop.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="19">
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="22">
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
@@ -66,14 +66,6 @@
   <object id="6" type="collision" x="144" y="176">
    <polygon points="0,0 0,-16 -16,-16 -16,0"/>
   </object>
-  <object id="8" type="collision" x="64" y="176">
-   <polygon points="0,0 16,0 16,16 0,16"/>
-  </object>
-  <object id="9" type="collision" x="0" y="128">
-   <polygon points="0,0 0,32 -16,32 -16,0"/>
-  </object>
-  <object id="10" type="collision" x="112" y="176" width="96" height="16"/>
-  <object id="11" type="collision" x="208" y="48" width="16" height="128"/>
   <object id="12" type="collision" x="0" y="160" width="64" height="16"/>
   <object id="13" type="collision" x="0" y="0" width="48" height="128"/>
   <object id="14" type="collision" x="48" y="0" width="160" height="48"/>
@@ -90,5 +82,28 @@
    </properties>
   </object>
   <object id="16" name="Player Spawn" type="event" x="96" y="96" width="16" height="16"/>
+  <object id="19" name="employee" type="event" x="16" y="80" width="16" height="16">
+   <properties>
+    <property name="act10" value="create_npc tuxemart_keeper,1,5,,stand"/>
+    <property name="act20" value="npc_face tuxemart_keeper,right"/>
+    <property name="act30" value="set_inventory tuxemart_keeper,leather_scoop"/>
+    <property name="act40" value="set_economy tuxemart_keeper,leather_scoop"/>
+    <property name="cond10" value="not npc_exists tuxemart_keeper"/>
+   </properties>
+  </object>
+  <object id="20" name="open shop" type="event" x="32" y="80" width="16" height="16">
+   <properties>
+    <property name="act10" value="open_shop tuxemart_keeper"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
+   </properties>
+  </object>
+  <object id="21" name="capture devices" type="event" x="32" y="96" width="16" height="16">
+   <properties>
+    <property name="act10" value="translated_dialog cash_register"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
+   </properties>
+  </object>
  </objectgroup>
 </map>

--- a/mods/tuxemon/maps/spyder_paper_mart.tmx
+++ b/mods/tuxemon/maps/spyder_paper_mart.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="64">
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="64">
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
@@ -18,50 +18,47 @@
  <tileset firstgid="1473" name="items" tilewidth="16" tileheight="16" tilecount="6" columns="3">
   <image source="../gfx/tilesets/items.png" width="48" height="32"/>
  </tileset>
- <layer id="1" name="Tile Layer 1" width="15" height="15">
+ <layer id="1" name="Tile Layer 1" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eAFjYBg4YAm0mlQMc60LkEEqhun1BzJIxTC9ekAGqXiw6AW5g1i3DxY3E+tekDoYIEUPTC1M70DQAOfXHN8=
+   eAGzZGBgsCQRuwDVk4r9gXpIxXpAPYMdA5046N1IqzAEAAOJHN8=
   </data>
  </layer>
- <layer id="2" name="Tile Layer 2" width="15" height="15">
+ <layer id="2" name="Tile Layer 2" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eAFjYBi5gJmVdL93sDAwtAPxXSAmF9BCby3QL7eBbqrH46ebZLiZGHPJDQdamo3NTXiCBptyuokBADwwClQ=
+   eAFjYKAvYGYl3r4OFgaGdiC+C8SkAmrqqQW6+TbQDfVY3H6TBLfhM4dU/8HU08JMmNkgGouX4dIAyYMKVA==
   </data>
  </layer>
- <layer id="3" name="Tile Layer 3" width="15" height="15">
+ <layer id="3" name="Tile Layer 3" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eAFjYBgF5IRAOCs5uiB6KNG7gYV8ezdToJd8W0d1EgoBAAF2AiQ=
+   eAFjYBj8IJyVdDeSo2cDC+n2bCZDD+m2DE4dAJ68AiQ=
   </data>
  </layer>
- <layer id="4" name="Above player" width="15" height="15">
+ <layer id="4" name="Above player" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eAFjYBgFgyUENrIwMGwC4s1ATE0AM5eaZsLMgplNbTfDzB8JNAAjywWw
+   eAFjYBhZYCMLA8MmIN4MxJQAmDmUmIGuF2YmpW5DN5dWfACakwWw
   </data>
  </layer>
- <layer id="5" name="Above player" width="15" height="15">
+ <layer id="5" name="Above player" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eAFjYBgFgyUEDrEyMIDwQSAmFRwF6gHhI2ToJdUudPWHgXaCMDngGFAfCI9kAAAqAgfY
+   eAFjYBhZ4BArAwMIHwRiYsFRoFoQPkKCHmLNRld3GGgHCJMCjgHVgzC9AQBPIwfY
   </data>
  </layer>
- <objectgroup color="#ff0000" id="6" name="Collision" visible="0">
-  <object id="4" type="collision" x="16" y="208" width="208" height="32"/>
-  <object id="11" type="collision" x="16" y="48" width="208" height="32"/>
-  <object id="12" type="collision" x="-16" y="64" width="32" height="160"/>
-  <object id="14" type="collision" x="224" y="64" width="32" height="160"/>
-  <object id="21" type="collision" x="48" y="80" width="16" height="64"/>
-  <object id="22" type="collision" x="16" y="144" width="48" height="16"/>
-  <object id="24" type="collision" x="144" y="112" width="48" height="16"/>
-  <object id="25" type="collision" x="144" y="160" width="48" height="16"/>
+ <objectgroup color="#ff0000" id="6" name="Collision">
+  <object id="11" type="collision" x="0" y="16" width="208" height="32"/>
+  <object id="21" type="collision" x="32" y="48" width="16" height="64"/>
+  <object id="22" type="collision" x="0" y="112" width="48" height="16"/>
+  <object id="24" type="collision" x="128" y="80" width="48" height="16"/>
+  <object id="25" type="collision" x="128" y="128" width="48" height="16"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="7" name="Events">
-  <object id="17" name="Go outside" type="event" x="112" y="192" width="16" height="16">
+  <object id="17" name="Go outside" type="event" x="96" y="160" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport map1.tmx,30,12,0.3"/>
+    <property name="act1" value="transition_teleport spyder_paper_town.tmx,19,13,0.3"/>
     <property name="cond1" value="is player_at"/>
     <property name="cond2" value="is player_facing down"/>
    </properties>
   </object>
-  <object id="27" name="Receive capture device" type="event" x="64" y="112" width="16" height="16">
+  <object id="27" name="Receive capture device" type="event" x="48" y="80" width="16" height="16">
    <properties>
     <property name="act1" value="open_shop tuxemart_keeper"/>
     <property name="cond1" value="is player_at"/>
@@ -69,7 +66,7 @@
     <property name="cond3" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
-  <object id="37" name="Talk to the professor" type="event" x="112" y="128" width="16" height="16">
+  <object id="37" name="Talk to the professor" type="event" x="96" y="96" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog professor_dialog\n"/>
     <property name="act2" value="translated_dialog_choice yes:no,serenademe"/>
@@ -79,9 +76,9 @@
     <property name="cond1" value="not variable_set ripmycodingskills:yes"/>
    </properties>
   </object>
-  <object id="42" name="hello Professor" type="event" x="144" y="192" width="16" height="16">
+  <object id="42" name="hello Professor" type="event" x="128" y="160" width="16" height="16">
    <properties>
-    <property name="act10" value="create_npc professor,7,7,professor,stand"/>
+    <property name="act10" value="create_npc professor,6,5,professor,stand"/>
     <property name="act30" value="set_variable tuxchoice:welcome"/>
     <property name="cond1" value="not variable_set tuxchoice:end"/>
     <property name="cond2" value="not npc_exists professor"/>
@@ -92,7 +89,7 @@
     <property name="cond7" value="not variable_set serenademe:no"/>
    </properties>
   </object>
-  <object id="46" name="choiceHydrone" type="event" x="112" y="128" width="16" height="16">
+  <object id="46" name="choiceHydrone" type="event" x="96" y="96" width="16" height="16">
    <properties>
     <property name="act1" value="add_monster hydrone,5"/>
     <property name="act2" value="set_variable tuxchoice:end"/>
@@ -104,7 +101,7 @@
     <property name="cond1" value="is variable_set tuxchoice:hydrone"/>
    </properties>
   </object>
-  <object id="47" name="choiceRockitten" type="event" x="112" y="128" width="16" height="16">
+  <object id="47" name="choiceRockitten" type="event" x="96" y="96" width="16" height="16">
    <properties>
     <property name="act1" value="add_monster rockitten,5"/>
     <property name="act2" value="set_variable tuxchoice:end"/>
@@ -116,7 +113,7 @@
     <property name="cond1" value="is variable_set tuxchoice:rockitten"/>
    </properties>
   </object>
-  <object id="51" name="choiceFruitera" type="event" x="112" y="128" width="16" height="16">
+  <object id="51" name="choiceFruitera" type="event" x="96" y="96" width="16" height="16">
    <properties>
     <property name="act1" value="add_monster fruitera,5"/>
     <property name="act2" value="set_variable tuxchoice:end"/>
@@ -128,9 +125,9 @@
     <property name="cond1" value="is variable_set tuxchoice:fruitera"/>
    </properties>
   </object>
-  <object id="56" name="employee" type="event" x="32" y="176" width="16" height="16">
+  <object id="56" name="employee" type="event" x="16" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc tuxemart_keeper,2,7,tuxemartemployee,stand"/>
+    <property name="act1" value="create_npc tuxemart_keeper,1,5,tuxemartemployee,stand"/>
     <property name="act2" value="npc_face tuxemart_keeper,right"/>
     <property name="act3" value="set_inventory tuxemart_keeper,spyder_paper_mart"/>
     <property name="act4" value="set_economy tuxemart_keeper,spyder_paper_mart"/>
@@ -143,7 +140,7 @@
     <property name="cond1" value="not music_playing JRPG_royalCourt_loop.ogg"/>
    </properties>
   </object>
-  <object id="59" name="yespls" type="event" x="112" y="128" width="16" height="16">
+  <object id="59" name="yespls" type="event" x="96" y="96" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog professor_yes"/>
     <property name="act2" value="set_variable serenademe:okay"/>
@@ -151,7 +148,7 @@
     <property name="cond1" value="is variable_set serenademe:yes"/>
    </properties>
   </object>
-  <object id="60" name="nopls" type="event" x="112" y="128" width="16" height="16">
+  <object id="60" name="nopls" type="event" x="96" y="96" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog professor_no"/>
     <property name="act2" value="set_variable serenademe:okay"/>
@@ -159,7 +156,7 @@
     <property name="cond1" value="is variable_set serenademe:no"/>
    </properties>
   </object>
-  <object id="61" name="more talk" type="event" x="112" y="128" width="16" height="16">
+  <object id="61" name="more talk" type="event" x="96" y="96" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog professor_dialog2\n"/>
     <property name="act2" value="npc_face professor,up"/>
@@ -171,15 +168,15 @@
     <property name="cond2" value="not variable_set tuxchoice:end"/>
    </properties>
   </object>
-  <object id="62" name="Create Shopkeeper" type="event" x="32" y="128" width="16" height="16">
+  <object id="62" name="Create Shopkeeper" type="event" x="16" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc shopkeeperpapertown,4,8,shopkeeper,stand"/>
+    <property name="act1" value="create_npc shopkeeperpapertown,3,6,shopkeeper,stand"/>
     <property name="cond2" value="not npc_exists shopkeeperpapertown"/>
    </properties>
   </object>
-  <object id="63" name="Create Dante" type="event" x="192" y="112" width="16" height="16">
+  <object id="63" name="Create Dante" type="event" x="176" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc danteinstore,12,7,shop_assistant,stand"/>
+    <property name="act1" value="create_npc danteinstore,11,5,shop_assistant,stand"/>
     <property name="cond1" value="is party_size less_than,1"/>
     <property name="cond2" value="not npc_exists danteinstore"/>
    </properties>

--- a/mods/tuxemon/maps/taba_town.tmx
+++ b/mods/tuxemon/maps/taba_town.tmx
@@ -335,7 +335,7 @@
   </object>
   <object id="108" name="Enter mart" type="event" x="480" y="176" width="16" height="16">
    <properties>
-    <property name="act10" value="transition_teleport tuxe_mart_taba.tmx,7,12,0.3"/>
+    <property name="act10" value="transition_teleport tuxe_mart_taba.tmx,6,10,0.3"/>
     <property name="cond10" value="is player_at"/>
     <property name="cond20" value="is player_facing up"/>
    </properties>

--- a/mods/tuxemon/maps/tuxe_mart_taba.tmx
+++ b/mods/tuxemon/maps/tuxe_mart_taba.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="69">
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="69">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -16,59 +16,56 @@
  <tileset firstgid="1401" name="items" tilewidth="16" tileheight="16" tilecount="6" columns="3">
   <image source="../gfx/tilesets/items.png" width="48" height="32"/>
  </tileset>
- <layer id="1" name="Tile Layer 1" width="15" height="15">
+ <layer id="1" name="Tile Layer 1" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eAFjYBg4YAm0mlQMc60LkEEqhun1BzJIxTC9ekAGqXiw6AW5g1i3DxY3E+tekDoYIEUPTC1M70DQAOfXHN8=
+   eAGzZGBgsCQRuwDVk4r9gXpIxXpAPYMdA5046N1IqzAEAAOJHN8=
   </data>
  </layer>
- <layer id="2" name="Tile Layer 2" width="15" height="15">
+ <layer id="2" name="Tile Layer 2" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eAFjYBi5YDcL6X53AOqxB+KpZOiF2UYLvaasDAyTgW4yB9K4wEQy3EyMubjsIyROS7Ox2Y0naLApp5sYABUeBtM=
+   eAFjYKAv2M1CvH0OQLX2QDyVBD0w06mpx5SVgWEy0A3mQBodTCTBbfjMQTeXWD4tzES2G4uX4dIAu8sG0w==
   </data>
  </layer>
- <layer id="3" name="Tile Layer 3" width="15" height="15">
+ <layer id="3" name="Tile Layer 3" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eAFjYBgF5IQAPys5uiB6KNGbwUK+vdkU6CXf1lGdhEIAANEJAQQ=
+   eAFjYBj8gJ+VdDeSoyeDhXR7ssnQQ7otg1MHACttAQQ=
   </data>
  </layer>
- <layer id="4" name="Above player" width="15" height="15">
+ <layer id="4" name="Above player" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eAFjYBgFgyUEMlkYGLKAOBuIqQlg5lLTTJhZMLOp7WaY+SOBBgCGzwNw
+   eAFjYBhZIJOFgSELiLOBmBIAM4cSM9D1wsyk1G3o5tKKDwBjdQNw
   </data>
  </layer>
- <layer id="5" name="Above player" width="15" height="15">
+ <layer id="5" name="Above player" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eAFjYBgFgyUEqlgZGEC4EohJBbVAPSBcQ4ZeUu1CV18NtBOEyQF1QH0gPJIBAMyXBQg=
+   eAFjYBhZoIqVgQGEK4GYWFALVAvCNSToIdZsdHXVQDtAmBRQB1QPwvQGAK9WBQg=
   </data>
  </layer>
  <objectgroup color="#ff0000" id="6" name="Collision">
-  <object id="4" type="collision" x="16" y="208" width="208" height="32"/>
-  <object id="11" type="collision" x="16" y="48" width="208" height="32"/>
-  <object id="12" type="collision" x="-16" y="64" width="32" height="160"/>
-  <object id="14" type="collision" x="224" y="64" width="32" height="160"/>
-  <object id="21" type="collision" x="48" y="80" width="16" height="64"/>
-  <object id="22" type="collision" x="16" y="144" width="48" height="16"/>
-  <object id="24" type="collision" x="144" y="112" width="48" height="16"/>
-  <object id="25" type="collision" x="144" y="160" width="48" height="16"/>
+  <object id="11" type="collision" x="0" y="16" width="208" height="32"/>
+  <object id="21" type="collision" x="32" y="48" width="16" height="64"/>
+  <object id="22" type="collision" x="0" y="112" width="48" height="16"/>
+  <object id="24" type="collision" x="128" y="80" width="48" height="16"/>
+  <object id="25" type="collision" x="128" y="128" width="48" height="16"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="7" name="Events">
-  <object id="17" name="Go outside" type="event" x="112" y="192" width="16" height="16">
+  <object id="17" name="Go outside" type="event" x="96" y="160" width="16" height="16">
    <properties>
     <property name="act10" value="transition_teleport taba_town.tmx,30,12,0.3"/>
     <property name="cond10" value="is player_at"/>
     <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
-  <object id="27" name="open shop" type="event" x="48" y="112" width="16" height="16">
+  <object id="27" name="open shop" type="event" x="32" y="80" width="16" height="16">
    <properties>
     <property name="act10" value="open_shop tuxemart_keeper"/>
     <property name="cond10" value="is player_facing_tile"/>
     <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
-  <object id="56" name="employee" type="event" x="32" y="112" width="16" height="16">
+  <object id="56" name="employee" type="event" x="16" y="80" width="16" height="16">
    <properties>
-    <property name="act10" value="create_npc tuxemart_keeper,2,7,,stand"/>
+    <property name="act10" value="create_npc tuxemart_keeper,1,5,,stand"/>
     <property name="act20" value="npc_face tuxemart_keeper,right"/>
     <property name="act30" value="set_inventory tuxemart_keeper,tuxe_mart_taba"/>
     <property name="act40" value="set_economy tuxemart_keeper,tuxe_mart_taba"/>
@@ -81,39 +78,39 @@
     <property name="cond10" value="not music_playing music_cathedral_theme"/>
    </properties>
   </object>
-  <object id="62" name="potions" type="event" x="144" y="112" width="48" height="16">
+  <object id="62" name="potions" type="event" x="128" y="80" width="48" height="16">
    <properties>
     <property name="act10" value="translated_dialog potions_in_shop"/>
     <property name="cond10" value="is player_facing_tile"/>
     <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
-  <object id="64" name="capture devices" type="event" x="160" y="160" width="32" height="16">
+  <object id="64" name="capture devices" type="event" x="144" y="128" width="32" height="16">
    <properties>
     <property name="act10" value="translated_dialog capture_devices_in_shop"/>
     <property name="cond10" value="is player_facing_tile"/>
     <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
-  <object id="65" name="capture devices" type="event" x="48" y="128" width="16" height="16">
+  <object id="65" name="capture devices" type="event" x="32" y="96" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog cash_register"/>
     <property name="cond10" value="is player_facing_tile"/>
     <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
-  <object id="66" name="professor pls" type="event" x="160" y="192" width="16" height="16">
+  <object id="66" name="professor pls" type="event" x="144" y="160" width="16" height="16">
    <properties>
     <property name="act10" value="lock_controls"/>
     <property name="act11" value="wait 0.7"/>
-    <property name="act20" value="create_npc professor,4,7,,stand"/>
+    <property name="act20" value="create_npc professor,3,5,,stand"/>
     <property name="act30" value="npc_face professor,left"/>
     <property name="act40" value="translated_dialog professorexists"/>
     <property name="act50" value="wait 1"/>
     <property name="act60" value="translated_dialog professorexists1"/>
     <property name="act70" value="npc_face professor,down"/>
     <property name="act80" value="translated_dialog professorexists1.5"/>
-    <property name="act90" value="pathfind professor,7,8"/>
+    <property name="act90" value="pathfind professor,6,6"/>
     <property name="act91" value="npc_face professor,down"/>
     <property name="act92" value="set_variable proftalk1:true"/>
     <property name="cond1" value="not npc_exists professor"/>
@@ -121,9 +118,9 @@
     <property name="cond3" value="not variable_set proftalk2:yes"/>
    </properties>
   </object>
-  <object id="68" name="professor pls2" type="event" x="176" y="192" width="16" height="16">
+  <object id="68" name="professor pls2" type="event" x="160" y="160" width="16" height="16">
    <properties>
-    <property name="act10" value="pathfind player, 7,9"/>
+    <property name="act10" value="pathfind player, 6,7"/>
     <property name="act20" value="translated_dialog professorexists2"/>
     <property name="act21" value="add_item potion"/>
     <property name="act22" value="add_item potion"/>
@@ -134,7 +131,7 @@
     <property name="act60" value="translated_dialog professorexists3"/>
     <property name="act70" value="translated_dialog professorexists4"/>
     <property name="act80" value="npc_speed professor,7"/>
-    <property name="act90" value="pathfind professor,7,12"/>
+    <property name="act90" value="pathfind professor,6,10"/>
     <property name="act91" value="remove_npc professor"/>
     <property name="act92" value="set_variable proftalk2:yes"/>
     <property name="act93" value="npc_face player,left"/>


### PR DESCRIPTION
PR addresses the standardization of the scoops.

Same as for the centers, but here the situation is very good. Only three places weren't standard:
- spyder_paper_mart
- tuxe_mart_taba
- cotton_scoop
- leather_scoop

It was always about the empty tiles around the map and pointless collisions, as usual all the coordinates are updated.
Regarding **cotton_scoop** and **leather_scoop**, the map was ok, but it was missing the open_shop as well as the shopkeeper, so I added both, at least now people can shop there.

Checked all the events + pathfinding and everything went good, no problems.