### PR TITLE
bedroom and downstairs maps

### DIFF
--- a/mods/tuxemon/maps/player_house_bedroom.tmx
+++ b/mods/tuxemon/maps/player_house_bedroom.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="11" height="9" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="28">
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="9" height="7" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="28">
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
@@ -18,38 +18,34 @@
  <tileset firstgid="177" name="plants" tilewidth="16" tileheight="16" tilecount="2" columns="1">
   <image source="../gfx/tilesets/plants.png" width="16" height="32"/>
  </tileset>
- <tileset firstgid="182" name="stairs" tilewidth="16" tileheight="16" tilecount="24" columns="8">
+ <tileset firstgid="179" name="stairs" tilewidth="16" tileheight="16" tilecount="24" columns="8">
   <image source="../gfx/tilesets/stairs.png" width="128" height="48"/>
  </tileset>
- <layer id="1" name="Tile Layer 1" width="11" height="9">
+ <layer id="1" name="Tile Layer 1" width="9" height="7">
   <data encoding="base64" compression="zlib">
-   eAFjYCANMAGVE8IwEyWADEIYplYZyCCEYWr1gAx8GGQODOBTB5Kjh1qYWwjRAIbzCHI=
+   eAFjYmBgYCKAJYDyhLAyUA0hrAdUgw+D9OOTB8lRUw0AWQUIcg==
   </data>
  </layer>
- <layer id="2" name="Tile Layer 2" width="11" height="9">
+ <layer id="2" name="Tile Layer 2" width="9" height="7">
   <data encoding="base64" compression="zlib">
-   eAFjYKAeYEEzqhbIb4KKxQDpOCR5fiQ2iNkJxH1APAuIS4C4DIhBYB8Q7wezEMRUKJMTSHNBMTeQPgbEx4EYGxABCopCsRg2BUhi8kC2AhQrIonTmgkANRwJAw==
+   eAFjYMANWKBStUC6CcqOAdJxUDaI4oeyO4F0HxDPAuISIC4DYhDYDcR7wCwGhqlQmhNIc0ExN5A+DMRHgBgZiAA5olAshiyBxJYHshWgWBFJnFgmAHJvCPc=
   </data>
  </layer>
- <layer id="3" name="Tile Layer 3" width="11" height="9">
+ <layer id="3" name="Tile Layer 3" width="9" height="7">
   <data encoding="base64" compression="zlib">
-   eAFjYKAtWAo1fiGQXkSkVXVEqkNXdgIocBJdcAjxAdSlA/g=
+   eAFjYCAOLIUqWwikFxHQUkdAHl36KFDgGLogHfgAkVoD8g==
   </data>
  </layer>
- <layer id="4" name="Above player" width="11" height="9">
+ <layer id="4" name="Above player" width="9" height="7">
   <data encoding="base64" compression="zlib">
-   eAFjYKA/2AG0cicOa2vQxA8A+QfRxAaKu5EEizchqZUEsglhkHIA6AUFsw==
+   eAFjYCAfbAVq3YamvQaNvxfI34cmRmvuRiIs2ARUAwBkPgTG
   </data>
  </layer>
  <objectgroup color="#ff0000" id="5" name="Collision">
-  <object id="1" type="collision" x="16" y="32" width="144" height="16"/>
-  <object id="2" type="collision" x="160" y="48" width="16" height="80"/>
-  <object id="3" type="collision" x="16" y="128" width="144" height="16"/>
-  <object id="4" type="collision" x="0" y="48" width="16" height="80"/>
-  <object id="5" type="collision" x="16" y="48" width="16" height="32"/>
-  <object id="6" type="collision" x="112" y="64" width="32" height="16"/>
-  <object id="7" type="collision" x="112" y="48" width="16" height="16"/>
-  <object id="8" type="collision" x="144" y="112" width="16" height="16"/>
-  <object id="27" type="collision" x="48" y="48" width="16" height="16"/>
+  <object id="1" type="collision" x="0" y="16" width="144" height="16"/>
+  <object id="5" type="collision" x="0" y="32" width="16" height="32"/>
+  <object id="6" type="collision" x="96" y="48" width="32" height="16"/>
+  <object id="7" type="collision" x="96" y="32" width="16" height="16"/>
+  <object id="8" type="collision" x="128" y="96" width="16" height="16"/>
  </objectgroup>
 </map>

--- a/mods/tuxemon/maps/player_house_bedroom.yaml
+++ b/mods/tuxemon/maps/player_house_bedroom.yaml
@@ -1,25 +1,25 @@
 events:
   Go Downstairs:
     actions:
-    - transition_teleport player_house_downstairs.tmx,1,3,0.3
+    - transition_teleport player_house_downstairs.tmx,0,2,0.3
     - player_face down
     conditions:
     - is player_at
     height: 1
     width: 1
-    x: 8
-    y: 3
+    x: 7
+    y: 2
   Use Computer:
     actions:
     - change_state PCState
     conditions:
-    - is player_at 4,3
+    - is player_at 3,2
     - is player_facing up
     - is button_pressed K_RETURN
     height: 1
     width: 1
-    x: 4
-    y: 3
+    x: 3
+    y: 2
     type: "event"
   Give Money:
     actions:
@@ -29,14 +29,14 @@ events:
     - not variable_set xero_starting_money:yes
     height: 1
     width: 1
-    x: 2
-    y: 1
+    x: 1
+    y: 0
     type: "event"
   Player Spawn:
     height: 1
     width: 1
-    x: 4
-    y: 5
+    x: 3
+    y: 4
   Resting in Bed:
     actions:
     - screen_transition 1
@@ -44,14 +44,14 @@ events:
     - translated_dialog spyder_papertown_restinbed
     - set_monster_health ,
     - set_monster_status ,
-    - set_variable teleport_faint:player_house_bedroom.tmx 7 6
+    - set_variable teleport_faint:player_house_bedroom.tmx 6 5
     conditions:
     - is button_pressed K_RETURN
     - is player_facing_tile
     height: 2
     width: 1
-    x: 1
-    y: 3
+    x: 0
+    y: 2
     type: "event"
   Auto Healing Teleported:
     actions:

--- a/mods/tuxemon/maps/player_house_downstairs.tmx
+++ b/mods/tuxemon/maps/player_house_downstairs.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="11" height="9" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="45">
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="9" height="7" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="45">
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
@@ -21,44 +21,41 @@
  <tileset firstgid="201" name="kitchen" tilewidth="16" tileheight="16" tilecount="16" columns="4">
   <image source="../gfx/tilesets/kitchen.png" width="64" height="64"/>
  </tileset>
- <layer id="1" name="Tile Layer 1" width="11" height="9">
+ <layer id="1" name="Tile Layer 1" width="9" height="7">
   <data encoding="base64" compression="zlib">
-   eAFjYCANLAMqZySAYSauAzLECWCYWhUggxCGqdUHMvBhkDkwgE8dSI4eamFuIUQDACBNCck=
+   eAFbxsDAwEgArwPKixPAKkB5QlgfqAYfBunHJw+So6YaAHvACck=
   </data>
  </layer>
- <layer id="2" name="Tile Layer 2" width="11" height="9">
+ <layer id="2" name="Tile Layer 2" width="9" height="7">
   <data encoding="base64" compression="zlib">
-   eAGdizsOQEAURScRrW2gRYul0LMX0QhL8mdHziQzyct04yYn95P3lPJX4PEScdtAa34OfIMdVrNJ6yg9vPDABTecYBUTEkjtYHzCNVIZJYdCjIvIs8gluYJabDoOMDqbW0N3+NE/EGgOKg==
+   eAGFyksOQFAMheEmYmobmGKKpTBnL2IiLMmbHfmb3Jt05iRfetpURCTAXyIeGrTu8WBu2LG6m44OPV48uHDjRIwEKWwmFqXJkKPQxWXxhTmjRIUaNgPLaA+mh6b7+gHZpQ4q
   </data>
  </layer>
- <layer id="3" name="Tile Layer 3" width="11" height="9">
+ <layer id="3" name="Tile Layer 3" width="9" height="7">
   <data encoding="base64" compression="zlib">
-   eAFjYBj+YD8WL5YDxSqxiGMTmgYUBGFaAwB/VwLc
+   eAFjYBh8YD8WJ5UDxSqxiCMLTQNyQJhYAADRWALc
   </data>
  </layer>
- <layer id="4" name="Above player" width="11" height="9">
+ <layer id="4" name="Above player" width="9" height="7">
   <data encoding="base64" compression="zlib">
-   eAFjYBiaYPcAOzsRaH8SECcT4Q5JoBpkDNKCzAexQQAACw8Cqg==
+   eAFjYKAv2E0n6xKB9iQBcTIe+wCL+AHi
   </data>
  </layer>
  <objectgroup color="#ff0000" id="5" name="Collision">
-  <object id="1" type="collision" x="112" y="80" width="32" height="16"/>
-  <object id="2" type="collision" x="32" y="32" width="128" height="16"/>
-  <object id="3" type="collision" x="160" y="48" width="16" height="80"/>
-  <object id="4" type="collision" x="16" y="112" width="48" height="16"/>
-  <object id="5" type="collision" x="32" y="80" width="16" height="16"/>
-  <object id="6" type="collision" x="0" y="16" width="16" height="112"/>
-  <object id="7" type="collision" x="16" y="16" width="16" height="16"/>
-  <object id="8" type="collision" x="16" y="128" width="144" height="16"/>
+  <object id="1" type="collision" x="96" y="64" width="32" height="16"/>
+  <object id="2" type="collision" x="16" y="16" width="128" height="16"/>
+  <object id="4" type="collision" x="0" y="96" width="48" height="16"/>
+  <object id="5" type="collision" x="16" y="64" width="16" height="16"/>
+  <object id="7" type="collision" x="0" y="0" width="16" height="16"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="6" name="Events">
-  <object id="23" name="Play Music" type="event" x="0" y="0" width="16" height="16">
+  <object id="23" name="Play Music" type="event" x="16" y="0" width="16" height="16">
    <properties>
     <property name="act10" value="play_music music_home"/>
     <property name="cond10" value="not music_playing music_home"/>
    </properties>
   </object>
-  <object id="24" name="Watch TV" type="event" x="32" y="96" width="16" height="16">
+  <object id="24" name="Watch TV" type="event" x="16" y="80" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog spyder_papertown_tvwatch"/>
     <property name="cond10" value="is party_size greater_than,0"/>
@@ -68,35 +65,35 @@
     <property name="cond50" value="not variable_set scene:yes"/>
    </properties>
   </object>
-  <object id="25" name="Read Sign" type="event" x="32" y="48" width="16" height="16">
+  <object id="25" name="Read Sign" type="event" x="16" y="32" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog spyder_papertown_home"/>
-    <property name="cond10" value="is player_at 2,3"/>
+    <property name="cond10" value="is player_at 1,2"/>
     <property name="cond20" value="is player_facing up"/>
     <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
-  <object id="26" name="Go Upstairs" type="event" x="16" y="32" width="16" height="16">
+  <object id="26" name="Go Upstairs" type="event" x="0" y="16" width="16" height="16">
    <properties>
-    <property name="act10" value="transition_teleport player_house_bedroom.tmx,9,3,0.3"/>
+    <property name="act10" value="transition_teleport player_house_bedroom.tmx,8,2,0.3"/>
     <property name="act20" value="player_face down"/>
-    <property name="cond10" value="is player_at 1,2"/>
+    <property name="cond10" value="is player_at 0,1"/>
     <property name="cond20" value="not variable_set scene:yes"/>
    </properties>
   </object>
-  <object id="27" name="Go Outside" type="event" x="80" y="112" width="16" height="16">
+  <object id="27" name="Go Outside" type="event" x="64" y="96" width="16" height="16">
    <properties>
     <property name="act10" value="transition_teleport taba_town.tmx,43,46,0.3"/>
     <property name="act20" value="player_face down"/>
-    <property name="cond10" value="is player_at 5,7"/>
+    <property name="cond10" value="is player_at 4,6"/>
     <property name="cond20" value="is player_facing down"/>
     <property name="cond30" value="not variable_set scene:yes"/>
    </properties>
   </object>
-  <object id="28" name="Player Spawn" type="event" x="80" y="64" width="16" height="16"/>
-  <object id="29" name="create mom" type="event" x="16" y="48" width="16" height="16">
+  <object id="28" name="Player Spawn" type="event" x="64" y="48" width="16" height="16"/>
+  <object id="29" name="create mom" type="event" x="0" y="32" width="16" height="16">
    <properties>
-    <property name="act10" value="create_npc npc_mom,9,4,,stand"/>
+    <property name="act10" value="create_npc npc_mom,8,3,,stand"/>
     <property name="act20" value="npc_face npc_mom,left"/>
     <property name="act40" value="npc_wander npc_mom,3.0"/>
     <property name="cond10" value="not npc_exists npc_mom"/>
@@ -104,7 +101,7 @@
     <property name="cond30" value="not variable_set backhome:no"/>
    </properties>
   </object>
-  <object id="30" name="talkwithmom" type="event" x="144" y="80" width="16" height="16">
+  <object id="30" name="talkwithmom" type="event" x="128" y="64" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog firsts"/>
     <property name="behav10" value="talk npc_mom"/>
@@ -112,9 +109,9 @@
     <property name="cond30" value="not variable_set scene:yes"/>
    </properties>
   </object>
-  <object id="31" name="create mom2" type="event" x="0" y="96" width="16" height="16">
+  <object id="31" name="create mom2" type="event" x="80" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc npc_mom,1,6,,stand"/>
+    <property name="act1" value="create_npc npc_mom,0,5,,stand"/>
     <property name="act2" value="npc_face npc_mom,right"/>
     <property name="act3" value="wait 1"/>
     <property name="act4" value="translated_dialog ipausedit"/>
@@ -127,7 +124,7 @@
     <property name="cond3" value="not variable_set can_exit_town:yes"/>
    </properties>
   </object>
-  <object id="32" name="announcement" type="event" x="32" y="96" width="16" height="16">
+  <object id="32" name="announcement" type="event" x="16" y="80" width="16" height="16">
    <properties>
     <property name="act001" value="lock_controls"/>
     <property name="act1" value="translated_dialog announcement1"/>
@@ -145,7 +142,7 @@
     <property name="cond4" value="is player_facing up"/>
    </properties>
   </object>
-  <object id="35" name="postannouncement" type="event" x="32" y="96" width="16" height="16">
+  <object id="35" name="postannouncement" type="event" x="16" y="80" width="16" height="16">
    <properties>
     <property name="act1" value="wait 1"/>
     <property name="act2" value="npc_face npc_mom,right"/>
@@ -160,7 +157,7 @@
     <property name="cond1" value="is variable_set aeble_talk:2"/>
    </properties>
   </object>
-  <object id="36" name="ohnoes" type="event" x="32" y="96" width="16" height="16">
+  <object id="36" name="ohnoes" type="event" x="16" y="80" width="16" height="16">
    <properties>
     <property name="act1" value="wait 0.4"/>
     <property name="act2" value="translated_dialog depressedmom"/>
@@ -169,7 +166,7 @@
     <property name="cond3" value="not variable_set backhome:no"/>
    </properties>
   </object>
-  <object id="37" name="water" type="event" x="112" y="48" width="16" height="16">
+  <object id="37" name="water" type="event" x="96" y="32" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog waterwater"/>
     <property name="cond1" value="is player_at"/>
@@ -177,16 +174,16 @@
     <property name="cond3" value="is player_facing up"/>
    </properties>
   </object>
-  <object id="38" name="create mom3" type="event" x="16" y="80" width="16" height="16">
+  <object id="38" name="create mom3" type="event" x="0" y="64" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc npc_mom,1,6,,stand"/>
+    <property name="act1" value="create_npc npc_mom,0,5,,stand"/>
     <property name="act2" value="npc_face npc_mom,right"/>
     <property name="act3" value="wait 1"/>
     <property name="cond1" value="is variable_set backhome:no"/>
     <property name="cond2" value="not npc_exists npc_mom"/>
    </properties>
   </object>
-  <object id="39" name="Start the anthem" type="event" x="0" y="80" width="16" height="16">
+  <object id="39" name="Start the anthem" type="event" x="64" y="0" width="16" height="16">
    <properties>
     <property name="act2" value="translated_dialog theanthemishere"/>
     <property name="act3" value="npc_face npc_mom,up"/>
@@ -198,7 +195,7 @@
     <property name="cond3" value="not variable_set anthem_started:yes"/>
    </properties>
   </object>
-  <object id="40" name="timetochat" type="event" x="32" y="96" width="16" height="16">
+  <object id="40" name="timetochat" type="event" x="16" y="80" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog moreannouncement"/>
     <property name="act2" value="translated_dialog moreannouncement2"/>
@@ -209,7 +206,7 @@
     <property name="cond4" value="is variable_set announce_trials:1"/>
    </properties>
   </object>
-  <object id="41" name="new possibilities" type="event" x="0" y="64" width="16" height="16">
+  <object id="41" name="new possibilities" type="event" x="48" y="0" width="16" height="16">
    <properties>
     <property name="act10" value="lock_controls"/>
     <property name="act11" value="wait 1"/>
@@ -226,9 +223,9 @@
     <property name="cond1" value="is variable_set announce_trials:2"/>
    </properties>
   </object>
-  <object id="42" name="new possibilities2" type="event" x="0" y="64" width="16" height="16">
+  <object id="42" name="new possibilities2" type="event" x="32" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc professor,5,7,,stand"/>
+    <property name="act1" value="create_npc professor,4,6,,stand"/>
     <property name="act2" value="npc_face professor,left"/>
     <property name="act3" value="translated_dialog iknowyou"/>
     <property name="act4" value="translated_dialog ihaveyourmoney2"/>
@@ -240,7 +237,7 @@
     <property name="cond1" value="is variable_set announce_trials:3"/>
    </properties>
   </object>
-  <object id="44" name="new possibilities3" type="event" x="32" y="96" width="16" height="16">
+  <object id="44" name="new possibilities3" type="event" x="16" y="80" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog hebenice"/>
     <property name="act2" value="clear_variable scene"/>

--- a/mods/tuxemon/maps/spyder_bedroom.tmx
+++ b/mods/tuxemon/maps/spyder_bedroom.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="11" height="9" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="30">
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="9" height="7" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="30">
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
@@ -21,73 +21,70 @@
  <tileset firstgid="179" name="stairs" tilewidth="16" tileheight="16" tilecount="24" columns="8">
   <image source="../gfx/tilesets/stairs.png" width="128" height="48"/>
  </tileset>
- <layer id="1" name="Tile Layer 1" width="11" height="9">
+ <layer id="1" name="Tile Layer 1" width="9" height="7">
   <data encoding="base64" compression="zlib">
-   eAFjYCANMAGVE8IwEyWADEIYplYZyCCEYWr1gAx8GGQODOBTB5Kjh1qYWwjRAIbzCHI=
+   eAFjYmBgYCKAJYDyhLAyUA0hrAdUgw+D9OOTB8lRUw0AWQUIcg==
   </data>
  </layer>
- <layer id="2" name="Tile Layer 2" width="11" height="9">
+ <layer id="2" name="Tile Layer 2" width="9" height="7">
   <data encoding="base64" compression="zlib">
-   eAFjYKAeYEEzqhbIb4KKxQDpOCR5fiQ2iNkJxH1APAuIS4C4DIhBYDcQ7wGzEMRUKJMTSHNBMTeQPgzER4AYGxABCopCsRg2BUhi8kC2AhQrIonTmgkAKywI9w==
+   eAFjYMANWKBStUC6CcqOAdJxUDaI4oeyO4F0HxDPAuISIC4DYhDYDcR7wCwGhqlQmhNIc0ExN5A+DMRHgBgZiAA5olAshiyBxJYHshWgWBFJnFgmAHJvCPc=
   </data>
  </layer>
- <layer id="3" name="Tile Layer 3" width="11" height="9">
+ <layer id="3" name="Tile Layer 3" width="9" height="7">
   <data encoding="base64" compression="zlib">
-   eAFjYKAtWAo1fiGQXkSkVXVEqkNXdhQocAxdcAjxAdAxA/I=
+   eAFjYCAOLIUqWwikFxHQUkdAHl36KFDgGLogHfgAkVoD8g==
   </data>
  </layer>
- <layer id="4" name="Above player" width="11" height="9">
+ <layer id="4" name="Above player" width="9" height="7">
   <data encoding="base64" compression="zlib">
-   eAFjYKA/2Aq0chsOa2vQxPcC+fvQxAaKu5EEizchqZUEsglhkHIA3AUFpw==
+   eAFjYCAfbAVq3YamvQaNvxfI34cmRmvuRiIs2ARUAwBkPgTG
   </data>
  </layer>
  <objectgroup color="#ff0000" id="5" name="Collision">
-  <object id="1" type="collision" x="16" y="32" width="144" height="16"/>
-  <object id="2" type="collision" x="160" y="48" width="16" height="80"/>
-  <object id="3" type="collision" x="16" y="128" width="144" height="16"/>
-  <object id="4" type="collision" x="0" y="48" width="16" height="80"/>
-  <object id="5" type="collision" x="16" y="48" width="16" height="32"/>
-  <object id="6" type="collision" x="112" y="64" width="32" height="16"/>
-  <object id="7" type="collision" x="112" y="48" width="16" height="16"/>
-  <object id="8" type="collision" x="144" y="112" width="16" height="16"/>
+  <object id="1" type="collision" x="0" y="16" width="144" height="16"/>
+  <object id="5" type="collision" x="0" y="32" width="16" height="32"/>
+  <object id="6" type="collision" x="96" y="48" width="32" height="16"/>
+  <object id="7" type="collision" x="96" y="32" width="16" height="16"/>
+  <object id="8" type="collision" x="128" y="96" width="16" height="16"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="6" name="Events">
-  <object id="9" name="Go Downstairs" type="event" x="128" y="48" width="16" height="16">
+  <object id="9" name="Go Downstairs" type="event" x="112" y="32" width="16" height="16">
    <properties>
     <property name="act1" value="transition_teleport spyder_downstairs.tmx,0,2,0.3"/>
     <property name="act2" value="player_face down"/>
     <property name="cond1" value="is player_at"/>
    </properties>
   </object>
-  <object id="10" name="Use Computer" type="event" x="64" y="48" width="16" height="16">
+  <object id="10" name="Use Computer" type="event" x="48" y="32" width="16" height="16">
    <properties>
     <property name="act1" value="change_state PCState"/>
-    <property name="cond1" value="is player_at 4,3"/>
+    <property name="cond1" value="is player_at 3,2"/>
     <property name="cond2" value="is player_facing up"/>
     <property name="cond3" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
-  <object id="26" name="Player Spawn" type="event" x="64" y="80" width="16" height="16"/>
-  <object id="27" name="Resting in Bed" type="event" x="16" y="48" width="16" height="32">
+  <object id="26" name="Player Spawn" type="event" x="48" y="64" width="16" height="16"/>
+  <object id="27" name="Resting in Bed" type="event" x="0" y="32" width="16" height="32">
    <properties>
     <property name="act1" value="screen_transition 1"/>
     <property name="act2" value="wait 0.5"/>
     <property name="act3" value="translated_dialog spyder_papertown_restinbed"/>
     <property name="act4" value="set_monster_health ,"/>
     <property name="act5" value="set_monster_status ,"/>
-    <property name="act6" value="set_variable teleport_faint:spyder_bedroom.tmx 7 6"/>
+    <property name="act6" value="set_variable teleport_faint:spyder_bedroom.tmx 6 5"/>
     <property name="cond1" value="is button_pressed K_RETURN"/>
     <property name="cond2" value="is player_facing_tile"/>
    </properties>
   </object>
-  <object id="28" name="Give Starting Money" type="event" x="32" y="16" width="16" height="16">
+  <object id="28" name="Give Starting Money" type="event" x="16" y="0" width="16" height="16">
    <properties>
     <property name="act30" value="set_money player,1000000"/>
     <property name="act40" value="set_variable spyder_starting_money:yes"/>
     <property name="cond1" value="not variable_set spyder_starting_money:yes"/>
    </properties>
   </object>
-  <object id="29" name="Auto Healing Teleported" type="event" x="0" y="16" width="16" height="16">
+  <object id="29" name="Auto Healing Teleported" type="event" x="0" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_monster_health ,"/>
     <property name="act2" value="set_monster_status ,"/>

--- a/mods/tuxemon/maps/spyder_downstairs.tmx
+++ b/mods/tuxemon/maps/spyder_downstairs.tmx
@@ -51,7 +51,7 @@
  <objectgroup color="#ffff00" id="6" name="Events">
   <object id="37" name="Go Upstairs" type="event" x="0" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="transition_teleport spyder_bedroom.tmx,9,3,0.3"/>
+    <property name="act1" value="transition_teleport spyder_bedroom.tmx,8,2,0.3"/>
     <property name="act2" value="player_face down"/>
     <property name="cond1" value="is player_at 1,2"/>
    </properties>

--- a/mods/tuxemon/maps/taba_town.tmx
+++ b/mods/tuxemon/maps/taba_town.tmx
@@ -214,7 +214,7 @@
  <objectgroup color="#ffff00" id="7" name="Events">
   <object id="67" name="Go to Player's house" type="event" x="688" y="720" width="16" height="16">
    <properties>
-    <property name="act10" value="transition_teleport player_house_downstairs.tmx,5,7,0.5"/>
+    <property name="act10" value="transition_teleport player_house_downstairs.tmx,4,6,0.3"/>
     <property name="cond10" value="is player_at"/>
    </properties>
   </object>
@@ -664,7 +664,7 @@
     <property name="act12" value="unlock_controls"/>
     <property name="act15" value="set_variable comeinside:done"/>
     <property name="act17" value="player_resume"/>
-    <property name="act18" value="transition_teleport player_house_downstairs.tmx,5,7,0.5"/>
+    <property name="act18" value="transition_teleport player_house_downstairs.tmx,4,6,0.3"/>
     <property name="cond1" value="is variable_set comeinside:yes"/>
    </properties>
   </object>
@@ -905,7 +905,7 @@
     <property name="act30" value="npc_face player,up"/>
     <property name="act35" value="unlock_controls"/>
     <property name="act36" value="set_variable moveplayer:false"/>
-    <property name="act40" value="transition_teleport player_house_downstairs.tmx,5,7,0.5"/>
+    <property name="act40" value="transition_teleport player_house_downstairs.tmx,4,6,0.3"/>
     <property name="cond1" value="is variable_set moveplayer:true"/>
    </properties>
   </object>


### PR DESCRIPTION
PR addresses the bedroom and downstairs maps.

Same as for the centers and scoops, here there were three maps with wrong dimensions (collisions + empty tiles around):
- player_house_bedroom
- player_house_downstairs
- spyder_bedroom

These maps have been resized as well as all the coordinates have been updated.

These modifications obliged me to intervene on:
- player_house_bedroom.yaml (1 transition teleport + some player at)
- taba_town (update of coordinates - 3 transition teleport)
- spyder_downstairs (update of coordinates - 1 transition teleport)

Everything has been checked.