### PR TITLE
black + isort and fix

### DIFF
--- a/tuxemon/event/actions/add_item.py
+++ b/tuxemon/event/actions/add_item.py
@@ -22,7 +22,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import NamedTuple, Optional, Union, final
+from typing import Optional, Union, final
 
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction

--- a/tuxemon/event/actions/battles_print.py
+++ b/tuxemon/event/actions/battles_print.py
@@ -63,7 +63,9 @@ class BattlesAction(EventAction):
             output, battle_date = player.battle_history[self.character]
             diff_date = today - battle_date
             if self.result == output:
-                print(f"{self.result} against {self.character} {diff_date} days ago")
+                print(
+                    f"{self.result} against {self.character} {diff_date} days ago"
+                )
             else:
                 print(f"Never {self.result} against {self.character}")
         else:

--- a/tuxemon/event/actions/open_shop.py
+++ b/tuxemon/event/actions/open_shop.py
@@ -29,7 +29,7 @@ from tuxemon.event.eventaction import EventAction
 from tuxemon.item.economy import Economy
 from tuxemon.states.choice import ChoiceState
 from tuxemon.states.items import ShopBuyMenuState, ShopSellMenuState
-from tuxemon.tools import assert_never, open_choice_dialog
+from tuxemon.tools import assert_never
 
 
 @final

--- a/tuxemon/event/actions/spawn_monster.py
+++ b/tuxemon/event/actions/spawn_monster.py
@@ -27,13 +27,11 @@ import logging
 import random
 import uuid
 from dataclasses import dataclass
-from typing import Optional, final
+from typing import final
 
 from tuxemon import formula, monster
-from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.locale import T
-from tuxemon.npc import NPC
 from tuxemon.states.dialog import DialogState
 from tuxemon.states.world import WorldState
 from tuxemon.tools import open_dialog

--- a/tuxemon/event/actions/translated_dialog_choice.py
+++ b/tuxemon/event/actions/translated_dialog_choice.py
@@ -24,14 +24,12 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from functools import partial
-from typing import Callable, Sequence, Tuple, final
+from typing import final
 
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.locale import T, replace_text
-from tuxemon.session import Session
 from tuxemon.states.choice import ChoiceState
-from tuxemon.tools import open_choice_dialog
 
 logger = logging.getLogger(__name__)
 
@@ -77,9 +75,10 @@ class TranslatedDialogChoiceAction(EventAction):
             text = T.translate(val)
             var_menu.append((text, text, partial(set_variable, val)))
 
-        open_choice_dialog(
-            self.session,
-            menu=var_menu,
+        self.session.client.push_state(
+            ChoiceState(
+                menu=var_menu,
+            )
         )
 
     def update(self) -> None:
@@ -87,11 +86,3 @@ class TranslatedDialogChoiceAction(EventAction):
             self.session.client.get_state_by_name(ChoiceState)
         except ValueError:
             self.stop()
-
-    def open_choice_dialog(
-        self,
-        session: Session,
-        menu: Sequence[Tuple[str, str, Callable[[], None]]],
-    ) -> ChoiceState:
-        logger.info("Opening choice window")
-        return session.client.push_state(ChoiceState(menu=menu))

--- a/tuxemon/states/items/__init__.py
+++ b/tuxemon/states/items/__init__.py
@@ -40,10 +40,7 @@ from tuxemon.item.item import InventoryItem, Item
 from tuxemon.locale import T
 from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.menu import Menu
-from tuxemon.menu.quantity import (
-    QuantityAndCostMenu,
-    QuantityAndPriceMenu,
-)
+from tuxemon.menu.quantity import QuantityAndCostMenu, QuantityAndPriceMenu
 from tuxemon.monster import Monster
 from tuxemon.session import local_session
 from tuxemon.sprite import Sprite

--- a/tuxemon/states/world/world_menus.py
+++ b/tuxemon/states/world/world_menus.py
@@ -41,7 +41,7 @@ from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.session import local_session
 from tuxemon.states.choice import ChoiceState
-from tuxemon.tools import open_choice_dialog, open_dialog
+from tuxemon.tools import open_dialog
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Run black and isort, fixes for small things

The other fix is: translated_dialog_choice

When opening a choice (action) there was this warning in the terminal:
```
/home/robespierre/Tuxemon/tuxemon/state.py:577: DeprecationWarning: Calling push_state with Type[State] is deprecated, use an instantiated State instead
  warnings.warn(
```
The PR addresses this.