### PR TITLE
fix shop

### DIFF
--- a/tuxemon/event/actions/open_shop.py
+++ b/tuxemon/event/actions/open_shop.py
@@ -29,7 +29,7 @@ from tuxemon.event.eventaction import EventAction
 from tuxemon.item.economy import Economy
 from tuxemon.states.choice import ChoiceState
 from tuxemon.states.items import ShopBuyMenuState, ShopSellMenuState
-from tuxemon.tools import assert_never, open_choice_dialog
+from tuxemon.tools import assert_never
 
 
 @final
@@ -74,7 +74,7 @@ class OpenShopAction(EventAction):
         def push_sell_menu():
             self.session.client.push_state(
                 ShopSellMenuState(
-                    buyer=None,
+                    buyer=npc,
                     seller=self.session.player,
                     economy=economy,
                 )

--- a/tuxemon/states/items/__init__.py
+++ b/tuxemon/states/items/__init__.py
@@ -40,10 +40,7 @@ from tuxemon.item.item import InventoryItem, Item
 from tuxemon.locale import T
 from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.menu import Menu
-from tuxemon.menu.quantity import (
-    QuantityAndCostMenu,
-    QuantityAndPriceMenu,
-)
+from tuxemon.menu.quantity import QuantityAndCostMenu, QuantityAndPriceMenu
 from tuxemon.monster import Monster
 from tuxemon.session import local_session
 from tuxemon.sprite import Sprite
@@ -317,11 +314,18 @@ class ShopMenuState(Menu[Item]):
 
     def initialize_items(self) -> Generator[MenuItem[Item], None, None]:
         """Get all player inventory items and add them to menu."""
-        inventory = [
-            item
-            for item in self.seller.inventory.values()
-            if not (self.seller.isplayer and item["item"].sort == "quest")
-        ]
+        inventory = []
+        # when the player buys
+        if self.buyer.isplayer:
+            inventory = [item for item in self.seller.inventory.values()]
+        # when the player sells
+        if self.seller.isplayer:
+            inventory = [
+                item
+                for item in self.seller.inventory.values()
+                for t in self.economy.items
+                if item["item"].slug == t.item_name
+            ]
 
         # required because the max() below will fail if inv empty
         if not inventory:


### PR DESCRIPTION
PR addresses an issue with the shop.

The issue is related to the selling process.

Precisely, you can have some items inside your bag and these are going to pop-up inside the shop screen (until now only the items labelled as quest were excluded). Now, if the item isn't inside the economy file (in the Xero scenario was reg_papers and allie address) and you try to sell, well, it results in a crash.

Since we can't have all the shops with all the items listed with all the prices and costs (neither filter out by hardcoding every label), here the fix for the issue.

With this fix, you can sell in the shop only the items that are in the economy (so listed with price and cost), the others aren't going to appear anymore. 

before the fix (sell menu)
![Screenshot from 2022-12-27 08-41-26](https://user-images.githubusercontent.com/64643719/209633178-8211645b-3081-4a2c-a039-5b31cc02cec5.png)
after the fix (sell menu)
![Screenshot from 2022-12-27 08-58-22](https://user-images.githubusercontent.com/64643719/209633181-618e0cfb-cbc0-44db-ba57-fd8a7e31e1a0.png)
