### PR TITLE
open choice dialog

### DIFF
--- a/tuxemon/states/items/__init__.py
+++ b/tuxemon/states/items/__init__.py
@@ -207,20 +207,22 @@ class ItemMenuState(Menu[Item]):
 
         def open_choice_menu() -> None:
             # open the menu for use/cancel
-            menu = self.client.push_state(Menu())
-            menu.shrink_to_items = True
-
-            menu_items_map = (
-                ("item_confirm_use", confirm),
-                ("item_confirm_cancel", cancel),
+            tools.open_choice_dialog(
+                local_session,
+                menu=(
+                    (
+                        "use",
+                        T.translate("item_confirm_use").upper(),
+                        confirm,
+                    ),
+                    (
+                        "cancel",
+                        T.translate("item_confirm_cancel").upper(),
+                        cancel,
+                    ),
+                ),
+                escape_key_exits=True,
             )
-
-            # add our options to the menu
-            for key, callback in menu_items_map:
-                label = T.translate(key).upper()
-                image = self.shadow_text(label)
-                item = MenuItem(image, label, None, callback)
-                menu.add(item)
 
         open_choice_menu()
 

--- a/tuxemon/states/persistance/save_menu.py
+++ b/tuxemon/states/persistance/save_menu.py
@@ -36,10 +36,10 @@ from typing import Optional
 import pygame
 from pygame import Rect
 
-from tuxemon import prepare, save
+from tuxemon import prepare, save, tools
 from tuxemon.locale import T
 from tuxemon.menu.interface import MenuItem
-from tuxemon.menu.menu import Menu, PopUpMenu
+from tuxemon.menu.menu import PopUpMenu
 from tuxemon.save import get_save_path
 from tuxemon.session import local_session
 from tuxemon.tools import open_dialog
@@ -193,25 +193,22 @@ class SaveMenuState(PopUpMenu[None]):
 
         def ask_confirmation() -> None:
             # open menu to confirm the save
-            menu = self.client.push_state(Menu())
-            menu.shrink_to_items = True
-
-            # add choices
-            yes = MenuItem(
-                self.shadow_text(T.translate("save_overwrite")),
-                None,
-                None,
-                positive_answer,
+            tools.open_choice_dialog(
+                local_session,
+                menu=(
+                    (
+                        "overwrite",
+                        T.translate("save_overwrite"),
+                        positive_answer,
+                    ),
+                    (
+                        "keep",
+                        T.translate("save_keep"),
+                        negative_answer,
+                    ),
+                ),
+                escape_key_exits=True,
             )
-            no = MenuItem(
-                self.shadow_text(T.translate("save_keep")),
-                None,
-                None,
-                negative_answer,
-            )
-
-            menu.add(yes)
-            menu.add(no)
 
         save_data = save.load(self.selected_index + 1)
         if save_data:

--- a/tuxemon/tools.py
+++ b/tuxemon/tools.py
@@ -231,9 +231,10 @@ def open_choice_dialog(
     from tuxemon.states.choice import ChoiceState
 
     return session.client.push_state(
-        ChoiceState,
-        menu=menu,
-        escape_key_exits=escape_key_exits,
+        ChoiceState(
+            menu=menu,
+            escape_key_exits=escape_key_exits,
+        )
     )
 
 


### PR DESCRIPTION
PR addresses **open_choice_dialog** in tools.py as well as the **open_choice_menu** in init (items) and save_menu.py

Everything started because I was testing a bunch of items for an idea.

I realized that **open_choice_dialog** in tools.py triggered:
```
/home/robespierre/Tuxemon/tuxemon/state.py:577: DeprecationWarning: Calling push_state with Type[State] is deprecated, use an instantiated State instead
  warnings.warn(
```
Again. The reason? It was missing a () after ChoiceState, now the issue above is solved.

Here I got curious and I looked inside the init (items), I noticed that **open_choice_menu** was created by "pushing" the Menu, I removed it and updated with the tools.open_choice_dialog (tools was already imported in the file). Identical output. No issues.

I looked for other places where there was **menu = self.client.push_state(Menu())** and there was one in **save_menu.py**, here I removed the pushing and implemented the open_choice_dialog by importing tools. Identical output. No issues.

Tested, it works
Black + isort, done