### PR TITLE
clean up ChoiceState not accessed elements

### DIFF
--- a/tuxemon/states/choice/__init__.py
+++ b/tuxemon/states/choice/__init__.py
@@ -1,16 +1,9 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Generator, Optional, Sequence, Tuple
-
-import pygame
-import pygame_menu
+from typing import Any, Callable, Sequence, Tuple
 
 from tuxemon.animation import Animation
-from tuxemon.menu.events import playerinput_to_event
-from tuxemon.menu.interface import MenuItem
-from tuxemon.menu.menu import PopUpMenu, PygameMenuState
-from tuxemon.menu.theme import get_theme
-from tuxemon.platform.events import PlayerInput
+from tuxemon.menu.menu import PygameMenuState
 
 ChoiceMenuGameObj = Callable[[], None]
 


### PR DESCRIPTION
PR addresses the cleaning up of the **choice init** from "not accessed". 

Everything started with the DeprecationWarning that I posted in other PRs.
I wanted to check the ChoiceState out of curiosity and I found the file with many not accessed elements.
I took the chance to clean up.

Tested, everything works without issues.
Black + isort