### PR TITLE
fix actions and issue

### DIFF
--- a/tuxemon/event/actions/add_item.py
+++ b/tuxemon/event/actions/add_item.py
@@ -51,7 +51,7 @@ class AddItemAction(EventAction):
     name = "add_item"
     item_slug: str
     quantity: Union[int, None] = None
-    trainer_slug: str = None
+    trainer_slug: Union[str, None] = None
 
     def start(self) -> None:
         trainer: Optional[NPC]

--- a/tuxemon/event/actions/spawn_monster.py
+++ b/tuxemon/event/actions/spawn_monster.py
@@ -27,7 +27,7 @@ import logging
 import random
 import uuid
 from dataclasses import dataclass
-from typing import final
+from typing import Union, final
 
 from tuxemon import formula, monster
 from tuxemon.event.eventaction import EventAction
@@ -64,7 +64,7 @@ class SpawnMonsterAction(EventAction):
     """
 
     name = "spawn_monster"
-    npc_slug: str
+    npc_slug: Union[str, None] = None
 
     def start(self) -> None:
         world = self.session.client.get_state_by_name(WorldState)

--- a/tuxemon/tools.py
+++ b/tuxemon/tools.py
@@ -60,7 +60,7 @@ from typing import (
 
 from tuxemon import prepare
 from tuxemon.compat import ReadOnlyRect
-from tuxemon.locale import T
+from tuxemon.locale import T, replace_text
 from tuxemon.math import Vector2
 
 if TYPE_CHECKING:
@@ -398,7 +398,7 @@ def show_item_result_as_dialog(
     msg_type = "use_success" if result["success"] else "use_failure"
     template = getattr(item, msg_type)
     if template:
-        message = T.translate(template)
+        message = T.translate(replace_text(session, template))
         open_dialog(session, [message])
 
 


### PR DESCRIPTION
PR fixes a couple of errors inside **add_item.py** and **spawn_monster.py** after the merging of #1385  

PR addresses an issue related to **show_item_result_as_dialog** in tools.py. Noticed while testing some items.
Let's say someone creates a specific msgid for a particular item and inside the msgid there is ${{name}} or some other variable.

Eg msgid = ${{name}} cannot access (use_failure)

Before it prints: ${{name}} cannot access.
After it prints: Red cannot access.

Tested, black and isort as usual.