### PR TITLE
flatpak-builder v5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
       run: cat org.tuxemon.Tuxemon/org.tuxemon.Tuxemon.yaml
 
     - name: Build package
-      uses: flatpak/flatpak-github-actions/flatpak-builder@v4
+      uses: flatpak/flatpak-github-actions/flatpak-builder@v5
       with:
         bundle: Tuxemon.flatpak
         manifest-path: org.tuxemon.Tuxemon/org.tuxemon.Tuxemon.yaml


### PR DESCRIPTION
flatpak-builder v5 has been released (https://github.com/flatpak/flatpak-github-actions/releases/tag/v5)

This will solve the following warning:

Flatpak
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: flatpak/flatpak-github-actions/flatpak-builder@v4