### PR TITLE
PCState: drop monster

### DIFF
--- a/tuxemon/states/pc/__init__.py
+++ b/tuxemon/states/pc/__init__.py
@@ -41,7 +41,6 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
-    no_type_check,
 )
 
 import pygame_menu
@@ -55,7 +54,7 @@ from tuxemon.menu.menu import Menu, PopUpMenu, PygameMenuState
 from tuxemon.menu.theme import get_theme
 from tuxemon.session import local_session
 from tuxemon.states.monster import MonsterMenuState
-from tuxemon.tools import open_dialog, transform_resource_filename
+from tuxemon.tools import open_dialog
 
 logger = logging.getLogger(__name__)
 
@@ -101,7 +100,7 @@ class PCState(PopUpMenu[MenuGameObj]):
         else:
             storage_callback = change_state("MonsterBoxChooseStorageState")
 
-        if not local_session.player.monsters:
+        if len(local_session.player.monsters) <= 1:
             dropoff_callback = partial(
                 open_dialog,
                 local_session,


### PR DESCRIPTION
PR addresses an issue with the PC State (drop monster inside the kennel).

Until now it was possible to drop all the monsters inside the kennel and moving freely in the world (without a single monster).

Fixed, if the player has 1 monster, then it's not possible to drop it inside the PC.
So at least 2 monsters to access the dropping function.

Since I was inside the file, I remove the elements not accessed:
- transform_resource_filename was wrong, because graphics.transform_resource_filename (not tools);
- no_type_check not used;

black, isort, tested