### PR TITLE
validators (translations)

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -99,6 +99,12 @@ msgstr "Rhincus Fossil"
 msgid "rhincus_fossil_description"
 msgstr ""
 
+msgid "aardant"
+msgstr "Aardant"
+
+msgid "aardant_description"
+msgstr ""
+
 # Boosters (items)
 msgid "greenwash_badge"
 msgstr "Badge: Greenwash"
@@ -773,6 +779,9 @@ msgstr "Mudslide"
 
 msgid "one_two"
 msgstr "One-Two"
+
+msgid "overfeed"
+msgstr "Overfeed"
 
 msgid "overgrowth"
 msgstr "Overgrowth"

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -196,6 +196,12 @@ class ItemModel(BaseModel):
             return v
         raise ValueError(f"no translation exists with msgid: {v}")
 
+    @validator("slug")
+    def translation_exists_item(cls, v):
+        if has.translation(v):
+            return v
+        raise ValueError(f"no translation exists with msgid: {v}")
+
     # Validate resources that should exist
     @validator("sprite")
     def file_exists(cls, v):
@@ -476,6 +482,12 @@ class TechniqueModel(BaseModel):
         # None is ok here
         if not v:
             return v
+        if has.translation(v):
+            return v
+        raise ValueError(f"no translation exists with msgid: {v}")
+
+    @validator("slug")
+    def translation_exists_tech(cls, v):
         if has.translation(v):
             return v
         raise ValueError(f"no translation exists with msgid: {v}")


### PR DESCRIPTION
PR addresses the additions of some validators for translations.

Since the db is growing (items, techniques, and monsters), it was necessary a validator to see if we missed something.

I thought about one for descriptions, I tried, but it flags me the all the descriptions empty (mgstr ""), so I removed it, but it helped us to understand that each item has _description msgid. By the way missing descriptions are here #1517 .

I thought about one for NPCs, but it would be pointless.

black + isort + tested