### PR TITLE
leap year (true/false)

### DIFF
--- a/tuxemon/player.py
+++ b/tuxemon/player.py
@@ -56,8 +56,17 @@ class Player(NPC):
         %j - Day number of year 001-366
         """
         var = self.game_variables
-        var["hour"] = int(dt.datetime.now().strftime("%H"))
-        var["day_of_year"] = int(dt.datetime.now().strftime("%j"))
+        var["hour"] = dt.datetime.now().strftime("%H")
+        var["day_of_year"] = dt.datetime.now().strftime("%-j")
+        var["year"] = dt.datetime.now().strftime("%Y")
+
+        # Leap year
+        if (int(var["year"]) % 400 == 0) and (int(var["year"]) % 100 == 0):
+            var["leap_year"] = "true"
+        elif (int(var["year"]) % 4 == 0) and (int(var["year"]) % 100 != 0):
+            var["leap_year"] = "true"
+        else:
+            var["leap_year"] = "false"
 
         # Day and night basic cycle (12h cycle)
         if int(var["hour"]) < 6:


### PR DESCRIPTION
PR addresses the addition of leap year (game_variable["leap_year"])

until now we had day_of_year, but it was difficult to set precise anniversary or birthday (like Mom player birthday, city anniversaries, festivities in game, etc) if it was after February. Are you interested @Sanglorian and @Qiangong2 ? Let me know.

Examples for using it, let say Mom's birthday is on the 25th May (https://en.wikipedia.org/wiki/May_25), 145th day of the year (146th in leap years)
```
<property name="cond1" value="is variable_set day_of_year:146"/>
<property name="cond2" value="is variable_set leap_year:true"/>
or
<property name="cond1" value="is variable_set day_of_year:145"/>
<property name="cond2" value="is variable_set leap_year:false"/>

moreover day_of_year until 59 (28th February), it doesn't need (leap_year) cond:
<property name="cond1" value="is variable_set day_of_year:59"/>
```
_(removed the two ints for 2 reasons: (1) variable_set is optional[str] and (2) these are marked as ints in the following operations. Tested. Everything works without issues.)_