### PR TITLE
fix stats

### DIFF
--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -457,10 +457,7 @@ class Monster:
         when called during a level up.
 
         """
-        if self.level < 10:
-            level = 10
-        else:
-            level = self.level
+        level = self.level
 
         multiplier = level + 7
         shape = SHAPES[self.shape]


### PR DESCRIPTION
PR addresses an issue (bug) related to set stats. Thanks @Qiangong2 for the issue #1558

There was this inside monster.py (set_stats()):
```
        if self.level < 10:
            level = 10
        else:
            level = self.level
```
So when someone fights against a Cataspike lv 5, the stats were:

Stats order: armour, dodge, hp, melee, ranged, speed
`119 85 119 68 136 85`
instead of 
`84 60 84 48 96 60`

It was like to fight against a Cataspike lv10