### PR TITLE
fix bug wild evolution

### DIFF
--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -418,6 +418,9 @@ class CombatState(CombatAnimations):
                     )
                 )
             else:
+                # remove monsters still around
+                for mon in self.ai_players:
+                    mon.monsters.pop()
                 var["battle_last_result"] = OutputBattle.ran
                 self.alert(T.translate("combat_player_run"))
 


### PR DESCRIPTION
PR addresses a bug I noticed while investigating for #1558 

When running away from a wild monster (Cataspike lv20), it appeared:
![Screenshot from 2023-01-13 09-21-57](https://user-images.githubusercontent.com/64643719/212296593-4913aad0-0666-4427-8b64-9942d121d6df.png)

So I added a small for and pop related to the ai.players (combat.py) inside the section for wild encounters (no trainers).
The problem was related only to wild encounters. 

pop + isort + tested (no pop evolution anymore)