### PR TITLE
black + fix maps

### DIFF
--- a/mods/tuxemon/maps/dryadsgrove.tmx
+++ b/mods/tuxemon/maps/dryadsgrove.tmx
@@ -85,7 +85,7 @@
   <object id="30" type="collision" x="496" y="128" width="48" height="32"/>
   <object id="31" type="collision" x="496" y="160" width="32" height="16"/>
   <object id="32" type="collision" x="528" y="272" width="64" height="16"/>
-  <object id="33" x="528" y="272" height="16"/>
+  <object id="33" type="collision" x="528" y="272" height="16"/>
   <object id="34" type="collision" x="576" y="144" width="16" height="64"/>
   <object id="35" type="collision" x="576" y="240" width="16" height="16"/>
  </objectgroup>

--- a/mods/tuxemon/maps/route2.tmx
+++ b/mods/tuxemon/maps/route2.tmx
@@ -203,7 +203,7 @@
     <property name="cond20" value="is player_facing up"/>
    </properties>
   </object>
-  <object id="82" name="Sign: Route 2" x="592" y="128" width="16" height="16">
+  <object id="82" name="Sign: Route 2" type="event" x="592" y="128" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_route2_routesign"/>
     <property name="act2" value="translated_dialog route2_to_cotton"/>

--- a/mods/tuxemon/maps/spyder_flower_city.tmx
+++ b/mods/tuxemon/maps/spyder_flower_city.tmx
@@ -138,7 +138,7 @@
   <object id="386" type="collision" x="480" y="96" width="32" height="224"/>
   <object id="387" type="collision" x="512" y="96" width="128" height="64"/>
   <object id="388" type="collision" x="576" y="160" width="64" height="96"/>
-  <object id="389" x="576" y="256" width="16" height="16"/>
+  <object id="389" type="collision" x="576" y="256" width="16" height="16"/>
   <object id="390" type="collision" x="560" y="272" width="32" height="16"/>
   <object id="391" type="collision" x="512" y="272" width="32" height="16"/>
   <object id="392" type="collision" x="544" y="256" width="16" height="16"/>

--- a/mods/tuxemon/maps/spyder_paper_town.tmx
+++ b/mods/tuxemon/maps/spyder_paper_town.tmx
@@ -131,7 +131,7 @@
   <object id="391" type="collision" x="0" y="16" width="96" height="80"/>
   <object id="392" type="collision" x="96" y="32" width="16" height="32"/>
   <object id="393" type="collision" x="0" y="96" width="64" height="32"/>
-  <object id="394" x="0" y="128" width="32" height="64"/>
+  <object id="394" type="collision" x="0" y="128" width="32" height="64"/>
   <object id="395" type="collision" x="96" y="160" width="96" height="48"/>
   <object id="397" type="collision" x="64" y="240" width="16" height="16"/>
   <object id="399" type="collision" x="0" y="304" width="192" height="16"/>

--- a/tuxemon/map_loader.py
+++ b/tuxemon/map_loader.py
@@ -209,7 +209,9 @@ class TMXMapLoader:
                 if colliders is not None:
                     for obj in colliders:
                         if obj.type is None:
-                            obj_type = getattr(obj, "class")  # obj.class is invalid syntax
+                            obj_type = getattr(
+                                obj, "class"
+                            )  # obj.class is invalid syntax
                         else:
                             obj_type = obj.type
                         if obj_type and obj_type.lower().startswith(


### PR DESCRIPTION
It follows #1556 because forgot to do black + isort;

Fix a couple of maps because after #1556 **spyder_paper_town** was crashing.
```
  File "/home/robespierre/.local/lib/python3.10/site-packages/pytmx/pytmx.py", line 417, in __getattr__
    raise AttributeError("Element has no property {0}".format(item))
AttributeError: Element has no property class
```
The reason was this line:
`  <object id="394" x="0" y="128" width="32" height="64"/>`
caused crash, because it was missing type collision
`  <object id="394" type="collision" x="0" y="128" width="32" height="64"/>`
(I guess old Tiled setting)

Missing type, well, the system tried to call class > crash.
I did a fast check and I found only another place where it was missing a type:collision (fixed). 