### PR TITLE
synch Professor PC

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -1348,6 +1348,9 @@ msgstr "Load"
 msgid "menu_monster"
 msgstr "Tuxemon"
 
+msgid "menu_professor_pc"
+msgstr "Professor PC"
+
 msgid "menu_storage"
 msgstr "Pick Up Tuxemon"
 
@@ -1425,6 +1428,12 @@ msgstr "shelter"
 
 msgid "kennel_label"
 msgstr "{box} ({qty})"
+
+msgid "synchronize_pc1"
+msgstr "Do you want to synchronize your Tuxepedia with the Professor's PC?"
+
+msgid "synchronize_pc2"
+msgstr "Tuxemon: seen {seen} - caught {caught} - Total: {all} Tuxemon. Progress:{value}%!\n Professor: Keep me posted!"
 
 # Default mod names on selection menu
 msgid "xero_campaign"

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -199,6 +199,12 @@ def simple_stuck(monster: Monster) -> None:
             move.power = move.default_power * 0.5
 
 
+def synch(player: NPC, value: int, total: int) -> float:
+    percent = round((value / total) * 100, 1)
+    player.game_variables["tuxepedia_progress"] = str(round(percent))
+    return percent
+
+
 def escape(level_user: int, level_target: int, attempts: int) -> bool:
     escape = 0.4 + (0.15 * (attempts + level_user - level_target))
     if random.random() <= escape:


### PR DESCRIPTION
PR addresses the addition to the Professor PC (PC State).

@Sanglorian @Qiangong2 

Months ago we added SeenStatus, that saves the names of the monsters seen / caught, but it wasn't possible to access the data.

It gives back the status of monsters seen/caught related to the total. It gives the percentage of progression (eg. 7.8%), interesting stuff is that there will be a variable called tuxepedia_progress with the rounded value (if 7.8 > 8), this can be used to trigger new conversations with the professor or anyone else involved. Some examples:
```
<property name="cond1" value="is variable_is tuxepedia_progress,<=,10"/>
<property name="cond1" value="is variable_is tuxepedia_progress,>=,11"/>
<property name="cond1" value="is variable_is tuxepedia_progress,>=,21"/>
```
It's an archive because there is a choice:
- do you prefer the number for tuxepedia_progress? 
- do you prefer a string for tuxepedia_progress? (eg tuxepedia_progress = "novice, etc", which will be on the wiki too)

Let me know

![Screenshot from 2023-01-17 09-38-08](https://user-images.githubusercontent.com/64643719/212850188-fbf0d6a5-5b4c-422e-8f5c-9eabd6f76e53.png)
![Screenshot from 2023-01-17 09-38-24](https://user-images.githubusercontent.com/64643719/212850181-829308d9-0f2f-42c9-9e02-f0d6e765e7c3.png)
![Screenshot from 2023-01-17 09-38-59](https://user-images.githubusercontent.com/64643719/212850166-a8b4aff6-83af-4165-a0b2-015ce765e4b2.png)


