### PR TITLE
max moves (AI)

### DIFF
--- a/tuxemon/ai.py
+++ b/tuxemon/ai.py
@@ -112,7 +112,8 @@ class RandomAI(AI):
         """
         # tracks next_use NPC ai
         filter_moves = []
-        for mov in monster.moves:
+        # it choses among the last 4 moves
+        for mov in monster.moves[-monster.max_moves :]:
             if mov.next_use <= 0:
                 filter_moves.append(mov)
         if not filter_moves:

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -161,6 +161,7 @@ SHAPES = {
 }
 
 MAX_LEVEL = 999
+MAX_MOVES = 4
 MISSING_IMAGE = "gfx/sprites/battle/missing.png"
 
 
@@ -221,6 +222,7 @@ class Monster:
 
         self.status: List[Technique] = []
 
+        self.max_moves = MAX_MOVES
         self.txmn_id = 0
         self.capture = 0
         self.height = 0.0


### PR DESCRIPTION
Part of #1496

I needed the MAX_MOVES value for setting up a limit for NPC/AI moves, because right now a monster (wild or trainer) lv 50 can use all the 12 techniques.

Eg.
before: Aardard lv 33 can use **tonguespear**, **hibernate**, **stampede**, **feint**, **sand_spray**, **mudslide**
after: Aardard lv 33 can use **stampede**, **feint**, **sand_spray**, **mudslide** (the last 4)

Created self.max_moves so I can send around the value, unable to import MAX_MOVES because if I move '' from tuxemon.monster import Monster'' outside (if type_checking), then it triggers: _ImportError: cannot import name 'MAX_MOVES' from partially initialized module 'tuxemon.monster' (most likely due to a circular import)_

black + isort + tested + no issue with monster with less than 4 techniques  