### PR TITLE
fix status (miss)

### DIFF
--- a/mods/tuxemon/db/technique/all_in.json
+++ b/mods/tuxemon/db/technique/all_in.json
@@ -12,7 +12,7 @@
   "is_area": false,
   "is_fast": false,
   "potency": 0.75,
-  "power": 3.0,
+  "power": 3,
   "range": "touch",
   "recharge": 3,
   "sfx": "sfx_blaster",

--- a/mods/tuxemon/db/technique/amnesia.json
+++ b/mods/tuxemon/db/technique/amnesia.json
@@ -3,6 +3,7 @@
   "accuracy": 0.75,
   "animation": "sparks_gold_alt",
   "effects": [
+    "damage 100",
     "exhausted target",
     "exhausted user"
   ],

--- a/mods/tuxemon/db/technique/battery_discharge.json
+++ b/mods/tuxemon/db/technique/battery_discharge.json
@@ -6,7 +6,7 @@
     "damage 100"
   ],
   "flip_axes": "",
-  "healing_power": 4.0,
+  "healing_power": 4,
   "icon": "",
   "is_area": false,
   "is_fast": false,

--- a/mods/tuxemon/db/technique/boulder.json
+++ b/mods/tuxemon/db/technique/boulder.json
@@ -3,6 +3,7 @@
   "accuracy": 1,
   "animation": "shield_rock",
   "effects": [
+    "enhance 100",
     "hardshell user"
   ],
   "flip_axes": "",
@@ -10,8 +11,8 @@
   "icon": "",
   "is_area": false,
   "is_fast": false,
-  "potency": null,
-  "power": 1.0,
+  "potency": 1,
+  "power": 1,
   "range": "special",
   "recharge": 2,
   "sfx": "sfx_crumble2",

--- a/mods/tuxemon/db/technique/clamp_on.json
+++ b/mods/tuxemon/db/technique/clamp_on.json
@@ -3,6 +3,7 @@
   "accuracy": 1,
   "animation": "bite",
   "effects": [
+    "enhance 100",
     "grabbed target"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/electrical_storm.json
+++ b/mods/tuxemon/db/technique/electrical_storm.json
@@ -11,7 +11,7 @@
   "is_area": true,
   "is_fast": false,
   "potency": null,
-  "power": 3.0,
+  "power": 3,
   "range": "ranged",
   "recharge": 2,
   "sfx": "sfx_lightning2",

--- a/mods/tuxemon/db/technique/energy_field.json
+++ b/mods/tuxemon/db/technique/energy_field.json
@@ -3,6 +3,7 @@
   "accuracy": 1,
   "animation": "screen",
   "effects": [
+    "enhance 100",
     "exhausted target"
   ],
   "flip_axes": "x",

--- a/mods/tuxemon/db/technique/eyebite.json
+++ b/mods/tuxemon/db/technique/eyebite.json
@@ -3,6 +3,7 @@
   "accuracy": 1,
   "animation": "bite",
   "effects": [
+    "enhance 100",
     "exhausted target"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/frostbite.json
+++ b/mods/tuxemon/db/technique/frostbite.json
@@ -12,7 +12,7 @@
   "is_area": false,
   "is_fast": false,
   "potency": 0.2,
-  "power": 3.0,
+  "power": 3,
   "range": "reach",
   "recharge": 3,
   "sfx": "sfx_blaster",

--- a/mods/tuxemon/db/technique/fume.json
+++ b/mods/tuxemon/db/technique/fume.json
@@ -3,6 +3,7 @@
   "accuracy": 1,
   "animation": "buff_rage",
   "effects": [
+    "enhance 100",
     "enraged user"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/give_all.json
+++ b/mods/tuxemon/db/technique/give_all.json
@@ -12,7 +12,7 @@
   "is_area": false,
   "is_fast": false,
   "potency": 1,
-  "power": 3.0,
+  "power": 3,
   "range": "melee",
   "recharge": 2,
   "sfx": "sfx_blaster",

--- a/mods/tuxemon/db/technique/glower.json
+++ b/mods/tuxemon/db/technique/glower.json
@@ -3,6 +3,7 @@
   "accuracy": 1,
   "animation": null,
   "effects": [
+    "enhance 100",
     "softened target"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/hibernate.json
+++ b/mods/tuxemon/db/technique/hibernate.json
@@ -2,9 +2,11 @@
   "tech_id": 45,
   "accuracy": 1,
   "animation": null,
-  "effects": [],
+  "effects": [
+    "enhance 100"
+  ],
   "flip_axes": "",
-  "healing_power": 8.0,
+  "healing_power": 8,
   "icon": "",
   "is_area": false,
   "is_fast": false,

--- a/mods/tuxemon/db/technique/levitate.json
+++ b/mods/tuxemon/db/technique/levitate.json
@@ -3,6 +3,7 @@
   "accuracy": 1,
   "animation": null,
   "effects": [
+    "enhance 100",
     "sniping target",
     "sniping user"
   ],

--- a/mods/tuxemon/db/technique/one_two.json
+++ b/mods/tuxemon/db/technique/one_two.json
@@ -11,7 +11,7 @@
   "is_area": false,
   "is_fast": false,
   "potency": null,
-  "power": 3.0,
+  "power": 3,
   "range": "touch",
   "recharge": 2,
   "sfx": "sfx_blaster",

--- a/mods/tuxemon/db/technique/petrify.json
+++ b/mods/tuxemon/db/technique/petrify.json
@@ -2,7 +2,9 @@
   "tech_id": 37,
   "accuracy": 1,
   "animation": "shield_rock",
-  "effects": [],
+  "effects": [
+    "enhance 100"
+  ],
   "flip_axes": "",
   "healing_power": 0,
   "icon": "",

--- a/mods/tuxemon/db/technique/probiscus.json
+++ b/mods/tuxemon/db/technique/probiscus.json
@@ -12,7 +12,7 @@
   "is_area": true,
   "is_fast": false,
   "potency": 0.5,
-  "power": 1.0,
+  "power": 1,
   "range": "reach",
   "recharge": 1,
   "sfx": "sfx_blaster",

--- a/mods/tuxemon/db/technique/refresh.json
+++ b/mods/tuxemon/db/technique/refresh.json
@@ -3,10 +3,11 @@
   "accuracy": 1,
   "animation": "heal_burst_120",
   "effects": [
+    "enhance 100",
     "recover all"
   ],
   "flip_axes": "",
-  "healing_power": 4.0,
+  "healing_power": 4,
   "icon": "",
   "is_area": false,
   "is_fast": false,

--- a/mods/tuxemon/db/technique/rot.json
+++ b/mods/tuxemon/db/technique/rot.json
@@ -3,6 +3,7 @@
   "accuracy": 1,
   "animation": "drip_green",
   "effects": [
+    "enhance 100",
     "poison target"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/shrapnel.json
+++ b/mods/tuxemon/db/technique/shrapnel.json
@@ -11,7 +11,7 @@
   "is_area": true,
   "is_fast": true,
   "potency": null,
-  "power": 3.0,
+  "power": 3,
   "range": "ranged",
   "recharge": 3,
   "sfx": "sfx_blaster",

--- a/mods/tuxemon/db/technique/sleeping_powder.json
+++ b/mods/tuxemon/db/technique/sleeping_powder.json
@@ -3,6 +3,7 @@
   "accuracy": 1,
   "animation": "explosion_dusty_96",
   "effects": [
+    "enhance 100",
     "focused user"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/snowstorm.json
+++ b/mods/tuxemon/db/technique/snowstorm.json
@@ -12,7 +12,7 @@
   "is_area": true,
   "is_fast": false,
   "potency": 1,
-  "power": 3.0,
+  "power": 3,
   "range": "melee",
   "recharge": 3,
   "sfx": "sfx_blaster",

--- a/mods/tuxemon/db/technique/static_field.json
+++ b/mods/tuxemon/db/technique/static_field.json
@@ -3,6 +3,7 @@
   "accuracy": 1,
   "animation": "disintegrate_83",
   "effects": [
+    "enhance 100",
     "exhausted target",
     "hardshell user"
   ],

--- a/mods/tuxemon/db/technique/status_lifeleech.json
+++ b/mods/tuxemon/db/technique/status_lifeleech.json
@@ -1,6 +1,9 @@
 {
   "animation": "drip_green",
   "category": "negative",
+	"conditions": [
+	  	"current_hp target,>,0"
+	],
   "effects": [
     "lifeleech all"
   ],

--- a/mods/tuxemon/db/technique/stone_rot.json
+++ b/mods/tuxemon/db/technique/stone_rot.json
@@ -3,6 +3,7 @@
   "accuracy": 1,
   "animation": "drip_green",
   "effects": [
+    "enhance 100",
     "poison target"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/sudden_glow.json
+++ b/mods/tuxemon/db/technique/sudden_glow.json
@@ -3,11 +3,12 @@
   "accuracy": 1,
   "animation": "heal_burst_120",
   "effects": [
+    "enhance 100",
     "focused target",
     "recover all"
   ],
   "flip_axes": "",
-  "healing_power": 2.0,
+  "healing_power": 2,
   "icon": "",
   "is_area": false,
   "is_fast": false,

--- a/mods/tuxemon/db/technique/supernova.json
+++ b/mods/tuxemon/db/technique/supernova.json
@@ -12,7 +12,7 @@
   "is_area": false,
   "is_fast": false,
   "potency": 1,
-  "power": 3.0,
+  "power": 3,
   "range": "ranged",
   "recharge": 3,
   "sfx": "sfx_blaster",

--- a/mods/tuxemon/db/technique/take_cover.json
+++ b/mods/tuxemon/db/technique/take_cover.json
@@ -3,6 +3,7 @@
   "accuracy": 1,
   "animation": "smokebomb",
   "effects": [
+    "enhance 100",
     "sniping user"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/tonguespear.json
+++ b/mods/tuxemon/db/technique/tonguespear.json
@@ -12,7 +12,7 @@
   "is_area": false,
   "is_fast": false,
   "potency": 1,
-  "power": 1.0,
+  "power": 1,
   "range": "melee",
   "recharge": 2,
   "sfx": "sfx_blaster",

--- a/mods/tuxemon/db/technique/wallow.json
+++ b/mods/tuxemon/db/technique/wallow.json
@@ -3,10 +3,11 @@
   "accuracy": 1,
   "animation": "waterspurt",
   "effects": [
+    "enhance 100",
     "focused user"
   ],
   "flip_axes": "",
-  "healing_power": 4.0,
+  "healing_power": 4,
   "icon": "",
   "is_area": false,
   "is_fast": false,

--- a/tuxemon/ai.py
+++ b/tuxemon/ai.py
@@ -84,8 +84,19 @@ class RandomAI(AI):
                     if user.is_item_sort(item_slug, "potion"):
                         if self.need_potion(monster):
                             item = self.item_healing(user, item_slug)
+                            # avoid lifeleech when using an item
+                            local_session.player.game_variables[
+                                "tech_accuracy"
+                            ] = 0
                             return user, item, monster
         technique, target = self.track_next_use(monster, opponents)
+        # saves accuracy lifeleech and excludes skip
+        if technique.tech_id > 0:
+            local_session.player.game_variables[
+                "tech_accuracy"
+            ] = technique.accuracy
+        if technique.slug == "skip":
+            local_session.player.game_variables["tech_accuracy"] = 0
         # send data
         return monster, technique, target
 
@@ -99,6 +110,13 @@ class RandomAI(AI):
         Wild encounters.
         """
         technique, target = self.track_next_use(monster, opponents)
+        # saves accuracy lifeleech and excludes skip
+        if technique.tech_id > 0:
+            local_session.player.game_variables[
+                "tech_accuracy"
+            ] = technique.accuracy
+        if technique.slug == "skip":
+            local_session.player.game_variables["tech_accuracy"] = 0
         # send data
         return monster, technique, target
 

--- a/tuxemon/ai.py
+++ b/tuxemon/ai.py
@@ -84,19 +84,8 @@ class RandomAI(AI):
                     if user.is_item_sort(item_slug, "potion"):
                         if self.need_potion(monster):
                             item = self.item_healing(user, item_slug)
-                            # avoid lifeleech when using an item
-                            local_session.player.game_variables[
-                                "tech_accuracy"
-                            ] = 0
                             return user, item, monster
         technique, target = self.track_next_use(monster, opponents)
-        # saves accuracy lifeleech and excludes skip
-        if technique.tech_id > 0:
-            local_session.player.game_variables[
-                "tech_accuracy"
-            ] = technique.accuracy
-        if technique.slug == "skip":
-            local_session.player.game_variables["tech_accuracy"] = 0
         # send data
         return monster, technique, target
 
@@ -110,13 +99,6 @@ class RandomAI(AI):
         Wild encounters.
         """
         technique, target = self.track_next_use(monster, opponents)
-        # saves accuracy lifeleech and excludes skip
-        if technique.tech_id > 0:
-            local_session.player.game_variables[
-                "tech_accuracy"
-            ] = technique.accuracy
-        if technique.slug == "skip":
-            local_session.player.game_variables["tech_accuracy"] = 0
         # send data
         return monster, technique, target
 

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -166,7 +166,12 @@ def simple_lifeleech(
         Inflicted damage.
 
     """
-    damage = min(target.hp // 16, target.current_hp, user.hp - user.current_hp)
+    if user.current_hp <= 0:
+        damage = 0
+    else:
+        damage = min(
+            target.hp // 16, target.current_hp, user.hp - user.current_hp
+        )
     return damage
 
 

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -377,6 +377,10 @@ class CombatState(CombatAnimations):
 
         elif phase == "decision phase":
             self.reset_status_icons()
+            # saves random value, so we are able to reproduce
+            # inside the condition files if a tech hit or missed
+            value = formula.random.random()
+            self.players[0].game_variables["random_tech_hit"] = value
             if not self._decision_queue:
                 for player in self.human_players:
                     # tracks human players who need to choose an action
@@ -979,10 +983,14 @@ class CombatState(CombatAnimations):
                 # Track damage
                 self._damage_map[target].add(user)
 
-                element_damage_key = MULT_MAP.get(result["element_multiplier"])
-                if element_damage_key:
-                    m = T.translate(element_damage_key)
-                    message += "\n" + m
+                # allows tackle to special range techniques too
+                if technique.range != "special":
+                    element_damage_key = MULT_MAP.get(
+                        result["element_multiplier"]
+                    )
+                    if element_damage_key:
+                        m = T.translate(element_damage_key)
+                        message += "\n" + m
 
             else:  # assume this was an item used
 

--- a/tuxemon/states/combat/combat_menus.py
+++ b/tuxemon/states/combat/combat_menus.py
@@ -261,8 +261,6 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
             combat_state = self.client.get_state_by_name(CombatState)
             # TODO: don't hardcode to player0
             combat_state.enqueue_action(combat_state.players[0], item, target)
-            # avoid lifeleech when using an item
-            local_session.player.game_variables["tech_accuracy"] = 0
 
             # close all the open menus
             self.client.pop_state()  # close target chooser
@@ -347,14 +345,9 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
             else:
                 combat_state = self.client.get_state_by_name(CombatState)
                 combat_state.enqueue_action(self.monster, technique, target)
-                player = local_session.player
                 # remove skip after using it
                 if technique.slug == "skip":
-                    player.game_variables["tech_accuracy"] = 0
                     self.monster.moves.pop()
-                # save accuracy lifeleech
-                if technique.tech_id > 0:
-                    player.game_variables["tech_accuracy"] = technique.accuracy
 
                 # close all the open menus
                 self.client.pop_state()  # close target chooser

--- a/tuxemon/states/combat/combat_menus.py
+++ b/tuxemon/states/combat/combat_menus.py
@@ -261,6 +261,8 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
             combat_state = self.client.get_state_by_name(CombatState)
             # TODO: don't hardcode to player0
             combat_state.enqueue_action(combat_state.players[0], item, target)
+            # avoid lifeleech when using an item
+            local_session.player.game_variables["tech_accuracy"] = 0
 
             # close all the open menus
             self.client.pop_state()  # close target chooser
@@ -345,9 +347,14 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
             else:
                 combat_state = self.client.get_state_by_name(CombatState)
                 combat_state.enqueue_action(self.monster, technique, target)
+                player = local_session.player
                 # remove skip after using it
                 if technique.slug == "skip":
+                    player.game_variables["tech_accuracy"] = 0
                     self.monster.moves.pop()
+                # save accuracy lifeleech
+                if technique.tech_id > 0:
+                    player.game_variables["tech_accuracy"] = technique.accuracy
 
                 # close all the open menus
                 self.client.pop_state()  # close target chooser

--- a/tuxemon/technique/effects/blinded.py
+++ b/tuxemon/technique/effects/blinded.py
@@ -29,8 +29,11 @@ class BlindedEffect(TechEffect):
     def apply(
         self, tech: Technique, user: Monster, target: Monster
     ) -> BlindedEffectResult:
+        player = self.session.player
+        potency = random.random()
+        value = float(player.game_variables["random_tech_hit"])
         obj = self.objective
-        success = tech.potency >= random.random()
+        success = tech.potency >= potency and tech.accuracy >= value
         if success:
             tech = Technique("status_blinded")
             if obj == "user":

--- a/tuxemon/technique/effects/chargedup.py
+++ b/tuxemon/technique/effects/chargedup.py
@@ -29,8 +29,11 @@ class ChargedUpEffect(TechEffect):
     def apply(
         self, tech: Technique, user: Monster, target: Monster
     ) -> ChargedUpEffectResult:
+        player = self.session.player
+        potency = random.random()
+        value = float(player.game_variables["random_tech_hit"])
         obj = self.objective
-        success = tech.potency >= random.random()
+        success = tech.potency >= potency and tech.accuracy >= value
         if success:
             tech = Technique("status_chargedup")
             if obj == "user":

--- a/tuxemon/technique/effects/enhance.py
+++ b/tuxemon/technique/effects/enhance.py
@@ -4,26 +4,21 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from tuxemon import formula
 from tuxemon.monster import Monster
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
 from tuxemon.technique.technique import Technique
 
 
-class DamageEffectResult(TechEffectResult):
+class EnhanceEffectResult(TechEffectResult):
     damage: int
-    element_multiplier: float
     should_tackle: bool
 
 
 @dataclass
-class DamageEffect(TechEffect):
+class EnhanceEffect(TechEffect):
     """
-    Apply damage.
-
-    This effect applies damage to a target monster. This effect will only
-    be applied if "damage" is defined in the relevant technique's effect
-    list.
+    Apply "damage" for special range. Allows to show the animation and
+    avoids a constant failure.
 
     Parameters:
         user: The Monster object that used this technique.
@@ -34,28 +29,16 @@ class DamageEffect(TechEffect):
 
     """
 
-    name = "damage"
+    name = "enhance"
     objective: int
 
     def apply(
         self, tech: Technique, user: Monster, target: Monster
-    ) -> DamageEffectResult:
+    ) -> EnhanceEffectResult:
         player = self.session.player
         value = float(player.game_variables["random_tech_hit"])
         hit = tech.accuracy >= value
         if hit or tech.is_area:
-            tech.can_apply_status = True
-            damage, mult = formula.simple_damage_calculate(tech, user, target)
-            if not hit:
-                damage //= 2
-            target.current_hp -= damage
+            return {"damage": 0, "should_tackle": True, "success": True}
         else:
-            damage = 0
-            mult = 1
-
-        return {
-            "damage": damage,
-            "element_multiplier": mult,
-            "should_tackle": bool(damage),
-            "success": bool(damage),
-        }
+            return {"damage": 0, "should_tackle": False, "success": False}

--- a/tuxemon/technique/effects/enraged.py
+++ b/tuxemon/technique/effects/enraged.py
@@ -29,8 +29,11 @@ class EnragedEffect(TechEffect):
     def apply(
         self, tech: Technique, user: Monster, target: Monster
     ) -> EnragedEffectResult:
+        player = self.session.player
+        potency = random.random()
+        value = float(player.game_variables["random_tech_hit"])
         obj = self.objective
-        success = tech.potency >= random.random()
+        success = tech.potency >= potency and tech.accuracy >= value
         if success:
             tech = Technique("status_enraged")
             if obj == "user":

--- a/tuxemon/technique/effects/exhausted.py
+++ b/tuxemon/technique/effects/exhausted.py
@@ -29,8 +29,11 @@ class ExhaustedEffect(TechEffect):
     def apply(
         self, tech: Technique, user: Monster, target: Monster
     ) -> ExhaustedEffectResult:
+        player = self.session.player
+        potency = random.random()
+        value = float(player.game_variables["random_tech_hit"])
         obj = self.objective
-        success = tech.potency >= random.random()
+        success = tech.potency >= potency and tech.accuracy >= value
         if success:
             tech = Technique("status_exhausted")
             if obj == "user":

--- a/tuxemon/technique/effects/focused.py
+++ b/tuxemon/technique/effects/focused.py
@@ -29,8 +29,11 @@ class FocusedEffect(TechEffect):
     def apply(
         self, tech: Technique, user: Monster, target: Monster
     ) -> FocusedEffectResult:
+        player = self.session.player
+        potency = random.random()
+        value = float(player.game_variables["random_tech_hit"])
         obj = self.objective
-        success = tech.potency >= random.random()
+        success = tech.potency >= potency and tech.accuracy >= value
         if success:
             tech = Technique("status_focused")
             if obj == "user":

--- a/tuxemon/technique/effects/grabbed.py
+++ b/tuxemon/technique/effects/grabbed.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-import random
 from dataclasses import dataclass
 from typing import Optional
 
@@ -30,8 +29,11 @@ class GrabbedEffect(TechEffect):
     def apply(
         self, tech: Technique, user: Monster, target: Monster
     ) -> GrabbedEffectResult:
+        player = self.session.player
+        potency = formula.random.random()
+        value = float(player.game_variables["random_tech_hit"])
         obj = self.objective
-        success = tech.potency >= random.random()
+        success = tech.potency >= potency and tech.accuracy >= value
         if success:
             tech = Technique("status_grabbed")
             if obj == "user":

--- a/tuxemon/technique/effects/hardshell.py
+++ b/tuxemon/technique/effects/hardshell.py
@@ -29,8 +29,11 @@ class HardShellEffect(TechEffect):
     def apply(
         self, tech: Technique, user: Monster, target: Monster
     ) -> HardShellEffectResult:
+        player = self.session.player
+        potency = random.random()
+        value = float(player.game_variables["random_tech_hit"])
         obj = self.objective
-        success = tech.potency >= random.random()
+        success = tech.potency >= potency and tech.accuracy >= value
         if success:
             tech = Technique("status_hardshell")
             if obj == "user":

--- a/tuxemon/technique/effects/lifeleech.py
+++ b/tuxemon/technique/effects/lifeleech.py
@@ -50,25 +50,20 @@ class LifeLeechEffect(TechEffect):
                 user.apply_status(tech)
             return {"status": tech}
 
-        accuracy = float(player.game_variables["tech_accuracy"])
-
-        if accuracy >= value:
-            # avoids Nonetype situation and reset the user
-            if user is None:
-                user = tech.link
-                assert user
-                damage = formula.simple_lifeleech(user, target)
-                target.current_hp -= damage
-                user.current_hp += damage
-            else:
-                damage = formula.simple_lifeleech(user, target)
-                target.current_hp -= damage
-                user.current_hp += damage
-
-            return {
-                "damage": damage,
-                "should_tackle": bool(damage),
-                "success": bool(damage),
-            }
+        # avoids Nonetype situation and reset the user
+        if user is None:
+            user = tech.link
+            assert user
+            damage = formula.simple_lifeleech(user, target)
+            target.current_hp -= damage
+            user.current_hp += damage
         else:
-            return {"damage": 0, "should_tackle": False, "success": False}
+            damage = formula.simple_lifeleech(user, target)
+            target.current_hp -= damage
+            user.current_hp += damage
+
+        return {
+            "damage": damage,
+            "should_tackle": bool(damage),
+            "success": bool(damage),
+        }

--- a/tuxemon/technique/effects/poison.py
+++ b/tuxemon/technique/effects/poison.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-import random
 from dataclasses import dataclass
 from typing import Optional
 
@@ -30,7 +29,10 @@ class PoisonEffect(TechEffect):
     def apply(
         self, tech: Technique, user: Monster, target: Monster
     ) -> PoisonEffectResult:
-        success = tech.potency >= random.random()
+        player = self.session.player
+        value = float(player.game_variables["random_tech_hit"])
+        potency = formula.random.random()
+        success = tech.potency >= potency and tech.accuracy >= value
         if success:
             tech = Technique("status_poison")
             if self.objective == "user":

--- a/tuxemon/technique/effects/recover.py
+++ b/tuxemon/technique/effects/recover.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-import random
 from dataclasses import dataclass
 from typing import Optional
 
@@ -30,7 +29,10 @@ class RecoverEffect(TechEffect):
     def apply(
         self, tech: Technique, user: Monster, target: Monster
     ) -> RecoverEffectResult:
-        success = tech.potency >= random.random()
+        player = self.session.player
+        value = float(player.game_variables["random_tech_hit"])
+        potency = formula.random.random()
+        success = tech.potency >= potency and tech.accuracy >= value
         if success:
             tech = Technique("status_recover", link=user)
             user.apply_status(tech)

--- a/tuxemon/technique/effects/sniping.py
+++ b/tuxemon/technique/effects/sniping.py
@@ -29,8 +29,11 @@ class SnipingEffect(TechEffect):
     def apply(
         self, tech: Technique, user: Monster, target: Monster
     ) -> SnipingEffectResult:
+        player = self.session.player
+        potency = random.random()
+        value = float(player.game_variables["random_tech_hit"])
         obj = self.objective
-        success = tech.potency >= random.random()
+        success = tech.potency >= potency and tech.accuracy >= value
         if success:
             tech = Technique("status_sniping")
             if obj == "user":

--- a/tuxemon/technique/effects/softened.py
+++ b/tuxemon/technique/effects/softened.py
@@ -29,8 +29,11 @@ class SoftenedEffect(TechEffect):
     def apply(
         self, tech: Technique, user: Monster, target: Monster
     ) -> SoftenedEffectResult:
+        player = self.session.player
+        potency = random.random()
+        value = float(player.game_variables["random_tech_hit"])
         obj = self.objective
-        success = tech.potency >= random.random()
+        success = tech.potency >= potency and tech.accuracy >= value
         if success:
             tech = Technique("status_softened")
             if obj == "user":

--- a/tuxemon/technique/effects/stuck.py
+++ b/tuxemon/technique/effects/stuck.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-import random
 from dataclasses import dataclass
 from typing import Optional
 
@@ -30,8 +29,11 @@ class StuckEffect(TechEffect):
     def apply(
         self, tech: Technique, user: Monster, target: Monster
     ) -> StuckEffectResult:
+        player = self.session.player
+        potency = formula.random.random()
+        value = float(player.game_variables["random_tech_hit"])
         obj = self.objective
-        success = tech.potency >= random.random()
+        success = tech.potency >= potency and tech.accuracy >= value
         if success:
             tech = Technique("status_stuck")
             if obj == "user":


### PR DESCRIPTION
PR addresses the following:
- fixes #1567;
- creates the effect enhance (enhance.py) > the damage.py for special range techniques
- the point 2 allows to fix (1) the constant fail of special range techs (hibernate, boulder, etc), (2) shows the tackle and (3) shows the animation
- added the check if the target or user monster have more than 0 HP;
- ~~excluded items (before if the player used a potion and the target monster was under lifeleech, it leeched, not anymore);~~
- ~~excluded skip (when you skip move, the monster don't leech);~~

Schematically it's better to understand what we changed.

Situation before:
- there is no connection between damage.py (where we know if a technique misses or hits) and whatsoever.py (condition)
```
damage.py
tech.accuracy >= random.value (1)

poison.py
tech.potency >= random.value (2) -> no clue if the technique hits or misses (act independently)
```
Situation after:
- there is connection between damage.py and whatsoever.py (condition)
- random value 1 is saved in variable, so we can retrieve it inside whatsoever.py (condition)
```
combat.py
random.value (1) <----- moved here the random from damage.py (centralized + saved in variable)

damage.py
tech.accuracy >= saved(random.value (1))

poison.py
tech.accuracy >= saved(random.value (1)) <----- added so we can check if the technique hits or misses
tech.potency >= random.value (2)
-> now the condition considers if the technique hits or misses 
```

black + isort + tested