### PR TITLE
has status (items / techs conditions)

### DIFF
--- a/tuxemon/item/conditions/has_status.py
+++ b/tuxemon/item/conditions/has_status.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tuxemon.item.itemcondition import ItemCondition
+from tuxemon.monster import Monster
+
+
+@dataclass
+class HasStatusCondition(ItemCondition):
+    """
+    Checks if the creature has a status or not.
+
+    Parameters:
+    -
+
+    Example:
+    "conditions": [
+        "has_status target"
+        "has_status target"
+    ],
+
+    """
+
+    name = "has_status"
+
+    def test(self, target: Monster) -> bool:
+        if target.status:
+            return True
+        else:
+            return False

--- a/tuxemon/technique/conditions/has_status.py
+++ b/tuxemon/technique/conditions/has_status.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tuxemon.monster import Monster
+from tuxemon.technique.techcondition import TechCondition
+
+
+@dataclass
+class HasStatusCondition(TechCondition):
+    """
+    Checks if the creature has a status or not.
+
+    Parameters:
+    -
+
+    Example:
+    "conditions": [
+        "has_status target"
+        "has_status target"
+    ],
+
+    """
+
+    name = "has_status"
+
+    def test(self, target: Monster) -> bool:
+        if target.status:
+            return True
+        else:
+            return False


### PR DESCRIPTION
PR addresses the addition of has_status.

It was present status, but its duty is to confirm or not if the target has "lifeleech" or "poison" or whatever.

Has_status is a more generic condition check:
```
    "conditions": [
        "has_status target,true" --> target has a status / condition
        "has_status target,false" --> target is free from statuses / conditions
    ],
```
There was the possibility to add the parameter to the other status.py (tech and item), but it would be more complex and less clear to understand than a new set of condition checks.