### PR TITLE
style create_npc (maps)

### DIFF
--- a/mods/tuxemon/maps/player_house_downstairs.tmx
+++ b/mods/tuxemon/maps/player_house_downstairs.tmx
@@ -144,14 +144,14 @@
   </object>
   <object id="35" name="postannouncement" type="event" x="16" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="wait 1"/>
-    <property name="act2" value="npc_face npc_mom,right"/>
-    <property name="act3" value="translated_dialog ohnoes"/>
-    <property name="act4" value="wait 0.7"/>
-    <property name="act5" value="translated_dialog ohnoes2"/>
-    <property name="act6" value="npc_face npc_mom,left"/>
-    <property name="act8" value="unlock_controls"/>
-    <property name="act9" value="set_variable can_exit_town:yes"/>
+    <property name="act01" value="wait 1"/>
+    <property name="act02" value="npc_face npc_mom,right"/>
+    <property name="act03" value="translated_dialog ohnoes"/>
+    <property name="act04" value="wait 0.7"/>
+    <property name="act05" value="translated_dialog ohnoes2"/>
+    <property name="act06" value="npc_face npc_mom,left"/>
+    <property name="act08" value="unlock_controls"/>
+    <property name="act09" value="set_variable can_exit_town:yes"/>
     <property name="act10" value="clear_variable scene"/>
     <property name="act11" value="clear_variable aeble_talk"/>
     <property name="cond1" value="is variable_set aeble_talk:2"/>
@@ -176,7 +176,7 @@
   </object>
   <object id="38" name="create mom3" type="event" x="0" y="64" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc npc_mom,0,5,,stand"/>
+    <property name="act1" value="create_npc npc_mom,0,5"/>
     <property name="act2" value="npc_face npc_mom,right"/>
     <property name="act3" value="wait 1"/>
     <property name="cond1" value="is variable_set backhome:no"/>
@@ -225,7 +225,7 @@
   </object>
   <object id="42" name="new possibilities2" type="event" x="32" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc professor,4,6,,stand"/>
+    <property name="act1" value="create_npc professor,4,6"/>
     <property name="act2" value="npc_face professor,left"/>
     <property name="act3" value="translated_dialog iknowyou"/>
     <property name="act4" value="translated_dialog ihaveyourmoney2"/>

--- a/mods/tuxemon/maps/sphalian_center.tmx
+++ b/mods/tuxemon/maps/sphalian_center.tmx
@@ -91,7 +91,7 @@
   </object>
   <object id="27" name="create npcs" type="event" x="16" y="0" width="16" height="16">
    <properties>
-    <property name="act10" value="create_npc tabanurse,5,4,nurse,stand"/>
+    <property name="act10" value="create_npc tabanurse,5,4"/>
     <property name="cond10" value="not npc_exists tabanurse"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_candy_center.tmx
+++ b/mods/tuxemon/maps/spyder_candy_center.tmx
@@ -70,7 +70,7 @@
   </object>
   <object id="25" name="create npcs" type="event" x="16" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc tabanurse,5,4,nurse,stand"/>
+    <property name="act1" value="create_npc tabanurse,5,4"/>
     <property name="cond1" value="not npc_exists tabanurse"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_flower_center.tmx
+++ b/mods/tuxemon/maps/spyder_flower_center.tmx
@@ -67,7 +67,7 @@
   </object>
   <object id="25" name="create npcs" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc tabanurse,5,4,nurse,stand"/>
+    <property name="act1" value="create_npc tabanurse,5,4"/>
     <property name="cond1" value="not npc_exists tabanurse"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_healing_center.tmx
+++ b/mods/tuxemon/maps/spyder_healing_center.tmx
@@ -68,7 +68,7 @@
   <object id="22" name="Player Spawn" type="event" x="96" y="128" width="16" height="16"/>
   <object id="25" name="create npcs" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc tabanurse,5,4,nurse,stand"/>
+    <property name="act1" value="create_npc tabanurse,5,4"/>
     <property name="cond1" value="not npc_exists tabanurse"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_leather_center.tmx
+++ b/mods/tuxemon/maps/spyder_leather_center.tmx
@@ -68,7 +68,7 @@
   <object id="22" name="Player Spawn" type="event" x="96" y="128" width="16" height="16"/>
   <object id="25" name="create npcs" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc tabanurse,5,4,nurse,stand"/>
+    <property name="act1" value="create_npc tabanurse,5,4"/>
     <property name="cond1" value="not npc_exists tabanurse"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_paper_mart.tmx
+++ b/mods/tuxemon/maps/spyder_paper_mart.tmx
@@ -78,7 +78,7 @@
   </object>
   <object id="42" name="hello Professor" type="event" x="128" y="160" width="16" height="16">
    <properties>
-    <property name="act10" value="create_npc professor,6,5,professor,stand"/>
+    <property name="act10" value="create_npc professor,6,5"/>
     <property name="act30" value="set_variable tuxchoice:welcome"/>
     <property name="cond1" value="not variable_set tuxchoice:end"/>
     <property name="cond2" value="not npc_exists professor"/>
@@ -127,7 +127,7 @@
   </object>
   <object id="56" name="employee" type="event" x="16" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc tuxemart_keeper,1,5,tuxemartemployee,stand"/>
+    <property name="act1" value="create_npc tuxemart_keeper,1,5"/>
     <property name="act2" value="npc_face tuxemart_keeper,right"/>
     <property name="act3" value="set_inventory tuxemart_keeper,spyder_paper_mart"/>
     <property name="act4" value="set_economy tuxemart_keeper,spyder_paper_mart"/>
@@ -170,13 +170,13 @@
   </object>
   <object id="62" name="Create Shopkeeper" type="event" x="16" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc shopkeeperpapertown,3,6,shopkeeper,stand"/>
+    <property name="act1" value="create_npc shopkeeperpapertown,3,6"/>
     <property name="cond2" value="not npc_exists shopkeeperpapertown"/>
    </properties>
   </object>
   <object id="63" name="Create Dante" type="event" x="176" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc danteinstore,11,5,shop_assistant,stand"/>
+    <property name="act1" value="create_npc danteinstore,11,5"/>
     <property name="cond1" value="is party_size less_than,1"/>
     <property name="cond2" value="not npc_exists danteinstore"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_timber_center.tmx
+++ b/mods/tuxemon/maps/spyder_timber_center.tmx
@@ -67,7 +67,7 @@
   </object>
   <object id="25" name="create npcs" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc tabanurse,5,4,nurse,stand"/>
+    <property name="act1" value="create_npc tabanurse,5,4"/>
     <property name="cond1" value="not npc_exists tabanurse"/>
    </properties>
   </object>


### PR DESCRIPTION
PR addresses a small style fix related to create_npc

it acts only on centers and fix the numeration of the postannouncement, so it's not resorted (every time) automatically in Tiled.