### PR TITLE
update encounters

### DIFF
--- a/mods/tuxemon/db/encounter/route1.json
+++ b/mods/tuxemon/db/encounter/route1.json
@@ -4,25 +4,61 @@
     {
       "monster": "pairagrin",
       "encounter_rate": 3.5,
+      "daytime": true,
+      "exp_req_mod": 1,
       "level_range": [
-        1,
+        2,
         4
       ]
     },
     {
       "monster": "aardorn",
       "encounter_rate": 3.5,
+      "daytime": true,
+      "exp_req_mod": 1,
       "level_range": [
-        1,
+        2,
         4
       ]
     },
     {
       "monster": "cataspike",
       "encounter_rate": 3.5,
+      "daytime": true,
+      "exp_req_mod": 1,
       "level_range": [
-        1,
+        2,
         4
+      ]
+    },
+    {
+      "monster": "pairagrin",
+      "encounter_rate": 3.5,
+      "daytime": false,
+      "exp_req_mod": 1,
+      "level_range": [
+        3,
+        5
+      ]
+    },
+    {
+      "monster": "aardorn",
+      "encounter_rate": 3.5,
+      "daytime": false,
+      "exp_req_mod": 1,
+      "level_range": [
+        3,
+        5
+      ]
+    },
+    {
+      "monster": "cataspike",
+      "encounter_rate": 3.5,
+      "daytime": false,
+      "exp_req_mod": 1,
+      "level_range": [
+        3,
+        5
       ]
     }
   ]

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -574,6 +574,10 @@ class EncounterItemModel(BaseModel):
     level_range: Sequence[int] = Field(
         ..., description="Level range to encounter"
     )
+    daytime: bool = Field(
+        True, description="Options: day (true), night (false)"
+    )
+    exp_req_mod: int = Field(1, description="Exp modifier wild monster")
 
     @validator("monster")
     def monster_exists(cls, v):

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -1082,8 +1082,14 @@ class CombatState(CombatAnimations):
             )
             awarded_mon = monster.level * monster.money_modifier
             for winners in self._damage_map[monster]:
-                winners.give_experience(awarded_exp)
-                self._prize += awarded_mon
+                if self.is_trainer_battle:
+                    winners.give_experience(awarded_exp)
+                    self._prize += awarded_mon
+                else:
+                    awarded = (
+                        awarded_exp * monster.experience_required_modifier
+                    )
+                    winners.give_experience(awarded)
 
             # Remove monster from damage map
             del self._damage_map[monster]


### PR DESCRIPTION
PR addresses encounters (wild monsters) @Qiangong2 and @Sanglorian 
It adds the following parameters:

(1) **daytime**: the possibility to spawn based night and day (set default True (day) inside db.py)
(2) **exp_req_mod**: the possibility to increase the amount of exp (if you want to give more exp when fighting during the night, or against certain monster, or whatever)

At the moment **route1** is the only one updated, it doesn't change much.
There are the same monsters during the night, but slightly more "powerful".
The **range** has been increased from 2/4 to 3/5, while the **exp_req_mod** is set at 1, as the default value.
It's mostly for showing how it works, the other routes can be updated later.

I updated the min_level for wild monster in **route1** from 1 to 2, because I was testing, I bumped into a Pairaigrin lv1, and the poor guy was skipping at each turn.
```
    {
      "monster": "cataspike",
      "encounter_rate": 6.9,
      "daytime": false, --> false (night), true (day)
      "exp_req_mod": 69, --> multiplier
      "level_range": [
        6,
        9
      ]
    }
```