### PR TITLE
level up combat.py + fixes

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -1312,6 +1312,9 @@ msgstr "Are you sure you would like to release {name}?"
 msgid "tuxemon_released"
 msgstr "{name} has been released."
 
+msgid "tuxemon_new_tech"
+msgstr "{name} learned technique {tech}!"
+
 msgid "evolution_confirmation"
 msgstr "{name} is trying to evolve into {evolve}. Allow evolution?"
 

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -520,17 +520,6 @@ class Monster:
         self.level = min(self.level, MAX_LEVEL)
         self.set_stats()
 
-        # Learn New Moves
-        for move in self.moveset:
-            if move.level_learned == self.level:
-                logger.info(
-                    "{} learned technique {}!".format(
-                        self.name, move.technique
-                    )
-                )
-                technique = Technique(move.technique)
-                self.learn(technique)
-
     def set_level(self, level: int = 5) -> None:
         """
         Set monster level.

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -1082,14 +1082,27 @@ class CombatState(CombatAnimations):
             )
             awarded_mon = monster.level * monster.money_modifier
             for winners in self._damage_map[monster]:
+                self._level_before = winners.level
+                self._level_after = winners.level
                 if self.is_trainer_battle:
                     winners.give_experience(awarded_exp)
                     self._prize += awarded_mon
+                    self._level_after = winners.level
                 else:
                     awarded = (
                         awarded_exp * monster.experience_required_modifier
                     )
                     winners.give_experience(awarded)
+                    self._level_after = winners.level
+                # it checks if there is a "level up"
+                if self._level_before != self._level_after:
+                    diff = self._level_after - self._level_before
+                    # checks and eventually teaches move/moves
+                    self.check_moves(winners, diff)
+                    # updates hud graphics
+                    self.build_hud(
+                        self._layout[self.players[0]]["hud"][0], winners
+                    )
 
             # Remove monster from damage map
             del self._damage_map[monster]
@@ -1192,6 +1205,32 @@ class CombatState(CombatAnimations):
         # TODO: perhaps change this to remaining "parties", or "teams",
         # instead of player/trainer
         return [p for p in self.players if not defeated(p)]
+
+    def check_moves(self, monster: Monster, levels: int) -> None:
+        for move in monster.moveset:
+            # monster levels up 1 level
+            if levels == 1:
+                if move.level_learned == monster.level:
+                    self.learn(monster, move.technique)
+            # monster levels up multiple levels
+            else:
+                level_before = monster.level - levels
+                # if there are techniques in this range
+                if level_before < move.level_learned <= monster.level:
+                    self.learn(monster, move.technique)
+
+    def learn(self, monster: Monster, tech: str) -> None:
+        technique = Technique(tech)
+        monster.learn(technique)
+        self.alert(
+            T.format(
+                "tuxemon_new_tech",
+                {
+                    "name": monster.name.upper(),
+                    "tech": technique.name.upper(),
+                },
+            )
+        )
 
     def evolve(self) -> None:
         self.client.pop_state()


### PR DESCRIPTION
The PR:
- removes **Learn New Moves** from monster.py;
- creates two defs related to **Learn New Moves** inside combat.py;
- adds the variables **self._level_before** and **self._level_after** in combat.py, so we can know if there is a level_up (included if the monster levels up multiple times);
- adds the **tuxemon_new_tech** to the PO file as well as the self.alert (the old logger string) -> see screenshot;
- adds **build_hud** refresh if leveling up,;

As you can see (testing)
![Screenshot from 2023-01-23 10-35-40](https://user-images.githubusercontent.com/64643719/214013605-47566335-d83f-4de5-811b-0aaf6b71e580.png)

Fixed:
- before there was no update in combat (if the monster leveled up) and the only way to know it: switch out and switch in or at the end checking the monster menu -> now the hub will refresh, the number lv XX will update;
- before if the monster was leveling up multiple times (eg. from lv 5 to lv 9), then there was only the checking at lv9. In case there was a technique set at lv8, well, nothing -> now it checks lv6, lv7, lv8 and lv9;

This isn't the definitive version, because it lacks of the overwriting step (if the monster has more than 4 moves), but it helps to simplify the next steps. It remains to know if we want the overwriting method (techniques) to happen between turns (after the adversary monster faints) or at the end of the fight like the evolution.

black + isort + tested