### PR TITLE
max moves combat

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -1390,6 +1390,10 @@ msgstr "{name} has been released."
 msgid "tuxemon_new_tech"
 msgstr "{name} learned technique {tech}!"
 
+msgid "new_tech_delete"
+msgstr "{name} has too many techniques.\n"
+"Which technique do you want to delete?"
+
 msgid "evolution_confirmation"
 msgstr "{name} is trying to evolve into {evolve}. Allow evolution?"
 

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -922,6 +922,42 @@ class NPC(Entity[NPCState]):
             ],
         )
 
+    def remove_technique(
+        self,
+        session: Session,
+        monster: Monster,
+    ) -> None:
+        """
+        Opens the choice dialog and removes the technique.
+        """
+
+        def set_variable(var_value: str) -> None:
+            monster.moves.remove(var_value)
+            session.client.pop_state()
+
+        var_list = monster.moves
+        var_menu = list()
+
+        for val in var_list:
+            text = T.translate(val.slug)
+            var_menu.append((text, text, partial(set_variable, val)))
+
+        open_choice_dialog(
+            session,
+            menu=var_menu,
+        )
+        open_dialog(
+            session,
+            [
+                T.format(
+                    "new_tech_delete",
+                    {
+                        "name": monster.name.upper(),
+                    },
+                )
+            ],
+        )
+
     def give_money(self, amount: int) -> None:
         self.money["player"] += amount
 

--- a/tuxemon/states/combat/combat_menus.py
+++ b/tuxemon/states/combat/combat_menus.py
@@ -16,7 +16,7 @@ from tuxemon.item.item import Item
 from tuxemon.locale import T
 from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.menu import Menu, PopUpMenu
-from tuxemon.monster import Monster
+from tuxemon.monster import MAX_MOVES, Monster
 from tuxemon.session import local_session
 from tuxemon.sprite import MenuSpriteGroup, SpriteGroup
 from tuxemon.state import State
@@ -354,7 +354,10 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                 self.client.pop_state()  # close technique menu
                 self.client.pop_state()  # close the monster action menu
 
-        choose_technique()
+        if len(self.monster.moves) > MAX_MOVES:
+            local_session.player.remove_technique(local_session, self.monster)
+        else:
+            choose_technique()
 
 
 class CombatTargetMenuState(Menu[Monster]):


### PR DESCRIPTION
PR addresses the implementation of remove technique:
- added an if inside combat_menu;
- added a new msgid inside PO file
- added a new def inside npc.py

It was planned as overwriting, but it's really complicated to implement it, especially exactly after learning the move, literally seconds before the end (or a new action).

Opted for a check inside combat_menu, you cannot choose the move (to start the action) if you don't get rid of the superfluous techniques. The pop up will keep appearing if there are > 4 techniques.

If the monster learns the move (or moves) at the end of the battle, then the check will show up during the next one. 

I'm unsure about the message inside the popup, if there are suggestions, then feel free.

![Screenshot from 2023-01-24 20-01-56](https://user-images.githubusercontent.com/64643719/214386377-1bfa14da-5135-423e-9f89-6a290b8e8964.png)

black + isort + tested