### PR TITLE
filter items during combat

### DIFF
--- a/tuxemon/states/items/__init__.py
+++ b/tuxemon/states/items/__init__.py
@@ -213,7 +213,20 @@ class ItemMenuState(Menu[Item]):
 
     def initialize_items(self) -> Generator[MenuItem[Item], None, None]:
         """Get all player inventory items and add them to menu."""
-        inventory = local_session.player.inventory.values()
+        state = self.determine_state_called_from()
+        inventory = []
+        # in battle shows only items with MainCombatMenuState (usable_in)
+        if state == "MainCombatMenuState":
+            inventory = [
+                item
+                for item in local_session.player.inventory.values()
+                if State[state] in item["item"].usable_in
+            ]
+        # shows all items
+        else:
+            inventory = [
+                item for item in local_session.player.inventory.values()
+            ]
 
         # required because the max() below will fail if inv empty
         if not inventory:


### PR DESCRIPTION
During combat, after opening items

before
![Screenshot from 2023-01-27 09-45-13](https://user-images.githubusercontent.com/64643719/215045169-8ad290d4-d54a-44bd-a8e9-5338efdbd2c3.png)
after
![Screenshot from 2023-01-27 09-45-41](https://user-images.githubusercontent.com/64643719/215045160-e4c8c234-595d-4355-a5b5-4de83f6f6501.png)

it doesn't make sense to show items that cannot be used during the fight (without MainCombatMenuState in usable_in)