### PR TITLE
update tech menu

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -355,6 +355,9 @@ msgstr "{name} can only be used in a {here}!"
 msgid "item_no_available_target"
 msgstr "{name} cannot be used on any of your Tuxemon right now."
 
+msgid "technique_description"
+msgstr "ID.{id} ({types}) - Accuracy {acc}%, Potency {pot}%, Power {pow}/3, Recharge {rec} turns"
+
 msgid "reg_papers"
 msgstr "Registration Papers"
 

--- a/tuxemon/states/techniques/__init__.py
+++ b/tuxemon/states/techniques/__init__.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-import uuid
 from typing import Generator
 
 import pygame
@@ -25,7 +24,9 @@ class TechniqueMenuState(Menu[Technique]):
     background_filename = "gfx/ui/item/item_menu_bg.png"
     draw_borders = False
 
-    def __init__(self) -> None:
+    def __init__(self, monster: Monster) -> None:
+        self.mon = monster
+
         super().__init__()
 
         self.item_center = self.rect.width * 0.164, self.rect.height * 0.13
@@ -126,42 +127,41 @@ class TechniqueMenuState(Menu[Technique]):
     def initialize_items(
         self,
     ) -> Generator[MenuItem[Technique], None, None]:
-        """Get all player techniques, remove duplicates, sort
-        and add them to menu."""
-        trainer = local_session.player
-        mon_id = uuid.UUID(trainer.game_variables["open_monster_techs"])
-        monster = trainer.find_monster_by_id(mon_id)
-
+        """Get all player techniques."""
         # load the backpack icon
         self.backpack_center = self.rect.width * 0.16, self.rect.height * 0.45
         self.load_sprite(
-            "gfx/sprites/battle/" + monster.slug + "-front.png",
+            self.mon.front_battle_sprite,
             center=self.backpack_center,
             layer=100,
         )
 
         moveset = []
-        for moves in monster.moves:
-            moveset.insert(moves.tech_id, moves.slug)
+        for moves in self.mon.moves:
+            moveset.append(moves)
 
-        output = sorted(moveset)
+        output = sorted(moveset, key=lambda x: x.tech_id)
+
         for tech in output:
-            obj = Technique(tech)
-            type2 = ""
-            if obj.type2 is not None:
-                type2 = T.translate(obj.type2)
-            image = self.shadow_text(obj.name, bg=(128, 128, 128))
-            label = (
-                "ID: "
-                + str(obj.tech_id)
-                + " - "
-                + obj.name
-                + " ("
-                + T.translate(obj.type1)
-                + type2
-                + ")"
+            name = tech.name
+            types = ""
+            if tech.type2 is not None:
+                types = T.translate(tech.type1) + " " + T.translate(tech.type2)
+            else:
+                types = T.translate(tech.type1)
+            image = self.shadow_text(name, bg=(128, 128, 128))
+            label = T.format(
+                "technique_description",
+                {
+                    "id": tech.tech_id,
+                    "types": types,
+                    "acc": int(tech.accuracy * 100),
+                    "pot": int(tech.potency * 100),
+                    "pow": tech.power,
+                    "rec": str(tech.recharge_length),
+                },
             )
-            yield MenuItem(image, obj.name, label, obj)
+            yield MenuItem(image, name, label, tech)
 
     def on_menu_selection_change(self) -> None:
         """Called when menu selection changes."""

--- a/tuxemon/states/world/world_menus.py
+++ b/tuxemon/states/world/world_menus.py
@@ -228,10 +228,7 @@ class WorldMenuState(PygameMenuState):
             """Show techniques."""
             self.client.pop_state()
             monster = monster_menu.get_selected_item().game_object
-            self.client.push_state(TechniqueMenuState())
-            local_session.player.game_variables[
-                "open_monster_techs"
-            ] = monster.instance_id.hex
+            self.client.push_state(TechniqueMenuState(monster=monster))
 
         def open_monster_submenu(
             menu_item: MenuItem[WorldMenuGameObj],


### PR DESCRIPTION
PR addresses a minor update in the tech menu.
While working on #1600  I noticed a small bug, if a tech has two types (eg. Wood/Earth), it appeared without space **WoodEarth** instead of **Wood Earth**)
Since I was fixing that I added some changes.
The data (monster) is sent by kwargs and not anymore through variable, less code, less pointless circles.

Before
![Screenshot from 2023-02-03 10-24-44](https://user-images.githubusercontent.com/64643719/216563208-4f806670-6ef6-4960-b886-84ca33005002.png)
After (finally sorted by tech_id, reason why I added the ID in the main menu), more space also for the description or other useful info
![Screenshot from 2023-02-03 10-19-45](https://user-images.githubusercontent.com/64643719/216563219-0f368920-b570-4387-b90f-c974e93d78e3.png)

black + isort + tested
this is only a minor change, because I'm working on refactoring the tech menu and getting rid of pygame/menu for pygame_menu