### PR TITLE
clear tuxepedia

### DIFF
--- a/tuxemon/event/actions/clear_tuxepedia.py
+++ b/tuxemon/event/actions/clear_tuxepedia.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import final
+
+from tuxemon.event.eventaction import EventAction
+
+
+@final
+@dataclass
+class ClearTuxepediaAction(EventAction):
+    """
+    Clear the key and value in the Tuxepedia dictionary.
+
+    Script usage:
+        .. code-block::
+
+            clear_tuxepedia <monster_slug>
+
+    Script parameters:
+        monster_slug: Monster slug name (e.g. "rockitten").
+
+    """
+
+    name = "clear_tuxepedia"
+    monster_key: str
+
+    def start(self) -> None:
+        player = self.session.player
+        if self.monster_key in player.tuxepedia:
+            player.tuxepedia.pop(self.monster_key)
+        else:
+            return


### PR DESCRIPTION
PR addresses a suggestion from @Sanglorian 

it exists the command to set any monster as captured or seen, but it's missing a command to clear a monster from Tuxepedia.