### PR TITLE
debug starting map

### DIFF
--- a/SPYDER_README.md
+++ b/SPYDER_README.md
@@ -4,7 +4,7 @@ The "spyder_" prefix identifies the maps and NPCs that belong to the Spyder in t
 
 Since the game is still being created, there are some concessions/workarounds: 
 
-1. To play, start the game with argument -s spyder_bedroom.tmx, or change the starting_map variable in your tuxemon.cfg file to spyder_bedroom.tmx.
+1. To play, choose Spyder after clicking on New Game.
 2. In some parts you can walk on water since surfing hasn't been implemented yet. 
 3. There's a different exit to the right of Drokoro since removing collisions hasn't been implemented yet. 
 4. For some reason, random_encounter didn't work if it was triggered by behaviour "talk", so I've changed that to condition "to_talk". However, that's not present in my version of the game, so I can't test it.

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -1481,6 +1481,9 @@ msgstr "Multiplayer"
 msgid "menu_new_game"
 msgstr "New Game"
 
+msgid "menu_scenarios"
+msgstr "Scenarios"
+
 msgid "menu_options"
 msgstr "Options"
 

--- a/mods/tuxemon/maps/debug.tmx
+++ b/mods/tuxemon/maps/debug.tmx
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="4" height="4" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="11">
+ <properties>
+  <property name="scenario" value="debug"/>
+  <property name="slug" value="debug"/>
+  <property name="types" value="notype"/>
+ </properties>
+ <layer id="1" name="Tile Layer 1" width="4" height="4">
+  <data encoding="base64" compression="zlib">
+   eAFjYKAMAAAAQAAB
+  </data>
+ </layer>
+ <layer id="2" name="Tile Layer 2" width="4" height="4">
+  <data encoding="base64" compression="zlib">
+   eAFjYKAMAAAAQAAB
+  </data>
+ </layer>
+ <layer id="3" name="Tile Layer 3" width="4" height="4">
+  <data encoding="base64" compression="zlib">
+   eAFjYKAMAAAAQAAB
+  </data>
+ </layer>
+ <objectgroup color="#ff0000" id="4" name="Collisions">
+  <object id="3" type="collision" x="0" y="0" width="16" height="64"/>
+  <object id="4" type="collision" x="48" y="0" width="16" height="64"/>
+  <object id="5" type="collision" x="16" y="0" width="32" height="16"/>
+  <object id="6" type="collision" x="16" y="48" width="32" height="16"/>
+ </objectgroup>
+ <objectgroup color="#ffff00" id="5" name="Event">
+  <object id="7" name="Scenario" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_money player,0"/>
+    <property name="act2" value="translated_dialog_choice spyder_campaign:xero_campaign,scenario_choice"/>
+    <property name="cond1" value="not variable_set scenario_choice:spyder_campaign"/>
+    <property name="cond2" value="not variable_set scenario_choice:xero_campaign"/>
+   </properties>
+  </object>
+  <object id="8" name="Spyder" type="event" x="48" y="48" width="16" height="16">
+   <properties>
+    <property name="act1" value="rename_player"/>
+    <property name="act2" value="transition_teleport spyder_bedroom.tmx,4,4,0.3"/>
+    <property name="act3" value="set_money player,10000"/>
+    <property name="act4" value="set_variable spyder_starting_money:yes"/>
+    <property name="cond1" value="is variable_set scenario_choice:spyder_campaign"/>
+    <property name="cond2" value="not variable_set spyder_starting_money:yes"/>
+   </properties>
+  </object>
+  <object id="9" name="Xero" type="event" x="0" y="48" width="16" height="16">
+   <properties>
+    <property name="act1" value="rename_player"/>
+    <property name="act2" value="transition_teleport player_house_bedroom.tmx,4,4,0.3"/>
+    <property name="act3" value="set_money player,10000"/>
+    <property name="act4" value="set_variable xero_starting_money:yes"/>
+    <property name="cond1" value="is variable_set scenario_choice:xero_campaign"/>
+    <property name="cond2" value="not variable_set xero_starting_money:yes"/>
+   </properties>
+  </object>
+  <object id="10" name="Player Spawn" type="event" x="16" y="16" width="16" height="16"/>
+ </objectgroup>
+</map>

--- a/mods/tuxemon/maps/player_house_bedroom.yaml
+++ b/mods/tuxemon/maps/player_house_bedroom.yaml
@@ -21,17 +21,6 @@ events:
     x: 3
     y: 2
     type: "event"
-  Give Money:
-    actions:
-    - set_money player,1000000
-    - set_variable xero_starting_money:yes
-    conditions:
-    - not variable_set xero_starting_money:yes
-    height: 1
-    width: 1
-    x: 1
-    y: 0
-    type: "event"
   Player Spawn:
     height: 1
     width: 1

--- a/mods/tuxemon/maps/spyder_bedroom.tmx
+++ b/mods/tuxemon/maps/spyder_bedroom.tmx
@@ -77,13 +77,6 @@
     <property name="cond2" value="is player_facing_tile"/>
    </properties>
   </object>
-  <object id="28" name="Give Starting Money" type="event" x="16" y="0" width="16" height="16">
-   <properties>
-    <property name="act30" value="set_money player,1000000"/>
-    <property name="act40" value="set_variable spyder_starting_money:yes"/>
-    <property name="cond1" value="not variable_set spyder_starting_money:yes"/>
-   </properties>
-  </object>
   <object id="29" name="Auto Healing Teleported" type="event" x="0" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_monster_health ,"/>

--- a/run_tuxemon.py
+++ b/run_tuxemon.py
@@ -30,16 +30,6 @@ if __name__ == "__main__":
         help="The index of the save file to load",
     )
     parser.add_argument(
-        "-s",
-        "--starting-map",
-        dest="starting_map",
-        metavar="map.tmx",
-        type=str,
-        nargs="?",
-        default=None,
-        help="The starting map",
-    )
-    parser.add_argument(
         "-t",
         "--test-map",
         dest="test_map",
@@ -52,10 +42,7 @@ if __name__ == "__main__":
 
     if args.mod:
         config.mods.insert(0, args.mod)
-    if args.starting_map:
-        config.starting_map = args.starting_map
     if args.test_map:
-        config.starting_map = args.test_map
         config.skip_titlescreen = True
         config.splash = False
 

--- a/tuxemon/config.py
+++ b/tuxemon/config.py
@@ -62,7 +62,6 @@ class TuxemonConfig:
 
         # [game]
         self.data = cfg.get("game", "data")
-        self.starting_map = cfg.get("game", "starting_map")
         self.cli = cfg.getboolean("game", "cli_enabled")
         self.net_controller_enabled = cfg.getboolean(
             "game",
@@ -237,7 +236,6 @@ def get_defaults() -> Mapping[str, Any]:
                 OrderedDict(
                     (
                         ("data", "tuxemon"),
-                        ("starting_map", "player_house_bedroom.tmx"),
                         ("skip_titlescreen", False),
                         ("cli_enabled", False),
                         ("net_controller_enabled", False),

--- a/tuxemon/main.py
+++ b/tuxemon/main.py
@@ -62,9 +62,8 @@ def main(
         client.push_state(SplashState(parent=client.state_manager))
         client.push_state(FadeInTransition())
 
-    # TODO: rename this to "debug map" or something
     if config.skip_titlescreen:
-        map_name = prepare.fetch("maps", prepare.CONFIG.starting_map)
+        map_name = prepare.fetch("maps", prepare.STARTING_MAP)
         client.push_state(WorldState(map_name=map_name))
 
     # block of code useful for testing

--- a/tuxemon/prepare.py
+++ b/tuxemon/prepare.py
@@ -53,6 +53,9 @@ config.generate_default_config()
 # Read "tuxemon.cfg" config from disk, update and write back
 CONFIG = config.TuxemonConfig(paths.USER_CONFIG_PATH)
 
+# Starting map
+STARTING_MAP = "debug.tmx"
+
 with open(paths.USER_CONFIG_PATH, "w") as fp:
     CONFIG.cfg.write(fp)
 

--- a/tuxemon/states/start/__init__.py
+++ b/tuxemon/states/start/__init__.py
@@ -6,19 +6,17 @@ from __future__ import annotations
 
 import logging
 from functools import partial
-from typing import Any, Callable, Tuple, Union
+from typing import Any, Callable, Union
 
 import pygame
 
 from tuxemon import formula, prepare
 from tuxemon.locale import T
-from tuxemon.menu.input import InputMenu
 from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.menu import PopUpMenu
 from tuxemon.save import get_index_of_latest_save
 from tuxemon.session import local_session
 from tuxemon.state import State
-from tuxemon.states.transition.fade import FadeInTransition
 
 logger = logging.getLogger(__name__)
 
@@ -95,51 +93,16 @@ class ModChooserMenuState(PopUpMenu[StartGameObj]):
 
         super().__init__()
 
-        self.map_name = prepare.CONFIG.starting_map
-
-        def new_game_callback(
-            map_name: str,
-        ) -> Callable:
-            return partial(new_game, map_name)
-
-        def set_player_name(text: str) -> None:
-            map_path = prepare.fetch("maps", self.map_name)
+        def new_game() -> None:
+            map_path = prepare.fetch("maps", prepare.STARTING_MAP)
             self.client.push_state("WorldState", map_name=map_path)
-            self.client.push_state(FadeInTransition())
-            local_session.player.name = text
             local_session.player.game_variables[
                 "date_start_game"
             ] = formula.today_ordinal()
             self.client.pop_state(self)
 
-        def new_game(map_name: str) -> None:
-            self.map_name = map_name
-            # load the starting map
-            self.client.push_state(
-                InputMenu(
-                    prompt=T.translate("input_name"),
-                    callback=set_player_name,
-                    escape_key_exits=True,
-                    char_limit=prepare.PLAYER_NAME_LIMIT,
-                )
-            )
-            self.client.push_state(FadeInTransition())
-
-        # Build a menu of the default mod choices:
-        menu_items_map: Tuple[Tuple[str, Callable], ...] = tuple()
-
-        # If a different map has been passed as a parameter, show as an option:
-        if prepare.CONFIG.starting_map != "player_house_bedroom.tmx":
-            menu_items_map = menu_items_map + (
-                (
-                    str(prepare.CONFIG.starting_map),
-                    new_game_callback(prepare.CONFIG.starting_map),
-                ),
-            )
-
-        menu_items_map = menu_items_map + (
-            ("spyder_campaign", new_game_callback("spyder_bedroom.tmx")),
-            ("xero_campaign", new_game_callback("player_house_bedroom.tmx")),
+        menu_items_map = (
+            ("menu_scenarios", new_game),
             ("cancel", self.close),
         )
 


### PR DESCRIPTION
PR adds a debug map (new starting map: debug.tmx) and removes the hardcoding related the new game structure.

Right now the options (scenarios) are hardcoded inside init.

debug.tmx is simple map, without any tileset, where it'll be set the scenario choice.

What will change for normal player? Nothing.

the old screen with "scenarios and cancel" will be replaced by:
![Screenshot from 2023-02-06 08-13-59](https://user-images.githubusercontent.com/64643719/216908269-2d106c5d-ff59-4897-9e29-c7d8de616691.png)
then will appear this
![Screenshot from 2023-02-06 08-14-08](https://user-images.githubusercontent.com/64643719/216908265-0488e9be-8762-49f1-a512-ddb860af0680.png)
then you'll end up in Xero or Spyder

This will allow us to have a new important variable **scenario_choice**, so we can easily set up actions, etc based on the scenario without hardcoding (eg. phone). This will simplify the additions of new scenarios

this line is necessary in the debug.tmx:
`<property name="act1" value="set_money player,0"/>`
because if not there will be a crash (the locale.py is checking for {{money}}, so we need to have it in the first place. No issue, the modder can decide in the option how much money the player will get.

tested + isort + black