### PR TITLE
fix kennel

### DIFF
--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -641,6 +641,10 @@ class NPC(Entity[NPCState]):
             monster: The monster to add to the npc's party.
 
         """
+        # it creates the kennel
+        if KENNEL not in self.monster_boxes.keys():
+            self.monster_boxes[KENNEL] = []
+
         monster.owner = self
         if len(self.monsters) >= self.party_limit:
             self.monster_boxes[KENNEL].append(monster)


### PR DESCRIPTION
fix #1621 

If the player doesn't look at the PC, then there is no kennel.
This was the reason for the crash when catching the 7th monster.

This fix the issue, because there could be a player catching monster and playing without checking the PC.