### PR TITLE
fix position

### DIFF
--- a/mods/tuxemon/maps/bedroom_test.tmx
+++ b/mods/tuxemon/maps/bedroom_test.tmx
@@ -50,12 +50,11 @@
     <property name="cond1" value="is player_at"/>
    </properties>
   </object>
-  <object id="10" name="Use Computer" type="event" x="64" y="48" width="16" height="16">
+  <object id="10" name="Use Computer" type="event" x="64" y="32" width="16" height="16">
    <properties>
     <property name="act1" value="change_state PCState"/>
-    <property name="cond1" value="is player_at 4,3"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="26" name="Player Spawn" type="event" x="64" y="80" width="16" height="16"/>

--- a/mods/tuxemon/maps/cotton_cathedral.tmx
+++ b/mods/tuxemon/maps/cotton_cathedral.tmx
@@ -67,15 +67,13 @@
     <property name="cond10" value="not npc_exists tabanurse"/>
    </properties>
   </object>
-  <object id="27" name="get those tuxemon healed" type="event" x="80" y="96" width="16" height="16">
+  <object id="27" name="hello there" type="event" x="80" y="80" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog tabanurse_dialog\n"/>
-    <property name="act20" value="translated_dialog healmytuxemon"/>
-    <property name="act30" value="translated_dialog_choice yes:no,healme"/>
-    <property name="cond10" value="is player_at"/>
-    <property name="cond20" value="is player_facing up"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
-    <property name="cond40" value="not variable_set healme:yes"/>
+    <property name="act20" value="translated_dialog_choice yes:no,chooses"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="not variable_set chooses:yes"/>
    </properties>
   </object>
   <object id="28" name="Heal Tuxemon" type="event" x="80" y="96" width="16" height="16">
@@ -87,9 +85,9 @@
     <property name="act50" value="wait 1"/>
     <property name="act60" value="npc_face tabanurse,down"/>
     <property name="act70" value="translated_dialog okaythen2"/>
-    <property name="act80" value="set_variable healme:none"/>
+    <property name="act80" value="set_variable chooses:none"/>
     <property name="act90" value="set_variable teleport_faint:cotton_cathedral.tmx 6 10"/>
-    <property name="cond10" value="is variable_set healme:yes"/>
+    <property name="cond10" value="is variable_set chooses:yes"/>
    </properties>
   </object>
   <object id="29" name="Auto Healing Teleported" type="event" x="16" y="0" width="16" height="16">
@@ -100,12 +98,11 @@
     <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>
   </object>
-  <object id="30" name="Use Computer" type="event" x="160" y="64" width="16" height="16">
+  <object id="30" name="Use Computer" type="event" x="160" y="48" width="16" height="16">
    <properties>
     <property name="act1" value="change_state PCState"/>
-    <property name="cond1" value="is player_at 10,4"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/healing_center.tmx
+++ b/mods/tuxemon/maps/healing_center.tmx
@@ -55,14 +55,13 @@
     <property name="cond10" value="not npc_exists tabanurse"/>
    </properties>
   </object>
-  <object id="26" name="hello there" type="event" x="80" y="96" width="16" height="16">
+  <object id="26" name="hello there" type="event" x="80" y="80" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog tabanurse_dialog\n"/>
     <property name="act20" value="translated_dialog_choice yes:no,chooses"/>
-    <property name="cond10" value="is player_at"/>
-    <property name="cond20" value="is player_facing up"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
-    <property name="cond40" value="not variable_set chooses:yes"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="not variable_set chooses:yes"/>
    </properties>
   </object>
   <object id="27" name="Heal Tuxemon" type="event" x="80" y="96" width="16" height="16">
@@ -132,12 +131,11 @@
     <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>
   </object>
-  <object id="37" name="Use Computer" type="event" x="160" y="64" width="16" height="16">
+  <object id="37" name="Use Computer" type="event" x="160" y="48" width="16" height="16">
    <properties>
     <property name="act1" value="change_state PCState"/>
-    <property name="cond1" value="is player_at 10,4"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/maple_bedroom.tmx
+++ b/mods/tuxemon/maps/maple_bedroom.tmx
@@ -56,12 +56,11 @@
    </properties>
   </object>
   <object id="30" name="Player Spawn" type="event" x="48" y="64" width="16" height="16"/>
-  <object id="31" name="Use Computer" type="event" x="64" y="48" width="16" height="16">
+  <object id="31" name="Use Computer" type="event" x="64" y="32" width="16" height="16">
    <properties>
     <property name="act1" value="change_state PCState"/>
-    <property name="cond1" value="is player_at 4,3"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="34" name="Read Sign" type="event" x="128" y="16" width="16" height="16">

--- a/mods/tuxemon/maps/maple_house.tmx
+++ b/mods/tuxemon/maps/maple_house.tmx
@@ -103,7 +103,7 @@
    <properties>
     <property name="act10" value="transition_teleport maple_bedroom.tmx,8,2,0.3"/>
     <property name="act20" value="player_face down"/>
-    <property name="cond10" value="is player_at 11,1"/>
+    <property name="cond10" value="is player_at"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/player_house_bedroom.yaml
+++ b/mods/tuxemon/maps/player_house_bedroom.yaml
@@ -13,13 +13,12 @@ events:
     actions:
     - change_state PCState
     conditions:
-    - is player_at 3,2
-    - is player_facing up
+    - is player_facing_tile
     - is button_pressed K_RETURN
     height: 1
     width: 1
     x: 3
-    y: 2
+    y: 1
     type: "event"
   Player Spawn:
     height: 1

--- a/mods/tuxemon/maps/player_house_downstairs.tmx
+++ b/mods/tuxemon/maps/player_house_downstairs.tmx
@@ -65,16 +65,15 @@
   <object id="25" name="Read Sign" type="event" x="16" y="32" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog spyder_papertown_home"/>
-    <property name="cond10" value="is player_at 1,2"/>
-    <property name="cond20" value="is player_facing up"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="26" name="Go Upstairs" type="event" x="0" y="16" width="16" height="16">
    <properties>
     <property name="act10" value="transition_teleport player_house_bedroom.tmx,8,2,0.3"/>
     <property name="act20" value="player_face down"/>
-    <property name="cond10" value="is player_at 0,1"/>
+    <property name="cond10" value="is player_at"/>
     <property name="cond20" value="not variable_set scene:yes"/>
    </properties>
   </object>
@@ -82,7 +81,7 @@
    <properties>
     <property name="act10" value="transition_teleport taba_town.tmx,43,46,0.3"/>
     <property name="act20" value="player_face down"/>
-    <property name="cond10" value="is player_at 4,6"/>
+    <property name="cond10" value="is player_at"/>
     <property name="cond20" value="is player_facing down"/>
     <property name="cond30" value="not variable_set scene:yes"/>
    </properties>

--- a/mods/tuxemon/maps/professor_lab.tmx
+++ b/mods/tuxemon/maps/professor_lab.tmx
@@ -61,7 +61,7 @@
    <properties>
     <property name="act10" value="transition_teleport taba_town.tmx,44,53,0.3"/>
     <property name="act20" value="player_face down"/>
-    <property name="cond10" value="is player_at 8,17"/>
+    <property name="cond10" value="is player_at"/>
     <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/sphalian_center.tmx
+++ b/mods/tuxemon/maps/sphalian_center.tmx
@@ -69,26 +69,24 @@
   <object id="22" name="Player Spawn" type="event" x="192" y="0" width="16" height="16"/>
   <object id="25" name="Create Npc" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc tabanurse,6,4,nurse,stand"/>
+    <property name="act1" value="create_npc tabanurse,5,4"/>
     <property name="cond1" value="not npc_exists tabanurse"/>
    </properties>
   </object>
-  <object id="26" name="hello there" type="event" x="96" y="96" width="16" height="16">
+  <object id="26" name="hello there" type="event" x="80" y="80" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_cotton_nurse1"/>
     <property name="act3" value="translated_dialog_choice yes:no,chooses"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
-    <property name="cond4" value="not variable_set chooses:yes"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="not variable_set chooses:yes"/>
    </properties>
   </object>
-  <object id="28" name="Use Computer" type="event" x="160" y="64" width="16" height="16">
+  <object id="28" name="Use Computer" type="event" x="160" y="48" width="16" height="16">
    <properties>
     <property name="act1" value="change_state PCState"/>
-    <property name="cond1" value="is player_at 11,6"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="29" name="Auto Healing Teleported" type="event" x="16" y="0" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_bedroom.tmx
+++ b/mods/tuxemon/maps/spyder_bedroom.tmx
@@ -53,12 +53,11 @@
     <property name="cond1" value="is player_at"/>
    </properties>
   </object>
-  <object id="10" name="Use Computer" type="event" x="48" y="32" width="16" height="16">
+  <object id="10" name="Use Computer" type="event" x="48" y="16" width="16" height="16">
    <properties>
     <property name="act1" value="change_state PCState"/>
-    <property name="cond1" value="is player_at 3,2"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="26" name="Player Spawn" type="event" x="48" y="64" width="16" height="16"/>

--- a/mods/tuxemon/maps/spyder_candy_center.tmx
+++ b/mods/tuxemon/maps/spyder_candy_center.tmx
@@ -77,14 +77,13 @@
     <property name="cond1" value="not npc_exists tabanurse"/>
    </properties>
   </object>
-  <object id="26" name="hello there" type="event" x="80" y="96" width="16" height="16">
+  <object id="26" name="hello there" type="event" x="80" y="80" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_cotton_nurse1"/>
     <property name="act3" value="translated_dialog_choice yes:no,chooses"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
-    <property name="cond4" value="not variable_set chooses:yes"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="not variable_set chooses:yes"/>
    </properties>
   </object>
   <object id="27" name="Route Music" type="event" x="16" y="0" width="16" height="16">
@@ -93,12 +92,11 @@
     <property name="cond1" value="not music_playing music_cathedral_theme"/>
    </properties>
   </object>
-  <object id="28" name="Use Computer" type="event" x="160" y="64" width="16" height="16">
+  <object id="28" name="Use Computer" type="event" x="160" y="48" width="16" height="16">
    <properties>
     <property name="act1" value="change_state PCState"/>
-    <property name="cond1" value="is player_at 10,4"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="29" name="Go upstairs" type="event" x="0" y="48" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_candy_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_candy_scoop.tmx
@@ -80,24 +80,22 @@
     <property name="cond1" value="not music_playing music_cathedral_theme"/>
    </properties>
   </object>
-  <object id="29" name="Open Shop" type="event" x="48" y="96" width="16" height="16">
+  <object id="29" name="Open Shop" type="event" x="32" y="96" width="16" height="16">
    <properties>
     <property name="act1" value="npc_face spyder_shopkeeper,right"/>
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
     <property name="act3" value="open_shop spyder_shopkeeper"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
-  <object id="30" name="Open Shop" type="event" x="16" y="128" width="16" height="16">
+  <object id="30" name="Open Shop" type="event" x="16" y="112" width="16" height="16">
    <properties>
     <property name="act1" value="npc_face spyder_shopkeeper,down"/>
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
     <property name="act3" value="open_shop spyder_shopkeeper"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="31" name="Talk/Open Shop" type="event" x="0" y="80" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_cotton_cafe.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_cafe.tmx
@@ -90,9 +90,8 @@
     <property name="cond1" value="is variable_set visitedcottoncafe:yes"/>
     <property name="cond2" value="not variable_set chooses:yes"/>
     <property name="cond3" value="is variable_set introdcottoncafe2:yes"/>
-    <property name="cond4" value="is player_at"/>
-    <property name="cond5" value="is player_facing up"/>
-    <property name="cond6" value="is button_pressed K_RETURN"/>
+    <property name="cond4" value="is player_facing_tile"/>
+    <property name="cond5" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="20" name="First Visit to Cotton Cafe" type="event" x="80" y="96" width="112" height="16">

--- a/mods/tuxemon/maps/spyder_cotton_house1.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_house1.tmx
@@ -75,12 +75,11 @@
     <property name="cond2" value="is player_facing down"/>
    </properties>
   </object>
-  <object id="73" name="Watch TV" type="event" x="144" y="48" width="16" height="16">
+  <object id="73" name="Watch TV" type="event" x="144" y="32" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_cottonhouse1_tvwatch"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond3" value="is player_facing up"/>
-    <property name="cond4" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_cotton_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_scoop.tmx
@@ -139,24 +139,22 @@
     <property name="behav1" value="talk spyder_shopkeeper"/>
    </properties>
   </object>
-  <object id="30" name="Open Shop" type="event" x="48" y="96" width="16" height="16">
+  <object id="30" name="Open Shop" type="event" x="32" y="96" width="16" height="16">
    <properties>
     <property name="act1" value="npc_face spyder_shopkeeper,right"/>
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
     <property name="act3" value="open_shop spyder_shopkeeper"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
-  <object id="31" name="Open Shop" type="event" x="16" y="128" width="16" height="16">
+  <object id="31" name="Open Shop" type="event" x="16" y="112" width="16" height="16">
    <properties>
     <property name="act1" value="npc_face spyder_shopkeeper,down"/>
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
     <property name="act3" value="open_shop spyder_shopkeeper"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_downstairs.tmx
+++ b/mods/tuxemon/maps/spyder_downstairs.tmx
@@ -50,7 +50,7 @@
    <properties>
     <property name="act1" value="transition_teleport spyder_bedroom.tmx,8,2,0.3"/>
     <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at 1,2"/>
+    <property name="cond1" value="is player_at"/>
    </properties>
   </object>
   <object id="38" name="Home Sign" type="event" x="16" y="16" width="16" height="16">
@@ -140,7 +140,7 @@
    <properties>
     <property name="act1" value="transition_teleport spyder_paper_town.tmx,8,7,0.3"/>
     <property name="act2" value="player_face down"/>
-    <property name="cond1" value="is player_at 5,7"/>
+    <property name="cond1" value="is player_at"/>
     <property name="cond2" value="is player_facing down"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_flower_center.tmx
+++ b/mods/tuxemon/maps/spyder_flower_center.tmx
@@ -71,14 +71,13 @@
     <property name="cond1" value="not npc_exists tabanurse"/>
    </properties>
   </object>
-  <object id="26" name="hello there" type="event" x="80" y="96" width="16" height="16">
+  <object id="26" name="hello there" type="event" x="80" y="80" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_cotton_nurse1"/>
     <property name="act3" value="translated_dialog_choice yes:no,chooses"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
-    <property name="cond4" value="not variable_set chooses:yes"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="not variable_set chooses:yes"/>
    </properties>
   </object>
   <object id="27" name="Route Music" type="event" x="32" y="0" width="16" height="16">
@@ -87,12 +86,11 @@
     <property name="cond1" value="not music_playing music_cathedral_theme"/>
    </properties>
   </object>
-  <object id="28" name="Use Computer" type="event" x="160" y="64" width="16" height="16">
+  <object id="28" name="Use Computer" type="event" x="160" y="48" width="16" height="16">
    <properties>
     <property name="act1" value="change_state PCState"/>
-    <property name="cond1" value="is player_at 10,4"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="29" name="Auto Healing Teleported" type="event" x="16" y="0" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_flower_petshop.tmx
+++ b/mods/tuxemon/maps/spyder_flower_petshop.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="14" height="9" tilewidth="16" tileheight="16" infinite="0" nextlayerid="10" nextobjectid="54">
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="14" height="9" tilewidth="16" tileheight="16" infinite="0" nextlayerid="10" nextobjectid="55">
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
@@ -53,13 +53,12 @@
     <property name="cond1" value="not npc_exists spyder_shopassistant"/>
    </properties>
   </object>
-  <object id="31" name="Talk Shop Assistant" type="event" x="112" y="96" width="16" height="16">
+  <object id="31" name="Talk Shop Assistant1" type="event" x="112" y="80" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_flower_petshopassistant"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
-    <property name="cond4" value="not variable_set chooses:yes"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="not variable_set chooses:yes"/>
    </properties>
   </object>
   <object id="38" name="Create Shop Keeper" type="event" x="32" y="80" width="16" height="16">
@@ -168,6 +167,14 @@
     <property name="cond1" value="is variable_set check_vivitron_morph:yes"/>
     <property name="cond2" value="is has_monster vivitron"/>
     <property name="cond3" value="not variable_set shows_vivitron:yes"/>
+   </properties>
+  </object>
+  <object id="54" name="Talk Shop Assistant2" type="event" x="128" y="64" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_flower_petshopassistant"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="not variable_set chooses:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_flower_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_flower_scoop.tmx
@@ -80,24 +80,22 @@
     <property name="cond1" value="not music_playing music_cathedral_theme"/>
    </properties>
   </object>
-  <object id="29" name="Open Shop" type="event" x="48" y="96" width="16" height="16">
+  <object id="29" name="Open Shop" type="event" x="32" y="96" width="16" height="16">
    <properties>
     <property name="act1" value="npc_face spyder_shopkeeper,right"/>
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
     <property name="act3" value="open_shop spyder_shopkeeper"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
-  <object id="30" name="Open Shop" type="event" x="16" y="128" width="16" height="16">
+  <object id="30" name="Open Shop" type="event" x="16" y="112" width="16" height="16">
    <properties>
     <property name="act1" value="npc_face spyder_shopkeeper,down"/>
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
     <property name="act3" value="open_shop spyder_shopkeeper"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="31" name="Talk/Open Shop" type="event" x="0" y="80" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_healing_center.tmx
+++ b/mods/tuxemon/maps/spyder_healing_center.tmx
@@ -71,14 +71,13 @@
     <property name="cond1" value="not npc_exists tabanurse"/>
    </properties>
   </object>
-  <object id="26" name="hello there" type="event" x="80" y="96" width="16" height="16">
+  <object id="26" name="hello there" type="event" x="80" y="80" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_cotton_nurse1"/>
     <property name="act3" value="translated_dialog_choice yes:no,chooses"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
-    <property name="cond4" value="not variable_set chooses:yes"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="not variable_set chooses:yes"/>
    </properties>
   </object>
   <object id="27" name="Route Music" type="event" x="32" y="0" width="16" height="16">
@@ -87,12 +86,11 @@
     <property name="cond1" value="not music_playing music_cathedral_theme"/>
    </properties>
   </object>
-  <object id="28" name="Use Computer" type="event" x="160" y="64" width="16" height="16">
+  <object id="28" name="Use Computer" type="event" x="160" y="48" width="16" height="16">
    <properties>
     <property name="act1" value="change_state PCState"/>
-    <property name="cond1" value="is player_at 10,4"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="29" name="Auto Healing Teleported" type="event" x="16" y="0" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_leather_center.tmx
+++ b/mods/tuxemon/maps/spyder_leather_center.tmx
@@ -72,14 +72,13 @@
     <property name="cond1" value="not npc_exists tabanurse"/>
    </properties>
   </object>
-  <object id="26" name="hello there" type="event" x="80" y="96" width="16" height="16">
+  <object id="26" name="hello there" type="event" x="80" y="80" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_cotton_nurse1"/>
     <property name="act3" value="translated_dialog_choice yes:no,chooses"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
-    <property name="cond4" value="not variable_set chooses:yes"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="not variable_set chooses:yes"/>
    </properties>
   </object>
   <object id="27" name="Route Music" type="event" x="32" y="0" width="16" height="16">
@@ -88,12 +87,11 @@
     <property name="cond1" value="not music_playing music_cathedral_theme"/>
    </properties>
   </object>
-  <object id="28" name="Use Computer" type="event" x="160" y="64" width="16" height="16">
+  <object id="28" name="Use Computer" type="event" x="160" y="48" width="16" height="16">
    <properties>
     <property name="act1" value="change_state PCState"/>
-    <property name="cond1" value="is player_at 10,4"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="29" name="Auto Healing Teleported" type="event" x="16" y="-3.55271e-15" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_leather_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_leather_scoop.tmx
@@ -66,24 +66,22 @@
     <property name="cond1" value="not music_playing music_cathedral_theme"/>
    </properties>
   </object>
-  <object id="19" name="Open Shop" type="event" x="48" y="96" width="16" height="16">
+  <object id="19" name="Open Shop" type="event" x="32" y="96" width="16" height="16">
    <properties>
     <property name="act1" value="npc_face spyder_shopkeeper,right"/>
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
     <property name="act3" value="open_shop spyder_shopkeeper"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
-  <object id="20" name="Open Shop" type="event" x="16" y="128" width="16" height="16">
+  <object id="20" name="Open Shop" type="event" x="16" y="112" width="16" height="16">
    <properties>
     <property name="act1" value="npc_face spyder_shopkeeper,down"/>
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
     <property name="act3" value="open_shop spyder_shopkeeper"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="21" name="Create Shopkeeper" type="event" x="16" y="96" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_route2.tmx
+++ b/mods/tuxemon/maps/spyder_route2.tmx
@@ -243,15 +243,15 @@
   <object id="84" name="Sign: Column 1" type="event" x="176" y="112" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_column1_sign"/>
+    <property name="cond1" value="is player_facing_tile"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
-    <property name="cond3" value="is player_facing_tile"/>
    </properties>
   </object>
   <object id="85" name="Sign: Column 2" type="event" x="240" y="80" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_column2_sign"/>
+    <property name="cond1" value="is player_facing_tile"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
-    <property name="cond3" value="is player_facing_tile"/>
    </properties>
   </object>
   <object id="97" name="random battle" type="event" x="160" y="192" width="16" height="48">

--- a/mods/tuxemon/maps/spyder_timber_center.tmx
+++ b/mods/tuxemon/maps/spyder_timber_center.tmx
@@ -71,14 +71,13 @@
     <property name="cond1" value="not npc_exists tabanurse"/>
    </properties>
   </object>
-  <object id="26" name="hello there" type="event" x="80" y="96" width="16" height="16">
+  <object id="26" name="hello there" type="event" x="80" y="80" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_cotton_nurse1"/>
     <property name="act3" value="translated_dialog_choice yes:no,chooses"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
-    <property name="cond4" value="not variable_set chooses:yes"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="not variable_set chooses:yes"/>
    </properties>
   </object>
   <object id="27" name="Route Music" type="event" x="32" y="0" width="16" height="16">
@@ -87,12 +86,11 @@
     <property name="cond1" value="not music_playing music_cathedral_theme"/>
    </properties>
   </object>
-  <object id="28" name="Use Computer" type="event" x="160" y="64" width="16" height="16">
+  <object id="28" name="Use Computer" type="event" x="160" y="48" width="16" height="16">
    <properties>
     <property name="act1" value="change_state PCState"/>
-    <property name="cond1" value="is player_at 10,4"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="29" name="Auto Healing Teleported" type="event" x="16" y="0" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_timber_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_timber_scoop.tmx
@@ -80,24 +80,22 @@
     <property name="cond1" value="not music_playing music_cathedral_theme"/>
    </properties>
   </object>
-  <object id="29" name="Open Shop" type="event" x="48" y="96" width="16" height="16">
+  <object id="29" name="Open Shop" type="event" x="32" y="96" width="16" height="16">
    <properties>
     <property name="act1" value="npc_face spyder_shopkeeper,right"/>
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
     <property name="act3" value="open_shop spyder_shopkeeper"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing left"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
-  <object id="30" name="Open Shop" type="event" x="16" y="128" width="16" height="16">
+  <object id="30" name="Open Shop" type="event" x="16" y="112" width="16" height="16">
    <properties>
     <property name="act1" value="npc_face spyder_shopkeeper,down"/>
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
     <property name="act3" value="open_shop spyder_shopkeeper"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_facing up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="32" name="Talk/Open Shop" type="event" x="0" y="80" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
+++ b/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
@@ -130,14 +130,13 @@
     <property name="cond1" value="is variable_set chooses:yes"/>
    </properties>
   </object>
-  <object id="49" name="Talk Shopkeeper" type="event" x="176" y="128" width="16" height="16">
+  <object id="49" name="Talk Shopkeeper" type="event" x="176" y="112" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_wayfarer_shopkeeper"/>
     <property name="act2" value="translated_dialog_choice yes:no,chooses"/>
-    <property name="cond2" value="not variable_set chooses:yes"/>
-    <property name="cond4" value="is player_at"/>
-    <property name="cond5" value="is player_facing up"/>
-    <property name="cond6" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="not variable_set chooses:yes"/>
    </properties>
   </object>
   <object id="50" name="Create Nurse" type="event" x="128" y="144" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_wayfarer_inn2.tmx
+++ b/mods/tuxemon/maps/spyder_wayfarer_inn2.tmx
@@ -154,12 +154,11 @@
     <property name="cond1" value="not variable_set wayfarer1james:yes"/>
    </properties>
   </object>
-  <object id="43" name="Watch TV" type="event" x="176" y="112" width="32" height="16">
+  <object id="43" name="Watch TV" type="event" x="176" y="96" width="32" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_wayfarerinn_tv1"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond3" value="is player_facing up"/>
-    <property name="cond4" value="is button_pressed K_RETURN"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="48" name="Environment" type="event" x="16" y="0" width="16" height="16">

--- a/mods/tuxemon/maps/taba_town_house1.tmx
+++ b/mods/tuxemon/maps/taba_town_house1.tmx
@@ -54,7 +54,7 @@
    <properties>
     <property name="act10" value="transition_teleport taba_town.tmx,49,7,0.3"/>
     <property name="act20" value="player_face down"/>
-    <property name="cond10" value="is player_at "/>
+    <property name="cond10" value="is player_at"/>
     <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/taba_town_house2.tmx
+++ b/mods/tuxemon/maps/taba_town_house2.tmx
@@ -53,7 +53,7 @@
    <properties>
     <property name="act10" value="transition_teleport taba_town.tmx,40,12,0.3"/>
     <property name="act20" value="player_face down"/>
-    <property name="cond10" value="is player_at "/>
+    <property name="cond10" value="is player_at"/>
     <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/taba_town_house3.tmx
+++ b/mods/tuxemon/maps/taba_town_house3.tmx
@@ -58,7 +58,7 @@
    <properties>
     <property name="act10" value="transition_teleport taba_town.tmx,33,4,0.3"/>
     <property name="act20" value="player_face down"/>
-    <property name="cond10" value="is player_at "/>
+    <property name="cond10" value="is player_at"/>
     <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/taba_town_house4.tmx
+++ b/mods/tuxemon/maps/taba_town_house4.tmx
@@ -55,7 +55,7 @@
    <properties>
     <property name="act10" value="transition_teleport taba_town.tmx,25,4,0.3"/>
     <property name="act20" value="player_face down"/>
-    <property name="cond10" value="is player_at "/>
+    <property name="cond10" value="is player_at"/>
     <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>


### PR DESCRIPTION
PR fix positions and events (something I noticed during the other PRs)

mostly use_pc, hello_there (centers) and open_shop (scoops), some missing signs

eg: using the PC
```
    <property name="act1" value="change_state PCState"/>
    <property name="cond1" value="is player_at 4,3"/>
    <property name="cond2" value="is player_facing up"/>
    <property name="cond3" value="is button_pressed K_RETURN"/>
```
when this would suffice
```
    <property name="act1" value="change_state PCState"/>
    <property name="cond1" value="is player_facing_tile"/>
    <property name="cond2" value="is button_pressed K_RETURN"/>
```