### PR TITLE
Class Battle (upgrade battle_history)

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -1507,6 +1507,9 @@ msgstr "Caught {param} out of {all} Tuxemon"
 msgid "player_start_adventure"
 msgstr "The adventure began {date} days ago."
 
+msgid "player_battles"
+msgstr "Battles: {tot} (W{won} D{draw} L{lost})"
+
 # Tuxepedia
 
 msgid "page_tuxepedia"

--- a/tuxemon/battle.py
+++ b/tuxemon/battle.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import uuid
+from typing import Any, List, Mapping, Optional, Sequence
+
+SIMPLE_PERSISTANCE_ATTRIBUTES = (
+    "opponent",
+    "outcome",
+    "date",
+)
+
+
+class Battle:
+    """
+    Tuxemon Battle.
+    """
+
+    def __init__(self, save_data: Optional[Mapping[str, Any]] = None) -> None:
+        if save_data is None:
+            save_data = dict()
+
+        self.instance_id = uuid.uuid4()
+        self.opponent = ""
+        self.outcome = ""
+        self.date = 0
+
+        self.set_state(save_data)
+
+    def get_state(self) -> Mapping[str, Any]:
+        """
+        Prepares a dictionary of the battle to be saved to a file.
+
+        Returns:
+            Dictionary containing all the information about the battle.
+
+        """
+        save_data = {
+            attr: getattr(self, attr)
+            for attr in SIMPLE_PERSISTANCE_ATTRIBUTES
+            if getattr(self, attr)
+        }
+
+        save_data["instance_id"] = self.instance_id.hex
+
+        return save_data
+
+    def set_state(self, save_data: Mapping[str, Any]) -> None:
+        """
+        Loads information from saved data.
+
+        Parameters:
+            save_data: Data used to reconstruct the battle.
+
+        """
+        if not save_data:
+            return
+
+        for key, value in save_data.items():
+            if key == "instance_id" and value:
+                self.instance_id = uuid.UUID(value)
+            elif key in SIMPLE_PERSISTANCE_ATTRIBUTES:
+                setattr(self, key, value)
+
+
+def decode_battle(
+    json_data: Optional[Sequence[Mapping[str, Any]]],
+) -> List[Battle]:
+    return [Battle(save_data=battle) for battle in json_data or {}]
+
+
+def encode_battle(battles: Sequence[Battle]) -> Sequence[Mapping[str, Any]]:
+    return [battle.get_state() for battle in battles]

--- a/tuxemon/event/actions/battles_print.py
+++ b/tuxemon/event/actions/battles_print.py
@@ -3,13 +3,10 @@
 from __future__ import annotations
 
 import datetime as dt
-import logging
 from dataclasses import dataclass
 from typing import Optional, final
 
 from tuxemon.event.eventaction import EventAction
-
-logger = logging.getLogger(__name__)
 
 
 @final
@@ -40,14 +37,20 @@ class BattlesAction(EventAction):
         player = self.session.player
         today = dt.date.today().toordinal()
 
-        if self.character in player.battle_history:
-            output, battle_date = player.battle_history[self.character]
-            diff_date = today - battle_date
-            if self.result == output:
-                print(
-                    f"{self.result} against {self.character} {diff_date} days ago"
+        for battle in player.battles:
+            if battle.opponent == self.character:
+                total = sum(
+                    1
+                    for battle in player.battles
+                    if battle.opponent == self.character
                 )
+                diff_date = today - battle.date
+                if self.result == battle.outcome:
+                    print(
+                        f"You {self.result} {total} times against {self.character}\n"
+                        f"{diff_date} days ago"
+                    )
+                else:
+                    print(f"Never {self.result} against {self.character}")
             else:
-                print(f"Never {self.result} against {self.character}")
-        else:
-            print(player.battle_history)
+                print(battle.opponent, battle.outcome, battle.date)

--- a/tuxemon/event/actions/set_battle.py
+++ b/tuxemon/event/actions/set_battle.py
@@ -6,6 +6,8 @@ import datetime as dt
 from dataclasses import dataclass
 from typing import final
 
+from tuxemon import battle
+from tuxemon.db import OutputBattle
 from tuxemon.event.eventaction import EventAction
 
 
@@ -13,12 +15,12 @@ from tuxemon.event.eventaction import EventAction
 @dataclass
 class SetBattleAction(EventAction):
     """
-    Set the key in the player.battle_history dictionary.
+    Append the element in player.battles.
 
     Script usage:
         .. code-block::
 
-            set_battle <character>:<result>
+            set_battle <character>,<result>
 
     Script parameters:
         character: Npc slug name (e.g. "npc_maple").
@@ -27,15 +29,19 @@ class SetBattleAction(EventAction):
     """
 
     name = "set_battle"
-    battle_list: str
+    battle_opponent: str
+    battle_outcome: str
 
     def start(self) -> None:
         player = self.session.player
 
-        # Split the variable into a key: value pair
-        battle_list = self.battle_list.split(":")
-        battle_key = str(battle_list[0])
-        battle_value = str(battle_list[1]), dt.date.today().toordinal()
+        new_battle = battle.Battle()
+        new_battle.opponent = self.battle_opponent
+        new_battle.outcome = self.battle_outcome
+        new_battle.date = dt.date.today().toordinal()
 
-        # set the value in battle history
-        player.battle_history[battle_key] = battle_value
+        outcomes = [otc.value for otc in OutputBattle]
+        if self.battle_outcome in outcomes:
+            player.battles.append(new_battle)
+        else:
+            return

--- a/tuxemon/event/actions/start_battle.py
+++ b/tuxemon/event/actions/start_battle.py
@@ -54,10 +54,12 @@ class StartBattleAction(EventAction):
             return
 
         # Rematch
-        if self.npc_slug in player.battle_history:
-            rematch = player.battle_history[self.npc_slug]
-            for mon in npc.monsters:
-                formula.rematch(player, npc, mon, rematch[1])
+        if player.battles:
+            if npc.slug != "random_encounter_dummy":
+                for battle in player.battles:
+                    if battle.opponent == npc.slug:
+                        for mon in npc.monsters:
+                            formula.rematch(player, npc, mon, battle.date)
 
         # Lookup the environment
         env_slug = player.game_variables.get("environment", "grass")

--- a/tuxemon/event/conditions/battle_is.py
+++ b/tuxemon/event/conditions/battle_is.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+from tuxemon.db import OutputBattle
 from tuxemon.event import MapCondition
 from tuxemon.event.eventcondition import EventCondition
 from tuxemon.session import Session
@@ -33,7 +34,7 @@ class BattleIsCondition(EventCondition):
             condition: The map condition object.
 
         Returns:
-            Whether the player has lost against character or not.
+            Whether the player has fought against a character or not.
 
         """
         player = session.player
@@ -42,10 +43,18 @@ class BattleIsCondition(EventCondition):
         character = condition.parameters[0]
         result = condition.parameters[1]
 
-        if character in player.battle_history:
-            output, date = player.battle_history[character]
-            if result == output:
-                return True
+        outcomes = [otc.value for otc in OutputBattle]
+
+        if player.battles:
+            if result in outcomes:
+                for battle in player.battles:
+                    if (
+                        battle.opponent == character
+                        and battle.outcome == result
+                    ):
+                        return True
+                    else:
+                        return False
             else:
                 return False
         else:

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -8,7 +8,6 @@ import random
 from typing import TYPE_CHECKING, NamedTuple, Optional, Sequence, Tuple
 
 if TYPE_CHECKING:
-    from tuxemon.db import OutputBattle
     from tuxemon.monster import Monster
     from tuxemon.npc import NPC
     from tuxemon.technique.technique import Technique
@@ -274,31 +273,6 @@ def convert_mi(steps: float) -> float:
     km = convert_km(steps)
     mi = round(km * 0.6213711922, 2)
     return mi
-
-
-def battle_math(player: NPC, output: OutputBattle) -> None:
-    player = player.game_variables
-    if "battle_total" not in player:
-        player["battle_total"] = 0
-        player["battle_won"] = 0
-        player["battle_lost"] = 0
-        player["battle_draw"] = 0
-    player["battle_total"] += 1
-    if output.won:
-        player["battle_won"] += 1
-        player["percent_win"] = round(
-            (player["battle_won"] / player["battle_total"]) * 100
-        )
-    elif output.lost:
-        player["battle_lost"] += 1
-        player["percent_lose"] = round(
-            (player["battle_lost"] / player["battle_total"]) * 100
-        )
-    elif output.draw:
-        player["battle_draw"] += 1
-        player["percent_draw"] = round(
-            (player["battle_draw"] / player["battle_total"]) * 100
-        )
 
 
 def rematch(

--- a/tuxemon/save_upgrader.py
+++ b/tuxemon/save_upgrader.py
@@ -59,11 +59,21 @@ def upgrade_save(save_data: Dict[str, Any]) -> SaveData:
             "date_start_game"
         ] = formula.today_ordinal()
 
-    save_data["battle_history"] = save_data.get("battle_history", {})
     save_data["money"] = save_data.get("money", {})
     save_data["tuxepedia"] = save_data.get("tuxepedia", {})
     save_data["contacts"] = save_data.get("contacts", {})
     save_data["items"] = save_data.get("items", [])
+    save_data["battles"] = save_data.get("battles", [])
+
+    print(save_data["battles"])
+
+    # trasfer data from "inventory" to "items"
+    if "battle_history" in save_data:
+        for key, value in save_data["battle_history"].items():
+            output, date = value
+            save_data["battles"].append(
+                {"opponent": key, "outcome": output, "date": date}
+            )
 
     # trasfer data from "inventory" to "items"
     if "inventory" in save_data:

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -26,7 +26,7 @@ from typing import (
 import pygame
 from pygame.rect import Rect
 
-from tuxemon import audio, formula, graphics, state, tools
+from tuxemon import audio, battle, formula, graphics, state, tools
 from tuxemon.animation import Task
 from tuxemon.combat import (
     check_status,
@@ -439,13 +439,13 @@ class CombatState(CombatAnimations):
             var = self.players[0].game_variables
             var["battle_last_result"] = OutputBattle.draw
             if self.is_trainer_battle:
-                formula.battle_math(self.players[0], OutputBattle.draw)
                 var["battle_last_trainer"] = self.players[1].slug
                 # track battles against NPC
-                self.players[0].battle_history[self.players[1].slug] = (
-                    OutputBattle.draw,
-                    dt.date.today().toordinal(),
-                )
+                opponent = battle.Battle()
+                opponent.opponent = self.players[1].slug
+                opponent.outcome = OutputBattle.draw
+                opponent.date = dt.date.today().toordinal()
+                self.players[0].battles.append(opponent)
 
             # it is a draw match; both players were defeated in same round
             self.alert(T.translate("combat_draw"))
@@ -476,11 +476,11 @@ class CombatState(CombatAnimations):
                     self.players[0].give_money(self._prize)
                     var["battle_last_trainer"] = self.players[1].slug
                     # track battles against NPC
-                    formula.battle_math(self.players[0], OutputBattle.won)
-                    self.players[0].battle_history[self.players[1].slug] = (
-                        OutputBattle.won,
-                        dt.date.today().toordinal(),
-                    )
+                    opponent = battle.Battle()
+                    opponent.opponent = self.players[1].slug
+                    opponent.outcome = OutputBattle.won
+                    opponent.date = dt.date.today().toordinal()
+                    self.players[0].battles.append(opponent)
                 else:
                     self.alert(T.translate("combat_victory"))
 
@@ -489,13 +489,12 @@ class CombatState(CombatAnimations):
                 var["battle_lost_faint"] = "true"
                 self.alert(T.translate("combat_defeat"))
                 if self.is_trainer_battle:
-                    formula.battle_math(self.players[0], OutputBattle.lost)
                     var["battle_last_trainer"] = self.players[1].slug
                     # track battles against NPC
-                    self.players[0].battle_history[self.players[1].slug] = (
-                        OutputBattle.lost,
-                        dt.date.today().toordinal(),
-                    )
+                    opponent = battle.Battle()
+                    opponent.opponent = self.players[1].slug
+                    opponent.outcome = OutputBattle.lost
+                    opponent.date = dt.date.today().toordinal()
 
             # after 3 seconds, push a state that blocks until enter is pressed
             # after the state is popped, the combat state will clean up and close

--- a/tuxemon/states/player/__init__.py
+++ b/tuxemon/states/player/__init__.py
@@ -8,7 +8,7 @@ import pygame_menu
 from pygame_menu import baseimage, locals
 
 from tuxemon import formula, graphics, prepare
-from tuxemon.db import SeenStatus, db
+from tuxemon.db import OutputBattle, SeenStatus, db
 from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.menu.theme import get_theme
@@ -79,6 +79,31 @@ class PlayerState(PygameMenuState):
             "player_start_adventure",
             {"date": str(date_begin)},
         )
+        tot = len(player.battles)
+        won = sum(
+            1
+            for battle in player.battles
+            if battle.outcome == OutputBattle.won
+        )
+        draw = sum(
+            1
+            for battle in player.battles
+            if battle.outcome == OutputBattle.draw
+        )
+        lost = sum(
+            1
+            for battle in player.battles
+            if battle.outcome == OutputBattle.lost
+        )
+        msg_battles = T.format(
+            "player_battles",
+            {
+                "tot": str(tot),
+                "won": str(won),
+                "draw": str(draw),
+                "lost": str(lost),
+            },
+        )
 
         # name
         menu._auto_centering = False
@@ -123,6 +148,14 @@ class PlayerState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         ).translate(fix_width(width, 0.45), fix_height(height, 0.40))
+        # battles
+        menu.add.label(
+            title=msg_battles,
+            label_id="battle",
+            font_size=15,
+            align=locals.ALIGN_LEFT,
+            float=True,
+        ).translate(fix_width(width, 0.45), fix_height(height, 0.45))
         # % tuxepedia
         menu.add.label(
             title=msg_progress,

--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -359,7 +359,6 @@ class WorldState(state.State):
 
         logger.debug("*** Game Loop Started ***")
         logger.debug("Player Variables:" + str(self.player.game_variables))
-        logger.debug("Battle History:" + str(self.player.battle_history))
         logger.debug("Money:" + str(self.player.money))
         logger.debug("Tuxepedia:" + str(self.player.tuxepedia))
 


### PR DESCRIPTION
PR creates the class Battle, it will replace battle_history.

Class Battle
in npc.py will be self.battles (ex. self.battle_history)
from **Dict[str, Tuple[OutputBattle, int]** to **Sequence[Mapping[str, Any]**

parameters saved are **opponent** (npc_slug), **outcome** (won, lost, draw), **date**.

If someone wants to add other parameters, then feel free to suggest. This will allow to expand it more easily.

Updated Player menu too (see below), and deleted the function in formula.py, since we have the output in the player menu.

![Screenshot from 2023-02-22 16-22-39](https://user-images.githubusercontent.com/64643719/220688469-6f751436-5b1a-4cec-b2ef-c073f4198071.png)
