### PR TITLE
fix types (monster and technique)

### DIFF
--- a/tuxemon/event/actions/spawn_monster.py
+++ b/tuxemon/event/actions/spawn_monster.py
@@ -82,31 +82,31 @@ class SpawnMonsterAction(EventAction):
             )
             return
 
-        # matrix, it respects the type1, strong against weak.
+        # matrix, it respects the types[0], strong against weak.
         # Mother (Water), Father (Earth)
         # Earth > Water => Child (Earth)
-        if mother.type1.water:
-            if father.type1.earth:
+        if mother.types[0].water:
+            if father.types[0].earth:
                 seed = father.slug
             else:
                 seed = mother.slug
-        elif mother.type1.fire:
-            if father.type1.water:
+        elif mother.types[0].fire:
+            if father.types[0].water:
                 seed = father.slug
             else:
                 seed = mother.slug
-        elif mother.type1.wood:
-            if father.type1.metal:
+        elif mother.types[0].wood:
+            if father.types[0].metal:
                 seed = father.slug
             else:
                 seed = mother.slug
-        elif mother.type1.metal:
-            if father.type1.fire:
+        elif mother.types[0].metal:
+            if father.types[0].fire:
                 seed = father.slug
             else:
                 seed = mother.slug
-        elif mother.type1.earth:
-            if father.type1.wood:
+        elif mother.types[0].earth:
+            if father.types[0].wood:
                 seed = father.slug
             else:
                 seed = mother.slug

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -105,8 +105,8 @@ def simple_damage_calculate(
         )
 
     mult = simple_damage_multiplier(
-        (technique.type1, technique.type2),
-        (target.type1, target.type2),
+        (technique.types),
+        (target.types),
     )
     move_strength = technique.power * mult
     damage = int(user_strength * move_strength / target_resist)

--- a/tuxemon/item/conditions/type.py
+++ b/tuxemon/item/conditions/type.py
@@ -12,7 +12,7 @@ from tuxemon.monster import Monster
 @dataclass
 class TypeCondition(ItemCondition):
     """
-    Compares the target Monster's type1 and type2 against the given types.
+    Compares the target Monster's types[0] and types[1] against the given types.
 
     Returns true if either is equal to any of the listed types.
 
@@ -27,9 +27,9 @@ class TypeCondition(ItemCondition):
 
     def test(self, target: Monster) -> bool:
         ret = False
-        if target.type1 is not None:
+        if target.types[0] is not None:
             ret = any(
-                target.type1 == p
+                target.types[0] == p
                 for p in (
                     self.type1,
                     self.type2,
@@ -39,9 +39,9 @@ class TypeCondition(ItemCondition):
                 )
                 if p is not None
             )
-        if target.type2 is not None:
+        if target.types[1] is not None:
             ret = ret or any(
-                target.type2 == p
+                target.types[1] == p
                 for p in (
                     self.type1,
                     self.type2,

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -216,8 +216,7 @@ class Monster:
         self.experience_required_modifier = 1
         self.total_experience = 0
 
-        self.type1 = ElementType.aether
-        self.type2: Optional[ElementType] = None
+        self.types: List[ElementType] = []
         self.shape = MonsterShape.landrace
 
         self.status: List[Technique] = []
@@ -286,11 +285,7 @@ class Monster:
         self.category = T.translate(f"cat_{results.category}")
         self.shape = results.shape or MonsterShape.landrace
         self.stage = results.stage or EvolutionStage.standalone
-        types = results.types
-        if types:
-            self.type1 = results.types[0]
-            if len(types) > 1:
-                self.type2 = results.types[1]
+        self.types = list(results.types)
 
         self.txmn_id = results.txmn_id
         self.capture = self.set_capture(self.capture)
@@ -334,8 +329,8 @@ class Monster:
             self.combat_call = results.sounds.combat_call
             self.faint_call = results.sounds.faint_call
         else:
-            self.combat_call = f"sound_{self.type1}_call"
-            self.faint_call = f"sound_{self.type1}_faint"
+            self.combat_call = f"sound_{self.types[0]}_call"
+            self.faint_call = f"sound_{self.types[0]}_faint"
 
         # Load the monster AI
         # TODO: clean up AI 'core' loading and what not

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -873,10 +873,10 @@ class NPC(Entity[NPCState]):
             type: The slug name of the type.
         """
         for mon in self.monsters:
-            if mon.type1 == element:
+            if element in mon.types:
                 return True
-            elif mon.type2 == element:
-                return True
+            else:
+                return False
         return False
 
     def check_max_moves(self, session: Session, monster: Monster) -> None:

--- a/tuxemon/states/journal/__init__.py
+++ b/tuxemon/states/journal/__init__.py
@@ -496,12 +496,14 @@ class MonsterInfoState(PygameMenuState):
             evo = T.translate("no_evolution")
         # types
         types = ""
-        if monster.type2 is not None:
-            types = (
-                T.translate(monster.type1) + " " + T.translate(monster.type2)
-            )
+        if len(monster.types) == 1:
+            types = T.translate(monster.types[0])
         else:
-            types = T.translate(monster.type1)
+            types = (
+                T.translate(monster.types[0])
+                + " "
+                + T.translate(monster.types[1])
+            )
         # weight and height
         results = db.lookup(monster.slug, table="monster")
         diff_weight, diff_height = formula.weight_height_diff(monster, results)

--- a/tuxemon/states/techniques/__init__.py
+++ b/tuxemon/states/techniques/__init__.py
@@ -145,10 +145,14 @@ class TechniqueMenuState(Menu[Technique]):
         for tech in output:
             name = tech.name
             types = ""
-            if tech.type2 is not None:
-                types = T.translate(tech.type1) + " " + T.translate(tech.type2)
+            if len(tech.types) == 1:
+                types = T.translate(tech.types[0])
             else:
-                types = T.translate(tech.type1)
+                types = (
+                    T.translate(tech.types[0])
+                    + " "
+                    + T.translate(tech.types[1])
+                )
             image = self.shadow_text(name, bg=(128, 128, 128))
             label = T.format(
                 "technique_description",

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -7,6 +7,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     ClassVar,
+    List,
     Mapping,
     Optional,
     Sequence,
@@ -79,8 +80,7 @@ class Technique:
         self.sort = ""
         self.slug = slug
         self.target: Sequence[str] = []
-        self.type1 = ElementType.aether
-        self.type2: Optional[ElementType] = None
+        self.types: List[ElementType] = []
         self.usable_on = False
         self.use_item = ""
         self.use_success = ""
@@ -131,15 +131,7 @@ class Technique:
         self.icon = results.icon
         self._combat_counter = 0
         self._life_counter = 0
-
-        if results.types:
-            self.type1 = results.types[0]
-            if len(results.types) > 1:
-                self.type2 = results.types[1]
-            else:
-                self.type2 = None
-        else:
-            self.type1 = self.type2 = None
+        self.types = list(results.types)
         # technique stats
         self.accuracy = results.accuracy or self.accuracy
         self.potency = results.potency or self.potency


### PR DESCRIPTION
connected indirectly to https://github.com/Tuxemon/Tuxemon/issues/1211 (I noticed it while I was working on typehints)

PR addresses the reduction of types.
From **type1**/**type2** to **types** (list of **ElementTypes**).

It doesn't change much, almost nothing, and at the same time we get rid of some annoying typehints.

Because sometimes we were obliged to invoke the db, load everything, and checking again (and this only to address properly types). Moreover it simplifies the operation if someone, somehow, it's going to add more Elements.