### PR TITLE
update start_battle (action) + new random_battle (action) + update trainer_battle (client)

### DIFF
--- a/tuxemon/event/actions/random_battle.py
+++ b/tuxemon/event/actions/random_battle.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import final
+
+from tuxemon import formula
+from tuxemon.combat import check_battle_legal
+from tuxemon.db import db
+from tuxemon.event.eventaction import EventAction
+from tuxemon.monster import Monster
+from tuxemon.npc import NPC
+from tuxemon.states.combat.combat import CombatState
+from tuxemon.states.world.worldstate import WorldState
+
+logger = logging.getLogger(__name__)
+
+
+@final
+@dataclass
+class RandomBattleAction(EventAction):
+    """
+    Start random battle with a random npc with a determined
+    number of monster in a certain range of levels.
+
+    Script usage:
+        .. code-block::
+
+            random_battle nr_txmns,min_level,max_level
+
+    Script parameters:
+        nr_txmns: Number of tuxemon (1 to 6).
+        min_level: Minimum level of the party.
+        max_level: Maximum level of the party.
+
+    """
+
+    name = "random_battle"
+    nr_txmns: int
+    min_level: int
+    max_level: int
+
+    def start(self) -> None:
+        player = self.session.player
+
+        if self.nr_txmns < 1 or self.nr_txmns > 6:
+            return
+
+        # random npc
+        npcs = list(db.database["npc"])
+        filters = []
+        for mov in npcs:
+            results = db.lookup(mov, table="npc")
+            if not results.monsters:
+                filters.append(results.slug)
+
+        opponent = formula.random.choice(filters)
+        world = self.session.client.get_state_by_name(WorldState)
+        npc = NPC(opponent, world=world)
+
+        # random monster
+        mons = list(db.database["monster"])
+        filtered = []
+        for mon in mons:
+            elements = db.lookup(mon, table="monster")
+            if elements.txmn_id > 0:
+                filtered.append(elements.slug)
+
+        output = formula.random.sample(filtered, self.nr_txmns)
+        for ele in output:
+            level = formula.random.randint(self.min_level, self.max_level)
+            current_monster = Monster()
+            current_monster.load_from_db(ele)
+            current_monster.set_level(level)
+            current_monster.set_moves(level)
+            current_monster.set_capture(formula.today_ordinal())
+            current_monster.current_hp = current_monster.hp
+            current_monster.money_modifier = level
+            current_monster.experience_required_modifier = level
+            npc.add_monster(current_monster)
+
+        # Don't start a battle if we don't even have monsters in our party yet.
+        if not check_battle_legal(player):
+            logger.warning("battle is not legal, won't start")
+            return
+
+        # Lookup the environment
+        env_slug = player.game_variables.get("environment", "grass")
+        env = db.lookup(env_slug, table="environment")
+
+        # Add our players and setup combat
+        logger.info("Starting battle with '{self.npc_slug}'!")
+        self.session.client.push_state(
+            CombatState(
+                players=(player, npc),
+                combat_type="trainer",
+                graphics=env.battle_graphics,
+            )
+        )
+
+        # Start some music!
+        filename = env.battle_music
+        self.session.client.event_engine.execute_action(
+            "play_music",
+            [filename],
+        )
+
+    def update(self) -> None:
+        try:
+            self.session.client.get_state_by_name(CombatState)
+        except ValueError:
+            self.stop()

--- a/tuxemon/event/actions/start_battle.py
+++ b/tuxemon/event/actions/start_battle.py
@@ -9,9 +9,9 @@ from typing import final
 from tuxemon import formula
 from tuxemon.combat import check_battle_legal
 from tuxemon.db import db
+from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.states.combat.combat import CombatState
-from tuxemon.states.world.worldstate import WorldState
 
 logger = logging.getLogger(__name__)
 
@@ -43,11 +43,9 @@ class StartBattleAction(EventAction):
             logger.warning("battle is not legal, won't start")
             return
 
-        world = self.session.client.get_state_by_name(WorldState)
-
-        npc = world.get_entity(self.npc_slug)
+        npc = get_npc(self.session, self.npc_slug)
         assert npc
-        if len(npc.monsters) == 0:
+        if not npc.monsters:
             logger.warning(
                 f"npc '{self.npc_slug}' has no monsters, won't start trainer battle."
             )


### PR DESCRIPTION
PR addresses the files:

- **start_battle**.py (action): getting rid of **get_entity**() in favor of **get_npc**()

- **random_battle**.py (new action): it works like start_battle, but it doesn't need the npc_slug, since it chooses a random npc without monsters

`random_battle nr_txmns,min_level,max_level`

nr_txmns = number of txmns of the opponent (from 1 to 6)
min and max level = it'll be the range of each monster

eg nr_txmn 6 with min: 1 and max 99, it can generate:
first monster lv 11, second monster level 42 and third monster level 69

- **trainer_battle**.py (client): connected to **random_battle**, so it's possible to start the random battle also directly from client (without action); the previous structure was broken and source of typehints.

black +  isort + tested + typehints free

_Right now we need to create a JSON, then add the monsters inside the JSON, but now we can have everything immediately through an action (money and exp modifier are equal to the level of the monster). So the strongest, the more exp/money you get. It'll simplify a lot the battles as well as we can have a lot more trainer battles than now._
