### PR TITLE
Number_or_variable: fix crash when passing float values (#1649)

### DIFF
--- a/tests/tuxemon/test_tools.py
+++ b/tests/tuxemon/test_tools.py
@@ -2,8 +2,18 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import unittest
 
-from tuxemon.tools import copy_dict_with_keys, round_to_divisible
+from tuxemon.tools import copy_dict_with_keys, round_to_divisible, number_or_variable
+from tuxemon.session import local_session
+from tuxemon.session import Session
+from unittest import mock
 
+from tuxemon.player import Player
+
+def mockPlayer(self) -> None:
+    self.game_variables = {"my_var": 2}
+
+def mockSession(self) -> None:
+    self.session = local_session
 
 class TestRoundToDivisible(unittest.TestCase):
     def test_round_down(self):
@@ -34,3 +44,23 @@ class TestCopyDictWithKeys(unittest.TestCase):
         expected = {"a": 1, "c": 3}
         result = copy_dict_with_keys(source, keys)
         self.assertEqual(result, expected)
+
+class TestVariableMoney(unittest.TestCase):
+    def test_var(self):
+        with mock.patch.object(Player, "__init__", mockPlayer):
+            #session = Session()
+            player = Player()
+            local_session.player = player
+
+            result = number_or_variable(local_session, "1")
+            self.assertEqual(result, 1.0)
+
+            result = number_or_variable(local_session, "1.5")
+            print(result)
+            self.assertEqual(result, 1.5)
+
+            with self.assertRaises(ValueError):
+                result = number_or_variable(local_session, "unbound_var")
+
+            result = number_or_variable(local_session, "my_var")
+            self.assertEqual(result, 2.0)

--- a/tuxemon/tools.py
+++ b/tuxemon/tools.py
@@ -242,6 +242,8 @@ def number_or_variable(
     player = session.player
     if value.isdigit():
         return float(value)
+    elif value.replace('.', '', 1).isdigit():
+        return float(value)
     else:
         try:
             return float(player.game_variables[value])


### PR DESCRIPTION
An error occurred when doing calculations with two different types.

Example:
> action set_variable money:10
> action variable_math money,+,10.5,money
> ERROR

The function number_or_variable receives a string, then checks whether this string is a number or a variable name. This way of doing this, crashes when the function receives a float value.
Indeed, this float value is seen as a variable name because it was not recognised as an integer.
Therefore, I upgraded the test so that it checks whether the value passed is an integer, a float or a variable name.

One test has been added, a new test class in tests/tuxemon/test_tools.py called "TestVariableMoney" with a method called "test_var". This method should try all kinds of calculations possible.