### PR TITLE
fix has item

### DIFF
--- a/tuxemon/event/conditions/has_item.py
+++ b/tuxemon/event/conditions/has_item.py
@@ -58,15 +58,14 @@ class HasItemCondition(EventCondition):
         if npc is not None:
             assert npc
             itm = npc.find_item(itm_slug)
-            assert itm
-            if len(condition.parameters) > 2:
-                operator = condition.parameters[2].lower()
-                qty = int(condition.parameters[3])
-                return op(itm.quantity, operator, qty)
+            if itm is None:
+                return False
             else:
-                if itm is None:
-                    return False
+                if len(condition.parameters) > 2:
+                    operator = condition.parameters[2].lower()
+                    qty = int(condition.parameters[3])
+                    return op(itm.quantity, operator, qty)
                 else:
-                    return True
+                    return False
         else:
             raise ValueError(f"{npc_slug} doesn't exist.")


### PR DESCRIPTION
I was doing some testing after the merging of multiple PRs and I noticed a crash in Xero related to has_item
the cause was the pointless assert (Taba Town)

tested + isort + black + typehints free