### PR TITLE
fix exp req mod

### DIFF
--- a/tuxemon/event/actions/random_encounter.py
+++ b/tuxemon/event/actions/random_encounter.py
@@ -177,7 +177,7 @@ def _create_monster_npc(
     current_monster.set_moves(level)
     current_monster.set_capture(formula.today_ordinal())
     current_monster.current_hp = current_monster.hp
-    current_monster.experience_required_modifier = encounter.exp_req_mod
+    current_monster.experience_modifier = encounter.exp_req_mod
 
     # Create an NPC object which will be this monster's "trainer"
     npc = NPC("random_encounter_dummy", world=world)

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -213,7 +213,7 @@ class Monster:
         self.possible_genders: List[GenderType] = []
 
         self.money_modifier = 0
-        self.experience_required_modifier = 1
+        self.experience_modifier = 1
         self.total_experience = 0
 
         self.types: List[ElementType] = []
@@ -567,9 +567,7 @@ class Monster:
             Required experience.
 
         """
-        return (
-            self.experience_required_modifier * (self.level + level_ofs) ** 3
-        )
+        return (self.level + level_ofs) ** 3
 
     def get_sprite(self, sprite: str, **kwargs: Any) -> Sprite:
         """

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -813,9 +813,7 @@ class NPC(Entity[NPCState]):
             # npc_monsters_details, which is a PartyMemberModel, is "slug"
             monster = Monster(save_data=npc_monster_details.dict())
             monster.money_modifier = npc_monster_details.money_mod
-            monster.experience_required_modifier = (
-                npc_monster_details.exp_req_mod
-            )
+            monster.experience_modifier = npc_monster_details.exp_req_mod
             monster.set_level(monster.level)
             monster.set_moves(monster.level)
             monster.current_hp = monster.hp

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -1084,23 +1084,17 @@ class CombatState(CombatAnimations):
         """
         if monster in self._damage_map:
             # Award Experience
-            awarded_exp = monster.total_experience // (
-                monster.level * len(self._damage_map[monster])
-            )
+            awarded_exp = (
+                monster.total_experience
+                // (monster.level * len(self._damage_map[monster]))
+            ) * monster.experience_modifier
             awarded_mon = monster.level * monster.money_modifier
             for winners in self._damage_map[monster]:
                 self._level_before = winners.level
                 self._level_after = winners.level
+                winners.give_experience(awarded_exp)
                 if self.is_trainer_battle:
-                    winners.give_experience(awarded_exp)
                     self._prize += awarded_mon
-                    self._level_after = winners.level
-                else:
-                    awarded = (
-                        awarded_exp * monster.experience_required_modifier
-                    )
-                    winners.give_experience(awarded)
-                    self._level_after = winners.level
                 # it checks if there is a "level up"
                 if self._level_before != self._level_after:
                     diff = self._level_after - self._level_before


### PR DESCRIPTION
PR addresses a small fix related to experience require modifier, after multiple testing I noticed something not clear in the mechanism. Weeks ago we added the exp modifier for wild encounters, but it wasn't triggering correctly, the reason was that  the **experience_required_modifier** was in the wrong position, it needed to be in combat.py, where there is the calculation of the award (exp). 

Now we can say that the only difference between wild encounters and trainer battles are the money. Wild encounters don't give money, while trainer battles yes.

PR allows to simplify the combat.py too.

Since I was acting on the parameter, I shortened it from:
**experience_required_modifier** to **experience_modifier**