### PR TITLE
fix player menu and fixes

### DIFF
--- a/tuxemon/event/actions/random_battle.py
+++ b/tuxemon/event/actions/random_battle.py
@@ -78,7 +78,7 @@ class RandomBattleAction(EventAction):
             current_monster.set_capture(formula.today_ordinal())
             current_monster.current_hp = current_monster.hp
             current_monster.money_modifier = level
-            current_monster.experience_required_modifier = level
+            current_monster.experience_modifier = level
             npc.add_monster(current_monster)
 
         # Don't start a battle if we don't even have monsters in our party yet.

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -285,6 +285,11 @@ class NPC(Entity[NPCState]):
         self.sprite_name = ""
         if not self.template:
             self.sprite_name = "adventurer"
+            template = Template()
+            template.slug = self.sprite_name
+            template.sprite_name = self.sprite_name
+            template.combat_front = self.sprite_name
+            self.template.append(template)
         else:
             for tmp in self.template:
                 self.sprite_name = tmp.sprite_name

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -1090,9 +1090,11 @@ class CombatState(CombatAnimations):
             ) * monster.experience_modifier
             awarded_mon = monster.level * monster.money_modifier
             for winners in self._damage_map[monster]:
+                # check before giving exp
                 self._level_before = winners.level
-                self._level_after = winners.level
                 winners.give_experience(awarded_exp)
+                # check after giving exp
+                self._level_after = winners.level
                 if self.is_trainer_battle:
                     self._prize += awarded_mon
                 # it checks if there is a "level up"


### PR DESCRIPTION
PR fix an issue with player menu for new players.

There was a crash when opening the player_menu because combat_front was missing.
PR inserts a standard template at the beginning.

added also a small fix to **random_battles**, **experience_modifier** wasn't updated (discovered through typehints);
added also a small fix in **combat.py**, because the sorting wasn't correct; 