### PR TITLE
fix battles + various

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -475,8 +475,8 @@ msgstr "route"
 msgid "dungeon"
 msgstr "dungeon"
 
-msgid "center"
-msgstr "center"
+msgid "clinic"
+msgstr "clinic"
 
 msgid "shop"
 msgstr "shop"

--- a/mods/tuxemon/maps/bedroom_test.tmx
+++ b/mods/tuxemon/maps/bedroom_test.tmx
@@ -61,8 +61,8 @@
   <object id="27" name="Resting in Bed" type="interact" x="16" y="48" width="16" height="32">
    <properties>
     <property name="act1" value="translated_dialog spyder_papertown_restinbed"/>
-    <property name="act2" value="set_monster_health ,"/>
-    <property name="act3" value="set_monster_status ,"/>
+    <property name="act2" value="set_monster_health"/>
+    <property name="act3" value="set_monster_status"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/cotton_cathedral.tmx
+++ b/mods/tuxemon/maps/cotton_cathedral.tmx
@@ -4,7 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="cotton_cathedral"/>
-  <property name="types" value="center"/>
+  <property name="types" value="clinic"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_walls" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_walls.png" width="736" height="1344"/>
@@ -92,8 +92,8 @@
   </object>
   <object id="29" name="Auto Healing Teleported" type="event" x="16" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="set_monster_health ,"/>
-    <property name="act2" value="set_monster_status ,"/>
+    <property name="act1" value="set_monster_health"/>
+    <property name="act2" value="set_monster_status"/>
     <property name="act3" value="set_variable battle_last_result:none"/>
     <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>

--- a/mods/tuxemon/maps/healing_center.tmx
+++ b/mods/tuxemon/maps/healing_center.tmx
@@ -4,7 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="healing_center"/>
-  <property name="types" value="center"/>
+  <property name="types" value="clinic"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_walls" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_walls.png" width="736" height="1344"/>
@@ -125,8 +125,8 @@
   </object>
   <object id="34" name="Auto Healing Teleported" type="event" x="16" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="set_monster_health ,"/>
-    <property name="act2" value="set_monster_status ,"/>
+    <property name="act1" value="set_monster_health"/>
+    <property name="act2" value="set_monster_status"/>
     <property name="act3" value="set_variable battle_last_result:none"/>
     <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>

--- a/mods/tuxemon/maps/player_house_bedroom.yaml
+++ b/mods/tuxemon/maps/player_house_bedroom.yaml
@@ -30,8 +30,8 @@ events:
     - screen_transition 1
     - wait 0.5
     - translated_dialog spyder_papertown_restinbed
-    - set_monster_health ,
-    - set_monster_status ,
+    - set_monster_health
+    - set_monster_status
     - set_variable teleport_faint:player_house_bedroom.tmx 6 5
     conditions:
     - is button_pressed K_RETURN
@@ -43,8 +43,8 @@ events:
     type: "event"
   Auto Healing Teleported:
     actions:
-    - set_monster_health ,
-    - set_monster_status ,
+    - set_monster_health
+    - set_monster_status
     - set_variable battle_last_result:none
     conditions:
     - is variable_set battle_last_result:lost

--- a/mods/tuxemon/maps/sphalian_center.tmx
+++ b/mods/tuxemon/maps/sphalian_center.tmx
@@ -4,7 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="tobedefined"/>
   <property name="slug" value="sphalian_center"/>
-  <property name="types" value="center"/>
+  <property name="types" value="clinic"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_walls" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_walls.png" width="736" height="1344"/>
@@ -46,8 +46,8 @@
  <objectgroup color="#ffff00" id="6" name="Events">
   <object id="16" name="Heal Tuxemon" type="event" x="96" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="set_monster_health ,"/>
-    <property name="act2" value="set_monster_status ,"/>
+    <property name="act1" value="set_monster_health"/>
+    <property name="act2" value="set_monster_status"/>
     <property name="act20" value="translated_dialog okaythen"/>
     <property name="act30" value="npc_face tabanurse,up"/>
     <property name="act40" value="wait 1"/>
@@ -91,8 +91,8 @@
   </object>
   <object id="29" name="Auto Healing Teleported" type="event" x="16" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="set_monster_health ,"/>
-    <property name="act2" value="set_monster_status ,"/>
+    <property name="act1" value="set_monster_health"/>
+    <property name="act2" value="set_monster_status"/>
     <property name="act3" value="set_variable battle_last_result:none"/>
     <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_bedroom.tmx
+++ b/mods/tuxemon/maps/spyder_bedroom.tmx
@@ -66,8 +66,8 @@
     <property name="act1" value="screen_transition 1"/>
     <property name="act2" value="wait 0.5"/>
     <property name="act3" value="translated_dialog spyder_papertown_restinbed"/>
-    <property name="act4" value="set_monster_health ,"/>
-    <property name="act5" value="set_monster_status ,"/>
+    <property name="act4" value="set_monster_health"/>
+    <property name="act5" value="set_monster_status"/>
     <property name="act6" value="set_variable teleport_faint:spyder_bedroom.tmx 6 5"/>
     <property name="cond1" value="is button_pressed K_RETURN"/>
     <property name="cond2" value="is player_facing_tile"/>
@@ -75,8 +75,8 @@
   </object>
   <object id="29" name="Auto Healing Teleported" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="set_monster_health ,"/>
-    <property name="act2" value="set_monster_status ,"/>
+    <property name="act1" value="set_monster_health"/>
+    <property name="act2" value="set_monster_status"/>
     <property name="act3" value="set_variable battle_last_result:none"/>
     <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_candy_center.tmx
+++ b/mods/tuxemon/maps/spyder_candy_center.tmx
@@ -4,7 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="candy_center"/>
-  <property name="types" value="center"/>
+  <property name="types" value="clinic"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_walls" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_walls.png" width="736" height="1344"/>
@@ -52,8 +52,8 @@
  <objectgroup color="#ffff00" id="6" name="Events">
   <object id="16" name="Heal Tuxemon" type="event" x="64" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="set_monster_health ,"/>
-    <property name="act2" value="set_monster_status ,"/>
+    <property name="act1" value="set_monster_health"/>
+    <property name="act2" value="set_monster_status"/>
     <property name="act20" value="translated_dialog okaythen"/>
     <property name="act30" value="npc_face tabanurse,up"/>
     <property name="act40" value="wait 1"/>
@@ -109,8 +109,8 @@
   </object>
   <object id="31" name="Auto Healing Teleported" type="event" x="0" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="set_monster_health ,"/>
-    <property name="act2" value="set_monster_status ,"/>
+    <property name="act1" value="set_monster_health"/>
+    <property name="act2" value="set_monster_status"/>
     <property name="act3" value="set_variable battle_last_result:none"/>
     <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_cotton_cafe.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_cafe.tmx
@@ -166,8 +166,8 @@
   </object>
   <object id="26" name="Heal Tuxemon" type="event" x="0" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="set_monster_health ,"/>
-    <property name="act2" value="set_monster_status ,"/>
+    <property name="act1" value="set_monster_health"/>
+    <property name="act2" value="set_monster_status"/>
     <property name="act20" value="translated_dialog okaythen"/>
     <property name="act30" value="npc_face spyder_cottontown_barmaid,up"/>
     <property name="act40" value="wait 1"/>
@@ -193,8 +193,8 @@
   </object>
   <object id="31" name="Auto Healing Teleported" type="event" x="0" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="set_monster_health ,"/>
-    <property name="act2" value="set_monster_status ,"/>
+    <property name="act1" value="set_monster_health"/>
+    <property name="act2" value="set_monster_status"/>
     <property name="act3" value="set_variable battle_last_result:none"/>
     <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_dragonscave.tmx
+++ b/mods/tuxemon/maps/spyder_dragonscave.tmx
@@ -195,8 +195,8 @@
     <property name="act2" value="translated_dialog spyder_dragonscave_benden1"/>
     <property name="act3" value="start_battle spyder_dragonscave_benden"/>
     <property name="act4" value="translated_dialog spyder_dragonscave_benden2"/>
-    <property name="act5" value="set_monster_health ,"/>
-    <property name="act7" value="set_monster_status ,"/>
+    <property name="act5" value="set_monster_health"/>
+    <property name="act7" value="set_monster_status"/>
     <property name="act8" value="set_variable dragonscavebenden:yes"/>
     <property name="behav1" value="talk spyder_dragonscave_benden"/>
     <property name="cond1" value="not variable_set dragonscavebenden:yes"/>
@@ -389,8 +389,8 @@
     <property name="act2" value="translated_dialog spyder_dragonscave_benden1"/>
     <property name="act3" value="start_battle spyder_dragonscave_benden"/>
     <property name="act4" value="translated_dialog spyder_dragonscave_benden2"/>
-    <property name="act5" value="set_monster_health ,"/>
-    <property name="act7" value="set_monster_status ,"/>
+    <property name="act5" value="set_monster_health"/>
+    <property name="act7" value="set_monster_status"/>
     <property name="act8" value="set_variable dragonscavebenden:yes"/>
     <property name="cond1" value="not variable_set dragonscavebenden:yes"/>
     <property name="cond2" value="is player_at"/>

--- a/mods/tuxemon/maps/spyder_flower_center.tmx
+++ b/mods/tuxemon/maps/spyder_flower_center.tmx
@@ -4,7 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="flower_center"/>
-  <property name="types" value="center"/>
+  <property name="types" value="clinic"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_walls" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_walls.png" width="736" height="1344"/>
@@ -46,8 +46,8 @@
  <objectgroup color="#ffff00" id="6" name="Events">
   <object id="16" name="Heal Tuxemon" type="event" x="80" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="set_monster_health ,"/>
-    <property name="act2" value="set_monster_status ,"/>
+    <property name="act1" value="set_monster_health"/>
+    <property name="act2" value="set_monster_status"/>
     <property name="act20" value="translated_dialog okaythen"/>
     <property name="act30" value="npc_face tabanurse,up"/>
     <property name="act40" value="wait 1"/>
@@ -95,8 +95,8 @@
   </object>
   <object id="29" name="Auto Healing Teleported" type="event" x="16" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="set_monster_health ,"/>
-    <property name="act2" value="set_monster_status ,"/>
+    <property name="act1" value="set_monster_health"/>
+    <property name="act2" value="set_monster_status"/>
     <property name="act3" value="set_variable battle_last_result:none"/>
     <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_healing_center.tmx
+++ b/mods/tuxemon/maps/spyder_healing_center.tmx
@@ -4,7 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="healing_center"/>
-  <property name="types" value="center"/>
+  <property name="types" value="clinic"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_walls" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_walls.png" width="736" height="1344"/>
@@ -46,8 +46,8 @@
  <objectgroup color="#ffff00" id="6" name="Events">
   <object id="16" name="Heal Tuxemon" type="event" x="80" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="set_monster_health ,"/>
-    <property name="act2" value="set_monster_status ,"/>
+    <property name="act1" value="set_monster_health"/>
+    <property name="act2" value="set_monster_status"/>
     <property name="act20" value="translated_dialog okaythen"/>
     <property name="act30" value="npc_face tabanurse,up"/>
     <property name="act40" value="wait 1"/>
@@ -95,8 +95,8 @@
   </object>
   <object id="29" name="Auto Healing Teleported" type="event" x="16" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="set_monster_health ,"/>
-    <property name="act2" value="set_monster_status ,"/>
+    <property name="act1" value="set_monster_health"/>
+    <property name="act2" value="set_monster_status"/>
     <property name="act3" value="set_variable battle_last_result:none"/>
     <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_leather_center.tmx
+++ b/mods/tuxemon/maps/spyder_leather_center.tmx
@@ -4,7 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="leather_center"/>
-  <property name="types" value="center"/>
+  <property name="types" value="clinic"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_walls" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_walls.png" width="736" height="1344"/>
@@ -46,8 +46,8 @@
  <objectgroup color="#ffff00" id="6" name="Events">
   <object id="16" name="Heal Tuxemon" type="event" x="80" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="set_monster_health ,"/>
-    <property name="act2" value="set_monster_status ,"/>
+    <property name="act1" value="set_monster_health"/>
+    <property name="act2" value="set_monster_status"/>
     <property name="act20" value="translated_dialog okaythen"/>
     <property name="act30" value="npc_face tabanurse,up"/>
     <property name="act40" value="wait 1"/>
@@ -96,8 +96,8 @@
   </object>
   <object id="29" name="Auto Healing Teleported" type="event" x="16" y="-3.55271e-15" width="16" height="16">
    <properties>
-    <property name="act1" value="set_monster_health ,"/>
-    <property name="act2" value="set_monster_status ,"/>
+    <property name="act1" value="set_monster_health"/>
+    <property name="act2" value="set_monster_status"/>
     <property name="act3" value="set_variable battle_last_result:none"/>
     <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_leather_town.tmx
+++ b/mods/tuxemon/maps/spyder_leather_town.tmx
@@ -255,8 +255,8 @@
   </object>
   <object id="276" name="Heal Tuxemon" type="event" x="112" y="160" width="16" height="16">
    <properties>
-    <property name="act1" value="set_monster_health ,"/>
-    <property name="act2" value="set_monster_status ,"/>
+    <property name="act1" value="set_monster_health"/>
+    <property name="act2" value="set_monster_status"/>
     <property name="act20" value="translated_dialog okaythen"/>
     <property name="act30" value="npc_face spyder_barmaid,up"/>
     <property name="act40" value="wait 1"/>
@@ -400,8 +400,8 @@
   </object>
   <object id="303" name="Auto Healing Teleported" type="event" x="0" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="set_monster_health ,"/>
-    <property name="act2" value="set_monster_status ,"/>
+    <property name="act1" value="set_monster_health"/>
+    <property name="act2" value="set_monster_status"/>
     <property name="act3" value="set_variable battle_last_result:none"/>
     <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_route2.tmx
+++ b/mods/tuxemon/maps/spyder_route2.tmx
@@ -19,12 +19,12 @@
  </layer>
  <layer id="2" name="Layer 2" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHtVdEJwjAQjaBu4oftBo7gh7iBKwjqBi7jLIKzCC5gnvjo40jSS9sfwYOQa/Lu7vX1kobwt19WoJmFwFF6j7XgiG/jmtcY78V7cat5CMjdJgKauObluKt4l0Sp7NI28ivl3jvrniJuma3SbShm0S1nPeiH3Ofv0HgEefkBy/c8VsYhNmfQT401uFbDjzFjZuhUshp+9kykerhUa8heDT+LHVKvLwb9Zw39o4b7JnWOS/xw9lNm+zuF0TXbf7pnfd6LnPu+5zWSeXoOqS0kz9CPQ5ZHuzcR6iV+bWLox1EbW8JvhNNB/FxMrleoHfswh7N58dl4Z9o9Pt8j6OHgBrzW1TuN2rEPFcc6dga3S889ZWP0OfXf1LrKT/WDrzjNSX8sN+YBR56zz/3AjTgrP9UPPv51JavVjT3A2fO5lZ/Vr8Rtir2+90cN1cDqNwWHKXO8Aem5IzI=
+   eAHtVdFNQzEMDFJhk3603YAR+KBswApIwAYswyxIzILEAvVVOvVkOY7Tvp9KtRTFiR37cs/xa+0m18zA9q41juweG/Gj/872qsLzVf+q33rVGmLvggNb26tifJ64S5Cqu/Vk+LLYL8W8e/N76GY5GdTn/rTd1cDfu8VG/I8gRxUfEvCeb6bPnOuCMwP4U2EO7i2Vh/FGMzjKZAaffxNRDWe5zrHN4PO+5+QbnUH9eUH9qKDfRO84w4e3H4m+j8ju93z9ebuu2Rc5j77nl4H5qzxSTeJ08MfhTBctv4Wof9Fng4I/jtmzmf+jYHoVvXemVyvkjnXY8/Nx8dnQC7J+8GNOvwVsiK15taeRO9ah+nlMXAPb56BP0Teao/+m5lV8yh909YtiX4qNMYGR7+zYH2iwWfEpf9Dxr8tkljfWAOfK51Z8nr8M2xK20f2RQznw/C2BYckYB1+jIuk=
   </data>
  </layer>
  <layer id="3" name="Layer 3" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHFletNAzEQhI0ECIlG8iiBGojohbtioBTgBzQCv6AOdpT7lMnK57soh1jJGe/T47XjW12Vso6xmsAyyFTc0v774LWLMYXwm4pb2v9+U8pHjL+S9UUpmzS2oUvk+7o8DOLk5xy+g9vPgvxYA9zuqRz9bkKTH584ujyEj3Nwe553kden3Bxzrh5Xq3TBR+N6KCZ+9G+qvjjOkbvb4yhfl/WFWfqwcca7wV/rX67vdT5ncnyJpNdhvHkBm8NBJvEQN9UX4qv1jz1QCh3E3kLqK0ZrSPp0t3MM9YWP5AT6/SOGfewrH/qOPob8F9wPP7dp3uIHD9BzsYHum5rXcs7hl/vk62t/Wg/RW9ASuHkO8fSV9052j+edIQ70949aoPff6+EHWYe9old5RhIc2b/HM6e2eu/3D7vQ+ZEHehzzmk+2LJy3/gP+3jDX20ctxY69f/DDTw6Y10XHD2IH4Yee0fNa/YMX/UVX/pjQA5BeeLzfNc5a/qfh/YEfyLpeQ/PMK+s5vqbrDPlW1fw1m3j5XWbdHMv5Zn/Wldelt9drncKRnoGqM9Y/+TinGso/V/gezIl3boqv9UP2/D2S7VR5bvRVtWr7dptiWv2T/7+F/v0CmnymPw==
+   eAHFletNAzEQhI0EiFLyqIWIXsgVA6UAP6AR+AV1sKPcpwwrn30hh1jJGe/T47XjW12Vso6x6mAZpRe3tP82eO1i9BB+vbil/a83pbzF+CtZX5SySWMbukS+j8vjIE5+zuEzuH0tyI81wO2Byo/fTWjy4xNHl7vwcQ5uz/N95A0pN8ecq8fVKvvgo3E9FhM/+terL46/EV+X9YVZhrBxxrvRP7d/1HqfyfEpEp7H8UJyQjjILB7ipvpCfLX+sQfKoYPYW0h9xWgNyZDudo6hvvCenEC/f8Swj0PlY9/Rp5D/gvvh5zbNW/zgAXouNtB9vXkt5xx+uU++vvan9RC9BS2Bm+cQT19572T3eN4Z4kB//6gFev+9Hn6QddgrepVnJMGR/Xs8c2qr937/sAudH3mgxzGv+WTLwnnrP+DvDXO9fdRS7NT7Bz/85IB5XXT8IHYQfugZPa/VP3jRX3TlTwk9AOmFx/td46zlfxjfH/iBrOs1NM+8sp7ja7rOkG9VzV+ziZffZdbNsZxv9mddefv09nqtUzjSM1B1pvonH+dUQ/nnCt+DOfHOTfG1fsiev0eynSqPjb6qVm3fblNMq3/y/7fQv2+7Z6Wz
   </data>
  </layer>
  <layer id="4" name="Above Player" width="40" height="20">
@@ -478,17 +478,23 @@
     <property name="cond2" value="is player_moved"/>
    </properties>
   </object>
-  <object id="156" name="Billie encounter" type="event" x="32" y="32" width="16" height="16">
+  <object id="156" name="Billie encounter" type="event" x="16" y="128" width="16" height="32">
    <properties>
-    <property name="act2" value="create_npc spyder_route2_billie,3,15"/>
-    <property name="act3" value="pathfind spyder_route2_billie,1,9"/>
-    <property name="act4" value="translated_dialog spyder_route2_billie1"/>
-    <property name="act7" value="start_battle spyder_route2_billie"/>
+    <property name="act01" value="player_stop"/>
+    <property name="act02" value="lock_controls"/>
+    <property name="act03" value="create_npc spyder_route2_billie,3,15"/>
+    <property name="act04" value="pathfind spyder_route2_billie,1,10"/>
+    <property name="act05" value="unlock_controls"/>
+    <property name="act06" value="npc_face player,down"/>
+    <property name="act07" value="npc_face spyder_route2_billie,up"/>
+    <property name="act08" value="translated_dialog spyder_route2_billie1"/>
+    <property name="act09" value="start_battle spyder_route2_billie"/>
     <property name="act71" value="translated_dialog spyder_route2_billie2"/>
     <property name="act75" value="pathfind spyder_route2_billie,3,15"/>
     <property name="act80" value="remove_npc spyder_route2_billie"/>
     <property name="act90" value="set_variable route2billie:yes"/>
     <property name="cond1" value="not variable_set route2billie:yes"/>
+    <property name="cond2" value="is player_at"/>
    </properties>
   </object>
   <object id="157" name="Sign: Route 2" type="event" x="16" y="112" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_scoop2.tmx
+++ b/mods/tuxemon/maps/spyder_scoop2.tmx
@@ -94,8 +94,8 @@
   </object>
   <object id="18" name="Auto Healing Teleported" type="event" x="0" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="set_monster_health ,"/>
-    <property name="act2" value="set_monster_status ,"/>
+    <property name="act1" value="set_monster_health"/>
+    <property name="act2" value="set_monster_status"/>
     <property name="act3" value="set_variable battle_last_result:none"/>
     <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_timber_center.tmx
+++ b/mods/tuxemon/maps/spyder_timber_center.tmx
@@ -4,7 +4,7 @@
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="timber_center"/>
-  <property name="types" value="center"/>
+  <property name="types" value="clinic"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_walls" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_walls.png" width="736" height="1344"/>
@@ -46,8 +46,8 @@
  <objectgroup color="#ffff00" id="6" name="Events">
   <object id="16" name="Heal Tuxemon" type="event" x="80" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="set_monster_health ,"/>
-    <property name="act2" value="set_monster_status ,"/>
+    <property name="act1" value="set_monster_health"/>
+    <property name="act2" value="set_monster_status"/>
     <property name="act20" value="translated_dialog okaythen"/>
     <property name="act30" value="npc_face tabanurse,up"/>
     <property name="act40" value="wait 1"/>
@@ -95,8 +95,8 @@
   </object>
   <object id="29" name="Auto Healing Teleported" type="event" x="16" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="set_monster_health ,"/>
-    <property name="act2" value="set_monster_status ,"/>
+    <property name="act1" value="set_monster_health"/>
+    <property name="act2" value="set_monster_status"/>
     <property name="act3" value="set_variable battle_last_result:none"/>
     <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
+++ b/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
@@ -119,8 +119,8 @@
   </object>
   <object id="48" name="Heal Tuxemon" type="event" x="192" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="set_monster_health ,"/>
-    <property name="act2" value="set_monster_status ,"/>
+    <property name="act1" value="set_monster_health"/>
+    <property name="act2" value="set_monster_status"/>
     <property name="act20" value="translated_dialog okaythen"/>
     <property name="act30" value="npc_face spyder_shopkeeper,up"/>
     <property name="act40" value="wait 1"/>
@@ -282,8 +282,8 @@
   </object>
   <object id="74" name="Auto Healing Teleported" type="event" x="0" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="set_monster_health ,"/>
-    <property name="act2" value="set_monster_status ,"/>
+    <property name="act1" value="set_monster_health"/>
+    <property name="act2" value="set_monster_status"/>
     <property name="act3" value="set_variable battle_last_result:none"/>
     <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>

--- a/tuxemon/battle.py
+++ b/tuxemon/battle.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import uuid
 from typing import Any, List, Mapping, Optional, Sequence
 
+from tuxemon.db import OutputBattle
+
 SIMPLE_PERSISTANCE_ATTRIBUTES = (
     "opponent",
     "outcome",
@@ -23,7 +25,7 @@ class Battle:
 
         self.instance_id = uuid.uuid4()
         self.opponent = ""
-        self.outcome = ""
+        self.outcome = OutputBattle.draw
         self.date = 0
 
         self.set_state(save_data)

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -140,7 +140,7 @@ class MapType(str, Enum):
     notype = "notype"
     town = "town"
     route = "route"
-    center = "center"
+    clinic = "clinic"
     shop = "shop"
     dungeon = "dungeon"
 

--- a/tuxemon/event/actions/set_battle.py
+++ b/tuxemon/event/actions/set_battle.py
@@ -6,7 +6,7 @@ import datetime as dt
 from dataclasses import dataclass
 from typing import final
 
-from tuxemon import battle
+from tuxemon.battle import Battle
 from tuxemon.db import OutputBattle
 from tuxemon.event.eventaction import EventAction
 
@@ -35,13 +35,19 @@ class SetBattleAction(EventAction):
     def start(self) -> None:
         player = self.session.player
 
-        new_battle = battle.Battle()
+        new_battle = Battle()
         new_battle.opponent = self.battle_opponent
-        new_battle.outcome = self.battle_outcome
         new_battle.date = dt.date.today().toordinal()
 
-        outcomes = [otc.value for otc in OutputBattle]
-        if self.battle_outcome in outcomes:
-            player.battles.append(new_battle)
+        if self.battle_outcome == "won":
+            new_battle.outcome = OutputBattle.won
+        elif self.battle_outcome == "draw":
+            new_battle.outcome = OutputBattle.draw
+        elif self.battle_outcome == "lost":
+            new_battle.outcome = OutputBattle.lost
         else:
-            return
+            raise ValueError(
+                f"{self.battle_outcome} must be won, lost or draw.",
+            )
+
+        player.battles.append(new_battle)

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -759,6 +759,9 @@ class NPC(Entity[NPCState]):
         new_monster.instance_id = old_monster.instance_id
         new_monster.gender = old_monster.gender
         new_monster.capture = old_monster.capture
+        new_monster.capture_device = old_monster.capture_device
+        new_monster.taste_cold = old_monster.taste_cold
+        new_monster.taste_warm = old_monster.taste_warm
         self.remove_monster(old_monster)
         self.add_monster(new_monster, slot)
 

--- a/tuxemon/player.py
+++ b/tuxemon/player.py
@@ -57,7 +57,7 @@ class Player(NPC):
         """
         var = self.game_variables
         var["hour"] = dt.datetime.now().strftime("%H")
-        var["day_of_year"] = dt.datetime.now().strftime("%-j")
+        var["day_of_year"] = dt.datetime.now().strftime("%j")
         var["year"] = dt.datetime.now().strftime("%Y")
 
         # Leap year

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -27,8 +27,9 @@ from typing import (
 import pygame
 from pygame.rect import Rect
 
-from tuxemon import audio, battle, graphics, state, tools
+from tuxemon import audio, graphics, state, tools
 from tuxemon.animation import Task
+from tuxemon.battle import Battle
 from tuxemon.combat import (
     check_status,
     check_status_connected,
@@ -366,7 +367,7 @@ class CombatState(CombatAnimations):
                 var = self.players[0].game_variables
                 var["battle_last_monster_name"] = monster_record.name
                 var["battle_last_monster_level"] = monster_record.level
-                var["battle_last_monster_type"] = monster_record.slug
+                var["battle_last_monster_type"] = monster_record.types[0]
                 var["battle_last_monster_category"] = monster_record.category
                 var["battle_last_monster_shape"] = monster_record.shape
                 # Avoid reset string to seen if monster has already been caught
@@ -441,11 +442,11 @@ class CombatState(CombatAnimations):
             if self.is_trainer_battle:
                 var["battle_last_trainer"] = self.players[1].slug
                 # track battles against NPC
-                opponent = battle.Battle()
-                opponent.opponent = self.players[1].slug
-                opponent.outcome = OutputBattle.draw
-                opponent.date = dt.date.today().toordinal()
-                self.players[0].battles.append(opponent)
+                battle = Battle()
+                battle.opponent = self.players[1].slug
+                battle.outcome = OutputBattle.draw
+                battle.date = dt.date.today().toordinal()
+                self.players[0].battles.append(battle)
 
             # it is a draw match; both players were defeated in same round
             self.alert(T.translate("combat_draw"))
@@ -476,11 +477,11 @@ class CombatState(CombatAnimations):
                     self.players[0].give_money(self._prize)
                     var["battle_last_trainer"] = self.players[1].slug
                     # track battles against NPC
-                    opponent = battle.Battle()
-                    opponent.opponent = self.players[1].slug
-                    opponent.outcome = OutputBattle.won
-                    opponent.date = dt.date.today().toordinal()
-                    self.players[0].battles.append(opponent)
+                    battle = Battle()
+                    battle.opponent = self.players[1].slug
+                    battle.outcome = OutputBattle.won
+                    battle.date = dt.date.today().toordinal()
+                    self.players[0].battles.append(battle)
                 else:
                     self.alert(T.translate("combat_victory"))
 
@@ -491,10 +492,11 @@ class CombatState(CombatAnimations):
                 if self.is_trainer_battle:
                     var["battle_last_trainer"] = self.players[1].slug
                     # track battles against NPC
-                    opponent = battle.Battle()
-                    opponent.opponent = self.players[1].slug
-                    opponent.outcome = OutputBattle.lost
-                    opponent.date = dt.date.today().toordinal()
+                    battle = Battle()
+                    battle.opponent = self.players[1].slug
+                    battle.outcome = OutputBattle.lost
+                    battle.date = dt.date.today().toordinal()
+                    self.players[0].battles.append(battle)
 
             # after 3 seconds, push a state that blocks until enter is pressed
             # after the state is popped, the combat state will clean up and close
@@ -713,7 +715,7 @@ class CombatState(CombatAnimations):
             # save iid monster fighting
             self.players[0].game_variables[
                 "iid_fighting_monster"
-            ] = monster.instance_id
+            ] = monster.instance_id.hex
         elif self.is_trainer_battle:
             self.alert(
                 T.format(

--- a/tuxemon/states/phone/__init__.py
+++ b/tuxemon/states/phone/__init__.py
@@ -75,7 +75,7 @@ class NuPhone(PygameMenuState):
         ]
 
         # menu
-        network = ["town", "center", "shop"]
+        network = ["town", "clinic", "shop"]
         desc = T.translate("nu_phone")
         if local_session.client.map_type in network:
             desc = T.translate("omnichannel_mobile")


### PR DESCRIPTION
PR addresses:
- fix **combat.py**, the missing **.hex** was causing a crash when trying to save the game after a combat (wild encounter or trainer);
- resorted the **spyder_route2_billie**, so it locks the controls and unlocks, the reason is that it was possible move the player (now both turn faces);
- some fixes in **battle.py** and the action **set_battle** (it changes nothing), mostly because I wasn't satisfied about the structure;
- added to **evolve_monster** in **npc.py** the missing parameters **capture_device** (the specific tuxeball that captured the monster) and the new **taste_cold** and **taste_warm**;
- fixed **battle_last_monster_type** in **combat.py**, it was saving the wrong parameter;
- fixed **set_monster_status** and **set_monster_health**, since both parameters are Optional, this action can be used without the comma at the end;
- replaced **center** with **clinic**, because **mypy --strict** flagged me **center** in **db.py**;
- fixed player variable `var["day_of_year"] = dt.datetime.now().strftime("%j")` as suggested here: https://github.com/Tuxemon/Tuxemon/pull/1553#issuecomment-1399851365

related to the center in db.py issue:
`tuxemon/db.py:143: error: Incompatible types in assignment (expression has type "str", base class "str" defined the type as "Callable[[str, SupportsIndex, str], str]")`
it was in conflict because of the word "center", so another typehint is gone.

tested, isort, black, no new typehints