### PR TITLE
fix target special techniques

### DIFF
--- a/mods/tuxemon/db/technique/boulder.json
+++ b/mods/tuxemon/db/technique/boulder.json
@@ -19,11 +19,11 @@
   "slug": "boulder",
   "sort": "damage",
   "target": {
-    "enemy monster": 2,
+    "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
     "item": 0,
-    "own monster": 0,
+    "own monster": 2,
     "own team": 0,
     "own trainer": 0
   },

--- a/mods/tuxemon/db/technique/clamp_on.json
+++ b/mods/tuxemon/db/technique/clamp_on.json
@@ -19,11 +19,11 @@
   "slug": "clamp_on",
   "sort": "damage",
   "target": {
-    "enemy monster": 2,
+    "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
     "item": 0,
-    "own monster": 0,
+    "own monster": 2,
     "own team": 0,
     "own trainer": 0
   },

--- a/mods/tuxemon/db/technique/energy_field.json
+++ b/mods/tuxemon/db/technique/energy_field.json
@@ -19,11 +19,11 @@
   "slug": "energy_field",
   "sort": "damage",
   "target": {
-    "enemy monster": 2,
+    "enemy monster": 1,
     "enemy team": 0,
     "enemy trainer": 0,
     "item": 0,
-    "own monster": 1,
+    "own monster": 2,
     "own team": 0,
     "own trainer": 0
   },

--- a/mods/tuxemon/db/technique/eyebite.json
+++ b/mods/tuxemon/db/technique/eyebite.json
@@ -19,11 +19,11 @@
   "slug": "eyebite",
   "sort": "damage",
   "target": {
-    "enemy monster": 2,
+    "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
     "item": 0,
-    "own monster": 0,
+    "own monster": 2,
     "own team": 0,
     "own trainer": 0
   },

--- a/mods/tuxemon/db/technique/fume.json
+++ b/mods/tuxemon/db/technique/fume.json
@@ -19,11 +19,11 @@
   "slug": "fume",
   "sort": "damage",
   "target": {
-    "enemy monster": 2,
+    "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
     "item": 0,
-    "own monster": 0,
+    "own monster": 2,
     "own team": 0,
     "own trainer": 0
   },

--- a/mods/tuxemon/db/technique/glower.json
+++ b/mods/tuxemon/db/technique/glower.json
@@ -19,11 +19,11 @@
   "slug": "glower",
   "sort": "damage",
   "target": {
-    "enemy monster": 2,
+    "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
     "item": 0,
-    "own monster": 0,
+    "own monster": 2,
     "own team": 0,
     "own trainer": 0
   },

--- a/mods/tuxemon/db/technique/hibernate.json
+++ b/mods/tuxemon/db/technique/hibernate.json
@@ -18,11 +18,11 @@
   "slug": "hibernate",
   "sort": "damage",
   "target": {
-    "enemy monster": 2,
+    "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
     "item": 0,
-    "own monster": 0,
+    "own monster": 2,
     "own team": 0,
     "own trainer": 0
   },

--- a/mods/tuxemon/db/technique/overfeed.json
+++ b/mods/tuxemon/db/technique/overfeed.json
@@ -19,11 +19,11 @@
   "slug": "overfeed",
   "sort": "meta",
   "target": {
-    "enemy monster": 2,
+    "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
     "item": 0,
-    "own monster": 0,
+    "own monster": 2,
     "own team": 0,
     "own trainer": 0
   },

--- a/mods/tuxemon/db/technique/petrify.json
+++ b/mods/tuxemon/db/technique/petrify.json
@@ -18,11 +18,11 @@
   "slug": "petrify",
   "sort": "damage",
   "target": {
-    "enemy monster": 2,
+    "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
     "item": 0,
-    "own monster": 0,
+    "own monster": 2,
     "own team": 0,
     "own trainer": 0
   },

--- a/mods/tuxemon/db/technique/refresh.json
+++ b/mods/tuxemon/db/technique/refresh.json
@@ -19,7 +19,7 @@
   "slug": "refresh",
   "sort": "damage",
   "target": {
-    "enemy monster": 1,
+    "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
     "item": 0,

--- a/mods/tuxemon/db/technique/rot.json
+++ b/mods/tuxemon/db/technique/rot.json
@@ -19,11 +19,11 @@
   "slug": "rot",
   "sort": "damage",
   "target": {
-    "enemy monster": 2,
+    "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
     "item": 0,
-    "own monster": 0,
+    "own monster": 2,
     "own team": 0,
     "own trainer": 0
   },

--- a/mods/tuxemon/db/technique/sleeping_powder.json
+++ b/mods/tuxemon/db/technique/sleeping_powder.json
@@ -19,11 +19,11 @@
   "slug": "sleeping_powder",
   "sort": "damage",
   "target": {
-    "enemy monster": 2,
+    "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
     "item": 0,
-    "own monster": 0,
+    "own monster": 2,
     "own team": 0,
     "own trainer": 0
   },

--- a/mods/tuxemon/db/technique/static_field.json
+++ b/mods/tuxemon/db/technique/static_field.json
@@ -20,11 +20,11 @@
   "slug": "static_field",
   "sort": "damage",
   "target": {
-    "enemy monster": 2,
+    "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
     "item": 0,
-    "own monster": 0,
+    "own monster": 2,
     "own team": 0,
     "own trainer": 0
   },

--- a/mods/tuxemon/db/technique/stone_rot.json
+++ b/mods/tuxemon/db/technique/stone_rot.json
@@ -19,11 +19,11 @@
   "slug": "stone_rot",
   "sort": "damage",
   "target": {
-    "enemy monster": 2,
+    "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
     "item": 0,
-    "own monster": 0,
+    "own monster": 2,
     "own team": 0,
     "own trainer": 0
   },

--- a/mods/tuxemon/db/technique/sudden_glow.json
+++ b/mods/tuxemon/db/technique/sudden_glow.json
@@ -20,11 +20,11 @@
   "slug": "sudden_glow",
   "sort": "damage",
   "target": {
-    "enemy monster": 2,
+    "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
     "item": 0,
-    "own monster": 0,
+    "own monster": 2,
     "own team": 0,
     "own trainer": 0
   },

--- a/mods/tuxemon/db/technique/take_cover.json
+++ b/mods/tuxemon/db/technique/take_cover.json
@@ -19,11 +19,11 @@
   "slug": "take_cover",
   "sort": "damage",
   "target": {
-    "enemy monster": 2,
+    "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
     "item": 0,
-    "own monster": 0,
+    "own monster": 2,
     "own team": 0,
     "own trainer": 0
   },

--- a/mods/tuxemon/db/technique/wallow.json
+++ b/mods/tuxemon/db/technique/wallow.json
@@ -19,11 +19,11 @@
   "slug": "wallow",
   "sort": "damage",
   "target": {
-    "enemy monster": 2,
+    "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
     "item": 0,
-    "own monster": 0,
+    "own monster": 2,
     "own team": 0,
     "own trainer": 0
   },

--- a/tuxemon/technique/effects/enhance.py
+++ b/tuxemon/technique/effects/enhance.py
@@ -10,7 +10,7 @@ from tuxemon.technique.technique import Technique
 
 
 class EnhanceEffectResult(TechEffectResult):
-    should_tackle: bool
+    pass
 
 
 @dataclass
@@ -37,6 +37,6 @@ class EnhanceEffect(TechEffect):
         value = float(player.game_variables["random_tech_hit"])
         hit = tech.accuracy >= value
         if hit or tech.is_area:
-            return {"should_tackle": True, "success": True}
+            return {"success": True}
         else:
-            return {"should_tackle": False, "success": False}
+            return {"success": False}


### PR DESCRIPTION
fix #1674 

PR:
- removes the tackle from the moves without damage, but it'll keep showing the animation;
- the techniques with "special" -> no damage must be targeted on the user; eg using overfeed or clamp_on on the user can provoke the effect on the target, but it remains a user move.

tested, black, isort, no new typehints