### PR TITLE
fix recover and technique effects

### DIFF
--- a/mods/tuxemon/db/technique/all_in.json
+++ b/mods/tuxemon/db/technique/all_in.json
@@ -3,8 +3,8 @@
   "accuracy": 0.75,
   "animation": "sparks_gold_alt",
   "effects": [
-    "damage",
-    "recover all"
+    "recover",
+    "damage"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/amnesia.json
+++ b/mods/tuxemon/db/technique/amnesia.json
@@ -3,9 +3,9 @@
   "accuracy": 0.75,
   "animation": "sparks_gold_alt",
   "effects": [
-    "damage",
     "exhausted target",
-    "exhausted user"
+    "exhausted user",
+    "damage"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/avalanche.json
+++ b/mods/tuxemon/db/technique/avalanche.json
@@ -3,8 +3,8 @@
   "accuracy": 0.8,
   "animation": "rockfall_193",
   "effects": [
-    "damage",
-    "exhausted target"
+    "exhausted target",
+    "damage"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/berserk.json
+++ b/mods/tuxemon/db/technique/berserk.json
@@ -3,8 +3,8 @@
   "accuracy": 0.8,
   "animation": "constantburn",
   "effects": [
-    "damage",
-    "enraged user"
+    "enraged user",
+    "damage"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/biting_winds.json
+++ b/mods/tuxemon/db/technique/biting_winds.json
@@ -3,8 +3,8 @@
   "accuracy": 0.8,
   "animation": "explosion_ice_112",
   "effects": [
-    "damage",
-    "softened target"
+    "softened target",
+    "damage"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/blood_bond.json
+++ b/mods/tuxemon/db/technique/blood_bond.json
@@ -3,8 +3,8 @@
   "accuracy": 0.8,
   "animation": "sparks_red",
   "effects": [
-    "damage",
-    "lifeleech all"
+    "lifeleech",
+    "damage"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/blossom.json
+++ b/mods/tuxemon/db/technique/blossom.json
@@ -3,8 +3,8 @@
   "accuracy": 0.75,
   "animation": "gloop_orange",
   "effects": [
-    "damage",
-    "recover all"
+    "recover",
+    "damage"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/boulder.json
+++ b/mods/tuxemon/db/technique/boulder.json
@@ -3,8 +3,8 @@
   "accuracy": 1,
   "animation": "shield_rock",
   "effects": [
-    "enhance",
-    "hardshell user"
+    "hardshell user",
+    "enhance"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/bubble_trap.json
+++ b/mods/tuxemon/db/technique/bubble_trap.json
@@ -3,9 +3,9 @@
   "accuracy": 0.75,
   "animation": "bomb_bright",
   "effects": [
-    "damage",
     "grabbed target",
-    "grabbed user"
+    "grabbed user",
+    "damage"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/clamp_on.json
+++ b/mods/tuxemon/db/technique/clamp_on.json
@@ -3,8 +3,8 @@
   "accuracy": 1,
   "animation": "bite",
   "effects": [
-    "enhance",
-    "grabbed target"
+    "grabbed target",
+    "enhance"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/constrict.json
+++ b/mods/tuxemon/db/technique/constrict.json
@@ -3,8 +3,8 @@
   "accuracy": 0.75,
   "animation": "icetacle",
   "effects": [
-    "damage",
-    "grabbed target"
+    "grabbed target",
+    "damage"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/energy_claws.json
+++ b/mods/tuxemon/db/technique/energy_claws.json
@@ -3,8 +3,8 @@
   "accuracy": 0.8,
   "animation": "slash_power",
   "effects": [
-    "damage",
-    "sniping user"
+    "sniping user",
+    "damage"
   ],
   "flip_axes": "x",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/energy_field.json
+++ b/mods/tuxemon/db/technique/energy_field.json
@@ -3,8 +3,8 @@
   "accuracy": 1,
   "animation": "screen",
   "effects": [
-    "enhance",
-    "exhausted target"
+    "exhausted target",
+    "enhance"
   ],
   "flip_axes": "x",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/eyebite.json
+++ b/mods/tuxemon/db/technique/eyebite.json
@@ -3,8 +3,8 @@
   "accuracy": 1,
   "animation": "bite",
   "effects": [
-    "enhance",
-    "exhausted target"
+    "exhausted target",
+    "enhance"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/feint.json
+++ b/mods/tuxemon/db/technique/feint.json
@@ -3,8 +3,8 @@
   "accuracy": 1,
   "animation": "lightning_bolt_138",
   "effects": [
-    "damage",
-    "focused user"
+    "focused user",
+    "damage"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/fluff_up.json
+++ b/mods/tuxemon/db/technique/fluff_up.json
@@ -3,8 +3,8 @@
   "accuracy": 0.75,
   "animation": "smokebomb",
   "effects": [
-    "damage",
-    "recover all"
+    "recover",
+    "damage"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/font.json
+++ b/mods/tuxemon/db/technique/font.json
@@ -3,8 +3,8 @@
   "accuracy": 0.75,
   "animation": "waterspurt",
   "effects": [
-    "damage",
-    "recover all"
+    "recover",
+    "damage"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/fume.json
+++ b/mods/tuxemon/db/technique/fume.json
@@ -3,8 +3,8 @@
   "accuracy": 1,
   "animation": "buff_rage",
   "effects": [
-    "enhance",
-    "enraged user"
+    "enraged user",
+    "enhance"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/give_all.json
+++ b/mods/tuxemon/db/technique/give_all.json
@@ -3,8 +3,8 @@
   "accuracy": 1,
   "animation": "firelion_front",
   "effects": [
-    "damage",
-    "exhausted user"
+    "exhausted user",
+    "damage"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/glower.json
+++ b/mods/tuxemon/db/technique/glower.json
@@ -3,8 +3,8 @@
   "accuracy": 1,
   "animation": null,
   "effects": [
-    "enhance",
-    "softened target"
+    "softened target",
+    "enhance"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/goad.json
+++ b/mods/tuxemon/db/technique/goad.json
@@ -3,8 +3,8 @@
   "accuracy": 0.8,
   "animation": "buff_rage",
   "effects": [
-    "damage",
-    "enraged target"
+    "enraged target",
+    "damage"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/invictus.json
+++ b/mods/tuxemon/db/technique/invictus.json
@@ -3,9 +3,9 @@
   "accuracy": 0.75,
   "animation": "triforce_163",
   "effects": [
-    "damage",
     "enraged user",
-    "grabbed target"
+    "grabbed target",
+    "damage"
   ],
   "flip_axes": "xy",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/kindling_flame.json
+++ b/mods/tuxemon/db/technique/kindling_flame.json
@@ -3,8 +3,8 @@
   "accuracy": 0.8,
   "animation": "constantburn",
   "effects": [
-    "damage",
-    "enraged user"
+    "enraged user",
+    "damage"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/levitate.json
+++ b/mods/tuxemon/db/technique/levitate.json
@@ -3,9 +3,9 @@
   "accuracy": 1,
   "animation": null,
   "effects": [
-    "enhance",
     "sniping target",
-    "sniping user"
+    "sniping user",
+    "enhance"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/muddle.json
+++ b/mods/tuxemon/db/technique/muddle.json
@@ -3,9 +3,9 @@
   "accuracy": 0.75,
   "animation": "sparks_white",
   "effects": [
-    "damage",
     "focused target",
-    "focused user"
+    "focused user",
+    "damage"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/mudslide.json
+++ b/mods/tuxemon/db/technique/mudslide.json
@@ -3,8 +3,8 @@
   "accuracy": 0.8,
   "animation": "spikes_rock",
   "effects": [
-    "damage",
-    "softened target"
+    "softened target",
+    "damage"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/overfeed.json
+++ b/mods/tuxemon/db/technique/overfeed.json
@@ -3,8 +3,8 @@
   "accuracy": 1,
   "animation": null,
   "effects": [
-    "enhance",
-    "overfeed target"
+    "overfeed target",
+    "enhance"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/overgrowth.json
+++ b/mods/tuxemon/db/technique/overgrowth.json
@@ -3,8 +3,8 @@
   "accuracy": 0.8,
   "animation": null,
   "effects": [
-    "damage",
-    "grabbed target"
+    "grabbed target",
+    "damage"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/probiscus.json
+++ b/mods/tuxemon/db/technique/probiscus.json
@@ -3,8 +3,8 @@
   "accuracy": 0.8,
   "animation": "lance_ice",
   "effects": [
-    "damage",
-    "lifeleech all"
+    "lifeleech",
+    "damage"
   ],
   "flip_axes": "xy",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/quicksand.json
+++ b/mods/tuxemon/db/technique/quicksand.json
@@ -3,8 +3,8 @@
   "accuracy": 0.8,
   "animation": "spikes_rock",
   "effects": [
-    "damage",
-    "stuck target"
+    "stuck target",
+    "damage"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/refresh.json
+++ b/mods/tuxemon/db/technique/refresh.json
@@ -3,8 +3,8 @@
   "accuracy": 1,
   "animation": "heal_burst_120",
   "effects": [
-    "enhance",
-    "recover all"
+    "recover",
+    "enhance"
   ],
   "flip_axes": "",
   "healing_power": 4,

--- a/mods/tuxemon/db/technique/rot.json
+++ b/mods/tuxemon/db/technique/rot.json
@@ -3,8 +3,8 @@
   "accuracy": 1,
   "animation": "drip_green",
   "effects": [
-    "enhance",
-    "poison target"
+    "poison target",
+    "enhance"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/sleeping_powder.json
+++ b/mods/tuxemon/db/technique/sleeping_powder.json
@@ -3,8 +3,8 @@
   "accuracy": 1,
   "animation": "explosion_dusty_96",
   "effects": [
-    "enhance",
-    "focused user"
+    "focused user",
+    "enhance"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/snowstorm.json
+++ b/mods/tuxemon/db/technique/snowstorm.json
@@ -3,8 +3,8 @@
   "accuracy": 0.5,
   "animation": "explosion_ice_112",
   "effects": [
-    "damage",
-    "exhausted target"
+    "exhausted target",
+    "damage"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/starfall.json
+++ b/mods/tuxemon/db/technique/starfall.json
@@ -3,8 +3,8 @@
   "accuracy": 0.7,
   "animation": "lightning_bolt_138",
   "effects": [
-    "damage",
-    "focused user"
+    "focused user",
+    "damage"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/static_field.json
+++ b/mods/tuxemon/db/technique/static_field.json
@@ -3,9 +3,9 @@
   "accuracy": 1,
   "animation": "disintegrate_83",
   "effects": [
-    "enhance",
     "exhausted target",
-    "hardshell user"
+    "hardshell user",
+    "enhance"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/status_lifeleech.json
+++ b/mods/tuxemon/db/technique/status_lifeleech.json
@@ -5,7 +5,7 @@
 	  	"current_hp target,>,0"
 	],
   "effects": [
-    "lifeleech all"
+    "lifeleech"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_lifeleech.png",

--- a/mods/tuxemon/db/technique/status_recover.json
+++ b/mods/tuxemon/db/technique/status_recover.json
@@ -2,7 +2,7 @@
   "animation": "drip_green",
   "category": "positive",
   "effects": [
-    "recover all"
+    "recover"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_recover.png",

--- a/mods/tuxemon/db/technique/stone_rot.json
+++ b/mods/tuxemon/db/technique/stone_rot.json
@@ -3,8 +3,8 @@
   "accuracy": 1,
   "animation": "drip_green",
   "effects": [
-    "enhance",
-    "poison target"
+    "poison target",
+    "enhance"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/suck_poison.json
+++ b/mods/tuxemon/db/technique/suck_poison.json
@@ -4,8 +4,8 @@
   "animation": "drip_green",
   "effects": [
     "poison target",
-    "damage",
-    "focused user"
+    "focused user",
+    "damage"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/sudden_glow.json
+++ b/mods/tuxemon/db/technique/sudden_glow.json
@@ -3,9 +3,9 @@
   "accuracy": 1,
   "animation": "heal_burst_120",
   "effects": [
-    "enhance",
     "focused target",
-    "recover all"
+    "recover",
+    "enhance"
   ],
   "flip_axes": "",
   "healing_power": 2,

--- a/mods/tuxemon/db/technique/supernova.json
+++ b/mods/tuxemon/db/technique/supernova.json
@@ -3,8 +3,8 @@
   "accuracy": 0.75,
   "animation": "fireball_114",
   "effects": [
-    "damage",
-    "chargedup target"
+    "chargedup target",
+    "damage"
   ],
   "flip_axes": "x",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/take_cover.json
+++ b/mods/tuxemon/db/technique/take_cover.json
@@ -3,8 +3,8 @@
   "accuracy": 1,
   "animation": "smokebomb",
   "effects": [
-    "enhance",
-    "sniping user"
+    "sniping user",
+    "enhance"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/thunderclap.json
+++ b/mods/tuxemon/db/technique/thunderclap.json
@@ -3,8 +3,8 @@
   "accuracy": 0.75,
   "animation": "thunderstrike",
   "effects": [
-    "damage",
-    "exhausted target"
+    "exhausted target",
+    "damage"
   ],
   "flip_axes": "",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/tonguespear.json
+++ b/mods/tuxemon/db/technique/tonguespear.json
@@ -3,8 +3,8 @@
   "accuracy": 0.8,
   "animation": "lance_ice",
   "effects": [
-    "damage",
-    "lifeleech all"
+    "lifeleech",
+    "damage"
   ],
   "flip_axes": "xy",
   "healing_power": 0,

--- a/mods/tuxemon/db/technique/wallow.json
+++ b/mods/tuxemon/db/technique/wallow.json
@@ -3,8 +3,8 @@
   "accuracy": 1,
   "animation": "waterspurt",
   "effects": [
-    "enhance",
-    "focused user"
+    "focused user",
+    "enhance"
   ],
   "flip_axes": "",
   "healing_power": 4,

--- a/mods/tuxemon/db/technique/web.json
+++ b/mods/tuxemon/db/technique/web.json
@@ -3,8 +3,8 @@
   "accuracy": 0.75,
   "animation": "snake_right",
   "effects": [
-    "damage",
-    "grabbed target"
+    "grabbed target",
+    "damage"
   ],
   "flip_axes": "x",
   "healing_power": 0,

--- a/tuxemon/technique/effects/grabbed.py
+++ b/tuxemon/technique/effects/grabbed.py
@@ -41,5 +41,7 @@ class GrabbedEffect(TechEffect):
                 target.apply_status(tech)
                 formula.simple_grabbed(target)
             return {"success": True}
+        if tech.slug == "status_grabbed":
+            return {"success": True}
 
         return {"success": False}

--- a/tuxemon/technique/effects/lifeleech.py
+++ b/tuxemon/technique/effects/lifeleech.py
@@ -12,8 +12,7 @@ from tuxemon.technique.technique import Technique
 
 
 class LifeLeechEffectResult(TechEffectResult):
-    damage: int
-    should_tackle: bool
+    pass
 
 
 @dataclass
@@ -31,7 +30,6 @@ class LifeLeechEffect(TechEffect):
     """
 
     name = "lifeleech"
-    objective: str
 
     def apply(
         self, tech: Technique, user: Monster, target: Monster
@@ -48,25 +46,23 @@ class LifeLeechEffect(TechEffect):
                 tech = Technique("status_lifeleech", carrier=user, link=target)
                 user.apply_status(tech)
             return {
-                "damage": 0,
-                "should_tackle": bool(success),
                 "success": True,
             }
 
-        # avoids Nonetype situation and reset the user
-        if user is None:
-            user = tech.link
-            assert user
-            damage = formula.simple_lifeleech(user, target)
-            target.current_hp -= damage
-            user.current_hp += damage
-        else:
-            damage = formula.simple_lifeleech(user, target)
-            target.current_hp -= damage
-            user.current_hp += damage
+        if tech.slug == "status_lifeleech":
+            # avoids Nonetype situation and reset the user
+            if user is None:
+                user = tech.link
+                assert user
+                damage = formula.simple_lifeleech(user, target)
+                target.current_hp -= damage
+                user.current_hp += damage
+            else:
+                damage = formula.simple_lifeleech(user, target)
+                target.current_hp -= damage
+                user.current_hp += damage
+            return {
+                "success": bool(damage),
+            }
 
-        return {
-            "damage": damage,
-            "should_tackle": bool(damage),
-            "success": bool(damage),
-        }
+        return {"success": False}

--- a/tuxemon/technique/effects/poison.py
+++ b/tuxemon/technique/effects/poison.py
@@ -12,8 +12,7 @@ from tuxemon.technique.technique import Technique
 
 
 class PoisonEffectResult(TechEffectResult):
-    damage: int
-    should_tackle: bool
+    pass
 
 
 @dataclass
@@ -39,16 +38,15 @@ class PoisonEffect(TechEffect):
             elif self.objective == "target":
                 target.apply_status(tech)
             return {
-                "damage": 0,
-                "should_tackle": bool(success),
                 "success": True,
             }
 
-        damage = formula.simple_poison(target)
-        target.current_hp -= damage
+        if tech.slug == "status_poison":
+            damage = formula.simple_poison(target)
+            target.current_hp -= damage
 
-        return {
-            "damage": damage,
-            "should_tackle": bool(damage),
-            "success": bool(damage),
-        }
+            return {
+                "success": bool(damage),
+            }
+
+        return {"success": False}

--- a/tuxemon/technique/effects/recover.py
+++ b/tuxemon/technique/effects/recover.py
@@ -12,8 +12,7 @@ from tuxemon.technique.technique import Technique
 
 
 class RecoverEffectResult(TechEffectResult):
-    damage: int
-    should_tackle: bool
+    pass
 
 
 @dataclass
@@ -23,7 +22,6 @@ class RecoverEffect(TechEffect):
     """
 
     name = "recover"
-    objective: str
 
     def apply(
         self, tech: Technique, user: Monster, target: Monster
@@ -36,23 +34,22 @@ class RecoverEffect(TechEffect):
             tech = Technique("status_recover", link=user)
             user.apply_status(tech)
             return {
-                "damage": 0,
-                "should_tackle": bool(success),
                 "success": True,
             }
 
-        # avoids Nonetype situation and reset the user
-        if user is None:
-            user = tech.link
-            assert user
-            heal = formula.simple_recover(user)
-            user.current_hp += heal
-        else:
-            heal = formula.simple_recover(user)
-            user.current_hp += heal
+        if tech.slug == "status_recover":
+            # avoids Nonetype situation and reset the user
+            if user is None:
+                user = tech.link
+                assert user
+                heal = formula.simple_recover(user)
+                user.current_hp += heal
+            else:
+                heal = formula.simple_recover(user)
+                user.current_hp += heal
 
-        return {
-            "damage": heal,
-            "should_tackle": False,
-            "success": bool(heal),
-        }
+            return {
+                "success": bool(heal),
+            }
+
+        return {"success": False}

--- a/tuxemon/technique/effects/stuck.py
+++ b/tuxemon/technique/effects/stuck.py
@@ -41,5 +41,7 @@ class StuckEffect(TechEffect):
                 target.apply_status(tech)
                 formula.simple_stuck(target)
             return {"success": True}
+        if tech.slug == "status_stuck":
+            return {"success": True}
 
         return {"success": False}


### PR DESCRIPTION
fix #1680 as reported by @Qiangong2 there was an issue with All_In technique.
After testing I found out the issue was the effect **recover**. Specifically the issue was the **damage** and **should_tackle** in the class.
```
class RecoverEffectResult(TechEffectResult):
    damage: int
    should_tackle: bool
```
I noticed another bug related to the message. This was caused by a wrong order of effects.
Damage must be at the bottom (same for enhance).

As well as it's necessary to define `tech.slug == status_xxx` (recover, poison and lifeleech) because so we can avoid the double damage. Recover, poison and lifeleech must continue to do their job without interfering with the basic move (at the end of the turn).

tested, isort, black, no new typehints.