### PR TITLE
fix update hud (name, level) during combat

### DIFF
--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -1102,11 +1102,13 @@ class CombatState(CombatAnimations):
                     # updates hud graphics player and ai
                     if winners in self.players[0].monsters:
                         self.build_hud(
-                            self._layout[self.players[0]]["hud"][0], winners
+                            self._layout[self.players[0]]["hud"][0],
+                            self.monsters_in_play[self.players[0]][0],
                         )
                     if winners in self.players[1].monsters:
                         self.build_hud(
-                            self._layout[self.players[1]]["hud"][0], winners
+                            self._layout[self.players[1]]["hud"][0],
+                            self.monsters_in_play[self.players[1]][0],
                         )
 
             # Remove monster from damage map

--- a/tuxemon/states/combat/combat_animations.py
+++ b/tuxemon/states/combat/combat_animations.py
@@ -41,7 +41,6 @@ logger = logging.getLogger(__name__)
 
 sprite_layer = 0
 hud_layer = 100
-monster_hud_move_in_time = 2
 
 
 def toggle_visible(sprite: Sprite) -> None:
@@ -411,7 +410,7 @@ class CombatAnimations(ABC, Menu[None]):
         text = self.build_hud_text(monster)
         animate = partial(
             self.animate,
-            duration=monster_hud_move_in_time,
+            duration=2.0,
             delay=1.3,
         )
         if self.get_side(home) == "right":


### PR DESCRIPTION
The fix focuses on the update of the hud (the graphics where there is monster, level, etc). Before there was the possibility that during the update, on the hud, it appeared the name of the fainted monster.

The reason was the following: `self._layout[self.players[1]]["hud"][0], winners`
**winners** is the result of a loop, and among the winners there are all the participants against a specific monster. Maybe the player started the fight with X and ended with Y, so there was the risk that during the update it appeared **X lv 8** instead of **Y lv 8**

Pretty annoying issue, because you have no idea about how many HP you have left, etc.

isort + black + tested + no new typehints