### PR TITLE
fix reset moves bug (1151) and fix poison (1138)

### DIFF
--- a/mods/tuxemon/db/technique/status_poison.json
+++ b/mods/tuxemon/db/technique/status_poison.json
@@ -2,7 +2,7 @@
   "animation": "drip_green",
   "category": "negative",
   "effects": [
-    "poison target"
+    "poison all"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_poison.png",

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -434,7 +434,7 @@ class Monster:
             self.status.append(status)
         else:
             # if the status exists
-            if any(t for t in self.status if t.slug == status):
+            if any(t for t in self.status if t.slug == status.slug):
                 return
             # if the status doesn't exist.
             else:

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -1324,7 +1324,7 @@ class CombatState(CombatAnimations):
     def end_combat(self) -> None:
         """End the combat."""
         # TODO: End combat differently depending on winning or losing
-        for player in self.active_players:
+        for player in self.players:
             for mon in player.monsters:
                 # reset status stats
                 mon.set_stats()

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -69,7 +69,7 @@ class Technique:
         self.is_fast = False
         self.link = link
         self.name = "Pound"
-        self.next_use = 0.0
+        self.next_use = 0
         self.potency = 0.0
         self.power = 1.0
         self.range = Range.melee


### PR DESCRIPTION
fix #1151 reported by @Qiangong2 back in 2022. I tried to reproduce it many times, but I was unable because it happens only if the player loses. Just lose, then random_encounter or trainer battle, and you'll notice grey moves on the battle menu.

What was the reason to block the full reset at the end of the combat?

This line `for player in self.active_players:` in **combat.py**.

Active players, simply the remaining (the winner), while the loser wasn't included inside the loop.

Replaced with `for player in self.players:`

tested, isort, black, no new typehints (-2)
typehint because next_use must be an int
typehint because of the missing .slug

added also small fix for poison fix #1138 (reported by @ultidonki ) the issue was that "poison target" when it was called the "status_poison", it didn't work, now with all it can execute everything (apply the status + poisoning correctly)