### PR TITLE
Replace windows binary part of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ python3 run_tuxemon.py
 
 ### Windows Binary
 
-Check the [release page](https://github.com/Tuxemon/Tuxemon/releases)
-for binaries.
+NOTICE: Windows binaries currently do not work currently (see https://github.com/Tuxemon/Tuxemon/issues/1229)
+
+In the meantime please use the windows source instructions above to run Tuxemon directly from source.
 
 
 ### Flatpak


### PR DESCRIPTION
Replace the windows binary part with a notice stating that the builds for windows are currently broken.