### PR TITLE
Modify player.py day of year code

### DIFF
--- a/tuxemon/player.py
+++ b/tuxemon/player.py
@@ -57,7 +57,7 @@ class Player(NPC):
         """
         var = self.game_variables
         var["hour"] = dt.datetime.now().strftime("%H")
-        var["day_of_year"] = dt.datetime.now().strftime("%j")
+        var["day_of_year"] = str(dt.datetime.now().timetuple().tm_yday))
         var["year"] = dt.datetime.now().strftime("%Y")
 
         # Leap year

--- a/tuxemon/player.py
+++ b/tuxemon/player.py
@@ -57,7 +57,7 @@ class Player(NPC):
         """
         var = self.game_variables
         var["hour"] = dt.datetime.now().strftime("%H")
-        var["day_of_year"] = str(dt.datetime.now().timetuple().tm_yday))
+        var["day_of_year"] = str(dt.datetime.now().timetuple().tm_yday)
         var["year"] = dt.datetime.now().strftime("%Y")
 
         # Leap year


### PR DESCRIPTION
The current behavior of the code produces the day of the year padded with zeros such as "003" "053" "032" "201". However previous behavior produced values without padding such as "3" "53" "32" "201". This change takes the value from tm_yday directly and puts it into string format via str() restoring previous behavior.