### PR TITLE
fix maps (3) useless spaces

### DIFF
--- a/mods/tuxemon/maps/professor_lab.tmx
+++ b/mods/tuxemon/maps/professor_lab.tmx
@@ -67,7 +67,7 @@
     <property name="act1" value="pathfind professor,9,9"/>
     <property name="act2" value="npc_face professor,up"/>
     <property name="act3" value="translated_dialog chooseyerfateRockitten"/>
-    <property name="act4" value="translated_dialog_choice yes:no,rockittenchoice "/>
+    <property name="act4" value="translated_dialog_choice yes:no,rockittenchoice"/>
     <property name="cond1" value="not variable_set havetuxemon:yes"/>
     <property name="cond2" value="is player_at"/>
     <property name="cond3" value="is player_facing down"/>
@@ -81,7 +81,7 @@
     <property name="act1" value="pathfind professor,10,9"/>
     <property name="act2" value="npc_face professor,up"/>
     <property name="act3" value="translated_dialog chooseyerfateCardiling"/>
-    <property name="act4" value="translated_dialog_choice yes:no,cardilingchoice "/>
+    <property name="act4" value="translated_dialog_choice yes:no,cardilingchoice"/>
     <property name="cond1" value="not variable_set havetuxemon:yes"/>
     <property name="cond2" value="is player_at"/>
     <property name="cond3" value="is player_facing down"/>

--- a/mods/tuxemon/maps/spyder_scoop4.tmx
+++ b/mods/tuxemon/maps/spyder_scoop4.tmx
@@ -172,7 +172,7 @@
     <property name="act4" value="translated_dialog spyder_scoop_landrace2"/>
     <property name="act6" value="set_variable scooplandrace:yes"/>
     <property name="act61" value="remove_npc spyder_scoop_landrace"/>
-    <property name="act71" value="pathfind spyder_scoop_weaver,11,3 "/>
+    <property name="act71" value="pathfind spyder_scoop_weaver,11,3"/>
     <property name="act81" value="remove_npc spyder_scoop_weaver"/>
     <property name="act89" value="pathfind spyder_scoop_arachne,10,4"/>
     <property name="act90" value="npc_face spyder_scoop_arachne,down"/>

--- a/mods/tuxemon/maps/test_pathfinding.tmx
+++ b/mods/tuxemon/maps/test_pathfinding.tmx
@@ -81,7 +81,7 @@
     <property name="act20" value="pathfind allie,3,11"/>
     <property name="act30" value="pathfind bob,3,11"/>
     <property name="act40" value="pathfind grace,3,11"/>
-    <property name="cond10" value="is player_at 7,7 "/>
+    <property name="cond10" value="is player_at 7,7"/>
    </properties>
   </object>
   <object id="29" name="Create NPCs" type="event" x="244.428" y="53.6729" width="16" height="16">


### PR DESCRIPTION
PR removes useless spaces in **spyder_scoop4.tmx**, **professor_lab.tmx** and **test_pathfinding.tmx**

tested, isort, black, no new typehints