### PR TITLE
walked field (Player menu)

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -1688,6 +1688,9 @@ msgstr "Caught {param} out of {all} Tuxemon"
 msgid "player_start_adventure"
 msgstr "The adventure began {date} days ago."
 
+msgid "player_walked"
+msgstr "Walked {distance} {unit}"
+
 msgid "player_battles"
 msgstr "Battles: {tot} (W{won} D{draw} L{lost})"
 

--- a/tuxemon/states/player/__init__.py
+++ b/tuxemon/states/player/__init__.py
@@ -104,7 +104,21 @@ class PlayerState(PygameMenuState):
                 "lost": str(lost),
             },
         )
-
+        # steps
+        steps = player.game_variables["steps"]
+        if prepare.CONFIG.unit == "metric":
+            walked = formula.convert_km(steps)
+            unit_walked = "km"
+        else:
+            walked = formula.convert_mi(steps)
+            unit_walked = "mi"
+        msg_walked = T.format(
+            "player_walked",
+            {
+                "distance": str(walked),
+                "unit": unit_walked,
+            },
+        )
         # name
         menu._auto_centering = False
         menu.add.label(
@@ -148,6 +162,14 @@ class PlayerState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         ).translate(fix_width(width, 0.45), fix_height(height, 0.40))
+        # walked
+        menu.add.label(
+            title=msg_walked,
+            label_id="walked",
+            font_size=15,
+            align=locals.ALIGN_LEFT,
+            float=True,
+        ).translate(fix_width(width, 0.45), fix_height(height, 0.45))
         # battles
         menu.add.label(
             title=msg_battles,
@@ -155,7 +177,7 @@ class PlayerState(PygameMenuState):
             font_size=15,
             align=locals.ALIGN_LEFT,
             float=True,
-        ).translate(fix_width(width, 0.45), fix_height(height, 0.45))
+        ).translate(fix_width(width, 0.45), fix_height(height, 0.50))
         # % tuxepedia
         menu.add.label(
             title=msg_progress,


### PR DESCRIPTION
The data was already present, but it wasn't shown (1 step = 1 tile = 1 meter)
If someone wants to modify the value (1 meter), then no problem, just tell me how much do you want.

Who set config in metrics will see in kilometers, the others in miles:
![Screenshot from 2023-03-19 09-55-48](https://user-images.githubusercontent.com/64643719/226164706-1114b7f6-f528-431f-8998-63058d4904b5.png)

tested, black, isort, no new typehints.