### PR TITLE
history (monster JSON)

### DIFF
--- a/mods/tuxemon/db/monster/aardart.json
+++ b/mods/tuxemon/db/monster/aardart.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "aardorn",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "varmint",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/aardorn.json
+++ b/mods/tuxemon/db/monster/aardorn.json
@@ -23,6 +23,12 @@
             "monster_slug": "aardart"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "aardart",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "varmint",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/abesnaki.json
+++ b/mods/tuxemon/db/monster/abesnaki.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "serpent",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/agnidon.json
+++ b/mods/tuxemon/db/monster/agnidon.json
@@ -35,6 +35,12 @@
             "monster_slug": "agnigon"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "agnite",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "dragon",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/agnigon.json
+++ b/mods/tuxemon/db/monster/agnigon.json
@@ -41,6 +41,16 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "agnite",
+            "evo_stage": "basic"
+        },
+        {
+            "mon_slug": "agnidon",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "dragon",
     "stage": "stage2",
     "types": [

--- a/mods/tuxemon/db/monster/agnite.json
+++ b/mods/tuxemon/db/monster/agnite.json
@@ -23,6 +23,16 @@
             "monster_slug": "agnidon"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "agnidon",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "agnigon",
+            "evo_stage": "stage2"
+        }
+    ],
     "shape": "dragon",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/allagon.json
+++ b/mods/tuxemon/db/monster/allagon.json
@@ -35,6 +35,12 @@
             "monster_slug": "ferricran"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "wrougon",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "dragon",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/altie.json
+++ b/mods/tuxemon/db/monster/altie.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "humanoid",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/angrito.json
+++ b/mods/tuxemon/db/monster/angrito.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "chromeye",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "blob",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/anoleaf.json
+++ b/mods/tuxemon/db/monster/anoleaf.json
@@ -23,6 +23,16 @@
             "monster_slug": "gectile"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "gectile",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "velocitile",
+            "evo_stage": "stage2"
+        }
+    ],
     "shape": "varmint",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/anu.json
+++ b/mods/tuxemon/db/monster/anu.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "varmint",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/apeoro.json
+++ b/mods/tuxemon/db/monster/apeoro.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "tetrchimp",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "humanoid",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/araignee.json
+++ b/mods/tuxemon/db/monster/araignee.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "grub",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/arthrobolt.json
+++ b/mods/tuxemon/db/monster/arthrobolt.json
@@ -41,6 +41,16 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "nut",
+            "evo_stage": "basic"
+        },
+        {
+            "mon_slug": "bolt",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "humanoid",
     "stage": "stage2",
     "types": [

--- a/mods/tuxemon/db/monster/av8r.json
+++ b/mods/tuxemon/db/monster/av8r.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "botbot",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "flier",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/axylightl.json
+++ b/mods/tuxemon/db/monster/axylightl.json
@@ -53,8 +53,9 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "polliwog",
-    "stage": "standalone",
+    "stage": "basic",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/b_ver_1.json
+++ b/mods/tuxemon/db/monster/b_ver_1.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "botbot",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "varmint",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/bamboon.json
+++ b/mods/tuxemon/db/monster/bamboon.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "budaye",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "sprite",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/banling.json
+++ b/mods/tuxemon/db/monster/banling.json
@@ -53,8 +53,9 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "brute",
-    "stage": "standalone",
+    "stage": "basic",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/baobaraffe.json
+++ b/mods/tuxemon/db/monster/baobaraffe.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "baoby",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "landrace",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/baoby.json
+++ b/mods/tuxemon/db/monster/baoby.json
@@ -23,6 +23,12 @@
             "monster_slug": "baobaraffe"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "baobaraffe",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "landrace",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/beenstalker.json
+++ b/mods/tuxemon/db/monster/beenstalker.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "turnipper",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "hunter",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/bigfin.json
+++ b/mods/tuxemon/db/monster/bigfin.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "dollfin",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "leviathan",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/birdling.json
+++ b/mods/tuxemon/db/monster/birdling.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "hatchling",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "flier",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/bolt.json
+++ b/mods/tuxemon/db/monster/bolt.json
@@ -35,6 +35,12 @@
             "monster_slug": "arthrobolt"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "nut",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "blob",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/boltnu.json
+++ b/mods/tuxemon/db/monster/boltnu.json
@@ -23,6 +23,12 @@
             "monster_slug": "exclawvate"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "exclawvate",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "blob",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/botbot.json
+++ b/mods/tuxemon/db/monster/botbot.json
@@ -48,6 +48,28 @@
             "item": "booster_tech"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "b_ver_1",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "k9",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "mrmoswitch",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "picc",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "av8r",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "grub",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/boxali.json
+++ b/mods/tuxemon/db/monster/boxali.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "brute",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/brewdin.json
+++ b/mods/tuxemon/db/monster/brewdin.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "varmint",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/budaye.json
+++ b/mods/tuxemon/db/monster/budaye.json
@@ -42,6 +42,16 @@
             "item": "peace_lily"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "bamboon",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "frondly",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "sprite",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/bugnin.json
+++ b/mods/tuxemon/db/monster/bugnin.json
@@ -41,6 +41,16 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "katapill",
+            "evo_stage": "basic"
+        },
+        {
+            "mon_slug": "katacoon",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "brute",
     "stage": "stage2",
     "types": [

--- a/mods/tuxemon/db/monster/bumbulus.json
+++ b/mods/tuxemon/db/monster/bumbulus.json
@@ -53,8 +53,9 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "blob",
-    "stage": "standalone",
+    "stage": "basic",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/bursa.json
+++ b/mods/tuxemon/db/monster/bursa.json
@@ -23,6 +23,12 @@
             "monster_slug": "flambear"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "flambear",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "humanoid",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/cairfrey.json
+++ b/mods/tuxemon/db/monster/cairfrey.json
@@ -23,6 +23,12 @@
             "monster_slug": "possessun"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "possessun",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "blob",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/capiti.json
+++ b/mods/tuxemon/db/monster/capiti.json
@@ -53,8 +53,9 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "sprite",
-    "stage": "standalone",
+    "stage": "basic",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/cardiling.json
+++ b/mods/tuxemon/db/monster/cardiling.json
@@ -23,6 +23,16 @@
             "monster_slug": "cardiwing"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "cardiwing",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "cardinale",
+            "evo_stage": "stage2"
+        }
+    ],
     "shape": "flier",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/cardinale.json
+++ b/mods/tuxemon/db/monster/cardinale.json
@@ -41,6 +41,16 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "cardiling",
+            "evo_stage": "basic"
+        },
+        {
+            "mon_slug": "cardiwing",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "flier",
     "stage": "stage2",
     "types": [

--- a/mods/tuxemon/db/monster/cardiwing.json
+++ b/mods/tuxemon/db/monster/cardiwing.json
@@ -35,6 +35,12 @@
             "monster_slug": "cardinale"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "cardiling",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "flier",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/cataspike.json
+++ b/mods/tuxemon/db/monster/cataspike.json
@@ -23,6 +23,16 @@
             "monster_slug": "puparmor"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "puparmor",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "weavifly",
+            "evo_stage": "stage2"
+        }
+    ],
     "shape": "grub",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/cateye.json
+++ b/mods/tuxemon/db/monster/cateye.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "hunter",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/chenipode.json
+++ b/mods/tuxemon/db/monster/chenipode.json
@@ -23,6 +23,12 @@
             "monster_slug": "exapode"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "flambear",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "grub",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/chibiro.json
+++ b/mods/tuxemon/db/monster/chibiro.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "varmint",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/chillimp.json
+++ b/mods/tuxemon/db/monster/chillimp.json
@@ -23,6 +23,12 @@
             "monster_slug": "snowrilla"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "snowrilla",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "brute",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/chloragon.json
+++ b/mods/tuxemon/db/monster/chloragon.json
@@ -23,6 +23,16 @@
             "monster_slug": "sapragon"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "sapragon",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "dragarbor",
+            "evo_stage": "stage2"
+        }
+    ],
     "shape": "dragon",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/chrome_robo.json
+++ b/mods/tuxemon/db/monster/chrome_robo.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "humanoid",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/chromeye.json
+++ b/mods/tuxemon/db/monster/chromeye.json
@@ -42,6 +42,24 @@
             "season": "autumn"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "sadito",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "neutrito",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "happito",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "angrito",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "blob",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/cochini.json
+++ b/mods/tuxemon/db/monster/cochini.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "varmint",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/coleorus.json
+++ b/mods/tuxemon/db/monster/coleorus.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "sprite",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/conifrost.json
+++ b/mods/tuxemon/db/monster/conifrost.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "blob",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/conileaf.json
+++ b/mods/tuxemon/db/monster/conileaf.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "blob",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/coproblight.json
+++ b/mods/tuxemon/db/monster/coproblight.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "blob",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/corvix.json
+++ b/mods/tuxemon/db/monster/corvix.json
@@ -35,6 +35,12 @@
             "monster_slug": "gryfix"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "flacono",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "flier",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/cowpignon.json
+++ b/mods/tuxemon/db/monster/cowpignon.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "sprite",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/criniotherme.json
+++ b/mods/tuxemon/db/monster/criniotherme.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "pantherafira",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "hunter",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/d0llf1n.json
+++ b/mods/tuxemon/db/monster/d0llf1n.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "aquatic",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/dandicub.json
+++ b/mods/tuxemon/db/monster/dandicub.json
@@ -23,6 +23,12 @@
             "monster_slug": "dandylion"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "dandylion",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "blob",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/dandylion.json
+++ b/mods/tuxemon/db/monster/dandylion.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "dandicub",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "hunter",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/dark_robo.json
+++ b/mods/tuxemon/db/monster/dark_robo.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "humanoid",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/dinoflop.json
+++ b/mods/tuxemon/db/monster/dinoflop.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "dragon",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/djinnbo.json
+++ b/mods/tuxemon/db/monster/djinnbo.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "humanoid",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/dollfin.json
+++ b/mods/tuxemon/db/monster/dollfin.json
@@ -42,6 +42,16 @@
             "item": "sea_girdle"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "bigfin",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "sharpfin",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "aquatic",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/dracune.json
+++ b/mods/tuxemon/db/monster/dracune.json
@@ -35,6 +35,12 @@
             "monster_slug": "fluttaflap"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "vamporm",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "blob",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/dragarbor.json
+++ b/mods/tuxemon/db/monster/dragarbor.json
@@ -41,6 +41,16 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "chloragon",
+            "evo_stage": "basic"
+        },
+        {
+            "mon_slug": "sapragon",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "dragon",
     "stage": "stage2",
     "types": [

--- a/mods/tuxemon/db/monster/drashimi.json
+++ b/mods/tuxemon/db/monster/drashimi.json
@@ -23,6 +23,16 @@
             "monster_slug": "tsushimi"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "tsushimi",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "tobishimi",
+            "evo_stage": "stage2"
+        }
+    ],
     "shape": "polliwog",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/drokoro.json
+++ b/mods/tuxemon/db/monster/drokoro.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "dragon",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/dune_pincher.json
+++ b/mods/tuxemon/db/monster/dune_pincher.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "grub",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/eaglace.json
+++ b/mods/tuxemon/db/monster/eaglace.json
@@ -41,6 +41,16 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "tweesher",
+            "evo_stage": "basic"
+        },
+        {
+            "mon_slug": "heronquak",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "flier",
     "stage": "stage2",
     "types": [

--- a/mods/tuxemon/db/monster/elofly.json
+++ b/mods/tuxemon/db/monster/elofly.json
@@ -23,6 +23,16 @@
             "monster_slug": "elowind"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "elowind",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "elostorm",
+            "evo_stage": "stage2"
+        }
+    ],
     "shape": "flier",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/elostorm.json
+++ b/mods/tuxemon/db/monster/elostorm.json
@@ -41,6 +41,16 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "elofly",
+            "evo_stage": "basic"
+        },
+        {
+            "mon_slug": "elowind",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "flier",
     "stage": "stage2",
     "types": [

--- a/mods/tuxemon/db/monster/elowind.json
+++ b/mods/tuxemon/db/monster/elowind.json
@@ -35,6 +35,12 @@
             "monster_slug": "elostorm"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "elofly",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "flier",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/embazook.json
+++ b/mods/tuxemon/db/monster/embazook.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "ignibus",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "polliwog",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/embra.json
+++ b/mods/tuxemon/db/monster/embra.json
@@ -23,6 +23,12 @@
             "monster_slug": "ruption"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "ruption",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "blob",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/enduros.json
+++ b/mods/tuxemon/db/monster/enduros.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "brute",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/eruptibus.json
+++ b/mods/tuxemon/db/monster/eruptibus.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "ignibus",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "landrace",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/exapode.json
+++ b/mods/tuxemon/db/monster/exapode.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "chenipode",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "grub",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/exclawvate.json
+++ b/mods/tuxemon/db/monster/exclawvate.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "boltnu",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "dragon",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/eyenemy.json
+++ b/mods/tuxemon/db/monster/eyenemy.json
@@ -23,6 +23,12 @@
             "monster_slug": "eyesore"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "eyesore",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "serpent",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/eyesore.json
+++ b/mods/tuxemon/db/monster/eyesore.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "eyenemy",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "serpent",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/f7u1t3ra.json
+++ b/mods/tuxemon/db/monster/f7u1t3ra.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "flier",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/fancair.json
+++ b/mods/tuxemon/db/monster/fancair.json
@@ -23,6 +23,12 @@
             "monster_slug": "windeye"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "windeye",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "sprite",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/ferricran.json
+++ b/mods/tuxemon/db/monster/ferricran.json
@@ -41,6 +41,16 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "wrougon",
+            "evo_stage": "basic"
+        },
+        {
+            "mon_slug": "allagon",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "dragon",
     "stage": "stage2",
     "types": [

--- a/mods/tuxemon/db/monster/flacono.json
+++ b/mods/tuxemon/db/monster/flacono.json
@@ -23,6 +23,16 @@
             "monster_slug": "corvix"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "corvix",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "gryfix",
+            "evo_stage": "stage2"
+        }
+    ],
     "shape": "flier",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/flambear.json
+++ b/mods/tuxemon/db/monster/flambear.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "bursa",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "brute",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/fluoresfin.json
+++ b/mods/tuxemon/db/monster/fluoresfin.json
@@ -23,6 +23,16 @@
             "monster_slug": "incandesfin"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "incandesfin",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "lightmare",
+            "evo_stage": "stage2"
+        }
+    ],
     "shape": "aquatic",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/fluttaflap.json
+++ b/mods/tuxemon/db/monster/fluttaflap.json
@@ -41,6 +41,16 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "vamporm",
+            "evo_stage": "basic"
+        },
+        {
+            "mon_slug": "dracune",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "grub",
     "stage": "stage2",
     "types": [

--- a/mods/tuxemon/db/monster/foofle.json
+++ b/mods/tuxemon/db/monster/foofle.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "varmint",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/fordin.json
+++ b/mods/tuxemon/db/monster/fordin.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "leviathan",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/forturtle.json
+++ b/mods/tuxemon/db/monster/forturtle.json
@@ -23,6 +23,12 @@
             "monster_slug": "prophetoise"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "prophetoise",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "humanoid",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/foxfire.json
+++ b/mods/tuxemon/db/monster/foxfire.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "varmint",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/frondly.json
+++ b/mods/tuxemon/db/monster/frondly.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "budaye",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "sprite",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/fruitera.json
+++ b/mods/tuxemon/db/monster/fruitera.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "flier",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/furnursus.json
+++ b/mods/tuxemon/db/monster/furnursus.json
@@ -23,6 +23,12 @@
             "monster_slug": "statursus"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "statursus",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "humanoid",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/galnec.json
+++ b/mods/tuxemon/db/monster/galnec.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "hunter",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/gectile.json
+++ b/mods/tuxemon/db/monster/gectile.json
@@ -35,6 +35,12 @@
             "monster_slug": "velocitile"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "anoleaf",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "humanoid",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/ghosteeth.json
+++ b/mods/tuxemon/db/monster/ghosteeth.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "blob",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/graffiki.json
+++ b/mods/tuxemon/db/monster/graffiki.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "humanoid",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/grimachin.json
+++ b/mods/tuxemon/db/monster/grimachin.json
@@ -23,6 +23,12 @@
             "monster_slug": "tigrock"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "tigrock",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "hunter",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/grinflare.json
+++ b/mods/tuxemon/db/monster/grinflare.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "grintot",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "brute",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/grintot.json
+++ b/mods/tuxemon/db/monster/grintot.json
@@ -42,6 +42,16 @@
             "item": "thunderstone"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "grinflare",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "grintrock",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "brute",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/grintrock.json
+++ b/mods/tuxemon/db/monster/grintrock.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "grintot",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "brute",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/grumpi.json
+++ b/mods/tuxemon/db/monster/grumpi.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "brute",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/gryfix.json
+++ b/mods/tuxemon/db/monster/gryfix.json
@@ -41,6 +41,16 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "flacono",
+            "evo_stage": "basic"
+        },
+        {
+            "mon_slug": "corvix",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "flier",
     "stage": "stage2",
     "types": [

--- a/mods/tuxemon/db/monster/hampotamos.json
+++ b/mods/tuxemon/db/monster/hampotamos.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "landrace",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/happito.json
+++ b/mods/tuxemon/db/monster/happito.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "chromeye",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "blob",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/hatchling.json
+++ b/mods/tuxemon/db/monster/hatchling.json
@@ -23,6 +23,12 @@
             "monster_slug": "birdling"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "birdling",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "flier",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/heronquak.json
+++ b/mods/tuxemon/db/monster/heronquak.json
@@ -35,6 +35,12 @@
             "monster_slug": "eaglace"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "tweesher",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "flier",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/hydrone.json
+++ b/mods/tuxemon/db/monster/hydrone.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "humanoid",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/ignibus.json
+++ b/mods/tuxemon/db/monster/ignibus.json
@@ -42,6 +42,16 @@
             "item": "stovepipe"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "embazook",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "eruptibus",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "polliwog",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/incandesfin.json
+++ b/mods/tuxemon/db/monster/incandesfin.json
@@ -35,6 +35,12 @@
             "monster_slug": "lightmare"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "fluoresfin",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "aquatic",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/jelillow.json
+++ b/mods/tuxemon/db/monster/jelillow.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "blob",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/jemuar.json
+++ b/mods/tuxemon/db/monster/jemuar.json
@@ -41,6 +41,16 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "rockitten",
+            "evo_stage": "basic"
+        },
+        {
+            "mon_slug": "rockat",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "hunter",
     "stage": "stage2",
     "types": [

--- a/mods/tuxemon/db/monster/k9.json
+++ b/mods/tuxemon/db/monster/k9.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "botbot",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "hunter",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/katacoon.json
+++ b/mods/tuxemon/db/monster/katacoon.json
@@ -44,6 +44,12 @@
             "stat2": "melee"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "katapill",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "grub",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/katapill.json
+++ b/mods/tuxemon/db/monster/katapill.json
@@ -23,6 +23,20 @@
             "monster_slug": "katacoon"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "katacoon",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "bugnin",
+            "evo_stage": "stage2"
+        },
+        {
+            "mon_slug": "sumchon",
+            "evo_stage": "stage2"
+        }
+    ],
     "shape": "grub",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/komodraw.json
+++ b/mods/tuxemon/db/monster/komodraw.json
@@ -53,8 +53,9 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "humanoid",
-    "stage": "standalone",
+    "stage": "basic",
     "types": [
         "fire"
     ],

--- a/mods/tuxemon/db/monster/l3gk0.json
+++ b/mods/tuxemon/db/monster/l3gk0.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "serpent",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/lambert.json
+++ b/mods/tuxemon/db/monster/lambert.json
@@ -23,6 +23,16 @@
             "monster_slug": "legko"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "legko",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "moloch",
+            "evo_stage": "stage2"
+        }
+    ],
     "shape": "sprite",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/lapinou.json
+++ b/mods/tuxemon/db/monster/lapinou.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "varmint",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/legko.json
+++ b/mods/tuxemon/db/monster/legko.json
@@ -35,6 +35,12 @@
             "monster_slug": "moloch"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "lambert",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "serpent",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/lightmare.json
+++ b/mods/tuxemon/db/monster/lightmare.json
@@ -41,6 +41,16 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "fluoresfin",
+            "evo_stage": "basic"
+        },
+        {
+            "mon_slug": "incandesfin",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "leviathan",
     "stage": "stage2",
     "types": [

--- a/mods/tuxemon/db/monster/loliferno.json
+++ b/mods/tuxemon/db/monster/loliferno.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "seirein",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "blob",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/lunight.json
+++ b/mods/tuxemon/db/monster/lunight.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "sprite",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/manosting.json
+++ b/mods/tuxemon/db/monster/manosting.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "blob",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/masknake.json
+++ b/mods/tuxemon/db/monster/masknake.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "serpent",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/medushock.json
+++ b/mods/tuxemon/db/monster/medushock.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "blob",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/memnomnom.json
+++ b/mods/tuxemon/db/monster/memnomnom.json
@@ -42,6 +42,16 @@
             "item": "pyramidion"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "pyraminx",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "miaownolith",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "hunter",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/merlicun.json
+++ b/mods/tuxemon/db/monster/merlicun.json
@@ -53,8 +53,9 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "varmint",
-    "stage": "standalone",
+    "stage": "basic",
     "types": [
         "fire"
     ],

--- a/mods/tuxemon/db/monster/metesaur.json
+++ b/mods/tuxemon/db/monster/metesaur.json
@@ -23,6 +23,12 @@
             "monster_slug": "qetzlrokilus"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "qetzlrokilus",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "flier",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/miaownolith.json
+++ b/mods/tuxemon/db/monster/miaownolith.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "memnomnom",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "hunter",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/mk01_alpha.json
+++ b/mods/tuxemon/db/monster/mk01_alpha.json
@@ -52,6 +52,12 @@
             "monster_slug": "mk01_gamma"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "mk01_proto",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "dragon",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/mk01_beta.json
+++ b/mods/tuxemon/db/monster/mk01_beta.json
@@ -52,6 +52,12 @@
             "monster_slug": "mk01_omega"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "mk01_proto",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "dragon",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/mk01_delta.json
+++ b/mods/tuxemon/db/monster/mk01_delta.json
@@ -53,6 +53,20 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "mk01_proto",
+            "evo_stage": "basic"
+        },
+        {
+            "mon_slug": "mk01_alpha",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "mk01_beta",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "dragon",
     "stage": "stage2",
     "types": [

--- a/mods/tuxemon/db/monster/mk01_gamma.json
+++ b/mods/tuxemon/db/monster/mk01_gamma.json
@@ -53,6 +53,16 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "mk01_alpha",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "mk01_proto",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "dragon",
     "stage": "stage2",
     "types": [

--- a/mods/tuxemon/db/monster/mk01_omega.json
+++ b/mods/tuxemon/db/monster/mk01_omega.json
@@ -53,6 +53,16 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "mk01_beta",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "mk01_proto",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "dragon",
     "stage": "stage2",
     "types": [

--- a/mods/tuxemon/db/monster/mk01_proto.json
+++ b/mods/tuxemon/db/monster/mk01_proto.json
@@ -32,6 +32,28 @@
             "monster_slug": "mk01_beta"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "mk01_alpha",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "mk01_beta",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "mk01_gamma",
+            "evo_stage": "stage2"
+        },
+        {
+            "mon_slug": "mk01_omega",
+            "evo_stage": "stage2"
+        },
+        {
+            "mon_slug": "mk01_delta",
+            "evo_stage": "stage2"
+        }
+    ],
     "shape": "dragon",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/moloch.json
+++ b/mods/tuxemon/db/monster/moloch.json
@@ -41,6 +41,16 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "lambert",
+            "evo_stage": "basic"
+        },
+        {
+            "mon_slug": "legko",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "brute",
     "stage": "stage2",
     "types": [

--- a/mods/tuxemon/db/monster/mrmoswitch.json
+++ b/mods/tuxemon/db/monster/mrmoswitch.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "botbot",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "sprite",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/mystikapi.json
+++ b/mods/tuxemon/db/monster/mystikapi.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "landrace",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/narcileaf.json
+++ b/mods/tuxemon/db/monster/narcileaf.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "shybulb",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "blob",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/neutrito.json
+++ b/mods/tuxemon/db/monster/neutrito.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "chromeye",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "blob",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/noctalo.json
+++ b/mods/tuxemon/db/monster/noctalo.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "noctula",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "flier",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/noctula.json
+++ b/mods/tuxemon/db/monster/noctula.json
@@ -23,6 +23,12 @@
             "monster_slug": "noctalo"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "noctalo",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "flier",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/nostray.json
+++ b/mods/tuxemon/db/monster/nostray.json
@@ -23,6 +23,12 @@
             "monster_slug": "shnark"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "shnark",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "aquatic",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/nudiflot_female.json
+++ b/mods/tuxemon/db/monster/nudiflot_female.json
@@ -23,6 +23,12 @@
             "monster_slug": "nudimind"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "nudimind",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "polliwog",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/nudiflot_male.json
+++ b/mods/tuxemon/db/monster/nudiflot_male.json
@@ -23,6 +23,12 @@
             "monster_slug": "nudikill"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "nudikill",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "polliwog",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/nudikill.json
+++ b/mods/tuxemon/db/monster/nudikill.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "nudiflot_male",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "polliwog",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/nudimind.json
+++ b/mods/tuxemon/db/monster/nudimind.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "nudiflot_female",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "polliwog",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/nuenflu.json
+++ b/mods/tuxemon/db/monster/nuenflu.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "varmint",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/nut.json
+++ b/mods/tuxemon/db/monster/nut.json
@@ -23,6 +23,16 @@
             "monster_slug": "bolt"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "bolt",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "arthrobolt",
+            "evo_stage": "stage2"
+        }
+    ],
     "shape": "blob",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/octabode.json
+++ b/mods/tuxemon/db/monster/octabode.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "skwib",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "polliwog",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/ouroboutlet.json
+++ b/mods/tuxemon/db/monster/ouroboutlet.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "pythwire",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "serpent",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/pairagrim.json
+++ b/mods/tuxemon/db/monster/pairagrim.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "pairagrin",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "flier",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/pairagrin.json
+++ b/mods/tuxemon/db/monster/pairagrin.json
@@ -23,6 +23,12 @@
             "monster_slug": "pairagrim"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "pairagrim",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "flier",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/pantherafira.json
+++ b/mods/tuxemon/db/monster/pantherafira.json
@@ -23,6 +23,12 @@
             "monster_slug": "criniotherme"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "criniotherme",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "hunter",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/pharfan.json
+++ b/mods/tuxemon/db/monster/pharfan.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "landrace",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/picc.json
+++ b/mods/tuxemon/db/monster/picc.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "botbot",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "aquatic",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/pigabyte.json
+++ b/mods/tuxemon/db/monster/pigabyte.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "blob",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/pilthropus.json
+++ b/mods/tuxemon/db/monster/pilthropus.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "humanoid",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/pipis.json
+++ b/mods/tuxemon/db/monster/pipis.json
@@ -23,6 +23,12 @@
             "monster_slug": "strella"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "strella",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "flier",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/poinchin.json
+++ b/mods/tuxemon/db/monster/poinchin.json
@@ -23,6 +23,12 @@
             "monster_slug": "saurchin"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "saurchin",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "grub",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/polyrock.json
+++ b/mods/tuxemon/db/monster/polyrock.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "brute",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/possessun.json
+++ b/mods/tuxemon/db/monster/possessun.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "cairfrey",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "blob",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/propellercat.json
+++ b/mods/tuxemon/db/monster/propellercat.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "flier",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/prophetoise.json
+++ b/mods/tuxemon/db/monster/prophetoise.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "forturtle",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "humanoid",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/puparmor.json
+++ b/mods/tuxemon/db/monster/puparmor.json
@@ -35,6 +35,12 @@
             "monster_slug": "weavifly"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "cataspike",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "blob",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/pyraminx.json
+++ b/mods/tuxemon/db/monster/pyraminx.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "memnomnom",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "hunter",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/pythock.json
+++ b/mods/tuxemon/db/monster/pythock.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "snock",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "serpent",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/pythwire.json
+++ b/mods/tuxemon/db/monster/pythwire.json
@@ -30,6 +30,16 @@
             "item": "metal_booster"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "ouroboutlet",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "sockeserp",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "serpent",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/qetzlrokilus.json
+++ b/mods/tuxemon/db/monster/qetzlrokilus.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "metesaur",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "flier",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/r0ck1tt3n.json
+++ b/mods/tuxemon/db/monster/r0ck1tt3n.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "hunter",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/rabbitosaur.json
+++ b/mods/tuxemon/db/monster/rabbitosaur.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "squabbit",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "varmint",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/rhincus.json
+++ b/mods/tuxemon/db/monster/rhincus.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "flier",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/rockat.json
+++ b/mods/tuxemon/db/monster/rockat.json
@@ -35,6 +35,12 @@
             "monster_slug": "jemuar"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "rockitten",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "hunter",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/rockitten.json
+++ b/mods/tuxemon/db/monster/rockitten.json
@@ -23,6 +23,16 @@
             "monster_slug": "rockat"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "rockat",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "jemuar",
+            "evo_stage": "stage2"
+        }
+    ],
     "shape": "hunter",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/rosarin.json
+++ b/mods/tuxemon/db/monster/rosarin.json
@@ -53,8 +53,9 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "humanoid",
-    "stage": "standalone",
+    "stage": "basic",
     "types": [
         "wood"
     ],

--- a/mods/tuxemon/db/monster/ruption.json
+++ b/mods/tuxemon/db/monster/ruption.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "embra",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "brute",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/sadito.json
+++ b/mods/tuxemon/db/monster/sadito.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "chromeye",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "blob",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/sampsack.json
+++ b/mods/tuxemon/db/monster/sampsack.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "brute",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/sampsage.json
+++ b/mods/tuxemon/db/monster/sampsage.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "humanoid",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/sapragon.json
+++ b/mods/tuxemon/db/monster/sapragon.json
@@ -35,6 +35,12 @@
             "monster_slug": "dragarbor"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "chloragon",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "dragon",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/sapsnap.json
+++ b/mods/tuxemon/db/monster/sapsnap.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "trapsnap",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "brute",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/saurchin.json
+++ b/mods/tuxemon/db/monster/saurchin.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "poinchin",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "dragon",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/sclairus.json
+++ b/mods/tuxemon/db/monster/sclairus.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "blob",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/seirein.json
+++ b/mods/tuxemon/db/monster/seirein.json
@@ -23,6 +23,12 @@
             "monster_slug": "loliferno"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "loliferno",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "blob",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/selket.json
+++ b/mods/tuxemon/db/monster/selket.json
@@ -23,6 +23,12 @@
             "monster_slug": "selmatek"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "selmatek",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "grub",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/selmatek.json
+++ b/mods/tuxemon/db/monster/selmatek.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "selket",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "grub",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/shammer.json
+++ b/mods/tuxemon/db/monster/shammer.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "hunter",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/sharpfin.json
+++ b/mods/tuxemon/db/monster/sharpfin.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "dollfin",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "aquatic",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/shelagu.json
+++ b/mods/tuxemon/db/monster/shelagu.json
@@ -53,8 +53,9 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "polliwog",
-    "stage": "standalone",
+    "stage": "stage1",
     "types": [
         "water"
     ],

--- a/mods/tuxemon/db/monster/shnark.json
+++ b/mods/tuxemon/db/monster/shnark.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "nostray",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "aquatic",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/shybulb.json
+++ b/mods/tuxemon/db/monster/shybulb.json
@@ -23,6 +23,12 @@
             "monster_slug": "narcileaf"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "narcileaf",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "sprite",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/skwib.json
+++ b/mods/tuxemon/db/monster/skwib.json
@@ -23,6 +23,12 @@
             "monster_slug": "octabode"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "octabode",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "polliwog",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/sludgehog.json
+++ b/mods/tuxemon/db/monster/sludgehog.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "landrace",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/snaki.json
+++ b/mods/tuxemon/db/monster/snaki.json
@@ -23,6 +23,12 @@
             "monster_slug": "snokari"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "snokari",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "serpent",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/snarlon.json
+++ b/mods/tuxemon/db/monster/snarlon.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "hunter",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/snock.json
+++ b/mods/tuxemon/db/monster/snock.json
@@ -23,6 +23,12 @@
             "monster_slug": "pythock"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "pythock",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "serpent",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/snokari.json
+++ b/mods/tuxemon/db/monster/snokari.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "snaki",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "serpent",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/snowrilla.json
+++ b/mods/tuxemon/db/monster/snowrilla.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "chillimp",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "brute",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/sockeserp.json
+++ b/mods/tuxemon/db/monster/sockeserp.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "pythwire",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "serpent",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/solight.json
+++ b/mods/tuxemon/db/monster/solight.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "sprite",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/spighter.json
+++ b/mods/tuxemon/db/monster/spighter.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "grub",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/spoilurm.json
+++ b/mods/tuxemon/db/monster/spoilurm.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "serpent",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/spycozeus.json
+++ b/mods/tuxemon/db/monster/spycozeus.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "varmint",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/squabbit.json
+++ b/mods/tuxemon/db/monster/squabbit.json
@@ -23,6 +23,12 @@
             "monster_slug": "rabbitosaur"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "rabbitosaur",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "varmint",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/statursus.json
+++ b/mods/tuxemon/db/monster/statursus.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "furnursus",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "humanoid",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/strella.json
+++ b/mods/tuxemon/db/monster/strella.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "pipis",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "flier",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/sumchon.json
+++ b/mods/tuxemon/db/monster/sumchon.json
@@ -41,6 +41,16 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "katapill",
+            "evo_stage": "basic"
+        },
+        {
+            "mon_slug": "katacoon",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "brute",
     "stage": "stage2",
     "types": [

--- a/mods/tuxemon/db/monster/tarpeur.json
+++ b/mods/tuxemon/db/monster/tarpeur.json
@@ -23,6 +23,12 @@
             "monster_slug": "vigueur"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "vigueur",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "grub",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/taupypus.json
+++ b/mods/tuxemon/db/monster/taupypus.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "varmint",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/teddisun.json
+++ b/mods/tuxemon/db/monster/teddisun.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "humanoid",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/tetrchimp.json
+++ b/mods/tuxemon/db/monster/tetrchimp.json
@@ -23,6 +23,12 @@
             "monster_slug": "apeoro"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "apeoro",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "humanoid",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/tigrock.json
+++ b/mods/tuxemon/db/monster/tigrock.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "grimachin",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "hunter",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/tikoal.json
+++ b/mods/tuxemon/db/monster/tikoal.json
@@ -23,6 +23,12 @@
             "monster_slug": "tikorch"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "tikorch",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "blob",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/tikorch.json
+++ b/mods/tuxemon/db/monster/tikorch.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "tikoal",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "blob",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/tobishimi.json
+++ b/mods/tuxemon/db/monster/tobishimi.json
@@ -41,6 +41,16 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "drashimi",
+            "evo_stage": "basic"
+        },
+        {
+            "mon_slug": "tsushimi",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "dragon",
     "stage": "stage2",
     "types": [

--- a/mods/tuxemon/db/monster/toufigel.json
+++ b/mods/tuxemon/db/monster/toufigel.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "varmint",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/tourbidi.json
+++ b/mods/tuxemon/db/monster/tourbidi.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "humanoid",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/trapsnap.json
+++ b/mods/tuxemon/db/monster/trapsnap.json
@@ -23,6 +23,12 @@
             "monster_slug": "sapsnap"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "sapsnap",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "brute",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/tsushimi.json
+++ b/mods/tuxemon/db/monster/tsushimi.json
@@ -35,6 +35,12 @@
             "monster_slug": "tobishimi"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "drashimi",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "dragon",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/tumblebee.json
+++ b/mods/tuxemon/db/monster/tumblebee.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "tumbleworm",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "flier",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/tumblequill.json
+++ b/mods/tuxemon/db/monster/tumblequill.json
@@ -53,8 +53,9 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "varmint",
-    "stage": "standalone",
+    "stage": "basic",
     "types": [
         "earth"
     ],

--- a/mods/tuxemon/db/monster/tumbleworm.json
+++ b/mods/tuxemon/db/monster/tumbleworm.json
@@ -23,6 +23,12 @@
             "monster_slug": "tumblebee"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "tumblebee",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "grub",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/turnipper.json
+++ b/mods/tuxemon/db/monster/turnipper.json
@@ -23,6 +23,12 @@
             "monster_slug": "beenstalker"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "beenstalker",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "hunter",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/tweesher.json
+++ b/mods/tuxemon/db/monster/tweesher.json
@@ -23,6 +23,16 @@
             "monster_slug": "heronquak"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "heronquak",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "eaglace",
+            "evo_stage": "stage2"
+        }
+    ],
     "shape": "flier",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/urcine.json
+++ b/mods/tuxemon/db/monster/urcine.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "brute",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/vamporm.json
+++ b/mods/tuxemon/db/monster/vamporm.json
@@ -23,6 +23,16 @@
             "monster_slug": "dracune"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "dracune",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "fluttaflap",
+            "evo_stage": "stage2"
+        }
+    ],
     "shape": "grub",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/velocitile.json
+++ b/mods/tuxemon/db/monster/velocitile.json
@@ -41,6 +41,16 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "anoleaf",
+            "evo_stage": "basic"
+        },
+        {
+            "mon_slug": "gectile",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "humanoid",
     "stage": "stage2",
     "types": [

--- a/mods/tuxemon/db/monster/vigueur.json
+++ b/mods/tuxemon/db/monster/vigueur.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "tarpeur",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "brute",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/vivicinder.json
+++ b/mods/tuxemon/db/monster/vivicinder.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "vivipere",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "serpent",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/vividactil.json
+++ b/mods/tuxemon/db/monster/vividactil.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "vivipere",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "flier",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/vivipere.json
+++ b/mods/tuxemon/db/monster/vivipere.json
@@ -71,6 +71,36 @@
             "gender": "male"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "vivisource",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "vividactil",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "vivitron",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "vivitrans",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "viviteel",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "viviphyta",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "vivicinder",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "serpent",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/viviphyta.json
+++ b/mods/tuxemon/db/monster/viviphyta.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "vivipere",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "serpent",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/vivisource.json
+++ b/mods/tuxemon/db/monster/vivisource.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "vivipere",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "serpent",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/viviteel.json
+++ b/mods/tuxemon/db/monster/viviteel.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "vivipere",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "serpent",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/vivitrans.json
+++ b/mods/tuxemon/db/monster/vivitrans.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "vivipere",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "serpent",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/vivitron.json
+++ b/mods/tuxemon/db/monster/vivitron.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "vivipere",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "serpent",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/volcoli.json
+++ b/mods/tuxemon/db/monster/volcoli.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "humanoid",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/weavifly.json
+++ b/mods/tuxemon/db/monster/weavifly.json
@@ -41,6 +41,16 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "cataspike",
+            "evo_stage": "basic"
+        },
+        {
+            "mon_slug": "puparmor",
+            "evo_stage": "stage1"
+        }
+    ],
     "shape": "grub",
     "stage": "stage2",
     "types": [

--- a/mods/tuxemon/db/monster/windeye.json
+++ b/mods/tuxemon/db/monster/windeye.json
@@ -29,6 +29,12 @@
         }
     ],
     "evolutions": [],
+    "history": [
+        {
+            "mon_slug": "fancair",
+            "evo_stage": "basic"
+        }
+    ],
     "shape": "humanoid",
     "stage": "stage1",
     "types": [

--- a/mods/tuxemon/db/monster/wrougon.json
+++ b/mods/tuxemon/db/monster/wrougon.json
@@ -23,6 +23,16 @@
             "monster_slug": "allagon"
         }
     ],
+    "history": [
+        {
+            "mon_slug": "allagon",
+            "evo_stage": "stage1"
+        },
+        {
+            "mon_slug": "ferricran",
+            "evo_stage": "stage2"
+        }
+    ],
     "shape": "dragon",
     "stage": "basic",
     "types": [

--- a/mods/tuxemon/db/monster/xeon.json
+++ b/mods/tuxemon/db/monster/xeon.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "humanoid",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/xeon_2.json
+++ b/mods/tuxemon/db/monster/xeon_2.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "humanoid",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/yiinaang.json
+++ b/mods/tuxemon/db/monster/yiinaang.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "blob",
     "stage": "standalone",
     "types": [

--- a/mods/tuxemon/db/monster/zunna.json
+++ b/mods/tuxemon/db/monster/zunna.json
@@ -53,6 +53,7 @@
         }
     ],
     "evolutions": [],
+    "history": [],
     "shape": "blob",
     "stage": "standalone",
     "types": [

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -268,6 +268,19 @@ class MonsterMovesetItemModel(BaseModel):
         raise ValueError(f"the technique {v} doesn't exist in the db")
 
 
+class MonsterHistoryItemModel(BaseModel):
+    mon_slug: str = Field(..., description="The monster in the evolution path")
+    evo_stage: EvolutionStage = Field(
+        ..., description="The evolution stage of the monster"
+    )
+
+    @validator("mon_slug")
+    def monster_exists(cls: MonsterHistoryItemModel, v: Any) -> Any:
+        if has.db_entry("monster", v):
+            return v
+        raise ValueError(f"the monster {v} doesn't exist in the db")
+
+
 class MonsterEvolutionItemModel(BaseModel):
     path: EvolutionType = Field(..., description="Paths to evolution")
     at_level: int = Field(
@@ -372,6 +385,9 @@ class MonsterModel(BaseModel):
     )
     moveset: Sequence[MonsterMovesetItemModel] = Field(
         [], description="The moveset of this monster"
+    )
+    history: Sequence[MonsterHistoryItemModel] = Field(
+        [], description="The evolution history of this monster"
     )
     evolutions: Sequence[MonsterEvolutionItemModel] = Field(
         [], description="The evolutions this monster has"

--- a/tuxemon/event/actions/spawn_monster.py
+++ b/tuxemon/event/actions/spawn_monster.py
@@ -87,35 +87,40 @@ class SpawnMonsterAction(EventAction):
         # Earth > Water => Child (Earth)
         if mother.types[0].water:
             if father.types[0].earth:
-                seed = father.slug
+                seed = father
             else:
-                seed = mother.slug
+                seed = mother
         elif mother.types[0].fire:
             if father.types[0].water:
-                seed = father.slug
+                seed = father
             else:
-                seed = mother.slug
+                seed = mother
         elif mother.types[0].wood:
             if father.types[0].metal:
-                seed = father.slug
+                seed = father
             else:
-                seed = mother.slug
+                seed = mother
         elif mother.types[0].metal:
             if father.types[0].fire:
-                seed = father.slug
+                seed = father
             else:
-                seed = mother.slug
+                seed = mother
         elif mother.types[0].earth:
             if father.types[0].wood:
-                seed = father.slug
+                seed = father
             else:
-                seed = mother.slug
+                seed = mother
         else:
-            seed = mother.slug
+            seed = mother
+
+        # retrieve the basic form
+        for element in seed.history:
+            if element.evo_stage.basic:
+                seed_slug = element.mon_slug
 
         # continues the creation of the child.
         child = monster.Monster()
-        child.load_from_db(seed)
+        child.load_from_db(seed_slug)
         child.set_level(5)
         child.set_moves(5)
         child.set_capture(formula.today_ordinal())

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -14,6 +14,7 @@ from tuxemon.db import (
     EvolutionStage,
     GenderType,
     MonsterEvolutionItemModel,
+    MonsterHistoryItemModel,
     MonsterMovesetItemModel,
     MonsterShape,
     StatType,
@@ -209,6 +210,7 @@ class Monster:
         self.moves: List[Technique] = []
         self.moveset: List[MonsterMovesetItemModel] = []
         self.evolutions: List[MonsterEvolutionItemModel] = []
+        self.history: List[MonsterHistoryItemModel] = []
         self.stage = EvolutionStage.standalone
         self.flairs: Dict[str, Flair] = {}
         self.battle_cry = ""
@@ -326,6 +328,12 @@ class Monster:
         if evolutions:
             for evolution in evolutions:
                 self.evolutions.append(evolution)
+
+        # history
+        history = results.history
+        if history:
+            for element in history:
+                self.history.append(element)
 
         # Look up the monster's sprite image paths
         if results.sprites:


### PR DESCRIPTION
it adds the history field, it's like the evolution, but it shows all the evolution path, this will help to retrieve all the stages from a single monster, without being forced to reload the JSON db again.

it fixes also some wrong stages (tuxepedia)

it fixes breeding too, before
a S2 and a S3 -> could have a baby S2 or S3
now
a S2 and a S3 -> S1

before: Rockat and Jemuar -> baby Rockat or Jemuar
after: Rockat and Jemuar -> baby Rockitten
it happens the same also with mixed tuxemon, it retrieves the stage1

S1 = Basic, while the others are Stage 2 and Stage 3