### PR TITLE
add pathfind_to_player (fix ambush)

### DIFF
--- a/tuxemon/event/actions/pathfind_to_player.py
+++ b/tuxemon/event/actions/pathfind_to_player.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Union, final
+
+from tuxemon.event import get_npc
+from tuxemon.event.eventaction import EventAction
+
+
+@final
+@dataclass
+class PathfindToPlayerAction(EventAction):
+    """
+    Pathfind npc close the player.
+
+    Script usage:
+        .. code-block::
+
+            pathfind_to_player <npc_slug>,[direction],[distance]
+
+    Script parameters:
+        npc_slug: Npc slug name (e.g. "npc_maple").
+        direction: Approaches the player from up, down, left or right.
+        distance: How many tiles (2, 3, 4, etc.)
+
+    """
+
+    name = "pathfind_to_player"
+    npc_slug: str
+    side: Union[str, None] = None
+    distance: Union[int, None] = None
+
+    def start(self) -> None:
+        self.npc = get_npc(self.session, self.npc_slug)
+        assert self.npc
+        x, y = self.session.player.tile_pos
+        if self.distance is None:
+            value = 1
+        else:
+            if self.distance == 0:
+                raise ValueError(
+                    f"{self.distance} cannot be 0 (player coordinates).",
+                )
+            else:
+                value = self.distance
+        if self.side is not None:
+            self.tile_pos_x = 0
+            self.tile_pos_y = 0
+            if self.side == "up":
+                closest = (x, y - value)
+                self.npc.facing = "down"
+            elif self.side == "down":
+                closest = (x, y + value)
+                self.npc.facing = "up"
+            elif self.side == "right":
+                closest = (x + value, y)
+                self.npc.facing = "left"
+            if self.side == "left":
+                closest = (x - value, y)
+                self.npc.facing = "right"
+            else:
+                raise ValueError(
+                    f"{self.side} must be up, down, left or right.",
+                )
+        else:
+            target = self.npc.tile_pos
+            destination = [
+                (x, y - value),
+                (x, y + value),
+                (x + value, y),
+                (x - value, y),
+            ]
+            closest = min(
+                destination,
+                key=lambda point: math.hypot(
+                    target[1] - point[1], target[0] - point[0]
+                ),
+            )
+        self.npc.pathfind(closest)
+
+    def update(self) -> None:
+        assert self.npc
+        if not self.npc.moving and not self.npc.path:
+            self.stop()


### PR DESCRIPTION
PR adds the action **pathfind_to_player** (fix #800 as requested by @Sanglorian + @ultidonki)

basic version: `pathfind_to_player <npc_slug>`
**npc_slug** is the slug of the npc you want to move

the NPC reaches the player, example code (screenshot below)
```
    <property name="act1" value="pathfind_to_player spyder_route2_roddick"/>
    <property name="act2" value="translated_dialog spyder_route2_roddick1"/>
    <property name="act3" value="start_battle spyder_route2_roddick"/>
```
complex version: `pathfind_to_player <npc_slug>,[direction],[distance]`
**npc_slug** is the slug of the npc you want to move
**direction** is an optional field, it means where the NPC will end up (up, down, left or right), self explaining:
```
		up
	left	player	right
		down
```
**distance** is an optional field, it means how distant from the player (default is 1), it means close (screenshot below), but you can put 2, the NPC will stop the tile before, etc.

example, the NPC reaches the player, before talking and starting the battle:
used the basic version
![Screenshot from 2023-03-23 11-24-54](https://user-images.githubusercontent.com/64643719/227176186-53fe0220-1c31-4213-af15-41783de89dde.png)
