### PR TITLE
fix xero

### DIFF
--- a/mods/tuxemon/db/npc/omnigrunt.json
+++ b/mods/tuxemon/db/npc/omnigrunt.json
@@ -6,14 +6,5 @@
       "combat_front": "knight",
       "slug": "knight"
     }
-  ],
-  "monsters": [
-    {
-      "level": 2,
-      "slug": "aardorn",
-      "money_mod": 10,
-      "exp_req_mod": 80,
-      "gender": "male"
-    }
   ]
 }

--- a/mods/tuxemon/db/npc/taba_acolyte_1.json
+++ b/mods/tuxemon/db/npc/taba_acolyte_1.json
@@ -6,15 +6,6 @@
         "combat_front": "disciple",
         "slug": "disciple"
       }
-    ],
-    "monsters": [
-      {
-        "level": 3,
-        "slug": "chloragon",
-        "money_mod": 100,
-        "exp_req_mod": 80,
-        "gender": "female"
-      }
     ]
   }
   

--- a/mods/tuxemon/maps/player_house_downstairs.tmx
+++ b/mods/tuxemon/maps/player_house_downstairs.tmx
@@ -157,9 +157,9 @@
    <properties>
     <property name="act1" value="wait 0.4"/>
     <property name="act2" value="translated_dialog depressedmom"/>
-    <property name="cond1" value="is to_talk npc_mom"/>
-    <property name="cond2" value="is variable_set can_exit_town:yes"/>
-    <property name="cond3" value="not variable_set backhome:no"/>
+    <property name="behav1" value="talk npc_mom"/>
+    <property name="cond1" value="is variable_set can_exit_town:yes"/>
+    <property name="cond2" value="not variable_set backhome:no"/>
    </properties>
   </object>
   <object id="37" name="water" type="event" x="96" y="32" width="16" height="16">
@@ -238,8 +238,8 @@
     <property name="act1" value="translated_dialog hebenice"/>
     <property name="act2" value="clear_variable scene"/>
     <property name="act5" value="set_variable go_get_tuxemon:yes"/>
+    <property name="behav1" value="talk npc_mom"/>
     <property name="cond1" value="is variable_set announce_trials:4"/>
-    <property name="cond2" value="is to_talk npc_mom"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/route1.tmx
+++ b/mods/tuxemon/maps/route1.tmx
@@ -382,7 +382,7 @@
    <properties>
     <property name="act10" value="lock_controls"/>
     <property name="act11" value="translated_dialog nobodygetsthrough"/>
-    <property name="act12" value="add_monster aardorn,2,omnigrunt,27,10"/>
+    <property name="act12" value="add_monster aardorn,2,omnigrunt,80,10"/>
     <property name="act20" value="start_battle omnigrunt"/>
     <property name="act21" value="wait 1.5"/>
     <property name="act30" value="set_variable whoartthou:done"/>

--- a/mods/tuxemon/maps/taba_ba_br_1.tmx
+++ b/mods/tuxemon/maps/taba_ba_br_1.tmx
@@ -164,6 +164,7 @@
     <property name="act42" value="wait 0.4"/>
     <property name="act43" value="translated_dialog challenger6"/>
     <property name="act50" value="translated_dialog challenger7"/>
+    <property name="act55" value="add_monster chloragon,3,acolyte,80,100"/>
     <property name="act60" value="start_battle acolyte"/>
     <property name="act99" value="set_variable battledone:yes"/>
     <property name="cond1" value="is variable_set battledone:start"/>
@@ -221,6 +222,7 @@
     <property name="act12" value="pathfind player,9,7"/>
     <property name="act13" value="npc_face player,left"/>
     <property name="act20" value="translated_dialog acolyte1redo"/>
+    <property name="act30" value="add_monster chloragon,3,acolyte,80,100"/>
     <property name="act40" value="start_battle acolyte"/>
     <property name="act98" value="set_variable redo:finished"/>
     <property name="act99" value="set_variable battledone:yes"/>

--- a/mods/tuxemon/maps/taba_town.tmx
+++ b/mods/tuxemon/maps/taba_town.tmx
@@ -820,7 +820,7 @@
   <object id="133" name="greeter_greets" type="event" x="480" y="192" width="16" height="16">
    <properties>
     <property name="act05" value="set_variable greeter_greets:yes"/>
-    <property name="act10" value="npc_face taba_greeter,player"/>
+    <property name="act10" value="npc_face taba_greeter,left"/>
     <property name="act20" value="translated_dialog taba_greeting1"/>
     <property name="act25" value="translated_dialog taba_greeting2a"/>
     <property name="act30" value="add_item tuxeball,5"/>
@@ -835,7 +835,7 @@
   <object id="134" name="greeter_greets2" type="event" x="480" y="192" width="16" height="16">
    <properties>
     <property name="act05" value="set_variable greeter_greets:yes"/>
-    <property name="act10" value="npc_face taba_greeter,player"/>
+    <property name="act10" value="npc_face taba_greeter,left"/>
     <property name="act20" value="translated_dialog taba_greeting1"/>
     <property name="act30" value="translated_dialog taba_greeting2b"/>
     <property name="act60" value="npc_face taba_greeter,down"/>
@@ -847,11 +847,10 @@
   </object>
   <object id="150" name="jaime3" type="event" x="456" y="176" width="16" height="16">
    <properties>
-    <property name="act0" value="npc_face taba_greeter,player"/>
     <property name="act10" value="translated_dialog taba_greeting3"/>
     <property name="act20" value="npc_face taba_greeter,down"/>
-    <property name="cond10" value="is to_talk taba_greeter"/>
-    <property name="cond20" value="is variable_set greeter_greets:yes"/>
+    <property name="behav10" value="talk taba_greeter"/>
+    <property name="cond10" value="is variable_set greeter_greets:yes"/>
    </properties>
   </object>
   <object id="135" name="secret_tuxeball" type="event" x="624" y="240" width="16" height="16">


### PR DESCRIPTION
some small fixes related to Xero:
- fixed three `npc_face taba_greeter,player`, since `npc_face` accept only **up**, **down**, **left** and **right**;
- removed to_talk in favor of behavior talk (it's the same function);
- updated the omnigrunt line based on your last PR and removed the monster from the JSON (if not the NPC will have 2 monsters);
from
`<property name="act12" value="add_monster aardorn,2,omnigrunt,27,10"/>`
to
`<property name="act12" value="add_monster aardorn,2,omnigrunt,80,10"/>`
- same as above, I did the same for the acolyte, remove JSON monster and added in map:
`<property name="act30" value="add_monster chloragon,3,acolyte,80,100"/>`

@Qiangong2 let me know if you're ok

tested, no issues