### PR TITLE
remove sprite field (create_npc action)

### DIFF
--- a/mods/tuxemon/maps/city1_mart_junkyard.tmx
+++ b/mods/tuxemon/maps/city1_mart_junkyard.tmx
@@ -79,7 +79,7 @@
  <objectgroup color="#ffff00" id="6" name="Events">
   <object id="15" type="event" x="160" y="304" width="16" height="16">
    <properties>
-    <property name="act10" value="create_npc maple_girl,10,6,girl1,wander"/>
+    <property name="act10" value="create_npc maple_girl,10,6,wander"/>
     <property name="cond10" value="is variable_set maple_bedroom1:true"/>
    </properties>
   </object>
@@ -144,7 +144,7 @@
   </object>
   <object id="35" type="event" x="256" y="368" width="16" height="16">
    <properties>
-    <property name="act10" value="create_npc cfanatic1,12,33,player,stand"/>
+    <property name="act10" value="create_npc cfanatic1,12,33,stand"/>
     <property name="act20" value="set_variable fanatics_in_junkyard:true"/>
     <property name="cond10" value="is variable_set maple_got_tuxemon1:true"/>
     <property name="cond20" value="not variable_set fanatics_in_junkyard:true"/>
@@ -152,7 +152,7 @@
   </object>
   <object id="36" type="event" x="64" y="368" width="16" height="16">
    <properties>
-    <property name="act10" value="create_npc cfanatic2,8,33,player,stand"/>
+    <property name="act10" value="create_npc cfanatic2,8,33,stand"/>
     <property name="act20" value="set_variable fanatics_in_junkyard:true"/>
     <property name="cond10" value="is variable_set maple_got_tuxemon1:true"/>
     <property name="cond20" value="not variable_set fanatics_in_junkyard:true"/>

--- a/mods/tuxemon/maps/citypark.tmx
+++ b/mods/tuxemon/maps/citypark.tmx
@@ -388,7 +388,7 @@
   </object>
   <object id="112" name="make npcs" type="event" x="48" y="0" width="16" height="16">
    <properties>
-    <property name="act10" value="create_npc knight1,12,13,knight,stand"/>
+    <property name="act10" value="create_npc knight1,12,13,stand"/>
     <property name="act20" value="npc_face knight1,right"/>
     <property name="act30" value="set_variable firstgo:no"/>
     <property name="cond10" value="not npc_exists knight1"/>

--- a/mods/tuxemon/maps/cotton_cathedral.tmx
+++ b/mods/tuxemon/maps/cotton_cathedral.tmx
@@ -63,7 +63,7 @@
   <object id="25" name="Player Spawn" type="event" x="96" y="112" width="16" height="16"/>
   <object id="26" name="create npcs" type="event" x="32" y="0" width="16" height="16">
    <properties>
-    <property name="act10" value="create_npc tabanurse,5,4,nurse,stand"/>
+    <property name="act10" value="create_npc tabanurse,5,4,stand"/>
     <property name="cond10" value="not npc_exists tabanurse"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/cotton_scoop.tmx
+++ b/mods/tuxemon/maps/cotton_scoop.tmx
@@ -71,7 +71,7 @@
   <object id="16" name="Player Spawn" type="event" x="80" y="128" width="16" height="16"/>
   <object id="17" name="employee" type="event" x="16" y="80" width="16" height="16">
    <properties>
-    <property name="act10" value="create_npc tuxemart_keeper,1,5,,stand"/>
+    <property name="act10" value="create_npc tuxemart_keeper,1,5,stand"/>
     <property name="act20" value="npc_face tuxemart_keeper,right"/>
     <property name="act30" value="set_economy tuxemart_keeper,cotton_scoop"/>
     <property name="cond10" value="not npc_exists tuxemart_keeper"/>

--- a/mods/tuxemon/maps/cotton_town.tmx
+++ b/mods/tuxemon/maps/cotton_town.tmx
@@ -176,7 +176,7 @@
    <properties>
     <property name="act10" value="translated_dialog itslockedboi"/>
     <property name="act20" value="translated_dialog hellothere"/>
-    <property name="act30" value="create_npc aeble,14,10,,stand"/>
+    <property name="act30" value="create_npc aeble,14,10,stand"/>
     <property name="act40" value="npc_face aeble,right"/>
     <property name="act50" value="translated_dialog kmere"/>
     <property name="cond10" value="is player_at"/>
@@ -311,7 +311,7 @@
   </object>
   <object id="252" name="create allie" type="event" x="0" y="352" width="16" height="16">
    <properties>
-    <property name="act10" value="create_npc allie,22,10,,stand"/>
+    <property name="act10" value="create_npc allie,22,10,stand"/>
     <property name="cond10" value="not npc_exists allie"/>
     <property name="cond20" value="not variable_set npcs_are_created:yes"/>
    </properties>
@@ -343,7 +343,7 @@
   </object>
   <object id="259" name="Create liela" type="event" x="16" y="80" width="16" height="16">
    <properties>
-    <property name="act10" value="create_npc liela,38,17,,stand"/>
+    <property name="act10" value="create_npc liela,38,17,stand"/>
     <property name="act20" value="npc_face liela,up"/>
     <property name="cond10" value="not npc_exists liela"/>
    </properties>
@@ -456,8 +456,8 @@
   </object>
   <object id="278" name="create grace and tallon" type="event" x="0" y="368" width="16" height="16">
    <properties>
-    <property name="act10" value="create_npc grace,0,29,,stand"/>
-    <property name="act20" value="create_npc tallon,0,28,,stand"/>
+    <property name="act10" value="create_npc grace,0,29,stand"/>
+    <property name="act20" value="create_npc tallon,0,28,stand"/>
     <property name="act30" value="npc_face grace,left"/>
     <property name="act40" value="npc_face tallon,left"/>
     <property name="cond10" value="not npc_exists grace"/>

--- a/mods/tuxemon/maps/daycare.tmx
+++ b/mods/tuxemon/maps/daycare.tmx
@@ -66,7 +66,7 @@
   <object id="19" name="Player Spawn" type="event" x="32" y="112" width="16" height="16"/>
   <object id="20" name="spawn_breeder" type="event" x="0" y="16" width="16" height="16">
    <properties>
-    <property name="act10" value="create_npc cotton_breeder,4,4,,stand"/>
+    <property name="act10" value="create_npc cotton_breeder,4,4,stand"/>
     <property name="act20" value="npc_face cotton_breeder,down"/>
     <property name="cond10" value="not npc_exists cotton_breeder"/>
    </properties>

--- a/mods/tuxemon/maps/healing_center.tmx
+++ b/mods/tuxemon/maps/healing_center.tmx
@@ -47,10 +47,10 @@
   <object id="22" name="Player Spawn" type="event" x="96" y="128" width="16" height="16"/>
   <object id="25" name="create npcs" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act10" value="create_npc tabanurse,5,4,nurse,stand"/>
-    <property name="act20" value="create_npc shady_guy,8,8,,stand"/>
+    <property name="act10" value="create_npc tabanurse,5,4,stand"/>
+    <property name="act20" value="create_npc shady_guy,8,8,stand"/>
     <property name="act30" value="npc_face shady_guy,right"/>
-    <property name="act40" value="create_npc happy_guy,11,8,,stand"/>
+    <property name="act40" value="create_npc happy_guy,11,8,stand"/>
     <property name="act50" value="npc_face happy_guy,left"/>
     <property name="cond10" value="not npc_exists tabanurse"/>
    </properties>

--- a/mods/tuxemon/maps/leather_scoop.tmx
+++ b/mods/tuxemon/maps/leather_scoop.tmx
@@ -67,7 +67,7 @@
   <object id="16" name="Player Spawn" type="event" x="96" y="96" width="16" height="16"/>
   <object id="19" name="employee" type="event" x="16" y="80" width="16" height="16">
    <properties>
-    <property name="act10" value="create_npc tuxemart_keeper,1,5,,stand"/>
+    <property name="act10" value="create_npc tuxemart_keeper,1,5,stand"/>
     <property name="act20" value="npc_face tuxemart_keeper,right"/>
     <property name="act30" value="set_economy tuxemart_keeper,leather_scoop"/>
     <property name="cond10" value="not npc_exists tuxemart_keeper"/>

--- a/mods/tuxemon/maps/maple_house.tmx
+++ b/mods/tuxemon/maps/maple_house.tmx
@@ -61,7 +61,7 @@
   </object>
   <object id="32" name="wife appears" type="event" x="96" y="160" width="16" height="16">
    <properties>
-    <property name="act10" value="create_npc npc_wife,8,6,,stand"/>
+    <property name="act10" value="create_npc npc_wife,8,6,stand"/>
     <property name="act20" value="npc_face npc_wife,down"/>
     <property name="act30" value="npc_wander npc_wife"/>
     <property name="cond10" value="is player_facing up"/>
@@ -79,7 +79,7 @@
   </object>
   <object id="40" name="create knight" type="event" x="176" y="80" width="16" height="16">
    <properties>
-    <property name="act010" value="create_npc knight3,6,10,,stand"/>
+    <property name="act010" value="create_npc knight3,6,10,stand"/>
     <property name="act020" value="npc_face knight3,up"/>
     <property name="act030" value="wait 0.7"/>
     <property name="act040" value="npc_face knight3,left"/>

--- a/mods/tuxemon/maps/player_house_downstairs.tmx
+++ b/mods/tuxemon/maps/player_house_downstairs.tmx
@@ -89,7 +89,7 @@
   <object id="28" name="Player Spawn" type="event" x="64" y="48" width="16" height="16"/>
   <object id="29" name="create mom" type="event" x="0" y="32" width="16" height="16">
    <properties>
-    <property name="act10" value="create_npc npc_mom,8,3,,stand"/>
+    <property name="act10" value="create_npc npc_mom,8,3,stand"/>
     <property name="act20" value="npc_face npc_mom,left"/>
     <property name="act40" value="npc_wander npc_mom,3.0"/>
     <property name="cond10" value="not npc_exists npc_mom"/>
@@ -107,7 +107,7 @@
   </object>
   <object id="31" name="create mom2" type="event" x="80" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc npc_mom,0,5,,stand"/>
+    <property name="act1" value="create_npc npc_mom,0,5,stand"/>
     <property name="act2" value="npc_face npc_mom,right"/>
     <property name="act3" value="wait 1"/>
     <property name="act4" value="translated_dialog ipausedit"/>

--- a/mods/tuxemon/maps/professor_lab.tmx
+++ b/mods/tuxemon/maps/professor_lab.tmx
@@ -107,7 +107,7 @@
   <object id="93" name="Player Spawn" type="event" x="96" y="240" width="16" height="16"/>
   <object id="95" name="createprofessor" type="event" x="0" y="192" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc professor,4,6,,stand"/>
+    <property name="act1" value="create_npc professor,4,6,stand"/>
     <property name="act2" value="npc_face professor,up"/>
     <property name="cond1" value="is variable_set go_get_tuxemon:yes"/>
     <property name="cond2" value="not npc_exists professor"/>
@@ -349,7 +349,7 @@
     <property name="act03" value="set_monster_status"/>
     <property name="act04" value="lock_controls"/>
     <property name="act10" value="translated_dialog yahaha"/>
-    <property name="act20" value="create_npc allie,6,15,,stand"/>
+    <property name="act20" value="create_npc allie,6,15,stand"/>
     <property name="act30" value="pathfind allie,4,8"/>
     <property name="act40" value="npc_face allie, right"/>
     <property name="act50" value="wait 0.7"/>
@@ -382,8 +382,8 @@
   </object>
   <object id="119" name="shesarrived3" type="event" x="192" y="192" width="16" height="16">
    <properties>
-    <property name="act10" value="create_npc knight1,7,15,,stand"/>
-    <property name="act20" value="create_npc knight2,7,16,,stand"/>
+    <property name="act10" value="create_npc knight1,7,15,stand"/>
+    <property name="act20" value="create_npc knight2,7,16,stand"/>
     <property name="act30" value="pathfind knight1,5,7"/>
     <property name="act40" value="pathfind knight2,7,7"/>
     <property name="act50" value="npc_face knight1,down"/>

--- a/mods/tuxemon/maps/route1.tmx
+++ b/mods/tuxemon/maps/route1.tmx
@@ -153,7 +153,7 @@
   </object>
   <object id="97" name="block the door" type="event" x="224" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc xerogrund1,12,14,,stand"/>
+    <property name="act1" value="create_npc xerogrund1,12,14,stand"/>
     <property name="cond1" value="not npc_exists xerogrund1"/>
    </properties>
   </object>
@@ -175,8 +175,8 @@
   </object>
   <object id="109" name="hi rocky" type="event" x="464" y="208" width="16" height="16">
    <properties>
-    <property name="act10" value="create_npc rock,33,14,,stand"/>
-    <property name="act20" value="create_npc postboy,32,14,,stand"/>
+    <property name="act10" value="create_npc rock,33,14,stand"/>
+    <property name="act20" value="create_npc postboy,32,14,stand"/>
     <property name="act21" value="npc_face postboy,right"/>
     <property name="cond1" value="not npc_exists rock"/>
     <property name="cond2" value="not npc_exists postboy"/>
@@ -192,18 +192,18 @@
   </object>
   <object id="111" name="angry populace" type="event" x="432" y="320" width="16" height="16">
    <properties>
-    <property name="act10" value="create_npc omnigrunt,31,27,,stand"/>
-    <property name="act11" value="create_npc omnigrunt2,32,27,,stand"/>
-    <property name="act12" value="create_npc omnigrunt3,33,27,,stand"/>
-    <property name="act13" value="create_npc omnigrunt4,34,27,,stand"/>
+    <property name="act10" value="create_npc omnigrunt,31,27,stand"/>
+    <property name="act11" value="create_npc omnigrunt2,32,27,stand"/>
+    <property name="act12" value="create_npc omnigrunt3,33,27,stand"/>
+    <property name="act13" value="create_npc omnigrunt4,34,27,stand"/>
     <property name="act14" value="npc_face omnigrunt,up"/>
     <property name="act15" value="npc_face omnigrunt2,up"/>
     <property name="act16" value="npc_face omnigrunt3,up"/>
     <property name="act17" value="npc_face omnigrunt4,up"/>
-    <property name="act20" value="create_npc liela,31,26,,stand"/>
-    <property name="act21" value="create_npc bob,32,26,,stand"/>
-    <property name="act22" value="create_npc marissa,33,26,,stand"/>
-    <property name="act23" value="create_npc tuxemart_keeper,34,26,,stand"/>
+    <property name="act20" value="create_npc liela,31,26,stand"/>
+    <property name="act21" value="create_npc bob,32,26,stand"/>
+    <property name="act22" value="create_npc marissa,33,26,stand"/>
+    <property name="act23" value="create_npc tuxemart_keeper,34,26,stand"/>
     <property name="cond1" value="not variable_set letusthrough:no"/>
     <property name="cond2" value="not variable_set letusthrough:almost"/>
    </properties>
@@ -249,7 +249,7 @@
     <property name="act14" value="npc_face tuxemart_keeper,up"/>
     <property name="act15" value="npc_face marissa,up"/>
     <property name="act16" value="set_variable theyrehere:yes"/>
-    <property name="act17" value="create_npc misa,33,20,,stand"/>
+    <property name="act17" value="create_npc misa,33,20,stand"/>
     <property name="act18" value="npc_move misa,down 3"/>
     <property name="act98" value="set_variable letusthrough:almost"/>
     <property name="act99" value="set_variable whoartthou:florist"/>
@@ -258,7 +258,7 @@
   </object>
   <object id="114" name="xero grunt" type="event" x="432" y="256" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc xerogrunt1,34,19,,stand"/>
+    <property name="act1" value="create_npc xerogrunt1,34,19,stand"/>
     <property name="act2" value="npc_move xerogrunt1,down 3"/>
     <property name="cond1" value="is variable_set theyrehere:yes"/>
     <property name="cond2" value="not npc_exists xerogrunt1"/>
@@ -267,7 +267,7 @@
   </object>
   <object id="115" name="xero grunt2" type="event" x="432" y="288" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc xerogrunt2,32,19,,stand"/>
+    <property name="act1" value="create_npc xerogrunt2,32,19,stand"/>
     <property name="act2" value="npc_move xerogrunt2,down 3"/>
     <property name="cond1" value="is variable_set theyrehere:yes"/>
     <property name="cond2" value="not npc_exists xerogrunt2"/>
@@ -421,7 +421,7 @@
     <property name="act30" value="translated_dialog ohaimisa"/>
     <property name="act31" value="npc_face player,down"/>
     <property name="act32" value="npc_face misa,down"/>
-    <property name="act33" value="create_npc kyle,32,32,,stand"/>
+    <property name="act33" value="create_npc kyle,32,32,stand"/>
     <property name="act34" value="npc_face kyle,up"/>
     <property name="act35" value="pathfind omnigrunt2,31,28"/>
     <property name="act36" value="pathfind kyle,32,27"/>
@@ -651,7 +651,7 @@
   </object>
   <object id="141" name="omnigrunt4" type="event" x="400" y="256" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc omnigrunt4,34,26,,stand"/>
+    <property name="act1" value="create_npc omnigrunt4,34,26,stand"/>
     <property name="act2" value="npc_face omnigrunt4,down"/>
     <property name="cond1" value="not npc_exists omnigrunt4"/>
    </properties>
@@ -669,10 +669,10 @@
   <object id="144" name="gym time" type="event" x="736" y="432" width="16" height="208">
    <properties>
     <property name="act10" value="lock_controls"/>
-    <property name="act11" value="create_npc christie,55,37,,stand"/>
+    <property name="act11" value="create_npc christie,55,37,stand"/>
     <property name="act12" value="npc_face christie,up"/>
-    <property name="act13" value="create_npc kyle,54,33,,stand"/>
-    <property name="act14" value="create_npc speck,54,37,,stand"/>
+    <property name="act13" value="create_npc kyle,54,33,stand"/>
+    <property name="act14" value="create_npc speck,54,37,stand"/>
     <property name="act15" value="npc_face speck,up"/>
     <property name="act16" value="translated_dialog welcometotaba"/>
     <property name="act17" value="npc_move player,right 3"/>

--- a/mods/tuxemon/maps/taba_ba_br_1.tmx
+++ b/mods/tuxemon/maps/taba_ba_br_1.tmx
@@ -60,8 +60,8 @@
   </object>
   <object id="12" name="create guards" type="event" x="32" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc omnigrunt7,13,7,,stand"/>
-    <property name="act2" value="create_npc omnigrunt8,13,8,,stand"/>
+    <property name="act1" value="create_npc omnigrunt7,13,7,stand"/>
+    <property name="act2" value="create_npc omnigrunt8,13,8,stand"/>
     <property name="act3" value="npc_face omnigrunt7,right"/>
     <property name="act4" value="npc_face omnigrunt8,right"/>
     <property name="cond1" value="not variable_set jason:gone"/>
@@ -143,7 +143,7 @@
   </object>
   <object id="20" name="start fight" type="event" x="144" y="16" width="16" height="16">
    <properties>
-    <property name="act10" value="create_npc acolyte,0,7,,stand"/>
+    <property name="act10" value="create_npc acolyte,0,7,stand"/>
     <property name="act11" value="npc_face acolyte,right"/>
     <property name="act12" value="wait 1"/>
     <property name="act20" value="pathfind acolyte,7,7"/>
@@ -208,7 +208,7 @@
   </object>
   <object id="23" name="redo" type="event" x="96" y="32" width="16" height="16">
    <properties>
-    <property name="act10" value="create_npc acolyte,7,7,,stand"/>
+    <property name="act10" value="create_npc acolyte,7,7,stand"/>
     <property name="act11" value="npc_face acolyte,right"/>
     <property name="act12" value="set_variable battledone:redo"/>
     <property name="cond1" value="is variable_set redo:please"/>

--- a/mods/tuxemon/maps/taba_ba_foyer.tmx
+++ b/mods/tuxemon/maps/taba_ba_foyer.tmx
@@ -37,7 +37,7 @@
   </object>
   <object id="8" name="timmy is here!" type="event" x="64" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc timmy,3,3,,stand"/>
+    <property name="act1" value="create_npc timmy,3,3,stand"/>
     <property name="cond1" value="not npc_exists timmy"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/taba_ba_main.tmx
+++ b/mods/tuxemon/maps/taba_ba_main.tmx
@@ -61,16 +61,16 @@
   </object>
   <object id="17" name="create most people" type="event" x="0" y="112" width="16" height="16">
    <properties>
-    <property name="act10" value="create_npc christie,10,8,,stand"/>
+    <property name="act10" value="create_npc christie,10,8,stand"/>
     <property name="act11" value="npc_face christie,up"/>
-    <property name="act12" value="create_npc speck,8,8,,stand"/>
+    <property name="act12" value="create_npc speck,8,8,stand"/>
     <property name="act13" value="npc_face speck,up"/>
-    <property name="act14" value="create_npc aeble,9,4,,stand"/>
-    <property name="act20" value="create_npc omnigrunt2,17,2,,stand"/>
+    <property name="act14" value="create_npc aeble,9,4,stand"/>
+    <property name="act20" value="create_npc omnigrunt2,17,2,stand"/>
     <property name="act21" value="npc_face omnigrunt2,right"/>
-    <property name="act22" value="create_npc omnigrunt3,16,12,,stand"/>
+    <property name="act22" value="create_npc omnigrunt3,16,12,stand"/>
     <property name="act23" value="npc_face omnigrunt3,up"/>
-    <property name="act24" value="create_npc omnigrunt4,17,12,,stand"/>
+    <property name="act24" value="create_npc omnigrunt4,17,12,stand"/>
     <property name="act25" value="npc_face omnigrunt4,up"/>
     <property name="act30" value="set_variable moveonnow:yes"/>
     <property name="cond1" value="not variable_set moveonnow:yes"/>
@@ -395,9 +395,9 @@
   </object>
   <object id="30" name="block3" type="event" x="176" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc omnigrunt5,14,14,,stand"/>
+    <property name="act1" value="create_npc omnigrunt5,14,14,stand"/>
     <property name="act2" value="pathfind omnigrunt5,14,12"/>
-    <property name="act3" value="create_npc omnigrunt6,13,14,,stand"/>
+    <property name="act3" value="create_npc omnigrunt6,13,14,stand"/>
     <property name="act4" value="pathfind omnigrunt6,13,12"/>
     <property name="cond1" value="is variable_set moveit3:now"/>
     <property name="cond2" value="not npc_exists omnigrunt5"/>
@@ -406,9 +406,9 @@
   </object>
   <object id="32" name="block2" type="event" x="112" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc omnigrunt7,5,14,,stand"/>
+    <property name="act1" value="create_npc omnigrunt7,5,14,stand"/>
     <property name="act2" value="pathfind omnigrunt7,5,12"/>
-    <property name="act3" value="create_npc omnigrunt8,4,14,,stand"/>
+    <property name="act3" value="create_npc omnigrunt8,4,14,stand"/>
     <property name="act4" value="pathfind omnigrunt8,4,12"/>
     <property name="cond1" value="is variable_set moveit2:now"/>
     <property name="cond2" value="not npc_exists omnigrunt7"/>
@@ -455,11 +455,11 @@
   </object>
   <object id="38" name="block4" type="event" x="0" y="64" width="16" height="16">
    <properties>
-    <property name="act20" value="create_npc omnigrunt2,17,2,,stand"/>
+    <property name="act20" value="create_npc omnigrunt2,17,2,stand"/>
     <property name="act21" value="npc_face omnigrunt2,right"/>
-    <property name="act22" value="create_npc omnigrunt3,16,12,,stand"/>
+    <property name="act22" value="create_npc omnigrunt3,16,12,stand"/>
     <property name="act23" value="npc_face omnigrunt3,up"/>
-    <property name="act24" value="create_npc omnigrunt4,17,12,,stand"/>
+    <property name="act24" value="create_npc omnigrunt4,17,12,stand"/>
     <property name="act25" value="npc_face omnigrunt4,up"/>
     <property name="cond1" value="not npc_exists omnigrunt2"/>
     <property name="cond2" value="not npc_exists omnigrunt3"/>
@@ -482,9 +482,9 @@
   </object>
   <object id="41" name="block1" type="event" x="0" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc omnigrunt9,2,14,,stand"/>
+    <property name="act1" value="create_npc omnigrunt9,2,14,stand"/>
     <property name="act2" value="pathfind omnigrunt9,2,12"/>
-    <property name="act3" value="create_npc omnigrunt10,1,14,,stand"/>
+    <property name="act3" value="create_npc omnigrunt10,1,14,stand"/>
     <property name="act4" value="pathfind omnigrunt10,1,12"/>
     <property name="cond1" value="is variable_set close1"/>
     <property name="cond2" value="not npc_exists omnigrunt9"/>

--- a/mods/tuxemon/maps/taba_ba_passageway_1.tmx
+++ b/mods/tuxemon/maps/taba_ba_passageway_1.tmx
@@ -118,7 +118,7 @@
   </object>
   <object id="31" name="create npc" type="event" x="224" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc omnigrunt2,16,5,,stand"/>
+    <property name="act1" value="create_npc omnigrunt2,16,5,stand"/>
     <property name="act2" value="npc_face omnigrunt2,left"/>
     <property name="cond1" value="not npc_exists omnigrunt2"/>
    </properties>

--- a/mods/tuxemon/maps/taba_town.tmx
+++ b/mods/tuxemon/maps/taba_town.tmx
@@ -363,8 +363,8 @@
   </object>
   <object id="125" name="bring on the nurses" type="event" x="352" y="640" width="16" height="16">
    <properties>
-    <property name="act10" value="create_npc nurse1,37,39,,stand"/>
-    <property name="act20" value="create_npc nurse2,38,39,,stand"/>
+    <property name="act10" value="create_npc nurse1,37,39,stand"/>
+    <property name="act20" value="create_npc nurse2,38,39,stand"/>
     <property name="act30" value="npc_face nurse1,down"/>
     <property name="act40" value="npc_face nurse2,down"/>
     <property name="cond10" value="not variable_set thewifedidspeak:yes"/>
@@ -383,11 +383,11 @@
     <property name="act10" value="player_stop"/>
     <property name="act11" value="lock_controls"/>
     <property name="act12" value="wait 1"/>
-    <property name="act20" value="create_npc allie,37,40,,stand"/>
-    <property name="act30" value="create_npc knight4,37,39,,stand"/>
-    <property name="act40" value="create_npc knight3,38,39,,stand"/>
+    <property name="act20" value="create_npc allie,37,40,stand"/>
+    <property name="act30" value="create_npc knight4,37,39,stand"/>
+    <property name="act40" value="create_npc knight3,38,39,stand"/>
     <property name="act60" value="translated_dialog hellolovelypeople"/>
-    <property name="act70" value="create_npc npc_mom,43,46,,stand"/>
+    <property name="act70" value="create_npc npc_mom,43,46,stand"/>
     <property name="act80" value="npc_face npc_mom, left"/>
     <property name="act90" value="set_variable goodbyeoldknight:hedead"/>
     <property name="cond10" value="is variable_set goodbyeoldknight:yes"/>
@@ -654,7 +654,7 @@
   </object>
   <object id="150" name="create traveler" type="event" x="336" y="368" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc xerogrund1,22,23,,stand"/>
+    <property name="act1" value="create_npc xerogrund1,22,23,stand"/>
     <property name="act2" value="npc_face xerogrund1,right"/>
     <property name="cond1" value="not npc_exists xerogrund1"/>
    </properties>
@@ -687,7 +687,7 @@
   </object>
   <object id="137" name="go, wander my children" type="event" x="704" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc bob,45,8,,stand"/>
+    <property name="act1" value="create_npc bob,45,8,stand"/>
     <property name="act2" value="npc_wander bob,2.0"/>
     <property name="cond1" value="not npc_exists bob"/>
    </properties>
@@ -700,9 +700,9 @@
   </object>
   <object id="139" name="npc blockers" type="event" x="336" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc conworker1,21,5,,stand"/>
-    <property name="act2" value="create_npc conworker2,21,6,,stand"/>
-    <property name="act3" value="create_npc conworker3,21,7,,stand"/>
+    <property name="act1" value="create_npc conworker1,21,5,stand"/>
+    <property name="act2" value="create_npc conworker2,21,6,stand"/>
+    <property name="act3" value="create_npc conworker3,21,7,stand"/>
     <property name="act4" value="npc_face conworker1,left"/>
     <property name="act5" value="npc_face conworker2,left"/>
     <property name="act6" value="npc_face conworker3,left"/>
@@ -744,7 +744,7 @@
    <properties>
     <property name="act10" value="player_stop"/>
     <property name="act11" value="lock_controls"/>
-    <property name="act20" value="create_npc npc_mom,38,41,,stand"/>
+    <property name="act20" value="create_npc npc_mom,38,41,stand"/>
     <property name="act30" value="translated_dialog timeforround2"/>
     <property name="act40" value="pathfind npc_mom,38,38"/>
     <property name="act50" value="npc_face npc_mom,up"/>
@@ -773,7 +773,7 @@
   </object>
   <object id="146" name="add jaime" type="event" x="456" y="128" width="16" height="16">
    <properties>
-    <property name="act10" value="create_npc taba_greeter,31,12,,stand"/>
+    <property name="act10" value="create_npc taba_greeter,31,12,stand"/>
     <property name="act20" value="npc_face taba_greeter,down"/>
     <property name="cond10" value="not npc_exists taba_greeter"/>
    </properties>
@@ -789,16 +789,16 @@
   </object>
   <object id="132" name="martgreeter" type="event" x="336" y="208" width="16" height="16">
    <properties>
-    <property name="act10" value="create_npc taba_greeter,29,12,,stand"/>
+    <property name="act10" value="create_npc taba_greeter,29,12,stand"/>
     <property name="act20" value="npc_face taba_greeter,down"/>
     <property name="cond1" value="not npc_exists taba_greeter"/>
    </properties>
   </object>
   <object id="147" name="mydogishurt" type="event" x="672" y="608" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc postboy,37,38,,stand"/>
+    <property name="act1" value="create_npc postboy,37,38,stand"/>
     <property name="act2" value="npc_face postboy,right"/>
-    <property name="act3" value="create_npc rock,38,38,,stand"/>
+    <property name="act3" value="create_npc rock,38,38,stand"/>
     <property name="cond1" value="is variable_set go_get_tuxemon:yes"/>
     <property name="cond2" value="not variable_set havetuxemon:yes"/>
    </properties>

--- a/mods/tuxemon/maps/tuxe_mart_taba.tmx
+++ b/mods/tuxemon/maps/tuxe_mart_taba.tmx
@@ -65,7 +65,7 @@
   </object>
   <object id="56" name="employee" type="event" x="16" y="80" width="16" height="16">
    <properties>
-    <property name="act10" value="create_npc tuxemart_keeper,1,5,,stand"/>
+    <property name="act10" value="create_npc tuxemart_keeper,1,5,stand"/>
     <property name="act20" value="npc_face tuxemart_keeper,right"/>
     <property name="act30" value="set_economy tuxemart_keeper,tuxe_mart_taba"/>
     <property name="cond10" value="not npc_exists tuxemart_keeper"/>
@@ -102,7 +102,7 @@
    <properties>
     <property name="act10" value="lock_controls"/>
     <property name="act11" value="wait 0.7"/>
-    <property name="act20" value="create_npc professor,3,5,,stand"/>
+    <property name="act20" value="create_npc professor,3,5,stand"/>
     <property name="act30" value="npc_face professor,left"/>
     <property name="act40" value="translated_dialog professorexists"/>
     <property name="act50" value="wait 1"/>

--- a/tuxemon/event/actions/create_npc.py
+++ b/tuxemon/event/actions/create_npc.py
@@ -38,7 +38,6 @@ class CreateNpcAction(EventAction):
     npc_slug: str
     tile_pos_x: int
     tile_pos_y: int
-    animations: Union[str, None] = None
     behavior: Union[str, None] = None
 
     def start(self) -> None:
@@ -51,14 +50,6 @@ class CreateNpcAction(EventAction):
         # Ensure that the NPC doesn't already exist on the map.
         if slug in world.npcs:
             return
-
-        sprite = self.animations
-        if sprite:
-            logger.warning(
-                "%s: setting npc sprites within a map is deprecated, and may be removed in the future. "
-                "Sprites should be defined in JSON before loading.",
-                slug,
-            )
 
         # Create a new NPC object
         npc = NPC(slug, world=world)


### PR DESCRIPTION
PR removes the sprite field from the `create_npc` action. The sprite is loaded from the JSON.

so that this:
`<property name="act10" value="create_npc tuxemart_keeper,1,5,,stand"/>`
will become
`<property name="act10" value="create_npc tuxemart_keeper,1,5,stand"/>`

@Qiangong2 so it will take only 1 comma instead of 2

black, isort, tested, no new typehints