### PR TITLE
update reqs.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,12 @@ babel
 cbor
 neteria
 pillow
-pygame-ce==2.1.3
+pygame-ce==2.2.0
 pyscroll==2.30
 pytmx==3.31
 requests>=2.19.1
 natsort
 PyYAML>=5.4.1
 prompt_toolkit
-pygame_menu>=4.2.8
+pygame-menu-ce>=4.4.1
 pydantic>=1.9.1


### PR DESCRIPTION
Almost a week ago [pygame-ce](https://github.com/pygame-community/pygame-ce/releases/tag/2.2.0) has been updated (v [2.2.0](https://pypi.org/project/pygame-ce/2.2.0/))
The update solved a lot of issues (we got rid of a dozen of typehints).
pygame-ce and pygame-menu-ce both Python >=3.7

Today **pygame-menu** has created [pygame-menu-ce](https://pypi.org/project/pygame-menu-ce), based on **pygame-ce**.

from pygame-ce
```
# if you're switching over from pygame/pygame,
# remove it first to avoid conflicting namespace
pip uninstall pygame
pip install pygame-ce==2.2.0
```
regarding pygame-menu
```
pip uninstall pygame-menu
pip install pygame-menu-ce
```