### PR TITLE
removing cast_parameters_to_namedtuple and cast_values (deprecated)

### DIFF
--- a/tuxemon/tools.py
+++ b/tuxemon/tools.py
@@ -289,33 +289,6 @@ def cast_value(
     )
 
 
-def cast_values(
-    parameters: Sequence[Any],
-    valid_parameters: Sequence[Tuple[ValidParameterTypes, str]],
-) -> Sequence[Any]:
-    """
-    Change all the string values to the expected type.
-
-    This will also check and enforce the correct parameters for actions.
-
-    Parameters:
-        parameters: Parameters passed to the scripted object.
-        valid_parameters: Allowed parameters and their types.
-
-    Returns:
-        Parameters converted to their correct type.
-
-    """
-
-    try:
-        return list(map(cast_value, zip_longest(valid_parameters, parameters)))
-    except ValueError:
-        logger.warning("Invalid parameters passed:")
-        logger.warning(f"expected: {valid_parameters}")
-        logger.warning(f"got: {parameters}")
-        raise
-
-
 def get_types_tuple(
     param_type: ValidParameterSingleType,
 ) -> Sequence[ValidParameterSingleType]:
@@ -340,19 +313,6 @@ def cast_dataclass_parameters(self) -> None:
             old_value = getattr(self, field_name)
             new_value = cast_value(((constructors, field_name), old_value))
             setattr(self, field_name, new_value)
-
-
-def cast_parameters_to_namedtuple(
-    parameters: Sequence[Any],
-    namedtuple_class: Type[NamedTupleTypeVar],
-) -> NamedTupleTypeVar:
-    valid_parameters = [
-        (get_types_tuple(typing.get_type_hints(namedtuple_class)[f]), f)
-        for f in namedtuple_class._fields
-    ]
-
-    values = cast_values(parameters, valid_parameters)
-    return namedtuple_class(*values)
 
 
 def show_item_result_as_dialog(


### PR DESCRIPTION
PR removes:
- def **cast_values**
- def **cast_parameters_to_namedtuple**

deprecated since #1385 + #1418 (and both don't pop up anywhere else).

unrelated - remember:
I noticed it while testing an upgrade to Python 3.10
if someone has a potion in the bag, when loading the game, it crashes because of `cast_value(((constructors, field_name), old_value))`, the reason was `value: int | float` instead of `value: Union[int, float]` in **current_hp** (**cast_dataclass_parameters**)

without items, it loads the game, but **transition_teleport** doesn't work because of `float | None = None` instead of `Optional[float] = None` (**cast_dataclass_parameters**)
```
before
(((<class 'int'>, <class 'float'>), 'amount'), '20')
after
(((int | float,), 'amount'), '20')
```