### PR TITLE
fix status icon combat + fix types (item condition)

### DIFF
--- a/tuxemon/item/conditions/type.py
+++ b/tuxemon/item/conditions/type.py
@@ -39,7 +39,7 @@ class TypeCondition(ItemCondition):
                 )
                 if p is not None
             )
-        if target.types[1] is not None:
+        if len(target.types) > 1:
             ret = ret or any(
                 target.types[1] == p
                 for p in (

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -255,8 +255,6 @@ class Item:
             "should_tackle": False,
             "success": False,
         }
-        # save iid
-        user.game_variables["save_item_slug"] = self.slug
 
         # Loop through all the effects of this technique and execute the effect's function.
         for effect in self.effects:

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -751,11 +751,12 @@ class CombatState(CombatAnimations):
                     # get the rect of the monster
                     rect = self._monster_sprite_map[monster].rect
                     # load the sprite and add it to the display
-                    self.load_sprite(
+                    icon = self.load_sprite(
                         status.icon,
                         layer=200,
                         center=rect.topleft,
                     )
+                    self._status_icons.append(icon)
 
     def show_combat_dialog(self) -> None:
         """Create and show the area where battle messages are displayed."""
@@ -990,16 +991,14 @@ class CombatState(CombatAnimations):
                 # handle the capture device
                 if result["capture"]:
                     # retrieve tuxeball
-                    itm_slug = self.players[0].game_variables["save_item_slug"]
-                    itm = Item()
-                    itm.load(itm_slug)
+                    tuxeball = technique.slug
                     message += "\n" + T.translate("attempting_capture")
                     action_time = result["num_shakes"] + 1.8
                     self.animate_capture_monster(
                         result["success"],
                         result["num_shakes"],
                         target,
-                        itm.slug,
+                        tuxeball,
                     )
 
                     # TODO: Don't end combat right away; only works with SP,


### PR DESCRIPTION
PR fixes the bug related to the status icon during the combat.

Before:
- a monster could get status poison, then switch monster, and the new one had the poison icon (although not the status).
- a monster could get status poison, the another one, and it would have been resulted in an icon over another (bad effect).

The PR fixes this behavior.
It simply adds the icon to the already present (but unused) **self._status_icons** list.
I tracked the list and it resulted empty all the time.

Someone opened an issue about this, I tried to find it, but I wasn't successful.

---

added a small fix for type condition too

---

removed **itm_slug = self.players[0].game_variables["save_item_slug"]** from combat.py, because the variable pass already through technique (both item/technique). It wasn't necessary. It'll follow a more precise division in #1661 

tested, black, isort, no new typehints