### PR TITLE
scrollbar color (theme)

### DIFF
--- a/tuxemon/menu/theme.py
+++ b/tuxemon/menu/theme.py
@@ -104,6 +104,8 @@ def get_theme() -> pygame_menu.Theme:
         selection_color=(0, 0, 0),
         border_color=tuxemon_border,
         scrollarea_position=locals.SCROLLAREA_POSITION_NONE,
+        scrollbar_color=(235, 235, 235),
+        scrollbar_slider_color=(200, 200, 200),
         widget_padding=(10, 20),
     )
 


### PR DESCRIPTION
PR adds the default color inside the code (theme).

(dark gray c8c8c8 -> 200, 200, 200
(light gray ebebeb -> 235, 235, 235)
![Screenshot from 2023-04-02 15-02-43](https://user-images.githubusercontent.com/64643719/229354583-f1f5e3f1-95b3-419c-8c43-6660c3d7f89d.png)

I thought about opening an issue, but it's pointless.
If someone has an idea to change the default color, then he or she can open a new issue.
This will allow to change scrollbar colors in others screen (eg kennel, etc).

tested, isort, black, no new typehints