### PR TITLE
pathfind_to_player (Spyder)

### DIFF
--- a/mods/tuxemon/maps/spyder_citypark.tmx
+++ b/mods/tuxemon/maps/spyder_citypark.tmx
@@ -297,7 +297,7 @@
     <property name="cond2" value="not npc_exists spyder_citypark_frances"/>
    </properties>
   </object>
-  <object id="226" name="Talk Frances&#10;" type="event" x="448" y="368" width="16" height="16">
+  <object id="226" name="Talk Frances" type="event" x="448" y="368" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_citypark_frances1"/>
     <property name="act2" value="add_monster shybulb,8,spyder_citypark_frances,27,10"/>
@@ -542,6 +542,7 @@
   </object>
   <object id="274" name="Talk Bobette" type="event" x="208" y="272" width="48" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_citypark_bobette"/>
     <property name="act1" value="translated_dialog spyder_citypark_bobette1"/>
     <property name="act2" value="add_monster aardorn,10,spyder_citypark_bobette,27,10"/>
     <property name="act3" value="start_battle spyder_citypark_bobette"/>

--- a/mods/tuxemon/maps/spyder_cotton_town.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_town.tmx
@@ -147,7 +147,7 @@
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
-  <object id="531" name="Talk hackerintro&#10;" type="event" x="400" y="608" width="128" height="16">
+  <object id="531" name="Talk hackerintro" type="event" x="400" y="608" width="128" height="16">
    <properties>
     <property name="act1" value="player_stop"/>
     <property name="act11" value="lock_controls"/>
@@ -214,7 +214,7 @@
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
-  <object id="542" name="Create Monk&#10;" type="event" x="80" y="112" width="16" height="16">
+  <object id="542" name="Create Monk" type="event" x="80" y="112" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_cottontown_monk,5,7"/>
     <property name="act2" value="npc_wander spyder_cottontown_monk"/>
@@ -222,13 +222,13 @@
     <property name="cond2" value="not variable_set dragonscavebenden:yes"/>
    </properties>
   </object>
-  <object id="543" name="Talk monk&#10;" type="event" x="96" y="128" width="16" height="16">
+  <object id="543" name="Talk monk" type="event" x="96" y="128" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_cottontown_monk"/>
     <property name="behav1" value="talk spyder_cottontown_monk"/>
    </properties>
   </object>
-  <object id="544" name="Create Enforcer&#10;" type="event" x="272" y="160" width="16" height="16">
+  <object id="544" name="Create Enforcer" type="event" x="272" y="160" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_omnichannel_enforcer,17,10"/>
     <property name="cond1" value="not npc_exists spyder_omnichannel_enforcer"/>

--- a/mods/tuxemon/maps/spyder_dragonscave.tmx
+++ b/mods/tuxemon/maps/spyder_dragonscave.tmx
@@ -349,6 +349,7 @@
   </object>
   <object id="92" name="Talk Tomas" type="event" x="240" y="528" width="48" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_dragonscave_tomas"/>
     <property name="act1" value="translated_dialog spyder_dragonscave_tomas1"/>
     <property name="act2" value="add_monster allagon,35,spyder_dragonscave_tomas,27,10"/>
     <property name="act3" value="start_battle spyder_dragonscave_tomas"/>
@@ -360,6 +361,7 @@
   </object>
   <object id="93" name="Talk Daenny" type="event" x="192" y="432" width="16" height="64">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_dragonscave_daenny"/>
     <property name="act1" value="translated_dialog spyder_dragonscave_daenny1"/>
     <property name="act2" value="add_monster eaglace,37,spyder_dragonscave_daenny,27,10"/>
     <property name="act3" value="start_battle spyder_dragonscave_daenny"/>
@@ -371,6 +373,7 @@
   </object>
   <object id="94" name="Talk Cailin" type="event" x="128" y="416" width="32" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_dragonscave_cailin"/>
     <property name="act1" value="translated_dialog spyder_dragonscave_cailin1"/>
     <property name="act2" value="add_monster dragarbor,36,spyder_dragonscave_cailin,27,10"/>
     <property name="act3" value="start_battle spyder_dragonscave_cailin"/>
@@ -382,6 +385,7 @@
   </object>
   <object id="95" name="Talk Lessa" type="event" x="256" y="336" width="16" height="48">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_dragonscave_lessa"/>
     <property name="act1" value="translated_dialog spyder_dragonscave_lessa1"/>
     <property name="act2" value="add_monster allagon,37,spyder_dragonscave_lessa,27,10"/>
     <property name="act3" value="start_battle spyder_dragonscave_lessa"/>
@@ -393,6 +397,7 @@
   </object>
   <object id="96" name="Talk Griffin" type="event" x="112" y="528" width="16" height="80">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_dragonscave_griffin"/>
     <property name="act1" value="translated_dialog spyder_dragonscave_griffin1"/>
     <property name="act2" value="add_monster bigfin,35,spyder_dragonscave_griffin,27,10"/>
     <property name="act3" value="start_battle spyder_dragonscave_griffin"/>
@@ -404,6 +409,7 @@
   </object>
   <object id="97" name="Talk Benden" type="event" x="80" y="240" width="16" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_dragonscave_benden"/>
     <property name="act1" value="translated_dialog spyder_dragonscave_benden1"/>
     <property name="act2" value="add_monster dragarbor,36,spyder_dragonscave_benden,27,10"/>
     <property name="act3" value="add_monster sapragon,38,spyder_dragonscave_benden,27,10"/>
@@ -418,6 +424,7 @@
   </object>
   <object id="98" name="Talk Ray" type="event" x="288" y="144" width="16" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_dragonscave_ray"/>
     <property name="act1" value="translated_dialog spyder_dragonscave_ray1"/>
     <property name="act2" value="add_monster ghosteeth,40,spyder_dragonscave_ray,27,10"/>
     <property name="act3" value="start_battle spyder_dragonscave_ray"/>
@@ -429,6 +436,7 @@
   </object>
   <object id="99" name="Talk Tru" type="event" x="240" y="112" width="16" height="48">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_dragonscave_tru"/>
     <property name="act1" value="translated_dialog spyder_dragonscave_tru1"/>
     <property name="act2" value="add_monster embazook,40,spyder_dragonscave_tru,27,10"/>
     <property name="act3" value="add_monster arthrobolt,40,spyder_dragonscave_tru,27,10"/>
@@ -442,6 +450,7 @@
   </object>
   <object id="100" name="Talk Lucille" type="event" x="208" y="128" width="16" height="32">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_dragonscave_lucille"/>
     <property name="act1" value="translated_dialog spyder_dragonscave_lucille1"/>
     <property name="act2" value="add_monster coleorus,40,spyder_dragonscave_lucille,27,10"/>
     <property name="act3" value="start_battle spyder_dragonscave_lucille"/>
@@ -453,6 +462,7 @@
   </object>
   <object id="101" name="Talk Mal" type="event" x="176" y="144" width="32" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_dragonscave_mal"/>
     <property name="act1" value="translated_dialog spyder_dragonscave_mal1"/>
     <property name="act2" value="add_monster djinnbo,40,spyder_dragonscave_mal,27,10"/>
     <property name="act3" value="start_battle spyder_dragonscave_mal"/>

--- a/mods/tuxemon/maps/spyder_dryadsgrove.tmx
+++ b/mods/tuxemon/maps/spyder_dryadsgrove.tmx
@@ -671,6 +671,7 @@
   </object>
   <object id="220" name="Talk Aquemini" type="event" x="544" y="192" width="16" height="48">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_dryadsgrove_aquemini"/>
     <property name="act1" value="translated_dialog spyder_dryadsgrove_aquemini1"/>
     <property name="act2" value="add_monster vivitrans,50,spyder_dryadsgrove_aquemini,27,10"/>
     <property name="act3" value="add_monster nudimind,50,spyder_dryadsgrove_aquemini,27,10"/>
@@ -684,6 +685,7 @@
   </object>
   <object id="221" name="Talk Ignatia" type="event" x="400" y="128" width="48" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_dryadsgrove_ignatia"/>
     <property name="act1" value="translated_dialog spyder_dryadsgrove_ignatia1"/>
     <property name="act2" value="add_monster vivicinder,50,spyder_dryadsgrove_ignatia,27,10"/>
     <property name="act3" value="add_monster masknake,50,spyder_dryadsgrove_ignatia,27,10"/>
@@ -697,6 +699,7 @@
   </object>
   <object id="222" name="Talk Petra" type="event" x="240" y="96" width="16" height="32">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_dryadsgrove_petra"/>
     <property name="act1" value="translated_dialog spyder_dryadsgrove_petra1"/>
     <property name="act2" value="add_monster vivitron,50,spyder_dryadsgrove_petra,27,10"/>
     <property name="act3" value="add_monster sumchon,50,spyder_dryadsgrove_petra,27,10"/>
@@ -736,6 +739,7 @@
   </object>
   <object id="227" name="Talk Ferris" type="event" x="592" y="112" width="16" height="32">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_dryadsgrove_ferris"/>
     <property name="act1" value="translated_dialog spyder_dryadsgrove_ferris1"/>
     <property name="act2" value="add_monster viviteel,50,spyder_dryadsgrove_ferris,27,10"/>
     <property name="act3" value="add_monster allagon,50,spyder_dryadsgrove_ferris,27,10"/>

--- a/mods/tuxemon/maps/spyder_greenwash.tmx
+++ b/mods/tuxemon/maps/spyder_greenwash.tmx
@@ -179,6 +179,7 @@
   </object>
   <object id="75" name="Talk Chip" type="event" x="80" y="224" width="16" height="48">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_greenwash_chip"/>
     <property name="act1" value="translated_dialog spyder_greenwash_chip1"/>
     <property name="act2" value="add_monster av8r,22,spyder_greenwash_chip,27,10"/>
     <property name="act3" value="add_monster criniotherme,22,spyder_greenwash_chip,27,10"/>
@@ -192,6 +193,7 @@
   </object>
   <object id="76" name="Talk Louis" type="event" x="96" y="64" width="16" height="32">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_greenwash_louis"/>
     <property name="act1" value="translated_dialog spyder_greenwash_louis1"/>
     <property name="act2" value="add_monster cateye,24,spyder_greenwash_louis,27,10"/>
     <property name="act3" value="start_battle spyder_greenwash_louis"/>
@@ -203,6 +205,7 @@
   </object>
   <object id="77" name="Talk Clarence" type="event" x="208" y="48" width="16" height="48">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_greenwash_clarence"/>
     <property name="act1" value="translated_dialog spyder_greenwash_clarence1"/>
     <property name="act2" value="add_monster pigabyte,25,spyder_greenwash_clarence,27,10"/>
     <property name="act3" value="add_monster cochini,23,spyder_greenwash_clarence,27,10"/>

--- a/mods/tuxemon/maps/spyder_greenwash_greenhouse.tmx
+++ b/mods/tuxemon/maps/spyder_greenwash_greenhouse.tmx
@@ -234,6 +234,7 @@
   </object>
   <object id="89" name="Talk Gregor" type="event" x="368" y="48" width="16" height="32">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_greenwash_gregor"/>
     <property name="act1" value="translated_dialog spyder_greenwash_gregor1"/>
     <property name="act2" value="add_monster sclairus,22,spyder_greenwash_gregor,27,10"/>
     <property name="act3" value="add_monster cateye,22,spyder_greenwash_gregor,27,10"/>

--- a/mods/tuxemon/maps/spyder_greenwash_level2.tmx
+++ b/mods/tuxemon/maps/spyder_greenwash_level2.tmx
@@ -166,6 +166,7 @@
   </object>
   <object id="92" name="Talk Aissa" type="event" x="176" y="48" width="16" height="48">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_greenwash_aissa"/>
     <property name="act1" value="translated_dialog spyder_greenwash_aissa1"/>
     <property name="act2" value="add_monster cateye,22,spyder_greenwash_aissa,27,10"/>
     <property name="act3" value="start_battle spyder_greenwash_aissa"/>
@@ -177,6 +178,7 @@
   </object>
   <object id="93" name="Talk Dippel" type="event" x="160" y="304" width="48" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_greenwash_dippel"/>
     <property name="act1" value="translated_dialog spyder_greenwash_dippel1"/>
     <property name="act2" value="add_monster criniotherme,22,spyder_greenwash_dippel,27,10"/>
     <property name="act3" value="add_monster tikorch,22,spyder_greenwash_dippel,27,10"/>
@@ -189,6 +191,7 @@
   </object>
   <object id="94" name="Talk Moreau" type="event" x="128" y="496" width="16" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_greenwash_moreau"/>
     <property name="act1" value="translated_dialog spyder_greenwash_moreau1"/>
     <property name="act2" value="add_monster sclairus,26,spyder_greenwash_moreau,27,10"/>
     <property name="act3" value="start_battle spyder_greenwash_moreau"/>

--- a/mods/tuxemon/maps/spyder_nimrod_bottom.tmx
+++ b/mods/tuxemon/maps/spyder_nimrod_bottom.tmx
@@ -157,6 +157,7 @@
   </object>
   <object id="53" name="Talk Rebel" type="event" x="208" y="240" width="32" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_nimrod_rebel"/>
     <property name="act1" value="translated_dialog spyder_nimrod_rebel1"/>
     <property name="act2" value="add_monster grimachin,30,spyder_nimrod_rebel,27,10"/>
     <property name="act3" value="start_battle spyder_nimrod_rebel"/>
@@ -168,6 +169,7 @@
   </object>
   <object id="54" name="Talk Tru" type="event" x="32" y="288" width="32" height="16">
    <properties>
+    <property name="act00" value="pathfind_to_player spyder_nimrod_tru"/>
     <property name="act01" value="translated_dialog spyder_nimrod_tru1"/>
     <property name="act02" value="add_monster grimachin,20,spyder_nimrod_tru,27,10"/>
     <property name="act03" value="add_monster tigrock,25,spyder_nimrod_tru,27,10"/>
@@ -185,6 +187,7 @@
   </object>
   <object id="55" name="Talk Bowie" type="event" x="16" y="256" width="16" height="32">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_nimrod_bowie"/>
     <property name="act1" value="translated_dialog spyder_nimrod_bowie1"/>
     <property name="act2" value="add_monster tigrock,35,spyder_nimrod_bowie,27,10"/>
     <property name="act3" value="add_monster embazook,35,spyder_nimrod_bowie,27,10"/>

--- a/mods/tuxemon/maps/spyder_nimrod_middle.tmx
+++ b/mods/tuxemon/maps/spyder_nimrod_middle.tmx
@@ -221,6 +221,7 @@
   </object>
   <object id="37" name="Talk Argon" type="event" x="224" y="144" width="16" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_nimrod_argon"/>
     <property name="act1" value="translated_dialog spyder_nimrod_argon1"/>
     <property name="act2" value="add_monster chrome-robo,25,spyder_nimrod_argon,27,10"/>
     <property name="act3" value="start_battle spyder_nimrod_argon"/>
@@ -232,6 +233,7 @@
   </object>
   <object id="38" name="Talk Honour" type="event" x="192" y="64" width="48" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_nimrod_honour"/>
     <property name="act1" value="translated_dialog spyder_nimrod_honour1"/>
     <property name="act2" value="add_monster embazook,20,spyder_nimrod_honour,27,10"/>
     <property name="act3" value="add_monster sharpfin,20,spyder_nimrod_honour,27,10"/>
@@ -244,6 +246,7 @@
   </object>
   <object id="40" name="Talk Xeon" type="event" x="160" y="176" width="16" height="64">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_nimrod_xeon"/>
     <property name="act1" value="translated_dialog spyder_nimrod_xeon1"/>
     <property name="act2" value="add_monster xeon,20,spyder_nimrod_xeon,27,10"/>
     <property name="act3" value="start_battle spyder_nimrod_xeon"/>
@@ -256,6 +259,7 @@
   </object>
   <object id="41" name="Talk Chrome Robo" type="event" x="144" y="192" width="16" height="64">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_nimrod_chromerobo"/>
     <property name="act1" value="translated_dialog spyder_nimrod_chromerobo1"/>
     <property name="act2" value="add_monster chrome-robo,20,spyder_nimrod_chromerobo,27,10"/>
     <property name="act3" value="start_battle spyder_nimrod_chromerobo"/>
@@ -268,6 +272,7 @@
   </object>
   <object id="42" name="Talk Archer" type="event" x="64" y="208" width="16" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_nimrod_archer"/>
     <property name="act1" value="translated_dialog spyder_nimrod_archer1"/>
     <property name="act2" value="add_monster sharpfin,20,spyder_nimrod_archer,27,10"/>
     <property name="act3" value="add_monster av8r,20,spyder_nimrod_archer,27,10"/>
@@ -281,6 +286,7 @@
   </object>
   <object id="43" name="Talk Antimony" type="event" x="64" y="192" width="16" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_nimrod_antimony"/>
     <property name="act1" value="translated_dialog spyder_nimrod_antimony1"/>
     <property name="act2" value="add_monster komodraw,30,spyder_nimrod_antimony,27,10"/>
     <property name="act3" value="start_battle spyder_nimrod_antimony"/>

--- a/mods/tuxemon/maps/spyder_nimrod_top.tmx
+++ b/mods/tuxemon/maps/spyder_nimrod_top.tmx
@@ -133,6 +133,7 @@
   </object>
   <object id="40" name="Talk Justice" type="event" x="240" y="256" width="48" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_nimrod_justice"/>
     <property name="act1" value="translated_dialog spyder_nimrod_justice1"/>
     <property name="act2" value="add_monster ghosteeth,16,spyder_nimrod_justice,27,10"/>
     <property name="act3" value="add_monster ghosteeth,16,spyder_nimrod_justice,27,10"/>
@@ -145,6 +146,7 @@
   </object>
   <object id="41" name="Talk Zircon" type="event" x="176" y="176" width="16" height="32">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_nimrod_zircon"/>
     <property name="act1" value="translated_dialog spyder_nimrod_zircon1"/>
     <property name="act2" value="add_monster dark_robo,25,spyder_nimrod_zircon,27,10"/>
     <property name="act3" value="start_battle spyder_nimrod_zircon"/>
@@ -156,6 +158,7 @@
   </object>
   <object id="42" name="Talk Maverick" type="event" x="144" y="128" width="32" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_nimrod_maverick"/>
     <property name="act1" value="translated_dialog spyder_nimrod_maverick1"/>
     <property name="act2" value="add_monster av8r,25,spyder_nimrod_maverick,27,10"/>
     <property name="act3" value="start_battle spyder_nimrod_maverick"/>
@@ -180,6 +183,7 @@
   </object>
   <object id="45" name="Talk Mace" type="event" x="256" y="176" width="32" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_nimrod_mace"/>
     <property name="act1" value="translated_dialog spyder_nimrod_mace1"/>
     <property name="act2" value="add_monster embazook,20,spyder_nimrod_mace,27,10"/>
     <property name="act3" value="add_monster av8r,20,spyder_nimrod_mace,27,10"/>

--- a/mods/tuxemon/maps/spyder_omnichannel3.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel3.tmx
@@ -151,6 +151,7 @@
   </object>
   <object id="35" name="Talk Strauss" type="event" x="48" y="48" width="16" height="48">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_omnichannel_strauss"/>
     <property name="act1" value="translated_dialog spyder_omnichannel_strauss1"/>
     <property name="act2" value="add_monster budaye,36,spyder_omnichannel_strauss,27,10"/>
     <property name="act3" value="add_monster frondly,40,spyder_omnichannel_strauss,27,10"/>
@@ -163,6 +164,7 @@
   </object>
   <object id="36" name="Talk Carnegie" type="event" x="160" y="144" width="16" height="48">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_omnichannel_carnegie"/>
     <property name="act1" value="translated_dialog spyder_omnichannel_carnegie1"/>
     <property name="act2" value="add_monster elofly,38,spyder_omnichannel_carnegie,27,10"/>
     <property name="act3" value="add_monster elostorm,38,spyder_omnichannel_carnegie,27,10"/>
@@ -175,6 +177,7 @@
   </object>
   <object id="37" name="Talk Byrne" type="event" x="192" y="304" width="16" height="32">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_omnichannel_byrne"/>
     <property name="act1" value="translated_dialog spyder_omnichannel_byrne1"/>
     <property name="act2" value="add_monster rockat,36,spyder_omnichannel_byrne,27,10"/>
     <property name="act3" value="add_monster jemuar,40,spyder_omnichannel_byrne,27,10"/>

--- a/mods/tuxemon/maps/spyder_route2.tmx
+++ b/mods/tuxemon/maps/spyder_route2.tmx
@@ -513,7 +513,7 @@
     <property name="cond2" value="not npc_exists spyder_route2_roddick"/>
    </properties>
   </object>
-  <object id="159" name="Create Marion&#10;" type="event" x="208" y="32" width="16" height="16">
+  <object id="159" name="Create Marion" type="event" x="208" y="32" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_route2_marion,22,9"/>
     <property name="cond2" value="not npc_exists spyder_route2_marion"/>
@@ -525,7 +525,7 @@
     <property name="cond2" value="not npc_exists spyder_route2_graf"/>
    </properties>
   </object>
-  <object id="161" name="Talk roddick&#10;" type="event" x="192" y="48" width="16" height="16">
+  <object id="161" name="Talk roddick" type="event" x="192" y="48" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_route2_roddick1"/>
     <property name="act2" value="add_monster spighter,8,spyder_route2_roddick,27,10"/>
@@ -536,7 +536,7 @@
     <property name="cond1" value="not variable_set route2roddick:yes"/>
    </properties>
   </object>
-  <object id="162" name="Talk marion&#10;" type="event" x="208" y="48" width="16" height="16">
+  <object id="162" name="Talk marion" type="event" x="208" y="48" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_route2_marion1"/>
     <property name="act2" value="add_monster aardorn,7,spyder_route2_marion,27,10"/>
@@ -548,7 +548,7 @@
     <property name="cond1" value="not variable_set route2marion:yes"/>
    </properties>
   </object>
-  <object id="163" name="Talk graf&#10;" type="event" x="224" y="48" width="16" height="16">
+  <object id="163" name="Talk graf" type="event" x="224" y="48" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_route2_graf1"/>
     <property name="act2" value="add_monster cardiling,7,spyder_route2_graf,27,10"/>
@@ -587,8 +587,9 @@
     <property name="cond1" value="is variable_set daytime:false"/>
    </properties>
   </object>
-  <object id="188" name="Talk roddick&#10;" type="event" x="80" y="64" width="16" height="48">
+  <object id="188" name="Talk roddick" type="event" x="80" y="64" width="16" height="80">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_route2_roddick"/>
     <property name="act1" value="translated_dialog spyder_route2_roddick1"/>
     <property name="act2" value="add_monster spighter,8,spyder_route2_roddick,27,10"/>
     <property name="act3" value="start_battle spyder_route2_roddick"/>
@@ -598,8 +599,9 @@
     <property name="cond2" value="is player_at"/>
    </properties>
   </object>
-  <object id="189" name="Talk marion&#10;" type="event" x="352" y="160" width="16" height="48">
+  <object id="189" name="Talk marion" type="event" x="352" y="160" width="16" height="64">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_route2_marion"/>
     <property name="act1" value="translated_dialog spyder_route2_marion1"/>
     <property name="act2" value="add_monster aardorn,7,spyder_route2_marion,27,10"/>
     <property name="act3" value="add_monster aardorn,7,spyder_route2_marion,27,10"/>
@@ -610,8 +612,9 @@
     <property name="cond2" value="is player_at"/>
    </properties>
   </object>
-  <object id="190" name="Talk graf&#10;" type="event" x="464" y="64" width="16" height="48">
+  <object id="190" name="Talk graf" type="event" x="464" y="64" width="16" height="80">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_route2_graf"/>
     <property name="act1" value="translated_dialog spyder_route2_graf1"/>
     <property name="act2" value="add_monster cardiling,7,spyder_route2_graf,27,10"/>
     <property name="act3" value="add_monster cataspike,5,spyder_route2_graf,27,10"/>

--- a/mods/tuxemon/maps/spyder_route3.tmx
+++ b/mods/tuxemon/maps/spyder_route3.tmx
@@ -764,6 +764,7 @@
   </object>
   <object id="679" name="Enforcer Talk" type="event" x="272" y="144" width="16" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_route3_weaver"/>
     <property name="act1" value="translated_dialog spyder_route3_weaver1"/>
     <property name="act2" value="add_monster pythwire,12,spyder_route3_weaver,27,10"/>
     <property name="act3" value="add_monster squabbit,12,spyder_route3_weaver,27,10"/>
@@ -776,6 +777,7 @@
   </object>
   <object id="680" name="Talk Twig" type="event" x="384" y="240" width="32" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_route3_twig"/>
     <property name="act1" value="translated_dialog spyder_route3_twig1"/>
     <property name="act2" value="add_monster aardorn,11,spyder_route3_twig,27,10"/>
     <property name="act3" value="add_monster foofle,11,spyder_route3_twig,27,10"/>
@@ -788,6 +790,7 @@
   </object>
   <object id="681" name="Talk Wanda" type="event" x="512" y="288" width="16" height="16">
    <properties>
+    <property name="act00" value="pathfind_to_player spyder_route3_wanda"/>
     <property name="act01" value="translated_dialog spyder_route3_wanda1"/>
     <property name="act02" value="add_monster nudiflot_male,8,spyder_route3_wanda,27,10"/>
     <property name="act03" value="add_monster nudiflot_female,8,spyder_route3_wanda,27,10"/>
@@ -805,6 +808,7 @@
   </object>
   <object id="682" name="Novak Talk" type="event" x="192" y="480" width="16" height="32">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_route3_novak"/>
     <property name="act1" value="translated_dialog spyder_route3_novak1"/>
     <property name="act2" value="add_monster elofly,13,spyder_route3_novak,27,10"/>
     <property name="act3" value="start_battle spyder_route3_novak"/>

--- a/mods/tuxemon/maps/spyder_route4.tmx
+++ b/mods/tuxemon/maps/spyder_route4.tmx
@@ -379,6 +379,7 @@
   </object>
   <object id="82" name="Talk Marshall" type="event" x="48" y="464" width="48" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_route4_marshall"/>
     <property name="act1" value="translated_dialog spyder_route4_marshall1"/>
     <property name="act2" value="add_monster puparmor,16,spyder_route4_marshall,27,10"/>
     <property name="act3" value="add_monster puparmor,16,spyder_route4_marshall,27,10"/>
@@ -391,6 +392,7 @@
   </object>
   <object id="83" name="Talk Beck" type="event" x="64" y="320" width="32" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_route4_beck"/>
     <property name="act1" value="translated_dialog spyder_route4_beck1"/>
     <property name="act2" value="add_monster katapill,14,spyder_route4_beck,27,10"/>
     <property name="act3" value="add_monster tumbleworm,12,spyder_route4_beck,27,10"/>
@@ -404,6 +406,7 @@
   </object>
   <object id="84" name="Talk Wulf" type="event" x="32" y="208" width="16" height="48">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_route4_wulf"/>
     <property name="act1" value="translated_dialog spyder_route4_wulf1"/>
     <property name="act2" value="add_monster cowpignon,14,spyder_route4_wulf,27,10"/>
     <property name="act3" value="add_monster cowpignon,14,spyder_route4_wulf,27,10"/>
@@ -417,6 +420,7 @@
   </object>
   <object id="85" name="Talk Rosamund" type="event" x="192" y="496" width="16" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_route4_rosamund"/>
     <property name="act1" value="translated_dialog spyder_route4_rosamund1"/>
     <property name="act2" value="add_monster foofle,18,spyder_route4_rosamund,27,10"/>
     <property name="act3" value="start_battle spyder_route4_rosamund"/>

--- a/mods/tuxemon/maps/spyder_route5.tmx
+++ b/mods/tuxemon/maps/spyder_route5.tmx
@@ -365,6 +365,7 @@
   </object>
   <object id="62" name="Talk Sara" type="event" x="384" y="128" width="16" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_route5_sara"/>
     <property name="act1" value="translated_dialog spyder_route5_sara1"/>
     <property name="act2" value="add_monster capiti,20,spyder_route5_sara,27,10"/>
     <property name="act3" value="start_battle spyder_route5_sara"/>
@@ -376,6 +377,7 @@
   </object>
   <object id="63" name="Talk Cleo" type="event" x="320" y="96" width="16" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_route5_cleo"/>
     <property name="act1" value="translated_dialog spyder_route5_cleo1"/>
     <property name="act2" value="add_monster memnomnom,20,spyder_route5_cleo,27,10"/>
     <property name="act3" value="add_monster memnomnom,20,spyder_route5_cleo,27,10"/>
@@ -388,6 +390,7 @@
   </object>
   <object id="64" name="Talk Tryphaena" type="event" x="288" y="96" width="16" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_route5_tryphaena"/>
     <property name="act1" value="translated_dialog spyder_route5_tryphaena1"/>
     <property name="act2" value="add_monster miaownolith,24,spyder_route5_tryphaena,27,10"/>
     <property name="act3" value="add_monster criniotherme,22,spyder_route5_tryphaena,27,10"/>
@@ -400,6 +403,7 @@
   </object>
   <object id="65" name="Talk Edith" type="event" x="304" y="240" width="16" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_route5_edith"/>
     <property name="act1" value="translated_dialog spyder_route5_edith1"/>
     <property name="act2" value="add_monster aardart,20,spyder_route5_edith,27,10"/>
     <property name="act3" value="start_battle spyder_route5_edith"/>

--- a/mods/tuxemon/maps/spyder_route6.tmx
+++ b/mods/tuxemon/maps/spyder_route6.tmx
@@ -430,6 +430,7 @@
   </object>
   <object id="213" name="Talk Maxwell" type="event" x="96" y="80" width="64" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_route6_maxwell"/>
     <property name="act1" value="translated_dialog spyder_route6_maxwell1"/>
     <property name="act2" value="add_monster propellercat,30,spyder_route6_maxwell,27,10"/>
     <property name="act3" value="add_monster birdling,30,spyder_route6_maxwell,27,10"/>
@@ -442,6 +443,7 @@
   </object>
   <object id="214" name="Talk Orion" type="event" x="336" y="48" width="16" height="48">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_route6_orion"/>
     <property name="act1" value="translated_dialog spyder_route6_orion1"/>
     <property name="act2" value="add_monster spighter,20,spyder_route6_orion,27,10"/>
     <property name="act3" value="add_monster zunna,30,spyder_route6_orion,27,10"/>
@@ -454,6 +456,7 @@
   </object>
   <object id="215" name="Talk Richard" type="event" x="432" y="176" width="64" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_route6_richard"/>
     <property name="act1" value="translated_dialog spyder_route6_richard1"/>
     <property name="act2" value="add_monster hydrone,30,spyder_route6_richard,27,10"/>
     <property name="act3" value="add_monster pigabyte,30,spyder_route6_richard,27,10"/>
@@ -466,6 +469,7 @@
   </object>
   <object id="216" name="Talk Blair" type="event" x="496" y="144" width="64" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_route6_blair"/>
     <property name="act1" value="translated_dialog spyder_route6_blair1"/>
     <property name="act2" value="add_monster grintrock,30,spyder_route6_blair,27,10"/>
     <property name="act3" value="add_monster grinflare,30,spyder_route6_blair,27,10"/>
@@ -478,6 +482,7 @@
   </object>
   <object id="217" name="Talk Mungo" type="event" x="464" y="48" width="48" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_route6_mungo"/>
     <property name="act1" value="translated_dialog spyder_route6_mungo1"/>
     <property name="act2" value="add_monster noctula,20,spyder_route6_mungo,27,10"/>
     <property name="act3" value="start_battle spyder_route6_mungo"/>

--- a/mods/tuxemon/maps/spyder_routec.tmx
+++ b/mods/tuxemon/maps/spyder_routec.tmx
@@ -298,6 +298,7 @@
   </object>
   <object id="222" name="Talk Rutherford" type="event" x="544" y="144" width="16" height="48">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_searoutec_rutherford"/>
     <property name="act1" value="translated_dialog spyder_searoutec_rutherford1"/>
     <property name="act2" value="add_monster incandesfin,26,spyder_searoutec_rutherford,27,10"/>
     <property name="act3" value="start_battle spyder_searoutec_rutherford"/>
@@ -309,6 +310,7 @@
   </object>
   <object id="223" name="Talk Gil" type="event" x="384" y="256" width="16" height="32">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_searoutec_gil"/>
     <property name="act2" value="translated_dialog spyder_searoutec_gil1"/>
     <property name="act3" value="add_monster nudiflot_female,22,spyder_searoutec_gil,27,10"/>
     <property name="act4" value="add_monster nudiflot_female,22,spyder_searoutec_gil,27,10"/>
@@ -322,6 +324,7 @@
   </object>
   <object id="224" name="Talk Carstair" type="event" x="384" y="96" width="16" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_searoutec_carstair"/>
     <property name="act1" value="translated_dialog spyder_searoutec_carstair1"/>
     <property name="act2" value="add_monster axylightl,24,spyder_searoutec_carstair,27,10"/>
     <property name="act3" value="start_battle spyder_searoutec_carstair"/>
@@ -333,6 +336,7 @@
   </object>
   <object id="225" name="Talk Wade" type="event" x="224" y="192" width="16" height="16">
    <properties>
+    <property name="act00" value="pathfind_to_player spyder_searoutec_wade"/>
     <property name="act01" value="translated_dialog spyder_searoutec_wade1"/>
     <property name="act02" value="add_monster picc,20,spyder_searoutec_wade,27,10"/>
     <property name="act03" value="add_monster picc,20,spyder_searoutec_wade,27,10"/>
@@ -349,6 +353,7 @@
   </object>
   <object id="226" name="Talk Sandy" type="event" x="80" y="240" width="16" height="48">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_searoutec_sandy"/>
     <property name="act1" value="translated_dialog spyder_searoutec_sandy1"/>
     <property name="act2" value="add_monster sharpfin,22,spyder_searoutec_sandy,27,10"/>
     <property name="act3" value="add_monster sharpfin,22,spyder_searoutec_sandy,27,10"/>

--- a/mods/tuxemon/maps/spyder_scoop1.tmx
+++ b/mods/tuxemon/maps/spyder_scoop1.tmx
@@ -295,6 +295,7 @@
   </object>
   <object id="65" name="Talk Lanth" type="event" x="0" y="80" width="16" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_scoop_lanth"/>
     <property name="act1" value="translated_dialog spyder_scoop_lanth1"/>
     <property name="act2" value="add_monster mrmoswitch,35,spyder_scoop_lanth,27,10"/>
     <property name="act3" value="add_monster picc,35,spyder_scoop_lanth,27,10"/>
@@ -307,6 +308,7 @@
   </object>
   <object id="66" name="Talk Berys" type="event" x="272" y="64" width="32" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_scoop_berys"/>
     <property name="act1" value="translated_dialog spyder_scoop_berys1"/>
     <property name="act2" value="add_monster propellercat,40,spyder_scoop_berys,27,10"/>
     <property name="act3" value="add_monster embazook,35,spyder_scoop_berys,27,10"/>
@@ -319,6 +321,7 @@
   </object>
   <object id="67" name="Talk Turner" type="event" x="16" y="160" width="16" height="48">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_scoop_turner"/>
     <property name="act1" value="translated_dialog spyder_scoop_turner1"/>
     <property name="act2" value="add_monster flacono,30,spyder_scoop_turner,27,10"/>
     <property name="act3" value="add_monster squabbit,30,spyder_scoop_turner,27,10"/>
@@ -331,6 +334,7 @@
   </object>
   <object id="68" name="Talk Paine" type="event" x="96" y="64" width="16" height="32">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_scoop_paine"/>
     <property name="act1" value="translated_dialog spyder_scoop_paine1"/>
     <property name="act2" value="add_monster possessun,35,spyder_scoop_paine,27,10"/>
     <property name="act3" value="add_monster cairfrey,30,spyder_scoop_paine,27,10"/>
@@ -343,6 +347,7 @@
   </object>
   <object id="69" name="Talk Rubid" type="event" x="192" y="160" width="16" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_scoop_rubid"/>
     <property name="act1" value="translated_dialog spyder_scoop_rubid1"/>
     <property name="act2" value="add_monster birdling,35,spyder_scoop_rubid,27,10"/>
     <property name="act3" value="add_monster hatchling,30,spyder_scoop_rubid,27,10"/>

--- a/mods/tuxemon/maps/spyder_scoop3.tmx
+++ b/mods/tuxemon/maps/spyder_scoop3.tmx
@@ -145,6 +145,7 @@
   </object>
   <object id="26" name="Talk Alyssa" type="event" x="64" y="160" width="16" height="32">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_scoop_alyssa"/>
     <property name="act1" value="translated_dialog spyder_scoop_alyssa1"/>
     <property name="act2" value="add_monster possessun,40,spyder_scoop_alyssa,27,10"/>
     <property name="act3" value="start_battle spyder_scoop_alyssa"/>
@@ -156,6 +157,7 @@
   </object>
   <object id="27" name="Talk Taggart" type="event" x="96" y="144" width="16" height="32">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_scoop_taggart"/>
     <property name="act1" value="translated_dialog spyder_scoop_taggart1"/>
     <property name="act2" value="add_monster elofly,30,spyder_scoop_taggart,27,10"/>
     <property name="act3" value="add_monster elowind,35,spyder_scoop_taggart,27,10"/>
@@ -169,6 +171,7 @@
   </object>
   <object id="28" name="Talk Donald" type="event" x="176" y="160" width="16" height="32">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_scoop_donald"/>
     <property name="act1" value="translated_dialog spyder_scoop_donald1"/>
     <property name="act2" value="add_monster birdling,35,spyder_scoop_donald,27,10"/>
     <property name="act3" value="add_monster pigabyte,35,spyder_scoop_donald,27,10"/>

--- a/mods/tuxemon/maps/spyder_scoop4.tmx
+++ b/mods/tuxemon/maps/spyder_scoop4.tmx
@@ -313,6 +313,7 @@
   </object>
   <object id="55" name="Talk Orba" type="event" x="0" y="192" width="32" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_scoop_orba"/>
     <property name="act1" value="translated_dialog spyder_scoop_orba1"/>
     <property name="act2" value="add_monster abesnaki,30,spyder_scoop_orba,27,10"/>
     <property name="act3" value="add_monster spighter,30,spyder_scoop_orba,27,10"/>
@@ -325,6 +326,7 @@
   </object>
   <object id="56" name="Talk Arachne" type="event" x="128" y="128" width="32" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_scoop_arachne"/>
     <property name="act1" value="translated_dialog spyder_scoop_arachne1"/>
     <property name="act2" value="add_monster cardiwing,35,spyder_scoop_arachne,27,10"/>
     <property name="act3" value="add_monster spighter,35,spyder_scoop_arachne,27,10"/>
@@ -338,6 +340,7 @@
   </object>
   <object id="57" name="Talk Weaver" type="event" x="112" y="112" width="16" height="32">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_scoop_weaver"/>
     <property name="act1" value="translated_dialog spyder_scoop_weaver1"/>
     <property name="act2" value="add_monster cardiling,30,spyder_scoop_weaver,27,10"/>
     <property name="act3" value="add_monster spighter,30,spyder_scoop_weaver,27,10"/>

--- a/mods/tuxemon/maps/spyder_tunnel.tmx
+++ b/mods/tuxemon/maps/spyder_tunnel.tmx
@@ -209,6 +209,7 @@
   </object>
   <object id="341" name="Talk Greta" type="event" x="208" y="576" width="16" height="32">
    <properties>
+    <property name="act00" value="pathfind_to_player spyder_tunnelb_greta"/>
     <property name="act01" value="translated_dialog spyder_tunnelb_greta1"/>
     <property name="act02" value="add_monster foofle,16,spyder_tunnelb_greta,27,10"/>
     <property name="act03" value="add_monster foofle,16,spyder_tunnelb_greta,27,10"/>

--- a/mods/tuxemon/maps/spyder_tunnel_below.tmx
+++ b/mods/tuxemon/maps/spyder_tunnel_below.tmx
@@ -168,6 +168,7 @@
   </object>
   <object id="50" name="Talk Meitner" type="event" x="256" y="240" width="16" height="48">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_tunnelb_meitner"/>
     <property name="act1" value="translated_dialog spyder_tunnelb_meitner1"/>
     <property name="act2" value="add_monster masknake,22,spyder_tunnelb_meitner,27,10"/>
     <property name="act3" value="start_battle spyder_tunnelb_meitner"/>
@@ -179,6 +180,7 @@
   </object>
   <object id="51" name="Talk Lute" type="event" x="128" y="576" width="16" height="16">
    <properties>
+    <property name="act00" value="pathfind_to_player spyder_tunnelb_lute"/>
     <property name="act01" value="translated_dialog spyder_tunnelb_lute1"/>
     <property name="act02" value="add_monster noctula,16,spyder_tunnelb_lute,27,10"/>
     <property name="act03" value="add_monster noctalo,18,spyder_tunnelb_lute,27,10"/>
@@ -193,6 +195,7 @@
   </object>
   <object id="52" name="Talk Beryll" type="event" x="144" y="512" width="16" height="32">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_tunnelb_beryll"/>
     <property name="act1" value="translated_dialog spyder_tunnelb_beryll1"/>
     <property name="act2" value="add_monster rockat,20,spyder_tunnelb_beryll,27,10"/>
     <property name="act3" value="add_monster ignibus,20,spyder_tunnelb_beryll,27,10"/>

--- a/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
+++ b/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
@@ -264,6 +264,7 @@
   </object>
   <object id="71" name="Talk Morningstar" type="event" x="32" y="48" width="16" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_wayfarer1_morningstar"/>
     <property name="act1" value="translated_dialog spyder_wayfarer1_morningstar1"/>
     <property name="act2" value="add_monster cairfrey,12,spyder_wayfarer1_morningstar,27,10"/>
     <property name="act3" value="add_monster cairfrey,12,spyder_wayfarer1_morningstar,27,10"/>
@@ -276,6 +277,7 @@
   </object>
   <object id="72" name="Talk Victor" type="event" x="176" y="32" width="32" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_wayfarer1_victor"/>
     <property name="act1" value="translated_dialog spyder_wayfarer1_victor1"/>
     <property name="act2" value="add_monster squabbit,14,spyder_wayfarer1_victor,27,10"/>
     <property name="act3" value="start_battle spyder_wayfarer1_victor"/>

--- a/mods/tuxemon/maps/spyder_wayfarer_inn2.tmx
+++ b/mods/tuxemon/maps/spyder_wayfarer_inn2.tmx
@@ -173,6 +173,7 @@
   </object>
   <object id="49" name="Talk Bravo" type="event" x="208" y="48" width="16" height="16">
    <properties>
+    <property name="act0" value="pathfind_to_player spyder_wayfarer1_bravo"/>
     <property name="act1" value="translated_dialog spyder_wayfarer1_bravo1"/>
     <property name="act2" value="add_monster elofly,12,spyder_wayfarer1_bravo,27,10"/>
     <property name="act3" value="add_monster flacono,12,spyder_wayfarer1_bravo,27,10"/>


### PR DESCRIPTION
Following #1678 

PR adds pathfind_to_player to all the trainer battles in Spyder.

added the action **pathfind_to_player** to all the **start_battle** where there is the condition **player_at**, in this way the NPC comes closer to the player, talk and then the battle starts. Here the example: #1701 (screenshot)

@Sanglorian let me know if it's ok for you