### PR TITLE
upgrade party_size condition

### DIFF
--- a/tuxemon/event/conditions/party_size.py
+++ b/tuxemon/event/conditions/party_size.py
@@ -2,13 +2,11 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-import logging
+from operator import eq, ge, gt, le, lt, ne
 
 from tuxemon.event import MapCondition
 from tuxemon.event.eventcondition import EventCondition
 from tuxemon.session import Session
-
-logger = logging.getLogger(__name__)
 
 
 class PartySizeCondition(EventCondition):
@@ -21,7 +19,9 @@ class PartySizeCondition(EventCondition):
             is party_size <operator>,<value>
 
     Script parameters:
-        operator: One of "equals", "less_than" or "greater_than".
+        operator: Numeric comparison operator. Accepted values are "less_than",
+            "less_or_equal", "greater_than", "greater_or_equal", "equals"
+            and "not_equals".
         value: The value to compare the party size with.
 
     """
@@ -45,18 +45,17 @@ class PartySizeCondition(EventCondition):
         number = int(condition.parameters[1])
         party_size = len(session.player.monsters)
 
-        # Check to see if the player's party size equals this number.
-        if check == "equals":
-            logger.debug("Equal check")
-            return party_size == number
-
-        # Check to see if the player's party size is LESS than this number.
-        elif check == "less_than":
-            return party_size < number
-
-        # Check to see if the player's part size is GREATER than this number.
+        if check == "less_than":
+            return bool(lt(party_size, number))
+        elif check == "less_or_equal":
+            return bool(le(party_size, number))
         elif check == "greater_than":
-            return party_size > number
-
+            return bool(gt(party_size, number))
+        elif check == "greater_or_equal":
+            return bool(ge(party_size, number))
+        elif check == "equals":
+            return bool(eq(party_size, number))
+        elif check == "not_equals":
+            return bool(ne(party_size, number))
         else:
-            raise Exception("Party size check parameters are incorrect.")
+            raise ValueError(f"{check} is incorrect.")


### PR DESCRIPTION
PR upgrades the condition in the title:

before:
operator: One of "equals", "less_than" or "greater_than".

after:
operator: Numeric comparison operator. Accepted values are "less_than", "less_or_equal", "greater_than", "greater_or_equal", "equals" and "not_equals".

updated: added the NE (not_equals) too, it can be really useful.

tested, black, isort, no new typehints