### PR TITLE
combat update (typehints, new structure + fix 877)

### DIFF
--- a/tuxemon/item/effects/capture.py
+++ b/tuxemon/item/effects/capture.py
@@ -16,7 +16,6 @@ logger = logging.getLogger(__name__)
 
 
 class CaptureEffectResult(ItemEffectResult):
-    capture: bool
     num_shakes: int
 
 
@@ -190,7 +189,7 @@ class CaptureEffect(ItemEffect):
                         if tuxeball:
                             tuxeball.quantity += 1
 
-                return {"success": False, "capture": True, "num_shakes": i + 1}
+                return {"success": False, "num_shakes": i + 1}
 
         if self.tuxeball is not None:
             # it increases the level +1 upon capture
@@ -205,4 +204,4 @@ class CaptureEffect(ItemEffect):
         self.user.add_monster(target, len(self.user.monsters))
 
         # TODO: remove monster from the other party
-        return {"success": True, "capture": True, "num_shakes": 4}
+        return {"success": True, "num_shakes": 4}

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -63,7 +63,6 @@ class Item:
         self.quantity = 1
         self.images: Sequence[str] = []
         self.type = ItemType.consumable
-        self.sfx = None
         # The path to the sprite to load.
         self.sprite = ""
         self.category = ItemCategory.none
@@ -208,16 +207,6 @@ class Item:
 
         return ret
 
-    def advance_round(self) -> None:
-        """
-        Advance round for items that take many rounds to use.
-
-        * This currently has no use, and may not stay.  It is added
-          so that the Item class and Technique class are interchangeable.
-
-        """
-        return
-
     def validate(self, target: Optional[Monster]) -> bool:
         """
         Check if the target meets all conditions that the item has on it's use.
@@ -261,7 +250,6 @@ class Item:
         meta_result: ItemEffectResult = {
             "name": self.name,
             "num_shakes": 0,
-            "capture": False,
             "should_tackle": False,
             "success": False,
         }

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -41,7 +41,6 @@ from tuxemon.monster import (
 )
 from tuxemon.prepare import CONFIG
 from tuxemon.session import Session
-from tuxemon.states.combat.combat import EnqueuedAction
 from tuxemon.states.pc import KENNEL, LOCKER
 from tuxemon.technique.technique import Technique
 from tuxemon.template import Template, decode_template, encode_template
@@ -51,6 +50,7 @@ if TYPE_CHECKING:
     import pygame
 
     from tuxemon.item.economy import Economy
+    from tuxemon.states.combat.combat import EnqueuedAction
     from tuxemon.states.world.worldstate import WorldState
 
     SpriteMap = Union[

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -9,7 +9,6 @@ from collections import defaultdict
 from functools import partial
 from itertools import chain
 from typing import (
-    TYPE_CHECKING,
     Dict,
     Iterable,
     List,
@@ -37,11 +36,17 @@ from tuxemon.combat import (
     fainted,
     get_awake_monsters,
 )
-from tuxemon.db import BattleGraphicsModel, OutputBattle, SeenStatus
+from tuxemon.db import (
+    BattleGraphicsModel,
+    ItemCategory,
+    OutputBattle,
+    SeenStatus,
+)
 from tuxemon.item.item import Item
 from tuxemon.locale import T
 from tuxemon.menu.interface import MenuItem
 from tuxemon.monster import Monster
+from tuxemon.npc import NPC
 from tuxemon.platform.const import buttons
 from tuxemon.platform.events import PlayerInput
 from tuxemon.session import local_session
@@ -55,9 +60,6 @@ from tuxemon.ui.draw import GraphicBox
 from tuxemon.ui.text import TextArea
 
 from .combat_animations import CombatAnimations
-
-if TYPE_CHECKING:
-    from tuxemon.npc import NPC
 
 logger = logging.getLogger(__name__)
 
@@ -705,34 +707,27 @@ class CombatState(CombatAnimations):
                 mon.status.clear()
 
         # TODO: not hardcode
+        message = T.format(
+            "combat_swap",
+            {
+                "target": monster.name.upper(),
+                "user": player.name.upper(),
+            },
+        )
+        self.alert(message)
+        # save iid monster fighting
         if player is self.players[0]:
-            self.alert(
-                T.format(
-                    "combat_call_tuxemon",
-                    {"name": monster.name.upper()},
-                ),
-            )
-            # save iid monster fighting
             self.players[0].game_variables[
                 "iid_fighting_monster"
             ] = monster.instance_id.hex
         elif self.is_trainer_battle:
-            self.alert(
-                T.format(
-                    "combat_swap",
-                    {
-                        "target": monster.name.upper(),
-                        "user": player.name.upper(),
-                    },
-                )
-            )
+            pass
         else:
-            self.alert(
-                T.format(
-                    "combat_wild_appeared",
-                    {"name": monster.name.upper()},
-                ),
+            message = T.format(
+                "combat_wild_appeared",
+                {"name": monster.name.upper()},
             )
+            self.alert(message)
 
     def reset_status_icons(self) -> None:
         """
@@ -926,37 +921,35 @@ class CombatState(CombatAnimations):
             target: Monster that receives the action.
 
         """
-        technique.advance_round()
-
         # This is the time, in seconds, that the animation takes to finish.
         action_time = 3.0
-
-        result = technique.use(user, target)
-
-        if technique.use_item:
-            # "Monster used move!"
-            context = {
-                "user": getattr(user, "name", ""),
-                "name": technique.name,
-                "target": target.name,
-            }
-            message = T.format(technique.use_item, context)
-        else:
-            message = ""
-
-        # TODO: caching sounds
-        audio.load_sound(technique.sfx).play()
-
         # action is performed, so now use sprites to animate it
         # this value will be None if the target is off screen
         target_sprite = self._monster_sprite_map.get(target, None)
-
         # slightly delay the monster shake, so technique animation
         # is synchronized with the damage shake motion
         hit_delay = 0.0
-        if user:
+        # monster uses move
+        if isinstance(technique, Technique) and isinstance(user, Monster):
+            technique.advance_round()
+            result_tech = technique.use(user, target)
+            context = {
+                "user": user.name,
+                "name": technique.name,
+                "target": target.name,
+            }
+            message = T.format(technique.use_tech, context)
+            if not result_tech["success"]:
+                # exclude skip
+                if technique.slug == "skip":
+                    m = ""
+                else:
+                    m = T.translate("combat_miss")
+                message += "\n" + m
+            # TODO: caching sounds
+            audio.load_sound(technique.sfx).play()
             # TODO: a real check or some params to test if should tackle, etc
-            if result["should_tackle"]:
+            if result_tech["should_tackle"]:
                 hit_delay += 0.5
                 user_sprite = self._monster_sprite_map[user]
                 self.animate_sprite_tackle(user_sprite)
@@ -981,46 +974,16 @@ class CombatState(CombatAnimations):
                 # allows tackle to special range techniques too
                 if technique.range != "special":
                     element_damage_key = MULT_MAP.get(
-                        result["element_multiplier"]
+                        result_tech["element_multiplier"]
                     )
                     if element_damage_key:
                         m = T.translate(element_damage_key)
                         message += "\n" + m
-
-            else:  # assume this was an item used
-                # handle the capture device
-                if result["capture"]:
-                    # retrieve tuxeball
-                    tuxeball = technique.slug
-                    message += "\n" + T.translate("attempting_capture")
-                    action_time = result["num_shakes"] + 1.8
-                    self.animate_capture_monster(
-                        result["success"],
-                        result["num_shakes"],
-                        target,
-                        tuxeball,
-                    )
-
-                    # TODO: Don't end combat right away; only works with SP,
-                    # and 1 member parties end combat right here
-                    if result["success"]:
-                        # Tuxepedia: set monster as caught (2)
-                        self.players[0].tuxepedia[
-                            target.slug
-                        ] = SeenStatus.caught
-                        # Display 'Gotcha!' first.
-                        self.task(self.end_combat, action_time + 0.5)
-                        self.task(
-                            partial(self.alert, T.translate("gotcha")),
-                            action_time,
-                        )
-                        self._animation_in_progress = True
-                        return
-
-                # generic handling of anything else
                 else:
                     msg_type = (
-                        "use_success" if result["success"] else "use_failure"
+                        "use_success"
+                        if result_tech["success"]
+                        else "use_failure"
                     )
                     context = {
                         "user": getattr(user, "name", ""),
@@ -1030,11 +993,65 @@ class CombatState(CombatAnimations):
                     template = getattr(technique, msg_type)
                     if template:
                         message += "\n" + T.format(template, context)
-
             self.alert(message)
             self.suppress_phase_change(action_time)
 
-        else:
+            is_flipped = False
+            for trainer in self.ai_players:
+                if user in self.monsters_in_play[trainer]:
+                    is_flipped = True
+                    break
+            tech_sprite = self._technique_cache.get(technique, is_flipped)
+
+            if result_tech["success"] and target_sprite and tech_sprite:
+                tech_sprite.rect.center = target_sprite.rect.center
+                assert tech_sprite.animation
+                self.task(tech_sprite.animation.play, hit_delay)
+                self.task(
+                    partial(self.sprites.add, tech_sprite, layer=50),
+                    hit_delay,
+                )
+                self.task(tech_sprite.kill, 3)
+
+        # player uses item
+        if isinstance(technique, Item) and isinstance(user, NPC):
+            result_item = technique.use(user, target)
+            context = {
+                "user": user.name,
+                "name": technique.name,
+                "target": target.name,
+            }
+            message = T.format(technique.use_item, context)
+            # handle the capture device
+            if technique.category == ItemCategory.capture:
+                # retrieve tuxeball
+                message += "\n" + T.translate("attempting_capture")
+                action_time = result_item["num_shakes"] + 1.8
+                self.animate_capture_monster(
+                    result_item["success"],
+                    result_item["num_shakes"],
+                    target,
+                    technique,
+                    self,
+                )
+            else:
+                msg_type = (
+                    "use_success" if result_item["success"] else "use_failure"
+                )
+                context = {
+                    "user": getattr(user, "name", ""),
+                    "name": technique.name,
+                    "target": target.name,
+                }
+                template = getattr(technique, msg_type)
+                if template:
+                    message += "\n" + T.format(template, context)
+
+            self.alert(message)
+            self.suppress_phase_change(action_time)
+        # statuses / conditions
+        if user is None and isinstance(technique, Technique):
+            result = technique.use(None, target)
             if result["success"]:
                 self.suppress_phase_change()
                 msg_type = (
@@ -1045,24 +1062,14 @@ class CombatState(CombatAnimations):
                     "target": target.name,
                 }
                 template = getattr(technique, msg_type)
-                self.alert(T.format(template, context))
-
-        is_flipped = False
-        for trainer in self.ai_players:
-            if user in self.monsters_in_play[trainer]:
-                is_flipped = True
-                break
-        tech_sprite = self._technique_cache.get(technique, is_flipped)
-
-        if result["success"] and target_sprite and tech_sprite:
-            tech_sprite.rect.center = target_sprite.rect.center
-            assert tech_sprite.animation
-            self.task(tech_sprite.animation.play, hit_delay)
-            self.task(
-                partial(self.sprites.add, tech_sprite, layer=50),
-                hit_delay,
-            )
-            self.task(tech_sprite.kill, 3)
+                message = T.format(template, context)
+                # swapping monster
+                if technique.slug == "swap":
+                    message = T.format(
+                        "combat_call_tuxemon",
+                        {"name": target.name.upper()},
+                    )
+                self.alert(message)
 
     def faint_monster(self, monster: Monster) -> None:
         """

--- a/tuxemon/states/combat/combat_animations.py
+++ b/tuxemon/states/combat/combat_animations.py
@@ -24,18 +24,21 @@ import pygame
 from pygame.rect import Rect
 
 from tuxemon import audio, graphics, tools
-from tuxemon.animation import Task
+from tuxemon.db import SeenStatus
 from tuxemon.locale import T
 from tuxemon.menu.interface import ExpBar, HpBar
 from tuxemon.menu.menu import Menu
-from tuxemon.monster import Monster
 from tuxemon.sprite import CaptureDeviceSprite, Sprite
 from tuxemon.surfanim import SurfaceAnimation
 from tuxemon.tools import scale, scale_sequence
 
 if TYPE_CHECKING:
+    from tuxemon.animation import Task
     from tuxemon.db import BattleGraphicsModel
+    from tuxemon.item.item import Item
+    from tuxemon.monster import Monster
     from tuxemon.npc import NPC
+    from tuxemon.states.combat import CombatState
 
 logger = logging.getLogger(__name__)
 
@@ -651,7 +654,8 @@ class CombatAnimations(ABC, Menu[None]):
         is_captured: bool,
         num_shakes: int,
         monster: Monster,
-        item: str,
+        item: Item,
+        combat: CombatState,
     ) -> None:
         """
         Animation for capturing monsters.
@@ -663,7 +667,7 @@ class CombatAnimations(ABC, Menu[None]):
 
         """
         monster_sprite = self._monster_sprite_map[monster]
-        capdev = self.load_sprite(f"gfx/items/{item}.png")
+        capdev = self.load_sprite(f"gfx/items/{item.slug}.png")
         animate = partial(
             self.animate, capdev.rect, transition="in_quad", duration=1.0
         )
@@ -724,6 +728,18 @@ class CombatAnimations(ABC, Menu[None]):
 
         if is_captured:
             self.task(kill, 2 + num_shakes)
+            action_time = num_shakes + 1.8
+            # Tuxepedia: set monster as caught (2)
+            self.players[0].tuxepedia[monster.slug] = SeenStatus.caught
+            # Display 'Gotcha!' first.
+            self.task(combat.end_combat, action_time + 0.5)
+            gotcha = T.translate("gotcha")
+            self.task(
+                partial(self.alert, gotcha),
+                action_time,
+            )
+            self._animation_in_progress = True
+            return
         else:
             breakout_delay = 1.8 + num_shakes * 1.0
             self.task(  # make the monster appear again!

--- a/tuxemon/states/combat/combat_menus.py
+++ b/tuxemon/states/combat/combat_menus.py
@@ -194,9 +194,8 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                     ],
                 )
                 return
-            player = local_session.player
             target = monster
-            combat_state.enqueue_action(player, swap, target)
+            combat_state.enqueue_action(None, swap, target)
             self.client.pop_state()  # close technique menu
             self.client.pop_state()  # close the monster action menu
 
@@ -246,8 +245,8 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
 
             # enqueue the item
             combat_state = self.client.get_state_by_name(CombatState)
-            # TODO: don't hardcode to player0
-            combat_state.enqueue_action(combat_state.players[0], item, target)
+            player = local_session.player
+            combat_state.enqueue_action(player, item, target)
 
             # close all the open menus
             self.client.pop_state()  # close target chooser

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -82,7 +82,6 @@ class Technique:
         self.target: Sequence[str] = []
         self.types: List[ElementType] = []
         self.usable_on = False
-        self.use_item = ""
         self.use_success = ""
         self.use_failure = ""
         self.use_tech = ""
@@ -123,7 +122,7 @@ class Technique:
         # technique use notifications (translated!)
         # NOTE: should be `self.use_tech`, but Technique and Item have
         # overlapping checks
-        self.use_item = T.maybe_translate(results.use_tech)
+        self.use_tech = T.maybe_translate(results.use_tech)
         self.use_success = T.maybe_translate(results.use_success)
         self.use_failure = T.maybe_translate(results.use_failure)
 
@@ -339,7 +338,6 @@ class Technique:
             "name": self.name,
             "success": False,
             "should_tackle": False,
-            "capture": False,
         }
 
         # Loop through all the effects of this technique and execute the effect's function.


### PR DESCRIPTION
PR updates #1661 (closed because too big).
- removes 5 typehints inside combat.py #1211 - Found 181 errors in 45 files (checked 294 source files);
- separates operations (see structure below);
- fix #877 (it was through)

structure:
```
if technique and monster (monster uses technique)
---> everything related
if item and player/npc (player uses item)
---> everything related
if technique and none (condition/status does)
---> everything else (in this case we are looking ahead towards class Status, so we can switch more easily)
```
moreover, regarding #877, it was true. By looking at the text area, you can clearly see "player uses Tuxeball, attempting....", when it appears, 100% fail. Fixed the bug by moving the piece inside combat animations, in this way the attempting text will be show for successful and unsuccessful attempts.

tested, isort, black, no new typehints