### PR TITLE
teleport_clinic (variable)

### DIFF
--- a/mods/tuxemon/maps/cotton_cathedral.tmx
+++ b/mods/tuxemon/maps/cotton_cathedral.tmx
@@ -86,7 +86,7 @@
     <property name="act60" value="npc_face tabanurse,down"/>
     <property name="act70" value="translated_dialog okaythen2"/>
     <property name="act80" value="set_variable chooses:none"/>
-    <property name="act90" value="set_variable teleport_faint:cotton_cathedral.tmx 6 10"/>
+    <property name="act90" value="set_variable teleport_faint:cotton_cathedral.tmx 6 7"/>
     <property name="cond10" value="is variable_set chooses:yes"/>
    </properties>
   </object>
@@ -94,8 +94,8 @@
    <properties>
     <property name="act1" value="set_monster_health"/>
     <property name="act2" value="set_monster_status"/>
-    <property name="act3" value="set_variable battle_last_result:none"/>
-    <property name="cond1" value="is variable_set battle_last_result:lost"/>
+    <property name="act3" value="set_variable teleport_clinic:none"/>
+    <property name="cond1" value="is variable_set teleport_clinic:lost"/>
    </properties>
   </object>
   <object id="30" name="Use Computer" type="event" x="160" y="48" width="16" height="16">

--- a/mods/tuxemon/maps/healing_center.tmx
+++ b/mods/tuxemon/maps/healing_center.tmx
@@ -75,7 +75,7 @@
     <property name="act61" value="wait 0.5"/>
     <property name="act70" value="translated_dialog okaythen2"/>
     <property name="act80" value="set_variable chooses:none"/>
-    <property name="act90" value="set_variable teleport_faint:healing_center.tmx 6 10"/>
+    <property name="act90" value="set_variable teleport_faint:healing_center.tmx 6 7"/>
     <property name="cond10" value="is variable_set chooses:yes"/>
    </properties>
   </object>
@@ -128,8 +128,8 @@
    <properties>
     <property name="act1" value="set_monster_health"/>
     <property name="act2" value="set_monster_status"/>
-    <property name="act3" value="set_variable battle_last_result:none"/>
-    <property name="cond1" value="is variable_set battle_last_result:lost"/>
+    <property name="act3" value="set_variable teleport_clinic:none"/>
+    <property name="cond1" value="is variable_set teleport_clinic:lost"/>
    </properties>
   </object>
   <object id="37" name="Use Computer" type="event" x="160" y="48" width="16" height="16">

--- a/mods/tuxemon/maps/player_house_bedroom.yaml
+++ b/mods/tuxemon/maps/player_house_bedroom.yaml
@@ -32,7 +32,7 @@ events:
     - translated_dialog spyder_papertown_restinbed
     - set_monster_health
     - set_monster_status
-    - set_variable teleport_faint:player_house_bedroom.tmx 6 5
+    - set_variable teleport_faint:player_house_bedroom.tmx 3 4
     conditions:
     - is button_pressed K_RETURN
     - is player_facing_tile

--- a/mods/tuxemon/maps/sphalian_center.tmx
+++ b/mods/tuxemon/maps/sphalian_center.tmx
@@ -54,7 +54,7 @@
     <property name="act50" value="npc_face tabanurse,down"/>
     <property name="act60" value="translated_dialog okaythen2"/>
     <property name="act70" value="set_variable chooses:none"/>
-    <property name="act80" value="set_variable teleport_faint:sphalian_town_center.tmx 6 10"/>
+    <property name="act80" value="set_variable teleport_faint:sphalian_town_center.tmx 6 7"/>
     <property name="cond1" value="is variable_set chooses:yes"/>
    </properties>
   </object>
@@ -93,8 +93,8 @@
    <properties>
     <property name="act1" value="set_monster_health"/>
     <property name="act2" value="set_monster_status"/>
-    <property name="act3" value="set_variable battle_last_result:none"/>
-    <property name="cond1" value="is variable_set battle_last_result:lost"/>
+    <property name="act3" value="set_variable teleport_clinic:none"/>
+    <property name="cond1" value="is variable_set teleport_clinic:lost"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_bedroom.tmx
+++ b/mods/tuxemon/maps/spyder_bedroom.tmx
@@ -77,8 +77,8 @@
    <properties>
     <property name="act1" value="set_monster_health"/>
     <property name="act2" value="set_monster_status"/>
-    <property name="act3" value="set_variable battle_last_result:none"/>
-    <property name="cond1" value="is variable_set battle_last_result:lost"/>
+    <property name="act3" value="set_variable teleport_clinic:none"/>
+    <property name="cond1" value="is variable_set teleport_clinic:lost"/>
    </properties>
   </object>
   <object id="30" name="intro question" type="event" x="60" y="0" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_candy_center.tmx
+++ b/mods/tuxemon/maps/spyder_candy_center.tmx
@@ -60,7 +60,7 @@
     <property name="act50" value="npc_face tabanurse,down"/>
     <property name="act60" value="translated_dialog okaythen2"/>
     <property name="act70" value="set_variable chooses:none"/>
-    <property name="act80" value="set_variable teleport_faint:spyder_candy_center.tmx 6 10"/>
+    <property name="act80" value="set_variable teleport_faint:spyder_candy_center.tmx 6 7"/>
     <property name="cond1" value="is variable_set chooses:yes"/>
    </properties>
   </object>
@@ -111,8 +111,8 @@
    <properties>
     <property name="act1" value="set_monster_health"/>
     <property name="act2" value="set_monster_status"/>
-    <property name="act3" value="set_variable battle_last_result:none"/>
-    <property name="cond1" value="is variable_set battle_last_result:lost"/>
+    <property name="act3" value="set_variable teleport_clinic:none"/>
+    <property name="cond1" value="is variable_set teleport_clinic:lost"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_cotton_cafe.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_cafe.tmx
@@ -195,8 +195,8 @@
    <properties>
     <property name="act1" value="set_monster_health"/>
     <property name="act2" value="set_monster_status"/>
-    <property name="act3" value="set_variable battle_last_result:none"/>
-    <property name="cond1" value="is variable_set battle_last_result:lost"/>
+    <property name="act3" value="set_variable teleport_clinic:none"/>
+    <property name="cond1" value="is variable_set teleport_clinic:lost"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_flower_center.tmx
+++ b/mods/tuxemon/maps/spyder_flower_center.tmx
@@ -54,7 +54,7 @@
     <property name="act50" value="npc_face tabanurse,down"/>
     <property name="act60" value="translated_dialog okaythen2"/>
     <property name="act70" value="set_variable chooses:none"/>
-    <property name="act80" value="set_variable teleport_faint:spyder_flower_center.tmx 6 10"/>
+    <property name="act80" value="set_variable teleport_faint:spyder_flower_center.tmx 6 7"/>
     <property name="cond1" value="is variable_set chooses:yes"/>
    </properties>
   </object>
@@ -97,8 +97,8 @@
    <properties>
     <property name="act1" value="set_monster_health"/>
     <property name="act2" value="set_monster_status"/>
-    <property name="act3" value="set_variable battle_last_result:none"/>
-    <property name="cond1" value="is variable_set battle_last_result:lost"/>
+    <property name="act3" value="set_variable teleport_clinic:none"/>
+    <property name="cond1" value="is variable_set teleport_clinic:lost"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_healing_center.tmx
+++ b/mods/tuxemon/maps/spyder_healing_center.tmx
@@ -54,7 +54,7 @@
     <property name="act50" value="npc_face tabanurse,down"/>
     <property name="act60" value="translated_dialog okaythen2"/>
     <property name="act70" value="set_variable chooses:none"/>
-    <property name="act80" value="set_variable teleport_faint:spyder_healing_center.tmx 6 10"/>
+    <property name="act80" value="set_variable teleport_faint:spyder_healing_center.tmx 6 7"/>
     <property name="cond1" value="is variable_set chooses:yes"/>
    </properties>
   </object>
@@ -97,8 +97,8 @@
    <properties>
     <property name="act1" value="set_monster_health"/>
     <property name="act2" value="set_monster_status"/>
-    <property name="act3" value="set_variable battle_last_result:none"/>
-    <property name="cond1" value="is variable_set battle_last_result:lost"/>
+    <property name="act3" value="set_variable teleport_clinic:none"/>
+    <property name="cond1" value="is variable_set teleport_clinic:lost"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_leather_center.tmx
+++ b/mods/tuxemon/maps/spyder_leather_center.tmx
@@ -54,7 +54,7 @@
     <property name="act50" value="npc_face tabanurse,down"/>
     <property name="act60" value="translated_dialog okaythen2"/>
     <property name="act70" value="set_variable chooses:none"/>
-    <property name="act80" value="set_variable teleport_faint:spyder_leather_center.tmx 6 10"/>
+    <property name="act80" value="set_variable teleport_faint:spyder_leather_center.tmx 6 7"/>
     <property name="cond1" value="is variable_set chooses:yes"/>
    </properties>
   </object>
@@ -98,8 +98,8 @@
    <properties>
     <property name="act1" value="set_monster_health"/>
     <property name="act2" value="set_monster_status"/>
-    <property name="act3" value="set_variable battle_last_result:none"/>
-    <property name="cond1" value="is variable_set battle_last_result:lost"/>
+    <property name="act3" value="set_variable teleport_clinic:none"/>
+    <property name="cond1" value="is variable_set teleport_clinic:lost"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_leather_town.tmx
+++ b/mods/tuxemon/maps/spyder_leather_town.tmx
@@ -402,8 +402,8 @@
    <properties>
     <property name="act1" value="set_monster_health"/>
     <property name="act2" value="set_monster_status"/>
-    <property name="act3" value="set_variable battle_last_result:none"/>
-    <property name="cond1" value="is variable_set battle_last_result:lost"/>
+    <property name="act3" value="set_variable teleport_clinic:none"/>
+    <property name="cond1" value="is variable_set teleport_clinic:lost"/>
    </properties>
   </object>
   <object id="306" name="Sign: Leather Scoop" type="event" x="192" y="144" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_paper_town.tmx
+++ b/mods/tuxemon/maps/spyder_paper_town.tmx
@@ -304,7 +304,7 @@
     <property name="act71" value="add_monster dollfin,5,spyder_billie,27,10"/>
     <property name="act80" value="start_battle spyder_billie"/>
     <property name="act90" value="set_variable firstfightdue:no"/>
-    <property name="act91" value="set_variable teleport_faint:spyder_bedroom.tmx 7 6"/>
+    <property name="act91" value="set_variable teleport_faint:spyder_bedroom.tmx 3 4"/>
     <property name="act92" value="set_variable firstfightend:yes"/>
     <property name="cond1" value="is variable_set firstfightdue:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_scoop2.tmx
+++ b/mods/tuxemon/maps/spyder_scoop2.tmx
@@ -96,8 +96,8 @@
    <properties>
     <property name="act1" value="set_monster_health"/>
     <property name="act2" value="set_monster_status"/>
-    <property name="act3" value="set_variable battle_last_result:none"/>
-    <property name="cond1" value="is variable_set battle_last_result:lost"/>
+    <property name="act3" value="set_variable teleport_clinic:none"/>
+    <property name="cond1" value="is variable_set teleport_clinic:lost"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_timber_center.tmx
+++ b/mods/tuxemon/maps/spyder_timber_center.tmx
@@ -54,7 +54,7 @@
     <property name="act50" value="npc_face tabanurse,down"/>
     <property name="act60" value="translated_dialog okaythen2"/>
     <property name="act70" value="set_variable chooses:none"/>
-    <property name="act80" value="set_variable teleport_faint:spyder_timber_center.tmx 6 10"/>
+    <property name="act80" value="set_variable teleport_faint:spyder_timber_center.tmx 6 7"/>
     <property name="cond1" value="is variable_set chooses:yes"/>
    </properties>
   </object>
@@ -97,8 +97,8 @@
    <properties>
     <property name="act1" value="set_monster_health"/>
     <property name="act2" value="set_monster_status"/>
-    <property name="act3" value="set_variable battle_last_result:none"/>
-    <property name="cond1" value="is variable_set battle_last_result:lost"/>
+    <property name="act3" value="set_variable teleport_clinic:none"/>
+    <property name="cond1" value="is variable_set teleport_clinic:lost"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
+++ b/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
@@ -297,8 +297,8 @@
    <properties>
     <property name="act1" value="set_monster_health"/>
     <property name="act2" value="set_monster_status"/>
-    <property name="act3" value="set_variable battle_last_result:none"/>
-    <property name="cond1" value="is variable_set battle_last_result:lost"/>
+    <property name="act3" value="set_variable teleport_clinic:none"/>
+    <property name="cond1" value="is variable_set teleport_clinic:lost"/>
    </properties>
   </object>
   <object id="75" name="Environment" type="event" x="16" y="0" width="16" height="16">

--- a/mods/tuxemon/maps/taba_town.tmx
+++ b/mods/tuxemon/maps/taba_town.tmx
@@ -892,7 +892,7 @@
   </object>
   <object id="160" name="Default" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="set_variable teleport_faint:healing_center.tmx 6 10"/>
+    <property name="act1" value="set_variable teleport_faint:healing_center.tmx 6 7"/>
     <property name="cond1" value="not variable_set teleport_faint"/>
    </properties>
   </object>

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -413,7 +413,8 @@ class CombatState(CombatAnimations):
             self.players[0].set_party_status()
             var = self.players[0].game_variables
             if self.is_trainer_battle:
-                var["battle_last_result"] = OutputBattle.lost
+                var["battle_last_result"] = OutputBattle.forfeit
+                var["teleport_clinic"] = OutputBattle.lost
                 self.alert(
                     T.format(
                         "combat_forfeit",
@@ -439,6 +440,7 @@ class CombatState(CombatAnimations):
             self.players[0].set_party_status()
             var = self.players[0].game_variables
             var["battle_last_result"] = OutputBattle.draw
+            var["teleport_clinic"] = OutputBattle.lost
             if self.is_trainer_battle:
                 var["battle_last_trainer"] = self.players[1].slug
                 # track battles against NPC
@@ -487,6 +489,7 @@ class CombatState(CombatAnimations):
 
             else:
                 var["battle_last_result"] = OutputBattle.lost
+                var["teleport_clinic"] = OutputBattle.lost
                 self.alert(T.translate("combat_defeat"))
                 if self.is_trainer_battle:
                     var["battle_last_trainer"] = self.players[1].slug


### PR DESCRIPTION
PR addresses:
- replacement of **battle_last_result** with **teleport_clinic** as variable (if losing in battle) --> teleport faint;
- adjustment of coordinates set_variable teleport_faint:xxx.tmx (the coordinates where to close to the door, results the player arrives in the center, then goes out, no... healing);
- add autohealing parameters for draw output (both lose, player and opponent);

**teleport_clinic** because there are 3 scenarios where the player can end up in the center: 1. lost, 2. draw (both lose), 3. forfeit
before everything was based on **battle_last_result**, but it was wrong
moreover draw was missing (while testing I ended up in draw and I noticed that the player was teleported in the center, but the monster was not healed).