### PR TITLE
lack_tech into has_tech

### DIFF
--- a/mods/tuxemon/db/item/tm_avalanche.json
+++ b/mods/tuxemon/db/item/tm_avalanche.json
@@ -2,7 +2,7 @@
   "conditions": [
     "is type earth,water",
     "is max_moves",
-    "is lack_tech avalanche"
+    "not has_tech avalanche"
   ],
   "effects": [
     "learn_tm avalanche"

--- a/mods/tuxemon/db/item/tm_blossom.json
+++ b/mods/tuxemon/db/item/tm_blossom.json
@@ -2,7 +2,7 @@
   "conditions": [
     "is type wood",
     "is max_moves",
-    "is lack_tech blossom"
+    "not has_tech blossom"
   ],
   "effects": [
     "learn_tm blossom"

--- a/tuxemon/item/conditions/has_tech.py
+++ b/tuxemon/item/conditions/has_tech.py
@@ -9,7 +9,7 @@ from tuxemon.monster import Monster
 
 
 @dataclass
-class LackTechCondition(ItemCondition):
+class HasTechCondition(ItemCondition):
     """
     Checks if the monster knows already the technique.
 
@@ -17,11 +17,11 @@ class LackTechCondition(ItemCondition):
 
     """
 
-    name = "lack_tech"
+    name = "has_tech"
     expected: str
 
     def test(self, target: Monster) -> bool:
         if any(t for t in target.moves if t.slug == self.expected):
-            return False
-        else:
             return True
+        else:
+            return False


### PR DESCRIPTION
regarding #1717 
@kerizane has_tech is an event condition, but it made me realize **has_tech** is a better name. So I changed the name, the output (true, false), in this way is more intuitive. I'm referring to item conditions.