### PR TITLE
randomly (technique json)

### DIFF
--- a/mods/tuxemon/db/technique/acid.json
+++ b/mods/tuxemon/db/technique/acid.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.9,

--- a/mods/tuxemon/db/technique/adamantine.json
+++ b/mods/tuxemon/db/technique/adamantine.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.6,

--- a/mods/tuxemon/db/technique/air_chain.json
+++ b/mods/tuxemon/db/technique/air_chain.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.8,

--- a/mods/tuxemon/db/technique/all_in.json
+++ b/mods/tuxemon/db/technique/all_in.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.75,

--- a/mods/tuxemon/db/technique/amnesia.json
+++ b/mods/tuxemon/db/technique/amnesia.json
@@ -8,8 +8,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/ants.json
+++ b/mods/tuxemon/db/technique/ants.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.3,

--- a/mods/tuxemon/db/technique/arcane_eye.json
+++ b/mods/tuxemon/db/technique/arcane_eye.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.1,

--- a/mods/tuxemon/db/technique/assault.json
+++ b/mods/tuxemon/db/technique/assault.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.5,

--- a/mods/tuxemon/db/technique/avalanche.json
+++ b/mods/tuxemon/db/technique/avalanche.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": true,
   "is_fast": false,
   "potency": 0.8,

--- a/mods/tuxemon/db/technique/barking.json
+++ b/mods/tuxemon/db/technique/barking.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.6,

--- a/mods/tuxemon/db/technique/battery_acid.json
+++ b/mods/tuxemon/db/technique/battery_acid.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.35,

--- a/mods/tuxemon/db/technique/battery_discharge.json
+++ b/mods/tuxemon/db/technique/battery_discharge.json
@@ -7,7 +7,6 @@
   ],
   "flip_axes": "",
   "healing_power": 4,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": null,

--- a/mods/tuxemon/db/technique/beam.json
+++ b/mods/tuxemon/db/technique/beam.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.75,

--- a/mods/tuxemon/db/technique/berserk.json
+++ b/mods/tuxemon/db/technique/berserk.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/biting_winds.json
+++ b/mods/tuxemon/db/technique/biting_winds.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/blade.json
+++ b/mods/tuxemon/db/technique/blade.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "x",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": true,
   "potency": null,

--- a/mods/tuxemon/db/technique/blood_bond.json
+++ b/mods/tuxemon/db/technique/blood_bond.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/blood_nets.json
+++ b/mods/tuxemon/db/technique/blood_nets.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.3,

--- a/mods/tuxemon/db/technique/blossom.json
+++ b/mods/tuxemon/db/technique/blossom.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/boulder.json
+++ b/mods/tuxemon/db/technique/boulder.json
@@ -7,8 +7,6 @@
     "enhance"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/breath.json
+++ b/mods/tuxemon/db/technique/breath.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.2,

--- a/mods/tuxemon/db/technique/breathe_fire.json
+++ b/mods/tuxemon/db/technique/breathe_fire.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "x",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": null,

--- a/mods/tuxemon/db/technique/bubble_trap.json
+++ b/mods/tuxemon/db/technique/bubble_trap.json
@@ -8,8 +8,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/bullet.json
+++ b/mods/tuxemon/db/technique/bullet.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": true,
   "potency": null,

--- a/mods/tuxemon/db/technique/canine.json
+++ b/mods/tuxemon/db/technique/canine.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/cat_calling.json
+++ b/mods/tuxemon/db/technique/cat_calling.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.4,

--- a/mods/tuxemon/db/technique/cavity.json
+++ b/mods/tuxemon/db/technique/cavity.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.1,

--- a/mods/tuxemon/db/technique/chameleon.json
+++ b/mods/tuxemon/db/technique/chameleon.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.6,

--- a/mods/tuxemon/db/technique/chill_mist.json
+++ b/mods/tuxemon/db/technique/chill_mist.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": true,
   "is_fast": false,
   "potency": null,

--- a/mods/tuxemon/db/technique/clairaudience.json
+++ b/mods/tuxemon/db/technique/clairaudience.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.8,

--- a/mods/tuxemon/db/technique/clamp_on.json
+++ b/mods/tuxemon/db/technique/clamp_on.json
@@ -7,8 +7,6 @@
     "enhance"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/clock.json
+++ b/mods/tuxemon/db/technique/clock.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.1,

--- a/mods/tuxemon/db/technique/cloud_aether.json
+++ b/mods/tuxemon/db/technique/cloud_aether.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.6,

--- a/mods/tuxemon/db/technique/conjurer.json
+++ b/mods/tuxemon/db/technique/conjurer.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.2,

--- a/mods/tuxemon/db/technique/constrict.json
+++ b/mods/tuxemon/db/technique/constrict.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.75,

--- a/mods/tuxemon/db/technique/crystal.json
+++ b/mods/tuxemon/db/technique/crystal.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.9,

--- a/mods/tuxemon/db/technique/demiurge.json
+++ b/mods/tuxemon/db/technique/demiurge.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.7,

--- a/mods/tuxemon/db/technique/earthquake.json
+++ b/mods/tuxemon/db/technique/earthquake.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.5,

--- a/mods/tuxemon/db/technique/electrical_storm.json
+++ b/mods/tuxemon/db/technique/electrical_storm.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": true,
   "is_fast": false,
   "potency": null,

--- a/mods/tuxemon/db/technique/energy_claws.json
+++ b/mods/tuxemon/db/technique/energy_claws.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "x",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/energy_field.json
+++ b/mods/tuxemon/db/technique/energy_field.json
@@ -7,8 +7,6 @@
     "enhance"
   ],
   "flip_axes": "x",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": true,
   "potency": 1,

--- a/mods/tuxemon/db/technique/evasion.json
+++ b/mods/tuxemon/db/technique/evasion.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.3,

--- a/mods/tuxemon/db/technique/eyebite.json
+++ b/mods/tuxemon/db/technique/eyebite.json
@@ -7,8 +7,6 @@
     "enhance"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": true,
   "potency": 1,

--- a/mods/tuxemon/db/technique/feint.json
+++ b/mods/tuxemon/db/technique/feint.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/feline.json
+++ b/mods/tuxemon/db/technique/feline.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.1,

--- a/mods/tuxemon/db/technique/fester.json
+++ b/mods/tuxemon/db/technique/fester.json
@@ -8,8 +8,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.8,

--- a/mods/tuxemon/db/technique/fiery.json
+++ b/mods/tuxemon/db/technique/fiery.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.9,

--- a/mods/tuxemon/db/technique/fire_ball.json
+++ b/mods/tuxemon/db/technique/fire_ball.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "x",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": null,

--- a/mods/tuxemon/db/technique/fire_claw.json
+++ b/mods/tuxemon/db/technique/fire_claw.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "x",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": null,

--- a/mods/tuxemon/db/technique/fire_shield.json
+++ b/mods/tuxemon/db/technique/fire_shield.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.3,

--- a/mods/tuxemon/db/technique/firestorm.json
+++ b/mods/tuxemon/db/technique/firestorm.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.4,

--- a/mods/tuxemon/db/technique/flamethrower.json
+++ b/mods/tuxemon/db/technique/flamethrower.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "x",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": null,

--- a/mods/tuxemon/db/technique/fledgling.json
+++ b/mods/tuxemon/db/technique/fledgling.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.6,

--- a/mods/tuxemon/db/technique/flood.json
+++ b/mods/tuxemon/db/technique/flood.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "x",
-  "healing_power": 0,
-  "icon": "",
   "is_area": true,
   "is_fast": false,
   "power": 1.5,

--- a/mods/tuxemon/db/technique/flow.json
+++ b/mods/tuxemon/db/technique/flow.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": true,
   "is_fast": false,
   "power": 1.5,

--- a/mods/tuxemon/db/technique/fluff_up.json
+++ b/mods/tuxemon/db/technique/fluff_up.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.5,

--- a/mods/tuxemon/db/technique/font.json
+++ b/mods/tuxemon/db/technique/font.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/frostbite.json
+++ b/mods/tuxemon/db/technique/frostbite.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "xy",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.2,

--- a/mods/tuxemon/db/technique/fume.json
+++ b/mods/tuxemon/db/technique/fume.json
@@ -7,8 +7,6 @@
     "enhance"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/give_all.json
+++ b/mods/tuxemon/db/technique/give_all.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/glower.json
+++ b/mods/tuxemon/db/technique/glower.json
@@ -7,8 +7,6 @@
     "enhance"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": true,
   "potency": 1,

--- a/mods/tuxemon/db/technique/goad.json
+++ b/mods/tuxemon/db/technique/goad.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": true,
   "potency": 0.8,

--- a/mods/tuxemon/db/technique/gold_digger.json
+++ b/mods/tuxemon/db/technique/gold_digger.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.4,

--- a/mods/tuxemon/db/technique/grinding.json
+++ b/mods/tuxemon/db/technique/grinding.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.9,

--- a/mods/tuxemon/db/technique/gust.json
+++ b/mods/tuxemon/db/technique/gust.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.9,

--- a/mods/tuxemon/db/technique/gyser.json
+++ b/mods/tuxemon/db/technique/gyser.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.2,

--- a/mods/tuxemon/db/technique/hawk.json
+++ b/mods/tuxemon/db/technique/hawk.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.2,

--- a/mods/tuxemon/db/technique/headbutt.json
+++ b/mods/tuxemon/db/technique/headbutt.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "x",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": null,

--- a/mods/tuxemon/db/technique/hibernate.json
+++ b/mods/tuxemon/db/technique/hibernate.json
@@ -7,7 +7,6 @@
   ],
   "flip_axes": "",
   "healing_power": 8,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/ice_claw.json
+++ b/mods/tuxemon/db/technique/ice_claw.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": null,

--- a/mods/tuxemon/db/technique/ice_storm.json
+++ b/mods/tuxemon/db/technique/ice_storm.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.5,

--- a/mods/tuxemon/db/technique/icicle_spear.json
+++ b/mods/tuxemon/db/technique/icicle_spear.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "xy",
-  "healing_power": 0,
-  "icon": "",
   "is_area": true,
   "is_fast": false,
   "potency": null,

--- a/mods/tuxemon/db/technique/insanity.json
+++ b/mods/tuxemon/db/technique/insanity.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.5,

--- a/mods/tuxemon/db/technique/invictus.json
+++ b/mods/tuxemon/db/technique/invictus.json
@@ -8,8 +8,6 @@
     "damage"
   ],
   "flip_axes": "xy",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.75,

--- a/mods/tuxemon/db/technique/kindling_flame.json
+++ b/mods/tuxemon/db/technique/kindling_flame.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/kraken.json
+++ b/mods/tuxemon/db/technique/kraken.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/lantern.json
+++ b/mods/tuxemon/db/technique/lantern.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.1,

--- a/mods/tuxemon/db/technique/lava.json
+++ b/mods/tuxemon/db/technique/lava.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.4,

--- a/mods/tuxemon/db/technique/levitate.json
+++ b/mods/tuxemon/db/technique/levitate.json
@@ -8,8 +8,6 @@
     "enhance"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/lightning_spheres.json
+++ b/mods/tuxemon/db/technique/lightning_spheres.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.4,

--- a/mods/tuxemon/db/technique/lineage.json
+++ b/mods/tuxemon/db/technique/lineage.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.9,

--- a/mods/tuxemon/db/technique/lust.json
+++ b/mods/tuxemon/db/technique/lust.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.3,

--- a/mods/tuxemon/db/technique/magma.json
+++ b/mods/tuxemon/db/technique/magma.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.3,

--- a/mods/tuxemon/db/technique/maori.json
+++ b/mods/tuxemon/db/technique/maori.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.4,

--- a/mods/tuxemon/db/technique/meltdown.json
+++ b/mods/tuxemon/db/technique/meltdown.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.1,

--- a/mods/tuxemon/db/technique/mending.json
+++ b/mods/tuxemon/db/technique/mending.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.3,

--- a/mods/tuxemon/db/technique/midnight_mantle.json
+++ b/mods/tuxemon/db/technique/midnight_mantle.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "x",
-  "healing_power": 0,
-  "icon": "",
   "is_area": true,
   "is_fast": true,
   "potency": null,

--- a/mods/tuxemon/db/technique/mobbing.json
+++ b/mods/tuxemon/db/technique/mobbing.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.1,

--- a/mods/tuxemon/db/technique/muck.json
+++ b/mods/tuxemon/db/technique/muck.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.9,

--- a/mods/tuxemon/db/technique/muddle.json
+++ b/mods/tuxemon/db/technique/muddle.json
@@ -8,8 +8,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/mudslide.json
+++ b/mods/tuxemon/db/technique/mudslide.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.8,

--- a/mods/tuxemon/db/technique/mystic_blending.json
+++ b/mods/tuxemon/db/technique/mystic_blending.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.4,

--- a/mods/tuxemon/db/technique/negation.json
+++ b/mods/tuxemon/db/technique/negation.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.7,

--- a/mods/tuxemon/db/technique/nest.json
+++ b/mods/tuxemon/db/technique/nest.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.9,

--- a/mods/tuxemon/db/technique/oedipus.json
+++ b/mods/tuxemon/db/technique/oedipus.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.8,

--- a/mods/tuxemon/db/technique/one_two.json
+++ b/mods/tuxemon/db/technique/one_two.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": null,

--- a/mods/tuxemon/db/technique/orbs.json
+++ b/mods/tuxemon/db/technique/orbs.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.7,

--- a/mods/tuxemon/db/technique/overfeed.json
+++ b/mods/tuxemon/db/technique/overfeed.json
@@ -7,8 +7,6 @@
     "enhance"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/overgrowth.json
+++ b/mods/tuxemon/db/technique/overgrowth.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/peck.json
+++ b/mods/tuxemon/db/technique/peck.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": null,

--- a/mods/tuxemon/db/technique/peregrine.json
+++ b/mods/tuxemon/db/technique/peregrine.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": true,
   "potency": null,

--- a/mods/tuxemon/db/technique/perfect_cut.json
+++ b/mods/tuxemon/db/technique/perfect_cut.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "x",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": null,

--- a/mods/tuxemon/db/technique/petrify.json
+++ b/mods/tuxemon/db/technique/petrify.json
@@ -6,8 +6,6 @@
     "enhance"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": true,
   "potency": 1,

--- a/mods/tuxemon/db/technique/phantasmal_force.json
+++ b/mods/tuxemon/db/technique/phantasmal_force.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.1,

--- a/mods/tuxemon/db/technique/pit.json
+++ b/mods/tuxemon/db/technique/pit.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.1,

--- a/mods/tuxemon/db/technique/platinum.json
+++ b/mods/tuxemon/db/technique/platinum.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.2,

--- a/mods/tuxemon/db/technique/poison_courtship.json
+++ b/mods/tuxemon/db/technique/poison_courtship.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.7,

--- a/mods/tuxemon/db/technique/probiscus.json
+++ b/mods/tuxemon/db/technique/probiscus.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "xy",
-  "healing_power": 0,
-  "icon": "",
   "is_area": true,
   "is_fast": false,
   "potency": 0.5,

--- a/mods/tuxemon/db/technique/pseudopod.json
+++ b/mods/tuxemon/db/technique/pseudopod.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "x",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": null,

--- a/mods/tuxemon/db/technique/quicksand.json
+++ b/mods/tuxemon/db/technique/quicksand.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.8,

--- a/mods/tuxemon/db/technique/radiance.json
+++ b/mods/tuxemon/db/technique/radiance.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.6,

--- a/mods/tuxemon/db/technique/ram.json
+++ b/mods/tuxemon/db/technique/ram.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": null,

--- a/mods/tuxemon/db/technique/refresh.json
+++ b/mods/tuxemon/db/technique/refresh.json
@@ -8,7 +8,6 @@
   ],
   "flip_axes": "",
   "healing_power": 4,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/ring.json
+++ b/mods/tuxemon/db/technique/ring.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.1,

--- a/mods/tuxemon/db/technique/rock.json
+++ b/mods/tuxemon/db/technique/rock.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": null,

--- a/mods/tuxemon/db/technique/rot.json
+++ b/mods/tuxemon/db/technique/rot.json
@@ -7,8 +7,6 @@
     "enhance"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": true,
   "potency": 1,

--- a/mods/tuxemon/db/technique/ruby.json
+++ b/mods/tuxemon/db/technique/ruby.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.6,

--- a/mods/tuxemon/db/technique/rust_bomb.json
+++ b/mods/tuxemon/db/technique/rust_bomb.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": true,
   "is_fast": false,
   "potency": 0.5,

--- a/mods/tuxemon/db/technique/saber.json
+++ b/mods/tuxemon/db/technique/saber.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.9,

--- a/mods/tuxemon/db/technique/salamander.json
+++ b/mods/tuxemon/db/technique/salamander.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.8,

--- a/mods/tuxemon/db/technique/sand_spray.json
+++ b/mods/tuxemon/db/technique/sand_spray.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.2,

--- a/mods/tuxemon/db/technique/shadow_boxing.json
+++ b/mods/tuxemon/db/technique/shadow_boxing.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": null,

--- a/mods/tuxemon/db/technique/shapechange.json
+++ b/mods/tuxemon/db/technique/shapechange.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.7,

--- a/mods/tuxemon/db/technique/shrapnel.json
+++ b/mods/tuxemon/db/technique/shrapnel.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": true,
   "is_fast": true,
   "potency": null,

--- a/mods/tuxemon/db/technique/shuriken.json
+++ b/mods/tuxemon/db/technique/shuriken.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/sleep_bomb.json
+++ b/mods/tuxemon/db/technique/sleep_bomb.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/sleeping_powder.json
+++ b/mods/tuxemon/db/technique/sleeping_powder.json
@@ -7,8 +7,6 @@
     "enhance"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": true,
   "potency": 1,

--- a/mods/tuxemon/db/technique/slime.json
+++ b/mods/tuxemon/db/technique/slime.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.1,

--- a/mods/tuxemon/db/technique/snowstorm.json
+++ b/mods/tuxemon/db/technique/snowstorm.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": true,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/splinter.json
+++ b/mods/tuxemon/db/technique/splinter.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "x",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.2,

--- a/mods/tuxemon/db/technique/spray.json
+++ b/mods/tuxemon/db/technique/spray.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.2,

--- a/mods/tuxemon/db/technique/stabilo.json
+++ b/mods/tuxemon/db/technique/stabilo.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.9,

--- a/mods/tuxemon/db/technique/stampede.json
+++ b/mods/tuxemon/db/technique/stampede.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/starfall.json
+++ b/mods/tuxemon/db/technique/starfall.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.7,

--- a/mods/tuxemon/db/technique/static_field.json
+++ b/mods/tuxemon/db/technique/static_field.json
@@ -8,8 +8,6 @@
     "enhance"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/status_faint.json
+++ b/mods/tuxemon/db/technique/status_faint.json
@@ -2,7 +2,6 @@
   "animation": null,
   "effects": [],
   "flip_axes": "",
-  "icon": "",
   "power": 10,
   "sfx": "sfx_faint",
   "slug": "status_faint",

--- a/mods/tuxemon/db/technique/sting.json
+++ b/mods/tuxemon/db/technique/sting.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.2,

--- a/mods/tuxemon/db/technique/stone_rot.json
+++ b/mods/tuxemon/db/technique/stone_rot.json
@@ -7,8 +7,6 @@
     "enhance"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": true,
   "potency": 1,

--- a/mods/tuxemon/db/technique/stonehenge.json
+++ b/mods/tuxemon/db/technique/stonehenge.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.6,

--- a/mods/tuxemon/db/technique/strangulation.json
+++ b/mods/tuxemon/db/technique/strangulation.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.8,

--- a/mods/tuxemon/db/technique/strike.json
+++ b/mods/tuxemon/db/technique/strike.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "x",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": null,

--- a/mods/tuxemon/db/technique/suck_poison.json
+++ b/mods/tuxemon/db/technique/suck_poison.json
@@ -8,8 +8,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/sudden_glow.json
+++ b/mods/tuxemon/db/technique/sudden_glow.json
@@ -9,7 +9,6 @@
   ],
   "flip_axes": "",
   "healing_power": 2,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/sunburst.json
+++ b/mods/tuxemon/db/technique/sunburst.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.3,

--- a/mods/tuxemon/db/technique/supernova.json
+++ b/mods/tuxemon/db/technique/supernova.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "x",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/surge.json
+++ b/mods/tuxemon/db/technique/surge.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/sword.json
+++ b/mods/tuxemon/db/technique/sword.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.7,

--- a/mods/tuxemon/db/technique/sylvan.json
+++ b/mods/tuxemon/db/technique/sylvan.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.4,

--- a/mods/tuxemon/db/technique/take_cover.json
+++ b/mods/tuxemon/db/technique/take_cover.json
@@ -7,8 +7,6 @@
     "enhance"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/terror.json
+++ b/mods/tuxemon/db/technique/terror.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.1,

--- a/mods/tuxemon/db/technique/thunderball.json
+++ b/mods/tuxemon/db/technique/thunderball.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": null,

--- a/mods/tuxemon/db/technique/thunderclap.json
+++ b/mods/tuxemon/db/technique/thunderclap.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/time_crisis.json
+++ b/mods/tuxemon/db/technique/time_crisis.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.6,

--- a/mods/tuxemon/db/technique/tip.json
+++ b/mods/tuxemon/db/technique/tip.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.9,

--- a/mods/tuxemon/db/technique/tonguespear.json
+++ b/mods/tuxemon/db/technique/tonguespear.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "xy",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/torch.json
+++ b/mods/tuxemon/db/technique/torch.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.8,

--- a/mods/tuxemon/db/technique/touch.json
+++ b/mods/tuxemon/db/technique/touch.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.9,

--- a/mods/tuxemon/db/technique/tsunami.json
+++ b/mods/tuxemon/db/technique/tsunami.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.6,

--- a/mods/tuxemon/db/technique/tux_attack.json
+++ b/mods/tuxemon/db/technique/tux_attack.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.1,

--- a/mods/tuxemon/db/technique/ubuntu.json
+++ b/mods/tuxemon/db/technique/ubuntu.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.6,

--- a/mods/tuxemon/db/technique/undertaker.json
+++ b/mods/tuxemon/db/technique/undertaker.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.9,

--- a/mods/tuxemon/db/technique/venom.json
+++ b/mods/tuxemon/db/technique/venom.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.5,

--- a/mods/tuxemon/db/technique/venomous_tentacle.json
+++ b/mods/tuxemon/db/technique/venomous_tentacle.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/viper.json
+++ b/mods/tuxemon/db/technique/viper.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.4,

--- a/mods/tuxemon/db/technique/vorpal.json
+++ b/mods/tuxemon/db/technique/vorpal.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.9,

--- a/mods/tuxemon/db/technique/wall_fire.json
+++ b/mods/tuxemon/db/technique/wall_fire.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.8,

--- a/mods/tuxemon/db/technique/wall_ice.json
+++ b/mods/tuxemon/db/technique/wall_ice.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.8,

--- a/mods/tuxemon/db/technique/wall_of_steel.json
+++ b/mods/tuxemon/db/technique/wall_of_steel.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "x",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": true,
   "potency": 1,

--- a/mods/tuxemon/db/technique/wallow.json
+++ b/mods/tuxemon/db/technique/wallow.json
@@ -8,7 +8,6 @@
   ],
   "flip_axes": "",
   "healing_power": 4,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.5,

--- a/mods/tuxemon/db/technique/walls.json
+++ b/mods/tuxemon/db/technique/walls.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.2,

--- a/mods/tuxemon/db/technique/web.json
+++ b/mods/tuxemon/db/technique/web.json
@@ -7,8 +7,6 @@
     "damage"
   ],
   "flip_axes": "x",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 1,

--- a/mods/tuxemon/db/technique/webs_wind.json
+++ b/mods/tuxemon/db/technique/webs_wind.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": false,
   "potency": 0.3,

--- a/mods/tuxemon/db/technique/whirlwind.json
+++ b/mods/tuxemon/db/technique/whirlwind.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": true,
   "potency": null,

--- a/mods/tuxemon/db/technique/wing_tip.json
+++ b/mods/tuxemon/db/technique/wing_tip.json
@@ -6,8 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 0,
-  "icon": "",
   "is_area": false,
   "is_fast": true,
   "potency": null,

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -458,7 +458,7 @@ class TechSort(str, Enum):
 class TechniqueModel(BaseModel):
     slug: str = Field(..., description="The slug of the technique")
     sort: TechSort = Field(..., description="The sort of technique this is")
-    icon: str = Field(..., description="The icon to use for the technique")
+    icon: str = Field(None, description="The icon to use for the technique")
     conditions: Sequence[str] = Field(
         [], description="Conditions that must be met"
     )
@@ -515,6 +515,10 @@ class TechniqueModel(BaseModel):
     is_area: bool = Field(
         False, description="Whether or not this is an area of effect technique"
     )
+    randomly: bool = Field(
+        True, description="Whether or not this is a fast technique"
+    )
+    healing_power: int = Field(0, description="Value of healing power.")
     recharge: int = Field(0, description="Recharge of this technique")
     range: Range = Field(..., description="The attack range of this technique")
     tech_id: int = Field(..., description="The id of this technique")

--- a/tuxemon/item/effects/learn_mm.py
+++ b/tuxemon/item/effects/learn_mm.py
@@ -27,8 +27,9 @@ class LearnMmEffect(ItemEffect):
         filters = []
         for mov in techs:
             results = db.lookup(mov, table="technique")
-            if self.element in results.types:
-                filters.append(results.slug)
+            if results.randomly == True:
+                if self.element in results.types:
+                    filters.append(results.slug)
         # monster moves
         moves = []
         for tech in target.moves:

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -68,12 +68,14 @@ class Technique:
         self.images: Sequence[str] = []
         self.is_area = False
         self.is_fast = False
+        self.randomly = True
         self.link: Optional[Monster] = None
         self.name = ""
         self.next_use = 0
         self.potency = 0.0
         self.power = 1.0
         self.range = Range.melee
+        self.healing_power = 0
         self.recharge_length = 0
         self.repl_pos = ""
         self.repl_neg = ""
@@ -149,6 +151,8 @@ class Technique:
         self.repl_pos = results.repl_pos or self.repl_pos
 
         self.is_fast = results.is_fast or self.is_fast
+        self.randomly = results.randomly or self.randomly
+        self.healing_power = results.healing_power or self.healing_power
         self.recharge_length = results.recharge or self.recharge_length
         self.is_area = results.is_area or self.is_area
         self.range = results.range or Range.melee


### PR DESCRIPTION
PR introduce the field **randomly** in the **technique** json. The field is a simple bool, set on True. Maybe there are some techniques people are not interested in being taught randomly.

Issue pointed out by @Sanglorian  here: https://github.com/Tuxemon/Tuxemon/pull/1734#issuecomment-1501042280

At the moment only the future **surf** technique doesn't need to be taught randomly, but if there are others, then feel free to tell me. 

Set **healing_power** to **0** in db.py, deleted from all the JSONs where it was set 0.

tested, isort, black, no new typehints

learn_mm updated too, I'm going to tackle #1662 as soon as it gets merged in another PR, probably #1734 