### PR TITLE
avoid teach technique (level up)

### DIFF
--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -1237,6 +1237,11 @@ class CombatState(CombatAnimations):
     def learn(self, monster: Monster, tech: str) -> None:
         technique = Technique()
         technique.load(tech)
+        duplicate = [
+            mov for mov in monster.moves if mov.slug == technique.slug
+        ]
+        if duplicate:
+            return
         monster.learn(technique)
         self.alert(
             T.format(


### PR DESCRIPTION
PR inserts a small check inside combat.py
originally planned with #1662 (closed because pointless)

let's say rockitten is going to learn "xxx" at level 8
rockitten levels up
right now if rockitten knows "xxx" is going to learn again "xxx", 2 "xxx"
with this fix it doesn't happen anymore

tested, black, isort, no new typehints