### PR TITLE
restore effect (item) + has_status

### DIFF
--- a/tuxemon/item/conditions/has_status.py
+++ b/tuxemon/item/conditions/has_status.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Union
 
 from tuxemon.item.itemcondition import ItemCondition
 from tuxemon.monster import Monster
@@ -25,9 +26,26 @@ class HasStatusCondition(ItemCondition):
     """
 
     name = "has_status"
+    category: Union[str, None] = None
 
     def test(self, target: Monster) -> bool:
-        if target.status:
-            return True
+        if self.category:
+            if self.category == "positive" or self.category == "negative":
+                checking = [
+                    ele
+                    for ele in target.status
+                    if ele.category == self.category
+                ]
+                if checking:
+                    return True
+                else:
+                    return False
+            else:
+                raise ValueError(
+                    f"{self.category} must be positive or negative"
+                )
         else:
-            return False
+            if target.status:
+                return True
+            else:
+                return False

--- a/tuxemon/item/effects/restore.py
+++ b/tuxemon/item/effects/restore.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
+from tuxemon.monster import Monster
+
+
+class RestoreEffectResult(ItemEffectResult):
+    pass
+
+
+@dataclass
+class RestoreEffect(ItemEffect):
+    """
+    Remove any condition.
+
+    """
+
+    name = "restore"
+
+    def apply(self, target: Monster) -> RestoreEffectResult:
+        target.status.clear()
+        return {"success": True}

--- a/tuxemon/technique/effects/recover.py
+++ b/tuxemon/technique/effects/recover.py
@@ -42,7 +42,7 @@ class RecoverEffect(TechEffect):
         if tech.slug == "status_recover":
             # avoids Nonetype situation and reset the user
             if user is None:
-                user = status.link
+                user = tech.link
                 assert user
                 heal = formula.simple_recover(user)
                 user.current_hp += heal


### PR DESCRIPTION
PR:
- adds **restore** effect (item) -> it removes all the statuses;
- updates **has_status** condition (item) -> it adds the parameter positive/negative condition;
- fixes a small bug in **recover** (tech.link instead of status.link) -> crash cause;

restore because there is an item to add (Spyder) called Cureall and Restoration
both need the restore effect as well as the condition (to remove only the negative ones)

black, isort, tested, no new typehints