### PR TITLE
fix pathfind_to_player ( event action) and has_item (event condition)

### DIFF
--- a/tuxemon/event/actions/pathfind_to_player.py
+++ b/tuxemon/event/actions/pathfind_to_player.py
@@ -58,7 +58,7 @@ class PathfindToPlayerAction(EventAction):
             elif self.side == "right":
                 closest = (x + value, y)
                 self.npc.facing = "left"
-            if self.side == "left":
+            elif self.side == "left":
                 closest = (x - value, y)
                 self.npc.facing = "right"
             else:

--- a/tuxemon/event/conditions/has_item.py
+++ b/tuxemon/event/conditions/has_item.py
@@ -66,6 +66,6 @@ class HasItemCondition(EventCondition):
                     qty = int(condition.parameters[3])
                     return op(itm.quantity, operator, qty)
                 else:
-                    return False
+                    return True
         else:
             raise ValueError(f"{npc_slug} doesn't exist.")


### PR DESCRIPTION
PR
fixes **pathfind_to_player** (action) -> **elif** instead of **if**, it was causing crash;
fixes **has_item** (conditions) -> return True instead of False, because the item exists in the bag;

tested, isort, black, no new typehints