### PR TITLE
upgrade set_tuxepedia (action)

### DIFF
--- a/tuxemon/event/actions/set_tuxepedia.py
+++ b/tuxemon/event/actions/set_tuxepedia.py
@@ -27,14 +27,28 @@ class SetTuxepediaAction(EventAction):
     """
 
     name = "set_tuxepedia"
-    monster_key: str
-    monster_str: str
+    monster_slug: str
+    status: str
 
     def start(self) -> None:
         player = self.session.player.tuxepedia
+        caught = []
+        seen = []
+        for key, value in player.items():
+            if value == SeenStatus.seen:
+                seen.append(key)
+            if value == SeenStatus.caught:
+                caught.append(key)
 
         # Append the tuxepedia with a key
-        if self.monster_str == "caught":
-            player[str(self.monster_key)] = SeenStatus.caught
-        elif self.monster_str == "seen":
-            player[str(self.monster_key)] = SeenStatus.seen
+        if self.status == SeenStatus.caught:
+            if self.monster_slug not in caught:
+                player[str(self.monster_slug)] = SeenStatus.caught
+        elif self.status == SeenStatus.seen:
+            # to avoid setting seen a monster caught
+            if self.monster_slug in caught:
+                return
+            else:
+                player[str(self.monster_slug)] = SeenStatus.seen
+        else:
+            raise ValueError(f"{self.status} must be caught or seen")


### PR DESCRIPTION
During #1742 I encountered a limitation of set_tuxepedia. At the end of the Dojo, there is a some sort of sharing, where some info from Billie are given to the player. I realized that there was the concrete risk to screw up Tuxepedia (eg you have caught rockitten, but then it would have been set it as seen).

This PR solves the issue.
- renamed parameters (more clearly);
- inserted the check, so that if the monster is registered as **caught**, it cannot be set on **seen**

if someone wants to do it, then he or she can clear tuxepedia (with the apposite action) and then setting it again.

tested, black, isort, no new typehints