### PR TITLE
monster box (PC)

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -1946,6 +1946,12 @@ msgstr "Your bag is full, you cannot take any more from storage."
 msgid "menu_storage_empty_kennel"
 msgstr "This shelter is empty, there are no monsters to take."
 
+msgid "menu_storage_full_kennel"
+msgstr "This shelter is full."
+
+msgid "menu_storage_hidden_kennel"
+msgstr "Unable to access the hidden storage."
+
 msgid "menu_storage_empty_locker"
 msgstr "This locker is empty, there are no items to take."
 

--- a/tuxemon/states/pc_kennel/__init__.py
+++ b/tuxemon/states/pc_kennel/__init__.py
@@ -391,8 +391,21 @@ class MonsterBoxChooseDropOffState(MonsterBoxChooseState):
         menu_items_map = []
         for box_name, monsters in player.monster_boxes.items():
             if box_name not in HIDDEN_LIST:
-                menu_callback = self.change_state(
-                    "MonsterDropOffState", box_name=box_name
+                if len(monsters) <= MAX_BOX:
+                    menu_callback = self.change_state(
+                        "MonsterDropOffState", box_name=box_name
+                    )
+                else:
+                    menu_callback = partial(
+                        open_dialog,
+                        local_session,
+                        [T.translate("menu_storage_full_kennel")],
+                    )
+            else:
+                menu_callback = partial(
+                    open_dialog,
+                    local_session,
+                    [T.translate("menu_storage_hidden_kennel")],
                 )
             menu_items_map.append((box_name, menu_callback))
         return menu_items_map


### PR DESCRIPTION
PR adds the pop up "box is full" as well as a pop up "unable to access hidden storage".