### PR TITLE
check_effect_give (combat)

### DIFF
--- a/tuxemon/combat.py
+++ b/tuxemon/combat.py
@@ -49,11 +49,31 @@ def check_battle_legal(player: Player) -> bool:
 
 
 def check_status(monster: Monster, status_name: str) -> bool:
+    """
+    Checks to see if the monster has a specific status/condition.
+    """
     return any(t for t in monster.status if t.slug == status_name)
 
 
 def check_effect(technique: Technique, effect_name: str) -> bool:
+    """
+    Checks to see if the technique has a specific effect (eg ram -> damage).
+    """
     return any(t for t in technique.effects if t.name == effect_name)
+
+
+def check_effect_give(technique: Technique, status: str) -> bool:
+    """
+    Checks to see if the give effect has the corresponding status.
+    """
+    effect_name: str = "give"
+    find: bool = False
+    for ele in technique.effects:
+        if ele.name == effect_name:
+            output = getattr(ele, "condition")
+            if output == status:
+                find = True
+    return find
 
 
 def check_status_connected(monster: Monster) -> bool:

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -30,7 +30,7 @@ from tuxemon import audio, graphics, state, tools
 from tuxemon.animation import Task
 from tuxemon.battle import Battle
 from tuxemon.combat import (
-    check_effect,
+    check_effect_give,
     check_status,
     check_status_connected,
     defeated,
@@ -1298,14 +1298,14 @@ class CombatState(CombatAnimations):
         - eventually shows a text
         """
         # removes enraged
-        if check_status(monster, "status_enraged") and not check_effect(
-            technique, "enraged"
+        if check_status(monster, "status_enraged") and not check_effect_give(
+            technique, "status_enraged"
         ):
             monster.status.clear()
             return True
         # removes sniping
-        if check_status(monster, "status_sniping") and not check_effect(
-            technique, "sniping"
+        if check_status(monster, "status_sniping") and not check_effect_give(
+            technique, "status_sniping"
         ):
             monster.status.clear()
             return True
@@ -1325,8 +1325,8 @@ class CombatState(CombatAnimations):
             self._lost_status = label
             return True
         # change exhausted -> tired
-        if check_status(monster, "status_exhausted") and not check_effect(
-            technique, "exhausted"
+        if check_status(monster, "status_exhausted") and not check_effect_give(
+            technique, "status_exhausted"
         ):
             monster.status.clear()
             status = Technique()
@@ -1334,8 +1334,8 @@ class CombatState(CombatAnimations):
             monster.apply_status(status)
             return True
         # change charging -> charged up
-        if check_status(monster, "status_charging") and not check_effect(
-            technique, "charging"
+        if check_status(monster, "status_charging") and not check_effect_give(
+            technique, "status_charging"
         ):
             monster.status.clear()
             status = Technique()
@@ -1343,8 +1343,8 @@ class CombatState(CombatAnimations):
             monster.apply_status(status)
             return True
         # change charged up -> exhausted
-        if check_status(monster, "status_chargedup") and not check_effect(
-            technique, "chargedup"
+        if check_status(monster, "status_chargedup") and not check_effect_give(
+            technique, "status_chargedup"
         ):
             monster.status.clear()
             status = Technique()
@@ -1352,9 +1352,9 @@ class CombatState(CombatAnimations):
             monster.apply_status(status)
             return True
         # change nodding off -> dozing
-        if check_status(monster, "status_noddingoff") and not check_effect(
-            technique, "chargedup"
-        ):
+        if check_status(
+            monster, "status_noddingoff"
+        ) and not check_effect_give(technique, "status_noddingoff"):
             monster.status.clear()
             status = Technique()
             status.load("status_dozing")

--- a/tuxemon/technique/effects/give.py
+++ b/tuxemon/technique/effects/give.py
@@ -21,8 +21,8 @@ class GiveEffect(TechEffect):
     """
 
     name = "give"
-    _status: str
-    _obj: str
+    condition: str
+    objective: str
 
     def apply(
         self, tech: Technique, user: Monster, target: Monster
@@ -33,11 +33,11 @@ class GiveEffect(TechEffect):
         success = tech.potency >= potency and tech.accuracy >= value
         if success:
             status = Technique()
-            status.load(self._status)
+            status.load(self.condition)
             status.link = user
-            if self._obj == "user":
+            if self.objective == "user":
                 user.apply_status(status)
-            elif self._obj == "target":
+            elif self.objective == "target":
                 target.apply_status(status)
             return {"success": True}
 


### PR DESCRIPTION
Follows the last PR #1747 with `give status_xxx,target/user`

Needed to update the checking by creating **check_effect_give**.

Why? Let's say a technique has:
```
  "effects": [
    "give status_exhausted,target",
    "give status_exhausted,user",
    "damage"
  ],
```
**check_effect** is able to get **give** and **damage**
**check_effect_give** is able to get **status_exhausted** and **status_exhausted**
