### PR TITLE
fix check_moves (combat)

### DIFF
--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -1139,10 +1139,10 @@ class CombatState(CombatAnimations):
                 # it checks if there is a "level up"
                 if self._level_before != self._level_after:
                     diff = self._level_after - self._level_before
-                    # checks and eventually teaches move/moves
-                    self.check_moves(winners, diff)
-                    # updates hud graphics player and ai
                     if winners in self.players[0].monsters:
+                        # checks and eventually teaches move/moves
+                        self.check_moves(winners, diff)
+                        # updates hud graphics player
                         self.build_hud(
                             self._layout[self.players[0]]["hud"][0],
                             self.monsters_in_play[self.players[0]][0],


### PR DESCRIPTION
PR fixes an issue with **check_moves** in **combat.py**
PR changes the position after the if (where it checks if the winner is "our" monster)

we were able to catch this bug because of this #1731 , without this PR, the only was to trigger this bug was:
- trainer battle vs wild encounter
- we lose against an enemy monster (eg eyenemy lv 11 or whatever other monster ready to learn a new move at lv12)

tested, black, isort, no new typehints