### PR TITLE
festering effect

### DIFF
--- a/mods/tuxemon/db/technique/fester.json
+++ b/mods/tuxemon/db/technique/fester.json
@@ -4,7 +4,7 @@
   "animation": "drip_green",
   "effects": [
     "give status_poison,user",
-    "give status_poison,target",
+    "give status_festering,target",
     "damage"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/meltdown.json
+++ b/mods/tuxemon/db/technique/meltdown.json
@@ -3,6 +3,7 @@
   "accuracy": 0.3,
   "animation": "meltdown",
   "effects": [
+    "give status_festering,target",
     "damage"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/pseudopod.json
+++ b/mods/tuxemon/db/technique/pseudopod.json
@@ -3,6 +3,7 @@
   "accuracy": 1,
   "animation": "snake_right",
   "effects": [
+    "give status_festering,target",
     "damage"
   ],
   "flip_axes": "x",

--- a/mods/tuxemon/db/technique/slime.json
+++ b/mods/tuxemon/db/technique/slime.json
@@ -3,6 +3,7 @@
   "accuracy": 0.3,
   "animation": "sparks_green_alt",
   "effects": [
+    "give status_festering,target",
     "damage"
   ],
   "flip_axes": "",

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -1102,6 +1102,7 @@ class CombatState(CombatAnimations):
                         {"name": target.name.upper()},
                     )
                 self.alert(message)
+                self.suppress_phase_change(action_time)
 
     def faint_monster(self, monster: Monster) -> None:
         """


### PR DESCRIPTION
PR adds status_festering to a bunch of techniques.

as suggested by @Sanglorian [here](https://github.com/Tuxemon/Tuxemon/pull/1684#issuecomment-1508499541) 

added also **suppress_phase_change** after the status messages block in perform_action (as it happens for items and techniques), it helps to recognize the phrasing. A bit more of quality of life.