### PR TITLE
fix (sound errors and others)

### DIFF
--- a/mods/tuxemon/maps/rubberduck_city_01.tmx
+++ b/mods/tuxemon/maps/rubberduck_city_01.tmx
@@ -329,8 +329,8 @@
   </object>
   <object id="156" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act10" value="play_music JRPG_town_loop.ogg"/>
-    <property name="cond10" value="not music_playing JRPG_town_loop.ogg"/>
+    <property name="act10" value="play_music music_town_theme"/>
+    <property name="cond10" value="not music_playing music_town_theme"/>
    </properties>
   </object>
   <object id="169" name="secret place" type="event" x="480" y="128" width="16" height="16">

--- a/mods/tuxemon/maps/rubberduck_route_01.tmx
+++ b/mods/tuxemon/maps/rubberduck_route_01.tmx
@@ -185,8 +185,8 @@
  <objectgroup color="#ffff00" id="7" name="Events">
   <object id="7" name="Route Music" type="event" x="64" y="16" width="16" height="16">
    <properties>
-    <property name="act10" value="play_music peasant_kingdom.ogg"/>
-    <property name="cond10" value="not music_playing peasant_kingdom.ogg"/>
+    <property name="act10" value="play_music music_the_wild_places"/>
+    <property name="cond10" value="not music_playing music_the_wild_places"/>
    </properties>
   </object>
   <object id="8" name="Teleport to map1 (lower)" type="event" x="608" y="128" width="16" height="80">

--- a/mods/tuxemon/maps/spyder_dryadsgrove.tmx
+++ b/mods/tuxemon/maps/spyder_dryadsgrove.tmx
@@ -56,8 +56,8 @@
  <objectgroup color="#ffff00" id="6" name="Events">
   <object id="114" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music JRPG_mysticIsle.ogg"/>
-    <property name="cond1" value="not music_playing JRPG_mysticIsle.ogg"/>
+    <property name="act1" value="play_music music_mystic_island"/>
+    <property name="cond1" value="not music_playing music_mystic_island"/>
    </properties>
   </object>
   <object id="115" name="Teleport to Cotton Town" type="event" x="624" y="112" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_mansion.tmx
+++ b/mods/tuxemon/maps/spyder_mansion.tmx
@@ -127,8 +127,8 @@
   </object>
   <object id="30" name="Play Music" type="event" x="0" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music melody_eternal.ogg"/>
-    <property name="cond1" value="not music_playing melody_eternal.ogg"/>
+    <property name="act1" value="play_music music_mansion_theme"/>
+    <property name="cond1" value="not music_playing music_mansion_theme"/>
    </properties>
   </object>
   <object id="32" name="Teleport to Side Route" type="event" x="176" y="272" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_mansion_basement.tmx
+++ b/mods/tuxemon/maps/spyder_mansion_basement.tmx
@@ -99,8 +99,8 @@
   </object>
   <object id="37" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music melody_eternal.ogg"/>
-    <property name="cond1" value="not music_playing melody_eternal.ogg"/>
+    <property name="act1" value="play_music music_mansion_theme"/>
+    <property name="cond1" value="not music_playing music_mansion_theme"/>
    </properties>
   </object>
   <object id="40" name="Create Captain" type="event" x="48" y="64" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_mansion_top.tmx
+++ b/mods/tuxemon/maps/spyder_mansion_top.tmx
@@ -90,8 +90,8 @@
   </object>
   <object id="27" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music melody_eternal.ogg"/>
-    <property name="cond1" value="not music_playing melody_eternal.ogg"/>
+    <property name="act1" value="play_music music_mansion_theme"/>
+    <property name="cond1" value="not music_playing music_mansion_theme"/>
    </properties>
   </object>
   <object id="28" name="Player Spawn" type="event" x="32" y="224" width="16" height="16"/>

--- a/mods/tuxemon/maps/spyder_route5.tmx
+++ b/mods/tuxemon/maps/spyder_route5.tmx
@@ -78,8 +78,8 @@
   </object>
   <object id="18" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music peasant_kingdom.ogg"/>
-    <property name="cond1" value="not music_playing peasant_kingdom.ogg"/>
+    <property name="act1" value="play_music music_the_wild_places"/>
+    <property name="cond1" value="not music_playing music_the_wild_places"/>
    </properties>
   </object>
   <object id="20" name="encounter 3" type="event" x="400" y="64" width="96" height="112">

--- a/mods/tuxemon/maps/spyder_scoop1.tmx
+++ b/mods/tuxemon/maps/spyder_scoop1.tmx
@@ -152,8 +152,8 @@
  <objectgroup color="#ffff00" id="6" name="Event">
   <object id="10" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music JRPG_docks_loop.ogg"/>
-    <property name="cond1" value="not music_playing JRPG_docks_loop.ogg"/>
+    <property name="act1" value="play_music music_omnichannel"/>
+    <property name="cond1" value="not music_playing music_omnichannel"/>
    </properties>
   </object>
   <object id="11" name="Teleport to Timber Town" type="event" x="0" y="64" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_scoop2.tmx
+++ b/mods/tuxemon/maps/spyder_scoop2.tmx
@@ -46,8 +46,8 @@
  <objectgroup color="#ffff00" id="2" name="Events">
   <object id="1" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music JRPG_docks_loop.ogg"/>
-    <property name="cond1" value="not music_playing JRPG_docks_loop.ogg"/>
+    <property name="act1" value="play_music music_omnichannel"/>
+    <property name="cond1" value="not music_playing music_omnichannel"/>
    </properties>
   </object>
   <object id="2" name="Teleport to Scoop 1" type="event" x="0" y="64" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_scoop3.tmx
+++ b/mods/tuxemon/maps/spyder_scoop3.tmx
@@ -56,13 +56,13 @@
  </objectgroup>
  <objectgroup color="#ffff00" id="5" name="Event">
   <properties>
-   <property name="act1" value="play_music JRPG_docks_loop.ogg"/>
-   <property name="cond1" value="not music_playing JRPG_docks_loop.ogg"/>
+   <property name="act1" value="play_music music_omnichannel"/>
+   <property name="cond1" value="not music_playing music_omnichannel"/>
   </properties>
   <object id="1" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="play_music JRPG_docks_loop.ogg"/>
-    <property name="cond1" value="not music_playing JRPG_docks_loop.ogg"/>
+    <property name="act1" value="play_music music_omnichannel"/>
+    <property name="cond1" value="not music_playing music_omnichannel"/>
    </properties>
   </object>
   <object id="2" name="Teleport to Scoop 2" type="event" x="16" y="176" width="16" height="16">

--- a/tuxemon/event/actions/get_party_monsters.py
+++ b/tuxemon/event/actions/get_party_monsters.py
@@ -2,20 +2,16 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass
 from typing import Union, final
 
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 
-logger = logging.getLogger(__name__)
 
-
-# noinspection PyAttributeOutsideInit
 @final
 @dataclass
-class GetPlayerMonsterAction(EventAction):
+class GetPartyMonsterAction(EventAction):
     """
     Saves all the iids (party) in variables.
 

--- a/tuxemon/item/effects/restore.py
+++ b/tuxemon/item/effects/restore.py
@@ -39,10 +39,11 @@ class RestoreEffect(ItemEffect):
                     for ele in target.status
                     if ele.category == self.category
                 ]
+                # removes negative or positive statuses
                 if checking:
-                    return True
+                    target.status.clear()
                 else:
-                    return False
+                    pass
             else:
                 raise ValueError(
                     f"{self.category} must be positive or negative."


### PR DESCRIPTION
after bumping into the issue with #1758 , I checked the code.

PR fixes almost all the **unable to play music** messages
```
2023-04-15 16:16:06,323 - tuxemon.event.actions.play_music - ERROR - 'taking_poison.ogg'
2023-04-15 16:16:06,324 - tuxemon.event.actions.play_music - ERROR - unable to play music
```
still one: **Come and Find Me.ogg** in rubberduck_cave01

Update:
added a fix for **restore.py**. I got confused and put True/False return, but it was an effect where the status needs to be cleaned;
added a fix for **get_monster_party**. There was the old name.

the second I got it after double checking, now https://wiki.tuxemon.org/Event_Reference is updated. Inserted some new examples too.