### PR TITLE
cast uuid.hex into str + fix issue store_monster

### DIFF
--- a/tuxemon/battle.py
+++ b/tuxemon/battle.py
@@ -44,7 +44,7 @@ class Battle:
             if getattr(self, attr)
         }
 
-        save_data["instance_id"] = self.instance_id.hex
+        save_data["instance_id"] = str(self.instance_id.hex)
 
         return save_data
 

--- a/tuxemon/event/actions/breeding.py
+++ b/tuxemon/event/actions/breeding.py
@@ -35,15 +35,15 @@ class BreedingAction(EventAction):
         if menu_item.game_object.stage != "basic":
             if self.gender == "male":
                 if menu_item.game_object.gender == self.gender:
-                    self.player.game_variables[
-                        "breeding_father"
-                    ] = menu_item.game_object.instance_id.hex
+                    self.player.game_variables["breeding_father"] = str(
+                        menu_item.game_object.instance_id.hex
+                    )
                     self.session.client.pop_state()
             elif self.gender == "female":
                 if menu_item.game_object.gender == self.gender:
-                    self.player.game_variables[
-                        "breeding_mother"
-                    ] = menu_item.game_object.instance_id.hex
+                    self.player.game_variables["breeding_mother"] = str(
+                        menu_item.game_object.instance_id.hex
+                    )
                     self.session.client.pop_state()
 
     def start(self) -> None:

--- a/tuxemon/event/actions/get_party_monsters.py
+++ b/tuxemon/event/actions/get_party_monsters.py
@@ -38,4 +38,6 @@ class GetPartyMonsterAction(EventAction):
         assert trainer
         for mon in trainer.monsters:
             index = trainer.monsters.index(mon)
-            player.game_variables[f"iid_slot_{index}"] = mon.instance_id.hex
+            player.game_variables[f"iid_slot_{index}"] = str(
+                mon.instance_id.hex
+            )

--- a/tuxemon/event/actions/get_player_monster.py
+++ b/tuxemon/event/actions/get_player_monster.py
@@ -35,9 +35,9 @@ class GetPlayerMonsterAction(EventAction):
     variable_name: str
 
     def set_var(self, menu_item: MenuItem[Monster]) -> None:
-        self.session.player.game_variables[
-            self.variable_name
-        ] = menu_item.game_object.instance_id.hex
+        self.session.player.game_variables[self.variable_name] = str(
+            menu_item.game_object.instance_id.hex
+        )
         self.session.client.pop_state()
 
     def start(self) -> None:

--- a/tuxemon/event/actions/store_monster.py
+++ b/tuxemon/event/actions/store_monster.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Union, final
 
 from tuxemon.event.eventaction import EventAction
-from tuxemon.states.pc_kennel import HIDDEN
+from tuxemon.states.pc import KENNEL
 
 
 @final
@@ -47,9 +47,7 @@ class StoreMonsterAction(EventAction):
             )
 
         if box is None:
-            if HIDDEN not in player.monster_boxes.keys():
-                player.monster_boxes[HIDDEN] = list()
-            store = HIDDEN
+            store = KENNEL
         else:
             if box not in player.monster_boxes.keys():
                 raise ValueError(

--- a/tuxemon/event/actions/trading.py
+++ b/tuxemon/event/actions/trading.py
@@ -37,9 +37,9 @@ class TradingAction(EventAction):
 
     def set_var(self, menu_item: MenuItem[Monster]) -> None:
         if menu_item.game_object.slug == self.remove:
-            self.player.game_variables[
-                "trading_monster"
-            ] = menu_item.game_object.instance_id.hex
+            self.player.game_variables["trading_monster"] = str(
+                menu_item.game_object.instance_id.hex
+            )
             self.switch_monster()
 
     def switch_monster(self) -> None:

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -281,7 +281,7 @@ class Item:
             if getattr(self, attr)
         }
 
-        save_data["instance_id"] = self.instance_id.hex
+        save_data["instance_id"] = str(self.instance_id.hex)
 
         return save_data
 

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -754,7 +754,7 @@ class Monster:
             if getattr(self, attr)
         }
 
-        save_data["instance_id"] = self.instance_id.hex
+        save_data["instance_id"] = str(self.instance_id.hex)
 
         body = self.body.get_state()
         if body:

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -735,9 +735,9 @@ class CombatState(CombatAnimations):
         self.alert(message)
         # save iid monster fighting
         if player is self.players[0]:
-            self.players[0].game_variables[
-                "iid_fighting_monster"
-            ] = monster.instance_id.hex
+            self.players[0].game_variables["iid_fighting_monster"] = str(
+                monster.instance_id.hex
+            )
         elif self.is_trainer_battle:
             pass
         else:

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -373,7 +373,7 @@ class Technique:
             if getattr(self, attr)
         }
 
-        save_data["instance_id"] = self.instance_id.hex
+        save_data["instance_id"] = str(self.instance_id.hex)
 
         return save_data
 


### PR DESCRIPTION
PR
- casts all the instance_id.hex into str when saving (game_variables too), it could help to solve the issue on Windows saving;
- fix an issue with store_monster (it didn't send the monster in the right kennel);

tested, black, isort, no new typehints