### PR TITLE
painting events (Spyder)

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -5856,6 +5856,24 @@ msgstr "Welcome back. Shall I chuck your tuxemon in the healing unit?"
 msgid "spyder_cottonart_barmaid"
 msgstr "Do you like my set? \n They capture my early days as a professional tuxemon trainer, before I retired on my winnings. \n  I call them: 'Monsters' Eyes Meet', 'Starry, Starry, Starry Night' and 'Trepidation'. They're for sale! \n Get them while they're hot! Just 1,000 each."
 
+msgid "spyder_cottonart_barmaid_bundle"
+msgstr "Do you want to buy all three paintings for ${{currency}}3,000?"
+
+msgid "spyder_cottonart_barmaid_single"
+msgstr "Do you want to buy this painting for ${{currency}}1,000?"
+
+msgid "spyder_cottonart_barmaid_painting_sold"
+msgstr "The painting has been bought by ${{name}}! This is a copy!"
+
+msgid "spyder_cottonart_barmaid_painting_sold_billie"
+msgstr "The painting has been bought and donated back to the gallery by Billie!"
+
+msgid "spyder_cottonart_barmaid_bundle_sold"
+msgstr "It looks like you're my collector now! I'll replace the original with copies!"
+
+msgid "spyder_cottonart_billie"
+msgstr "I see you're trying to broaden your horizons. That's cute. Just try not to touch anything."
+
 msgid "spyder_cottonart_granny"
 msgstr "I must be getting nostalgic. I almost said \n \"Back in my day, things were better!\""
 
@@ -6433,6 +6451,8 @@ msgid "spyder_flower_muse1"
 msgstr "He's so hard on himself, never happy with something he's painted. He's so forgetful, too. Perhaps I could buy a painting "
 msgid "spyder_flower_muse2"
 msgstr "What? You have a painting. Oooh - would you let me buy it? I have ${{currency}}2,000."
+msgid "spyder_flower_muse4"
+msgstr "What? You have all the paintings. Oooh - would you let me buy it? I have ${{currency}}6,000."
 msgid "spyder_flower_artist_clipping"
 msgstr "A newspaper clipping is on the wall. It begins: \n \"The famous art critic has put away his poison pen and picked up the paint brush. \n After years of tearing down artists, can he do any better himself?\""
 msgid "spyder_flower_artist2"

--- a/mods/tuxemon/maps/spyder_candy_house1.tmx
+++ b/mods/tuxemon/maps/spyder_candy_house1.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="10" height="8" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="81">
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="10" height="8" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="83">
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
@@ -63,10 +63,11 @@
     <property name="cond1" value="not npc_exists spyder_maniac"/>
    </properties>
   </object>
-  <object id="69" name="Talk Maniac" type="event" x="48" y="80" width="16" height="16">
+  <object id="69" name="Talk Maniac Before" type="event" x="48" y="80" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_flower_artist1"/>
     <property name="behav1" value="talk spyder_maniac"/>
+    <property name="cond1" value="not variable_set muse_bought:yes"/>
    </properties>
   </object>
   <object id="70" name="Create Picnicker" type="event" x="128" y="80" width="16" height="16">
@@ -75,10 +76,129 @@
     <property name="cond1" value="not npc_exists spyder_picnicker"/>
    </properties>
   </object>
-  <object id="71" name="Talk Picnicker" type="event" x="128" y="64" width="16" height="16">
+  <object id="71" name="Talk Picnicker" type="event" x="112" y="16" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_flower_muse1"/>
     <property name="behav1" value="talk spyder_picnicker"/>
+    <property name="cond1" value="not has_item player,p_starry_night"/>
+    <property name="cond2" value="not has_item player,p_trepidation"/>
+    <property name="cond3" value="not has_item player,p_monsters_eyes"/>
+    <property name="cond4" value="not variable_set muse_bought:yes"/>
+   </properties>
+  </object>
+  <object id="72" name="Talk Picnicker" type="event" x="64" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_flower_muse1"/>
+    <property name="act2" value="translated_dialog spyder_flower_muse2"/>
+    <property name="act3" value="translated_dialog_choice yes:no,muse_starry"/>
+    <property name="behav1" value="talk spyder_picnicker"/>
+    <property name="cond1" value="is has_item player,p_starry_night"/>
+    <property name="cond2" value="not has_item player,p_trepidation"/>
+    <property name="cond3" value="not has_item player,p_monsters_eyes"/>
+    <property name="cond4" value="not variable_set muse_bought:yes"/>
+   </properties>
+  </object>
+  <object id="73" name="Talk Picnicker" type="event" x="144" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_flower_muse1"/>
+    <property name="act2" value="translated_dialog spyder_flower_muse2"/>
+    <property name="act3" value="translated_dialog_choice yes:no,muse_trepidation"/>
+    <property name="behav1" value="talk spyder_picnicker"/>
+    <property name="cond1" value="is has_item player,p_trepidation"/>
+    <property name="cond2" value="not has_item player,p_starry_night"/>
+    <property name="cond3" value="not has_item player,p_monsters_eyes"/>
+    <property name="cond4" value="not variable_set muse_bought:yes"/>
+   </properties>
+  </object>
+  <object id="74" name="Talk Picnicker" type="event" x="128" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_flower_muse1"/>
+    <property name="act2" value="translated_dialog spyder_flower_muse2"/>
+    <property name="act3" value="translated_dialog_choice yes:no,muse_monsters"/>
+    <property name="behav1" value="talk spyder_picnicker"/>
+    <property name="cond1" value="is has_item player,p_monsters_eyes"/>
+    <property name="cond2" value="not has_item player,p_starry_night"/>
+    <property name="cond3" value="not has_item player,p_trepidation"/>
+    <property name="cond4" value="not variable_set muse_bought:yes"/>
+   </properties>
+  </object>
+  <object id="75" name="Talk Starry" type="event" x="112" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="transfer_money +,2000"/>
+    <property name="act2" value="set_variable muse_bought:yes"/>
+    <property name="act3" value="add_item p_starry_night,-1"/>
+    <property name="cond1" value="is has_item player,p_starry_night"/>
+    <property name="cond2" value="not variable_set muse_bought:yes"/>
+    <property name="cond3" value="is variable_set muse_starry:yes"/>
+    <property name="cond4" value="not has_item player,p_trepidation"/>
+    <property name="cond5" value="not has_item player,p_monsters_eyes"/>
+   </properties>
+  </object>
+  <object id="76" name="Talk Trepidation" type="event" x="96" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="transfer_money +,2000"/>
+    <property name="act2" value="set_variable muse_bought:yes"/>
+    <property name="act3" value="add_item p_trepidation,-1"/>
+    <property name="cond1" value="is has_item player,p_trepidation"/>
+    <property name="cond2" value="not variable_set muse_bought:yes"/>
+    <property name="cond3" value="is variable_set muse_trepidation:yes"/>
+    <property name="cond4" value="not has_item player,p_monsters_eyes"/>
+    <property name="cond5" value="not has_item player,p_starry_night"/>
+   </properties>
+  </object>
+  <object id="77" name="Talk Monsters" type="event" x="80" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="transfer_money +,2000"/>
+    <property name="act2" value="set_variable muse_bought:yes"/>
+    <property name="act3" value="add_item p_monsters_eyes,-1"/>
+    <property name="cond1" value="is has_item player,p_monsters_eyes"/>
+    <property name="cond2" value="not variable_set muse_bought:yes"/>
+    <property name="cond3" value="is variable_set muse_monsters:yes"/>
+    <property name="cond4" value="not has_item player,p_trepidation"/>
+    <property name="cond5" value="not has_item player,p_starry_night"/>
+   </properties>
+  </object>
+  <object id="78" name="Talk Picnicker" type="event" x="32" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_flower_muse1"/>
+    <property name="act2" value="translated_dialog spyder_flower_muse4"/>
+    <property name="act3" value="translated_dialog_choice yes:no,muse_bundle"/>
+    <property name="behav1" value="talk spyder_picnicker"/>
+    <property name="cond1" value="is has_item player,p_starry_night"/>
+    <property name="cond2" value="is has_item player,p_trepidation"/>
+    <property name="cond3" value="is has_item player,p_monsters_eyes"/>
+    <property name="cond4" value="not variable_set muse_bought:yes"/>
+   </properties>
+  </object>
+  <object id="79" name="Talk Monsters" type="event" x="48" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="transfer_money +,6000"/>
+    <property name="act2" value="set_variable muse_bought:yes"/>
+    <property name="act3" value="add_item p_starry_night,-1"/>
+    <property name="act4" value="add_item p_trepidation,-1"/>
+    <property name="act5" value="add_item p_monsters_eyes,-1"/>
+    <property name="cond1" value="is variable_set muse_bundle:yes"/>
+    <property name="cond2" value="not variable_set muse_bought:yes"/>
+    <property name="cond3" value="is has_item player,p_starry_night"/>
+    <property name="cond4" value="is has_item player,p_trepidation"/>
+    <property name="cond5" value="is has_item player,p_monsters_eyes"/>
+   </properties>
+  </object>
+  <object id="81" name="Talk Picnicker Sold" type="event" x="96" y="16" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_flower_muse3"/>
+    <property name="behav1" value="talk spyder_picnicker"/>
+    <property name="cond1" value="not has_item player,p_starry_night"/>
+    <property name="cond2" value="not has_item player,p_trepidation"/>
+    <property name="cond3" value="not has_item player,p_monsters_eyes"/>
+    <property name="cond4" value="is variable_set muse_bought:yes"/>
+   </properties>
+  </object>
+  <object id="82" name="Talk Maniac After" type="event" x="32" y="80" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_flower_artist2"/>
+    <property name="behav1" value="talk spyder_maniac"/>
+    <property name="cond1" value="is variable_set muse_bought:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_cotton_artshop.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_artshop.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" width="20" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="35">
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" width="20" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="46">
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
@@ -102,10 +102,13 @@
     <property name="cond1" value="not npc_exists spyder_florist"/>
    </properties>
   </object>
-  <object id="26" name="Barmaid Talk" type="event" x="176" y="64" width="16" height="16">
+  <object id="26" name="Barmaid Sold Bundle" type="event" x="176" y="64" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_cottonart_barmaid"/>
+    <property name="act1" value="translated_dialog spyder_cottonart_barmaid_bundle_sold"/>
     <property name="behav1" value="talk spyder_cottontown_barmaid"/>
+    <property name="cond2" value="is has_item player,p_starry_night"/>
+    <property name="cond3" value="is has_item player,p_monsters_eyes"/>
+    <property name="cond4" value="is has_item player,p_trepidation"/>
    </properties>
   </object>
   <object id="27" name="Make Shopkeeper" type="event" x="64" y="144" width="16" height="16">
@@ -130,6 +133,10 @@
     <property name="cond2" value="is player_facing up"/>
     <property name="cond3" value="not variable_set paygallery:yes"/>
     <property name="cond4" value="not variable_set paygallery:no"/>
+    <property name="cond5" value="not variable_set bought_monsters_eyes:yes"/>
+    <property name="cond6" value="not variable_set bought_starry:yes"/>
+    <property name="cond7" value="not variable_set bought_trepidation:yes"/>
+    <property name="cond8" value="not variable_set bought_bundle:yes"/>
    </properties>
   </object>
   <object id="30" name="Pay" type="event" x="0" y="112" width="16" height="16">
@@ -145,6 +152,154 @@
     <property name="act1" value="pathfind player,2,10"/>
     <property name="act2" value="set_variable paygallery:null"/>
     <property name="cond1" value="is variable_set paygallery:no"/>
+   </properties>
+  </object>
+  <object id="35" name="Barmaid Sell Bundle Op" type="event" x="160" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_cottonart_barmaid"/>
+    <property name="act2" value="translated_dialog spyder_cottonart_barmaid_bundle"/>
+    <property name="act3" value="translated_dialog player_wallet"/>
+    <property name="act4" value="translated_dialog_choice yes:no,barmaid_sell_bundle"/>
+    <property name="behav1" value="talk spyder_cottontown_barmaid"/>
+    <property name="cond1" value="is money_is player,greater_or_equal,3000"/>
+    <property name="cond2" value="not has_item player,p_starry_night"/>
+    <property name="cond3" value="not has_item player,p_monsters_eyes"/>
+    <property name="cond4" value="not has_item player,p_trepidation"/>
+    <property name="cond5" value="not variable_set has_sold_paintings:yes"/>
+   </properties>
+  </object>
+  <object id="36" name="Barmaid Sell Starry" type="event" x="144" y="48" width="32" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog p_starry_night_description"/>
+    <property name="act2" value="translated_dialog spyder_cottonart_barmaid_single"/>
+    <property name="act3" value="translated_dialog player_wallet"/>
+    <property name="act4" value="translated_dialog_choice yes:no,barmaid_starry"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="not has_item player,p_starry_night"/>
+    <property name="cond4" value="is money_is player,greater_or_equal,1000"/>
+   </properties>
+  </object>
+  <object id="44" name="Player Bought Starry" type="event" x="144" y="48" width="32" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_cottonart_barmaid_painting_sold"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is has_item player,p_starry_night"/>
+   </properties>
+  </object>
+  <object id="37" name="Barmaid Sell Trepidation" type="event" x="176" y="48" width="32" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog p_trepidation_description"/>
+    <property name="act2" value="translated_dialog spyder_cottonart_barmaid_single"/>
+    <property name="act3" value="translated_dialog player_wallet"/>
+    <property name="act4" value="translated_dialog_choice yes:no,barmaid_trepidation"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="not has_item player,p_trepidation"/>
+    <property name="cond4" value="is money_is player,greater_or_equal,1000"/>
+   </properties>
+  </object>
+  <object id="45" name="Player Bought Starry" type="event" x="176" y="48" width="32" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_cottonart_barmaid_painting_sold"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is has_item player,p_trepidation"/>
+   </properties>
+  </object>
+  <object id="38" name="Barmaid Sell Monsters" type="event" x="112" y="48" width="32" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog p_monsters_eyes_description"/>
+    <property name="act2" value="translated_dialog spyder_cottonart_barmaid_single"/>
+    <property name="act3" value="translated_dialog player_wallet"/>
+    <property name="act4" value="translated_dialog_choice yes:no,barmaid_monsters"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="not has_item player,p_monsters_eyes"/>
+    <property name="cond4" value="is money_is player,greater_or_equal,1000"/>
+   </properties>
+  </object>
+  <object id="46" name="Player Bought Starry" type="event" x="112" y="48" width="32" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_cottonart_barmaid_painting_sold"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is has_item player,p_monsters_eyes"/>
+   </properties>
+  </object>
+  <object id="38" name="Barmaid Sell Monsters Op" type="event" x="112" y="32" width="32" height="16">
+   <properties>
+    <property name="act1" value="set_variable has_sold_painting:yes"/>
+    <property name="act2" value="add_item p_monsters_eyes"/>
+    <property name="act3" value="set_variable bought_monsters_eyes:yes"/>
+    <property name="act4" value="transfer_money -,1000"/>
+    <property name="cond1" value="is variable_set barmaid_monsters:yes"/>
+    <property name="cond2" value="not variable_set bought_monsters_eyes:yes"/>
+   </properties>
+  </object>
+  <object id="39" name="Barmaid Sell Starry Op" type="event" x="144" y="32" width="32" height="16">
+   <properties>
+    <property name="act1" value="set_variable has_sold_painting:yes"/>
+    <property name="act2" value="add_item p_starry_night"/>
+    <property name="act3" value="set_variable bought_starry:yes"/>
+    <property name="act4" value="transfer_money -,1000"/>
+    <property name="cond1" value="is variable_set barmaid_starry:yes"/>
+    <property name="cond2" value="not variable_set bought_starry:yes"/>
+   </properties>
+  </object>
+  <object id="40" name="Barmaid Sell Trepidation Op" type="event" x="176" y="32" width="32" height="16">
+   <properties>
+    <property name="act1" value="set_variable has_sold_painting:yes"/>
+    <property name="act2" value="add_item p_trepidation"/>
+    <property name="act3" value="set_variable bought_trepidation:yes"/>
+    <property name="act4" value="transfer_money -,1000"/>
+    <property name="cond1" value="is variable_set barmaid_trepidation:yes"/>
+    <property name="cond2" value="not variable_set bought_trepidation:yes"/>
+   </properties>
+  </object>
+  <object id="42" name="Barmaid Sell Bundle" type="event" x="112" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_variable has_sold_paintings:yes"/>
+    <property name="act10" value="add_item p_starry_night"/>
+    <property name="act11" value="add_item p_trepidation"/>
+    <property name="act12" value="add_item p_monsters_eyes"/>
+    <property name="act2" value="set_variable bought_bundle:yes"/>
+    <property name="act3" value="transfer_money -,3000"/>
+    <property name="cond1" value="is variable_set barmaid_sell_bundle:yes"/>
+    <property name="cond2" value="not variable_set bought_bundle:yes"/>
+   </properties>
+  </object>
+  <object id="43" name="Barmaid Sold Nothing" type="event" x="96" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_cottonart_barmaid"/>
+    <property name="behav1" value="talk spyder_cottontown_barmaid"/>
+    <property name="cond1" value="is money_is player,less_than,3000"/>
+    <property name="cond2" value="not has_item player,p_starry_night"/>
+    <property name="cond3" value="not has_item player,p_monsters_eyes"/>
+    <property name="cond4" value="not has_item player,p_trepidation"/>
+   </properties>
+  </object>
+  <object id="44" name="Player Bought Billie" type="event" x="48" y="48" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_cottonart_barmaid_painting_sold_billie"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+   </properties>
+  </object>
+  <object id="45" name="Billie Visit" type="event" x="48" y="64" width="16" height="48">
+   <properties>
+    <property name="act01" value="player_stop"/>
+    <property name="act02" value="lock_controls"/>
+    <property name="act03" value="create_npc spyder_billie,16,6"/>
+    <property name="act04" value="pathfind_to_player spyder_billie"/>
+    <property name="act05" value="translated_dialog spyder_cottonart_billie"/>
+    <property name="act15" value="pathfind spyder_billie,2,10"/>
+    <property name="act20" value="remove_npc spyder_billie"/>
+    <property name="act25" value="set_variable artshop_billie:yes"/>
+    <property name="act30" value="unlock_controls"/>
+    <property name="cond1" value="not variable_set artshop_billie:yes"/>
+    <property name="cond2" value="is player_at"/>
    </properties>
   </object>
  </objectgroup>

--- a/tuxemon/event/conditions/money_is.py
+++ b/tuxemon/event/conditions/money_is.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+from operator import eq, ge, gt, le, lt, ne
+
 from tuxemon.event import MapCondition
 from tuxemon.event.eventcondition import EventCondition
 from tuxemon.session import Session
@@ -18,8 +20,10 @@ class MoneyIsCondition(EventCondition):
 
     Script parameters:
         slug: Slug name (e.g. player or NPC, etc.).
-        operator: One of "==", "!=", ">", ">=", "<" or "<=".
-        amount: amoung of money
+        operator: Numeric comparison operator. Accepted values are "less_than",
+            "less_or_equal", "greater_than", "greater_or_equal", "equals"
+            and "not_equals".
+        amount: Amount of money
 
     """
 
@@ -46,19 +50,19 @@ class MoneyIsCondition(EventCondition):
 
         # Check if the condition is true
         if wallet in player.money:
-            if operator == "==":
-                return player.money[wallet] == int(amount)
-            elif operator == "!=":
-                return player.money[wallet] != int(amount)
-            elif operator == ">":
-                return player.money[wallet] > int(amount)
-            elif operator == ">=":
-                return player.money[wallet] >= int(amount)
-            elif operator == "<":
-                return player.money[wallet] < int(amount)
-            elif operator == "<=":
-                return player.money[wallet] <= int(amount)
+            if operator == "less_than":
+                return bool(lt(player.money[wallet], int(amount)))
+            elif operator == "less_or_equal":
+                return bool(le(player.money[wallet], int(amount)))
+            elif operator == "greater_than":
+                return bool(gt(player.money[wallet], int(amount)))
+            elif operator == "greater_or_equal":
+                return bool(ge(player.money[wallet], int(amount)))
+            elif operator == "equals":
+                return bool(eq(player.money[wallet], int(amount)))
+            elif operator == "not_equals":
+                return bool(ne(player.money[wallet], int(amount)))
             else:
-                raise ValueError(f"invalid operation type {operator}")
+                raise ValueError(f"{operator} is incorrect.")
         else:
             return False


### PR DESCRIPTION
PR adds painting events.

money_is part of #1726 

Painting events between Cotton and Candy are done. The player can buy: starry or monsters or trepidation or bundle (all 3).

the player can buy the bundle (all three) or each one by clicking on the painting. When bought it'll replace the text with.
![Screenshot from 2023-04-18 07-58-48](https://user-images.githubusercontent.com/64643719/232685040-52e81e88-d3e6-4b40-9c5e-78eacd42cffb.png)
added this here
![Screenshot from 2023-04-18 07-57-39](https://user-images.githubusercontent.com/64643719/232685046-1ce3d6a5-0b45-40f9-b5ad-2d5b5b711e37.png)
if the player buys all three paintings
![Screenshot from 2023-04-18 08-03-59](https://user-images.githubusercontent.com/64643719/232685824-3b1bc347-e458-4402-a54c-49e208440e85.png)