### PR TITLE
 gui size

### DIFF
--- a/tuxemon/menu/menu.py
+++ b/tuxemon/menu/menu.py
@@ -585,7 +585,7 @@ class Menu(Generic[T], state.State):
 
     def set_font(
         self,
-        size: int = 5,
+        size: int = 4,
         font: Optional[str] = None,
         color: ColorLike = (10, 10, 10),
         line_spacing: int = 10,


### PR DESCRIPTION
PR proposes to modify the value size in set_font (menu.py).

at the moment the value is 5, but my proposal is 4.

reason, the gui is too big. Moreover inside this def there is:
```
        if prepare.CONFIG.large_gui: <---------- it's a bool (true/false)
            self.font_size = tools.scale(size + 1)
        else:
            self.font_size = tools.scale(size)
```
so if someone decides for large gui, then it'll get 6 font size, more bigger than the actual.
if accepted the 4, the large gui will be 5 (the one we have right now)

![Screenshot from 2023-04-19 20-51-04](https://user-images.githubusercontent.com/64643719/233173631-5839207c-39e4-44d3-96ff-e37d82aaded6.png) 
in this case, smaller with value 4, we can help Latin languages too, we can fill it more stuff, we can also talk about monster names
![Screenshot from 2023-04-19 20-49-28](https://user-images.githubusercontent.com/64643719/233173641-164d3ed8-62f6-4f05-9d48-0c150615487c.png)
for confrontation, this is the actual large gui (value 6)
![Screenshot from 2023-04-19 21-08-14](https://user-images.githubusercontent.com/64643719/233176083-e47b0115-91ab-4436-b628-b9a8c00845fc.png)

![Screenshot from 2023-04-19 20-50-36](https://user-images.githubusercontent.com/64643719/233173638-e81a3e34-2bf6-4b17-a4ba-fb21bd1f05db.png)
at the moment we are obliged to put \n after 90 characters, here it'll help to fit more stuff
![Screenshot from 2023-04-19 20-49-12](https://user-images.githubusercontent.com/64643719/233173644-713d3599-d450-459a-b959-d4babdaf922f.png)

![Screenshot from 2023-04-19 20-48-51](https://user-images.githubusercontent.com/64643719/233173647-29c050ce-456f-4fc8-ae43-b7c853820d50.png)
same as above (description too)
![Screenshot from 2023-04-19 20-47-28](https://user-images.githubusercontent.com/64643719/233173651-fb609863-059b-4377-81d3-b7dfac0d4de4.png)

![Screenshot from 2023-04-19 20-47-00](https://user-images.githubusercontent.com/64643719/233173663-db2f97a6-6602-4689-a348-59b0da04f0bf.png)
this is important, because with this dimension of text we can consider to insert more details, above we are at the limit (without considering that a pop up "status" - like poison, etc. can fill all the space)
![Screenshot from 2023-04-19 20-48-18](https://user-images.githubusercontent.com/64643719/233173648-f72834bf-2b21-4623-a71f-7d2d664a5c7c.png)

What do you think @Sanglorian ? You know about our struggle to fit everything inside the dialogue box.