### PR TITLE
combat quality of life + fixes

### DIFF
--- a/tuxemon/combat.py
+++ b/tuxemon/combat.py
@@ -57,14 +57,14 @@ def has_status(monster: Monster, status_name: str) -> bool:
     return any(t for t in monster.status if t.slug == status_name)
 
 
-def check_effect(technique: Technique, effect_name: str) -> bool:
+def has_effect(technique: Technique, effect_name: str) -> bool:
     """
     Checks to see if the technique has a specific effect (eg ram -> damage).
     """
     return any(t for t in technique.effects if t.name == effect_name)
 
 
-def check_effect_give(technique: Technique, status: str) -> bool:
+def has_effect_give(technique: Technique, status: str) -> bool:
     """
     Checks to see if the give effect has the corresponding status.
     """

--- a/tuxemon/states/combat/combat_animations.py
+++ b/tuxemon/states/combat/combat_animations.py
@@ -268,7 +268,7 @@ class CombatAnimations(ABC, Menu[None]):
             del self.hud[monster]
 
         self.animate_monster_leave(monster)
-        self.suppress_phase_change(2)
+        self.suppress_phase_change()
         self.task(kill, 2)
 
         for monsters in self.monsters_in_play.values():

--- a/tuxemon/states/combat/combat_menus.py
+++ b/tuxemon/states/combat/combat_menus.py
@@ -330,7 +330,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                 return
 
             if (
-                combat.check_effect(technique, "damage")
+                combat.has_effect(technique, "damage")
                 and target == self.monster
             ):
                 params = {"name": self.monster.name}

--- a/tuxemon/states/items/__init__.py
+++ b/tuxemon/states/items/__init__.py
@@ -114,30 +114,26 @@ class ItemMenuState(Menu[Item]):
         item = menu_item.game_object
         state = self.determine_state_called_from()
 
-        if not any(
-            menu_item.game_object.validate(m)
-            for m in local_session.player.monsters
-        ):
+        if not any(item.validate(m) for m in local_session.player.monsters):
+            self.on_menu_selection_change()
             msg = T.format("item_no_available_target", {"name": item.name})
-            for i in menu_item.game_object.conditions:
+            for i in item.conditions:
                 if i.name == "location_inside":
+                    loc_inside = getattr(i, "location_inside")
                     msg = T.format(
                         "item_used_wrong_location_inside",
                         {
                             "name": item.name,
-                            "here": T.translate(
-                                i.__getattribute__("location_inside")
-                            ),
+                            "here": T.translate(loc_inside),
                         },
                     )
                 elif i.name == "location_type":
+                    loc_type = getattr(i, "location_type")
                     msg = T.format(
                         "item_used_wrong_location_type",
                         {
                             "name": item.name,
-                            "here": T.translate(
-                                i.__getattribute__("location_type")
-                            ),
+                            "here": T.translate(loc_type),
                         },
                     )
             tools.open_dialog(local_session, [msg])


### PR DESCRIPTION
PR addresses the combat quality of life (fix #1208) as well as the replacement of **__getattribute__** in init (item) and the renaming of a couple of **defs** (always has instead of check) and **restores** animations for conditions.

Now, regarding quality of life. It has always been an issue reading the text, but with some techniques was almost ok, while with others not at all. The source of the issue was: **action_time = 3** and specifically the fact that **action_time** didn't take in consideration that we have **different animations** and **different nr of frames** as well as if there are **additional texts** (eg the technique was resisted, etc)

POUND animation has 4 frames, short, text was load, time to read, almost acceptable.
SHIELD_ROCK animation has 16 frames, time to speed up, 3 seconds aren't enough, unacceptable.

Small example (log) while tracking a combat:
```
animation -> nr of frames
lance_ice 5
pound 4
shield_rock 16
bite 7
lightning_bolt_138 5
explosion_small 5
sparks_gold_alt 4
ruby 6
firelion_front 16
drip_green 7
```
It's clear with action_time 3.0 wasn't enough. That's why after thinking I replaced it with:
```
        action_time: float
        if isinstance(technique, Technique):
            diff = len(technique.images) * 0.25
            if diff < 3.0:
                action_time = 3.0
            elif diff > 4.0:
                action_time = 4.0
            else:
                action_time = diff
        else:
            action_time = 3.0
```
This will guarantee an acceptable span, let's take for instance **firelion_front (16 frames)**. So, 16*0.25 = 4 seconds, time to enjoy the animation. In this way we don't limit the number of frames.

But this wasn't enough, because there was an issue related to self.alert, the messages (like statuses) cut in half because of the speed, this is why I added: `letter_time: float = 0.02`
example:
```
                if technique.category == ItemCategory.potion and has_status(
                    target, "status_festering"
                ):
                    tmpl = T.translate("combat_state_festering_item")
                if template:
                    message += "\n" + tmpl
                    action_time += len(message) * letter_time
```
festering message is 37 characters, so 0.74 (37 x 0.02), so in total (previous 3), it'll give almost an 3.74 seconds to load and read the message. Result? No more cutting.

Now, I don't care much about these numbers (3 and 0.02), I just run some testing and I noticed it was acceptable.
At the end these are only numbers, we can change, adjust, but at least now we have the method to say "this is too fast" or "this is too slow" or "we want to decide our speed" or "we want the values in config", that's fine, after this PR it'll be possible to do it.

black, isort, tested, no new typehints