### PR TITLE
track cathedral

### DIFF
--- a/mods/tuxemon/maps/cotton_cathedral.tmx
+++ b/mods/tuxemon/maps/cotton_cathedral.tmx
@@ -80,6 +80,7 @@
    <properties>
     <property name="act10" value="set_monster_health"/>
     <property name="act20" value="set_monster_status"/>
+    <property name="act25" value="variable_math cathedral_ads,+,1"/>
     <property name="act30" value="translated_dialog okaythen"/>
     <property name="act40" value="npc_face tabanurse,up"/>
     <property name="act50" value="wait 1"/>
@@ -95,6 +96,7 @@
     <property name="act1" value="set_monster_health"/>
     <property name="act2" value="set_monster_status"/>
     <property name="act3" value="set_variable teleport_clinic:none"/>
+    <property name="act4" value="variable_math cathedral_ads,+,1"/>
     <property name="cond1" value="is variable_set teleport_clinic:lost"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/healing_center.tmx
+++ b/mods/tuxemon/maps/healing_center.tmx
@@ -68,6 +68,7 @@
    <properties>
     <property name="act10" value="set_monster_health"/>
     <property name="act20" value="set_monster_status"/>
+    <property name="act25" value="variable_math cathedral_ads,+,1"/>
     <property name="act30" value="translated_dialog okaythen"/>
     <property name="act40" value="npc_face tabanurse,up"/>
     <property name="act50" value="wait 3"/>
@@ -129,6 +130,7 @@
     <property name="act1" value="set_monster_health"/>
     <property name="act2" value="set_monster_status"/>
     <property name="act3" value="set_variable teleport_clinic:none"/>
+    <property name="act4" value="variable_math cathedral_ads,+,1"/>
     <property name="cond1" value="is variable_set teleport_clinic:lost"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/sphalian_center.tmx
+++ b/mods/tuxemon/maps/sphalian_center.tmx
@@ -48,6 +48,7 @@
    <properties>
     <property name="act1" value="set_monster_health"/>
     <property name="act2" value="set_monster_status"/>
+    <property name="act3" value="variable_math cathedral_ads,+,1"/>
     <property name="act20" value="translated_dialog okaythen"/>
     <property name="act30" value="npc_face tabanurse,up"/>
     <property name="act40" value="wait 1"/>
@@ -94,6 +95,7 @@
     <property name="act1" value="set_monster_health"/>
     <property name="act2" value="set_monster_status"/>
     <property name="act3" value="set_variable teleport_clinic:none"/>
+    <property name="act4" value="variable_math cathedral_ads,+,1"/>
     <property name="cond1" value="is variable_set teleport_clinic:lost"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_candy_center.tmx
+++ b/mods/tuxemon/maps/spyder_candy_center.tmx
@@ -54,6 +54,7 @@
    <properties>
     <property name="act1" value="set_monster_health"/>
     <property name="act2" value="set_monster_status"/>
+    <property name="act3" value="variable_math cathedral_ads,+,1"/>
     <property name="act20" value="translated_dialog okaythen"/>
     <property name="act30" value="npc_face tabanurse,up"/>
     <property name="act40" value="wait 1"/>
@@ -112,6 +113,7 @@
     <property name="act1" value="set_monster_health"/>
     <property name="act2" value="set_monster_status"/>
     <property name="act3" value="set_variable teleport_clinic:none"/>
+    <property name="act4" value="variable_math cathedral_ads,+,1"/>
     <property name="cond1" value="is variable_set teleport_clinic:lost"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_flower_center.tmx
+++ b/mods/tuxemon/maps/spyder_flower_center.tmx
@@ -48,6 +48,7 @@
    <properties>
     <property name="act1" value="set_monster_health"/>
     <property name="act2" value="set_monster_status"/>
+    <property name="act3" value="variable_math cathedral_ads,+,1"/>
     <property name="act20" value="translated_dialog okaythen"/>
     <property name="act30" value="npc_face tabanurse,up"/>
     <property name="act40" value="wait 1"/>
@@ -98,6 +99,7 @@
     <property name="act1" value="set_monster_health"/>
     <property name="act2" value="set_monster_status"/>
     <property name="act3" value="set_variable teleport_clinic:none"/>
+    <property name="act4" value="variable_math cathedral_ads,+,1"/>
     <property name="cond1" value="is variable_set teleport_clinic:lost"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_healing_center.tmx
+++ b/mods/tuxemon/maps/spyder_healing_center.tmx
@@ -48,6 +48,7 @@
    <properties>
     <property name="act1" value="set_monster_health"/>
     <property name="act2" value="set_monster_status"/>
+    <property name="act3" value="variable_math cathedral_ads,+,1"/>
     <property name="act20" value="translated_dialog okaythen"/>
     <property name="act30" value="npc_face tabanurse,up"/>
     <property name="act40" value="wait 1"/>
@@ -98,6 +99,7 @@
     <property name="act1" value="set_monster_health"/>
     <property name="act2" value="set_monster_status"/>
     <property name="act3" value="set_variable teleport_clinic:none"/>
+    <property name="act4" value="variable_math cathedral_ads,+,1"/>
     <property name="cond1" value="is variable_set teleport_clinic:lost"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_leather_center.tmx
+++ b/mods/tuxemon/maps/spyder_leather_center.tmx
@@ -48,6 +48,7 @@
    <properties>
     <property name="act1" value="set_monster_health"/>
     <property name="act2" value="set_monster_status"/>
+    <property name="act3" value="variable_math cathedral_ads,+,1"/>
     <property name="act20" value="translated_dialog okaythen"/>
     <property name="act30" value="npc_face tabanurse,up"/>
     <property name="act40" value="wait 1"/>
@@ -99,6 +100,7 @@
     <property name="act1" value="set_monster_health"/>
     <property name="act2" value="set_monster_status"/>
     <property name="act3" value="set_variable teleport_clinic:none"/>
+    <property name="act4" value="variable_math cathedral_ads,+,1"/>
     <property name="cond1" value="is variable_set teleport_clinic:lost"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_timber_center.tmx
+++ b/mods/tuxemon/maps/spyder_timber_center.tmx
@@ -48,6 +48,7 @@
    <properties>
     <property name="act1" value="set_monster_health"/>
     <property name="act2" value="set_monster_status"/>
+    <property name="act3" value="variable_math cathedral_ads,+,1"/>
     <property name="act20" value="translated_dialog okaythen"/>
     <property name="act30" value="npc_face tabanurse,up"/>
     <property name="act40" value="wait 1"/>
@@ -98,6 +99,7 @@
     <property name="act1" value="set_monster_health"/>
     <property name="act2" value="set_monster_status"/>
     <property name="act3" value="set_variable teleport_clinic:none"/>
+    <property name="act4" value="variable_math cathedral_ads,+,1"/>
     <property name="cond1" value="is variable_set teleport_clinic:lost"/>
    </properties>
   </object>

--- a/tuxemon/save_upgrader.py
+++ b/tuxemon/save_upgrader.py
@@ -60,6 +60,8 @@ def upgrade_save(save_data: Dict[str, Any]) -> SaveData:
             save_data["game_variables"]["billie_choice"] = random.choice(
                 starter
             )
+    if "cathedral_ads" not in save_data["game_variables"]:
+        save_data["game_variables"]["cathedral_ads"] = 0
     if "steps" not in save_data["game_variables"]:
         save_data["game_variables"]["steps"] = 0
     if "gender_choice" not in save_data["game_variables"]:


### PR DESCRIPTION
Related to #1782 

The PR implements the tracking inside the cathedral centers.
It creates a game variable called "cathedral_ads" and this will be incremented each time the player visits the center (+1) (healing by replying Y).

@Sanglorian open issues:
- auto-healing increases the counter? Y/N
- do we need to show it in the player menu? Y/N (no issue at all, like 3 lines of code, I need only the sentence like "visited cathedral centers xxx times")