### PR TITLE
typehints (npc_face and player_face)

### DIFF
--- a/tuxemon/event/actions/npc_face.py
+++ b/tuxemon/event/actions/npc_face.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import final
+from typing import cast, final
 
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
-from tuxemon.map import dirs2, get_direction
+from tuxemon.map import Direction, dirs2, get_direction
 from tuxemon.npc import NPC
 
 
@@ -47,5 +47,5 @@ class NpcFaceAction(EventAction):
                 assert maybe_target
                 target = maybe_target
             direction = get_direction(npc.tile_pos, target.tile_pos)
-
-        npc.facing = direction
+        # Pending https://github.com/python/mypy/issues/9718
+        npc.facing = cast(Direction, direction)

--- a/tuxemon/event/actions/player_face.py
+++ b/tuxemon/event/actions/player_face.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import final
+from typing import cast, final
 
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
-from tuxemon.map import dirs2, get_direction
+from tuxemon.map import Direction, dirs2, get_direction
 from tuxemon.states.world.worldstate import WorldState
 
 
@@ -45,8 +45,8 @@ class PlayerFaceAction(EventAction):
         # If we're doing a transition, only change the player's facing when
         # we've reached the apex of the transition.
         world_state = self.session.client.get_state_by_name(WorldState)
-
+        # Pending https://github.com/python/mypy/issues/9718
         if world_state.in_transition:
-            world_state.delayed_facing = direction
+            world_state.delayed_facing = cast(Direction, direction)
         else:
-            self.session.player.facing = direction
+            self.session.player.facing = cast(Direction, direction)


### PR DESCRIPTION
PR addresses the typehints in **npc_face** and **player_face** #1211 

it applies the same solution as **npc_move** by casting the values as Direction.

By the way, the issue is still open on mypy, but it looks like something is moving.

tested, black, isort