### PR TITLE
surfable map + fishing

### DIFF
--- a/mods/tuxemon/db/item/fishing_rod.json
+++ b/mods/tuxemon/db/item/fishing_rod.json
@@ -1,5 +1,10 @@
 {
-  "effects": [],
+  "conditions": [
+    "is facing_tile surfable"
+  ],
+  "effects": [
+    "fishing basic"
+  ],
   "slug": "fishing_rod",
   "sort": "utility",
   "sprite": "gfx/items/fishing_rod.png",
@@ -17,7 +22,7 @@
   "usable_in": [
     "WorldState"
   ],
-  "use_failure": "generic_failure",
+  "use_failure": "fishing_rod_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"
 }

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -4227,6 +4227,13 @@ msgstr "Acolyte Corren"
 
 ## DIALOG TRANSLATIONS ##
 # general dialogs
+
+msgid "fishing_rod_failure"
+msgstr "The water ripples, but nothing bites."
+
+msgid "itsswimmingtime"
+msgstr "Do you want to swim?"
+
 msgid "haveagoodday"
 msgstr "Have a good day!"
 

--- a/mods/tuxemon/maps/spyder_candy_town.tmx
+++ b/mods/tuxemon/maps/spyder_candy_town.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="436">
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="440">
  <properties>
   <property name="east" value="routec"/>
   <property name="edges" value="clamped"/>
@@ -501,6 +501,37 @@
     <property name="act2" value="player_face up"/>
     <property name="cond1" value="is player_at"/>
     <property name="cond2" value="is player_facing up"/>
+   </properties>
+  </object>
+  <object id="436" name="Choice Surf" type="event" x="624" y="576" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog itsswimmingtime"/>
+    <property name="act2" value="translated_dialog_choice yes:no,swimming"/>
+    <property name="cond1" value="is has_item player,surfboard"/>
+    <property name="cond2" value="is player_facing_tile surfable"/>
+    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond4" value="not player_in surfable"/>
+   </properties>
+  </object>
+  <object id="437" name="surfable" type="event" x="592" y="576" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_player_template swimmer"/>
+    <property name="cond1" value="is player_in surfable"/>
+    <property name="cond2" value="not has_sprite swimmer"/>
+   </properties>
+  </object>
+  <object id="438" name="not surfable" type="event" x="576" y="576" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_player_template default"/>
+    <property name="act2" value="set_variable swimming:no"/>
+    <property name="cond1" value="not player_in surfable"/>
+    <property name="cond2" value="is has_sprite swimmer"/>
+   </properties>
+  </object>
+  <object id="439" name="Remove Obstacle" type="event" x="608" y="576" width="16" height="16">
+   <properties>
+    <property name="act1" value="remove_collision water"/>
+    <property name="cond1" value="is variable_set swimming:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_paper_town.tmx
+++ b/mods/tuxemon/maps/spyder_paper_town.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="466">
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="471">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="north" value="route1"/>
@@ -115,6 +115,7 @@
     <property name="key" value="water"/>
    </properties>
   </object>
+  <object id="470" type="collision" x="64" y="256" width="16" height="16"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="7" name="Events">
   <object id="335" name="Mart Sign" type="event" x="256" y="192" width="16" height="16">
@@ -481,10 +482,35 @@
     <property name="cond2" value="is party_size less_than,1"/>
    </properties>
   </object>
-  <object id="465" name="Remove obstacle 1" type="event" x="160" y="304" width="16" height="16">
+  <object id="465" name="Choice Surf" type="event" x="160" y="304" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog itsswimmingtime"/>
+    <property name="act2" value="translated_dialog_choice yes:no,swimming"/>
+    <property name="cond1" value="is has_item player,surfboard"/>
+    <property name="cond2" value="is player_facing_tile surfable"/>
+    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond4" value="not player_in surfable"/>
+   </properties>
+  </object>
+  <object id="466" name="surfable" type="event" x="128" y="304" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_player_template swimmer"/>
+    <property name="cond1" value="is player_in surfable"/>
+    <property name="cond2" value="not has_sprite swimmer"/>
+   </properties>
+  </object>
+  <object id="467" name="not surfable" type="event" x="112" y="304" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_player_template default"/>
+    <property name="act2" value="set_variable swimming:no"/>
+    <property name="cond1" value="not player_in surfable"/>
+    <property name="cond2" value="is has_sprite swimmer"/>
+   </properties>
+  </object>
+  <object id="468" name="Remove Obstacle" type="event" x="144" y="304" width="16" height="16">
    <properties>
     <property name="act1" value="remove_collision water"/>
-    <property name="cond1" value="is has_item player,surfboard"/>
+    <property name="cond1" value="is variable_set swimming:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/tuxemon/event/actions/set_player_template.py
+++ b/tuxemon/event/actions/set_player_template.py
@@ -30,7 +30,7 @@ class SetPlayerTemplateAction(EventAction):
             set_player_template <sprite>[,combat_front]
 
     Script parameters:
-        sprite: must be inside mods/tuxemon/sprites,
+        sprite: must be inside mods/tuxemon/sprites (default = original)
         eg: adventurer_brown_back.png -> adventurer
         combat_front: must be inside mods/tuxemon/gfx/sprites/player
         eg: adventurer.png -> adventurer
@@ -44,7 +44,16 @@ class SetPlayerTemplateAction(EventAction):
     def start(self) -> None:
         player = self.session.player
         for ele in player.template:
-            ele.sprite_name = self.sprite
+            # repristinate default sprite (gender_choice)
+            if self.sprite == "default":
+                if player.game_variables["gender_choice"] == "gender_male":
+                    ele.sprite_name = "adventurer"
+                elif player.game_variables["gender_choice"] == "gender_female":
+                    ele.sprite_name = "heroine"
+                else:
+                    ele.sprite_name = player.game_variables["gender_choice"]
+            else:
+                ele.sprite_name = self.sprite
             if self.combat_front is not None:
                 ele.combat_front = self.combat_front
         player.load_sprites()

--- a/tuxemon/event/conditions/has_sprite.py
+++ b/tuxemon/event/conditions/has_sprite.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+
+from tuxemon.event import MapCondition
+from tuxemon.event.eventcondition import EventCondition
+from tuxemon.session import Session
+
+
+class HasSpriteCondition(EventCondition):
+    """
+    Check to see if a NPC has a specific sprite.
+
+    Script usage:
+        .. code-block::
+
+            is has_sprite <sprite>
+
+    Script parameters:
+        sprite: Sprite slug (eg. adventurer, heroine, swimmer, etc.)
+
+    """
+
+    name = "has_sprite"
+
+    def test(self, session: Session, condition: MapCondition) -> bool:
+        player = session.player
+        if player.sprite_name == condition.parameters[0]:
+            return True
+        else:
+            return False

--- a/tuxemon/event/conditions/player_facing_tile.py
+++ b/tuxemon/event/conditions/player_facing_tile.py
@@ -7,6 +7,7 @@ import logging
 from tuxemon.event import MapCondition
 from tuxemon.event.eventcondition import EventCondition
 from tuxemon.session import Session
+from tuxemon.states.world.worldstate import WorldState
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +19,10 @@ class PlayerFacingTileCondition(EventCondition):
     Script usage:
         .. code-block::
 
-            is player_facing_tile
+            is player_facing_tile [value]
+
+    Script parameters:
+        value: value (eg surfable) inside the tileset.
 
     """
 
@@ -43,6 +47,13 @@ class PlayerFacingTileCondition(EventCondition):
             for h in range(0, condition.height)
         ]
         tile_location = None
+
+        # check if the NPC is facing a specific set of tiles
+        world = session.client.get_state_by_name(WorldState)
+        if condition.parameters:
+            prop = condition.parameters[0]
+            if prop == "surfable":
+                tiles = list(world.surfable_map)
 
         # Next, we check the player position and see if we're one tile
         # away from the tile.

--- a/tuxemon/event/conditions/player_in.py
+++ b/tuxemon/event/conditions/player_in.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from tuxemon.event import MapCondition
+from tuxemon.event.eventcondition import EventCondition
+from tuxemon.session import Session
+from tuxemon.states.world.worldstate import WorldState
+
+
+class PlayerInCondition(EventCondition):
+    """
+    Check to see if the player is at the condition position
+    on a specific set of tiles.
+
+    Script usage:
+        .. code-block::
+
+            is player_in <value>
+
+    Script parameters:
+        value: value (eg surfable) inside the tileset.
+
+    """
+
+    name = "player_in"
+
+    def test(self, session: Session, condition: MapCondition) -> bool:
+        player = session.player
+        prop = condition.parameters[0]
+        world = session.client.get_state_by_name(WorldState)
+
+        if prop == "surfable":
+            if player.tile_pos in world.surfable_map:
+                return True
+            else:
+                return False
+        else:
+            raise ValueError(f"{prop} isn't valid.")

--- a/tuxemon/item/conditions/facing_tile.py
+++ b/tuxemon/item/conditions/facing_tile.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tuxemon.item.itemcondition import ItemCondition
+from tuxemon.monster import Monster
+from tuxemon.states.world.worldstate import WorldState
+
+
+@dataclass
+class FacingTileCondition(ItemCondition):
+    """
+    Checks if the player is facing specific tiles.
+
+    """
+
+    name = "facing_tile"
+    facing_tile: str
+
+    def test(self, target: Monster) -> bool:
+        player = self.session.player
+        client = self.session.client
+        tiles = []
+        tile_location = None
+
+        # check if the NPC is facing a specific set of tiles
+        world = client.get_state_by_name(WorldState)
+        if self.facing_tile == "surfable":
+            tiles = list(world.surfable_map)
+
+        # Next, we check the player position and see if we're one tile
+        # away from the tile.
+        for coordinates in tiles:
+            if coordinates[1] == player.tile_pos[1]:
+                # Check to see if the tile is to the left of the player
+                if coordinates[0] == player.tile_pos[0] - 1:
+                    tile_location = "left"
+                # Check to see if the tile is to the right of the player
+                elif coordinates[0] == player.tile_pos[0] + 1:
+                    tile_location = "right"
+
+            elif coordinates[0] == player.tile_pos[0]:
+                # Check to see if the tile is above the player
+                if coordinates[1] == player.tile_pos[1] - 1:
+                    tile_location = "up"
+                elif coordinates[1] == player.tile_pos[1] + 1:
+                    tile_location = "down"
+
+            # Then we check to see if we're facing the Tile
+            if player.facing == tile_location:
+                return True
+
+        return False

--- a/tuxemon/item/effects/fishing.py
+++ b/tuxemon/item/effects/fishing.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+
+from tuxemon.db import EvolutionStage, MonsterShape, db
+from tuxemon.event.actions.wild_encounter import WildEncounterAction
+from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
+from tuxemon.monster import Monster
+
+
+class FishingEffectResult(ItemEffectResult):
+    pass
+
+
+@dataclass
+class FishingEffect(ItemEffect):
+    """This effect triggers fishing."""
+
+    name = "fishing"
+    value: str
+
+    def apply(self, target: Monster) -> FishingEffectResult:
+        # level of the rod
+        levels = ["basic", "advanced", "pro"]
+        if self.value not in levels:
+            raise ValueError(f"{self.value} must be bas, adv or pro")
+
+        # define random encounters
+        bas = []
+        adv = []
+        pro = []
+        monsters = list(db.database["monster"])
+        for mon in monsters:
+            results = db.lookup(mon, table="monster")
+            if results.txmn_id > 0:
+                if results.stage == EvolutionStage.basic:
+                    if (
+                        results.shape == MonsterShape.polliwog
+                        or results.shape == MonsterShape.aquatic
+                    ):
+                        bas.append(results.slug)
+                if (
+                    results.stage == EvolutionStage.stage1
+                    or results.stage == EvolutionStage.basic
+                ):
+                    if (
+                        results.shape == MonsterShape.polliwog
+                        or results.shape == MonsterShape.aquatic
+                    ):
+                        adv.append(results.slug)
+                if results.stage != EvolutionStage.basic:
+                    if (
+                        results.shape == MonsterShape.polliwog
+                        or results.shape == MonsterShape.aquatic
+                        or results.shape == MonsterShape.leviathan
+                    ):
+                        pro.append(results.slug)
+
+        # bait probability
+        bait = random.randint(1, 100)
+        if self.value == "basic":
+            if bait <= 35:
+                mon_slug = random.choice(bas)
+                level = random.randint(5, 15)
+                WildEncounterAction(
+                    monster_slug=mon_slug, monster_level=level, env="ocean"
+                ).start()
+                return {"success": True}
+            else:
+                return {"success": False}
+        elif self.value == "advanced":
+            if bait <= 65:
+                mon_slug = random.choice(adv)
+                level = random.randint(15, 25)
+                WildEncounterAction(
+                    monster_slug=mon_slug, monster_level=level, env="ocean"
+                ).start()
+                return {"success": True}
+            else:
+                return {"success": False}
+        elif self.value == "pro":
+            if bait <= 85:
+                mon_slug = random.choice(pro)
+                level = random.randint(25, 35)
+                WildEncounterAction(
+                    monster_slug=mon_slug, monster_level=level, env="ocean"
+                ).start()
+                return {"success": True}
+            else:
+                return {"success": False}
+        return {"success": False}

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -233,7 +233,7 @@ class Item:
             result = result and event
         return result
 
-    def use(self, user: NPC, target: Monster) -> ItemEffectResult:
+    def use(self, user: NPC, target: Optional[Monster]) -> ItemEffectResult:
         """
         Applies this items's effects as defined in the "effect" column of
         the item database.

--- a/tuxemon/map.py
+++ b/tuxemon/map.py
@@ -378,6 +378,7 @@ class TuxemonMap:
         events: Sequence[EventObject],
         inits: Sequence[EventObject],
         interacts: Sequence[EventObject],
+        surfable_map: Sequence[Tuple[int, int]],
         collision_map: Mapping[Tuple[int, int], Optional[RegionProperties]],
         collisions_lines_map: Set[Tuple[Tuple[int, int], Direction]],
         tiled_map: TiledMap,
@@ -402,6 +403,7 @@ class TuxemonMap:
             events: List of map events.
             inits: List of events to be loaded once, when map is entered.
             interacts: List of intractable spaces.
+            surfable_map: Surfable map.
             collision_map: Collision map.
             collisions_lines_map: Collision map of lines.
             tiled_map: Original tiled map.
@@ -411,6 +413,7 @@ class TuxemonMap:
         """
         self.interacts = interacts
         self.collision_map = collision_map
+        self.surfable_map = surfable_map
         self.collision_lines_map = collisions_lines_map
         self.size = tiled_map.width, tiled_map.height
         self.inits = inits

--- a/tuxemon/map_loader.py
+++ b/tuxemon/map_loader.py
@@ -185,6 +185,7 @@ class TMXMapLoader:
         events = list()
         inits = list()
         interacts = list()
+        surfable_map = list()
         collision_map: Dict[Tuple[int, int], Optional[RegionProperties]] = {}
         collision_lines_map = set()
         maps = data.properties
@@ -192,12 +193,16 @@ class TMXMapLoader:
         # get all tiles which have properties and/or collisions
         gids_with_props = dict()
         gids_with_colliders = dict()
+        gids_with_surfable = dict()
         for gid, props in data.tile_properties.items():
             conds = extract_region_properties(props)
             gids_with_props[gid] = conds if conds else None
             colliders = props.get("colliders")
             if colliders is not None:
                 gids_with_colliders[gid] = colliders
+            surfable = props.get("surfable")
+            if surfable is not None:
+                gids_with_surfable[gid] = surfable
 
         # for each tile, apply the properties and collisions for the tile location
         for layer in data.visible_tile_layers:
@@ -206,6 +211,7 @@ class TMXMapLoader:
                 tile_props = gids_with_props.get(gid)
                 if tile_props is not None:
                     collision_map[(x, y)] = tile_props
+                # colliders
                 colliders = gids_with_colliders.get(gid)
                 if colliders is not None:
                     for obj in colliders:
@@ -230,6 +236,10 @@ class TMXMapLoader:
                             lx, ly = coords
                             line = (lx + x, ly + y), direction
                             collision_lines_map.add(line)
+                # surfable
+                surfable = gids_with_surfable.get(gid)
+                if surfable is not None:
+                    surfable_map.append((x, y))
 
         for obj in data.objects:
             if obj.type is None:
@@ -243,6 +253,8 @@ class TMXMapLoader:
                     collision_map[tile_position] = props
                 for line in self.collision_lines_from_object(obj, tile_size):
                     collision_lines_map.add(line)
+            elif obj_type and obj_type.lower().startswith("surfable"):
+                surfable_map.append(tile_size)
             elif obj_type == "event":
                 events.append(self.load_event(obj, tile_size))
             elif obj_type == "init":
@@ -254,6 +266,7 @@ class TMXMapLoader:
             events,
             inits,
             interacts,
+            surfable_map,
             collision_map,
             collision_lines_map,
             data,

--- a/tuxemon/states/items/__init__.py
+++ b/tuxemon/states/items/__init__.py
@@ -136,6 +136,8 @@ class ItemMenuState(Menu[Item]):
                             "here": T.translate(loc_type),
                         },
                     )
+                elif i.name == "facing_tile":
+                    msg = T.format("item_cannot_use_here", {"name": item.name})
             tools.open_dialog(local_session, [msg])
         elif State[state] not in item.usable_in:
             msg = T.format("item_cannot_use_here", {"name": item.name})
@@ -175,13 +177,22 @@ class ItemMenuState(Menu[Item]):
                         local_session, item, result
                     )
 
+        def use_item_no_monster(itm: Item) -> None:
+            player = local_session.player
+            self.client.pop_state()
+            result = itm.use(player, None)
+            if item.category == "fish" and not result["success"]:
+                tools.show_item_result_as_dialog(local_session, item, result)
+
         def confirm() -> None:
             self.client.pop_state()  # close the confirm dialog
-            # TODO: allow items to be used on player or "in general"
 
-            menu = self.client.push_state(MonsterMenuState())
-            menu.is_valid_entry = item.validate  # type: ignore[assignment]
-            menu.on_menu_selection = use_item  # type: ignore[assignment]
+            if item.category == "fish":
+                use_item_no_monster(item)
+            else:
+                menu = self.client.push_state(MonsterMenuState())
+                menu.is_valid_entry = item.validate  # type: ignore[assignment]
+                menu.on_menu_selection = use_item  # type: ignore[assignment]
 
         def cancel() -> None:
             self.client.pop_state()  # close the use/cancel menu

--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -1151,6 +1151,7 @@ class WorldState(state.State):
 
         self.current_map = map_data
         self.collision_map = map_data.collision_map
+        self.surfable_map = map_data.surfable_map
         self.collision_lines_map = map_data.collision_lines_map
         self.map_size = map_data.size
 


### PR DESCRIPTION
PR addresses the surfable propriety inside the tileset.
- creates **player_in** condition (if the player is in the area eg. surfable tiles), similar to **player_at**
- creates **has_sprite** condition;
- creates **facing_tile** item condition (fishing_rod);
- creates **fishing** item effect (fishing_rod) with three possible values (bas, adv, pro), depending on the value, different probabilities;
- edits **item.py** and **init** always item to grant the possibility to use the item without popping up the monster menu;
- upgrades **set_player_template** (default sprite);
- upgrades **player_facing_tile** with an optional **value** (the value could be surfable, so it'll say if the player is facing a tile with the property surfable);
- implements automatic **change sprites** (swimmer > default, default > swimmer in Paper Town and Candy Town);
- **it doesn't change or redraw any maps**:
- implements fishing (whatever scenario, if the player has a fishing_rod, it can fish close to any water body) > menu > item > fishing rod;

there are tiles with surfable 1, now these will be added inside the map.py
`surfable_map: Sequence[Tuple[int, int]]`
here there will be all the sea tiles (or at least the ones with the propriety surfable)

an event with **player_in** + **set_player_template** will grant automatically the change of sprite (default > swimmer, and vice versa).

before there were too many events, this way will crack down the number of events and it'll avoid hardcoding (using actions + conditions = modder choice).

Split out the Sea Route #1795

it'll follow PR to implement surfing in other maps + random_encounters while swimming

tested, black, isort, no new typehints