### PR TITLE
fishing (Spyder)

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -924,6 +924,9 @@ msgid "combat_state_plague3"
 msgstr "{target} wiped it off."
 
 # Generic notifications
+msgid "fishing_time"
+msgstr "Do you want to fish?"
+
 msgid "empty_slot"
 msgstr "Empty Slot"
 

--- a/mods/tuxemon/maps/spyder_candy_cafe.tmx
+++ b/mods/tuxemon/maps/spyder_candy_cafe.tmx
@@ -23,12 +23,12 @@
  </layer>
  <layer id="2" name="Tile Layer 2" width="12" height="12">
   <data encoding="base64" compression="zlib">
-   eAFjYKAtUJZnYFABYm4g5gHieYoQ+14B2cjAWo6BwQaInYDizkCsBcTaQLwXqh5ZLYgdBVQbDcTo4A4O9f8VICp/AOV/AvEvKP6NQz26ubj471QYGN4DMQYAmYuMoQp4VRkY+IAYGTAB1ZUpMDCUQ3EFkGbE4y6Q+qlANdOgeDoB9QxAsAWoZisUbwPS5IBDQE0wDNK/DRj+AI/hHVY=
+   eAFjYKAtUJZnYFABYm4g5gHieYrY7bOWY2CwAWInoBpnINYCYm0g3otDfRRQbTQQo4M7ONT/V4Co/AGU/wnEv6D4Nw716Obi4r9TYWB4D8QYAGQuMoYq4FVlYOADYmTABFRXpsDAUA7FFUCaEY+7QOqnAtVMg+LpBNQzAMEWoJqtULwNSJMDDgE1wTBI/zZg+AMAt9ocTQ==
   </data>
  </layer>
  <layer id="4" name="Above Player" width="12" height="12">
   <data encoding="base64" compression="zlib">
-   eAFjYBia4IECfd39EGgfMobZ7g0UB2Fk8BiND5J7BBXLAtIgjAzwqUdWR2v2dDnSbQAA3IgLrg==
+   eAFjYBia4IECfd39EGgfMsZn+2OgWnTwCIsYTA2p6mH6qE1PlyPdRAAqjQnE
   </data>
  </layer>
  <objectgroup color="#ff0000" id="5" name="Collisions">

--- a/mods/tuxemon/maps/spyder_citypark.tmx
+++ b/mods/tuxemon/maps/spyder_citypark.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="277">
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="280">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="spyder"/>
@@ -556,6 +556,31 @@
    <properties>
     <property name="act1" value="teleport_faint"/>
     <property name="cond1" value="is player_defeated"/>
+   </properties>
+  </object>
+  <object id="277" name="Fishing" type="event" x="32" y="128" width="144" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog fishing_time"/>
+    <property name="act2" value="translated_dialog_choice yes:no,fishing_time"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is has_item player,fishing_rod"/>
+   </properties>
+  </object>
+  <object id="278" name="Fishing" type="event" x="32" y="144" width="112" height="32">
+   <properties>
+    <property name="act1" value="translated_dialog fishing_time"/>
+    <property name="act2" value="translated_dialog_choice yes:no,fishing_time"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is has_item player,fishing_rod"/>
+   </properties>
+  </object>
+  <object id="279" name="Fishing Time" type="event" x="16" y="112" width="16" height="16">
+   <properties>
+    <property name="act1" value="random_encounter routea"/>
+    <property name="act2" value="set_variable fishing_time:null"/>
+    <property name="cond1" value="is variable_set fishing_time:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_routea.tmx
+++ b/mods/tuxemon/maps/spyder_routea.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="97">
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="100">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="spyder"/>
@@ -458,6 +458,31 @@
     <property name="behav1" value="talk spyder_routea_vince"/>
     <property name="cond1" value="is variable_set vincefirst:yes"/>
     <property name="cond2" value="not variable_set vincesecond:yes"/>
+   </properties>
+  </object>
+  <object id="97" name="Fishing" type="event" x="64" y="208" width="32" height="80">
+   <properties>
+    <property name="act1" value="translated_dialog fishing_time"/>
+    <property name="act2" value="translated_dialog_choice yes:no,fishing_time"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is has_item player,fishing_rod"/>
+   </properties>
+  </object>
+  <object id="98" name="Fishing" type="event" x="128" y="208" width="32" height="80">
+   <properties>
+    <property name="act1" value="translated_dialog fishing_time"/>
+    <property name="act2" value="translated_dialog_choice yes:no,fishing_time"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is has_item player,fishing_rod"/>
+   </properties>
+  </object>
+  <object id="99" name="Fishing Time" type="event" x="48" y="192" width="16" height="16">
+   <properties>
+    <property name="act1" value="random_encounter routea"/>
+    <property name="act2" value="set_variable fishing_time:null"/>
+    <property name="cond1" value="is variable_set fishing_time:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_timber_cafe.tmx
+++ b/mods/tuxemon/maps/spyder_timber_cafe.tmx
@@ -22,7 +22,7 @@
  </layer>
  <layer id="2" name="Tile Layer 2" width="12" height="12">
   <data encoding="base64" compression="zlib">
-   eAFjYKAtUJZnYFABYm4g5gHieYoQ+14B2cjAWo6BwQaInYDizkCsBcTaQLwXqh5ZLYgdBVQbDcTo4A4O9f8VICp/AOV/AvEvKP6Nrh7ERxdDtwTKZwKqewB0w0MgZsSlB8k8kPr/IDcD/YVNPVHmIbmFkHlISuFMPgUGBhAmBywFaloGxMuhmrcB/QIAi7IZSA==
+   eAFjYKAtUJZnYFABYm4g5gHieYrY7bOWY2CwAWInoBpnINYCYm0g3otDfRRQbTQQo4M7ONT/V4Co/AGU/wnEv6D4N7p6EB9dDN0SKJ8JqO4B0A0PgZgRlx4k80Dq/4PcDPQXNvVEmYfkFkLmISmFM/kUGBhAmBywFKhpGRAvh2reBvQLALOrGD8=
   </data>
  </layer>
  <layer id="4" name="Above Player" width="12" height="12">
@@ -103,6 +103,6 @@
     <property name="act3" value="set_variable teleport_clinic:none"/>
     <property name="cond1" value="is variable_set teleport_clinic:lost"/>
    </properties>
-  </object> 
+  </object>
  </objectgroup>
 </map>


### PR DESCRIPTION
My favorite moment in the Spyder campaign: when a NPC said "It's fishing time."
PR introduces fishing, nothing too fancy, just a couple of events (results of a long step by step).

@Sanglorian **Citypark** (ponds) and **Side Route A** (both ponds)

how it works? just having the fishing rod inside the bag, then approach the body of water and click, yeah, press the usual button.

![Screenshot from 2023-04-28 12-15-12](https://user-images.githubusercontent.com/64643719/235122362-1fc1f614-cddf-4fa4-abbd-aff3d2d9dd31.png)
![Screenshot from 2023-04-28 12-13-45](https://user-images.githubusercontent.com/64643719/235122372-19fadf4b-6db5-46ff-94dc-7a8fedd5fd8d.png)
![Screenshot from 2023-04-28 12-13-54](https://user-images.githubusercontent.com/64643719/235122369-9f497582-44b7-4feb-aff1-632801627a27.png)

~~At the moment it triggers 100%, so the fishing is always successful!~~
it doesn't trigger always
after testing, default value, like 1 out of 11, but yeah, we can set up a multiple output system as explained below.

Eventually we can adjust the probability (different outputs like the plain fail with the old boot, an actual item - like a fish - so the player can sell it to the scoop or feed a monster, etc) or using different fishing rods.

It's not complete because the level range is missing https://github.com/Tuxemon/Tuxemon/pull/1787#issuecomment-1523858402