### PR TITLE
fix encounters (dragonscave and tunnel below) (Spyder)

### DIFF
--- a/mods/tuxemon/maps/spyder_dragonscave.tmx
+++ b/mods/tuxemon/maps/spyder_dragonscave.tmx
@@ -327,13 +327,6 @@
     <property name="cond2" value="not variable_set dragonscavebenden2:yes"/>
    </properties>
   </object>
-  <object id="89" name="encounter 3" type="event" x="16" y="256" width="304" height="384">
-   <properties>
-    <property name="act1" value="random_encounter dragonscave,6"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
-   </properties>
-  </object>
   <object id="90" name="Teleport to Cotton Tunnel" type="event" x="256" y="16" width="16" height="16">
    <properties>
     <property name="act1" value="transition_teleport spyder_cotton_tunnel.tmx,3,16,0.3"/>
@@ -491,6 +484,12 @@
    <properties>
     <property name="act1" value="remove_collision drokoro"/>
     <property name="cond1" value="is variable_set dragonscavedrokoro:yes"/>
+   </properties>
+  </object>
+  <object id="89" name="Encounters" type="event" x="16" y="208" width="16" height="16">
+   <properties>
+    <property name="act1" value="random_encounter dragonscave,6"/>
+    <property name="cond1" value="not variable_set dragonscavebenden:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_tunnel_below.tmx
+++ b/mods/tuxemon/maps/spyder_tunnel_below.tmx
@@ -95,13 +95,6 @@
    </properties>
   </object>
   <object id="41" name="Player Spawn" type="event" x="160" y="32" width="16" height="16"/>
-  <object id="42" name="encounter 3" type="event" x="16" y="0" width="304" height="640">
-   <properties>
-    <property name="act1" value="random_encounter routeb,6"/>
-    <property name="cond1" value="is player_at"/>
-    <property name="cond2" value="is player_moved"/>
-   </properties>
-  </object>
   <object id="43" name="Create Beryll" type="event" x="144" y="496" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_tunnelb_beryll,9,31"/>
@@ -211,6 +204,11 @@
    <properties>
     <property name="act1" value="teleport_faint"/>
     <property name="cond1" value="is player_defeated"/>
+   </properties>
+  </object>
+  <object id="42" name="Encounters" type="event" x="0" y="64" width="16" height="16">
+   <properties>
+    <property name="act1" value="random_encounter routeb,6"/>
    </properties>
   </object>
  </objectgroup>


### PR DESCRIPTION
PR fixes the encounter areas. 

It's possible to trigger random encounters without having an event area as big as the map.

In Dragonscave random encounters will stop after Benden battle (as it was before).