### PR TITLE
improve item effects

### DIFF
--- a/mods/tuxemon/db/item/earth_booster.json
+++ b/mods/tuxemon/db/item/earth_booster.json
@@ -4,7 +4,7 @@
     "is has_path earth_booster"
   ],
   "effects": [
-    "evolve earth_booster"
+    "evolve"
   ],
   "slug": "earth_booster",
   "sort": "utility",

--- a/mods/tuxemon/db/item/fire_booster.json
+++ b/mods/tuxemon/db/item/fire_booster.json
@@ -4,7 +4,7 @@
     "is has_path fire_booster"
   ],
   "effects": [
-    "evolve fire_booster"
+    "evolve"
   ],
   "slug": "fire_booster",
   "sort": "utility",

--- a/mods/tuxemon/db/item/flintstone.json
+++ b/mods/tuxemon/db/item/flintstone.json
@@ -4,7 +4,7 @@
     "is has_path flintstone"
   ],
   "effects": [
-    "evolve flintstone"
+    "evolve"
   ],
   "slug": "flintstone",
   "sort": "utility",

--- a/mods/tuxemon/db/item/lucky_bamboo.json
+++ b/mods/tuxemon/db/item/lucky_bamboo.json
@@ -4,7 +4,7 @@
     "is has_path lucky_bamboo"
   ],
   "effects": [
-    "evolve lucky_bamboo"
+    "evolve"
   ],
   "slug": "lucky_bamboo",
   "sort": "utility",

--- a/mods/tuxemon/db/item/metal_booster.json
+++ b/mods/tuxemon/db/item/metal_booster.json
@@ -4,7 +4,7 @@
     "is has_path metal_booster"
   ],
   "effects": [
-    "evolve metal_booster"
+    "evolve"
   ],
   "slug": "metal_booster",
   "sort": "utility",

--- a/mods/tuxemon/db/item/miaow_milk.json
+++ b/mods/tuxemon/db/item/miaow_milk.json
@@ -4,7 +4,7 @@
     "is has_path miaow_milk"
   ],
   "effects": [
-    "evolve miaow_milk"
+    "evolve"
   ],
   "slug": "miaow_milk",
   "sort": "utility",

--- a/mods/tuxemon/db/item/ox_stick.json
+++ b/mods/tuxemon/db/item/ox_stick.json
@@ -4,7 +4,7 @@
     "is has_path ox_stick"
   ],
   "effects": [
-    "evolve ox_stick"
+    "evolve"
   ],
   "slug": "ox_stick",
   "sort": "utility",

--- a/mods/tuxemon/db/item/peace_lily.json
+++ b/mods/tuxemon/db/item/peace_lily.json
@@ -4,7 +4,7 @@
     "is has_path peace_lily"
   ],
   "effects": [
-    "evolve peace_lily"
+    "evolve"
   ],
   "slug": "peace_lily",
   "sort": "utility",

--- a/mods/tuxemon/db/item/petrified_dung.json
+++ b/mods/tuxemon/db/item/petrified_dung.json
@@ -4,7 +4,7 @@
     "is has_path petrified_dung"
   ],
   "effects": [
-    "evolve petrified_dung"
+    "evolve"
   ],
   "slug": "petrified_dung",
   "sort": "utility",

--- a/mods/tuxemon/db/item/pyramidion.json
+++ b/mods/tuxemon/db/item/pyramidion.json
@@ -4,7 +4,7 @@
     "is has_path pyramidion"
   ],
   "effects": [
-    "evolve pyramidion"
+    "evolve"
   ],
   "slug": "pyramidion",
   "sort": "utility",

--- a/mods/tuxemon/db/item/rhincus_fossil.json
+++ b/mods/tuxemon/db/item/rhincus_fossil.json
@@ -4,7 +4,7 @@
     "is has_path rhincus_fossil"
   ],
   "effects": [
-    "evolve rhincus_fossil"
+    "evolve"
   ],
   "slug": "rhincus_fossil",
   "sort": "utility",

--- a/mods/tuxemon/db/item/sea_girdle.json
+++ b/mods/tuxemon/db/item/sea_girdle.json
@@ -4,7 +4,7 @@
     "is has_path sea_girdle"
   ],
   "effects": [
-    "evolve sea_girdle"
+    "evolve"
   ],
   "slug": "sea_girdle",
   "sort": "utility",

--- a/mods/tuxemon/db/item/shammer_fossil.json
+++ b/mods/tuxemon/db/item/shammer_fossil.json
@@ -4,7 +4,7 @@
     "is has_path shammer_fossil"
   ],
   "effects": [
-    "evolve shammer_fossil"
+    "evolve"
   ],
   "slug": "shammer_fossil",
   "sort": "utility",

--- a/mods/tuxemon/db/item/stovepipe.json
+++ b/mods/tuxemon/db/item/stovepipe.json
@@ -4,7 +4,7 @@
     "is has_path stovepipe"
   ],
   "effects": [
-    "evolve stovepipe"
+    "evolve"
   ],
   "slug": "stovepipe",
   "sort": "utility",

--- a/mods/tuxemon/db/item/sweet_sand.json
+++ b/mods/tuxemon/db/item/sweet_sand.json
@@ -4,7 +4,7 @@
     "is has_path sweet_sand"
   ],
   "effects": [
-    "evolve sweet_sand"
+    "evolve"
   ],
   "slug": "sweet_sand",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tectonic_drill.json
+++ b/mods/tuxemon/db/item/tectonic_drill.json
@@ -4,7 +4,7 @@
     "is has_path tectonic_drill"
   ],
   "effects": [
-    "evolve tectonic_drill"
+    "evolve"
   ],
   "slug": "tectonic_drill",
   "sort": "utility",

--- a/mods/tuxemon/db/item/thunderstone.json
+++ b/mods/tuxemon/db/item/thunderstone.json
@@ -4,7 +4,7 @@
     "is has_path thunderstone"
   ],
   "effects": [
-    "evolve thunderstone"
+    "evolve"
   ],
   "slug": "thunderstone",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tuxeball_ancient.json
+++ b/mods/tuxemon/db/item/tuxeball_ancient.json
@@ -5,7 +5,7 @@
     "not threat"
   ],
   "effects": [
-    "capture tuxeball_ancient"
+    "capture"
   ],
   "slug": "tuxeball_ancient",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tuxeball_candy.json
+++ b/mods/tuxemon/db/item/tuxeball_candy.json
@@ -5,7 +5,7 @@
     "not threat"
   ],
   "effects": [
-    "capture tuxeball_candy"
+    "capture"
   ],
   "slug": "tuxeball_candy",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tuxeball_crusher.json
+++ b/mods/tuxemon/db/item/tuxeball_crusher.json
@@ -5,7 +5,7 @@
     "not threat"
   ],
   "effects": [
-    "capture tuxeball_crusher"
+    "capture"
   ],
   "slug": "tuxeball_crusher",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tuxeball_earth.json
+++ b/mods/tuxemon/db/item/tuxeball_earth.json
@@ -5,7 +5,7 @@
     "not threat"
   ],
   "effects": [
-    "capture tuxeball_earth"
+    "capture"
   ],
   "slug": "tuxeball_earth",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tuxeball_female.json
+++ b/mods/tuxemon/db/item/tuxeball_female.json
@@ -5,7 +5,7 @@
     "not threat"
   ],
   "effects": [
-    "capture tuxeball_female"
+    "capture"
   ],
   "slug": "tuxeball_female",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tuxeball_fire.json
+++ b/mods/tuxemon/db/item/tuxeball_fire.json
@@ -5,7 +5,7 @@
     "not threat"
   ],
   "effects": [
-    "capture tuxeball_fire"
+    "capture"
   ],
   "slug": "tuxeball_fire",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tuxeball_hardened.json
+++ b/mods/tuxemon/db/item/tuxeball_hardened.json
@@ -5,7 +5,7 @@
     "not threat"
   ],
   "effects": [
-    "capture tuxeball_hardened"
+    "capture"
   ],
   "slug": "tuxeball_hardened",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tuxeball_hearty.json
+++ b/mods/tuxemon/db/item/tuxeball_hearty.json
@@ -5,7 +5,7 @@
     "not threat"
   ],
   "effects": [
-    "capture tuxeball_hearty"
+    "capture"
   ],
   "slug": "tuxeball_hearty",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tuxeball_lavish.json
+++ b/mods/tuxemon/db/item/tuxeball_lavish.json
@@ -5,7 +5,7 @@
     "not threat"
   ],
   "effects": [
-    "capture tuxeball_lavish"
+    "capture"
   ],
   "slug": "tuxeball_lavish",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tuxeball_male.json
+++ b/mods/tuxemon/db/item/tuxeball_male.json
@@ -5,7 +5,7 @@
     "not threat"
   ],
   "effects": [
-    "capture tuxeball_male"
+    "capture"
   ],
   "slug": "tuxeball_male",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tuxeball_metal.json
+++ b/mods/tuxemon/db/item/tuxeball_metal.json
@@ -5,7 +5,7 @@
     "not threat"
   ],
   "effects": [
-    "capture tuxeball_metal"
+    "capture"
   ],
   "slug": "tuxeball_metal",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tuxeball_neuter.json
+++ b/mods/tuxemon/db/item/tuxeball_neuter.json
@@ -5,7 +5,7 @@
     "not threat"
   ],
   "effects": [
-    "capture tuxeball_neuter"
+    "capture"
   ],
   "slug": "tuxeball_neuter",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tuxeball_omni.json
+++ b/mods/tuxemon/db/item/tuxeball_omni.json
@@ -5,7 +5,7 @@
     "not threat"
   ],
   "effects": [
-    "capture tuxeball_omni"
+    "capture"
   ],
   "slug": "tuxeball_omni",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tuxeball_peppy.json
+++ b/mods/tuxemon/db/item/tuxeball_peppy.json
@@ -5,7 +5,7 @@
     "not threat"
   ],
   "effects": [
-    "capture tuxeball_peppy"
+    "capture"
   ],
   "slug": "tuxeball_peppy",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tuxeball_refined.json
+++ b/mods/tuxemon/db/item/tuxeball_refined.json
@@ -5,7 +5,7 @@
     "not threat"
   ],
   "effects": [
-    "capture tuxeball_refined"
+    "capture"
   ],
   "slug": "tuxeball_refined",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tuxeball_salty.json
+++ b/mods/tuxemon/db/item/tuxeball_salty.json
@@ -5,7 +5,7 @@
     "not threat"
   ],
   "effects": [
-    "capture tuxeball_salty"
+    "capture"
   ],
   "slug": "tuxeball_salty",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tuxeball_water.json
+++ b/mods/tuxemon/db/item/tuxeball_water.json
@@ -5,7 +5,7 @@
     "not threat"
   ],
   "effects": [
-    "capture tuxeball_water"
+    "capture"
   ],
   "slug": "tuxeball_water",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tuxeball_wood.json
+++ b/mods/tuxemon/db/item/tuxeball_wood.json
@@ -5,7 +5,7 @@
     "not threat"
   ],
   "effects": [
-    "capture tuxeball_wood"
+    "capture"
   ],
   "slug": "tuxeball_wood",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tuxeball_xero.json
+++ b/mods/tuxemon/db/item/tuxeball_xero.json
@@ -5,7 +5,7 @@
     "not threat"
   ],
   "effects": [
-    "capture tuxeball_xero"
+    "capture"
   ],
   "slug": "tuxeball_xero",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tuxeball_zesty.json
+++ b/mods/tuxemon/db/item/tuxeball_zesty.json
@@ -5,7 +5,7 @@
     "not threat"
   ],
   "effects": [
-    "capture tuxeball_zesty"
+    "capture"
   ],
   "slug": "tuxeball_zesty",
   "sort": "utility",

--- a/mods/tuxemon/db/item/water_booster.json
+++ b/mods/tuxemon/db/item/water_booster.json
@@ -4,7 +4,7 @@
     "is has_path water_booster"
   ],
   "effects": [
-    "evolve water_booster"
+    "evolve"
   ],
   "slug": "water_booster",
   "sort": "utility",

--- a/mods/tuxemon/db/item/wood_booster.json
+++ b/mods/tuxemon/db/item/wood_booster.json
@@ -4,7 +4,7 @@
     "is has_path wood_booster"
   ],
   "effects": [
-    "evolve wood_booster"
+    "evolve"
   ],
   "slug": "wood_booster",
   "sort": "utility",

--- a/tuxemon/item/effects/buff.py
+++ b/tuxemon/item/effects/buff.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Union
 
 from tuxemon.db import StatType
 from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
-from tuxemon.monster import Monster
+
+if TYPE_CHECKING:
+    from tuxemon.item.item import Item
+    from tuxemon.monster import Monster
 
 
 class BuffEffectResult(ItemEffectResult):
@@ -24,7 +28,10 @@ class BuffEffect(ItemEffect):
     stat: StatType
     amount: float
 
-    def apply(self, target: Monster) -> BuffEffectResult:
+    def apply(
+        self, item: Item, target: Union[Monster, None]
+    ) -> BuffEffectResult:
+        assert target
         if self.stat == StatType.hp:
             value = target.hp * self.amount
             target.hp += int(value)

--- a/tuxemon/item/effects/capture.py
+++ b/tuxemon/item/effects/capture.py
@@ -6,12 +6,14 @@ import logging
 import random
 from dataclasses import dataclass
 from math import sqrt
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 from tuxemon.db import TasteWarm
 from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
-from tuxemon.monster import Monster
 
+if TYPE_CHECKING:
+    from tuxemon.item.item import Item
+    from tuxemon.monster import Monster
 logger = logging.getLogger(__name__)
 
 
@@ -24,9 +26,11 @@ class CaptureEffect(ItemEffect):
     """Attempts to capture the target."""
 
     name = "capture"
-    tuxeball: Union[str, None] = None
 
-    def apply(self, target: Monster) -> CaptureEffectResult:
+    def apply(
+        self, item: Item, target: Union[Monster, None]
+    ) -> CaptureEffectResult:
+        assert target
         capture_device = "tuxeball"
         # The number of shakes that a tuxemon can do to escape.
         total_shakes = 4
@@ -51,83 +55,82 @@ class CaptureEffect(ItemEffect):
         fighting_monster = self.user.find_monster_by_id(iid)
         # Check type tuxeball and address malus/bonus
         tuxeball_modifier = 1.0
-        if self.tuxeball is not None:
-            # type based tuxeball
-            if self.tuxeball == "tuxeball_earth":
-                if target.types[0] != "earth":
-                    tuxeball_modifier = 0.2
-                else:
-                    tuxeball_modifier = 1.5
-            if self.tuxeball == "tuxeball_fire":
-                if target.types[0] != "fire":
-                    tuxeball_modifier = 0.2
-                else:
-                    tuxeball_modifier = 1.5
-            if self.tuxeball == "tuxeball_metal":
-                if target.types[0] != "metal":
-                    tuxeball_modifier = 0.2
-                else:
-                    tuxeball_modifier = 1.5
-            if self.tuxeball == "tuxeball_water":
-                if target.types[0] != "water":
-                    tuxeball_modifier = 0.2
-                else:
-                    tuxeball_modifier = 1.5
-            if self.tuxeball == "tuxeball_wood":
-                if target.types[0] != "wood":
-                    tuxeball_modifier = 0.2
-                else:
-                    tuxeball_modifier = 1.5
-            # flavoured based tuxeball
-            if self.tuxeball == "tuxeball_hearty":
-                target.taste_warm = TasteWarm.hearty
-            if self.tuxeball == "tuxeball_peppy":
-                target.taste_warm = TasteWarm.peppy
-            if self.tuxeball == "tuxeball_refined":
-                target.taste_warm = TasteWarm.refined
-            if self.tuxeball == "tuxeball_salty":
-                target.taste_warm = TasteWarm.salty
-            if self.tuxeball == "tuxeball_zesty":
-                target.taste_warm = TasteWarm.zesty
-            # gender based tuxeball
-            if self.tuxeball == "tuxeball_male":
-                if target.gender != "male":
-                    tuxeball_modifier = 0.2
-                else:
-                    tuxeball_modifier = 1.5
-            if self.tuxeball == "tuxeball_female":
-                if target.gender != "female":
-                    tuxeball_modifier = 0.2
-                else:
-                    tuxeball_modifier = 1.5
-            if self.tuxeball == "tuxeball_neuter":
-                if target.gender != "neuter":
-                    tuxeball_modifier = 0.2
-                else:
-                    tuxeball_modifier = 1.5
-            # Qiangong2 tuxeball ideas
-            if self.tuxeball == "tuxeball_ancient":
-                tuxeball_modifier = 99
-            if self.tuxeball == "tuxeball_crusher":
-                crusher = ((target.armour / 5) * 0.01) + 1
-                if crusher >= 1.4:
-                    crusher = 1.4
-                if status_category == "positive":
-                    crusher = 0.01
-                tuxeball_modifier = crusher
+        # type based tuxeball
+        if item.slug == "tuxeball_earth":
+            if target.types[0] != "earth":
+                tuxeball_modifier = 0.2
+            else:
+                tuxeball_modifier = 1.5
+        if item.slug == "tuxeball_fire":
+            if target.types[0] != "fire":
+                tuxeball_modifier = 0.2
+            else:
+                tuxeball_modifier = 1.5
+        if item.slug == "tuxeball_metal":
+            if target.types[0] != "metal":
+                tuxeball_modifier = 0.2
+            else:
+                tuxeball_modifier = 1.5
+        if item.slug == "tuxeball_water":
+            if target.types[0] != "water":
+                tuxeball_modifier = 0.2
+            else:
+                tuxeball_modifier = 1.5
+        if item.slug == "tuxeball_wood":
+            if target.types[0] != "wood":
+                tuxeball_modifier = 0.2
+            else:
+                tuxeball_modifier = 1.5
+        # flavoured based tuxeball
+        if item.slug == "tuxeball_hearty":
+            target.taste_warm = TasteWarm.hearty
+        if item.slug == "tuxeball_peppy":
+            target.taste_warm = TasteWarm.peppy
+        if item.slug == "tuxeball_refined":
+            target.taste_warm = TasteWarm.refined
+        if item.slug == "tuxeball_salty":
+            target.taste_warm = TasteWarm.salty
+        if item.slug == "tuxeball_zesty":
+            target.taste_warm = TasteWarm.zesty
+        # gender based tuxeball
+        if item.slug == "tuxeball_male":
+            if target.gender != "male":
+                tuxeball_modifier = 0.2
+            else:
+                tuxeball_modifier = 1.5
+        if item.slug == "tuxeball_female":
+            if target.gender != "female":
+                tuxeball_modifier = 0.2
+            else:
+                tuxeball_modifier = 1.5
+        if item.slug == "tuxeball_neuter":
+            if target.gender != "neuter":
+                tuxeball_modifier = 0.2
+            else:
+                tuxeball_modifier = 1.5
+        # Qiangong2 tuxeball ideas
+        if item.slug == "tuxeball_ancient":
+            tuxeball_modifier = 99
+        if item.slug == "tuxeball_crusher":
+            crusher = ((target.armour / 5) * 0.01) + 1
+            if crusher >= 1.4:
+                crusher = 1.4
+            if status_category == "positive":
+                crusher = 0.01
+            tuxeball_modifier = crusher
         if fighting_monster:
-            if self.tuxeball == "tuxeball_xero":
+            if item.slug == "tuxeball_xero":
                 if fighting_monster.types[0] != target.types[0]:
                     tuxeball_modifier = 1.4
                 else:
                     tuxeball_modifier = 0.3
-            if self.tuxeball == "tuxeball_omni":
+            if item.slug == "tuxeball_omni":
                 if fighting_monster.types[0] != target.types[0]:
                     tuxeball_modifier = 0.3
                 else:
                     tuxeball_modifier = 1.4
             # Sanglorian tuxeball ideas
-            if self.tuxeball == "tuxeball_lavish":
+            if item.slug == "tuxeball_lavish":
                 tuxeball_modifier = 1.5
 
         # TODO: debug logging this info
@@ -182,22 +185,19 @@ class CaptureEffect(ItemEffect):
             random_num = random.randint(0, max_shake_rate)
             logger.debug(f"shake check {i}: random number {random_num}")
             if random_num > round(shake_check):
-                # check for self.tuxeball
-                if self.tuxeball is not None:
-                    if self.tuxeball == "tuxeball_hardened":
-                        tuxeball = self.user.find_item(self.tuxeball)
-                        if tuxeball:
-                            tuxeball.quantity += 1
+                if item.slug == "tuxeball_hardened":
+                    tuxeball = self.user.find_item(item.slug)
+                    if tuxeball:
+                        tuxeball.quantity += 1
 
                 return {"success": False, "num_shakes": i + 1}
 
-        if self.tuxeball is not None:
-            # it increases the level +1 upon capture
-            if self.tuxeball == "tuxeball_candy":
-                capture_device = self.tuxeball
-                target.level += 1
-            else:
-                capture_device = self.tuxeball
+        # it increases the level +1 upon capture
+        if item.slug == "tuxeball_candy":
+            capture_device = item.slug
+            target.level += 1
+        else:
+            capture_device = item.slug
 
         # add creature to the player's monster list
         target.capture_device = capture_device

--- a/tuxemon/item/effects/evolve.py
+++ b/tuxemon/item/effects/evolve.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 import random
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Union
 
 from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
-from tuxemon.monster import Monster
+
+if TYPE_CHECKING:
+    from tuxemon.item.item import Item
+    from tuxemon.monster import Monster
 
 
 class EvolveEffectResult(ItemEffectResult):
@@ -18,16 +22,20 @@ class EvolveEffect(ItemEffect):
     """This effect evolves the target into the monster in the parameters."""
 
     name = "evolve"
-    item: str
+    value: Union[str, None]
 
-    def apply(self, target: Monster) -> EvolveEffectResult:
-        if self.item == "random":
-            choices = [d for d in target.evolutions if d.path == "item"]
-            evolution = random.choice(choices).monster_slug
-            self.user.evolve_monster(target, evolution)
-            return {"success": True}
+    def apply(
+        self, item: Item, target: Union[Monster, None]
+    ) -> EvolveEffectResult:
+        assert target
+        if self.value:
+            if self.value == "random":
+                choices = [d for d in target.evolutions if d.path == "item"]
+                evolution = random.choice(choices).monster_slug
+                self.user.evolve_monster(target, evolution)
+                return {"success": True}
         else:
-            choices = [d for d in target.evolutions if d.item == self.item]
+            choices = [d for d in target.evolutions if d.item == item.slug]
             if len(choices) == 1:
                 self.user.evolve_monster(target, choices[0].monster_slug)
                 return {"success": True}

--- a/tuxemon/item/effects/fishing.py
+++ b/tuxemon/item/effects/fishing.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 import random
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Union
 
 from tuxemon.db import EvolutionStage, MonsterShape, db
 from tuxemon.event.actions.wild_encounter import WildEncounterAction
 from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
-from tuxemon.monster import Monster
+
+if TYPE_CHECKING:
+    from tuxemon.item.item import Item
+    from tuxemon.monster import Monster
 
 
 class FishingEffectResult(ItemEffectResult):
@@ -22,7 +26,9 @@ class FishingEffect(ItemEffect):
     name = "fishing"
     value: str
 
-    def apply(self, target: Monster) -> FishingEffectResult:
+    def apply(
+        self, item: Item, target: Union[Monster, None]
+    ) -> FishingEffectResult:
         # level of the rod
         levels = ["basic", "advanced", "pro"]
         if self.value not in levels:

--- a/tuxemon/item/effects/gain_xp.py
+++ b/tuxemon/item/effects/gain_xp.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Union
 
 from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
-from tuxemon.monster import Monster
+
+if TYPE_CHECKING:
+    from tuxemon.item.item import Item
+    from tuxemon.monster import Monster
 
 
 class GainXpEffectResult(ItemEffectResult):
@@ -21,6 +25,9 @@ class GainXpEffect(ItemEffect):
     name = "gain_xp"
     amount: int
 
-    def apply(self, target: Monster) -> GainXpEffectResult:
+    def apply(
+        self, item: Item, target: Union[Monster, None]
+    ) -> GainXpEffectResult:
+        assert target
         target.give_experience(self.amount)
         return {"success": True}

--- a/tuxemon/item/effects/heal.py
+++ b/tuxemon/item/effects/heal.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 from tuxemon.combat import has_status
 from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
-from tuxemon.monster import Monster
+
+if TYPE_CHECKING:
+    from tuxemon.item.item import Item
+    from tuxemon.monster import Monster
 
 
 class HealEffectResult(ItemEffectResult):
@@ -32,7 +35,10 @@ class HealEffect(ItemEffect):
     name = "heal"
     amount: Union[int, float]
 
-    def apply(self, target: Monster) -> HealEffectResult:
+    def apply(
+        self, item: Item, target: Union[Monster, None]
+    ) -> HealEffectResult:
+        assert target
         healing_amount = self.amount
         # condition festering = no healing
         if has_status(target, "status_festering"):

--- a/tuxemon/item/effects/increase.py
+++ b/tuxemon/item/effects/increase.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Union
 
 from tuxemon.db import StatType
 from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
-from tuxemon.monster import Monster
+
+if TYPE_CHECKING:
+    from tuxemon.item.item import Item
+    from tuxemon.monster import Monster
 
 
 class IncreaseEffectResult(ItemEffectResult):
@@ -24,7 +28,10 @@ class IncreaseEffect(ItemEffect):
     stat: StatType
     amount: float
 
-    def apply(self, target: Monster) -> IncreaseEffectResult:
+    def apply(
+        self, item: Item, target: Union[Monster, None]
+    ) -> IncreaseEffectResult:
+        assert target
         if self.stat == StatType.hp:
             value = target.hp * self.amount
             target.mod_hp += int(value)

--- a/tuxemon/item/effects/learn_mm.py
+++ b/tuxemon/item/effects/learn_mm.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 import random
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Union
 
 from tuxemon.db import ElementType, db
 from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
-from tuxemon.monster import Monster
+
+if TYPE_CHECKING:
+    from tuxemon.item.item import Item
+    from tuxemon.monster import Monster
 
 
 class LearnMmEffectResult(ItemEffectResult):
@@ -21,7 +25,10 @@ class LearnMmEffect(ItemEffect):
     name = "learn_mm"
     element: ElementType
 
-    def apply(self, target: Monster) -> LearnMmEffectResult:
+    def apply(
+        self, item: Item, target: Union[Monster, None]
+    ) -> LearnMmEffectResult:
+        assert target
         techs = list(db.database["technique"])
         # type moves
         filters = []

--- a/tuxemon/item/effects/learn_tm.py
+++ b/tuxemon/item/effects/learn_tm.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Union
 
 from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
-from tuxemon.monster import Monster
+
+if TYPE_CHECKING:
+    from tuxemon.item.item import Item
+    from tuxemon.monster import Monster
 
 
 class LearnTmEffectResult(ItemEffectResult):
@@ -19,7 +23,10 @@ class LearnTmEffect(ItemEffect):
     name = "learn_tm"
     technique: str
 
-    def apply(self, target: Monster) -> LearnTmEffectResult:
+    def apply(
+        self, item: Item, target: Union[Monster, None]
+    ) -> LearnTmEffectResult:
+        assert target
         # monster moves
         moves = []
         for tech in target.moves:

--- a/tuxemon/item/effects/restore.py
+++ b/tuxemon/item/effects/restore.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 from tuxemon.db import CategoryCondition
 from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
-from tuxemon.monster import Monster
+
+if TYPE_CHECKING:
+    from tuxemon.item.item import Item
+    from tuxemon.monster import Monster
 
 
 class RestoreEffectResult(ItemEffectResult):
@@ -28,7 +31,10 @@ class RestoreEffect(ItemEffect):
     name = "restore"
     category: Union[str, None] = None
 
-    def apply(self, target: Monster) -> RestoreEffectResult:
+    def apply(
+        self, item: Item, target: Union[Monster, None]
+    ) -> RestoreEffectResult:
+        assert target
         if self.category:
             if (
                 self.category == CategoryCondition.positive

--- a/tuxemon/item/effects/revive.py
+++ b/tuxemon/item/effects/revive.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Union
 
 from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
-from tuxemon.monster import Monster
+
+if TYPE_CHECKING:
+    from tuxemon.item.item import Item
+    from tuxemon.monster import Monster
 
 
 class ReviveEffectResult(ItemEffectResult):
@@ -21,7 +25,10 @@ class ReviveEffect(ItemEffect):
     name = "revive"
     hp: int
 
-    def apply(self, target: Monster) -> ReviveEffectResult:
+    def apply(
+        self, item: Item, target: Union[Monster, None]
+    ) -> ReviveEffectResult:
+        assert target
         target.status = []
         target.current_hp = self.hp
 

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -256,7 +256,7 @@ class Item:
 
         # Loop through all the effects of this technique and execute the effect's function.
         for effect in self.effects:
-            result = effect.apply(target)
+            result = effect.apply(self, target)
             meta_result.update(result)
 
         # If this is a consumable item, remove it from the player's inventory.

--- a/tuxemon/item/itemeffect.py
+++ b/tuxemon/item/itemeffect.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, ClassVar, TypedDict
+from typing import TYPE_CHECKING, ClassVar, TypedDict, Union
 
 from tuxemon.session import Session, local_session
 from tuxemon.tools import cast_dataclass_parameters
 
 if TYPE_CHECKING:
+    from tuxemon.item.item import Item
     from tuxemon.monster import Monster
 
 logger = logging.getLogger(__name__)
@@ -69,5 +70,7 @@ class ItemEffect:
         self.user = local_session.player
         cast_dataclass_parameters(self)
 
-    def apply(self, target: Monster) -> ItemEffectResult:
+    def apply(
+        self, item: Item, target: Union[Monster, None]
+    ) -> ItemEffectResult:
         pass


### PR DESCRIPTION
PR improves item effects.
- passes **item** in the effect files;
- get rid of item **duplication** (eg "**evolve miaow_milk**" -> "**evolve**");
- adds **TYPE_CHECKING** inside effect files;

Everything started to get rid of 1 typehint (successfully).

from
`def apply(self, target: Monster) -> CaptureEffectResult:`
to
```
    def apply(
        self, item: Item, target: Union[Monster, None]
    ) -> CaptureEffectResult:
```
new entry item, while target is Union because it has been set to optional
(it was necessary to allow the use of items without the monster menu)