### PR TITLE
has bag (condition event)

### DIFF
--- a/tuxemon/event/conditions/has_bag.py
+++ b/tuxemon/event/conditions/has_bag.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from operator import eq, ge, gt, le, lt, ne
+
+from tuxemon.db import ItemCategory
+from tuxemon.event import MapCondition
+from tuxemon.event.eventcondition import EventCondition
+from tuxemon.session import Session
+
+
+class HasBagCondition(EventCondition):
+    """
+    Check to see how many items are in the bag.
+
+    Script usage:
+        .. code-block::
+
+            is has_bag <operator>,<value>
+
+    Script parameters:
+        operator: Numeric comparison operator. Accepted values are "less_than",
+            "less_or_equal", "greater_than", "greater_or_equal", "equals"
+            and "not_equals".
+        value: The value to compare the bag with.
+
+    """
+
+    name = "has_bag"
+
+    def test(self, session: Session, condition: MapCondition) -> bool:
+        check = str(condition.parameters[0])
+        number = int(condition.parameters[1])
+        player = session.player
+        sum_total = []
+        for itm in player.items:
+            # excludes the phone + apps
+            if itm.category != ItemCategory.phone:
+                sum_total.append(itm.quantity)
+        bag_size = sum(sum_total)
+        if check == "less_than":
+            return bool(lt(bag_size, number))
+        elif check == "less_or_equal":
+            return bool(le(bag_size, number))
+        elif check == "greater_than":
+            return bool(gt(bag_size, number))
+        elif check == "greater_or_equal":
+            return bool(ge(bag_size, number))
+        elif check == "equals":
+            return bool(eq(bag_size, number))
+        elif check == "not_equals":
+            return bool(ne(bag_size, number))
+        else:
+            raise ValueError(f"{check} is incorrect.")

--- a/tuxemon/technique/effects/damage.py
+++ b/tuxemon/technique/effects/damage.py
@@ -50,7 +50,7 @@ class DamageEffect(TechEffect):
             target.current_hp -= damage
         else:
             damage = 0
-            mult = 1
+            mult = 1.0
 
         return {
             "damage": damage,

--- a/tuxemon/technique/effects/local_damage.py
+++ b/tuxemon/technique/effects/local_damage.py
@@ -49,9 +49,10 @@ class LocalDamageEffect(TechEffect):
             # tech: panjandrum
             if tech.slug == "panjandrum":
                 damage = formula.damage_panjandrum(target)
+            target.current_hp -= damage
         else:
             damage = 0
-            mult = 1
+            mult = 1.0
 
         return {
             "damage": damage,


### PR DESCRIPTION
PR adds has_bag condition event.
`<property name="cond1" value="is has_bag equals,5"/>`
it would be possible to check the number of items inside the bag, for instance my NPC has 7 items (5 potions and 2 tuxeball)
so it's 7 items and related to the example above:
7 equals to 5, nope, no event.

As requested by @Sanglorian here https://github.com/Tuxemon/Tuxemon/pull/1796#issuecomment-1529034031

added a small fix for **local_damage** effect action