### PR TITLE
shape (condition item) + type_checking (conditions item)

### DIFF
--- a/mods/tuxemon/db/item/tm_surf.json
+++ b/mods/tuxemon/db/item/tm_surf.json
@@ -1,6 +1,7 @@
 {
   "conditions": [
     "is type water",
+    "is shape aquatic:polliwog:leviathan",
     "is max_moves",
     "not has_tech surf"
   ],

--- a/tuxemon/item/conditions/current_hp.py
+++ b/tuxemon/item/conditions/current_hp.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from operator import eq, ge, gt, le, lt
-from typing import Callable, Mapping, Optional, Union
+from typing import TYPE_CHECKING, Callable, Mapping, Optional, Union
 
 from tuxemon.item.itemcondition import ItemCondition
-from tuxemon.monster import Monster
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
 
 cmp_dict: Mapping[Optional[str], Callable[[float, float], bool]] = {
     None: ge,

--- a/tuxemon/item/conditions/facing_tile.py
+++ b/tuxemon/item/conditions/facing_tile.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from tuxemon.item.itemcondition import ItemCondition
-from tuxemon.monster import Monster
 from tuxemon.states.world.worldstate import WorldState
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
 
 
 @dataclass

--- a/tuxemon/item/conditions/has_path.py
+++ b/tuxemon/item/conditions/has_path.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from tuxemon.item.itemcondition import ItemCondition
-from tuxemon.monster import Monster
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
 
 
 @dataclass

--- a/tuxemon/item/conditions/has_status.py
+++ b/tuxemon/item/conditions/has_status.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from tuxemon.item.itemcondition import ItemCondition
-from tuxemon.monster import Monster
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
 
 
 @dataclass

--- a/tuxemon/item/conditions/has_tech.py
+++ b/tuxemon/item/conditions/has_tech.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from tuxemon.item.itemcondition import ItemCondition
-from tuxemon.monster import Monster
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
 
 
 @dataclass

--- a/tuxemon/item/conditions/level.py
+++ b/tuxemon/item/conditions/level.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from operator import eq, ge, gt, le, lt
-from typing import Callable, Mapping, Optional
+from typing import TYPE_CHECKING, Callable, Mapping, Optional
 
 from tuxemon.item.itemcondition import ItemCondition
-from tuxemon.monster import Monster
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
 
 cmp_dict: Mapping[Optional[str], Callable[[float, float], bool]] = {
     None: ge,

--- a/tuxemon/item/conditions/location_inside.py
+++ b/tuxemon/item/conditions/location_inside.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from tuxemon.item.itemcondition import ItemCondition
-from tuxemon.monster import Monster
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
 
 
 @dataclass

--- a/tuxemon/item/conditions/location_type.py
+++ b/tuxemon/item/conditions/location_type.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from tuxemon.db import MapType
 from tuxemon.item.itemcondition import ItemCondition
-from tuxemon.monster import Monster
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
 
 
 @dataclass

--- a/tuxemon/item/conditions/shape.py
+++ b/tuxemon/item/conditions/shape.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Union
+from typing import TYPE_CHECKING, List
 
 from tuxemon.item.itemcondition import ItemCondition
-from tuxemon.monster import Monster
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
 
 
 @dataclass
@@ -19,19 +21,15 @@ class ShapeCondition(ItemCondition):
     """
 
     name = "shape"
-    shape1: str
-    shape2: Union[str, None] = None
-    shape3: Union[str, None] = None
-    shape4: Union[str, None] = None
-    shape5: Union[str, None] = None
+    shapes: str
 
     def test(self, target: Monster) -> bool:
-        ret = False
-        if target.shape is not None:
-            ret = any(
-                target.shape.lower() == p.lower()
-                for p in self.shape1
-                if p is not None
-            )
-
-        return ret
+        shapes: List[str] = []
+        if self.shapes.find(":"):
+            shapes = self.shapes.split(":")
+        else:
+            shapes.append(self.shapes)
+        if target.shape in shapes:
+            return True
+        else:
+            return False

--- a/tuxemon/item/conditions/status.py
+++ b/tuxemon/item/conditions/status.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from tuxemon.item.itemcondition import ItemCondition
-from tuxemon.monster import Monster
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
 
 
 @dataclass

--- a/tuxemon/item/conditions/threat.py
+++ b/tuxemon/item/conditions/threat.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from tuxemon.item.itemcondition import ItemCondition
-from tuxemon.monster import Monster
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
 
 
 @dataclass

--- a/tuxemon/item/conditions/type.py
+++ b/tuxemon/item/conditions/type.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 from tuxemon.item.itemcondition import ItemCondition
-from tuxemon.monster import Monster
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
 
 
 @dataclass

--- a/tuxemon/item/conditions/variable.py
+++ b/tuxemon/item/conditions/variable.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 from tuxemon.item.itemcondition import ItemCondition
-from tuxemon.monster import Monster
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
 
 
 @dataclass

--- a/tuxemon/item/conditions/wild_monster.py
+++ b/tuxemon/item/conditions/wild_monster.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from tuxemon.item.itemcondition import ItemCondition
-from tuxemon.monster import Monster
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
 
 
 @dataclass


### PR DESCRIPTION
PR updates shape (condition item).
the condition was broken if the player used more than 1 shape

this is the new format:
`"is shape aquatic:polliwog:leviathan",`
in this way it's possible to list multiple shapes, before it was limited to 5

added type_checking inside item conditions too (as we did in the other PR for effects)

tested, black, isort, no new typehints