### PR TITLE
facing npc (condition item) + remove (npc) (effect item)

### DIFF
--- a/tuxemon/event/__init__.py
+++ b/tuxemon/event/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections import namedtuple
-from typing import TYPE_CHECKING, NamedTuple, Optional, Sequence
+from typing import TYPE_CHECKING, NamedTuple, Optional, Sequence, Tuple
 
 from tuxemon.session import Session
 
@@ -67,3 +67,20 @@ def get_npc(session: Session, slug: str) -> Optional[NPC]:
 
     # logger.error("Unable to find NPC: " + slug)
     return world.get_entity(slug)
+
+
+def get_npc_pos(session: Session, pos: Tuple[int, int]) -> Optional[NPC]:
+    """
+    Gets an NPC object by its position.
+
+    """
+    from tuxemon.states.world.worldstate import WorldState
+
+    player = session.player
+    if player.tile_pos == pos:
+        return session.player
+
+    # Loop through the NPC list and see if the slug matches any in the list
+    world = session.client.get_state_by_name(WorldState)
+
+    return world.get_entity_pos(pos)

--- a/tuxemon/item/conditions/facing_npc.py
+++ b/tuxemon/item/conditions/facing_npc.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from tuxemon.event import get_npc
+from tuxemon.item.itemcondition import ItemCondition
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
+
+
+@dataclass
+class FacingNpcCondition(ItemCondition):
+    """
+    Checks if the player is facing a NPC.
+
+    """
+
+    name = "facing_npc"
+    npc_slug: str
+
+    def test(self, target: Monster) -> bool:
+        player = self.session.player
+        npc_location = None
+        npc = get_npc(self.session, self.npc_slug)
+        if not npc:
+            return False
+
+        if npc.tile_pos[1] == player.tile_pos[1]:
+            if npc.tile_pos[0] == player.tile_pos[0] - 1:
+                npc_location = "left"
+            elif npc.tile_pos[0] == player.tile_pos[0] + 1:
+                npc_location = "right"
+
+        if npc.tile_pos[0] == player.tile_pos[0]:
+            if npc.tile_pos[1] == player.tile_pos[1] - 1:
+                npc_location = "up"
+            elif npc.tile_pos[1] == player.tile_pos[1] + 1:
+                npc_location = "down"
+
+        return player.facing == npc_location

--- a/tuxemon/item/effects/remove.py
+++ b/tuxemon/item/effects/remove.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Tuple, Union
+
+from tuxemon.event import get_npc_pos
+from tuxemon.event.actions.remove_npc import RemoveNpcAction
+from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
+
+if TYPE_CHECKING:
+    from tuxemon.item.item import Item
+    from tuxemon.monster import Monster
+
+
+class RemoveEffectResult(ItemEffectResult):
+    pass
+
+
+@dataclass
+class RemoveEffect(ItemEffect):
+    """
+    Removes the NPC and creates a variable.
+    """
+
+    name = "remove"
+
+    def apply(
+        self, item: Item, target: Union[Monster, None]
+    ) -> RemoveEffectResult:
+        coords: Tuple[int, int] = (0, 0)
+        player = self.session.player
+        facing = player.facing
+        player_x = player.tile_pos[0]
+        player_y = player.tile_pos[1]
+        if facing == "down":
+            y = player_y - 1
+            coords = player_x, y
+        elif facing == "up":
+            y = player_y + 1
+            coords = player_x, y
+        elif facing == "right":
+            x = player_x + 1
+            coords = x, player_y
+        elif facing == "left":
+            x = player_x - 1
+            coords = x, player_y
+
+        npc = get_npc_pos(self.session, coords)
+        if npc:
+            RemoveNpcAction(npc_slug=npc.slug).start()
+            self.session.player.game_variables[npc.slug] = self.name
+            return {"success": True}
+        else:
+            return {"success": False}

--- a/tuxemon/states/items/__init__.py
+++ b/tuxemon/states/items/__init__.py
@@ -136,7 +136,7 @@ class ItemMenuState(Menu[Item]):
                             "here": T.translate(loc_type),
                         },
                     )
-                elif i.name == "facing_tile":
+                elif i.name == "facing_tile" or i.name == "facing_npc":
                     msg = T.format("item_cannot_use_here", {"name": item.name})
             tools.open_dialog(local_session, [msg])
         elif State[state] not in item.usable_in:

--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -600,6 +600,19 @@ class WorldState(state.State):
         """
         return self.npcs.get(slug)
 
+    def get_entity_pos(self, pos: Tuple[int, int]) -> Optional[NPC]:
+        """
+        Get an entity from the world by its position.
+
+        Parameters:
+            pos: The entity position.
+
+        """
+        for npc in self.npcs.values():
+            if npc.tile_pos == pos:
+                return npc
+        return None
+
     def remove_entity(self, slug: str) -> None:
         """
         Remove an entity from the world.


### PR DESCRIPTION
PR allows to remove NPCs (npcs trainer or other entities - such as log, boulder, etc) by using an item.
- creates **facing_npc** (condition item);
- creates **remove** (condition item);
- creates **get_npc_pos** in **event init**, so we are able to retrieve the NPC based on the position, without using the slug;
- creates **get_entity_pos** in **worldstate.py** (related to the one above)

an item.json effects / conditions will be like this:
```
  "conditions": [
    "is facing_npc spyder_log"
  ],
  "effects": [
    "remove" <--- is going to remove the NPC the player is facing
  ],
```
it'll be created a new variable during the removal effect (generated, not hardcoded: slug + remove:
`spyder_log:remove`
this requires to add the following line when you create the NPC.
```
    <property name="act1" value="create_npc spyder_log,7,8"/>
    <property name="cond1" value="not npc_exists spyder_log"/>
    <property name="cond2" value="not variable_set spyder_log:remove"/> <------- this line
```
so the log will disappear. Without variable the log doesn't disappear, that's because spawn again.

tested, isort, black, no new typehints