### PR TITLE
skip target (combat menu) (1/3)

### DIFF
--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -415,7 +415,9 @@ class CombatState(CombatAnimations):
             # apply status effects to the monsters
             for monster in self.active_monsters:
                 for technique in monster.status:
-                    self.enqueue_action(None, technique, monster)
+                    # validate status
+                    if technique.validate(monster):
+                        self.enqueue_action(None, technique, monster)
                     # avoid multiple effect status
                     monster.set_stats()
 
@@ -1324,6 +1326,22 @@ class CombatState(CombatAnimations):
 
         """
         return list(chain.from_iterable(self.monsters_in_play.values()))
+
+    @property
+    def remaining_monsters(self) -> Sequence[Monster]:
+        """
+        List of any non-fainted monsters in party (human).
+
+        """
+        return [p for p in self.players[0].monsters if not fainted(p)]
+
+    @property
+    def remaining_monsters_ai(self) -> Sequence[Monster]:
+        """
+        List of any non-fainted monsters in party (ai).
+
+        """
+        return [p for p in self.players[1].monsters if not fainted(p)]
 
     @property
     def remaining_players(self) -> Sequence[NPC]:

--- a/tuxemon/states/combat/combat_animations.py
+++ b/tuxemon/states/combat/combat_animations.py
@@ -561,10 +561,10 @@ class CombatAnimations(ABC, Menu[None]):
 
         combat_front = ""
         combat_back = ""
-        for ele in opponent.template:
-            combat_front = ele.combat_front
-        for ele in player.template:
-            combat_back = ele.combat_front
+        for opp in opponent.template:
+            combat_front = opp.combat_front
+        for pla in player.template:
+            combat_back = pla.combat_front
 
         if self.is_trainer_battle:
             enemy = self.load_sprite(


### PR DESCRIPTION
PR addresses issue fix #1804 
- it removes the target (1 vs 1); -> it's the square around the monster
- it maintains the target (2 vs 2) or (1 vs 2)
- it adds validation for statuses;
- if fixes targeting for battles (2 vs 2) or (1 vs 2); -> screenshots below
- it adds the textarea for battle (2 vs 2) or (1 vs 2) -> screenshots below (where it appear the name of the monster);
- it adds properties remaining_monsters and remaining_monsters_ai, to check how many non-fainted monster there are in the party (related more to the 2 vs 2 or 1 vs 2);

tested, black, isort, no new typehints

![Screenshot from 2023-05-03 10-08-13](https://user-images.githubusercontent.com/64643719/235863170-3a606d76-efc6-4563-87d7-a775c9e7ad52.png)
![Screenshot from 2023-05-03 10-07-49](https://user-images.githubusercontent.com/64643719/235863175-50caa014-6dca-4981-b6b5-8fabdba090e1.png)

we are still far from having an operative system 2v2, but it's a starting point.

remember:
- fix swapping in 2 vs 2 / fainting;
- insert checks with the new properties inside (fill_battlefield_positions) before ask_player_for_monster and add_monster_into_play, line 726;
- separate slightly more the two sprites;
- add both monsters hp bars;