### PR TITLE
remove item field from technique target

### DIFF
--- a/mods/tuxemon/db/technique/acid.json
+++ b/mods/tuxemon/db/technique/acid.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/adamantine.json
+++ b/mods/tuxemon/db/technique/adamantine.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/air_chain.json
+++ b/mods/tuxemon/db/technique/air_chain.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/all_in.json
+++ b/mods/tuxemon/db/technique/all_in.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/amnesia.json
+++ b/mods/tuxemon/db/technique/amnesia.json
@@ -21,7 +21,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 1,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/ants.json
+++ b/mods/tuxemon/db/technique/ants.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/arcane_eye.json
+++ b/mods/tuxemon/db/technique/arcane_eye.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/assault.json
+++ b/mods/tuxemon/db/technique/assault.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/avalanche.json
+++ b/mods/tuxemon/db/technique/avalanche.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/barking.json
+++ b/mods/tuxemon/db/technique/barking.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/battery_acid.json
+++ b/mods/tuxemon/db/technique/battery_acid.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/battery_discharge.json
+++ b/mods/tuxemon/db/technique/battery_discharge.json
@@ -21,7 +21,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/beam.json
+++ b/mods/tuxemon/db/technique/beam.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/berserk.json
+++ b/mods/tuxemon/db/technique/berserk.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/biting_winds.json
+++ b/mods/tuxemon/db/technique/biting_winds.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/blade.json
+++ b/mods/tuxemon/db/technique/blade.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/blood_bond.json
+++ b/mods/tuxemon/db/technique/blood_bond.json
@@ -21,7 +21,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/blood_nets.json
+++ b/mods/tuxemon/db/technique/blood_nets.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/blossom.json
+++ b/mods/tuxemon/db/technique/blossom.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/boulder.json
+++ b/mods/tuxemon/db/technique/boulder.json
@@ -20,7 +20,6 @@
     "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 2,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/breath.json
+++ b/mods/tuxemon/db/technique/breath.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/breathe_fire.json
+++ b/mods/tuxemon/db/technique/breathe_fire.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/bubble_trap.json
+++ b/mods/tuxemon/db/technique/bubble_trap.json
@@ -21,7 +21,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/bullet.json
+++ b/mods/tuxemon/db/technique/bullet.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/canine.json
+++ b/mods/tuxemon/db/technique/canine.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/cat_calling.json
+++ b/mods/tuxemon/db/technique/cat_calling.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/cavity.json
+++ b/mods/tuxemon/db/technique/cavity.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/chameleon.json
+++ b/mods/tuxemon/db/technique/chameleon.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/chill_mist.json
+++ b/mods/tuxemon/db/technique/chill_mist.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/clairaudience.json
+++ b/mods/tuxemon/db/technique/clairaudience.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/clamp_on.json
+++ b/mods/tuxemon/db/technique/clamp_on.json
@@ -21,7 +21,6 @@
     "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 2,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/clock.json
+++ b/mods/tuxemon/db/technique/clock.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/cloud_aether.json
+++ b/mods/tuxemon/db/technique/cloud_aether.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/conjurer.json
+++ b/mods/tuxemon/db/technique/conjurer.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/constrict.json
+++ b/mods/tuxemon/db/technique/constrict.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/crystal.json
+++ b/mods/tuxemon/db/technique/crystal.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/demiurge.json
+++ b/mods/tuxemon/db/technique/demiurge.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/earthquake.json
+++ b/mods/tuxemon/db/technique/earthquake.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/electrical_storm.json
+++ b/mods/tuxemon/db/technique/electrical_storm.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/energy_claws.json
+++ b/mods/tuxemon/db/technique/energy_claws.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/energy_field.json
+++ b/mods/tuxemon/db/technique/energy_field.json
@@ -21,7 +21,6 @@
     "enemy monster": 1,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 2,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/evasion.json
+++ b/mods/tuxemon/db/technique/evasion.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/eyebite.json
+++ b/mods/tuxemon/db/technique/eyebite.json
@@ -20,7 +20,6 @@
     "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 2,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/feint.json
+++ b/mods/tuxemon/db/technique/feint.json
@@ -21,7 +21,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/feline.json
+++ b/mods/tuxemon/db/technique/feline.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/fester.json
+++ b/mods/tuxemon/db/technique/fester.json
@@ -21,7 +21,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/fiery.json
+++ b/mods/tuxemon/db/technique/fiery.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/fire_ball.json
+++ b/mods/tuxemon/db/technique/fire_ball.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/fire_claw.json
+++ b/mods/tuxemon/db/technique/fire_claw.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/fire_shield.json
+++ b/mods/tuxemon/db/technique/fire_shield.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/firestorm.json
+++ b/mods/tuxemon/db/technique/firestorm.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/flamethrower.json
+++ b/mods/tuxemon/db/technique/flamethrower.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/fledgling.json
+++ b/mods/tuxemon/db/technique/fledgling.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/flood.json
+++ b/mods/tuxemon/db/technique/flood.json
@@ -18,7 +18,6 @@
     "enemy monster": 2,
     "enemy team": 2,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/flow.json
+++ b/mods/tuxemon/db/technique/flow.json
@@ -18,7 +18,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/fluff_up.json
+++ b/mods/tuxemon/db/technique/fluff_up.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/font.json
+++ b/mods/tuxemon/db/technique/font.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/forfeit.json
+++ b/mods/tuxemon/db/technique/forfeit.json
@@ -18,8 +18,7 @@
 		"enemy trainer": 0,
 		"own monster": 0,
 		"own team": 0,
-		"own trainer": 0,
-		"item": 0
+		"own trainer": 0
 	},
 	"tech_id": 0,
 	"use_failure": "generic_failure",

--- a/mods/tuxemon/db/technique/frostbite.json
+++ b/mods/tuxemon/db/technique/frostbite.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/fume.json
+++ b/mods/tuxemon/db/technique/fume.json
@@ -20,7 +20,6 @@
     "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 2,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/give_all.json
+++ b/mods/tuxemon/db/technique/give_all.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/glower.json
+++ b/mods/tuxemon/db/technique/glower.json
@@ -20,7 +20,6 @@
     "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 2,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/goad.json
+++ b/mods/tuxemon/db/technique/goad.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/gold_digger.json
+++ b/mods/tuxemon/db/technique/gold_digger.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/grinding.json
+++ b/mods/tuxemon/db/technique/grinding.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/gust.json
+++ b/mods/tuxemon/db/technique/gust.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/gyser.json
+++ b/mods/tuxemon/db/technique/gyser.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/hawk.json
+++ b/mods/tuxemon/db/technique/hawk.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/headbutt.json
+++ b/mods/tuxemon/db/technique/headbutt.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/hibernate.json
+++ b/mods/tuxemon/db/technique/hibernate.json
@@ -21,7 +21,6 @@
     "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 2,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/ice_claw.json
+++ b/mods/tuxemon/db/technique/ice_claw.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/ice_storm.json
+++ b/mods/tuxemon/db/technique/ice_storm.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/icicle_spear.json
+++ b/mods/tuxemon/db/technique/icicle_spear.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/insanity.json
+++ b/mods/tuxemon/db/technique/insanity.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/invictus.json
+++ b/mods/tuxemon/db/technique/invictus.json
@@ -21,7 +21,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/kindling_flame.json
+++ b/mods/tuxemon/db/technique/kindling_flame.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/kraken.json
+++ b/mods/tuxemon/db/technique/kraken.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/lantern.json
+++ b/mods/tuxemon/db/technique/lantern.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/lava.json
+++ b/mods/tuxemon/db/technique/lava.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/levitate.json
+++ b/mods/tuxemon/db/technique/levitate.json
@@ -21,7 +21,6 @@
     "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 2,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/life_surge.json
+++ b/mods/tuxemon/db/technique/life_surge.json
@@ -21,7 +21,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/lightning_spheres.json
+++ b/mods/tuxemon/db/technique/lightning_spheres.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/lineage.json
+++ b/mods/tuxemon/db/technique/lineage.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/lust.json
+++ b/mods/tuxemon/db/technique/lust.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/magma.json
+++ b/mods/tuxemon/db/technique/magma.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/maori.json
+++ b/mods/tuxemon/db/technique/maori.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/meltdown.json
+++ b/mods/tuxemon/db/technique/meltdown.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/mending.json
+++ b/mods/tuxemon/db/technique/mending.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/midnight_mantle.json
+++ b/mods/tuxemon/db/technique/midnight_mantle.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/mobbing.json
+++ b/mods/tuxemon/db/technique/mobbing.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/muck.json
+++ b/mods/tuxemon/db/technique/muck.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/muddle.json
+++ b/mods/tuxemon/db/technique/muddle.json
@@ -21,7 +21,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/mudslide.json
+++ b/mods/tuxemon/db/technique/mudslide.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/mystic_blending.json
+++ b/mods/tuxemon/db/technique/mystic_blending.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/negation.json
+++ b/mods/tuxemon/db/technique/negation.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/nest.json
+++ b/mods/tuxemon/db/technique/nest.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/oedipus.json
+++ b/mods/tuxemon/db/technique/oedipus.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/one_two.json
+++ b/mods/tuxemon/db/technique/one_two.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/orbs.json
+++ b/mods/tuxemon/db/technique/orbs.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/overfeed.json
+++ b/mods/tuxemon/db/technique/overfeed.json
@@ -20,7 +20,6 @@
     "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 2,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/overgrowth.json
+++ b/mods/tuxemon/db/technique/overgrowth.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/panjandrum.json
+++ b/mods/tuxemon/db/technique/panjandrum.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/peck.json
+++ b/mods/tuxemon/db/technique/peck.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/peregrine.json
+++ b/mods/tuxemon/db/technique/peregrine.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/perfect_cut.json
+++ b/mods/tuxemon/db/technique/perfect_cut.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/petrify.json
+++ b/mods/tuxemon/db/technique/petrify.json
@@ -20,7 +20,6 @@
     "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 2,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/phantasmal_force.json
+++ b/mods/tuxemon/db/technique/phantasmal_force.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/pit.json
+++ b/mods/tuxemon/db/technique/pit.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/platinum.json
+++ b/mods/tuxemon/db/technique/platinum.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/poison_courtship.json
+++ b/mods/tuxemon/db/technique/poison_courtship.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/probiscus.json
+++ b/mods/tuxemon/db/technique/probiscus.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/pseudopod.json
+++ b/mods/tuxemon/db/technique/pseudopod.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/quicksand.json
+++ b/mods/tuxemon/db/technique/quicksand.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/radiance.json
+++ b/mods/tuxemon/db/technique/radiance.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/ram.json
+++ b/mods/tuxemon/db/technique/ram.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/refresh.json
+++ b/mods/tuxemon/db/technique/refresh.json
@@ -21,7 +21,6 @@
     "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 2,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/ring.json
+++ b/mods/tuxemon/db/technique/ring.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/rock.json
+++ b/mods/tuxemon/db/technique/rock.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/rot.json
+++ b/mods/tuxemon/db/technique/rot.json
@@ -20,7 +20,6 @@
     "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 2,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/ruby.json
+++ b/mods/tuxemon/db/technique/ruby.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/run.json
+++ b/mods/tuxemon/db/technique/run.json
@@ -18,8 +18,7 @@
 		"enemy trainer": 0,
 		"own monster": 0,
 		"own team": 0,
-		"own trainer": 0,
-		"item": 0
+		"own trainer": 0
 	},
 	"tech_id": 0,
 	"use_failure": "generic_failure",

--- a/mods/tuxemon/db/technique/rust_bomb.json
+++ b/mods/tuxemon/db/technique/rust_bomb.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/saber.json
+++ b/mods/tuxemon/db/technique/saber.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/salamander.json
+++ b/mods/tuxemon/db/technique/salamander.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/sand_spray.json
+++ b/mods/tuxemon/db/technique/sand_spray.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/scope.json
+++ b/mods/tuxemon/db/technique/scope.json
@@ -17,7 +17,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/shadow_boxing.json
+++ b/mods/tuxemon/db/technique/shadow_boxing.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/shapechange.json
+++ b/mods/tuxemon/db/technique/shapechange.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/shrapnel.json
+++ b/mods/tuxemon/db/technique/shrapnel.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/shuriken.json
+++ b/mods/tuxemon/db/technique/shuriken.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/skip.json
+++ b/mods/tuxemon/db/technique/skip.json
@@ -14,8 +14,7 @@
 		"enemy trainer": 0,
 		"own monster": 2,
 		"own team": 0,
-		"own trainer": 0,
-		"item": 0
+		"own trainer": 0
 	},
 	"tech_id": 0,
 	"types": [],

--- a/mods/tuxemon/db/technique/sleep_bomb.json
+++ b/mods/tuxemon/db/technique/sleep_bomb.json
@@ -21,7 +21,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/sleeping_powder.json
+++ b/mods/tuxemon/db/technique/sleeping_powder.json
@@ -21,7 +21,6 @@
     "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 2,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/slime.json
+++ b/mods/tuxemon/db/technique/slime.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/snowstorm.json
+++ b/mods/tuxemon/db/technique/snowstorm.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/splinter.json
+++ b/mods/tuxemon/db/technique/splinter.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/spray.json
+++ b/mods/tuxemon/db/technique/spray.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/stabilo.json
+++ b/mods/tuxemon/db/technique/stabilo.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/stampede.json
+++ b/mods/tuxemon/db/technique/stampede.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/starfall.json
+++ b/mods/tuxemon/db/technique/starfall.json
@@ -21,7 +21,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/static_field.json
+++ b/mods/tuxemon/db/technique/static_field.json
@@ -21,7 +21,6 @@
     "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 2,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/status_blinded.json
+++ b/mods/tuxemon/db/technique/status_blinded.json
@@ -26,8 +26,7 @@
     "enemy trainer": 0,
     "own monster": 0,
     "own team": 0,
-    "own trainer": 0,
-    "item": 0
+    "own trainer": 0
   },
   "tech_id": 0,
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/technique/status_chargedup.json
+++ b/mods/tuxemon/db/technique/status_chargedup.json
@@ -37,8 +37,7 @@
     "enemy trainer": 0,
     "own monster": 0,
     "own team": 0,
-    "own trainer": 0,
-    "item": 0
+    "own trainer": 0
   },
   "tech_id": 0,
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/technique/status_charging.json
+++ b/mods/tuxemon/db/technique/status_charging.json
@@ -15,8 +15,7 @@
     "enemy trainer": 0,
     "own monster": 0,
     "own team": 0,
-    "own trainer": 0,
-    "item": 0
+    "own trainer": 0
   },
   "tech_id": 0,
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/technique/status_confused.json
+++ b/mods/tuxemon/db/technique/status_confused.json
@@ -16,8 +16,7 @@
     "enemy trainer": 0,
     "own monster": 0,
     "own team": 0,
-    "own trainer": 0,
-    "item": 0
+    "own trainer": 0
   },
   "tech_id": 0,
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/technique/status_diehard.json
+++ b/mods/tuxemon/db/technique/status_diehard.json
@@ -16,8 +16,7 @@
     "enemy trainer": 0,
     "own monster": 0,
     "own team": 0,
-    "own trainer": 0,
-    "item": 0
+    "own trainer": 0
   },
   "tech_id": 0,
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/technique/status_dozing.json
+++ b/mods/tuxemon/db/technique/status_dozing.json
@@ -14,8 +14,7 @@
     "enemy trainer": 0,
     "own monster": 0,
     "own team": 0,
-    "own trainer": 0,
-    "item": 0
+    "own trainer": 0
   },
   "tech_id": 0,
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/technique/status_eliminated.json
+++ b/mods/tuxemon/db/technique/status_eliminated.json
@@ -13,8 +13,7 @@
     "enemy trainer": 0,
     "own monster": 0,
     "own team": 0,
-    "own trainer": 0,
-    "item": 0
+    "own trainer": 0
   },
   "tech_id": 0,
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/technique/status_enraged.json
+++ b/mods/tuxemon/db/technique/status_enraged.json
@@ -26,8 +26,7 @@
     "enemy trainer": 0,
     "own monster": 0,
     "own team": 0,
-    "own trainer": 0,
-    "item": 0
+    "own trainer": 0
   },
   "tech_id": 0,
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/technique/status_exhausted.json
+++ b/mods/tuxemon/db/technique/status_exhausted.json
@@ -25,8 +25,7 @@
     "enemy trainer": 0,
     "own monster": 0,
     "own team": 0,
-    "own trainer": 0,
-    "item": 0
+    "own trainer": 0
   },
   "tech_id": 0,
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/technique/status_faint.json
+++ b/mods/tuxemon/db/technique/status_faint.json
@@ -13,8 +13,7 @@
     "enemy trainer": 0,
     "own monster": 0,
     "own team": 0,
-    "own trainer": 0,
-    "item": 0
+    "own trainer": 0
   },
   "tech_id": 0,
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/technique/status_festering.json
+++ b/mods/tuxemon/db/technique/status_festering.json
@@ -15,8 +15,7 @@
     "enemy trainer": 0,
     "own monster": 0,
     "own team": 0,
-    "own trainer": 0,
-    "item": 0
+    "own trainer": 0
   },
   "tech_id": 0,
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/technique/status_focused.json
+++ b/mods/tuxemon/db/technique/status_focused.json
@@ -22,8 +22,7 @@
     "enemy trainer": 0,
     "own monster": 0,
     "own team": 0,
-    "own trainer": 0,
-    "item": 0
+    "own trainer": 0
   },
   "tech_id": 0,
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/technique/status_grabbed.json
+++ b/mods/tuxemon/db/technique/status_grabbed.json
@@ -18,8 +18,7 @@
     "enemy trainer": 0,
     "own monster": 0,
     "own team": 0,
-    "own trainer": 0,
-    "item": 0
+    "own trainer": 0
   },
   "tech_id": 0,
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/technique/status_hardshell.json
+++ b/mods/tuxemon/db/technique/status_hardshell.json
@@ -22,8 +22,7 @@
     "enemy trainer": 0,
     "own monster": 0,
     "own team": 0,
-    "own trainer": 0,
-    "item": 0
+    "own trainer": 0
   },
   "tech_id": 0,
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/technique/status_lifeleech.json
+++ b/mods/tuxemon/db/technique/status_lifeleech.json
@@ -21,8 +21,7 @@
     "enemy trainer": 0,
     "own monster": 0,
     "own team": 0,
-    "own trainer": 0,
-    "item": 0
+    "own trainer": 0
   },
   "tech_id": 0,
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/technique/status_noddingoff.json
+++ b/mods/tuxemon/db/technique/status_noddingoff.json
@@ -15,8 +15,7 @@
     "enemy trainer": 0,
     "own monster": 0,
     "own team": 0,
-    "own trainer": 0,
-    "item": 0
+    "own trainer": 0
   },
   "tech_id": 0,
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/technique/status_overfeed.json
+++ b/mods/tuxemon/db/technique/status_overfeed.json
@@ -22,8 +22,7 @@
     "enemy trainer": 0,
     "own monster": 0,
     "own team": 0,
-    "own trainer": 0,
-    "item": 0
+    "own trainer": 0
   },
   "tech_id": 0,
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/technique/status_poison.json
+++ b/mods/tuxemon/db/technique/status_poison.json
@@ -18,8 +18,7 @@
     "enemy trainer": 0,
     "own monster": 0,
     "own team": 0,
-    "own trainer": 0,
-    "item": 0
+    "own trainer": 0
   },
   "tech_id": 0,
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/technique/status_recover.json
+++ b/mods/tuxemon/db/technique/status_recover.json
@@ -18,8 +18,7 @@
     "enemy trainer": 0,
     "own monster": 0,
     "own team": 0,
-    "own trainer": 0,
-    "item": 0
+    "own trainer": 0
   },
   "tech_id": 0,
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/technique/status_sniping.json
+++ b/mods/tuxemon/db/technique/status_sniping.json
@@ -26,8 +26,7 @@
     "enemy trainer": 0,
     "own monster": 0,
     "own team": 0,
-    "own trainer": 0,
-    "item": 0
+    "own trainer": 0
   },
   "tech_id": 0,
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/technique/status_softened.json
+++ b/mods/tuxemon/db/technique/status_softened.json
@@ -26,8 +26,7 @@
     "enemy trainer": 0,
     "own monster": 0,
     "own team": 0,
-    "own trainer": 0,
-    "item": 0
+    "own trainer": 0
   },
   "tech_id": 0,
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/technique/status_spyderbite.json
+++ b/mods/tuxemon/db/technique/status_spyderbite.json
@@ -13,8 +13,7 @@
     "enemy trainer": 0,
     "own monster": 0,
     "own team": 0,
-    "own trainer": 0,
-    "item": 0
+    "own trainer": 0
   },
   "tech_id": 0,
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/technique/status_stuck.json
+++ b/mods/tuxemon/db/technique/status_stuck.json
@@ -18,8 +18,7 @@
     "enemy trainer": 0,
     "own monster": 0,
     "own team": 0,
-    "own trainer": 0,
-    "item": 0
+    "own trainer": 0
   },
   "tech_id": 0,
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/technique/status_tired.json
+++ b/mods/tuxemon/db/technique/status_tired.json
@@ -16,8 +16,7 @@
     "enemy trainer": 0,
     "own monster": 0,
     "own team": 0,
-    "own trainer": 0,
-    "item": 0
+    "own trainer": 0
   },
   "tech_id": 0,
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/technique/sting.json
+++ b/mods/tuxemon/db/technique/sting.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/stone_rot.json
+++ b/mods/tuxemon/db/technique/stone_rot.json
@@ -20,7 +20,6 @@
     "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 2,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/stonehenge.json
+++ b/mods/tuxemon/db/technique/stonehenge.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/strangulation.json
+++ b/mods/tuxemon/db/technique/strangulation.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/strike.json
+++ b/mods/tuxemon/db/technique/strike.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/suck_poison.json
+++ b/mods/tuxemon/db/technique/suck_poison.json
@@ -21,7 +21,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/sudden_glow.json
+++ b/mods/tuxemon/db/technique/sudden_glow.json
@@ -22,7 +22,6 @@
     "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 2,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/sunburst.json
+++ b/mods/tuxemon/db/technique/sunburst.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/supernova.json
+++ b/mods/tuxemon/db/technique/supernova.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/surf.json
+++ b/mods/tuxemon/db/technique/surf.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 2,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/surge.json
+++ b/mods/tuxemon/db/technique/surge.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/swap.json
+++ b/mods/tuxemon/db/technique/swap.json
@@ -20,8 +20,7 @@
 		"enemy trainer": 0,
 		"own monster": 2,
 		"own team": 0,
-		"own trainer": 0,
-		"item": 0
+		"own trainer": 0
 	},
 	"tech_id": 0,
 	"types": [],

--- a/mods/tuxemon/db/technique/sword.json
+++ b/mods/tuxemon/db/technique/sword.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/sylvan.json
+++ b/mods/tuxemon/db/technique/sylvan.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/take_cover.json
+++ b/mods/tuxemon/db/technique/take_cover.json
@@ -20,7 +20,6 @@
     "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 2,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/terror.json
+++ b/mods/tuxemon/db/technique/terror.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/thunderball.json
+++ b/mods/tuxemon/db/technique/thunderball.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/thunderclap.json
+++ b/mods/tuxemon/db/technique/thunderclap.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/time_crisis.json
+++ b/mods/tuxemon/db/technique/time_crisis.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/tip.json
+++ b/mods/tuxemon/db/technique/tip.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/tonguespear.json
+++ b/mods/tuxemon/db/technique/tonguespear.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/torch.json
+++ b/mods/tuxemon/db/technique/torch.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/touch.json
+++ b/mods/tuxemon/db/technique/touch.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/tsunami.json
+++ b/mods/tuxemon/db/technique/tsunami.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/tux_attack.json
+++ b/mods/tuxemon/db/technique/tux_attack.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/ubuntu.json
+++ b/mods/tuxemon/db/technique/ubuntu.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/undertaker.json
+++ b/mods/tuxemon/db/technique/undertaker.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/venom.json
+++ b/mods/tuxemon/db/technique/venom.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/venomous_tentacle.json
+++ b/mods/tuxemon/db/technique/venomous_tentacle.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/viper.json
+++ b/mods/tuxemon/db/technique/viper.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/vorpal.json
+++ b/mods/tuxemon/db/technique/vorpal.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/wall_fire.json
+++ b/mods/tuxemon/db/technique/wall_fire.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/wall_ice.json
+++ b/mods/tuxemon/db/technique/wall_ice.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/wall_of_steel.json
+++ b/mods/tuxemon/db/technique/wall_of_steel.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/wallow.json
+++ b/mods/tuxemon/db/technique/wallow.json
@@ -21,7 +21,6 @@
     "enemy monster": 0,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 2,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/walls.json
+++ b/mods/tuxemon/db/technique/walls.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/web.json
+++ b/mods/tuxemon/db/technique/web.json
@@ -20,7 +20,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/webs_wind.json
+++ b/mods/tuxemon/db/technique/webs_wind.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/whirlwind.json
+++ b/mods/tuxemon/db/technique/whirlwind.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0

--- a/mods/tuxemon/db/technique/wing_tip.json
+++ b/mods/tuxemon/db/technique/wing_tip.json
@@ -19,7 +19,6 @@
     "enemy monster": 2,
     "enemy team": 0,
     "enemy trainer": 0,
-    "item": 0,
     "own monster": 0,
     "own team": 0,
     "own trainer": 0


### PR DESCRIPTION
PR addresses the complete elimination of the **item: 0** field in all the techniques.
Honestly I have no idea what it could have been the reason behind it.

team makes sense (monsters in the field in a 2 vs 2)
trainer is going to address all the party
but... addressing the item?

It's a part of the task of updating the target fields in technique, while the items (as you can see from the other PRs) will be completely removed. By the way all the 205 files had item = 0.

from
```
    "enemy monster": 2,
    "enemy team": 0, <--- currently not implemented
    "enemy trainer": 0, <--- currently not implemented
    "item": 0, <--- currently not implemented (?)
    "own monster": 0, 
    "own team": 0, <--- currently not implemented
    "own trainer": 0 <--- currently not implemented
```
to
```
    "enemy monster": 2,
    "enemy team": 0,
    "enemy trainer": 0,
    "own monster": 0,
    "own team": 0,
    "own trainer": 0
```