### PR TITLE
use technique outside combat

### DIFF
--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -524,7 +524,7 @@ class TechniqueModel(BaseModel):
         False, description="Whether or not this is an area of effect technique"
     )
     randomly: bool = Field(
-        True, description="Whether or not this is a fast technique"
+        True, description="Whether or not this can be picked randomly"
     )
     healing_power: int = Field(0, description="Value of healing power.")
     recharge: int = Field(0, description="Recharge of this technique")

--- a/tuxemon/states/techniques/__init__.py
+++ b/tuxemon/states/techniques/__init__.py
@@ -87,18 +87,30 @@ class TechniqueMenuState(Menu[Technique]):
         """
 
         def use_technique(menu_technique: MenuItem[Monster]) -> None:
+            self.client.pop_state()  # close y/n
+            self.client.pop_state()  # close technique menu
+            self.client.pop_state()  # close world menu
             monster = menu_technique.game_object
-
             result = technique.use(monster, monster)
-            self.client.pop_state()  # pop the monster screen
-            self.client.pop_state()  # pop the technique screen
+            technique.full_recharge()
+            tools.show_item_result_as_dialog(local_session, technique, result)
+
+        def use_tech_no_monster(tech: Technique) -> None:
+            self.client.pop_state()  # close y/n
+            self.client.pop_state()  # close technique menu
+            self.client.pop_state()  # close world menu
+            tech.use(None, None)
+            tech.full_recharge()
 
         def confirm() -> None:
-            self.client.pop_state()  # close the confirm dialog
+            self.client.pop_state()
 
-            menu = self.client.push_state(MonsterMenuState())
-            menu.is_valid_entry = technique.validate  # type: ignore[assignment]
-            menu.on_menu_selection = use_technique  # type: ignore[assignment]
+            if technique.usable_on:
+                use_tech_no_monster(technique)
+            else:
+                menu = self.client.push_state(MonsterMenuState())
+                menu.is_valid_entry = technique.validate  # type: ignore[assignment]
+                menu.on_menu_selection = use_technique  # type: ignore[assignment]
 
         def cancel() -> None:
             self.client.pop_state()  # close the use/cancel menu

--- a/tuxemon/technique/conditions/facing_sprite.py
+++ b/tuxemon/technique/conditions/facing_sprite.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Tuple
+
+from tuxemon.event import get_npc_pos
+from tuxemon.technique.techcondition import TechCondition
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
+
+
+@dataclass
+class FacingSpriteCondition(TechCondition):
+    """
+    Checks if the player is facing a specific sprite.
+    (eg. maniac, swimmer, log)
+
+    """
+
+    name = "facing_sprite"
+    sprite: str
+
+    def test(self, target: Monster) -> bool:
+        coords: Tuple[int, int] = (0, 0)
+        player = self.session.player
+        facing = player.facing
+        player_x = player.tile_pos[0]
+        player_y = player.tile_pos[1]
+        if facing == "down":
+            y = player_y - 1
+            coords = player_x, y
+        elif facing == "up":
+            y = player_y + 1
+            coords = player_x, y
+        elif facing == "right":
+            x = player_x + 1
+            coords = x, player_y
+        elif facing == "left":
+            x = player_x - 1
+            coords = x, player_y
+
+        npc = get_npc_pos(self.session, coords)
+        if npc:
+            if npc.sprite_name == self.sprite:
+                return True
+            else:
+                return False
+        else:
+            return False

--- a/tuxemon/technique/effects/damage.py
+++ b/tuxemon/technique/effects/damage.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from tuxemon import formula
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
@@ -40,20 +40,31 @@ class DamageEffect(TechEffect):
     name = "damage"
 
     def apply(
-        self, tech: Technique, user: Monster, target: Monster
+        self,
+        tech: Technique,
+        user: Union[Monster, None],
+        target: Union[Monster, None],
     ) -> DamageEffectResult:
+        damage: int = 0
+        mult: float = 0.0
         player = self.session.player
-        value = float(player.game_variables["random_tech_hit"])
-        hit = tech.accuracy >= value
-        if hit or tech.is_area:
-            tech.advance_counter_success()
-            damage, mult = formula.simple_damage_calculate(tech, user, target)
-            if not hit:
-                damage //= 2
-            target.current_hp -= damage
-        else:
-            damage = 0
-            mult = 1.0
+        if user and target:
+            value = float(player.game_variables["random_tech_hit"])
+            hit = tech.accuracy >= value
+            if hit or tech.is_area:
+                tech.advance_counter_success()
+                damage, mult = formula.simple_damage_calculate(
+                    tech, user, target
+                )
+                if not hit:
+                    damage //= 2
+                target.current_hp -= damage
+            else:
+                damage = 0
+                mult = 1.0
+        # using technique in the worldstate
+        elif not user and not target:
+            damage = 1
 
         return {
             "damage": damage,

--- a/tuxemon/technique/effects/enhance.py
+++ b/tuxemon/technique/effects/enhance.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
 
@@ -34,7 +34,10 @@ class EnhanceEffect(TechEffect):
     name = "enhance"
 
     def apply(
-        self, tech: Technique, user: Monster, target: Monster
+        self,
+        tech: Technique,
+        user: Union[Monster, None],
+        target: Union[Monster, None],
     ) -> EnhanceEffectResult:
         player = self.session.player
         value = float(player.game_variables["random_tech_hit"])

--- a/tuxemon/technique/effects/give.py
+++ b/tuxemon/technique/effects/give.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import random
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
 from tuxemon.technique.technique import Technique
@@ -28,13 +28,16 @@ class GiveEffect(TechEffect):
     objective: str
 
     def apply(
-        self, tech: Technique, user: Monster, target: Monster
+        self,
+        tech: Technique,
+        user: Union[Monster, None],
+        target: Union[Monster, None],
     ) -> GiveEffectResult:
         player = self.session.player
         potency = random.random()
         value = float(player.game_variables["random_tech_hit"])
         success = tech.potency >= potency and tech.accuracy >= value
-        if success:
+        if success and target and user:
             status = Technique()
             status.load(self.condition)
             status.link = user

--- a/tuxemon/technique/effects/grabbed.py
+++ b/tuxemon/technique/effects/grabbed.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from tuxemon import formula
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
@@ -26,9 +26,12 @@ class GrabbedEffect(TechEffect):
     name = "grabbed"
 
     def apply(
-        self, tech: Technique, user: Monster, target: Monster
+        self,
+        tech: Technique,
+        user: Union[Monster, None],
+        target: Union[Monster, None],
     ) -> GrabbedEffectResult:
-        if tech.slug == "status_grabbed":
+        if tech.slug == "status_grabbed" and target:
             formula.simple_grabbed(target)
             return {"success": True}
 

--- a/tuxemon/technique/effects/lifeleech.py
+++ b/tuxemon/technique/effects/lifeleech.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from tuxemon import formula
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
@@ -34,9 +34,12 @@ class LifeLeechEffect(TechEffect):
     name = "lifeleech"
 
     def apply(
-        self, tech: Technique, user: Monster, target: Monster
+        self,
+        tech: Technique,
+        user: Union[Monster, None],
+        target: Union[Monster, None],
     ) -> LifeLeechEffectResult:
-        if tech.slug == "status_lifeleech":
+        if tech.slug == "status_lifeleech" and target:
             # avoids Nonetype situation and reset the user
             if user is None:
                 user = tech.link

--- a/tuxemon/technique/effects/poison.py
+++ b/tuxemon/technique/effects/poison.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from tuxemon import formula
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
@@ -26,9 +26,12 @@ class PoisonEffect(TechEffect):
     name = "poison"
 
     def apply(
-        self, tech: Technique, user: Monster, target: Monster
+        self,
+        tech: Technique,
+        user: Union[Monster, None],
+        target: Union[Monster, None],
     ) -> PoisonEffectResult:
-        if tech.slug == "status_poison":
+        if tech.slug == "status_poison" and target:
             damage = formula.simple_poison(target)
             target.current_hp -= damage
 

--- a/tuxemon/technique/effects/recover.py
+++ b/tuxemon/technique/effects/recover.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from tuxemon import formula
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
@@ -26,7 +26,10 @@ class RecoverEffect(TechEffect):
     name = "recover"
 
     def apply(
-        self, tech: Technique, user: Monster, target: Monster
+        self,
+        tech: Technique,
+        user: Union[Monster, None],
+        target: Union[Monster, None],
     ) -> RecoverEffectResult:
         if tech.slug == "status_recover":
             # avoids Nonetype situation and reset the user

--- a/tuxemon/technique/effects/remove.py
+++ b/tuxemon/technique/effects/remove.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Tuple, Union
+
+from tuxemon.event import get_npc_pos
+from tuxemon.event.actions.remove_npc import RemoveNpcAction
+from tuxemon.technique.techeffect import TechEffect, TechEffectResult
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
+    from tuxemon.technique.technique import Technique
+
+
+class RemoveEffectResult(TechEffectResult):
+    pass
+
+
+@dataclass
+class RemoveEffect(TechEffect):
+    """
+    Removes the NPC and creates a variable.
+    """
+
+    name = "remove"
+
+    def apply(
+        self,
+        tech: Technique,
+        user: Union[Monster, None],
+        target: Union[Monster, None],
+    ) -> RemoveEffectResult:
+        if target:
+            return {"success": True}
+        # using technique in the worldstate
+        else:
+            coords: Tuple[int, int] = (0, 0)
+            player = self.session.player
+            facing = player.facing
+            player_x = player.tile_pos[0]
+            player_y = player.tile_pos[1]
+            if facing == "down":
+                y = player_y - 1
+                coords = player_x, y
+            elif facing == "up":
+                y = player_y + 1
+                coords = player_x, y
+            elif facing == "right":
+                x = player_x + 1
+                coords = x, player_y
+            elif facing == "left":
+                x = player_x - 1
+                coords = x, player_y
+
+            npc = get_npc_pos(self.session, coords)
+            if npc:
+                RemoveNpcAction(npc_slug=npc.slug).start()
+                self.session.player.game_variables[npc.slug] = self.name
+                return {"success": True}
+            else:
+                return {"success": False}

--- a/tuxemon/technique/effects/stuck.py
+++ b/tuxemon/technique/effects/stuck.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from tuxemon import formula
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
@@ -26,9 +26,12 @@ class StuckEffect(TechEffect):
     name = "stuck"
 
     def apply(
-        self, tech: Technique, user: Monster, target: Monster
+        self,
+        tech: Technique,
+        user: Union[Monster, None],
+        target: Union[Monster, None],
     ) -> StuckEffectResult:
-        if tech.slug == "status_stuck":
+        if tech.slug == "status_stuck" and target:
             formula.simple_stuck(target)
             return {"success": True}
 

--- a/tuxemon/technique/effects/swap.py
+++ b/tuxemon/technique/effects/swap.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
 
@@ -31,19 +31,23 @@ class SwapEffect(TechEffect):
     name = "swap"
 
     def apply(
-        self, tech: Technique, user: Monster, target: Monster
+        self,
+        tech: Technique,
+        user: Union[Monster, None],
+        target: Union[Monster, None],
     ) -> SwapEffectResult:
         # TODO: implement actions as events, so that combat state can find them
         # TODO: relies on setting "combat_state" attribute.  maybe clear it up
         # later
         # TODO: these values are set in combat_menus.py
         player = self.session.player
-        assert tech.combat_state
+        assert tech.combat_state and target
         # TODO: find a way to pass values. this will only work for SP games with one monster party
         combat_state = tech.combat_state
 
         def swap_add() -> None:
             # TODO: make accommodations for battlefield positions
+            assert target
             combat_state.add_monster_into_play(player, target)
 
         # get the original monster to be swapped out

--- a/tuxemon/technique/techeffect.py
+++ b/tuxemon/technique/techeffect.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, ClassVar, TypedDict
+from typing import TYPE_CHECKING, ClassVar, TypedDict, Union
 
 from tuxemon.session import Session, local_session
 from tuxemon.tools import cast_dataclass_parameters
@@ -67,6 +67,9 @@ class TechEffect:
         cast_dataclass_parameters(self)
 
     def apply(
-        self, tech: Technique, user: Monster, target: Monster
+        self,
+        tech: Technique,
+        user: Union[Monster, None],
+        target: Union[Monster, None],
     ) -> TechEffectResult:
         pass

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -13,6 +13,7 @@ from typing import (
     Optional,
     Sequence,
     Type,
+    Union,
 )
 
 from tuxemon import plugin, prepare
@@ -273,7 +274,7 @@ class Technique:
         """
         self.counter_success += 1
 
-    def validate(self, target: Optional[Monster]) -> bool:
+    def validate(self, target: Union[Monster, None]) -> bool:
         """
         Check if the target meets all conditions that the technique has on it's use.
 
@@ -305,7 +306,9 @@ class Technique:
     def full_recharge(self) -> None:
         self.next_use = 0
 
-    def use(self, user: Monster, target: Monster) -> TechEffectResult:
+    def use(
+        self, user: Union[Monster, None], target: Union[Monster, None]
+    ) -> TechEffectResult:
         """
         Apply the technique.
 

--- a/tuxemon/tools.py
+++ b/tuxemon/tools.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     from tuxemon.session import Session
     from tuxemon.sprite import Sprite
     from tuxemon.state import State
+    from tuxemon.technique.technique import Technique
 
 
 logger = logging.getLogger(__name__)
@@ -316,7 +317,7 @@ def cast_dataclass_parameters(self) -> None:
 
 def show_item_result_as_dialog(
     session: Session,
-    item: Item,
+    item: Union[Item, Technique],
     result: Mapping[str, Any],
 ) -> None:
     """


### PR DESCRIPTION
waiting #1818 + another

PR allows to use technique outside combat (world)
menu > monster > techniques > technique (use)
 
- it adds the technique condition **facing_npc**;
- it adds the technique effect **remove** (remove npc the player is facing, exactly like in item, eg boulder, logs, etc.);
- it allows us to get rid of an ultra annoying typehint inside combat.py;

we can destroy a boulder or cut a tree (if NPC) by using a technique, at the moment with no use (no such techniques).

tested, black, isort, -1 typehint