### PR TITLE
fix techs accuracy

### DIFF
--- a/mods/tuxemon/db/technique/acid.json
+++ b/mods/tuxemon/db/technique/acid.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 119,
-  "accuracy": 0.4,
+  "accuracy": 0.6,
   "animation": "drip_orange",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/air_chain.json
+++ b/mods/tuxemon/db/technique/air_chain.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 121,
-  "accuracy": 0.5,
+  "accuracy": 0.6,
   "animation": "triforce_163",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/barking.json
+++ b/mods/tuxemon/db/technique/barking.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 112,
-  "accuracy": 0.1,
+  "accuracy": 0.6,
   "animation": "pound",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/blood_nets.json
+++ b/mods/tuxemon/db/technique/blood_nets.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 164,
-  "accuracy": 0.5,
+  "accuracy": 0.6,
   "animation": "ruby_radiate",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/canine.json
+++ b/mods/tuxemon/db/technique/canine.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 123,
-  "accuracy": 0.3,
+  "accuracy": 0.6,
   "animation": "claws_twice_blue",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/cat_calling.json
+++ b/mods/tuxemon/db/technique/cat_calling.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 124,
-  "accuracy": 0.4,
+  "accuracy": 0.6,
   "animation": "calling",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/cavity.json
+++ b/mods/tuxemon/db/technique/cavity.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 118,
-  "accuracy": 0.4,
+  "accuracy": 0.6,
   "animation": "slash_power",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/clairaudience.json
+++ b/mods/tuxemon/db/technique/clairaudience.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 125,
-  "accuracy": 0.3,
+  "accuracy": 0.6,
   "animation": "metallic_radiate",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/clock.json
+++ b/mods/tuxemon/db/technique/clock.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 105,
-  "accuracy": 0.2,
+  "accuracy": 0.6,
   "animation": "clock",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/cloud_aether.json
+++ b/mods/tuxemon/db/technique/cloud_aether.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 126,
-  "accuracy": 0.2,
+  "accuracy": 0.6,
   "animation": "sparks_blue_alt",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/evasion.json
+++ b/mods/tuxemon/db/technique/evasion.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 116,
-  "accuracy": 0.5,
+  "accuracy": 0.6,
   "animation": "x_attack",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/feline.json
+++ b/mods/tuxemon/db/technique/feline.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 129,
-  "accuracy": 0.2,
+  "accuracy": 0.6,
   "animation": "claws_twice_red",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/fiery.json
+++ b/mods/tuxemon/db/technique/fiery.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 98,
-  "accuracy": 0.1,
+  "accuracy": 0.6,
   "animation": "pound_bright",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/fire_shield.json
+++ b/mods/tuxemon/db/technique/fire_shield.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 167,
-  "accuracy": 0.1,
+  "accuracy": 0.6,
   "animation": "shield_fire",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/fledgling.json
+++ b/mods/tuxemon/db/technique/fledgling.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 117,
-  "accuracy": 0.2,
+  "accuracy": 0.6,
   "animation": "turquoise_circle",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/flood.json
+++ b/mods/tuxemon/db/technique/flood.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 10,
-  "accuracy": 0.5,
+  "accuracy": 0.6,
   "animation": "watershot",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/flow.json
+++ b/mods/tuxemon/db/technique/flow.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 9,
-  "accuracy": 0.5,
+  "accuracy": 0.6,
   "animation": "waterspurt",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/grinding.json
+++ b/mods/tuxemon/db/technique/grinding.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 109,
-  "accuracy": 0.3,
+  "accuracy": 0.6,
   "animation": "bite_zombie",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/gust.json
+++ b/mods/tuxemon/db/technique/gust.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 161,
-  "accuracy": 0.3,
+  "accuracy": 0.6,
   "animation": "x_attack",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/gyser.json
+++ b/mods/tuxemon/db/technique/gyser.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 91,
-  "accuracy": 0.1,
+  "accuracy": 0.6,
   "animation": "smokebomb_plume",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/ice_storm.json
+++ b/mods/tuxemon/db/technique/ice_storm.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 171,
-  "accuracy": 0.4,
+  "accuracy": 0.6,
   "animation": "ice_storm",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/lantern.json
+++ b/mods/tuxemon/db/technique/lantern.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 133,
-  "accuracy": 0.4,
+  "accuracy": 0.6,
   "animation": "gloop_orange",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/lava.json
+++ b/mods/tuxemon/db/technique/lava.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 134,
-  "accuracy": 0.4,
+  "accuracy": 0.6,
   "animation": "shield_lava",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/lust.json
+++ b/mods/tuxemon/db/technique/lust.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 136,
-  "accuracy": 0.4,
+  "accuracy": 0.6,
   "animation": "drip_red",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/maori.json
+++ b/mods/tuxemon/db/technique/maori.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 106,
-  "accuracy": 0.4,
+  "accuracy": 0.6,
   "animation": "slash_power",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/meltdown.json
+++ b/mods/tuxemon/db/technique/meltdown.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 103,
-  "accuracy": 0.3,
+  "accuracy": 0.6,
   "animation": "meltdown",
   "effects": [
     "give status_festering,target",

--- a/mods/tuxemon/db/technique/muck.json
+++ b/mods/tuxemon/db/technique/muck.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 138,
-  "accuracy": 0.2,
+  "accuracy": 0.6,
   "animation": "x_attack",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/mystic_blending.json
+++ b/mods/tuxemon/db/technique/mystic_blending.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 139,
-  "accuracy": 0.2,
+  "accuracy": 0.6,
   "animation": "sparks_blue",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/oedipus.json
+++ b/mods/tuxemon/db/technique/oedipus.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 100,
-  "accuracy": 0.5,
+  "accuracy": 0.6,
   "animation": "skull_fire",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/phantasmal_force.json
+++ b/mods/tuxemon/db/technique/phantasmal_force.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 162,
-  "accuracy": 0.1,
+  "accuracy": 0.6,
   "animation": "sparks_green",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/pit.json
+++ b/mods/tuxemon/db/technique/pit.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 142,
-  "accuracy": 0.1,
+  "accuracy": 0.6,
   "animation": "x_attack",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/ring.json
+++ b/mods/tuxemon/db/technique/ring.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 145,
-  "accuracy": 0.1,
+  "accuracy": 0.6,
   "animation": "pulse_absorb",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/ruby.json
+++ b/mods/tuxemon/db/technique/ruby.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 146,
-  "accuracy": 0.5,
+  "accuracy": 0.6,
   "animation": "ruby",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/rust_bomb.json
+++ b/mods/tuxemon/db/technique/rust_bomb.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 86,
-  "accuracy": 0.5,
+  "accuracy": 0.6,
   "animation": "smokebomb_puff_128",
   "effects": [
     "give status_poison,target",

--- a/mods/tuxemon/db/technique/saber.json
+++ b/mods/tuxemon/db/technique/saber.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 102,
-  "accuracy": 0.3,
+  "accuracy": 0.6,
   "animation": "x_attack",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/shapechange.json
+++ b/mods/tuxemon/db/technique/shapechange.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 160,
-  "accuracy": 0.2,
+  "accuracy": 0.6,
   "animation": "x_attack",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/shrapnel.json
+++ b/mods/tuxemon/db/technique/shrapnel.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 60,
-  "accuracy": 0.5,
+  "accuracy": 0.6,
   "animation": "explosion_small",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/slime.json
+++ b/mods/tuxemon/db/technique/slime.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 96,
-  "accuracy": 0.3,
+  "accuracy": 0.6,
   "animation": "sparks_green_alt",
   "effects": [
     "give status_festering,target",

--- a/mods/tuxemon/db/technique/snowstorm.json
+++ b/mods/tuxemon/db/technique/snowstorm.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 25,
-  "accuracy": 0.5,
+  "accuracy": 0.6,
   "animation": "explosion_ice_112",
   "effects": [
     "give status_exhausted,target",

--- a/mods/tuxemon/db/technique/stonehenge.json
+++ b/mods/tuxemon/db/technique/stonehenge.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 107,
-  "accuracy": 0.1,
+  "accuracy": 0.6,
   "animation": "pound_rock",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/strangulation.json
+++ b/mods/tuxemon/db/technique/strangulation.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 93,
-  "accuracy": 0.1,
+  "accuracy": 0.6,
   "animation": "x_attack",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/sunburst.json
+++ b/mods/tuxemon/db/technique/sunburst.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 159,
-  "accuracy": 0.4,
+  "accuracy": 0.6,
   "animation": "explosion_sun_32",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/sylvan.json
+++ b/mods/tuxemon/db/technique/sylvan.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 148,
-  "accuracy": 0.5,
+  "accuracy": 0.6,
   "animation": "emerald",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/terror.json
+++ b/mods/tuxemon/db/technique/terror.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 149,
-  "accuracy": 0.2,
+  "accuracy": 0.6,
   "animation": "x_attack",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/time_crisis.json
+++ b/mods/tuxemon/db/technique/time_crisis.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 104,
-  "accuracy": 0.1,
+  "accuracy": 0.6,
   "animation": "x_attack",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/tsunami.json
+++ b/mods/tuxemon/db/technique/tsunami.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 170,
-  "accuracy": 0.4,
+  "accuracy": 0.6,
   "animation": "waterfall",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/tux_attack.json
+++ b/mods/tuxemon/db/technique/tux_attack.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 92,
-  "accuracy": 0.3,
+  "accuracy": 0.6,
   "animation": "tux_attack",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/ubuntu.json
+++ b/mods/tuxemon/db/technique/ubuntu.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 95,
-  "accuracy": 0.4,
+  "accuracy": 0.6,
   "animation": "ubuntu",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/undertaker.json
+++ b/mods/tuxemon/db/technique/undertaker.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 152,
-  "accuracy": 0.2,
+  "accuracy": 0.6,
   "animation": "x_attack",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/vorpal.json
+++ b/mods/tuxemon/db/technique/vorpal.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 155,
-  "accuracy": 0.4,
+  "accuracy": 0.6,
   "animation": "amethyst_radiate",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/wall_fire.json
+++ b/mods/tuxemon/db/technique/wall_fire.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 165,
-  "accuracy": 0.3,
+  "accuracy": 0.6,
   "animation": "wall_fire",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/wall_ice.json
+++ b/mods/tuxemon/db/technique/wall_ice.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 172,
-  "accuracy": 0.3,
+  "accuracy": 0.6,
   "animation": "wall_ice",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/walls.json
+++ b/mods/tuxemon/db/technique/walls.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 156,
-  "accuracy": 0.1,
+  "accuracy": 0.6,
   "animation": "wall_wood",
   "effects": [
     "damage"

--- a/mods/tuxemon/db/technique/webs_wind.json
+++ b/mods/tuxemon/db/technique/webs_wind.json
@@ -1,6 +1,6 @@
 {
   "tech_id": 157,
-  "accuracy": 0.3,
+  "accuracy": 0.6,
   "animation": "tornado_bulk",
   "effects": [
     "damage"


### PR DESCRIPTION
fix #1825 

@Sanglorian here we go, this PR is going to set 0.5 minimum accuracy for the techs, so all the techs below will be set at 0.5 (eg 0.1 > 0.5, etc.).

If you want to set 0.6 as minimum, then no problem.
if you want to change successful is something else, the let me know.
If you want to change something else (adding types, condition/status, changing other parameters, etc), then no problem, feel free to share (or update directly the wiki and I'm going to sync here)

Let me know