### PR TITLE
set volume in event action (sound and music) + update control state (options) to pygame_menu

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -2021,6 +2021,30 @@ msgstr "Cancel Key"
 msgid "menu_back_key"
 msgstr "Back Key"
 
+msgid "menu_music_volume"
+msgstr "Music Volume"
+
+msgid "menu_sound_volume"
+msgstr "Sound Volume"
+
+msgid "menu_units"
+msgstr "Unit"
+
+msgid "menu_units_metric"
+msgstr "Metric"
+
+msgid "menu_units_imperial"
+msgstr "Imperial"
+
+msgid "menu_hemisphere"
+msgstr "Hemisphere"
+
+msgid "menu_hemisphere_north"
+msgstr "Northern"
+
+msgid "menu_hemisphere_south"
+msgstr "Southern"
+
 msgid "options_new_input_key0"
 msgstr "Press a key to set your new input key"
 

--- a/mods/tuxemon/maps/debug.tmx
+++ b/mods/tuxemon/maps/debug.tmx
@@ -30,7 +30,11 @@
   <object id="7" name="Scenario" type="event" x="0" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_money player,0"/>
-    <property name="act2" value="translated_dialog_choice spyder_campaign:xero_campaign,scenario_choice"/>
+    <property name="act2" value="set_variable unit_measure:Metric"/>
+    <property name="act3" value="set_variable hemisphere:Northern"/>
+    <property name="act4" value="set_variable music_volume:0.5"/>
+    <property name="act5" value="set_variable sound_volume:0.3"/>
+    <property name="act6" value="translated_dialog_choice spyder_campaign:xero_campaign,scenario_choice"/>
     <property name="cond1" value="not variable_set scenario_choice:spyder_campaign"/>
     <property name="cond2" value="not variable_set scenario_choice:xero_campaign"/>
    </properties>

--- a/mods/tuxemon/maps/player_house_bedroom.yaml
+++ b/mods/tuxemon/maps/player_house_bedroom.yaml
@@ -1,4 +1,13 @@
 events:
+  Music:
+    actions:
+    - play_music music_home
+    conditions:
+    - not music_playing music_home
+    height: 1
+    width: 1
+    x: 7
+    y: 0
   Go Downstairs:
     actions:
     - transition_teleport player_house_downstairs.tmx,0,2,0.3

--- a/mods/tuxemon/maps/spyder_bedroom.tmx
+++ b/mods/tuxemon/maps/spyder_bedroom.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="9" height="7" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="33">
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="9" height="7" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="34">
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
@@ -121,6 +121,12 @@
     <property name="act2" value="transition_teleport spyder_paper_mart.tmx,4,8,0.3"/>
     <property name="cond1" value="is variable_set question_intro:yes"/>
     <property name="cond2" value="not variable_set spyder_intro:yes"/>
+   </properties>
+  </object>
+  <object id="33" name="Play Music" type="event" x="32" y="0" width="16" height="16">
+   <properties>
+    <property name="act10" value="play_music music_home"/>
+    <property name="cond10" value="not music_playing music_home"/>
    </properties>
   </object>
  </objectgroup>

--- a/tuxemon/config.py
+++ b/tuxemon/config.py
@@ -56,10 +56,6 @@ class TuxemonConfig:
         self.hide_mouse = cfg.getboolean("display", "hide_mouse")
         self.window_caption = cfg.get("display", "window_caption")
 
-        # [sound]
-        self.sound_volume = cfg.getfloat("sound", "sound_volume")
-        self.music_volume = cfg.getfloat("sound", "music_volume")
-
         # [game]
         self.data = cfg.get("game", "data")
         self.cli = cfg.getboolean("game", "cli_enabled")
@@ -68,8 +64,6 @@ class TuxemonConfig:
             "net_controller_enabled",
         )
         self.locale = cfg.get("game", "locale")
-        self.hemisphere = cfg.get("game", "hemisphere")
-        self.unit = cfg.get("game", "unit")
         self.dev_tools = cfg.getboolean("game", "dev_tools")
         self.recompile_translations = cfg.getboolean(
             "game",
@@ -225,15 +219,6 @@ def get_defaults() -> Mapping[str, Any]:
                 ),
             ),
             (
-                "sound",
-                OrderedDict(
-                    (
-                        ("sound_volume", 0.3),
-                        ("music_volume", 1.0),
-                    )
-                ),
-            ),
-            (
                 "game",
                 OrderedDict(
                     (
@@ -242,8 +227,6 @@ def get_defaults() -> Mapping[str, Any]:
                         ("cli_enabled", False),
                         ("net_controller_enabled", False),
                         ("locale", "en_US"),
-                        ("hemisphere", "north"),
-                        ("unit", "metric"),
                         ("dev_tools", False),
                         ("recompile_translations", True),
                         ("compress_save", None),

--- a/tuxemon/event/actions/play_music.py
+++ b/tuxemon/event/actions/play_music.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import final
+from typing import Union, final
 
 from tuxemon import prepare
 from tuxemon.db import db
@@ -23,23 +23,42 @@ class PlayMusicAction(EventAction):
     Script usage:
         .. code-block::
 
-            play_music <filename>
+            play_music <filename>[,volume]
 
     Script parameters:
         filename: Music file to load.
+        volume: Number between 0.0 and 1.0.
+        Attention!
+        The volume will be based on the main value
+        in the options menu.
+        e.g. volume = 0.5, main 0.5 -> 0.25
 
     """
 
     name = "play_music"
     filename: str
+    volume: Union[float, None] = None
 
     def start(self) -> None:
+        player = self.session.player
+        volume: float = 0.0
+        if not self.volume:
+            volume = float(player.game_variables["music_volume"])
+        else:
+            if 0.0 <= self.volume <= 1.0:
+                volume = self.volume * float(
+                    player.game_variables["music_volume"]
+                )
+            else:
+                raise ValueError(
+                    f"{self.volume} must be between 0.0 and 1.0",
+                )
         try:
             path = prepare.fetch(
                 "music", db.lookup_file("music", self.filename)
             )
             mixer.music.load(path)
-            mixer.music.set_volume(prepare.CONFIG.music_volume)
+            mixer.music.set_volume(volume)
             mixer.music.play(-1)
         except Exception as e:
             logger.error(e)

--- a/tuxemon/event/actions/play_sound.py
+++ b/tuxemon/event/actions/play_sound.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import final
+from typing import Union, final
 
 from tuxemon import audio
 from tuxemon.event.eventaction import EventAction
@@ -18,16 +18,35 @@ class PlaySoundAction(EventAction):
     Script usage:
         .. code-block::
 
-            play_sound <filename>
+            play_sound <filename>[,volume]
 
     Script parameters:
         filename: Sound file to load.
+        volume: Number between 0.0 and 1.0.
+        Attention!
+        The volume will be based on the main value
+        in the options menu.
+        e.g. volume = 0.5, main 0.5 -> 0.25
 
     """
 
     name = "play_sound"
     filename: str
+    volume: Union[float, None] = None
 
     def start(self) -> None:
-        sound = audio.load_sound(self.filename)
+        player = self.session.player
+        volume: float = 0.0
+        if not self.volume:
+            volume = float(player.game_variables["sound_volume"])
+        else:
+            if 0.0 <= self.volume <= 1.0:
+                volume = self.volume * float(
+                    player.game_variables["sound_volume"]
+                )
+            else:
+                raise ValueError(
+                    f"{self.volume} must be between 0.0 and 1.0",
+                )
+        sound = audio.load_sound(self.filename, volume)
         sound.play()

--- a/tuxemon/locale.py
+++ b/tuxemon/locale.py
@@ -224,7 +224,7 @@ def replace_text(session: Session, text: str) -> str:
     text = text.replace(r"\n", "\n")
     text = text.replace("${{money}}", str(player.money["player"]))
     # distance (metric / imperial)
-    if prepare.CONFIG.unit == "metric":
+    if player.game_variables["unit_measure"] == "Metric":
         text = text.replace("${{length}}", "km")
         text = text.replace("${{weight}}", "kg")
         text = text.replace("${{height}}", "cm")

--- a/tuxemon/menu/menu.py
+++ b/tuxemon/menu/menu.py
@@ -466,7 +466,7 @@ class Menu(Generic[T], state.State):
     def reload_sounds(self) -> None:
         """Reload sounds."""
         self.menu_select_sound = audio.load_sound(
-            self.menu_select_sound_filename,
+            self.menu_select_sound_filename, None
         )
 
     def shadow_text(

--- a/tuxemon/player.py
+++ b/tuxemon/player.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import datetime as dt
 import logging
 
-from tuxemon import prepare
 from tuxemon.map import proj
 from tuxemon.npc import NPC
 from tuxemon.states.world.worldstate import WorldState
@@ -91,7 +90,7 @@ class Player(NPC):
             var["stage_of_day"] = "night"
 
         # Seasons
-        if prepare.CONFIG.hemisphere == "north":
+        if var["hemisphere"] == "Northern":
             if int(var["day_of_year"]) < 81:
                 var["season"] = "winter"
             elif 81 <= int(var["day_of_year"]) < 173:

--- a/tuxemon/save_upgrader.py
+++ b/tuxemon/save_upgrader.py
@@ -64,6 +64,14 @@ def upgrade_save(save_data: Dict[str, Any]) -> SaveData:
         save_data["game_variables"]["cathedral_ads"] = 0
     if "steps" not in save_data["game_variables"]:
         save_data["game_variables"]["steps"] = 0
+    if "music_volume" not in save_data["game_variables"]:
+        save_data["game_variables"]["music_volume"] = 0.5
+    if "sound_volume" not in save_data["game_variables"]:
+        save_data["game_variables"]["sound_volume"] = 0.2
+    if "unit_measure" not in save_data["game_variables"]:
+        save_data["game_variables"]["unit_measure"] = "Metric"
+    if "hemisphere" not in save_data["game_variables"]:
+        save_data["game_variables"]["hemisphere"] = "Northern"
     if "gender_choice" not in save_data["game_variables"]:
         save_data["game_variables"]["gender_choice"] = "gender_male"
     if "date_start_game" not in save_data["game_variables"]:

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -1006,7 +1006,7 @@ class CombatState(CombatAnimations):
                 message += "\n" + m
                 action_time += len(message) * letter_time
             # TODO: caching sounds
-            audio.load_sound(technique.sfx).play()
+            audio.load_sound(technique.sfx, None).play()
             # animation own monster AI NPC
             if "own monster" in technique.target:
                 target_sprite = self._monster_sprite_map.get(user, None)

--- a/tuxemon/states/combat/combat_animations.py
+++ b/tuxemon/states/combat/combat_animations.py
@@ -223,7 +223,7 @@ class CombatAnimations(ABC, Menu[None]):
         self.task(partial(self.sprites.add, sprite), delay)
 
         # attempt to load and queue up combat_call
-        call_sound = audio.load_sound(monster.combat_call)
+        call_sound = audio.load_sound(monster.combat_call, None)
         if call_sound:
             self.task(call_sound.play, delay)
 
@@ -383,7 +383,7 @@ class CombatAnimations(ABC, Menu[None]):
             if monster.current_hp > 0
             else monster.faint_call
         )
-        sound = audio.load_sound(cry)
+        sound = audio.load_sound(cry, None)
         sound.play()
         self.animate(sprite.rect, x=x_diff, relative=True, duration=2)
 
@@ -623,7 +623,9 @@ class CombatAnimations(ABC, Menu[None]):
         self.task(flip, 1.5)
 
         if not self.is_trainer_battle:
-            self.task(audio.load_sound(right_monster.combat_call).play, 1.5)
+            self.task(
+                audio.load_sound(right_monster.combat_call, None).play, 1.5
+            )
 
         animate = partial(
             self.animate, transition="out_quad", duration=duration
@@ -747,7 +749,7 @@ class CombatAnimations(ABC, Menu[None]):
                 breakout_delay,
             )
             self.task(
-                audio.load_sound(monster.combat_call).play,
+                audio.load_sound(monster.combat_call, None).play,
                 breakout_delay,
             )
             self.task(tech.play, breakout_delay)

--- a/tuxemon/states/journal/__init__.py
+++ b/tuxemon/states/journal/__init__.py
@@ -274,7 +274,8 @@ class JournalInfoState(PygameMenuState):
                 + T.translate(monster.types[1])
             )
         # weight and height
-        if prepare.CONFIG.unit == "metric":
+        unit = local_session.player.game_variables["unit_measure"]
+        if unit == "Metric":
             mon_weight = monster.weight
             mon_height = monster.height
             unit_weight = "kg"
@@ -530,7 +531,8 @@ class MonsterInfoState(PygameMenuState):
         # weight and height
         results = db.lookup(monster.slug, table="monster")
         diff_weight, diff_height = formula.weight_height_diff(monster, results)
-        if prepare.CONFIG.unit == "metric":
+        unit = local_session.player.game_variables["unit_measure"]
+        if unit == "Metric":
             mon_weight = monster.weight
             mon_height = monster.height
             unit_weight = "kg"

--- a/tuxemon/states/player/__init__.py
+++ b/tuxemon/states/player/__init__.py
@@ -106,7 +106,8 @@ class PlayerState(PygameMenuState):
         )
         # steps
         steps = player.game_variables["steps"]
-        if prepare.CONFIG.unit == "metric":
+        unit = player.game_variables["unit_measure"]
+        if unit == "Metric":
             walked = formula.convert_km(steps)
             unit_walked = "km"
         else:

--- a/tuxemon/states/splash/__init__.py
+++ b/tuxemon/states/splash/__init__.py
@@ -47,7 +47,7 @@ class SplashState(state.State):
             height - splash_border - cc.rect.height,
         )
 
-        audio.load_sound("sound_ding").play()
+        audio.load_sound("sound_ding", None).play()
 
     def resume(self) -> None:
         if self.triggered:

--- a/tuxemon/states/start/__init__.py
+++ b/tuxemon/states/start/__init__.py
@@ -89,12 +89,6 @@ class StartState(PygameMenuState):
             button_id="menu_new_game",
         )
         menu.add.button(
-            title=T.translate("menu_options"),
-            action=change_state("ControlState"),
-            font_size=30,
-            button_id="menu_options",
-        )
-        menu.add.button(
             title=T.translate("menu_minigame"),
             action=change_state("MinigameState"),
             font_size=30,


### PR DESCRIPTION
PR:
- removes the variables **music_volume** and **sound_volume** from **tuxemon.cfg**;
- introduces the **volume** inside **play_music** and **play_sound** event action;
- updates the **control state**, called **options** and inserts **two range selectors** (music and sound), so it'll be possible to make changes in game;
- adds **hemisphere choice** inside options (default **northern**) -> default based on number of people living here;
- adds **unit measure choice** inside options (default **metric**) -> default based on number of people using metric vs imperial;
- removes **options** from the start screen, it'll be accessible only in game;
- gets rid of some typehints in control;

fix #1824

regarding event actions:
from
`play_sound <filename>`
to
`play_sound <filename>[,volume]`

same for **play_music**, where the volume is optional, if not set the volume will be 0.5, while the sound 0.2. 

disclaimer inside both actions:
```
        Attention!
        The volume will be based on the main value
        in the options menu.
        e.g. volume = 0.5, main 0.5 -> 0.25
```
In this way the modders can set the tone without acting on a "global" variable.

`it doesn't change anything of the existing values (since there are no values)`

@Sanglorian I had this in the pipeline, I don't know if it can help with the #1824, let me know. I know you prefer the toggle, but in this way you can set different tones depending on the event.

The PR updates the control state too:
you can set a value from 1 to 100, but only 10 increment is possible:
here is southern because I was testing stuff eh
![Screenshot from 2023-05-11 12-03-13](https://github.com/Tuxemon/Tuxemon/assets/64643719/4ac36904-ed03-40ca-a83d-e09d39a645d2)

We got rid of 5/6 typehints.

tested, black, isort, -5/6 typehints