### PR TITLE
opponent_party_tray (wild encounters) + icon position (combat)

### DIFF
--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -794,13 +794,22 @@ class CombatState(CombatAnimations):
         for monster in self.active_monsters:
             for status in monster.status:
                 if status.icon:
-                    # get the rect of the monster
-                    rect = self._monster_sprite_map[monster].rect
+                    status_ico: Tuple[float, float] = (0.0, 0.0)
+                    if monster in self.players[1].monsters:
+                        status_ico = (
+                            self.rect.width * 0.06,
+                            self.rect.height * 0.12,
+                        )
+                    elif monster in self.players[0].monsters:
+                        status_ico = (
+                            self.rect.width * 0.64,
+                            self.rect.height * 0.52,
+                        )
                     # load the sprite and add it to the display
                     icon = self.load_sprite(
                         status.icon,
                         layer=200,
-                        center=rect.topleft,
+                        center=status_ico,
                     )
                     self._status_icons.append(icon)
 

--- a/tuxemon/states/combat/combat_animations.py
+++ b/tuxemon/states/combat/combat_animations.py
@@ -436,15 +436,20 @@ class CombatAnimations(ABC, Menu[None]):
 
         """
         if self.get_side(home) == "left":
-            tray = self.load_sprite(
-                "gfx/ui/combat/opponent_party_tray.png",
-                bottom=home.bottom,
-                right=0,
-                layer=hud_layer,
-            )
-            self.animate(tray.rect, right=home.right, duration=2, delay=1.5)
-            centerx = home.right - scale(13)
-            offset = scale(8)
+            if self.is_trainer_battle:
+                tray = self.load_sprite(
+                    "gfx/ui/combat/opponent_party_tray.png",
+                    bottom=home.bottom,
+                    right=0,
+                    layer=hud_layer,
+                )
+                self.animate(
+                    tray.rect, right=home.right, duration=2, delay=1.5
+                )
+                centerx = home.right - scale(13)
+                offset = scale(8)
+            else:
+                pass
 
         else:
             tray = self.load_sprite(


### PR DESCRIPTION
PR requested by @Sanglorian , so he is happy and he can set 6 out of 10 tasks done instead of 3 out of 10 #1805

>  In battles with wild tuxemon, the opponent_party_tray image shows up. However, we only need it for battles with trainers, so we know how many monsters they have.

with this PR the bar doesn't appear anymore, but it keeps appearing in trainer battles.

![Screenshot from 2023-05-11 20-15-42](https://github.com/Tuxemon/Tuxemon/assets/64643719/cf46e092-6c88-4be0-b82e-0e35ed8d2073)

>  The combat screen seems to be cropped a little - for example, when I poison a monster, only the bottom half of the poisoned symbol appears.

and

>  I think the condition symbols should display on the little panel, next to the monster's HP bar. This may require making smaller versions than the current ~16px sprites. But I think that's easier to read than putting it to the top-left of the sprite. Interested to hear what others think!

![Screenshot from 2023-05-11 20-42-36](https://github.com/Tuxemon/Tuxemon/assets/64643719/65cec869-5817-4570-ae2c-af772da8f426)

the position is hardcoded, but it's percentage, so adaptable
