### PR TITLE
none tech (combat)

### DIFF
--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -20,7 +20,6 @@ from typing import (
     Set,
     Tuple,
     Union,
-    overload,
 )
 
 import pygame
@@ -85,7 +84,7 @@ CombatPhase = Literal[
 
 class EnqueuedAction(NamedTuple):
     user: Union[Monster, NPC, None]
-    technique: Union[Technique, Item]
+    technique: Union[Technique, Item, None]
     target: Monster
 
 
@@ -598,6 +597,8 @@ class CombatState(CombatAnimations):
         """
 
         def rank_action(action: EnqueuedAction) -> Tuple[int, int]:
+            if action.technique is None:
+                return 0, 0
             sort = action.technique.sort
             primary_order = sort_order.index(sort)
 
@@ -859,7 +860,7 @@ class CombatState(CombatAnimations):
     def enqueue_action(
         self,
         user: Union[NPC, Monster, None],
-        technique: Union[Item, Technique],
+        technique: Union[Item, Technique, None],
         target: Monster,
     ) -> None:
         """
@@ -952,28 +953,10 @@ class CombatState(CombatAnimations):
             delay,
         )
 
-    @overload
-    def perform_action(
-        self,
-        user: Optional[Monster],
-        technique: Technique,
-        target: Monster,
-    ) -> None:
-        pass
-
-    @overload
-    def perform_action(
-        self,
-        user: Optional[NPC],
-        technique: Item,
-        target: Monster,
-    ) -> None:
-        pass
-
     def perform_action(
         self,
         user: Union[Monster, NPC, None],
-        technique: Union[Technique, Item],
+        technique: Union[Technique, Item, None],
         target: Monster,
     ) -> None:
         """


### PR DESCRIPTION
PR will allow to pass **none** as well as **technique** and **item** in combat, so we are not forced to create an empty technique.

Explained here: https://github.com/Tuxemon/Tuxemon/pull/1796#discussion_r1182248650

We can retrieve it in **perform_action** with: `if isinstance(user, Monster) and technique is None:`

at the moment nothing changes because #1818 is still pending, but the idea is fixing the two empty actions (dozing and spyderbite). I noticed there are some pending condition/status as well as technique that can trigger empty actions too.

eg dozing will pass  as: `combat_state.enqueue_action(self.monster, None, target)` (in **combat_menu**, it would be the same in **AI**).

Ah, I removed the two overload because those were causing two typehints:
```
tuxemon/states/combat/combat.py:660: error: Argument 1 to "perform_action" of "CombatState" has incompatible type "*EnqueuedAction"; expected "Optional[Monster]"  [arg-type]
tuxemon/states/combat/combat.py:660: error: Argument 1 to "perform_action" of "CombatState" has incompatible type "*EnqueuedAction"; expected "Technique"  [arg-type]
```
I tested, and nothing changed, no new typehints popped up after this removal.

tested, black, isort, -2 typehints
