### PR TITLE
upgrade get_awake_monsters (combat.py)

### DIFF
--- a/tuxemon/combat.py
+++ b/tuxemon/combat.py
@@ -11,7 +11,8 @@ Code here might be shared by states, actions, conditions, etc.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Generator, Sequence
+import random
+from typing import TYPE_CHECKING, Generator, List, Sequence
 
 from tuxemon.db import PlagueType
 from tuxemon.locale import T
@@ -96,7 +97,9 @@ def fainted(monster: Monster) -> bool:
     return has_status(monster, "status_faint") or monster.current_hp <= 0
 
 
-def get_awake_monsters(player: NPC) -> Generator[Monster, None, None]:
+def get_awake_monsters(
+    player: NPC, monsters: List[Monster]
+) -> Generator[Monster, None, None]:
     """
     Iterate all non-fainted monsters in party.
 
@@ -107,9 +110,21 @@ def get_awake_monsters(player: NPC) -> Generator[Monster, None, None]:
         Non-fainted monsters.
 
     """
-    for monster in player.monsters:
-        if not fainted(monster):
-            yield monster
+    mons = [
+        ele
+        for ele in player.monsters
+        if not fainted(ele) and ele not in monsters
+    ]
+    if mons:
+        if len(mons) > 1:
+            mon = random.choice(mons)
+            # avoid random choice filling battlefield (1st turn)
+            if player.isplayer:
+                yield from mons
+            else:
+                yield mon
+        else:
+            yield mons[0]
 
 
 def fainted_party(party: Sequence[Monster]) -> bool:

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -723,7 +723,9 @@ class CombatState(CombatAnimations):
                 self.monsters_in_play[player]
             )
             if positions_available:
-                available = get_awake_monsters(player)
+                available = get_awake_monsters(
+                    player, self.monsters_in_play[player]
+                )
                 for _ in range(positions_available):
                     released = True
                     if player in humans and ask:


### PR DESCRIPTION
Split from #1835 

PR upgrades **get_awake_monsters** in combat.py 

Right know the function is written without considering 2 vs 2 (1 vs 2 or 2 vs 1) and it doesn't consider other monsters in the battlefield.

eg 2 vs 2 (player (alpha, beta, gamma) vs ai (delta, epsilon, zeta)

alpha & beta **vs** delta & epsilon
**before**
**delta** faints
_get_awake_monsters sends in **delta** again (how ends up? crash)_

**after**
**delta** faints
_get_awake_monsters sends in **zeta**_

Moreover! There is no more lineup for AI trainer, the monster will be chosen randomly.
You add alpha, beta and gamma for the ai trainer (as usual with add_monster or random_monster), then the trainer will decide randomly with which monster start as well as the replacement.

This will be temporary, because there will be more specific mechanism (especially for replacement) that could consider elements like type, body shape, etc.

tested, black, isort, no new typehints
