### PR TITLE
gain xp text (combat.py)

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -730,6 +730,9 @@ msgstr "Phone keeps ringing but no answer!"
 msgid "combat_scope"
 msgstr "AR:{AR} DE:{DE} ME:{ME} RD:{RD} SD:{SD}"
 
+msgid "combat_gain_exp"
+msgstr "{name} gains {xp}px"
+
 msgid "combat_none"
 msgstr " "
 
@@ -1872,9 +1875,6 @@ msgstr "Are you sure you would like to release {name}?"
 
 msgid "tuxemon_released"
 msgstr "{name} has been released."
-
-msgid "tuxemon_new_tech"
-msgstr "{name} learned technique {tech}!"
 
 msgid "new_tech_delete"
 msgstr "{name} has too many techniques.\n"

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -1200,6 +1200,9 @@ class CombatState(CombatAnimations):
         Any monsters who contributed any amount of damage will be awarded.
         Experience is distributed evenly to all participants.
         """
+        message: str = ""
+        action_time: float = 3.0
+        letter_time: float = 0.02
         if monster in self._damage_map:
             # Award Experience
             awarded_exp = (
@@ -1228,6 +1231,15 @@ class CombatState(CombatAnimations):
                             self._layout[self.players[0]]["hud"][0],
                             self.monsters_in_play[self.players[0]][0],
                         )
+                if winners in self.players[0].monsters:
+                    m = T.format(
+                        "combat_gain_exp",
+                        {"name": winners.name.upper(), "xp": awarded_exp},
+                    )
+                    message += "\n" + m
+            action_time += len(message) * letter_time
+            self.alert(message)
+            self.suppress_phase_change(action_time)
 
             # Remove monster from damage map
             del self._damage_map[monster]
@@ -1306,6 +1318,7 @@ class CombatState(CombatAnimations):
                     # cause a crash
                     for monster in self.monsters_in_play[local_session.player]:
                         self.task(partial(self.animate_exp, monster), 2.5)
+                        self.suppress_phase_change()
 
     @property
     def active_players(self) -> Iterable[NPC]:
@@ -1481,15 +1494,6 @@ class CombatState(CombatAnimations):
         if duplicate:
             return
         monster.learn(technique)
-        self.alert(
-            T.format(
-                "tuxemon_new_tech",
-                {
-                    "name": monster.name.upper(),
-                    "tech": technique.name.upper(),
-                },
-            )
-        )
 
     def evolve(self) -> None:
         self.client.pop_state()


### PR DESCRIPTION
as requested in #1805

> When a tuxemon gains XP, it would be good if the XP bar increased while the player is watching - as well as saying in the text box how many XP the monster gains.

it'll appear **ROCKITTEN gains 99px**
at the same time I got rid of the new technique text, it was too much clogged, especially during the acquisition of a new technique.

tested, black, isort, no new typehints