### PR TITLE
typehints + status icon (monster menu)

### DIFF
--- a/tuxemon/event/actions/add_collision.py
+++ b/tuxemon/event/actions/add_collision.py
@@ -42,8 +42,9 @@ class AddCollisionAction(EventAction):
                 "key": self.label,
             }
         else:
-            world.collision_map[coords] = {
-                "enter": [],
-                "exit": [],
-                "key": self.label,
-            }
+            if coords:
+                world.collision_map[coords] = {
+                    "enter": [],
+                    "exit": [],
+                    "key": self.label,
+                }

--- a/tuxemon/event/eventcondition.py
+++ b/tuxemon/event/eventcondition.py
@@ -26,6 +26,7 @@ class EventCondition:
             Value of the condition.
 
         """
+        return True
 
     def get_persist(self, session: Session) -> Dict[str, Any]:
         """

--- a/tuxemon/item/itemeffect.py
+++ b/tuxemon/item/itemeffect.py
@@ -73,4 +73,4 @@ class ItemEffect:
     def apply(
         self, item: Item, target: Union[Monster, None]
     ) -> ItemEffectResult:
-        pass
+        return {"success": True}

--- a/tuxemon/map.py
+++ b/tuxemon/map.py
@@ -10,6 +10,7 @@ from typing import (
     List,
     Literal,
     Mapping,
+    MutableMapping,
     Optional,
     Sequence,
     Set,
@@ -379,7 +380,9 @@ class TuxemonMap:
         inits: Sequence[EventObject],
         interacts: Sequence[EventObject],
         surfable_map: Sequence[Tuple[int, int]],
-        collision_map: Mapping[Tuple[int, int], Optional[RegionProperties]],
+        collision_map: MutableMapping[
+            Tuple[int, int], Optional[RegionProperties]
+        ],
         collisions_lines_map: Set[Tuple[Tuple[int, int], Direction]],
         tiled_map: TiledMap,
         maps: dict,

--- a/tuxemon/map_loader.py
+++ b/tuxemon/map_loader.py
@@ -228,7 +228,11 @@ class TMXMapLoader:
                                 region_conditions = copy_dict_with_keys(
                                     obj.properties, region_properties
                                 )
-                                collision_map[(x, y)] = region_conditions
+                                collision_map[
+                                    (x, y)
+                                ] = extract_region_properties(
+                                    region_conditions
+                                )
                         for line in self.collision_lines_from_object(
                             obj, tile_size
                         ):

--- a/tuxemon/sprite.py
+++ b/tuxemon/sprite.py
@@ -53,15 +53,16 @@ class Sprite(pygame.sprite.DirtySprite):
         animation: Optional[SurfaceAnimation] = None,
     ) -> None:
         super().__init__(*args)
-        self.visible = True
-        self._rotation = 0
+        self.visible: bool = True
+        self._rotation: int = 0
         self._rect = Rect(0, 0, 0, 0)
         self.image = image
         self.animation = animation
-        self._width = 0
-        self._height = 0
-        self._needs_rescale = False
-        self._needs_update = False
+        self._width: int = 0
+        self._height: int = 0
+        self._needs_rescale: bool = False
+        self._needs_update: bool = False
+        self.player: bool = False
 
     def update(self, time_delta: float = 0, *args: Any, **kwargs: Any) -> None:
         super().update(time_delta, *args, **kwargs)

--- a/tuxemon/states/items/__init__.py
+++ b/tuxemon/states/items/__init__.py
@@ -183,6 +183,8 @@ class ItemMenuState(Menu[Item]):
             result = itm.use(player, None)
             if item.category == "fish" and not result["success"]:
                 tools.show_item_result_as_dialog(local_session, item, result)
+            elif item.category == "fish" and result["success"]:
+                pass
             else:
                 tools.show_item_result_as_dialog(local_session, item, result)
 

--- a/tuxemon/states/monster/__init__.py
+++ b/tuxemon/states/monster/__init__.py
@@ -221,7 +221,7 @@ class MonsterMenuState(Menu[Optional[Monster]]):
                 image = graphics.load_and_scale(status.icon)
                 pos = (
                     (rect.width * 0.45) + (index * tools.scale(6)),
-                    rect.y + tools.scale(0),
+                    rect.y + tools.scale(4),
                 )
                 surface.blit(image, pos)
 

--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -12,6 +12,7 @@ from typing import (
     List,
     Literal,
     Mapping,
+    MutableMapping,
     Optional,
     Sequence,
     Set,
@@ -635,7 +636,7 @@ class WorldState(state.State):
 
     def check_collision_zones(
         self,
-        map: Mapping[Tuple[int, int], Optional[RegionProperties]],
+        map: MutableMapping[Tuple[int, int], Optional[RegionProperties]],
         label: str,
     ) -> Optional[Tuple[int, int]]:
         """

--- a/tuxemon/technique/techeffect.py
+++ b/tuxemon/technique/techeffect.py
@@ -69,4 +69,4 @@ class TechEffect:
     def apply(
         self, tech: Technique, user: Monster, target: Monster
     ) -> TechEffectResult:
-        pass
+        return {"success": True}


### PR DESCRIPTION
Split from #1835 
never-ending was against typehints #1211 

mypy 1.3 (always -strict)
from 
Found 183 errors in 45 files (checked 310 source files)
to
Found 171 errors in 39 files (checked 310 source files)

PR
- fixes typehints;
- fixes the fishing action (the successful dialogue was blocking the fishing action);
- fixes the position of the status icon in the monster menu;

moreover, the following typehints are triggered by **Mapping**
```
tuxemon/event/actions/add_collision.py:39: error: Unsupported target for indexed assignment ("Mapping[Tuple[int, int], Optional[RegionProperties]]")  [index]
tuxemon/event/actions/add_collision.py:45: error: Unsupported target for indexed assignment ("Mapping[Tuple[int, int], Optional[RegionProperties]]")  [index]
```
so changing this:
`collision_map: Mapping[Tuple[int, int], Optional[RegionProperties]],`
into
`collision_map: MutableMapping[Tuple[int, int], Optional[RegionProperties]],`
fixes both typehints above



tested, black, isort