### PR TITLE
tech text + fix combat

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -733,6 +733,9 @@ msgstr "AR:{AR} DE:{DE} ME:{ME} RD:{RD} SD:{SD}"
 msgid "combat_gain_exp"
 msgstr "{name} gains {xp}px"
 
+msgid "tuxemon_new_tech"
+msgstr "{name} learned technique {tech}!"
+
 msgid "combat_none"
 msgstr " "
 

--- a/tuxemon/combat.py
+++ b/tuxemon/combat.py
@@ -12,16 +12,16 @@ from __future__ import annotations
 
 import logging
 import random
-from typing import TYPE_CHECKING, Generator, List, Sequence
+from typing import TYPE_CHECKING, Generator, List, Sequence, Union
 
 from tuxemon.db import PlagueType
 from tuxemon.locale import T
+from tuxemon.technique.technique import Technique
 
 if TYPE_CHECKING:
     from tuxemon.monster import Monster
     from tuxemon.npc import NPC
     from tuxemon.player import Player
-    from tuxemon.technique.technique import Technique
 
 
 logger = logging.getLogger()
@@ -166,3 +166,38 @@ def spyderbite(monster: Monster) -> str:
             },
         )
     return message
+
+
+def check_moves(monster: Monster, levels: int) -> Union[str, None]:
+    for move in monster.moveset:
+        # monster levels up 1 level
+        if levels == 1:
+            if move.level_learned == monster.level:
+                technique = learn(monster, move.technique)
+        # monster levels up multiple levels
+        else:
+            level_before = monster.level - levels
+            # if there are techniques in this range
+            if level_before < move.level_learned <= monster.level:
+                technique = learn(monster, move.technique)
+    if technique:
+        monster.learn(technique)
+        message = T.format(
+            "tuxemon_new_tech",
+            {
+                "name": monster.name.upper(),
+                "tech": technique.name.upper(),
+            },
+        )
+        return message
+    else:
+        return None
+
+
+def learn(monster: Monster, tech: str) -> Union[Technique, None]:
+    technique = Technique()
+    technique.load(tech)
+    duplicate = [mov for mov in monster.moves if mov.slug == technique.slug]
+    if duplicate:
+        return None
+    return technique

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -29,6 +29,7 @@ from tuxemon import audio, graphics, state, tools
 from tuxemon.animation import Task
 from tuxemon.battle import Battle
 from tuxemon.combat import (
+    check_moves,
     defeated,
     fainted,
     get_awake_monsters,
@@ -95,6 +96,11 @@ MULT_MAP = {
     0.5: "attack_resisted",
     0.25: "attack_weak",
 }
+
+# This is the time, in seconds, that the text takes to display.
+LETTER_TIME: float = 0.02
+# This is the time, in seconds, that the animation takes to finish.
+ACTION_TIME: float = 3.0
 
 
 class TechniqueAnimationCache:
@@ -359,8 +365,8 @@ class CombatState(CombatAnimations):
             phase: Name of phase to transition to.
 
         """
-        letter_time: float = 0.02
-        action_time: float = 3.0
+        letter_time = LETTER_TIME
+        action_time = ACTION_TIME
         if phase == "begin" or phase == "ready" or phase == "pre action phase":
             pass
 
@@ -970,10 +976,8 @@ class CombatState(CombatAnimations):
             target: Monster that receives the action.
 
         """
-        # This is the time, in seconds, that the text takes to display.
-        letter_time: float = 0.02
-        # This is the time, in seconds, that the animation takes to finish.
-        action_time: float = 3.0
+        letter_time = LETTER_TIME
+        action_time = ACTION_TIME
         # action is performed, so now use sprites to animate it
         # this value will be None if the target is off screen
         target_sprite = self._monster_sprite_map.get(target, None)
@@ -1186,8 +1190,8 @@ class CombatState(CombatAnimations):
         Experience is distributed evenly to all participants.
         """
         message: str = ""
-        action_time: float = 3.0
-        letter_time: float = 0.02
+        action_time = ACTION_TIME
+        letter_time = LETTER_TIME
         if monster in self._damage_map:
             # Award Experience
             awarded_exp = (
@@ -1208,9 +1212,12 @@ class CombatState(CombatAnimations):
                     diff = self._level_after - self._level_before
                     if winners in self.players[0].monsters:
                         # checks and eventually teaches move/moves
-                        self.check_moves(
+                        mex = check_moves(
                             self.monsters_in_play[self.players[0]][0], diff
                         )
+                        if mex:
+                            message += "\n" + mex
+                            action_time += len(message) * letter_time
                         # updates hud graphics player
                         self.build_hud(
                             self._layout[self.players[0]]["hud"][0],
@@ -1456,29 +1463,6 @@ class CombatState(CombatAnimations):
             monster.apply_status(status)
             return True
         return False
-
-    def check_moves(self, monster: Monster, levels: int) -> None:
-        for move in monster.moveset:
-            # monster levels up 1 level
-            if levels == 1:
-                if move.level_learned == monster.level:
-                    self.learn(monster, move.technique)
-            # monster levels up multiple levels
-            else:
-                level_before = monster.level - levels
-                # if there are techniques in this range
-                if level_before < move.level_learned <= monster.level:
-                    self.learn(monster, move.technique)
-
-    def learn(self, monster: Monster, tech: str) -> None:
-        technique = Technique()
-        technique.load(tech)
-        duplicate = [
-            mov for mov in monster.moves if mov.slug == technique.slug
-        ]
-        if duplicate:
-            return
-        monster.learn(technique)
 
     def evolve(self) -> None:
         self.client.pop_state()


### PR DESCRIPTION
PR:
- adds again technique text, @Sanglorian wanted back, I slowed down, but good luck ;;spotting it if there is more than 1 monster getting exp;
- moves the **check_moves** and **learn** from **states/combat.py** to **combat.py**;
- centralizes **Action Time** and **Letter Time** values;

tested, black, isort, no new typehints