### PR TITLE
fix healing crash (Xero)

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -5700,6 +5700,9 @@ msgstr "The grave says:\n"
 "Here lies Jimmy. A friend, a knight, and ... bad person overall. However, ... never ... ... Help! ...\n"
 "The rest is weathered away."
 
+msgid "tabanurse_dialog_welcome"
+msgstr "Welcome to the Taba Town Tuxecenter!"
+
 msgid "tabanurse_dialog_taba"
 msgstr "Welcome to the Taba Town Tuxecenter!\n"
 "Do you want to heal your Tuxemon?\n"

--- a/mods/tuxemon/maps/healing_center.tmx
+++ b/mods/tuxemon/maps/healing_center.tmx
@@ -55,6 +55,14 @@
     <property name="cond10" value="not npc_exists tabanurse"/>
    </properties>
   </object>
+  <object id="21" name="hello there no monsters" type="event" x="80" y="80" width="16" height="16">
+   <properties>
+    <property name="act10" value="translated_dialog tabanurse_dialog_welcome"/>
+    <property name="cond10" value="is player_facing_tile"/>
+    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is party_size less_than,1"/>
+   </properties>
+  </object>
   <object id="26" name="hello there" type="event" x="80" y="80" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog tabanurse_dialog_taba"/>
@@ -62,6 +70,7 @@
     <property name="cond10" value="is player_facing_tile"/>
     <property name="cond20" value="is button_pressed K_RETURN"/>
     <property name="cond30" value="not variable_set chooses:yes"/>
+    <property name="cond40" value="is party_size greater_than,0"/>
    </properties>
   </object>
   <object id="27" name="Heal Tuxemon" type="event" x="80" y="96" width="16" height="16">

--- a/tuxemon/event/actions/set_monster_health.py
+++ b/tuxemon/event/actions/set_monster_health.py
@@ -54,6 +54,8 @@ class SetMonsterHealthAction(EventAction):
         monster_health = self.health
 
         if monster_slot is None:
+            if not self.session.player.monsters:
+                return
             for monster in self.session.player.monsters:
                 self.set_health(monster, monster_health)
         else:

--- a/tuxemon/event/actions/set_monster_status.py
+++ b/tuxemon/event/actions/set_monster_status.py
@@ -52,6 +52,8 @@ class SetMonsterStatusAction(EventAction):
             return
 
         if self.slot is None:
+            if not self.session.player.monsters:
+                return
             for monster in self.session.player.monsters:
                 self.set_status(monster, self.status)
         else:


### PR DESCRIPTION
fix #1842

PR fixes bug regarding healing in the Xero campaign, healing center Taba Town
The issue: someone without monsters can talk with the nurse -> crash (since no monsters)

PR adds in **set_monster_health** and **set_monster_status** (event actions) a return:
```
            if not self.session.player.monsters:
                return
```

@Qiangong2 

regarding the issue I have created a new event inside the hospital:
```
    <property name="act10" value="translated_dialog tabanurse_dialog_welcome"/>
    <property name="cond10" value="is player_facing_tile"/>
    <property name="cond20" value="is button_pressed K_RETURN"/>
    <property name="cond30" value="is party_size less_than,1"/>
```
if a player without monsters tries to talk with the nurse, then she replies only:
`"Welcome to the Taba Town Tuxecenter!"`
without asking the Y/N question about healing

this solve the issue, but there is an alternative:
- blocking the access to the hospital until the fight with the professor, we can put a person blocking the door, if the player interacts with the guy, then she/he would say "blocked access" (I don't know, something in line with the announcement).

If you're ok with this, then we can merge.
If you prefer the alternative, then no issue.
If you have other ideas, then let me know.