### PR TITLE
dialogue box position (gui)

### DIFF
--- a/tuxemon/tools.py
+++ b/tuxemon/tools.py
@@ -149,7 +149,9 @@ def calc_dialog_rect(screen_rect: pygame.rect.Rect) -> pygame.rect.Rect:
         rect.height //= 4
         rect.width *= 8
         rect.width //= 10
-        rect.center = screen_rect.centerx, screen_rect.bottom - rect.height
+        rect.center = screen_rect.centerx, screen_rect.bottom - (
+            rect.height // 2
+        )
     return rect
 
 


### PR DESCRIPTION
related to #1846 

@Sanglorian 

the existing dialogue:
![dialogue0](https://github.com/Tuxemon/Tuxemon/assets/64643719/643fc6a6-f4a5-4f47-bc17-ecf712a9dc33)
the dialogue modified (lowered)
![dialogue1](https://github.com/Tuxemon/Tuxemon/assets/64643719/2ae21532-f762-4f08-9117-6005557be9ba)
by the way, if someone chooses **large gui** in tuxemon.cfg, this is the result (**the font is bigger**)
![dialoguelargegui](https://github.com/Tuxemon/Tuxemon/assets/64643719/a4b35a87-39f2-4712-99e9-9783401e34ee)