### PR TITLE
removal field is_area (techniques JSONs) + status confused

### DIFF
--- a/mods/tuxemon/db/technique/acid.json
+++ b/mods/tuxemon/db/technique/acid.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.9,
   "power": 1.4,

--- a/mods/tuxemon/db/technique/adamantine.json
+++ b/mods/tuxemon/db/technique/adamantine.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.6,
   "power": 1.4,

--- a/mods/tuxemon/db/technique/air_chain.json
+++ b/mods/tuxemon/db/technique/air_chain.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.8,
   "power": 2.2,

--- a/mods/tuxemon/db/technique/all_in.json
+++ b/mods/tuxemon/db/technique/all_in.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.75,
   "power": 3,

--- a/mods/tuxemon/db/technique/amnesia.json
+++ b/mods/tuxemon/db/technique/amnesia.json
@@ -8,7 +8,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 2.25,

--- a/mods/tuxemon/db/technique/ants.json
+++ b/mods/tuxemon/db/technique/ants.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.3,
   "power": 1.7,

--- a/mods/tuxemon/db/technique/arcane_eye.json
+++ b/mods/tuxemon/db/technique/arcane_eye.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.1,
   "power": 2.9,

--- a/mods/tuxemon/db/technique/assault.json
+++ b/mods/tuxemon/db/technique/assault.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.5,
   "power": 1.7,

--- a/mods/tuxemon/db/technique/avalanche.json
+++ b/mods/tuxemon/db/technique/avalanche.json
@@ -4,10 +4,9 @@
   "animation": "rockfall_193",
   "effects": [
     "give status_exhausted,target",
-    "damage"
+    "splash"
   ],
   "flip_axes": "",
-  "is_area": true,
   "is_fast": false,
   "potency": 0.8,
   "power": 2.25,

--- a/mods/tuxemon/db/technique/barking.json
+++ b/mods/tuxemon/db/technique/barking.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.6,
   "power": 2.7,

--- a/mods/tuxemon/db/technique/battery_acid.json
+++ b/mods/tuxemon/db/technique/battery_acid.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.35,
   "power": 2.25,

--- a/mods/tuxemon/db/technique/battery_discharge.json
+++ b/mods/tuxemon/db/technique/battery_discharge.json
@@ -8,7 +8,6 @@
   ],
   "flip_axes": "",
   "healing_power": 4,
-  "is_area": false,
   "is_fast": false,
   "potency": null,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/beam.json
+++ b/mods/tuxemon/db/technique/beam.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.75,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/berserk.json
+++ b/mods/tuxemon/db/technique/berserk.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 2.25,

--- a/mods/tuxemon/db/technique/biting_winds.json
+++ b/mods/tuxemon/db/technique/biting_winds.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/blade.json
+++ b/mods/tuxemon/db/technique/blade.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "x",
-  "is_area": false,
   "is_fast": true,
   "potency": null,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/blood_bond.json
+++ b/mods/tuxemon/db/technique/blood_bond.json
@@ -8,7 +8,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 2.25,

--- a/mods/tuxemon/db/technique/blood_nets.json
+++ b/mods/tuxemon/db/technique/blood_nets.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.3,
   "power": 1.7,

--- a/mods/tuxemon/db/technique/blossom.json
+++ b/mods/tuxemon/db/technique/blossom.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/boulder.json
+++ b/mods/tuxemon/db/technique/boulder.json
@@ -7,7 +7,6 @@
     "enhance"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 1,

--- a/mods/tuxemon/db/technique/breath.json
+++ b/mods/tuxemon/db/technique/breath.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.2,
   "power": 1.9,

--- a/mods/tuxemon/db/technique/breathe_fire.json
+++ b/mods/tuxemon/db/technique/breathe_fire.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "x",
-  "is_area": false,
   "is_fast": false,
   "potency": null,
   "power": 2.25,

--- a/mods/tuxemon/db/technique/bubble_trap.json
+++ b/mods/tuxemon/db/technique/bubble_trap.json
@@ -8,7 +8,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 2.25,

--- a/mods/tuxemon/db/technique/bullet.json
+++ b/mods/tuxemon/db/technique/bullet.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": true,
   "potency": null,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/canine.json
+++ b/mods/tuxemon/db/technique/canine.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 1,

--- a/mods/tuxemon/db/technique/cat_calling.json
+++ b/mods/tuxemon/db/technique/cat_calling.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.4,
   "power": 1.9,

--- a/mods/tuxemon/db/technique/cavity.json
+++ b/mods/tuxemon/db/technique/cavity.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.1,
   "power": 2.9,

--- a/mods/tuxemon/db/technique/chameleon.json
+++ b/mods/tuxemon/db/technique/chameleon.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.6,
   "power": 1,

--- a/mods/tuxemon/db/technique/chill_mist.json
+++ b/mods/tuxemon/db/technique/chill_mist.json
@@ -3,10 +3,9 @@
   "accuracy": 1,
   "animation": "waterspurt",
   "effects": [
-    "damage"
+    "splash"
   ],
   "flip_axes": "",
-  "is_area": true,
   "is_fast": false,
   "potency": null,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/clairaudience.json
+++ b/mods/tuxemon/db/technique/clairaudience.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.8,
   "power": 2.7,

--- a/mods/tuxemon/db/technique/clamp_on.json
+++ b/mods/tuxemon/db/technique/clamp_on.json
@@ -8,7 +8,6 @@
     "enhance"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 0,

--- a/mods/tuxemon/db/technique/clock.json
+++ b/mods/tuxemon/db/technique/clock.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.1,
   "power": 2,

--- a/mods/tuxemon/db/technique/cloud_aether.json
+++ b/mods/tuxemon/db/technique/cloud_aether.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.6,
   "power": 1.4,

--- a/mods/tuxemon/db/technique/conjurer.json
+++ b/mods/tuxemon/db/technique/conjurer.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.2,
   "power": 1.4,

--- a/mods/tuxemon/db/technique/constrict.json
+++ b/mods/tuxemon/db/technique/constrict.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.75,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/crystal.json
+++ b/mods/tuxemon/db/technique/crystal.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.9,
   "power": 1,

--- a/mods/tuxemon/db/technique/demiurge.json
+++ b/mods/tuxemon/db/technique/demiurge.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.7,
   "power": 1.3,

--- a/mods/tuxemon/db/technique/earthquake.json
+++ b/mods/tuxemon/db/technique/earthquake.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.5,
   "power": 2.9,

--- a/mods/tuxemon/db/technique/electrical_storm.json
+++ b/mods/tuxemon/db/technique/electrical_storm.json
@@ -3,10 +3,9 @@
   "accuracy": 0.75,
   "animation": "lightning_claw",
   "effects": [
-    "damage"
+    "splash"
   ],
   "flip_axes": "",
-  "is_area": true,
   "is_fast": false,
   "potency": null,
   "power": 3,

--- a/mods/tuxemon/db/technique/energy_claws.json
+++ b/mods/tuxemon/db/technique/energy_claws.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "x",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 2.25,

--- a/mods/tuxemon/db/technique/energy_field.json
+++ b/mods/tuxemon/db/technique/energy_field.json
@@ -8,7 +8,6 @@
     "enhance"
   ],
   "flip_axes": "x",
-  "is_area": false,
   "is_fast": true,
   "potency": 1,
   "power": 0,

--- a/mods/tuxemon/db/technique/evasion.json
+++ b/mods/tuxemon/db/technique/evasion.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.3,
   "power": 2.2,

--- a/mods/tuxemon/db/technique/eyebite.json
+++ b/mods/tuxemon/db/technique/eyebite.json
@@ -7,7 +7,6 @@
     "enhance"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": true,
   "potency": 1,
   "power": 0,

--- a/mods/tuxemon/db/technique/feint.json
+++ b/mods/tuxemon/db/technique/feint.json
@@ -8,7 +8,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 1,

--- a/mods/tuxemon/db/technique/feline.json
+++ b/mods/tuxemon/db/technique/feline.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.1,
   "power": 2.8,

--- a/mods/tuxemon/db/technique/fester.json
+++ b/mods/tuxemon/db/technique/fester.json
@@ -8,7 +8,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.8,
   "power": 2.25,

--- a/mods/tuxemon/db/technique/fiery.json
+++ b/mods/tuxemon/db/technique/fiery.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.9,
   "power": 2.4,

--- a/mods/tuxemon/db/technique/fire_ball.json
+++ b/mods/tuxemon/db/technique/fire_ball.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "x",
-  "is_area": false,
   "is_fast": false,
   "potency": null,
   "power": 1.75,

--- a/mods/tuxemon/db/technique/fire_claw.json
+++ b/mods/tuxemon/db/technique/fire_claw.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "x",
-  "is_area": false,
   "is_fast": false,
   "potency": null,
   "power": 1.75,

--- a/mods/tuxemon/db/technique/fire_shield.json
+++ b/mods/tuxemon/db/technique/fire_shield.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.3,
   "power": 1.5,

--- a/mods/tuxemon/db/technique/firestorm.json
+++ b/mods/tuxemon/db/technique/firestorm.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.4,
   "power": 2.6,

--- a/mods/tuxemon/db/technique/flamethrower.json
+++ b/mods/tuxemon/db/technique/flamethrower.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "x",
-  "is_area": false,
   "is_fast": false,
   "potency": null,
   "power": 2.25,

--- a/mods/tuxemon/db/technique/fledgling.json
+++ b/mods/tuxemon/db/technique/fledgling.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.6,
   "power": 1.7,

--- a/mods/tuxemon/db/technique/flood.json
+++ b/mods/tuxemon/db/technique/flood.json
@@ -3,10 +3,9 @@
   "accuracy": 0.6,
   "animation": "watershot",
   "effects": [
-    "damage"
+    "splash"
   ],
   "flip_axes": "x",
-  "is_area": true,
   "is_fast": false,
   "power": 1.5,
   "range": "ranged",

--- a/mods/tuxemon/db/technique/flow.json
+++ b/mods/tuxemon/db/technique/flow.json
@@ -3,10 +3,9 @@
   "accuracy": 0.6,
   "animation": "waterspurt",
   "effects": [
-    "damage"
+    "splash"
   ],
   "flip_axes": "",
-  "is_area": true,
   "is_fast": false,
   "power": 1.5,
   "range": "melee",

--- a/mods/tuxemon/db/technique/fluff_up.json
+++ b/mods/tuxemon/db/technique/fluff_up.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.5,
   "power": 2.25,

--- a/mods/tuxemon/db/technique/font.json
+++ b/mods/tuxemon/db/technique/font.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/frostbite.json
+++ b/mods/tuxemon/db/technique/frostbite.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "xy",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.2,
   "power": 3,

--- a/mods/tuxemon/db/technique/fume.json
+++ b/mods/tuxemon/db/technique/fume.json
@@ -7,7 +7,6 @@
     "enhance"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 0,

--- a/mods/tuxemon/db/technique/give_all.json
+++ b/mods/tuxemon/db/technique/give_all.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 3,

--- a/mods/tuxemon/db/technique/glower.json
+++ b/mods/tuxemon/db/technique/glower.json
@@ -7,7 +7,6 @@
     "enhance"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": true,
   "potency": 1,
   "power": 0,

--- a/mods/tuxemon/db/technique/goad.json
+++ b/mods/tuxemon/db/technique/goad.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": true,
   "potency": 0.8,
   "power": 1.75,

--- a/mods/tuxemon/db/technique/gold_digger.json
+++ b/mods/tuxemon/db/technique/gold_digger.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.4,
   "power": 2.8,

--- a/mods/tuxemon/db/technique/grinding.json
+++ b/mods/tuxemon/db/technique/grinding.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.9,
   "power": 2.2,

--- a/mods/tuxemon/db/technique/gust.json
+++ b/mods/tuxemon/db/technique/gust.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.9,
   "power": 1.5,

--- a/mods/tuxemon/db/technique/gyser.json
+++ b/mods/tuxemon/db/technique/gyser.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.2,
   "power": 2.5,

--- a/mods/tuxemon/db/technique/hawk.json
+++ b/mods/tuxemon/db/technique/hawk.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.2,
   "power": 1.5,

--- a/mods/tuxemon/db/technique/headbutt.json
+++ b/mods/tuxemon/db/technique/headbutt.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "x",
-  "is_area": false,
   "is_fast": false,
   "potency": null,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/hibernate.json
+++ b/mods/tuxemon/db/technique/hibernate.json
@@ -8,7 +8,6 @@
   ],
   "flip_axes": "",
   "healing_power": 8,
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 0,

--- a/mods/tuxemon/db/technique/ice_claw.json
+++ b/mods/tuxemon/db/technique/ice_claw.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": null,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/ice_storm.json
+++ b/mods/tuxemon/db/technique/ice_storm.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.5,
   "power": 2.2,

--- a/mods/tuxemon/db/technique/icicle_spear.json
+++ b/mods/tuxemon/db/technique/icicle_spear.json
@@ -3,10 +3,9 @@
   "accuracy": 0.75,
   "animation": "lance_ice",
   "effects": [
-    "damage"
+    "splash"
   ],
   "flip_axes": "xy",
-  "is_area": true,
   "is_fast": false,
   "potency": null,
   "power": 2.25,

--- a/mods/tuxemon/db/technique/insanity.json
+++ b/mods/tuxemon/db/technique/insanity.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.5,
   "power": 2.2,

--- a/mods/tuxemon/db/technique/invictus.json
+++ b/mods/tuxemon/db/technique/invictus.json
@@ -8,7 +8,6 @@
     "damage"
   ],
   "flip_axes": "xy",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.75,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/kindling_flame.json
+++ b/mods/tuxemon/db/technique/kindling_flame.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 2.25,

--- a/mods/tuxemon/db/technique/kraken.json
+++ b/mods/tuxemon/db/technique/kraken.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 1.7,

--- a/mods/tuxemon/db/technique/lantern.json
+++ b/mods/tuxemon/db/technique/lantern.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.1,
   "power": 1.1,

--- a/mods/tuxemon/db/technique/lava.json
+++ b/mods/tuxemon/db/technique/lava.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.4,
   "power": 2.9,

--- a/mods/tuxemon/db/technique/levitate.json
+++ b/mods/tuxemon/db/technique/levitate.json
@@ -8,7 +8,6 @@
     "enhance"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 0,

--- a/mods/tuxemon/db/technique/life_surge.json
+++ b/mods/tuxemon/db/technique/life_surge.json
@@ -8,7 +8,6 @@
   ],
   "flip_axes": "",
   "healing_power": 2,
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 0,

--- a/mods/tuxemon/db/technique/lightning_spheres.json
+++ b/mods/tuxemon/db/technique/lightning_spheres.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.4,
   "power": 1.2,

--- a/mods/tuxemon/db/technique/lineage.json
+++ b/mods/tuxemon/db/technique/lineage.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.9,
   "power": 1.3,

--- a/mods/tuxemon/db/technique/lust.json
+++ b/mods/tuxemon/db/technique/lust.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.3,
   "power": 2.8,

--- a/mods/tuxemon/db/technique/magma.json
+++ b/mods/tuxemon/db/technique/magma.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.3,
   "power": 1.4,

--- a/mods/tuxemon/db/technique/maori.json
+++ b/mods/tuxemon/db/technique/maori.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.4,
   "power": 3,

--- a/mods/tuxemon/db/technique/meltdown.json
+++ b/mods/tuxemon/db/technique/meltdown.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.1,
   "power": 2.8,

--- a/mods/tuxemon/db/technique/mending.json
+++ b/mods/tuxemon/db/technique/mending.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.3,
   "power": 2.3,

--- a/mods/tuxemon/db/technique/midnight_mantle.json
+++ b/mods/tuxemon/db/technique/midnight_mantle.json
@@ -3,10 +3,9 @@
   "accuracy": 0.7,
   "animation": "claw_blue",
   "effects": [
-    "damage"
+    "splash"
   ],
   "flip_axes": "x",
-  "is_area": true,
   "is_fast": true,
   "potency": null,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/mobbing.json
+++ b/mods/tuxemon/db/technique/mobbing.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.1,
   "power": 1.6,

--- a/mods/tuxemon/db/technique/muck.json
+++ b/mods/tuxemon/db/technique/muck.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.9,
   "power": 2.4,

--- a/mods/tuxemon/db/technique/muddle.json
+++ b/mods/tuxemon/db/technique/muddle.json
@@ -8,7 +8,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/mudslide.json
+++ b/mods/tuxemon/db/technique/mudslide.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.8,
   "power": 2.25,

--- a/mods/tuxemon/db/technique/mystic_blending.json
+++ b/mods/tuxemon/db/technique/mystic_blending.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.4,
   "power": 1.2,

--- a/mods/tuxemon/db/technique/negation.json
+++ b/mods/tuxemon/db/technique/negation.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.7,
   "power": 2.9,

--- a/mods/tuxemon/db/technique/nest.json
+++ b/mods/tuxemon/db/technique/nest.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.9,
   "power": 1.6,

--- a/mods/tuxemon/db/technique/oedipus.json
+++ b/mods/tuxemon/db/technique/oedipus.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.8,
   "power": 2.2,

--- a/mods/tuxemon/db/technique/one_two.json
+++ b/mods/tuxemon/db/technique/one_two.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": null,
   "power": 3,

--- a/mods/tuxemon/db/technique/orbs.json
+++ b/mods/tuxemon/db/technique/orbs.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.7,
   "power": 2.8,

--- a/mods/tuxemon/db/technique/overfeed.json
+++ b/mods/tuxemon/db/technique/overfeed.json
@@ -7,7 +7,6 @@
     "enhance"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 0,

--- a/mods/tuxemon/db/technique/overgrowth.json
+++ b/mods/tuxemon/db/technique/overgrowth.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 2.25,

--- a/mods/tuxemon/db/technique/panjandrum.json
+++ b/mods/tuxemon/db/technique/panjandrum.json
@@ -6,7 +6,6 @@
     "local_damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": null,
   "power": 0,

--- a/mods/tuxemon/db/technique/peck.json
+++ b/mods/tuxemon/db/technique/peck.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": null,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/peregrine.json
+++ b/mods/tuxemon/db/technique/peregrine.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": true,
   "potency": null,
   "power": 1.75,

--- a/mods/tuxemon/db/technique/perfect_cut.json
+++ b/mods/tuxemon/db/technique/perfect_cut.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "x",
-  "is_area": false,
   "is_fast": false,
   "potency": null,
   "power": 1.75,

--- a/mods/tuxemon/db/technique/petrify.json
+++ b/mods/tuxemon/db/technique/petrify.json
@@ -7,7 +7,6 @@
     "enhance"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": true,
   "potency": 1,
   "power": 0,

--- a/mods/tuxemon/db/technique/phantasmal_force.json
+++ b/mods/tuxemon/db/technique/phantasmal_force.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.1,
   "power": 1.6,

--- a/mods/tuxemon/db/technique/pit.json
+++ b/mods/tuxemon/db/technique/pit.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.1,
   "power": 1.1,

--- a/mods/tuxemon/db/technique/platinum.json
+++ b/mods/tuxemon/db/technique/platinum.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.2,
   "power": 1.7,

--- a/mods/tuxemon/db/technique/poison_courtship.json
+++ b/mods/tuxemon/db/technique/poison_courtship.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.7,
   "power": 2.1,

--- a/mods/tuxemon/db/technique/probiscus.json
+++ b/mods/tuxemon/db/technique/probiscus.json
@@ -4,10 +4,9 @@
   "animation": "lance_ice",
   "effects": [
     "give status_lifeleech,target",
-    "damage"
+    "splash"
   ],
   "flip_axes": "xy",
-  "is_area": true,
   "is_fast": false,
   "potency": 0.5,
   "power": 1,

--- a/mods/tuxemon/db/technique/pseudopod.json
+++ b/mods/tuxemon/db/technique/pseudopod.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "x",
-  "is_area": false,
   "is_fast": false,
   "potency": null,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/quicksand.json
+++ b/mods/tuxemon/db/technique/quicksand.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.8,
   "power": 2.25,

--- a/mods/tuxemon/db/technique/radiance.json
+++ b/mods/tuxemon/db/technique/radiance.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.6,
   "power": 1.6,

--- a/mods/tuxemon/db/technique/ram.json
+++ b/mods/tuxemon/db/technique/ram.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": null,
   "power": 1.5,

--- a/mods/tuxemon/db/technique/refresh.json
+++ b/mods/tuxemon/db/technique/refresh.json
@@ -8,7 +8,6 @@
   ],
   "flip_axes": "",
   "healing_power": 4,
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 0,

--- a/mods/tuxemon/db/technique/ring.json
+++ b/mods/tuxemon/db/technique/ring.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.1,
   "power": 2.4,

--- a/mods/tuxemon/db/technique/rock.json
+++ b/mods/tuxemon/db/technique/rock.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": null,
   "power": 1.5,

--- a/mods/tuxemon/db/technique/rot.json
+++ b/mods/tuxemon/db/technique/rot.json
@@ -7,7 +7,6 @@
     "enhance"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": true,
   "potency": 1,
   "power": 0,

--- a/mods/tuxemon/db/technique/ruby.json
+++ b/mods/tuxemon/db/technique/ruby.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.6,
   "power": 3,

--- a/mods/tuxemon/db/technique/rust_bomb.json
+++ b/mods/tuxemon/db/technique/rust_bomb.json
@@ -4,10 +4,9 @@
   "animation": "smokebomb_puff_128",
   "effects": [
     "give status_poison,target",
-    "damage"
+    "splash"
   ],
   "flip_axes": "",
-  "is_area": true,
   "is_fast": false,
   "potency": 0.5,
   "power": 2.25,

--- a/mods/tuxemon/db/technique/saber.json
+++ b/mods/tuxemon/db/technique/saber.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.9,
   "power": 2.2,

--- a/mods/tuxemon/db/technique/salamander.json
+++ b/mods/tuxemon/db/technique/salamander.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.8,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/sand_spray.json
+++ b/mods/tuxemon/db/technique/sand_spray.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.2,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/scope.json
+++ b/mods/tuxemon/db/technique/scope.json
@@ -4,7 +4,6 @@
   "animation": "meltdown",
   "effects": [],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 0,

--- a/mods/tuxemon/db/technique/shadow_boxing.json
+++ b/mods/tuxemon/db/technique/shadow_boxing.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": null,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/shapechange.json
+++ b/mods/tuxemon/db/technique/shapechange.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.7,
   "power": 1.1,

--- a/mods/tuxemon/db/technique/shrapnel.json
+++ b/mods/tuxemon/db/technique/shrapnel.json
@@ -3,10 +3,9 @@
   "accuracy": 0.6,
   "animation": "explosion_small",
   "effects": [
-    "damage"
+    "splash"
   ],
   "flip_axes": "",
-  "is_area": true,
   "is_fast": true,
   "potency": null,
   "power": 3,

--- a/mods/tuxemon/db/technique/shuriken.json
+++ b/mods/tuxemon/db/technique/shuriken.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 2.25,

--- a/mods/tuxemon/db/technique/sleep_bomb.json
+++ b/mods/tuxemon/db/technique/sleep_bomb.json
@@ -8,7 +8,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 2.25,

--- a/mods/tuxemon/db/technique/sleeping_powder.json
+++ b/mods/tuxemon/db/technique/sleeping_powder.json
@@ -8,7 +8,6 @@
     "enhance"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": true,
   "potency": 1,
   "power": 0,

--- a/mods/tuxemon/db/technique/slime.json
+++ b/mods/tuxemon/db/technique/slime.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.1,
   "power": 1.1,

--- a/mods/tuxemon/db/technique/snowstorm.json
+++ b/mods/tuxemon/db/technique/snowstorm.json
@@ -4,10 +4,9 @@
   "animation": "explosion_ice_112",
   "effects": [
     "give status_exhausted,target",
-    "damage"
+    "splash"
   ],
   "flip_axes": "",
-  "is_area": true,
   "is_fast": false,
   "potency": 1,
   "power": 3,

--- a/mods/tuxemon/db/technique/splinter.json
+++ b/mods/tuxemon/db/technique/splinter.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "x",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.2,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/spray.json
+++ b/mods/tuxemon/db/technique/spray.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.2,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/stabilo.json
+++ b/mods/tuxemon/db/technique/stabilo.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.9,
   "power": 1.9,

--- a/mods/tuxemon/db/technique/stampede.json
+++ b/mods/tuxemon/db/technique/stampede.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/starfall.json
+++ b/mods/tuxemon/db/technique/starfall.json
@@ -8,7 +8,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.7,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/static_field.json
+++ b/mods/tuxemon/db/technique/static_field.json
@@ -8,7 +8,6 @@
     "enhance"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 0,

--- a/mods/tuxemon/db/technique/sting.json
+++ b/mods/tuxemon/db/technique/sting.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.2,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/stone_rot.json
+++ b/mods/tuxemon/db/technique/stone_rot.json
@@ -7,7 +7,6 @@
     "enhance"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": true,
   "potency": 1,
   "power": 0,

--- a/mods/tuxemon/db/technique/stonehenge.json
+++ b/mods/tuxemon/db/technique/stonehenge.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.6,
   "power": 1.2,

--- a/mods/tuxemon/db/technique/strangulation.json
+++ b/mods/tuxemon/db/technique/strangulation.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.8,
   "power": 1.2,

--- a/mods/tuxemon/db/technique/strike.json
+++ b/mods/tuxemon/db/technique/strike.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "x",
-  "is_area": false,
   "is_fast": false,
   "potency": null,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/suck_poison.json
+++ b/mods/tuxemon/db/technique/suck_poison.json
@@ -8,7 +8,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/sudden_glow.json
+++ b/mods/tuxemon/db/technique/sudden_glow.json
@@ -9,7 +9,6 @@
   ],
   "flip_axes": "",
   "healing_power": 2,
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 0,

--- a/mods/tuxemon/db/technique/sunburst.json
+++ b/mods/tuxemon/db/technique/sunburst.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.3,
   "power": 1.5,

--- a/mods/tuxemon/db/technique/supernova.json
+++ b/mods/tuxemon/db/technique/supernova.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "x",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 3,

--- a/mods/tuxemon/db/technique/surf.json
+++ b/mods/tuxemon/db/technique/surf.json
@@ -3,10 +3,9 @@
   "accuracy": 0.9,
   "animation": "waterfall",
   "effects": [
-    "damage"
+    "splash"
   ],
   "flip_axes": "",
-  "is_area": true,
   "is_fast": false,
   "potency": 0.8,
   "power": 2.6,

--- a/mods/tuxemon/db/technique/surge.json
+++ b/mods/tuxemon/db/technique/surge.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/sword.json
+++ b/mods/tuxemon/db/technique/sword.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.7,
   "power": 1.2,

--- a/mods/tuxemon/db/technique/sylvan.json
+++ b/mods/tuxemon/db/technique/sylvan.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.4,
   "power": 2.3,

--- a/mods/tuxemon/db/technique/take_cover.json
+++ b/mods/tuxemon/db/technique/take_cover.json
@@ -7,7 +7,6 @@
     "enhance"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 0,

--- a/mods/tuxemon/db/technique/terror.json
+++ b/mods/tuxemon/db/technique/terror.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.1,
   "power": 2.9,

--- a/mods/tuxemon/db/technique/thunderball.json
+++ b/mods/tuxemon/db/technique/thunderball.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": null,
   "power": 2.25,

--- a/mods/tuxemon/db/technique/thunderclap.json
+++ b/mods/tuxemon/db/technique/thunderclap.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/time_crisis.json
+++ b/mods/tuxemon/db/technique/time_crisis.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.6,
   "power": 1.3,

--- a/mods/tuxemon/db/technique/tip.json
+++ b/mods/tuxemon/db/technique/tip.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.9,
   "power": 1.5,

--- a/mods/tuxemon/db/technique/tonguespear.json
+++ b/mods/tuxemon/db/technique/tonguespear.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "xy",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 1,

--- a/mods/tuxemon/db/technique/torch.json
+++ b/mods/tuxemon/db/technique/torch.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.8,
   "power": 1.4,

--- a/mods/tuxemon/db/technique/touch.json
+++ b/mods/tuxemon/db/technique/touch.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.9,
   "power": 1.8,

--- a/mods/tuxemon/db/technique/tsunami.json
+++ b/mods/tuxemon/db/technique/tsunami.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.6,
   "power": 2.7,

--- a/mods/tuxemon/db/technique/tux_attack.json
+++ b/mods/tuxemon/db/technique/tux_attack.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.1,
   "power": 1.1,

--- a/mods/tuxemon/db/technique/ubuntu.json
+++ b/mods/tuxemon/db/technique/ubuntu.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.6,
   "power": 1.5,

--- a/mods/tuxemon/db/technique/undertaker.json
+++ b/mods/tuxemon/db/technique/undertaker.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.9,
   "power": 1.4,

--- a/mods/tuxemon/db/technique/venom.json
+++ b/mods/tuxemon/db/technique/venom.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.5,
   "power": 2.2,

--- a/mods/tuxemon/db/technique/venomous_tentacle.json
+++ b/mods/tuxemon/db/technique/venomous_tentacle.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 2.25,

--- a/mods/tuxemon/db/technique/viper.json
+++ b/mods/tuxemon/db/technique/viper.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.4,
   "power": 2.9,

--- a/mods/tuxemon/db/technique/vorpal.json
+++ b/mods/tuxemon/db/technique/vorpal.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.9,
   "power": 2.7,

--- a/mods/tuxemon/db/technique/wall_fire.json
+++ b/mods/tuxemon/db/technique/wall_fire.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.8,
   "power": 1.9,

--- a/mods/tuxemon/db/technique/wall_ice.json
+++ b/mods/tuxemon/db/technique/wall_ice.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.8,
   "power": 2.5,

--- a/mods/tuxemon/db/technique/wall_of_steel.json
+++ b/mods/tuxemon/db/technique/wall_of_steel.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "x",
-  "is_area": false,
   "is_fast": true,
   "potency": 1,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/wallow.json
+++ b/mods/tuxemon/db/technique/wallow.json
@@ -8,7 +8,6 @@
   ],
   "flip_axes": "",
   "healing_power": 4,
-  "is_area": false,
   "is_fast": false,
   "potency": 0.5,
   "power": 0,

--- a/mods/tuxemon/db/technique/walls.json
+++ b/mods/tuxemon/db/technique/walls.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.2,
   "power": 1,

--- a/mods/tuxemon/db/technique/web.json
+++ b/mods/tuxemon/db/technique/web.json
@@ -7,7 +7,6 @@
     "damage"
   ],
   "flip_axes": "x",
-  "is_area": false,
   "is_fast": false,
   "potency": 1,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/webs_wind.json
+++ b/mods/tuxemon/db/technique/webs_wind.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": false,
   "potency": 0.3,
   "power": 1.8,

--- a/mods/tuxemon/db/technique/whirlwind.json
+++ b/mods/tuxemon/db/technique/whirlwind.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": true,
   "potency": null,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/wing_tip.json
+++ b/mods/tuxemon/db/technique/wing_tip.json
@@ -6,7 +6,6 @@
     "damage"
   ],
   "flip_axes": "",
-  "is_area": false,
   "is_fast": true,
   "potency": null,
   "power": 1.25,

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -872,6 +872,9 @@ msgstr "{target} is charging power."
 msgid "combat_state_confused_get"
 msgstr "{target} is confused."
 
+msgid "combat_state_confused_tech"
+msgstr "{target} gets muddled and uses {name} instead!"
+
 msgid "combat_state_diehard_get"
 msgstr "{target} will keep fighting."
 

--- a/scripts/create_tech_json.py
+++ b/scripts/create_tech_json.py
@@ -29,7 +29,6 @@ DataRow = namedtuple("DataRow", [
     "power",
     "healing_power",
     "is_fast",
-    "is_area"
 ])
 
 axes_flip_mapping = {
@@ -72,7 +71,6 @@ def create_json(data_row):
         "effects": effects,
         "flip_axes": get_animation_flip_axes(data_row.animation),
         "healing_power": float(data_row.healing_power) if data_row.healing_power else 0,
-        "is_area": bool(data_row.is_area),
         "is_fast": bool(data_row.is_fast),
         "potency": data_row.potency,
         "power": float(data_row.power) if data_row.power else 0,

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -517,9 +517,6 @@ class TechniqueModel(BaseModel):
     is_fast: bool = Field(
         False, description="Whether or not this is a fast technique"
     )
-    is_area: bool = Field(
-        False, description="Whether or not this is an area of effect technique"
-    )
     randomly: bool = Field(
         True, description="Whether or not this is a fast technique"
     )

--- a/tuxemon/states/combat/combat_menus.py
+++ b/tuxemon/states/combat/combat_menus.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import random
 from collections import defaultdict
 from functools import partial
 from typing import TYPE_CHECKING, Callable, DefaultDict, Generator, List, Union
@@ -12,7 +11,7 @@ import pygame
 from pygame.rect import Rect
 
 from tuxemon import combat, formula, graphics, tools
-from tuxemon.db import ItemCategory, PlagueType, State
+from tuxemon.db import ItemCategory, State
 from tuxemon.item.item import Item
 from tuxemon.locale import T
 from tuxemon.menu.interface import MenuItem
@@ -163,19 +162,19 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
         """Open menus to swap monsters in party."""
 
         def swap_it(menuitem: MenuItem[Monster]) -> None:
-            monster = menuitem.game_object
+            added = menuitem.game_object
             combat_state = self.client.get_state_by_name(CombatState)
 
-            if monster in combat_state.active_monsters:
+            if added in combat_state.active_monsters:
                 tools.open_dialog(
                     local_session,
-                    [T.format("combat_isactive", {"name": monster.name})],
+                    [T.format("combat_isactive", {"name": added.name})],
                 )
                 return
-            elif monster.current_hp < 1:
+            elif added.current_hp < 1:
                 tools.open_dialog(
                     local_session,
-                    [T.format("combat_fainted", {"name": monster.name})],
+                    [T.format("combat_fainted", {"name": added.name})],
                 )
                 return
             swap = Technique()
@@ -195,8 +194,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                     ],
                 )
                 return
-            target = monster
-            combat_state.enqueue_action(None, swap, target)
+            combat_state.enqueue_action(self.monster, swap, added)
             self.client.pop_state()  # close technique menu
             self.client.pop_state()  # close the monster action menu
 
@@ -343,25 +341,10 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                 return
             else:
                 combat_state = self.client.get_state_by_name(CombatState)
-                # null action for dozing
-                if combat.has_status(self.monster, "status_dozing"):
-                    status = Technique()
-                    status.load("status_dozing")
-                    technique = status
-                # null action for plague - spyder_bite
-                if self.monster.plague == PlagueType.infected:
-                    value = random.randint(1, 8)
-                    if value == 1:
-                        status = Technique()
-                        status.load("status_spyderbite")
-                        technique = status
-                        # infect mechanism
-                        if (
-                            self.enemy.plague == PlagueType.infected
-                            or self.enemy.plague == PlagueType.healthy
-                        ):
-                            target.plague = PlagueType.infected
-                # continue combat action
+                # pre checking (look for null actions)
+                technique = combat.pre_checking(
+                    self.monster, technique, target, self.player, self.enemy
+                )
                 combat_state.enqueue_action(self.monster, technique, target)
                 # check status response
                 if combat_state.status_response_technique(

--- a/tuxemon/technique/effects/enhance.py
+++ b/tuxemon/technique/effects/enhance.py
@@ -39,8 +39,10 @@ class EnhanceEffect(TechEffect):
         player = self.session.player
         value = float(player.game_variables["random_tech_hit"])
         hit = tech.accuracy >= value
-        if hit or tech.is_area:
+        if hit:
+            tech.hit = True
             tech.advance_counter_success()
             return {"success": True}
         else:
+            tech.hit = False
             return {"success": False}

--- a/tuxemon/technique/effects/healing.py
+++ b/tuxemon/technique/effects/healing.py
@@ -50,6 +50,7 @@ class HealingEffect(TechEffect):
             heal = (7 + mon.level) * tech.healing_power
         diff = mon.hp - mon.current_hp
         if hit:
+            tech.hit = True
             tech.advance_counter_success()
             if diff > 0:
                 if heal >= diff:
@@ -60,4 +61,5 @@ class HealingEffect(TechEffect):
             else:
                 return {"success": False}
         else:
+            tech.hit = False
             return {"success": False}

--- a/tuxemon/technique/effects/local_damage.py
+++ b/tuxemon/technique/effects/local_damage.py
@@ -43,17 +43,17 @@ class LocalDamageEffect(TechEffect):
         player = self.session.player
         value = float(player.game_variables["random_tech_hit"])
         hit = tech.accuracy >= value
-        if hit or tech.is_area:
+        if hit:
+            tech.hit = True
             tech.advance_counter_success()
             damage, mult = formula.simple_damage_calculate(tech, user, target)
-            if not hit:
-                damage //= 2
             # land of ifs
             # tech: panjandrum
             if tech.slug == "panjandrum":
                 damage = formula.damage_panjandrum(target)
             target.current_hp -= damage
         else:
+            tech.hit = False
             damage = 0
             mult = 1.0
 

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -73,7 +73,7 @@ class Technique:
         self.flip_axes = ""
         self.icon = ""
         self.images: Sequence[str] = []
-        self.is_area = False
+        self.hit = False
         self.is_fast = False
         self.randomly = True
         self.link: Optional[Monster] = None
@@ -157,11 +157,11 @@ class Technique:
         self.repl_neg = results.repl_neg or self.repl_neg
         self.repl_pos = results.repl_pos or self.repl_pos
 
+        self.hit = self.hit
         self.is_fast = results.is_fast or self.is_fast
         self.randomly = results.randomly or self.randomly
         self.healing_power = results.healing_power or self.healing_power
         self.recharge_length = results.recharge or self.recharge_length
-        self.is_area = results.is_area or self.is_area
         self.range = results.range or Range.melee
         self.tech_id = results.tech_id or self.tech_id
 


### PR DESCRIPTION
PR syncs changes on Tuxepedia:
- complete removal of the **is_area** field in techniques;
- addition of **splash** effect (similar to damage, but it'll provoke **half damage** if missing);
- cleaning up **damage** and **local_damage** from **not hit** (related to the old is_area);
- **area** effect is not added, I'm going to include it in #1835 (mostly because testing for 2vs2, technique with "area" will inflict damage to all the enemy monster on the battlefield);
- addition of field bool "hit" inside technique (no db), so it can be saved if the technique hit;
- creation of **pre_checking** inside **combat.py** in this way we can clean up **combat_menu**, I'll connect the AI to **pre_checking** in #1818 will be merged or not;
- fixes **check_moves** in combat.py;
- fixes **swapping** combat_menu.py, because we need to pass the monster removed for new statuses;

tech.is_area has been removed and replaced with two effects **splash** and **area**.

this modification is part of a bigger task of cleaning up and setting correctly techniques

@Sanglorian as you did on Tuxepedia, if there is something else, then let me know