### PR TITLE
fix wall ice animation

### DIFF
--- a/mods/tuxemon/db/technique/ice_shield.json
+++ b/mods/tuxemon/db/technique/ice_shield.json
@@ -1,7 +1,7 @@
 {
   "tech_id": 172,
   "accuracy": 0.6,
-  "animation": "ice_shield",
+  "animation": "wall_ice",
   "effects": [
     "give status_elementalshield,user",
     "give status_slow,target",


### PR DESCRIPTION
PR corrects a small mistake.
```
2023-05-21 08:36:21,883 - tuxemon.db - ERROR - validation failed for 'ice_shield': 1 validation error for TechniqueModel
animation
  the animation ice_shield doesn't exist in the db (type=value_error)
```
by renaming the technique, I renamed the animation too.
