### PR TITLE
fix forfeit

### DIFF
--- a/mods/tuxemon/db/npc/professor.json
+++ b/mods/tuxemon/db/npc/professor.json
@@ -1,5 +1,6 @@
 {
   "slug": "professor",
+  "forfeit": false,
   "template": [
     {
       "sprite_name": "professor",

--- a/mods/tuxemon/db/npc/spyder_dojo_billie.json
+++ b/mods/tuxemon/db/npc/spyder_dojo_billie.json
@@ -1,5 +1,6 @@
 {
   "slug": "spyder_dojo_billie",
+  "forfeit": false,
   "template": [
     {
       "sprite_name": "fashionista",

--- a/mods/tuxemon/db/npc/spyder_hospital_billie.json
+++ b/mods/tuxemon/db/npc/spyder_hospital_billie.json
@@ -1,5 +1,6 @@
 {
   "slug": "spyder_hospital_billie",
+  "forfeit": false,
   "template": [
     {
       "sprite_name": "fashionista",

--- a/mods/tuxemon/db/npc/spyder_rivalbillie.json
+++ b/mods/tuxemon/db/npc/spyder_rivalbillie.json
@@ -1,5 +1,6 @@
 {
   "slug": "spyder_billie",
+  "forfeit": false,
   "template": [
     {
       "sprite_name": "fashionista",

--- a/mods/tuxemon/db/npc/spyder_route2_billie.json
+++ b/mods/tuxemon/db/npc/spyder_route2_billie.json
@@ -1,5 +1,6 @@
 {
   "slug": "spyder_route2_billie",
+  "forfeit": false,
   "template": [
     {
       "sprite_name": "fashionista",

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -748,6 +748,9 @@ msgstr "You have forfeited!\n{npc} is disappointed."
 msgid "combat_can't_run_from_trainer"
 msgstr "Can't run!"
 
+msgid "combat_forfeit_trainer"
+msgstr "Can't forfeit!"
+
 msgid "combat_player_run"
 msgstr "You have run away!"
 

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -647,6 +647,7 @@ class NpcTemplateModel(BaseModel):
 
 class NpcModel(BaseModel):
     slug: str = Field(..., description="Slug of the name of the NPC")
+    forfeit: bool = Field(True, description="Whether you can forfeit or not")
     template: Sequence[NpcTemplateModel] = Field(
         [], description="List of templates"
     )

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -132,6 +132,7 @@ class NPC(Entity[NPCState]):
         self.behavior: Optional[str] = "wander"  # not used for now
         self.game_variables: Dict[str, Any] = {}  # Tracks the game state
         self.battles: List[Battle] = []  # Tracks the battles
+        self.forfeit: bool = True
         # Tracks Tuxepedia (monster seen or caught)
         self.tuxepedia: Dict[str, SeenStatus] = {}
         self.contacts: Dict[str, str] = {}
@@ -139,7 +140,7 @@ class NPC(Entity[NPCState]):
         self.interactions: Sequence[
             str
         ] = []  # List of ways player can interact with the Npc
-        self.isplayer = False  # used for various tests, idk
+        self.isplayer: bool = False  # used for various tests, idk
         # This is a list of tuxemon the npc has. Do not modify directly
         self.monsters: List[Monster] = []
         # The player's items.
@@ -835,6 +836,7 @@ class NPC(Entity[NPCState]):
 
         # Look up the NPC's details from our NPC database
         npc_details = db.lookup(self.slug, "npc")
+        self.forfeit = npc_details.forfeit
         npc_party = npc_details.monsters
         for npc_monster_details in npc_party:
             # This seems slightly wrong. The only useable element in

--- a/tuxemon/states/combat/combat_menus.py
+++ b/tuxemon/states/combat/combat_menus.py
@@ -97,12 +97,30 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
             )
             return
         self.client.pop_state(self)
-        # trigger forfeit
-        for mon in self.player.monsters:
-            faint = Technique()
-            faint.load("status_faint")
-            mon.current_hp = 0
-            mon.status = [faint]
+        combat_state = self.client.get_state_by_name(CombatState)
+        enemy = combat_state.players[1]
+        if not enemy.forfeit:
+
+            def open_menu() -> None:
+                combat_state.task(
+                    partial(
+                        combat_state.show_monster_action_menu,
+                        self.monster,
+                    ),
+                    1,
+                )
+
+            combat_state.alert(
+                T.translate("combat_forfeit_trainer"),
+                open_menu,
+            )
+        else:
+            # trigger forfeit
+            for mon in self.player.monsters:
+                faint = Technique()
+                faint.load("status_faint")
+                mon.current_hp = 0
+                mon.status = [faint]
 
     def run(self) -> None:
         """


### PR DESCRIPTION
fix #1862

PR implements a new field inside the NPC JSON, where it'll be possible to set forfeit to false, in this way it wouldn't be possible to forfeit from that specific NPC. There are encounters that cannot be skipped by forfeiting.

`  "forfeit": false,`

by default all the others are set on True.

@kerizane thanks, I had this on queue

tested, black, isort, no new typehints
