### PR TITLE
add status_burn + fixes

### DIFF
--- a/mods/tuxemon/db/technique/amnesia.json
+++ b/mods/tuxemon/db/technique/amnesia.json
@@ -3,8 +3,7 @@
   "accuracy": 0.75,
   "animation": "sparks_gold_alt",
   "effects": [
-    "give status_exhausted,target",
-    "give status_exhausted,user",
+    "give status_exhausted,both",
     "damage"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/ants.json
+++ b/mods/tuxemon/db/technique/ants.json
@@ -27,6 +27,6 @@
     "aether"
   ],
   "use_failure": "combat_miss",
-  "use_success": "combat_none",
+  "use_success": null,
   "use_tech": "combat_used_x"
 }

--- a/mods/tuxemon/db/technique/blood_bond.json
+++ b/mods/tuxemon/db/technique/blood_bond.json
@@ -3,8 +3,7 @@
   "accuracy": 0.8,
   "animation": "sparks_red",
   "effects": [
-    "give status_lifeleech,user",
-    "give status_lifeleech,target",
+    "give status_lifeleech,both",
     "damage"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/bubble_trap.json
+++ b/mods/tuxemon/db/technique/bubble_trap.json
@@ -3,8 +3,7 @@
   "accuracy": 0.75,
   "animation": "bomb_bright",
   "effects": [
-    "give status_grabbed,target",
-    "give status_grabbed,user",
+    "give status_grabbed,both",
     "damage"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/cloud_aether.json
+++ b/mods/tuxemon/db/technique/cloud_aether.json
@@ -27,6 +27,6 @@
     "aether"
   ],
   "use_failure": "combat_miss",
-  "use_success": "combat_none",
+  "use_success": null,
   "use_tech": "combat_used_x"
 }

--- a/mods/tuxemon/db/technique/electroplate.json
+++ b/mods/tuxemon/db/technique/electroplate.json
@@ -27,6 +27,6 @@
     "aether"
   ],
   "use_failure": "combat_miss",
-  "use_success": "combat_none",
+  "use_success": null,
   "use_tech": "combat_used_x"
 }

--- a/mods/tuxemon/db/technique/fiery.json
+++ b/mods/tuxemon/db/technique/fiery.json
@@ -27,6 +27,6 @@
     "aether"
   ],
   "use_failure": "combat_miss",
-  "use_success": "combat_none",
+  "use_success": null,
   "use_tech": "combat_used_x"
 }

--- a/mods/tuxemon/db/technique/fire_claw.json
+++ b/mods/tuxemon/db/technique/fire_claw.json
@@ -3,11 +3,12 @@
   "accuracy": 0.7,
   "animation": "slash_power",
   "effects": [
+    "give status_burn,target",
     "damage"
   ],
   "flip_axes": "x",
   "is_fast": false,
-  "potency": null,
+  "potency": 0.2,
   "power": 1.75,
   "range": "melee",
   "recharge": 2,

--- a/mods/tuxemon/db/technique/flamethrower.json
+++ b/mods/tuxemon/db/technique/flamethrower.json
@@ -3,11 +3,12 @@
   "accuracy": 0.8,
   "animation": "firelion_right",
   "effects": [
+    "give status_burn,target",
     "damage"
   ],
   "flip_axes": "x",
   "is_fast": false,
-  "potency": null,
+  "potency": 0.5,
   "power": 2.25,
   "range": "reach",
   "recharge": 3,

--- a/mods/tuxemon/db/technique/gyser.json
+++ b/mods/tuxemon/db/technique/gyser.json
@@ -27,6 +27,6 @@
     "aether"
   ],
   "use_failure": "combat_miss",
-  "use_success": "combat_none",
+  "use_success": null,
   "use_tech": "combat_used_x"
 }

--- a/mods/tuxemon/db/technique/lava.json
+++ b/mods/tuxemon/db/technique/lava.json
@@ -3,6 +3,7 @@
   "accuracy": 0.6,
   "animation": "shield_lava",
   "effects": [
+    "give status_burn,both",
     "damage"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/levitate.json
+++ b/mods/tuxemon/db/technique/levitate.json
@@ -3,8 +3,7 @@
   "accuracy": 1,
   "animation": null,
   "effects": [
-    "give status_sniping,target",
-    "give status_sniping,user",
+    "give status_sniping,both",
     "enhance"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/muddle.json
+++ b/mods/tuxemon/db/technique/muddle.json
@@ -3,8 +3,7 @@
   "accuracy": 0.75,
   "animation": "sparks_white",
   "effects": [
-    "give status_focused,target",
-    "give status_focused,user",
+    "give status_focused,both",
     "damage"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/sleep_bomb.json
+++ b/mods/tuxemon/db/technique/sleep_bomb.json
@@ -3,8 +3,7 @@
   "accuracy": 0.75,
   "animation": "sparks_white",
   "effects": [
-    "give status_noddingoff,user",
-    "give status_noddingoff,target",
+    "give status_noddingoff,both",
     "damage"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/technique/status_burn.json
+++ b/mods/tuxemon/db/technique/status_burn.json
@@ -1,16 +1,16 @@
 {
-  "animation": "drip_green",
+  "animation": null,
   "category": "negative",
   "effects": [
     "drain"
   ],
   "flip_axes": "",
-  "icon": "gfx/ui/icons/status/icon_poison.png",
+  "icon": "gfx/ui/icons/status/icon_burn.png",
   "range": "special",
   "repl_pos": "replaced",
   "repl_neg": "replaced",
   "sfx": "sfx_pulse",
-  "slug": "status_poison",
+  "slug": "status_burn",
   "sort": "meta",
   "target": {
     "enemy monster": 0,
@@ -21,7 +21,7 @@
     "own trainer": 0
   },
   "tech_id": 0,
-  "use_failure": "combat_none",
-  "use_success": "combat_state_poison_end",
-  "use_tech": "combat_state_poison_get"
+  "use_failure": "generic_failure",
+  "use_success": "combat_state_burn_end",
+  "use_tech": "combat_state_burn_get"
 }

--- a/mods/tuxemon/db/technique/status_dozing.json
+++ b/mods/tuxemon/db/technique/status_dozing.json
@@ -1,7 +1,9 @@
 {
   "animation": null,
   "category": "negative",
-  "effects": [],
+  "effects": [
+    "default"
+  ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_dozing.png",
   "range": "special",

--- a/mods/tuxemon/db/technique/ubuntu.json
+++ b/mods/tuxemon/db/technique/ubuntu.json
@@ -27,6 +27,6 @@
     "aether"
   ],
   "use_failure": "combat_miss",
-  "use_success": "combat_none",
+  "use_success": null,
   "use_tech": "combat_used_x"
 }

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -866,6 +866,12 @@ msgstr "The attack was strongly resisted!"
 msgid "combat_state_blinded_get"
 msgstr "{target} is blinded."
 
+msgid "combat_state_burn_end"
+msgstr "{target} takes damage from burns."
+
+msgid "combat_state_burn_get"
+msgstr "{target} is burned."
+
 msgid "combat_state_chargedup_get"
 msgstr "{target} is fully charged."
 
@@ -1068,6 +1074,9 @@ msgstr "Slot"
 ## STATUSES
 msgid "status_blinded"
 msgstr "Blinded"
+
+msgid "status_burn"
+msgstr "Burn"
 
 msgid "status_chargedup"
 msgstr "Charged Up"

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -114,27 +114,19 @@ def simple_damage_calculate(
     return damage, mult
 
 
-def damage_panjandrum(target: Monster) -> int:
+def damage_full_hp(target: Monster, value: int) -> int:
     """
-    The target takes damage equal to 1/4 of their maximum HP.
-    """
-    damage = target.hp * 0.25
-    return int(damage)
-
-
-def simple_poison(target: Monster) -> int:
-    """
-    Simple poison based on target's full hp.
+    Damage based on target's full hp.
 
     Parameters:
-        technique: The technique causing poison.
         target: The one the technique is being used on.
+        value: Numerical value (target.hp // value).
 
     Returns:
         Inflicted damage.
 
     """
-    damage = target.hp // 8
+    damage = target.hp // value
     return damage
 
 

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -39,6 +39,7 @@ from tuxemon.combat import (
     has_effect_param,
     has_status,
     has_status_bond,
+    pre_checking,
     scope,
     spyderbite,
 )
@@ -576,20 +577,9 @@ class CombatState(CombatAnimations):
             )
         # check status response
         if isinstance(user, Monster) and isinstance(technique, Technique):
-            # null action for dozing
-            if has_status(user, "status_dozing"):
-                status = Technique()
-                status.load("skip")
-                technique = status
-            # null action for plague - spyder_bite
-            if user.plague == PlagueType.infected:
-                value = random.randint(1, 8)
-                if value == 1:
-                    status = Technique()
-                    status.load("status_spyderbite")
-                    technique = status
-                    if self.players[1].plague == PlagueType.infected:
-                        target.plague = PlagueType.infected
+            technique = pre_checking(
+                user, technique, target, self.players[0], self.players[0]
+            )
             # check status response
             if self.status_response_technique(user, technique):
                 self._lost_monster = user
@@ -770,7 +760,7 @@ class CombatState(CombatAnimations):
         self.monsters_in_play[player].append(monster)
 
         # remove "connected" status (eg. lifeleech, etc.)
-        for mon in self.monsters_in_play[self.players[0]]:
+        for mon in self.active_monsters:
             if has_status_bond(mon):
                 mon.status.clear()
 

--- a/tuxemon/technique/effects/drain.py
+++ b/tuxemon/technique/effects/drain.py
@@ -13,27 +13,30 @@ if TYPE_CHECKING:
     from tuxemon.technique.technique import Technique
 
 
-class PoisonEffectResult(TechEffectResult):
+class DrainEffectResult(TechEffectResult):
     pass
 
 
 @dataclass
-class PoisonEffect(TechEffect):
+class DrainEffect(TechEffect):
     """
-    This effect has a chance to apply the poison status effect.
+    This effect has a chance to apply the drain status effect.
+    Like poison, burn, etc.
     """
 
-    name = "poison"
+    name = "drain"
 
     def apply(
         self, tech: Technique, user: Monster, target: Monster
-    ) -> PoisonEffectResult:
+    ) -> DrainEffectResult:
+        drained: bool = False
         if tech.slug == "status_poison":
-            damage = formula.simple_poison(target)
+            damage = formula.damage_full_hp(target, 8)
             target.current_hp -= damage
+            drained = True
+        if tech.slug == "status_burn":
+            damage = formula.damage_full_hp(target, 8)
+            target.current_hp -= damage
+            drained = True
 
-            return {
-                "success": bool(damage),
-            }
-
-        return {"success": False}
+        return {"success": drained}

--- a/tuxemon/technique/effects/give.py
+++ b/tuxemon/technique/effects/give.py
@@ -30,6 +30,7 @@ class GiveEffect(TechEffect):
     def apply(
         self, tech: Technique, user: Monster, target: Monster
     ) -> GiveEffectResult:
+        done: bool = False
         player = self.session.player
         potency = random.random()
         value = float(player.game_variables["random_tech_hit"])
@@ -40,8 +41,12 @@ class GiveEffect(TechEffect):
             status.link = user
             if self.objective == "user":
                 user.apply_status(status)
+                done = True
             elif self.objective == "target":
                 target.apply_status(status)
-            return {"success": True}
-
-        return {"success": False}
+                done = True
+            elif self.objective == "both":
+                user.apply_status(status)
+                target.apply_status(status)
+                done = True
+        return {"success": done}

--- a/tuxemon/technique/effects/local_damage.py
+++ b/tuxemon/technique/effects/local_damage.py
@@ -50,7 +50,7 @@ class LocalDamageEffect(TechEffect):
             # land of ifs
             # tech: panjandrum
             if tech.slug == "panjandrum":
-                damage = formula.damage_panjandrum(target)
+                damage = formula.damage_full_hp(target, 4)
             target.current_hp -= damage
         else:
             tech.hit = False


### PR DESCRIPTION
split #1853 

PR:
- adds **status_burn**;
- renames technique effect **poison** into **drain**, that's because it'll be used by **burn** too, it's the same formula, same concept, it doesn't make sense having two files doing the same thing;
- renames **simple_poison** in formula.py in **damage_full_hp**, **damage_full_hp** will be used by drain, so poison and burn;
- replaces **damage_panjandrum** with **damage_full_hp** (as explained above, it doesn't make sense having three formulas doing the same thing but with a different number eg  `damage = target.hp // 8 or damage = target.hp // 4`);
- forgot to add **default** to **status_dozing**;
- fixes **use_success** of the technique with **switch** by setting **null**;
- adds **pre_checking** (inside combat.py) as we did for the player in combat_menu;
- upgrades **give** tech effect by allowing to set **both**;