### PR TITLE
run (cost turn)

### DIFF
--- a/mods/tuxemon/db/technique/run.json
+++ b/mods/tuxemon/db/technique/run.json
@@ -7,7 +7,7 @@
 	"effects": [],
 	"flip_axes": "",
 	"icon": "",
-	"power": 50,
+	"is_fast": true,
 	"range": "special",
 	"sfx": "sfx_blaster",
 	"slug": "menu_run",
@@ -21,7 +21,7 @@
 		"own trainer": 0
 	},
 	"tech_id": 0,
-	"use_failure": "generic_failure",
+	"use_failure": "combat_cannot_run_away",
 	"use_success": "generic_success",
 	"use_tech": "combat_used_x"
 }

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -745,8 +745,8 @@ msgstr "It missed..."
 msgid "combat_forfeit"
 msgstr "You have forfeited!\n{npc} is disappointed."
 
-msgid "combat_can't_run_from_trainer"
-msgstr "Can't run!"
+msgid "combat_cannot_run_away"
+msgstr "But can't run away!"
 
 msgid "combat_forfeit_trainer"
 msgstr "Can't forfeit!"

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -1587,9 +1587,8 @@ class CombatState(CombatAnimations):
         self.client.pop_state()
         self.client.pop_state()
 
-    def end_combat(self) -> None:
-        """End the combat."""
-        # TODO: End combat differently depending on winning or losing
+    def clean_combat(self) -> None:
+        """Clean combat."""
         for player in self.players:
             for mon in player.monsters:
                 # reset status stats
@@ -1604,6 +1603,10 @@ class CombatState(CombatAnimations):
         # clear action queue
         self._action_queue = list()
         self._log_action = list()
+
+    def end_combat(self) -> None:
+        """End the combat."""
+        self.clean_combat()
 
         # fade music out
         self.client.event_engine.execute_action("fadeout_music", [1000])

--- a/tuxemon/states/combat/combat_menus.py
+++ b/tuxemon/states/combat/combat_menus.py
@@ -156,25 +156,14 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
             and combat_state._run == "on"
         ):
             var["run_attempts"] += 1
+            # clean up
+            combat_state.clean_combat()
             # trigger run
             del combat_state.monsters_in_play[self.player]
             combat_state.players.remove(self.player)
         else:
-
-            def open_menu() -> None:
-                combat_state.task(
-                    partial(
-                        combat_state.show_monster_action_menu,
-                        self.monster,
-                    ),
-                    1,
-                )
-
-            combat_state.alert(
-                T.translate("combat_can't_run_from_trainer"),
-                open_menu,
-            )
             combat_state._run = "off"
+            combat_state.enqueue_action(player, run, enemy)
 
     def open_swap_menu(self) -> None:
         """Open menus to swap monsters in party."""


### PR DESCRIPTION
fix #1874 as requested by @Sanglorian 
```
Rockitten used Run!
But can't run away!
```
and it costs a turn

updated: it fixes a bug too, after testing I discovered that running away didn't trigger **end_combat**.
this was causing no recharge (techniques) and no reset of statuses
I split **end_combat** in **clean_combat** (called from combat_menu), in this way I can reset the main values without triggering an immediate end.