### PR TITLE
fix maps + translations

### DIFF
--- a/mods/tuxemon/db/npc/cotton_misa_bro.json
+++ b/mods/tuxemon/db/npc/cotton_misa_bro.json
@@ -1,0 +1,10 @@
+{
+  "slug": "cotton_misa_bro",
+  "template": [
+    {
+      "sprite_name": "childactor",
+      "combat_front": "yellowbelt",
+      "slug": "childactor"
+    }
+  ]
+}

--- a/mods/tuxemon/db/npc/cotton_misa_gramps.json
+++ b/mods/tuxemon/db/npc/cotton_misa_gramps.json
@@ -1,0 +1,10 @@
+{
+  "slug": "cotton_misa_gramps",
+  "template": [
+    {
+      "sprite_name": "granny",
+      "combat_front": "heroine",
+      "slug": "granny"
+    }
+  ]
+}

--- a/mods/tuxemon/db/npc/spyder_omnichannel_thedukeofdeadair.json
+++ b/mods/tuxemon/db/npc/spyder_omnichannel_thedukeofdeadair.json
@@ -1,5 +1,5 @@
 {
-  "slug": "spyder_omnichannel_dukeofdeadair",
+  "slug": "spyder_omnichannel_thedukeofdeadair",
   "template": [
     {
       "sprite_name": "rogue",

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -8093,7 +8093,7 @@ msgstr "Wow! One day I'm going to be a trainer just like you!"
 msgid "spyder_successful_boulder"
 msgstr "The sledgehammer smashes the boulder apart."
 
-msgid "spyder_stop_dante"
+msgid "spyder_dante"
 msgstr "Dante"
 
 msgid "spyder_frolicking_rockitten"
@@ -8959,6 +8959,26 @@ msgstr "Tuxecenter - A place to heal your tuxemon"
 
 msgid "leather_town_open_air"
 msgstr "Open Air Cafe and Marketplace"
+
+msgid "xero_citypark_achievement"
+msgstr "Achievement Maniac's House: Closed."
+
+msgid "xero_shaft1_sign"
+msgstr "Shaft Headquarters: Mining Division"
+msgid "xero_shaft2_sign"
+msgstr "Shaft Headquarters: Public Relations Division"
+
+msgid "xero_taba_tvwatch"
+msgstr "What's on TV? A prom queen is breaking her tiara into pieces and handing it out."
+
+msgid "xero_taba_poster"
+msgstr "Home sweet home!"
+
+msgid "xero_taba_restinbed"
+msgstr "You awake fully rested!"
+
+msgid "xero_skip_question"
+msgstr "Do you want to skip the intro?"
 
 ## Sphalian Town ##
 

--- a/mods/tuxemon/l18n/es_ES/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/es_ES/LC_MESSAGES/base.po
@@ -2317,7 +2317,7 @@ msgstr "Conileaf"
 msgid "spyder_frolicking_rockitten"
 msgstr "Rockitten"
 
-msgid "spyder_stop_dante"
+msgid "spyder_dante"
 msgstr "Dante"
 
 msgid "spyder_cotton_nurse1"

--- a/mods/tuxemon/l18n/fr_FR/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/fr_FR/LC_MESSAGES/base.po
@@ -3989,7 +3989,7 @@ msgstr "Vous êtes dans nos pattes depuis bien trop longtemps !"
 msgid "spyder_dryadsgrove_ferris2"
 msgstr "Il est peut-être temps qu'on retourne dans le monde réel."
 
-msgid "spyder_stop_dante"
+msgid "spyder_dante"
 msgstr "Dante"
 
 msgid "spyder_dragonscave_mal2"

--- a/mods/tuxemon/l18n/it_IT/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/it_IT/LC_MESSAGES/base.po
@@ -2802,7 +2802,7 @@ msgstr "Eccoti qui vecchio amico! Lascia che ti riporti al fiume."
 msgid "spyder_dryadsgrove_volcoli1"
 msgstr "Bree! Bree!"
 
-msgid "spyder_stop_dante"
+msgid "spyder_dante"
 msgstr "Dante"
 
 msgid "spyder_granny"

--- a/mods/tuxemon/l18n/zh_CN/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/zh_CN/LC_MESSAGES/base.po
@@ -5970,7 +5970,7 @@ msgstr "欢迎!"
 msgid "spyder_successful_boulder"
 msgstr "大锤子将巨石砸开."
 
-msgid "spyder_stop_dante"
+msgid "spyder_dante"
 msgstr "但丁"
 
 msgid "spyder_frolicking_rockitten"

--- a/mods/tuxemon/maps/citypark.tmx
+++ b/mods/tuxemon/maps/citypark.tmx
@@ -366,7 +366,7 @@
   </object>
   <object id="101" name="Sign: Achievement Maniac's House" type="event" x="512" y="48" width="16" height="16">
    <properties>
-    <property name="act10" value="translated_dialog spyder_citypark_achievement"/>
+    <property name="act10" value="translated_dialog xero_citypark_achievement"/>
     <property name="cond10" value="is player_facing_tile"/>
     <property name="cond20" value="is button_pressed K_RETURN"/>
    </properties>

--- a/mods/tuxemon/maps/cotton_misa_house.tmx
+++ b/mods/tuxemon/maps/cotton_misa_house.tmx
@@ -69,17 +69,17 @@
   <object id="53" name="Granny" type="event" x="32" y="64" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog cotton_misa_granny"/>
-    <property name="behav1" value="talk taba_house1_wife"/>
+    <property name="behav1" value="talk cotton_misa_gramps"/>
    </properties>
   </object>
   <object id="54" name="Create NPCs" type="event" x="96" y="0" width="16" height="16">
    <properties>
-    <property name="act11" value="create_npc taba_house1_wife,2,4"/>
-    <property name="act12" value="create_npc spyder_flower_sandy,9,3"/>
-    <property name="act21" value="npc_face taba_house1_wife,down"/>
-    <property name="act22" value="npc_face spyder_flower_sandy,right"/>
-    <property name="cond1" value="not npc_exists taba_house1_wife"/>
-    <property name="cond2" value="not npc_exists spyder_flower_sandy"/>
+    <property name="act11" value="create_npc cotton_misa_gramps,2,4"/>
+    <property name="act12" value="create_npc cotton_misa_bro,9,3"/>
+    <property name="act21" value="npc_face cotton_misa_gramps,down"/>
+    <property name="act22" value="npc_face cotton_misa_bro,right"/>
+    <property name="cond1" value="not npc_exists cotton_misa_gramps"/>
+    <property name="cond2" value="not npc_exists cotton_misa_bro"/>
    </properties>
   </object>
   <object id="55" name="TV" type="event" x="16" y="144" width="32" height="16">
@@ -92,7 +92,7 @@
   <object id="57" name="LittleBro" type="event" x="144" y="48" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog cotton_misa_littlebro"/>
-    <property name="behav1" value="talk spyder_flower_sandy"/>
+    <property name="behav1" value="talk cotton_misa_bro"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/leather_shaft1.tmx
+++ b/mods/tuxemon/maps/leather_shaft1.tmx
@@ -47,62 +47,6 @@
     <property name="cond20" value="is player_facing down"/>
    </properties>
   </object>
-  <object id="17" name="Sign" type="event" x="160" y="160" width="16" height="32">
-   <properties>
-    <property name="act1" value="translated_dialog spyder_leathershaft1_sign"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
-   </properties>
-  </object>
-  <object id="18" name="Create NPCs" type="event" x="160" y="112" width="16" height="16">
-   <properties>
-    <property name="act11" value="create_npc spyder_miner,4,8"/>
-    <property name="act12" value="create_npc spyder_searoutec_rutherford,8,4"/>
-    <property name="act13" value="create_npc spyder_tunnelb_beryll,8,8"/>
-    <property name="act14" value="create_npc spyder_route3_surat,12,6"/>
-    <property name="act15" value="create_npc spyder_route3_roxby,4,13"/>
-    <property name="act21" value="npc_face spyder_miner,up"/>
-    <property name="act22" value="npc_face spyder_searoutec_rutherford,up"/>
-    <property name="act23" value="npc_face spyder_tunnelb_beryll,up"/>
-    <property name="act24" value="npc_face spyder_route3_surat,right"/>
-    <property name="act25" value="npc_face spyder_route3_roxby,right"/>
-    <property name="cond1" value="not npc_exists spyder_miner"/>
-    <property name="cond2" value="not npc_exists spyder_searoutec_rutherford"/>
-    <property name="cond3" value="not npc_exists spyder_tunnelb_beryll"/>
-    <property name="cond4" value="not npc_exists spyder_route3_surat"/>
-    <property name="cond5" value="not npc_exists spyder_route3_roxby"/>
-   </properties>
-  </object>
-  <object id="19" name="Guy5" type="event" x="64" y="208" width="16" height="16">
-   <properties>
-    <property name="act1" value="translated_dialog spyder_leathershaft1_roxby"/>
-    <property name="behav1" value="talk spyder_route3_roxby"/>
-   </properties>
-  </object>
-  <object id="20" name="Guy1" type="event" x="64" y="128" width="16" height="16">
-   <properties>
-    <property name="act1" value="translated_dialog spyder_leathershaft1_miner"/>
-    <property name="behav1" value="talk spyder_miner"/>
-   </properties>
-  </object>
-  <object id="21" name="Guy3" type="event" x="128" y="128" width="16" height="16">
-   <properties>
-    <property name="act1" value="translated_dialog spyder_leathershaft1_beryll"/>
-    <property name="behav1" value="talk spyder_tunnelb_beryll"/>
-   </properties>
-  </object>
-  <object id="22" name="Guy2" type="event" x="128" y="64" width="16" height="16">
-   <properties>
-    <property name="act1" value="translated_dialog spyder_leathershaft1_rutherford"/>
-    <property name="behav1" value="talk spyder_searoutec_rutherford"/>
-   </properties>
-  </object>
-  <object id="23" name="Guy4" type="event" x="192" y="96" width="16" height="16">
-   <properties>
-    <property name="act1" value="translated_dialog spyder_leathershaft1_surat"/>
-    <property name="behav1" value="talk spyder_route3_surat"/>
-   </properties>
-  </object>
  </objectgroup>
  <objectgroup color="#ff0000" id="6" name="Collision">
   <object id="5" type="collision" x="0" y="32" width="240" height="16"/>

--- a/mods/tuxemon/maps/leather_shaft2.tmx
+++ b/mods/tuxemon/maps/leather_shaft2.tmx
@@ -21,22 +21,22 @@
  </tileset>
  <layer id="1" name="Tile Layer 1" width="10" height="10">
   <data encoding="base64" compression="zlib">
-   eAHTZmFg0CYCRwLVEIPbgeqIwX1yDAyjGDMMABEwOe8=
+   eJzTZmFg0CYCRxKJ24nEfXKjGBsGABEwOe8=
   </data>
  </layer>
  <layer id="2" name="Tile Layer 2" width="10" height="10">
   <data encoding="base64" compression="zlib">
-   eAFjYCAPTOZnYJgCxOjgiwADw1cg/gbE34F4JVDNKjR124DiXIIMDNxAzAPEvEAMAjOh9DohBoY1QPYZoDoFIK0IxEpArAzEILASSK+C4j1QGiKDSu4Eyu1Cw5JAt0hDsRSau5B16wPlDKHYAI86ZD2ksBfKMTAsBmJksB3oXwAeNhdp
+   eJxjYCAPTOZnYJjCjyn+RYCB4SsQfwPi70C8EqhmFZq6bUBxLkEGBm4g5gFiXkGI+EwovU6IgWENkH0GqE4BSCsCsRIQK0PlVwLpVVC8B0pjAzuB4rvQsCTQLdJQLIXF/TCgD5QzhGIDPOrIBQvlGBgWy6GKbQf6FwAeNhdp
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="10" height="10">
   <data encoding="base64" compression="zlib">
-   eAFjYKAMPBIgTv8PItXxCRJnHrmqWvgZGFqBWB7oHhDGBWYB1cwGYnoDABiDBPI=
+   eJxjYKAMPBIgTt0PItXxCZLvFmJACz8DQysQywtAMC4wC6hmNj9t3YINAAAYgwTy
   </data>
  </layer>
  <layer id="4" name="Above player" width="10" height="10">
   <data encoding="base64" compression="zlib">
-   eAFjYBgeII+fgSEfiOkJugWIs20hkepApgEAFMkCSA==
+   eJxjYBgeII+fgSGfn752dgsQp24hkepAAAAUyQJI
   </data>
  </layer>
  <objectgroup color="#ff0000" id="5" name="Collision">
@@ -49,51 +49,10 @@
  <objectgroup color="#ffff00" id="6" name="Events">
   <object id="67" name="Go Outside" type="event" x="64" y="144" width="32" height="16">
    <properties>
-    <property name="act1" value="transition_teleport spyder_leather_town.tmx,24,4,0.3"/>
+    <property name="act1" value="transition_teleport leather_town.tmx,22,4,0.3"/>
     <property name="act2" value="player_face down"/>
     <property name="cond1" value="is player_at"/>
     <property name="cond2" value="is player_facing down"/>
-   </properties>
-  </object>
-  <object id="68" name="PC" type="event" x="0" y="96" width="32" height="16">
-   <properties>
-    <property name="act1" value="translated_dialog spyder_leathershaft2_pc"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
-   </properties>
-  </object>
-  <object id="69" name="Papers" type="event" x="32" y="96" width="32" height="16">
-   <properties>
-    <property name="act1" value="translated_dialog spyder_leathershaft2_papers"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
-   </properties>
-  </object>
-  <object id="70" name="Dude" type="event" x="112" y="64" width="16" height="16">
-   <properties>
-    <property name="act1" value="translated_dialog spyder_leathershaft2_dude"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
-   </properties>
-  </object>
-  <object id="71" name="Achievement" type="event" x="64" y="32" width="16" height="16">
-   <properties>
-    <property name="act1" value="translated_dialog spyder_leathershaft2_achievement"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
-   </properties>
-  </object>
-  <object id="72" name="Create NPCs" type="event" x="16" y="16" width="16" height="16">
-   <properties>
-    <property name="act1" value="create_npc spyder_maniac,7,7"/>
-    <property name="act2" value="npc_face spyder_maniac,up"/>
-    <property name="cond1" value="not npc_exists spyder_maniac"/>
-   </properties>
-  </object>
-  <object id="73" name="Skeptic" type="event" x="112" y="112" width="16" height="16">
-   <properties>
-    <property name="act1" value="translated_dialog spyder_leathershaft2_skeptic"/>
-    <property name="behav1" value="talk spyder_maniac"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/leather_town.tmx
+++ b/mods/tuxemon/maps/leather_town.tmx
@@ -281,14 +281,14 @@
   </object>
   <object id="98" name="Sign: Shaft 1" type="event" x="288" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_shaft1_sign"/>
+    <property name="act1" value="translated_dialog xero_shaft1_sign"/>
     <property name="cond1" value="is player_facing_tile"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="99" name="Sign: Shaft 2" type="event" x="400" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_shaft2_sign"/>
+    <property name="act1" value="translated_dialog xero_shaft2_sign"/>
     <property name="cond1" value="is player_facing_tile"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>

--- a/mods/tuxemon/maps/player_house_bedroom.yaml
+++ b/mods/tuxemon/maps/player_house_bedroom.yaml
@@ -38,7 +38,7 @@ events:
     actions:
     - screen_transition 1
     - wait 0.5
-    - translated_dialog spyder_papertown_restinbed
+    - translated_dialog xero_taba_restinbed
     - set_monster_health
     - set_monster_status
     - set_variable teleport_faint:player_house_bedroom.tmx 3 4
@@ -65,7 +65,7 @@ events:
   Intro:
     actions:
     - change_bg spyder_roc
-    - translated_dialog spyder_intro_question
+    - translated_dialog xero_skip_question
     - translated_dialog_choice no:yes,question_xero
     conditions:
     - not variable_set question_xero:yes

--- a/mods/tuxemon/maps/player_house_downstairs.tmx
+++ b/mods/tuxemon/maps/player_house_downstairs.tmx
@@ -55,7 +55,7 @@
   </object>
   <object id="24" name="Watch TV" type="event" x="16" y="80" width="16" height="16">
    <properties>
-    <property name="act10" value="translated_dialog spyder_papertown_tvwatch"/>
+    <property name="act10" value="translated_dialog xero_taba_tvwatch"/>
     <property name="cond10" value="is party_size greater_than,0"/>
     <property name="cond20" value="is player_at"/>
     <property name="cond30" value="is player_facing up"/>
@@ -63,9 +63,9 @@
     <property name="cond50" value="not variable_set scene:yes"/>
    </properties>
   </object>
-  <object id="25" name="Read Sign" type="event" x="16" y="32" width="16" height="16">
+  <object id="25" name="Read Sign" type="event" x="16" y="16" width="16" height="16">
    <properties>
-    <property name="act10" value="translated_dialog spyder_papertown_home"/>
+    <property name="act10" value="translated_dialog xero_taba_poster"/>
     <property name="cond1" value="is player_facing_tile"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
@@ -163,12 +163,11 @@
     <property name="cond2" value="not variable_set backhome:no"/>
    </properties>
   </object>
-  <object id="37" name="water" type="event" x="96" y="32" width="16" height="16">
+  <object id="37" name="water" type="event" x="96" y="16" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog waterwater"/>
-    <property name="cond1" value="is player_at"/>
+    <property name="cond1" value="is player_facing_tile"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
-    <property name="cond3" value="is player_facing up"/>
    </properties>
   </object>
   <object id="38" name="create mom3" type="event" x="0" y="64" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_radiotower.tmx
+++ b/mods/tuxemon/maps/spyder_radiotower.tmx
@@ -156,8 +156,8 @@
   </object>
   <object id="30" name="Create The Duke of Dead Air" type="event" x="128" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc spyder_omnichannel_dukeofdeadair,8,2"/>
-    <property name="cond1" value="not npc_exists spyder_omnichannel_dukeofdeadair"/>
+    <property name="act1" value="create_npc spyder_omnichannel_thedukeofdeadair,8,2"/>
+    <property name="cond1" value="not npc_exists spyder_omnichannel_thedukeofdeadair"/>
    </properties>
   </object>
   <object id="31" name="Stop!" type="event" x="16" y="80" width="208" height="16">


### PR DESCRIPTION
split from #1878

PR:
- changes **spyder_omnichannel_dukeofdeadair** into **spyder_omnichannel_thedukeofdeadair**, that's because **spyder_omnichannel_thedukeofdeadair** is the right msgid inside the PO;
- changes **spyder_stop_dante** into **spyder_dante**, same as above;
- creates a bunch of signs related only to xero, so we can split and not create confusion;
- when I created shaft 1 and shaft2, I forgot to remove the spyder content in the xero scenario, it'll be modder choice to define the locations as he wishes;
- creates two new NPCs to replace the spyder ones used in Xero;
- it fixes a wrong transition teleport;
- a couple of small fixes about event position;
