### PR TITLE
chore: use python in windows instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Run:
 ```shell
 git clone https://github.com/Tuxemon/Tuxemon.git
 cd Tuxemon
-python3 -m pip install -U -r requirements.txt
-python3 run_tuxemon.py
+py -3 -m pip install -U -r requirements.txt
+py -3 run_tuxemon.py
 ```
 
 ### Windows Binary


### PR DESCRIPTION
By default, Windows does not have a `python3` alias.

Some users may have set this up manually, or certain methods of installations may include such an alias, but the official Python installation certainly doesn't.

On Windows, it'd be better to refer to the `python` command rather than `python3`.