### PR TITLE
fix po (remove bracket)

### DIFF
--- a/mods/tuxemon/l18n/de_DE/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/de_DE/LC_MESSAGES/base.po
@@ -2799,8 +2799,7 @@ msgstr ""
 msgid "booster_tech"
 msgstr "Technologie Booster"
 
-# Boosters (items)
-
+# Boosters
 msgid "greenwash_badge"
 msgstr "Abzeichen: Greenwash"
 

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -502,7 +502,7 @@ msgstr "Aardant"
 msgid "aardant_description"
 msgstr ""
 
-# Boosters (items)
+# Boosters
 msgid "greenwash_badge"
 msgstr "Badge: Greenwash"
 

--- a/mods/tuxemon/l18n/fr_FR/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/fr_FR/LC_MESSAGES/base.po
@@ -6071,7 +6071,7 @@ msgstr ""
 msgid "frondly"
 msgstr "Frondly"
 
-# Boosters (items)
+# Boosters
 msgid "greenwash_badge"
 msgstr "Badge : Greenwash"
 

--- a/mods/tuxemon/l18n/it_IT/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/it_IT/LC_MESSAGES/base.po
@@ -3167,7 +3167,7 @@ msgstr "Forse siamo andati troppo oltre …"
 msgid "spyder_greenwash_dippel2"
 msgstr "Oppure non abbastanza! "
 
-# Boosters (items)
+# Boosters
 msgid "greenwash_badge"
 msgstr "Medaglia: Greenwash"
 

--- a/mods/tuxemon/l18n/pl/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/pl/LC_MESSAGES/base.po
@@ -2337,7 +2337,7 @@ msgstr "Przypomina czaszkę starożytnego psa, ale jest twarda jak kamień."
 msgid "rhincus_fossil_description"
 msgstr "Przypomina czaszkę ząbkowanego ptaka, ale jest twarda jak kamień."
 
-# Boosters (items)
+# Boosters
 #, fuzzy
 msgid "greenwash_badge"
 msgstr "Odznaka: Greenwash"

--- a/mods/tuxemon/l18n/pt_BR/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/pt_BR/LC_MESSAGES/base.po
@@ -3162,7 +3162,7 @@ msgstr "Crachá: Omnichannel"
 msgid "nimrod_badge"
 msgstr "Crachá: Nimrod"
 
-# Boosters (items)
+# Boosters
 msgid "greenwash_badge"
 msgstr "Crachá: Greenwash"
 

--- a/mods/tuxemon/l18n/zh_CN/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/zh_CN/LC_MESSAGES/base.po
@@ -814,7 +814,7 @@ msgstr "沙默化石"
 msgid "rhincus_fossil"
 msgstr "沙默化石"
 
-# Boosters (items)
+# Boosters
 msgid "greenwash_badge"
 msgstr "徽章：漂绿"
 


### PR DESCRIPTION
PR removes a bracket from all PO files.

from `# Boosters (items)` to `# Boosters`

I was looking the cause of the issues with Weblate.
The last merged commit contained `# Boosters (items)` in the German version.
It's the exact line with the `error: Syntax error on line 2803: '# Boosters (items)\nmsgid "greenwash_badge"\r\n'`
If it's not this, then I have no idea.