### PR TITLE
back door daycare (Spyder)

### DIFF
--- a/mods/tuxemon/maps/spyder.world
+++ b/mods/tuxemon/maps/spyder.world
@@ -496,6 +496,20 @@
             "width": 320,
             "x": -960,
             "y": 1920
+        },
+        {
+            "fileName": "spyder_flower_house2.tmx",
+            "height": 128,
+            "width": 160,
+            "x": 1280,
+            "y": 512
+        },
+        {
+            "fileName": "spyder_flower_house1.tmx",
+            "height": 128,
+            "width": 160,
+            "x": 1440,
+            "y": 512
         }
     ],
     "onlyShowAdjacentMaps": false,

--- a/mods/tuxemon/maps/spyder_bedroom.tmx
+++ b/mods/tuxemon/maps/spyder_bedroom.tmx
@@ -82,15 +82,15 @@
     <property name="cond1" value="is variable_set teleport_clinic:lost"/>
    </properties>
   </object>
-  <object id="30" name="intro question" type="event" x="60" y="0" width="16" height="16">
+  <object id="30" name="intro question" type="event" x="64" y="0" width="16" height="16">
    <properties>
     <property name="act01" value="translated_dialog spyder_intro_question"/>
     <property name="act02" value="translated_dialog_choice no:yes,question_intro"/>
     <property name="cond1" value="not variable_set question_intro:yes"/>
     <property name="cond2" value="not variable_set question_intro:no"/>
    </properties>
-  </object>  
-  <object id="31" name="Spyder Intro" type="event" x="76" y="0" width="16" height="16">
+  </object>
+  <object id="31" name="Spyder Intro" type="event" x="80" y="0" width="16" height="16">
    <properties>
     <property name="act05" value="change_bg spyder_intro01"/>
     <property name="act06" value="translated_dialog spyder_intro00"/>
@@ -116,7 +116,7 @@
     <property name="cond2" value="not variable_set spyder_intro:yes"/>
    </properties>
   </object>
-  <object id="32" name="No Intro" type="event" x="92" y="0" width="16" height="16">
+  <object id="32" name="No Intro" type="event" x="96" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable spyder_intro:yes"/>
     <property name="act2" value="transition_teleport spyder_paper_mart.tmx,4,8,0.3"/>

--- a/mods/tuxemon/maps/spyder_daycare.tmx
+++ b/mods/tuxemon/maps/spyder_daycare.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="12" height="9" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="23">
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="14" height="9" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="24">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -16,24 +16,24 @@
  <tileset firstgid="7729" name="core_set pieces" tilewidth="16" tileheight="16" tilecount="1550" columns="31">
   <image source="../gfx/tilesets/core_set pieces.png" width="496" height="800"/>
  </tileset>
- <layer id="1" name="Layer 1" width="12" height="9">
+ <layer id="1" name="Layer 1" width="14" height="9">
   <data encoding="base64" compression="zlib">
-   eAG7JcTAcIsEzCHMwEAKNgOqJwVPYmBgGMW4wwAAITE40Q==
+   eAG7JcTAcIsMzCHMwEAONgPqIwdPYmBgGMXUCwMAEChCSQ==
   </data>
  </layer>
- <layer id="2" name="Layer 2" width="12" height="9">
+ <layer id="2" name="Layer 2" width="14" height="9">
   <data encoding="base64" compression="zlib">
-   eAFjYBhcgIuFgYGbSMwDVGcBxJZEYqtBqD4N6KZ0InEGUB0Aw0ERKQ==
+   eAFjYBgagIuFgYGbSMwDVAcDFkC2JZHYagD0TQfaOQOISXXnUaCeY0CcBsTpROIMoLrPQPwFiAFKRhXi
   </data>
  </layer>
- <layer id="3" name="Layer 3" width="12" height="9">
+ <layer id="3" name="Layer 3" width="14" height="9">
   <data encoding="base64" compression="zlib">
-   eAGNj0EKwjAUBV/BK0i30VtqD6L1ItWlaNN9Be/RgsWdTuAvosTGgeEt/lAaKU/vpBvGnFfSBVMMThox5krrv/o7TTDFi7ZYf14eTgr+w4Zua1bsHBP3PdbmgX3iL5b8W8P9aJ7YMnrbbsH3zJrN0dJ4s8v0b7KzHdQ=
+   eAGVj0EKwjAQRX/BK0i30VuqB9F6kepS1LpX8B4KFnf6BmYWRrDxweOT4U9IpG/OSbpgkJ9jbrmbSHs0bkm6Y5CfY255YKfzvZhfk2T+4sVONf1sPJJk/sOM/txdkCX09FbYuGvyiUOMeXNLb+NuyTr7u92xHHG/25ClHOl27qlw7w1n+yHc
   </data>
  </layer>
- <layer id="4" name="Above Player" width="12" height="9" opacity="0.97">
+ <layer id="4" name="Above Player" width="14" height="9" opacity="0.97">
   <data encoding="base64" compression="zlib">
-   eAFjYBh+4LoCwk9CihD2TSQxhCwqS1mJgaEQqh5Vhna8Piz2rcUiBnMBAH/wBHg=
+   eAFjYBh54LoCws9CihD2TSQxhCx2lrISA0MhVB92FfQT7cPijrVYxNBdBAD8eAR4
   </data>
  </layer>
  <objectgroup color="#ff0000" id="5" name="Collisions">
@@ -43,7 +43,7 @@
   <object id="4" type="collision" x="16" y="144">
    <polygon points="0,0 0,-16 -16,-16 -16,0 0,0"/>
   </object>
-  <object id="8" type="collision" x="0" y="0" width="192" height="48"/>
+  <object id="8" type="collision" x="0" y="0" width="224" height="48"/>
   <object id="12" type="collision" x="160" y="80" width="16" height="16"/>
   <object id="13" type="collision" x="80" y="80" width="16" height="16"/>
   <object id="16" type="collision" x="112" y="48" width="32" height="16"/>
@@ -85,6 +85,14 @@
     <property name="act2" value="set_variable spokengrannypiper:yes"/>
     <property name="behav1" value="talk spyder_grannypiper"/>
     <property name="cond2" value="is variable_set spokengrannypiper:yes"/>
+   </properties>
+  </object>
+  <object id="23" name="Teleport to Back" type="event" x="208" y="112" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport spyder_paper_town.tmx,22,3,0.3"/>
+    <property name="act2" value="player_face right"/>
+    <property name="cond1" value="is player_at"/>
+    <property name="cond2" value="is player_facing right"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_downstairs.tmx
+++ b/mods/tuxemon/maps/spyder_downstairs.tmx
@@ -137,13 +137,6 @@
     <property name="cond2" value="is player_facing down"/>
    </properties>
   </object>
-  <object id="57" name="Get Mon" type="event" x="16" y="0" width="16" height="16">
-   <properties>
-    <property name="act1" value="add_monster budaye,100"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
-   </properties>
-  </object>
   <object id="58" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="play_music music_home"/>

--- a/mods/tuxemon/maps/spyder_paper_town.tmx
+++ b/mods/tuxemon/maps/spyder_paper_town.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="472">
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="273">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="north" value="route1"/>
@@ -24,7 +24,7 @@
  </layer>
  <layer id="2" name="Tile Layer 2" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAG9VjtOQzEQ3CofQUEDlFBwCkTN5xZQ0yPgFEjUiFNwAuA9OATQ0SSHYFZhpMfKYzvgsNJo4l17Z7IxFt3UrAe6wCbiAvtKsTky28pgG7Wop9Yz6M2ByCkPe+s/s7dhzeo+9HNxgHrUU2vlO9e/VKvxp3RjXvkuecjVa/wp3ZiPfrnO6ZdqNf6oU+Lol+ubtZILXff7f5rB2R/un1ZtUynNK9Y5L3IbF7oLdWqZfnXH5SuXeK8eK3CNPdRXzO+xvIvFifNwTx+wvnPdxNv4hNwzQL7HPuorpu+o81u/PDdL+GON7P6or5i+eaYVp+Y37N3Df838NvC37vjv+c2//am5Mf82NnO8A62D90z1rZkfz35MFj5b+K39LWruH/1Fdr+p8LfjaoDUHpWLb47v4/1XrHqpvL8dDP9/i/dkVUytWv4c+PMz6nu3yr/smI12zcZAKSbYMwWGsaq5se8r/B1C8wjwzx3QA+7b2dee9/Ux9pwAw2g1J9XnCwB0Qaw=
+   eAHNVjtOA0EMdZWPoKABSig4BaLmcwqgpkfAAaiRqCNOwQmAXTgE0NEkh+BZYGWw5nkm7AZh6cnrz/q9OJNRmrFICzTOC7Fz9JVsfSCyEWATNc/H4in4ZoD3OQ07qz+zty626i74I9tD3fOxmOmO5pdqNfoYr88z3SUNUV31XQc7/A/7i3ao+vyeWMz2d7MSbSiu6fk/Bk4ITpFnvD7vdcfM3auerxR7vd0VxBM8Xyk2/fHUxaoXuK8eKnCFHuNn3vQvpmDefebO6T3iifJm7sZH5J4A83foM37mTbfnmSv43dM0o89PUn3Gz7zp9u92jXP7S2e20F+zvzX81hV/vb/Ztz62N8u/DkUUb0DfZueMza3Zn737PvrS2Yfe2u+i5vyZPu9Vb8707rhMkOthOX/naJ+df+bZLJbXu8NM/2/ZOVmWN65a/5Ho03fY5+4r/7wlMtgWGQIlG6FnDKS2rL3Z3Bfo2wfnAaDPDdACqlu9xprX+BA9R0Bqfe2JzfkEAThCdw==
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="40" height="20">
@@ -46,113 +46,113 @@
   <properties>
    <property name="Collision" value=""/>
   </properties>
-  <object id="333" type="collision" x="192" y="240" width="336" height="80"/>
-  <object id="364" type="collision" x="512" y="0" width="128" height="320"/>
-  <object id="365" type="collision" x="432" y="80" width="80" height="16"/>
-  <object id="366" type="collision" x="336" y="0" width="16" height="80"/>
-  <object id="367" type="collision" x="448" y="96" width="64" height="32"/>
-  <object id="368" type="collision" x="336" y="128" width="176" height="16"/>
-  <object id="369" type="collision" x="432" y="144" width="64" height="16"/>
-  <object id="370" type="collision" x="480" y="176" width="16" height="32"/>
-  <object id="371" type="collision" x="352" y="144" width="16" height="64"/>
-  <object id="373" type="collision" x="368" y="208" width="32" height="16"/>
-  <object id="374" type="collision" x="272" y="160" width="80" height="32"/>
-  <object id="375" type="collision" x="320" y="192" width="32" height="16"/>
-  <object id="378" type="collision" x="256" y="192" width="48" height="16"/>
-  <object id="379" type="collision" x="240" y="0" width="16" height="16"/>
-  <object id="380" type="collision" x="256" y="16" width="16" height="16"/>
-  <object id="381" type="collision" x="272" y="32" width="64" height="32"/>
-  <object id="382" type="collision" x="256" y="64" width="64" height="16"/>
-  <object id="383" type="collision" x="192" y="16" width="16" height="16"/>
-  <object id="386" type="collision" x="112" y="64" width="80" height="32"/>
-  <object id="387" type="collision" x="176" y="96" width="32" height="16"/>
-  <object id="388" type="collision" x="112" y="96" width="48" height="16"/>
-  <object id="389" type="collision" x="0" y="0" width="208" height="16"/>
-  <object id="391" type="collision" x="0" y="16" width="96" height="80"/>
-  <object id="392" type="collision" x="96" y="32" width="96" height="32"/>
-  <object id="393" type="collision" x="0" y="96" width="64" height="32"/>
-  <object id="394" type="collision" x="0" y="128" width="32" height="64"/>
-  <object id="395" type="collision" x="96" y="160" width="96" height="32"/>
-  <object id="397" type="collision" x="64" y="240" width="16" height="16"/>
-  <object id="399" type="collision" x="0" y="304" width="192" height="16"/>
-  <object id="401" type="collision" x="176" y="288" width="16" height="16"/>
-  <object id="402" type="collision" x="176" y="192" width="32" height="16"/>
-  <object id="425" type="collision" x="0" y="192" width="32" height="32"/>
-  <object id="427" type="collision" x="0" y="288" width="48" height="16"/>
-  <object id="431" type="collision" x="336" y="144" width="16" height="16"/>
-  <object id="447" type="collision" x="352" y="64" width="112" height="16"/>
-  <object id="448" type="collision" x="352" y="0" width="112" height="16"/>
-  <object id="449" type="collision" x="464" y="0" width="16" height="80"/>
-  <object id="453" type="collision" x="96" y="192" width="64" height="16"/>
-  <object id="456" type="collision" x="96" y="256" width="64" height="16">
+  <object id="133" type="collision" x="192" y="240" width="336" height="80"/>
+  <object id="164" type="collision" x="512" y="0" width="128" height="320"/>
+  <object id="165" type="collision" x="432" y="80" width="80" height="16"/>
+  <object id="166" type="collision" x="336" y="0" width="16" height="80"/>
+  <object id="167" type="collision" x="448" y="96" width="64" height="32"/>
+  <object id="168" type="collision" x="336" y="128" width="176" height="16"/>
+  <object id="169" type="collision" x="432" y="144" width="64" height="16"/>
+  <object id="170" type="collision" x="480" y="176" width="16" height="32"/>
+  <object id="171" type="collision" x="352" y="144" width="16" height="64"/>
+  <object id="173" type="collision" x="368" y="208" width="32" height="16"/>
+  <object id="174" type="collision" x="272" y="160" width="80" height="32"/>
+  <object id="175" type="collision" x="320" y="192" width="32" height="16"/>
+  <object id="178" type="collision" x="256" y="192" width="48" height="16"/>
+  <object id="179" type="collision" x="240" y="0" width="16" height="16"/>
+  <object id="180" type="collision" x="256" y="16" width="16" height="16"/>
+  <object id="181" type="collision" x="272" y="32" width="64" height="32"/>
+  <object id="182" type="collision" x="256" y="64" width="64" height="16"/>
+  <object id="183" type="collision" x="192" y="16" width="16" height="16"/>
+  <object id="186" type="collision" x="112" y="64" width="80" height="32"/>
+  <object id="187" type="collision" x="176" y="96" width="32" height="16"/>
+  <object id="188" type="collision" x="112" y="96" width="48" height="16"/>
+  <object id="189" type="collision" x="0" y="0" width="208" height="16"/>
+  <object id="191" type="collision" x="0" y="16" width="96" height="80"/>
+  <object id="192" type="collision" x="96" y="32" width="96" height="32"/>
+  <object id="193" type="collision" x="0" y="96" width="64" height="32"/>
+  <object id="194" type="collision" x="0" y="128" width="32" height="64"/>
+  <object id="195" type="collision" x="96" y="160" width="96" height="32"/>
+  <object id="197" type="collision" x="64" y="240" width="16" height="16"/>
+  <object id="199" type="collision" x="0" y="304" width="192" height="16"/>
+  <object id="201" type="collision" x="176" y="288" width="16" height="16"/>
+  <object id="202" type="collision" x="176" y="192" width="32" height="16"/>
+  <object id="225" type="collision" x="0" y="192" width="32" height="32"/>
+  <object id="227" type="collision" x="0" y="288" width="48" height="16"/>
+  <object id="231" type="collision" x="336" y="144" width="16" height="16"/>
+  <object id="247" type="collision" x="352" y="64" width="112" height="16"/>
+  <object id="248" type="collision" x="352" y="0" width="112" height="16"/>
+  <object id="249" type="collision" x="464" y="0" width="16" height="80"/>
+  <object id="253" type="collision" x="96" y="192" width="64" height="16"/>
+  <object id="256" type="collision" x="96" y="256" width="64" height="16">
    <properties>
     <property name="key" value="water"/>
    </properties>
   </object>
-  <object id="458" type="collision" x="80" y="240" width="16" height="16">
+  <object id="258" type="collision" x="80" y="240" width="16" height="16">
    <properties>
     <property name="key" value="water"/>
    </properties>
   </object>
-  <object id="459" type="collision" x="144" y="272" width="16" height="16">
+  <object id="259" type="collision" x="144" y="272" width="16" height="16">
    <properties>
     <property name="key" value="water"/>
    </properties>
   </object>
-  <object id="460" type="collision" x="160" y="288" width="16" height="16">
+  <object id="260" type="collision" x="160" y="288" width="16" height="16">
    <properties>
     <property name="key" value="water"/>
    </properties>
   </object>
-  <object id="462" type="collision" x="16" y="224" width="16" height="16">
+  <object id="262" type="collision" x="16" y="224" width="16" height="16">
    <properties>
     <property name="key" value="water"/>
    </properties>
   </object>
-  <object id="463" type="collision" x="32" y="240" width="32" height="16">
+  <object id="263" type="collision" x="32" y="240" width="32" height="16">
    <properties>
     <property name="key" value="water"/>
    </properties>
   </object>
-  <object id="470" type="collision" x="64" y="256" width="16" height="16"/>
+  <object id="270" type="collision" x="64" y="256" width="16" height="16"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="7" name="Events">
-  <object id="335" name="Mart Sign" type="event" x="256" y="192" width="16" height="16">
+  <object id="135" name="Mart Sign" type="event" x="256" y="192" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_multi_martsign"/>
     <property name="cond1" value="is player_facing_tile"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
-  <object id="336" name="Teleport to Protagonist House" type="event" x="160" y="96" width="16" height="16">
+  <object id="136" name="Teleport to Protagonist House" type="event" x="160" y="96" width="16" height="16">
    <properties>
     <property name="act1" value="transition_teleport spyder_downstairs.tmx,4,6,0.3"/>
     <property name="act2" value="player_face up"/>
     <property name="cond1" value="is player_at"/>
    </properties>
   </object>
-  <object id="337" name="Sign for Protagonist House" type="event" x="192" y="96" width="16" height="16">
+  <object id="137" name="Sign for Protagonist House" type="event" x="192" y="96" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_papertown_home"/>
     <property name="cond1" value="is player_facing_tile"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
-  <object id="338" name="Under Repairs" type="event" x="64" y="240" width="16" height="16">
+  <object id="138" name="Under Repairs" type="event" x="64" y="240" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_multi_underrepairs"/>
     <property name="cond1" value="is player_facing_tile"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
-  <object id="339" name="Paper Town Sign" type="event" x="192" y="16" width="16" height="16">
+  <object id="139" name="Paper Town Sign" type="event" x="192" y="16" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog welcome_location_town"/>
     <property name="cond1" value="is player_facing_tile"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
-  <object id="341" name="Sign for Daycare, Before Opening" type="event" x="256" y="64" width="16" height="16">
+  <object id="141" name="Sign for Daycare, Before Opening" type="event" x="256" y="64" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_papertown_daycare1"/>
     <property name="cond1" value="not variable_set timberreached:yes"/>
@@ -160,7 +160,7 @@
     <property name="cond3" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
-  <object id="342" name="Teleport to Route 1" type="event" x="224" y="0" width="16" height="16">
+  <object id="142" name="Teleport to Route 1" type="event" x="224" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="transition_teleport spyder_route1.tmx,14,19,0.3"/>
     <property name="act2" value="player_face up"/>
@@ -169,7 +169,7 @@
     <property name="cond3" value="is variable_set firstfightdue:no"/>
    </properties>
   </object>
-  <object id="343" name="Teleport to Route 1" type="event" x="208" y="0" width="16" height="16">
+  <object id="143" name="Teleport to Route 1" type="event" x="208" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="transition_teleport spyder_route1.tmx,13,19,0.3"/>
     <property name="act2" value="player_face up"/>
@@ -178,21 +178,21 @@
     <property name="cond3" value="is variable_set firstfightdue:no"/>
    </properties>
   </object>
-  <object id="345" name="Teleport to Daycare" type="event" x="320" y="64" width="16" height="16">
+  <object id="145" name="Teleport to Daycare" type="event" x="320" y="64" width="16" height="16">
    <properties>
     <property name="act1" value="transition_teleport spyder_daycare.tmx,3,8,0.3"/>
     <property name="act2" value="player_face up"/>
     <property name="cond1" value="is player_at"/>
    </properties>
   </object>
-  <object id="352" name="Teleport to Mart" type="event" x="304" y="192" width="16" height="16">
+  <object id="152" name="Teleport to Mart" type="event" x="304" y="192" width="16" height="16">
    <properties>
     <property name="act1" value="transition_teleport spyder_paper_scoop.tmx,6,10,0.3"/>
     <property name="act2" value="player_face up"/>
     <property name="cond1" value="is player_at"/>
    </properties>
   </object>
-  <object id="355" name="Stop!" type="event" x="208" y="16" width="32" height="16">
+  <object id="155" name="Stop!" type="event" x="208" y="16" width="32" height="16">
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act10" value="player_stop"/>
@@ -209,7 +209,7 @@
     <property name="cond2" value="is party_size less_than,1"/>
    </properties>
   </object>
-  <object id="357" name="Sign for Daycare, After Opening" type="event" x="256" y="64" width="16" height="16">
+  <object id="157" name="Sign for Daycare, After Opening" type="event" x="256" y="64" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_papertown_daycare2"/>
     <property name="cond1" value="is variable_set timberreached:yes"/>
@@ -217,7 +217,7 @@
     <property name="cond3" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
-  <object id="358" name="Create Conileaf" type="event" x="384" y="32" width="16" height="16">
+  <object id="158" name="Create Conileaf" type="event" x="384" y="32" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_rockittenfrolicking,24,2"/>
     <property name="act2" value="npc_wander spyder_rockittenfrolicking"/>
@@ -225,7 +225,7 @@
     <property name="cond2" value="is variable_set captainreturns:yes"/>
    </properties>
   </object>
-  <object id="360" name="Create Rockitten" type="event" x="400" y="32" width="16" height="16">
+  <object id="160" name="Create Rockitten" type="event" x="400" y="32" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_conileaffrolicking,27,3"/>
     <property name="act2" value="npc_wander spyder_conileaffrolicking"/>
@@ -233,24 +233,24 @@
     <property name="cond2" value="is variable_set captainreturns:yes"/>
    </properties>
   </object>
-  <object id="362" name="Create Homemaker" type="event" x="160" y="224" width="16" height="16">
+  <object id="162" name="Create Homemaker" type="event" x="160" y="224" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_florist,10,14"/>
     <property name="cond2" value="not npc_exists spyder_florist"/>
    </properties>
   </object>
-  <object id="363" name="Talk homemaker" type="event" x="400" y="112" width="16" height="16">
+  <object id="163" name="Talk homemaker" type="event" x="400" y="112" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_papertown_homemaker1"/>
     <property name="behav1" value="talk spyder_florist"/>
    </properties>
   </object>
-  <object id="416" name="Homemaker Wander" type="event" x="304" y="96" width="16" height="16">
+  <object id="216" name="Homemaker Wander" type="event" x="304" y="96" width="16" height="16">
    <properties>
     <property name="act1" value="npc_move spyder_homemakerpapertown, down 1, right 1, up 1, left 1"/>
    </properties>
   </object>
-  <object id="417" name="Teleport to Sea Route" type="event" x="0" y="224" width="16" height="64">
+  <object id="217" name="Teleport to Sea Route" type="event" x="0" y="224" width="16" height="64">
    <properties>
     <property name="act1" value="transition_teleport spyder_routec.tmx,39,35,0.3"/>
     <property name="act2" value="player_face left"/>
@@ -258,7 +258,7 @@
     <property name="cond2" value="is player_facing left"/>
    </properties>
   </object>
-  <object id="418" name="My First Mon" type="event" x="368" y="176" width="144" height="16">
+  <object id="218" name="My First Mon" type="event" x="368" y="176" width="144" height="16">
    <properties>
     <property name="act10" value="player_stop"/>
     <property name="act11" value="lock_controls"/>
@@ -280,7 +280,7 @@
     <property name="cond2" value="is party_size less_than,1"/>
    </properties>
   </object>
-  <object id="419" name="Chosen - Rockitten" type="event" x="512" y="128" width="16" height="16">
+  <object id="219" name="Chosen - Rockitten" type="event" x="512" y="128" width="16" height="16">
    <properties>
     <property name="act1" value="add_monster rockitten,5"/>
     <property name="act2" value="translated_dialog spyder_papertown_rockittenchosen"/>
@@ -289,7 +289,7 @@
     <property name="cond2" value="is party_size less_than,1"/>
    </properties>
   </object>
-  <object id="420" name="Chosen - Lambert" type="event" x="512" y="160" width="16" height="16">
+  <object id="220" name="Chosen - Lambert" type="event" x="512" y="160" width="16" height="16">
    <properties>
     <property name="act1" value="add_monster lambert,5"/>
     <property name="act2" value="translated_dialog spyder_papertown_lambertchosen"/>
@@ -298,7 +298,7 @@
     <property name="cond2" value="is party_size less_than,1"/>
    </properties>
   </object>
-  <object id="421" name="Chosen - Nut" type="event" x="512" y="192" width="16" height="16">
+  <object id="221" name="Chosen - Nut" type="event" x="512" y="192" width="16" height="16">
    <properties>
     <property name="act1" value="add_monster nut,5"/>
     <property name="act2" value="translated_dialog spyder_papertown_nutchosen"/>
@@ -307,7 +307,7 @@
     <property name="cond2" value="is party_size less_than,1"/>
    </properties>
   </object>
-  <object id="422" name="Chosen - Tweesher" type="event" x="512" y="224" width="16" height="16">
+  <object id="222" name="Chosen - Tweesher" type="event" x="512" y="224" width="16" height="16">
    <properties>
     <property name="act1" value="add_monster tweesher,5"/>
     <property name="act2" value="translated_dialog spyder_papertown_tweesherchosen"/>
@@ -316,7 +316,7 @@
     <property name="cond2" value="is party_size less_than,1"/>
    </properties>
   </object>
-  <object id="423" name="Chosen - Agnite" type="event" x="512" y="256" width="16" height="16">
+  <object id="223" name="Chosen - Agnite" type="event" x="512" y="256" width="16" height="16">
    <properties>
     <property name="act1" value="add_monster agnite,5"/>
     <property name="act2" value="translated_dialog spyder_papertown_agnitechosen"/>
@@ -325,7 +325,7 @@
     <property name="cond2" value="is party_size less_than,1"/>
    </properties>
   </object>
-  <object id="424" name="First Fight - Start" type="event" x="400" y="160" width="16" height="16">
+  <object id="224" name="First Fight - Start" type="event" x="400" y="160" width="16" height="16">
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act10" value="translated_dialog spyder_papertown_wrapup"/>
@@ -344,7 +344,7 @@
     <property name="cond1" value="is variable_set firstfightdue:yes"/>
    </properties>
   </object>
-  <object id="425" name="First Fight - Win" type="event" x="384" y="144" width="16" height="16">
+  <object id="225" name="First Fight - Win" type="event" x="384" y="144" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog spyder_papertown_firstfight_win"/>
     <property name="act11" value="pathfind spyder_billie,25,14"/>
@@ -361,7 +361,7 @@
     <property name="cond2" value="is variable_set firstfightend:yes"/>
    </properties>
   </object>
-  <object id="426" name="First Fight - Lose" type="event" x="416" y="144" width="16" height="16">
+  <object id="226" name="First Fight - Lose" type="event" x="416" y="144" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog spyder_papertown_firstfight_lose"/>
     <property name="act11" value="pathfind spyder_billie,25,14"/>
@@ -378,20 +378,20 @@
     <property name="cond2" value="is variable_set firstfightend:yes"/>
    </properties>
   </object>
-  <object id="428" name="Play Music" type="event" x="0" y="0" width="16" height="16">
+  <object id="228" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="play_music music_town_theme"/>
     <property name="cond1" value="not music_playing music_town_theme"/>
    </properties>
   </object>
-  <object id="430" name="Sign for Sunnyside Manor" type="event" x="192" y="192" width="16" height="16">
+  <object id="230" name="Sign for Sunnyside Manor" type="event" x="192" y="192" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_papertown_sunnyside"/>
     <property name="cond1" value="is player_facing_tile"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
-  <object id="432" name="Create Captain" type="event" x="64" y="224" width="16" height="16">
+  <object id="232" name="Create Captain" type="event" x="64" y="224" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_captain,4,14"/>
     <property name="act2" value="npc_face spyder_captain,up"/>
@@ -399,7 +399,7 @@
     <property name="cond2" value="is variable_set captainreturns:yes"/>
    </properties>
   </object>
-  <object id="433" name="Talk Captain - Flower" type="event" x="208" y="240" width="16" height="16">
+  <object id="233" name="Talk Captain - Flower" type="event" x="208" y="240" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_river_captain2"/>
     <property name="act2" value="translated_dialog_choice paper:leather:flower,rivergoto"/>
@@ -407,7 +407,7 @@
     <property name="cond1" value="not variable_set seentimber:yes"/>
    </properties>
   </object>
-  <object id="437" name="Talk Captain - Timber" type="event" x="240" y="240" width="16" height="16">
+  <object id="237" name="Talk Captain - Timber" type="event" x="240" y="240" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_river_captain2"/>
     <property name="act2" value="translated_dialog_choice paper:leather:flower:timber,rivergoto"/>
@@ -416,7 +416,7 @@
     <property name="cond2" value="is variable_set seentimber:yes"/>
    </properties>
   </object>
-  <object id="440" name="Talk Captain - Candy" type="event" x="224" y="240" width="16" height="16">
+  <object id="240" name="Talk Captain - Candy" type="event" x="224" y="240" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_river_captain2"/>
     <property name="act2" value="translated_dialog_choice paper:leather:flower:timber:candy,rivergoto"/>
@@ -424,7 +424,7 @@
     <property name="cond1" value="is variable_set seencandy:yes"/>
    </properties>
   </object>
-  <object id="441" name="Destination - Flower" type="event" x="208" y="256" width="16" height="16">
+  <object id="241" name="Destination - Flower" type="event" x="208" y="256" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable rivergoto:nothing"/>
     <property name="act4" value="player_face up"/>
@@ -432,7 +432,7 @@
     <property name="cond1" value="is variable_set rivergoto:flower"/>
    </properties>
   </object>
-  <object id="442" name="Destination - Leather" type="event" x="224" y="256" width="16" height="16">
+  <object id="242" name="Destination - Leather" type="event" x="224" y="256" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable rivergoto:nothing"/>
     <property name="act2" value="transition_teleport spyder_leather_town.tmx,17,19,0.3"/>
@@ -440,7 +440,7 @@
     <property name="cond1" value="is variable_set rivergoto:leather"/>
    </properties>
   </object>
-  <object id="443" name="Destination - Paper" type="event" x="192" y="256" width="16" height="16">
+  <object id="243" name="Destination - Paper" type="event" x="192" y="256" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable rivergoto:nothing"/>
     <property name="act2" value="transition_teleport spyder_paper_town.tmx,4,13,0.3"/>
@@ -448,7 +448,7 @@
     <property name="cond1" value="is variable_set rivergoto:paper"/>
    </properties>
   </object>
-  <object id="445" name="Destination - Candy" type="event" x="192" y="240" width="16" height="16">
+  <object id="245" name="Destination - Candy" type="event" x="192" y="240" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable rivergoto:nothing"/>
     <property name="act2" value="transition_teleport spyder_candy_town.tmx,26,29,0.3"/>
@@ -456,19 +456,19 @@
     <property name="cond1" value="is variable_set rivergoto:candy"/>
    </properties>
   </object>
-  <object id="446" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
+  <object id="246" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="is variable_set daytime:true"/>
    </properties>
   </object>
-  <object id="451" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
+  <object id="251" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
     <property name="cond1" value="is variable_set daytime:false"/>
    </properties>
   </object>
-  <object id="450" name="Destination - Timber" type="event" x="240" y="256" width="16" height="16">
+  <object id="250" name="Destination - Timber" type="event" x="240" y="256" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable rivergoto:nothing"/>
     <property name="act2" value="transition_teleport spyder_timber_town.tmx,8,21,0.3"/>
@@ -476,14 +476,14 @@
     <property name="cond1" value="is variable_set rivergoto:timber"/>
    </properties>
   </object>
-  <object id="452" name="Teleport to Manor" type="event" x="160" y="192" width="16" height="16">
+  <object id="252" name="Teleport to Manor" type="event" x="160" y="192" width="16" height="16">
    <properties>
     <property name="act1" value="transition_teleport spyder_paper_manor.tmx,6,7,0.3"/>
     <property name="act2" value="player_face up"/>
     <property name="cond1" value="is player_at"/>
    </properties>
   </object>
-  <object id="454" name="Stop 2!" type="event" x="16" y="240" width="16" height="48">
+  <object id="254" name="Stop 2!" type="event" x="16" y="240" width="16" height="48">
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act10" value="player_stop"/>
@@ -498,7 +498,7 @@
     <property name="cond2" value="is party_size less_than,1"/>
    </properties>
   </object>
-  <object id="465" name="Choice Surf" type="event" x="160" y="304" width="16" height="16">
+  <object id="265" name="Choice Surf" type="event" x="160" y="304" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog itsswimmingtime"/>
     <property name="act2" value="translated_dialog_choice yes:no,swimming"/>
@@ -508,14 +508,14 @@
     <property name="cond4" value="not player_in surfable"/>
    </properties>
   </object>
-  <object id="466" name="surfable" type="event" x="128" y="304" width="16" height="16">
+  <object id="266" name="surfable" type="event" x="128" y="304" width="16" height="16">
    <properties>
     <property name="act1" value="set_player_template swimmer"/>
     <property name="cond1" value="is player_in surfable"/>
     <property name="cond2" value="not has_sprite swimmer"/>
    </properties>
   </object>
-  <object id="467" name="not surfable" type="event" x="112" y="304" width="16" height="16">
+  <object id="267" name="not surfable" type="event" x="112" y="304" width="16" height="16">
    <properties>
     <property name="act1" value="set_player_template default"/>
     <property name="act2" value="set_variable swimming:no"/>
@@ -523,16 +523,24 @@
     <property name="cond2" value="is has_sprite swimmer"/>
    </properties>
   </object>
-  <object id="468" name="Remove Obstacle" type="event" x="144" y="304" width="16" height="16">
+  <object id="268" name="Remove Obstacle" type="event" x="144" y="304" width="16" height="16">
    <properties>
     <property name="act1" value="remove_collision water"/>
     <property name="cond1" value="is variable_set swimming:yes"/>
    </properties>
   </object>
-  <object id="471" name="Swim Encounters" type="event" x="176" y="288" width="16" height="16">
+  <object id="271" name="Swim Encounters" type="event" x="176" y="288" width="16" height="16">
    <properties>
     <property name="act1" value="random_encounter routec"/>
     <property name="cond1" value="is has_sprite swimmer"/>
+   </properties>
+  </object>
+  <object id="272" name="Teleport to Daycare Back" type="event" x="352" y="48" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport spyder_daycare.tmx,13,7,0.3"/>
+    <property name="act2" value="player_face left"/>
+    <property name="cond1" value="is player_at"/>
+    <property name="cond2" value="is player_facing left"/>
    </properties>
   </object>
  </objectgroup>


### PR DESCRIPTION
PR:
- resizes Daycare Map (+ 2 tiles horizontally);
- adds teleport outside (small fenced area);
- adds teleport daycare (from the small fenced area);
- adds to spyder.world two missing maps;
- fixes numbers in Paper Town map;
- removes an old event from downstairs (Spyder);
- fixes some events coordinates in bedroom (Spyder);

![spyder_daycare](https://github.com/Tuxemon/Tuxemon/assets/64643719/131c77ca-2998-49b2-b08f-475bbcc63397)
