### PR TITLE
update table types (formula.py)

### DIFF
--- a/tuxemon/locale.py
+++ b/tuxemon/locale.py
@@ -20,8 +20,9 @@ from typing import (
 from babel.messages.mofile import write_mo
 from babel.messages.pofile import read_po
 
-from tuxemon import formula, prepare
+from tuxemon import prepare
 from tuxemon.constants import paths
+from tuxemon.formula import convert_km, convert_mi
 from tuxemon.session import Session
 
 logger = logging.getLogger(__name__)
@@ -230,7 +231,7 @@ def replace_text(session: Session, text: str) -> str:
         text = text.replace("${{height}}", "cm")
         text = text.replace(
             "${{steps}}",
-            str(formula.convert_km(player.game_variables["steps"])),
+            str(convert_km(player.game_variables["steps"])),
         )
     else:
         text = text.replace("${{length}}", "mi")
@@ -238,7 +239,7 @@ def replace_text(session: Session, text: str) -> str:
         text = text.replace("${{height}}", "ft")
         text = text.replace(
             "${{steps}}",
-            str(formula.convert_mi(player.game_variables["steps"])),
+            str(convert_mi(player.game_variables["steps"])),
         )
     # maps
     text = text.replace("${{map_name}}", client.map_name)


### PR DESCRIPTION
PR:
- updates **table types** (formula.py);
- updates **two imports** in locale.py related to formula.py (I pushed my testing further than this PR and I got blocked by a damned circular import, and the cause was a generic formula import);
- **normal** has been removed because there are no signs of it inside the entire db (techniques types + monsters types);

from:
```
    strong_attack: Optional[str]
    weak_attack: Optional[str]
    extra_damage: Optional[str]
    resist_damage: Optional[str]
    "aether": TypeChart(None, None, None, None),
    "normal": TypeChart(None, None, None, None),
    "wood": TypeChart("earth", "fire", "metal", "water"),
    "fire": TypeChart("metal", "earth", "water", "wood"),
    "earth": TypeChart("water", "metal", "wood", "fire"),
    "metal": TypeChart("wood", "water", "fire", "earth"),
    "water": TypeChart("fire", "wood", "earth", "metal"),
```
to:
```
    earth: float
    fire: float
    metal: float
    water: float
    wood: float
    "earth": TypeChart(1, 1, 0.5, 2, 1),
    "fire": TypeChart(0.5, 1, 2, 1, 1),
    "metal": TypeChart(1, 1, 1, 0.5, 2),
    "water": TypeChart(1, 2, 1, 1, 0.5),
    "wood": TypeChart(2, 0.5, 1, 1, 1),
```
this is the table https://wiki.tuxemon.org/Category:Type#Associations, sorted alphabetically:
ultra simplified legend: 1 no change, 0.5 less, 2 more
```
te/ta	Earth	Fire	Metal	Water	Wood
Earth	1	1	0.5	2	1
Fire	0.5	1	2	1	1
Metal	1	1	1	0.5	2
Water	1	2	1	1	0.5
Wood	2	0.5	1	1	1
```
it doesn't change anything, because it respects the table: 
it would be great to move it inside a JSON file, or more generically inside the MODS folder.

tested, black, isort, no new typehints