### PR TITLE
set_player_name (event action)

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -5201,6 +5201,24 @@ msgstr "Professor"
 msgid "npc_red"
 msgstr "Red"
 
+msgid "m_default1"
+msgstr "Jimmy"
+
+msgid "m_default2"
+msgstr "Linus"
+
+msgid "m_default3"
+msgstr "Richard"
+
+msgid "f_default1"
+msgstr "Ada"
+
+msgid "f_default2"
+msgstr "Christine"
+
+msgid "f_default3"
+msgstr "Hawthorn"
+
 msgid "tabanurse"
 msgstr "Taba Nurse"
 

--- a/mods/tuxemon/maps/debug.tmx
+++ b/mods/tuxemon/maps/debug.tmx
@@ -71,12 +71,14 @@
   <object id="11" name="Gender Male" type="event" x="48" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_player_template adventurer,adventurer"/>
+    <property name="act2" value="set_player_name m_default1:m_default2:m_default3"/>
     <property name="cond1" value="is variable_set gender_choice:gender_male"/>
    </properties>
   </object>
   <object id="12" name="Gender Female" type="event" x="48" y="16" width="16" height="16">
    <properties>
     <property name="act1" value="set_player_template heroine,heroine"/>
+    <property name="act2" value="set_player_name f_default1:f_default2:f_default3"/>
     <property name="cond1" value="is variable_set gender_choice:gender_female"/>
    </properties>
   </object>

--- a/tuxemon/event/actions/set_player_name.py
+++ b/tuxemon/event/actions/set_player_name.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import final
+
+from tuxemon.event.eventaction import EventAction
+from tuxemon.locale import T
+
+
+@final
+@dataclass
+class SetPlayerNameAction(EventAction):
+    """
+    Set player name without opening the input screen.
+
+    Script usage:
+        .. code-block::
+
+            set_player_name name
+            set_player_name name:name
+
+    Script parameters:
+        choice: single name or multiple names
+        separated by ":" (random choice)
+        the names must be in the PO file
+
+    """
+
+    name = "set_player_name"
+    choice: str
+
+    def start(self) -> None:
+        name: str = ""
+        if self.choice.find(":"):
+            elements = self.choice.split(":")
+            name = random.choice(elements)
+        else:
+            name = self.choice
+        self.session.player.name = T.translate(name)


### PR DESCRIPTION
PR introduces a new event action, so the modder can set/change a name (or multiple where one is chosen randomly) without opening the input. Requested by @DavidLiang1129 because he realized that the name **Red** popped up in the input and no matter that the player can write a new one or picking up one randomly, that name was wrong. 

fix #1898

In this way the default names (eg male), it'll be chosen randomly among Jimmy, Linus or Richard
```
msgid "m_default1"
msgstr "Jimmy"
msgid "m_default2"
msgstr "Linus"
msgid "m_default3"
msgstr "Richard"
msgid "f_default1"
msgstr "Ada"
msgid "f_default2"
msgstr "Christine"
msgid "f_default3"
msgstr "Hawthorn"
```
Thanks @Sanglorian for the default suggestions