### PR TITLE
fix catch rate

### DIFF
--- a/mods/tuxemon/db/monster/aardart.json
+++ b/mods/tuxemon/db/monster/aardart.json
@@ -55,7 +55,7 @@
     "txmn_id": 43,
     "height": 185,
     "weight": 45,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/aardorn.json
+++ b/mods/tuxemon/db/monster/aardorn.json
@@ -49,7 +49,7 @@
     "txmn_id": 42,
     "height": 40,
     "weight": 18,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/abesnaki.json
+++ b/mods/tuxemon/db/monster/abesnaki.json
@@ -62,7 +62,7 @@
     "txmn_id": 99,
     "height": 104,
     "weight": 14,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/agnidon.json
+++ b/mods/tuxemon/db/monster/agnidon.json
@@ -57,7 +57,7 @@
     "txmn_id": 14,
     "height": 320,
     "weight": 230,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/agnigon.json
+++ b/mods/tuxemon/db/monster/agnigon.json
@@ -67,7 +67,7 @@
     "txmn_id": 15,
     "height": 600,
     "weight": 2000,
-    "catch_rate": 45.0,
+    "catch_rate": 35.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/agnite.json
+++ b/mods/tuxemon/db/monster/agnite.json
@@ -49,7 +49,7 @@
     "txmn_id": 13,
     "height": 80,
     "weight": 24,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/agnsher.json
+++ b/mods/tuxemon/db/monster/agnsher.json
@@ -63,7 +63,7 @@
     "txmn_id": 0,
     "height": 60,
     "weight": 5,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/allagon.json
+++ b/mods/tuxemon/db/monster/allagon.json
@@ -61,7 +61,7 @@
     "txmn_id": 160,
     "height": 162,
     "weight": 145,
-    "catch_rate": 3.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.8,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/altie.json
+++ b/mods/tuxemon/db/monster/altie.json
@@ -62,7 +62,7 @@
     "txmn_id": 201,
     "height": 130,
     "weight": 30,
-    "catch_rate": 85.0,
+    "catch_rate": 5.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/ambuwl.json
+++ b/mods/tuxemon/db/monster/ambuwl.json
@@ -62,7 +62,7 @@
     "txmn_id": 249,
     "height": 98,
     "weight": 38,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/angesnow.json
+++ b/mods/tuxemon/db/monster/angesnow.json
@@ -49,7 +49,7 @@
     "txmn_id": 263,
     "height": 120,
     "weight": 30,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/angrito.json
+++ b/mods/tuxemon/db/monster/angrito.json
@@ -52,7 +52,7 @@
     "txmn_id": 175,
     "height": 90,
     "weight": 55,
-    "catch_rate": 120.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/anoleaf.json
+++ b/mods/tuxemon/db/monster/anoleaf.json
@@ -49,7 +49,7 @@
     "txmn_id": 65,
     "height": 33,
     "weight": 2,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/anu.json
+++ b/mods/tuxemon/db/monster/anu.json
@@ -62,7 +62,7 @@
     "txmn_id": 171,
     "height": 100,
     "weight": 10,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/apeoro.json
+++ b/mods/tuxemon/db/monster/apeoro.json
@@ -51,7 +51,7 @@
     "txmn_id": 197,
     "height": 197,
     "weight": 145,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/araignee.json
+++ b/mods/tuxemon/db/monster/araignee.json
@@ -62,7 +62,7 @@
     "txmn_id": 100,
     "height": 68,
     "weight": 7,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/arthrobolt.json
+++ b/mods/tuxemon/db/monster/arthrobolt.json
@@ -59,7 +59,7 @@
     "txmn_id": 6,
     "height": 110,
     "weight": 125,
-    "catch_rate": 45.0,
+    "catch_rate": 35.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/av8r.json
+++ b/mods/tuxemon/db/monster/av8r.json
@@ -55,7 +55,7 @@
         "combat_call": "sound_av8r",
         "faint_call": "sound_av8r_faint"
     },
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/axylightl.json
+++ b/mods/tuxemon/db/monster/axylightl.json
@@ -62,7 +62,7 @@
     "txmn_id": 101,
     "height": 80,
     "weight": 15,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/b_ver_1.json
+++ b/mods/tuxemon/db/monster/b_ver_1.json
@@ -51,7 +51,7 @@
     "txmn_id": 130,
     "height": 100,
     "weight": 50,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/bamboon.json
+++ b/mods/tuxemon/db/monster/bamboon.json
@@ -51,7 +51,7 @@
     "txmn_id": 28,
     "height": 120,
     "weight": 40,
-    "catch_rate": 120.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/banling.json
+++ b/mods/tuxemon/db/monster/banling.json
@@ -62,7 +62,7 @@
     "txmn_id": 200,
     "height": 120,
     "weight": 180,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/baobaraffe.json
+++ b/mods/tuxemon/db/monster/baobaraffe.json
@@ -55,7 +55,7 @@
     "txmn_id": 193,
     "height": 320,
     "weight": 302,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/baoby.json
+++ b/mods/tuxemon/db/monster/baoby.json
@@ -49,7 +49,7 @@
     "txmn_id": 192,
     "height": 54,
     "weight": 23,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/bearloch.json
+++ b/mods/tuxemon/db/monster/bearloch.json
@@ -63,7 +63,7 @@
     "txmn_id": 0,
     "height": 131,
     "weight": 46,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/beenstalker.json
+++ b/mods/tuxemon/db/monster/beenstalker.json
@@ -51,7 +51,7 @@
     "txmn_id": 199,
     "height": 98,
     "weight": 41,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/bigfin.json
+++ b/mods/tuxemon/db/monster/bigfin.json
@@ -51,7 +51,7 @@
     "txmn_id": 25,
     "height": 1200,
     "weight": 50000,
-    "catch_rate": 45.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/birdling.json
+++ b/mods/tuxemon/db/monster/birdling.json
@@ -51,7 +51,7 @@
     "txmn_id": 82,
     "height": 40,
     "weight": 8,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/blasdoor.json
+++ b/mods/tuxemon/db/monster/blasdoor.json
@@ -59,7 +59,7 @@
     "txmn_id": 251,
     "height": 2040,
     "weight": 204,
-    "catch_rate": 120.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/bolt.json
+++ b/mods/tuxemon/db/monster/bolt.json
@@ -49,7 +49,7 @@
     "txmn_id": 5,
     "height": 90,
     "weight": 15.6,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/boltnu.json
+++ b/mods/tuxemon/db/monster/boltnu.json
@@ -45,7 +45,7 @@
     "txmn_id": 194,
     "height": 47,
     "weight": 8,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/botbot.json
+++ b/mods/tuxemon/db/monster/botbot.json
@@ -86,7 +86,7 @@
     "txmn_id": 125,
     "height": 40,
     "weight": 4,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/boxali.json
+++ b/mods/tuxemon/db/monster/boxali.json
@@ -62,7 +62,7 @@
     "txmn_id": 213,
     "height": 180,
     "weight": 90,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/brewdin.json
+++ b/mods/tuxemon/db/monster/brewdin.json
@@ -62,7 +62,7 @@
     "txmn_id": 215,
     "height": 22,
     "weight": 1,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/bricgard.json
+++ b/mods/tuxemon/db/monster/bricgard.json
@@ -57,7 +57,7 @@
     "txmn_id": 260,
     "height": 50,
     "weight": 35,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/brickhemoth.json
+++ b/mods/tuxemon/db/monster/brickhemoth.json
@@ -67,7 +67,7 @@
     "txmn_id": 261,
     "height": 180,
     "weight": 120,
-    "catch_rate": 45.0,
+    "catch_rate": 35.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/budaye.json
+++ b/mods/tuxemon/db/monster/budaye.json
@@ -68,7 +68,7 @@
     "txmn_id": 27,
     "height": 80,
     "weight": 20,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/bugnin.json
+++ b/mods/tuxemon/db/monster/bugnin.json
@@ -64,7 +64,7 @@
     "txmn_id": 58,
     "height": 150,
     "weight": 52,
-    "catch_rate": 3.0,
+    "catch_rate": 35.0,
     "lower_catch_resistance": 0.8,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/bumbulus.json
+++ b/mods/tuxemon/db/monster/bumbulus.json
@@ -61,7 +61,7 @@
     "txmn_id": 210,
     "height": 78,
     "weight": 1,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/bursa.json
+++ b/mods/tuxemon/db/monster/bursa.json
@@ -49,7 +49,7 @@
     "txmn_id": 83,
     "height": 180,
     "weight": 110,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/cairfrey.json
+++ b/mods/tuxemon/db/monster/cairfrey.json
@@ -61,7 +61,7 @@
     "txmn_id": 71,
     "height": 54,
     "weight": 10,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/capinyah.json
+++ b/mods/tuxemon/db/monster/capinyah.json
@@ -79,7 +79,7 @@
     "txmn_id": 234,
     "height": 160,
     "weight": 55,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/capiti.json
+++ b/mods/tuxemon/db/monster/capiti.json
@@ -73,7 +73,7 @@
     "txmn_id": 102,
     "height": 100,
     "weight": 20,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/cardiling.json
+++ b/mods/tuxemon/db/monster/cardiling.json
@@ -49,7 +49,7 @@
     "txmn_id": 62,
     "height": 30,
     "weight": 2,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/cardinale.json
+++ b/mods/tuxemon/db/monster/cardinale.json
@@ -67,7 +67,7 @@
     "txmn_id": 64,
     "height": 60,
     "weight": 8,
-    "catch_rate": 45.0,
+    "catch_rate": 35.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/cardiwing.json
+++ b/mods/tuxemon/db/monster/cardiwing.json
@@ -57,7 +57,7 @@
     "txmn_id": 63,
     "height": 45,
     "weight": 5,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/cataspike.json
+++ b/mods/tuxemon/db/monster/cataspike.json
@@ -49,7 +49,7 @@
     "txmn_id": 33,
     "height": 12,
     "weight": 1,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/cateye.json
+++ b/mods/tuxemon/db/monster/cateye.json
@@ -62,7 +62,7 @@
     "txmn_id": 103,
     "height": 45,
     "weight": 19,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/chenipode.json
+++ b/mods/tuxemon/db/monster/chenipode.json
@@ -45,7 +45,7 @@
     "txmn_id": 60,
     "height": 15,
     "weight": 0.5,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/cherubat.json
+++ b/mods/tuxemon/db/monster/cherubat.json
@@ -62,7 +62,7 @@
     "txmn_id": 248,
     "height": 30,
     "weight": 0.5,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/chibiro.json
+++ b/mods/tuxemon/db/monster/chibiro.json
@@ -62,7 +62,7 @@
     "txmn_id": 212,
     "height": 36,
     "weight": 3,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/chillimp.json
+++ b/mods/tuxemon/db/monster/chillimp.json
@@ -46,7 +46,7 @@
     "txmn_id": 154,
     "height": 115,
     "weight": 54,
-    "catch_rate": 45.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/chloragon.json
+++ b/mods/tuxemon/db/monster/chloragon.json
@@ -53,7 +53,7 @@
     "txmn_id": 140,
     "height": 102,
     "weight": 85,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/chrome_robo.json
+++ b/mods/tuxemon/db/monster/chrome_robo.json
@@ -62,7 +62,7 @@
     "txmn_id": 0,
     "height": 0,
     "weight": 100,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/chromeye.json
+++ b/mods/tuxemon/db/monster/chromeye.json
@@ -76,7 +76,7 @@
     "txmn_id": 174,
     "height": 38,
     "weight": 3.5,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/cochini.json
+++ b/mods/tuxemon/db/monster/cochini.json
@@ -62,7 +62,7 @@
     "txmn_id": 104,
     "height": 80,
     "weight": 15,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/coleorus.json
+++ b/mods/tuxemon/db/monster/coleorus.json
@@ -63,7 +63,7 @@
     "txmn_id": 105,
     "height": 39,
     "weight": 6,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/conglolem.json
+++ b/mods/tuxemon/db/monster/conglolem.json
@@ -75,7 +75,7 @@
     "txmn_id": 274,
     "height": 245,
     "weight": 197,
-    "catch_rate": 45.0,
+    "catch_rate": 35.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/conifrost.json
+++ b/mods/tuxemon/db/monster/conifrost.json
@@ -63,7 +63,7 @@
     "txmn_id": 106,
     "height": 250,
     "weight": 371,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/conileaf.json
+++ b/mods/tuxemon/db/monster/conileaf.json
@@ -62,7 +62,7 @@
     "txmn_id": 148,
     "height": 45,
     "weight": 3,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/coproblight.json
+++ b/mods/tuxemon/db/monster/coproblight.json
@@ -62,7 +62,7 @@
     "txmn_id": 173,
     "height": 45,
     "weight": 8,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/corvix.json
+++ b/mods/tuxemon/db/monster/corvix.json
@@ -57,7 +57,7 @@
     "txmn_id": 157,
     "height": 55,
     "weight": 4,
-    "catch_rate": 45.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/cowpignon.json
+++ b/mods/tuxemon/db/monster/cowpignon.json
@@ -63,7 +63,7 @@
     "txmn_id": 107,
     "height": 30.48,
     "weight": 2,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/criniotherme.json
+++ b/mods/tuxemon/db/monster/criniotherme.json
@@ -51,7 +51,7 @@
     "txmn_id": 23,
     "height": 210,
     "weight": 170,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/d0llf1n.json
+++ b/mods/tuxemon/db/monster/d0llf1n.json
@@ -63,7 +63,7 @@
     "txmn_id": 0,
     "height": 0,
     "weight": 25,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/dandicub.json
+++ b/mods/tuxemon/db/monster/dandicub.json
@@ -45,7 +45,7 @@
     "txmn_id": 73,
     "height": 46,
     "weight": 2,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/dandylion.json
+++ b/mods/tuxemon/db/monster/dandylion.json
@@ -51,7 +51,7 @@
     "txmn_id": 74,
     "height": 138,
     "weight": 45,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/dankush.json
+++ b/mods/tuxemon/db/monster/dankush.json
@@ -64,7 +64,7 @@
     "height": 40,
     "weight": 0.5,
     "randomly": false,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/dark_robo.json
+++ b/mods/tuxemon/db/monster/dark_robo.json
@@ -62,7 +62,7 @@
     "txmn_id": 0,
     "height": 0,
     "weight": 100,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/demosnow.json
+++ b/mods/tuxemon/db/monster/demosnow.json
@@ -49,7 +49,7 @@
     "txmn_id": 264,
     "height": 120,
     "weight": 35,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/dinoflop.json
+++ b/mods/tuxemon/db/monster/dinoflop.json
@@ -62,7 +62,7 @@
     "txmn_id": 166,
     "height": 120,
     "weight": 120,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/djinnbo.json
+++ b/mods/tuxemon/db/monster/djinnbo.json
@@ -62,7 +62,7 @@
     "txmn_id": 108,
     "height": 160,
     "weight": 0,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/dollfin.json
+++ b/mods/tuxemon/db/monster/dollfin.json
@@ -68,7 +68,7 @@
     "txmn_id": 24,	
     "height": 250,
     "weight": 190,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/dracune.json
+++ b/mods/tuxemon/db/monster/dracune.json
@@ -49,7 +49,7 @@
     "txmn_id": 37,
     "height": 35,
     "weight": 3.5,
-    "catch_rate": 120.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/dragarbor.json
+++ b/mods/tuxemon/db/monster/dragarbor.json
@@ -71,7 +71,7 @@
     "txmn_id": 142,
     "height": 397,
     "weight": 336,
-    "catch_rate": 45.0,
+    "catch_rate": 35.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/drashimi.json
+++ b/mods/tuxemon/db/monster/drashimi.json
@@ -50,7 +50,7 @@
     "txmn_id": 185,
     "height": 38,
     "weight": 12,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/drokoro.json
+++ b/mods/tuxemon/db/monster/drokoro.json
@@ -62,7 +62,7 @@
     "txmn_id": 145,
     "height": 1200,
     "weight": 10000,
-    "catch_rate": 3.0,
+    "catch_rate": 5.0,
     "lower_catch_resistance": 0.8,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/dune_pincher.json
+++ b/mods/tuxemon/db/monster/dune_pincher.json
@@ -62,7 +62,7 @@
     "txmn_id": 109,
     "height": 37,
     "weight": 7,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/eaglace.json
+++ b/mods/tuxemon/db/monster/eaglace.json
@@ -67,7 +67,7 @@
     "txmn_id": 9,
     "height": 150,
     "weight": 36,
-    "catch_rate": 45.0,
+    "catch_rate": 35.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/elofly.json
+++ b/mods/tuxemon/db/monster/elofly.json
@@ -49,7 +49,7 @@
     "txmn_id": 39,
     "height": 75,
     "weight": 3,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/elostorm.json
+++ b/mods/tuxemon/db/monster/elostorm.json
@@ -67,7 +67,7 @@
     "txmn_id": 41,
     "height": 144,
     "weight": 25,
-    "catch_rate": 45.0,
+    "catch_rate": 35.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/elowind.json
+++ b/mods/tuxemon/db/monster/elowind.json
@@ -57,7 +57,7 @@
     "txmn_id": 40,
     "height": 115,
     "weight": 15,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/embazook.json
+++ b/mods/tuxemon/db/monster/embazook.json
@@ -52,7 +52,7 @@
     "txmn_id": 31,
     "height": 137,
     "weight": 502,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/embra.json
+++ b/mods/tuxemon/db/monster/embra.json
@@ -61,7 +61,7 @@
     "txmn_id": 75,
     "height": 48,
     "weight": 2,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/enduros.json
+++ b/mods/tuxemon/db/monster/enduros.json
@@ -62,7 +62,7 @@
     "txmn_id": 167,
     "height": 170,
     "weight": 65,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/eruptibus.json
+++ b/mods/tuxemon/db/monster/eruptibus.json
@@ -51,7 +51,7 @@
     "txmn_id": 32,
     "height": 600,
     "weight": 12000,
-    "catch_rate": 45.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/exapode.json
+++ b/mods/tuxemon/db/monster/exapode.json
@@ -51,7 +51,7 @@
     "txmn_id": 61,
     "height": 44,
     "weight": 5,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/exclawvate.json
+++ b/mods/tuxemon/db/monster/exclawvate.json
@@ -51,7 +51,7 @@
     "txmn_id": 195,
     "height": 213,
     "weight": 1000,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/eyenemy.json
+++ b/mods/tuxemon/db/monster/eyenemy.json
@@ -45,7 +45,7 @@
     "txmn_id": 46,
     "height": 104,
     "weight": 2,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/eyesore.json
+++ b/mods/tuxemon/db/monster/eyesore.json
@@ -51,7 +51,7 @@
     "txmn_id": 47,
     "height": 135,
     "weight": 4,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/f7u1t3ra.json
+++ b/mods/tuxemon/db/monster/f7u1t3ra.json
@@ -63,7 +63,7 @@
     "txmn_id": 0,
     "height": 0,
     "weight": 25,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/fancair.json
+++ b/mods/tuxemon/db/monster/fancair.json
@@ -45,7 +45,7 @@
     "txmn_id": 179,
     "height": 45,
     "weight": 18,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/ferricran.json
+++ b/mods/tuxemon/db/monster/ferricran.json
@@ -71,7 +71,7 @@
     "txmn_id": 161,
     "height": 230,
     "weight": 214,
-    "catch_rate": 85.0,
+    "catch_rate": 35.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/firomenis.json
+++ b/mods/tuxemon/db/monster/firomenis.json
@@ -63,7 +63,7 @@
     "txmn_id": 245,
     "height": 183,
     "weight": 30,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/flacono.json
+++ b/mods/tuxemon/db/monster/flacono.json
@@ -49,7 +49,7 @@
     "txmn_id": 156,
     "height": 70,
     "weight": 6,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/flambear.json
+++ b/mods/tuxemon/db/monster/flambear.json
@@ -55,7 +55,7 @@
     "txmn_id": 84,
     "height": 250,
     "weight": 500,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/flisces.json
+++ b/mods/tuxemon/db/monster/flisces.json
@@ -62,7 +62,7 @@
     "txmn_id": 238,
     "height": 28,
     "weight": 1.5,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/fluoresfin.json
+++ b/mods/tuxemon/db/monster/fluoresfin.json
@@ -49,7 +49,7 @@
     "txmn_id": 68,
     "height": 80,
     "weight": 11,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/fluttaflap.json
+++ b/mods/tuxemon/db/monster/fluttaflap.json
@@ -63,7 +63,7 @@
     "txmn_id": 38,
     "height": 47,
     "weight": 7,
-    "catch_rate": 120.0,
+    "catch_rate": 35.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/foofle.json
+++ b/mods/tuxemon/db/monster/foofle.json
@@ -62,7 +62,7 @@
     "txmn_id": 110,
     "height": 53,
     "weight": 8,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/fordin.json
+++ b/mods/tuxemon/db/monster/fordin.json
@@ -62,7 +62,7 @@
     "txmn_id": 211,
     "height": 56,
     "weight": 19,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/forturtle.json
+++ b/mods/tuxemon/db/monster/forturtle.json
@@ -45,7 +45,7 @@
     "txmn_id": 87,
     "height": 85,
     "weight": 55,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/foxfire.json
+++ b/mods/tuxemon/db/monster/foxfire.json
@@ -62,7 +62,7 @@
     "txmn_id": 149,
     "height": 41,
     "weight": 2,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/foxko.json
+++ b/mods/tuxemon/db/monster/foxko.json
@@ -63,7 +63,7 @@
     "txmn_id": 0,
     "height": 71,
     "weight": 10,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/fribbit.json
+++ b/mods/tuxemon/db/monster/fribbit.json
@@ -59,7 +59,7 @@
     "txmn_id": 269,
     "height": 50,
     "weight": 20,
-    "catch_rate": 120.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/frondly.json
+++ b/mods/tuxemon/db/monster/frondly.json
@@ -51,7 +51,7 @@
     "txmn_id": 29,
     "height": 160,
     "weight": 60,
-    "catch_rate": 3.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.8,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/fruitera.json
+++ b/mods/tuxemon/db/monster/fruitera.json
@@ -62,7 +62,7 @@
     "txmn_id": 169,
     "height": 30,
     "weight": 2,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/furnursus.json
+++ b/mods/tuxemon/db/monster/furnursus.json
@@ -45,7 +45,7 @@
     "txmn_id": 190,
     "height": 110,
     "weight": 47,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/fuzzina.json
+++ b/mods/tuxemon/db/monster/fuzzina.json
@@ -67,7 +67,7 @@
     "txmn_id": 237,
     "height": 50,
     "weight": 1,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/fuzzlet.json
+++ b/mods/tuxemon/db/monster/fuzzlet.json
@@ -61,7 +61,7 @@
     "txmn_id": 236,
     "height": 33,
     "weight": 0.5,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/galnec.json
+++ b/mods/tuxemon/db/monster/galnec.json
@@ -62,7 +62,7 @@
     "txmn_id": 168,
     "height": 40,
     "weight": 6,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/gectile.json
+++ b/mods/tuxemon/db/monster/gectile.json
@@ -57,7 +57,7 @@
     "txmn_id": 66,
     "height": 54,
     "weight": 7,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/ghosteeth.json
+++ b/mods/tuxemon/db/monster/ghosteeth.json
@@ -62,7 +62,7 @@
     "txmn_id": 111,
     "height": 70,
     "weight": 0,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/glombroc.json
+++ b/mods/tuxemon/db/monster/glombroc.json
@@ -70,7 +70,7 @@
     "txmn_id": 273,
     "height": 87,
     "weight": 35,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/graffiki.json
+++ b/mods/tuxemon/db/monster/graffiki.json
@@ -62,7 +62,7 @@
     "txmn_id": 205,
     "height": 65,
     "weight": 13,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/grimachin.json
+++ b/mods/tuxemon/db/monster/grimachin.json
@@ -49,7 +49,7 @@
     "txmn_id": 93,
     "height": 45,
     "weight": 3,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/grinflare.json
+++ b/mods/tuxemon/db/monster/grinflare.json
@@ -52,7 +52,7 @@
     "txmn_id": 17,
     "height": 160,
     "weight": 3000,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/grintot.json
+++ b/mods/tuxemon/db/monster/grintot.json
@@ -68,7 +68,7 @@
     "txmn_id": 16,
     "height": 70,
     "weight": 375,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/grintrock.json
+++ b/mods/tuxemon/db/monster/grintrock.json
@@ -52,7 +52,7 @@
     "txmn_id": 18,
     "height": 160,
     "weight": 3000,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/grumpi.json
+++ b/mods/tuxemon/db/monster/grumpi.json
@@ -63,7 +63,7 @@
     "txmn_id": 206,
     "height": 150,
     "weight": 160,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/gryfix.json
+++ b/mods/tuxemon/db/monster/gryfix.json
@@ -67,7 +67,7 @@
     "txmn_id": 158,
     "height": 180,
     "weight": 31,
-    "catch_rate": 85.0,
+    "catch_rate": 35.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/hampotamos.json
+++ b/mods/tuxemon/db/monster/hampotamos.json
@@ -62,7 +62,7 @@
     "txmn_id": 150,
     "height": 150,
     "weight": 180,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/happito.json
+++ b/mods/tuxemon/db/monster/happito.json
@@ -52,7 +52,7 @@
     "txmn_id": 176,
     "height": 90,
     "weight": 55,
-    "catch_rate": 120.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/hatchling.json
+++ b/mods/tuxemon/db/monster/hatchling.json
@@ -45,7 +45,7 @@
     "txmn_id": 81,
     "height": 20,
     "weight": 1,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/hectapod.json
+++ b/mods/tuxemon/db/monster/hectapod.json
@@ -55,7 +55,7 @@
     "txmn_id": 271,
     "height": 120,
     "weight": 45,
-    "catch_rate": 120.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/heronquak.json
+++ b/mods/tuxemon/db/monster/heronquak.json
@@ -57,7 +57,7 @@
     "txmn_id": 8,
     "height": 150,
     "weight": 12,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/hotline.json
+++ b/mods/tuxemon/db/monster/hotline.json
@@ -63,7 +63,7 @@
     "height": 150,
     "weight": 50,
     "randomly": false,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/howl.json
+++ b/mods/tuxemon/db/monster/howl.json
@@ -62,7 +62,7 @@
     "txmn_id": 235,
     "height": 63,
     "weight": 2.5,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/hydrone.json
+++ b/mods/tuxemon/db/monster/hydrone.json
@@ -63,7 +63,7 @@
     "txmn_id": 112,
     "height": 155,
     "weight": 200,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/ignibus.json
+++ b/mods/tuxemon/db/monster/ignibus.json
@@ -68,7 +68,7 @@
     "txmn_id": 30,
     "height": 68,
     "weight": 27,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/imbrickcile.json
+++ b/mods/tuxemon/db/monster/imbrickcile.json
@@ -49,7 +49,7 @@
     "txmn_id": 259,
     "height": 35,
     "weight": 2,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/incandesfin.json
+++ b/mods/tuxemon/db/monster/incandesfin.json
@@ -57,7 +57,7 @@
     "txmn_id": 69,
     "height": 250,
     "weight": 150,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/jelillow.json
+++ b/mods/tuxemon/db/monster/jelillow.json
@@ -62,7 +62,7 @@
     "txmn_id": 207,
     "height": 66,
     "weight": 10,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/jemuar.json
+++ b/mods/tuxemon/db/monster/jemuar.json
@@ -67,7 +67,7 @@
     "txmn_id": 3,
     "height": 160,
     "weight": 150,
-    "catch_rate": 45.0,
+    "catch_rate": 35.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/joulraton.json
+++ b/mods/tuxemon/db/monster/joulraton.json
@@ -62,7 +62,7 @@
     "txmn_id": 244,
     "height": 30,
     "weight": 2.5,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/k9.json
+++ b/mods/tuxemon/db/monster/k9.json
@@ -51,7 +51,7 @@
     "txmn_id": 129,
     "height": 60,
     "weight": 5,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/katacoon.json
+++ b/mods/tuxemon/db/monster/katacoon.json
@@ -59,7 +59,7 @@
     "txmn_id": 57,
     "height": 58,
     "weight": 12,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/katapill.json
+++ b/mods/tuxemon/db/monster/katapill.json
@@ -54,7 +54,7 @@
     "txmn_id": 56,
     "height": 32,
     "weight": 3,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/kernel.json
+++ b/mods/tuxemon/db/monster/kernel.json
@@ -62,7 +62,7 @@
     "txmn_id": 253,
     "height": 30,
     "weight": 0,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/komodraw.json
+++ b/mods/tuxemon/db/monster/komodraw.json
@@ -62,7 +62,7 @@
     "txmn_id": 92,
     "height": 155,
     "weight": 55,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/l3gk0.json
+++ b/mods/tuxemon/db/monster/l3gk0.json
@@ -63,7 +63,7 @@
     "txmn_id": 0,
     "height": 0,
     "weight": 25,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/lambert.json
+++ b/mods/tuxemon/db/monster/lambert.json
@@ -49,7 +49,7 @@
     "txmn_id": 10,
     "height": 69,
     "weight": 37,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/lapinou.json
+++ b/mods/tuxemon/db/monster/lapinou.json
@@ -62,7 +62,7 @@
     "txmn_id": 113,
     "height": 60,
     "weight": 8,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/legko.json
+++ b/mods/tuxemon/db/monster/legko.json
@@ -57,7 +57,7 @@
     "txmn_id": 11,
     "height": 123,
     "weight": 52,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/lendos.json
+++ b/mods/tuxemon/db/monster/lendos.json
@@ -67,7 +67,7 @@
     "txmn_id": 241,
     "height": 97,
     "weight": 7,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/lightmare.json
+++ b/mods/tuxemon/db/monster/lightmare.json
@@ -67,7 +67,7 @@
     "txmn_id": 70,
     "height": 300,
     "weight": 200,
-    "catch_rate": 45.0,
+    "catch_rate": 35.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/loliferno.json
+++ b/mods/tuxemon/db/monster/loliferno.json
@@ -51,7 +51,7 @@
     "txmn_id": 163,
     "height": 60,
     "weight": 0,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/lucifice.json
+++ b/mods/tuxemon/db/monster/lucifice.json
@@ -63,7 +63,7 @@
     "txmn_id": 265,
     "height": 180,
     "weight": 90,
-    "catch_rate": 45.0,
+    "catch_rate": 35.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/lunight.json
+++ b/mods/tuxemon/db/monster/lunight.json
@@ -63,7 +63,7 @@
     "txmn_id": 229,
     "height": 55,
     "weight": 17,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/manosting.json
+++ b/mods/tuxemon/db/monster/manosting.json
@@ -62,7 +62,7 @@
     "txmn_id": 114,
     "height": 180,
     "weight": 0,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/masknake.json
+++ b/mods/tuxemon/db/monster/masknake.json
@@ -62,7 +62,7 @@
     "txmn_id": 115,
     "height": 112,
     "weight": 8,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/mauai.json
+++ b/mods/tuxemon/db/monster/mauai.json
@@ -51,7 +51,7 @@
     "txmn_id": 232,
     "height": 203,
     "weight": 139,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/medushock.json
+++ b/mods/tuxemon/db/monster/medushock.json
@@ -63,7 +63,7 @@
     "txmn_id": 208,
     "height": 133,
     "weight": 3,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/memnomnom.json
+++ b/mods/tuxemon/db/monster/memnomnom.json
@@ -84,7 +84,7 @@
     "txmn_id": 19,
     "height": 70,
     "weight": 7,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/merlicun.json
+++ b/mods/tuxemon/db/monster/merlicun.json
@@ -49,7 +49,7 @@
     "txmn_id": 209,
     "height": 28,
     "weight": 3,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/metesaur.json
+++ b/mods/tuxemon/db/monster/metesaur.json
@@ -54,7 +54,7 @@
     "txmn_id": 202,
     "height": 95,
     "weight": 10,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/miaownolith.json
+++ b/mods/tuxemon/db/monster/miaownolith.json
@@ -52,7 +52,7 @@
     "txmn_id": 20,
     "height": 210,
     "weight": 255,
-    "catch_rate": 170.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/mingdyn.json
+++ b/mods/tuxemon/db/monster/mingdyn.json
@@ -62,7 +62,7 @@
     "txmn_id": 239,
     "height": 274,
     "weight": 124,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/mk01_alpha.json
+++ b/mods/tuxemon/db/monster/mk01_alpha.json
@@ -66,7 +66,7 @@
     "txmn_id": 0,
     "height": 0,
     "weight": 100,
-    "catch_rate": 120.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/mk01_beta.json
+++ b/mods/tuxemon/db/monster/mk01_beta.json
@@ -66,7 +66,7 @@
     "txmn_id": 0,
     "height": 0,
     "weight": 100,
-    "catch_rate": 120.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/mk01_delta.json
+++ b/mods/tuxemon/db/monster/mk01_delta.json
@@ -75,7 +75,7 @@
     "txmn_id": 0,
     "height": 0,
     "weight": 100,
-    "catch_rate": 120.0,
+    "catch_rate": 35.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/mk01_gamma.json
+++ b/mods/tuxemon/db/monster/mk01_gamma.json
@@ -71,7 +71,7 @@
     "txmn_id": 0,
     "height": 0,
     "weight": 100,
-    "catch_rate": 120.0,
+    "catch_rate": 35.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/mk01_omega.json
+++ b/mods/tuxemon/db/monster/mk01_omega.json
@@ -71,7 +71,7 @@
     "txmn_id": 0,
     "height": 0,
     "weight": 100,
-    "catch_rate": 120.0,
+    "catch_rate": 35.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/mk01_proto.json
+++ b/mods/tuxemon/db/monster/mk01_proto.json
@@ -62,7 +62,7 @@
     "txmn_id": 0,
     "height": 0,
     "weight": 100,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/moloch.json
+++ b/mods/tuxemon/db/monster/moloch.json
@@ -67,7 +67,7 @@
     "txmn_id": 12,
     "height": 216,
     "weight": 90,
-    "catch_rate": 45.0,
+    "catch_rate": 35.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/mrmoswitch.json
+++ b/mods/tuxemon/db/monster/mrmoswitch.json
@@ -51,7 +51,7 @@
     "txmn_id": 128,
     "height": 56,
     "weight": 4,
-    "catch_rate": 170.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/mystikapi.json
+++ b/mods/tuxemon/db/monster/mystikapi.json
@@ -62,7 +62,7 @@
     "txmn_id": 223,
     "height": 160,
     "weight": 250,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/narcileaf.json
+++ b/mods/tuxemon/db/monster/narcileaf.json
@@ -51,7 +51,7 @@
     "txmn_id": 78,
     "height": 42,
     "weight": 4,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/neutrito.json
+++ b/mods/tuxemon/db/monster/neutrito.json
@@ -52,7 +52,7 @@
     "txmn_id": 177,
     "height": 90,
     "weight": 55,
-    "catch_rate": 120.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/nimbulex.json
+++ b/mods/tuxemon/db/monster/nimbulex.json
@@ -67,7 +67,7 @@
     "txmn_id": 233,
     "height": 141,
     "weight": 1,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/noctalo.json
+++ b/mods/tuxemon/db/monster/noctalo.json
@@ -51,7 +51,7 @@
     "txmn_id": 51,
     "height": 100,
     "weight": 12,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/noctula.json
+++ b/mods/tuxemon/db/monster/noctula.json
@@ -45,7 +45,7 @@
     "txmn_id": 50,
     "height": 50,
     "weight": 3,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/nostray.json
+++ b/mods/tuxemon/db/monster/nostray.json
@@ -45,7 +45,7 @@
     "txmn_id": 152,
     "height": 120,
     "weight": 30,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/nudiflot_female.json
+++ b/mods/tuxemon/db/monster/nudiflot_female.json
@@ -45,7 +45,7 @@
     "txmn_id": 54,
     "height": 29,
     "weight": 3,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/nudiflot_male.json
+++ b/mods/tuxemon/db/monster/nudiflot_male.json
@@ -45,7 +45,7 @@
     "txmn_id": 52,
     "height": 36,
     "weight": 3,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/nudikill.json
+++ b/mods/tuxemon/db/monster/nudikill.json
@@ -51,7 +51,7 @@
     "txmn_id": 53,
     "height": 122,
     "weight": 35,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/nudimind.json
+++ b/mods/tuxemon/db/monster/nudimind.json
@@ -51,7 +51,7 @@
     "txmn_id": 55,
     "height": 98,
     "weight": 34,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/nuenflu.json
+++ b/mods/tuxemon/db/monster/nuenflu.json
@@ -62,7 +62,7 @@
     "txmn_id": 224,
     "height": 75,
     "weight": 21,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/nut.json
+++ b/mods/tuxemon/db/monster/nut.json
@@ -49,7 +49,7 @@
     "txmn_id": 4,
     "height": 45,
     "weight": 4,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/octabode.json
+++ b/mods/tuxemon/db/monster/octabode.json
@@ -55,7 +55,7 @@
     "txmn_id": 184,
     "height": 44,
     "weight": 19,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/ouroboutlet.json
+++ b/mods/tuxemon/db/monster/ouroboutlet.json
@@ -52,7 +52,7 @@
     "txmn_id": 90,
     "height": 62,
     "weight": 4,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/pairagrim.json
+++ b/mods/tuxemon/db/monster/pairagrim.json
@@ -55,7 +55,7 @@
     "txmn_id": 182,
     "height": 110,
     "weight": 10,
-    "catch_rate": 120.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/pairagrin.json
+++ b/mods/tuxemon/db/monster/pairagrin.json
@@ -49,7 +49,7 @@
     "txmn_id": 181,
     "height": 70,
     "weight": 4,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/pantherafira.json
+++ b/mods/tuxemon/db/monster/pantherafira.json
@@ -45,7 +45,7 @@
     "txmn_id": 22,
     "height": 90,
     "weight": 25,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/pharfan.json
+++ b/mods/tuxemon/db/monster/pharfan.json
@@ -62,7 +62,7 @@
     "txmn_id": 151,
     "height": 200,
     "weight": 500,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/picc.json
+++ b/mods/tuxemon/db/monster/picc.json
@@ -51,7 +51,7 @@
     "txmn_id": 127,
     "height": 55,
     "weight": 4,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/pigabyte.json
+++ b/mods/tuxemon/db/monster/pigabyte.json
@@ -62,7 +62,7 @@
     "txmn_id": 116,
     "height": 155,
     "weight": 180,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/pilthropus.json
+++ b/mods/tuxemon/db/monster/pilthropus.json
@@ -62,7 +62,7 @@
     "txmn_id": 172,
     "height": 154,
     "weight": 82,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/pipis.json
+++ b/mods/tuxemon/db/monster/pipis.json
@@ -45,7 +45,7 @@
     "txmn_id": 48,
     "height": 40,
     "weight": 2,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/poinchin.json
+++ b/mods/tuxemon/db/monster/poinchin.json
@@ -45,7 +45,7 @@
     "txmn_id": 164,
     "height": 30,
     "weight": 6,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/polyrock.json
+++ b/mods/tuxemon/db/monster/polyrock.json
@@ -62,7 +62,7 @@
     "txmn_id": 117,
     "height": 133,
     "weight": 66,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/possessun.json
+++ b/mods/tuxemon/db/monster/possessun.json
@@ -67,7 +67,7 @@
     "txmn_id": 72,
     "height": 69,
     "weight": 0,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/potturmeist.json
+++ b/mods/tuxemon/db/monster/potturmeist.json
@@ -49,7 +49,7 @@
     "txmn_id": 257,
     "height": 48,
     "weight": 2.5,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/potturney.json
+++ b/mods/tuxemon/db/monster/potturney.json
@@ -59,7 +59,7 @@
     "txmn_id": 258,
     "height": 45,
     "weight": 6,
-    "catch_rate": 120.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/propellercat.json
+++ b/mods/tuxemon/db/monster/propellercat.json
@@ -62,7 +62,7 @@
     "txmn_id": 118,
     "height": 55,
     "weight": 6,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/prophetoise.json
+++ b/mods/tuxemon/db/monster/prophetoise.json
@@ -51,7 +51,7 @@
     "txmn_id": 88,
     "height": 108,
     "weight": 88,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/puparmor.json
+++ b/mods/tuxemon/db/monster/puparmor.json
@@ -53,7 +53,7 @@
     "txmn_id": 34,
     "height": 35,
     "weight": 8.5,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/pyraminx.json
+++ b/mods/tuxemon/db/monster/pyraminx.json
@@ -51,7 +51,7 @@
     "txmn_id": 21,
     "height": 210,
     "weight": 190,
-    "catch_rate": 45.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/pythock.json
+++ b/mods/tuxemon/db/monster/pythock.json
@@ -55,7 +55,7 @@
     "txmn_id": 226,
     "height": 154,
     "weight": 32,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/pythwire.json
+++ b/mods/tuxemon/db/monster/pythwire.json
@@ -56,7 +56,7 @@
     "txmn_id": 89,
     "height": 200,
     "weight": 4,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/qetzlrokilus.json
+++ b/mods/tuxemon/db/monster/qetzlrokilus.json
@@ -60,7 +60,7 @@
     "txmn_id": 203,
     "height": 183,
     "weight": 41,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/r0ck1tt3n.json
+++ b/mods/tuxemon/db/monster/r0ck1tt3n.json
@@ -63,7 +63,7 @@
     "txmn_id": 0,
     "height": 0,
     "weight": 25,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/rabbitosaur.json
+++ b/mods/tuxemon/db/monster/rabbitosaur.json
@@ -51,7 +51,7 @@
     "txmn_id": 45,
     "height": 120,
     "weight": 80,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/rhincus.json
+++ b/mods/tuxemon/db/monster/rhincus.json
@@ -62,7 +62,7 @@
     "txmn_id": 143,
     "height": 92,
     "weight": 17,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/rhinocarpe.json
+++ b/mods/tuxemon/db/monster/rhinocarpe.json
@@ -62,7 +62,7 @@
     "txmn_id": 252,
     "height": 225,
     "weight": 95,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/rinocereed.json
+++ b/mods/tuxemon/db/monster/rinocereed.json
@@ -62,7 +62,7 @@
     "txmn_id": 256,
     "height": 92,
     "weight": 402,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/rockat.json
+++ b/mods/tuxemon/db/monster/rockat.json
@@ -57,7 +57,7 @@
     "txmn_id": 2,
     "height": 120,
     "weight": 60,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/rockitten.json
+++ b/mods/tuxemon/db/monster/rockitten.json
@@ -49,7 +49,7 @@
     "txmn_id": 1,
     "height": 55,
     "weight": 9,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/rocktot.json
+++ b/mods/tuxemon/db/monster/rocktot.json
@@ -62,7 +62,7 @@
     "txmn_id": 0,
     "height": 62,
     "weight": 58,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/rosarin.json
+++ b/mods/tuxemon/db/monster/rosarin.json
@@ -62,7 +62,7 @@
     "txmn_id": 204,
     "height": 48,
     "weight": 14,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/ruption.json
+++ b/mods/tuxemon/db/monster/ruption.json
@@ -67,7 +67,7 @@
     "txmn_id": 76,
     "height": 169,
     "weight": 16,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/sadito.json
+++ b/mods/tuxemon/db/monster/sadito.json
@@ -52,7 +52,7 @@
     "txmn_id": 178,
     "height": 90,
     "weight": 55,
-    "catch_rate": 120.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/sampsack.json
+++ b/mods/tuxemon/db/monster/sampsack.json
@@ -62,7 +62,7 @@
     "txmn_id": 97,
     "height": 225,
     "weight": 235,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/sampsage.json
+++ b/mods/tuxemon/db/monster/sampsage.json
@@ -62,7 +62,7 @@
     "txmn_id": 98,
     "height": 180,
     "weight": 122,
-    "catch_rate": 45.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/sapragon.json
+++ b/mods/tuxemon/db/monster/sapragon.json
@@ -61,7 +61,7 @@
     "txmn_id": 141,
     "height": 122,
     "weight": 115,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/sapsnap.json
+++ b/mods/tuxemon/db/monster/sapsnap.json
@@ -51,7 +51,7 @@
     "txmn_id": 86,
     "height": 210,
     "weight": 125,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/saurchin.json
+++ b/mods/tuxemon/db/monster/saurchin.json
@@ -51,7 +51,7 @@
     "txmn_id": 165,
     "height": 800,
     "weight": 3000,
-    "catch_rate": 120.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/sclairus.json
+++ b/mods/tuxemon/db/monster/sclairus.json
@@ -62,7 +62,7 @@
     "txmn_id": 119,
     "height": 85,
     "weight": 3,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/seirein.json
+++ b/mods/tuxemon/db/monster/seirein.json
@@ -46,7 +46,7 @@
     "txmn_id": 162,
     "height": 30,
     "weight": 0,
-    "catch_rate": 45.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/selket.json
+++ b/mods/tuxemon/db/monster/selket.json
@@ -45,7 +45,7 @@
     "txmn_id": 188,
     "height": 17,
     "weight": 10,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/selmatek.json
+++ b/mods/tuxemon/db/monster/selmatek.json
@@ -51,7 +51,7 @@
     "txmn_id": 189,
     "height": 155,
     "weight": 80,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/seraphice.json
+++ b/mods/tuxemon/db/monster/seraphice.json
@@ -63,7 +63,7 @@
     "txmn_id": 266,
     "height": 180,
     "weight": 85,
-    "catch_rate": 45.0,
+    "catch_rate": 35.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/shammer.json
+++ b/mods/tuxemon/db/monster/shammer.json
@@ -62,7 +62,7 @@
     "txmn_id": 144,
     "height": 80,
     "weight": 40,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/sharpfin.json
+++ b/mods/tuxemon/db/monster/sharpfin.json
@@ -52,7 +52,7 @@
     "txmn_id": 26,
     "height": 300,
     "weight": 200,
-    "catch_rate": 45.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/shelagu.json
+++ b/mods/tuxemon/db/monster/shelagu.json
@@ -62,7 +62,7 @@
     "txmn_id": 221,
     "height": 60,
     "weight": 4,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/shnark.json
+++ b/mods/tuxemon/db/monster/shnark.json
@@ -51,7 +51,7 @@
     "txmn_id": 153,
     "height": 205,
     "weight": 120,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/shybulb.json
+++ b/mods/tuxemon/db/monster/shybulb.json
@@ -45,7 +45,7 @@
     "txmn_id": 77,
     "height": 29,
     "weight": 2,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/skwib.json
+++ b/mods/tuxemon/db/monster/skwib.json
@@ -49,7 +49,7 @@
     "txmn_id": 183,
     "height": 30,
     "weight": 9,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/slichen.json
+++ b/mods/tuxemon/db/monster/slichen.json
@@ -57,7 +57,7 @@
     "txmn_id": 272,
     "height": 37,
     "weight": 1,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/sludgehog.json
+++ b/mods/tuxemon/db/monster/sludgehog.json
@@ -62,7 +62,7 @@
     "txmn_id": 120,
     "height": 125,
     "weight": 95,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/snaki.json
+++ b/mods/tuxemon/db/monster/snaki.json
@@ -45,7 +45,7 @@
     "txmn_id": 227,
     "height": 70,
     "weight": 15,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/snarlon.json
+++ b/mods/tuxemon/db/monster/snarlon.json
@@ -62,7 +62,7 @@
     "txmn_id": 147,
     "height": 160,
     "weight": 130,
-    "catch_rate": 120.0,
+    "catch_rate": 5.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/snock.json
+++ b/mods/tuxemon/db/monster/snock.json
@@ -49,7 +49,7 @@
     "txmn_id": 225,
     "height": 30,
     "weight": 1,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/snokari.json
+++ b/mods/tuxemon/db/monster/snokari.json
@@ -51,7 +51,7 @@
     "txmn_id": 228,
     "height": 145,
     "weight": 45,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/snowrilla.json
+++ b/mods/tuxemon/db/monster/snowrilla.json
@@ -51,7 +51,7 @@
     "txmn_id": 155,
     "height": 192,
     "weight": 112,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/sockeserp.json
+++ b/mods/tuxemon/db/monster/sockeserp.json
@@ -51,7 +51,7 @@
     "txmn_id": 91,
     "height": 100,
     "weight": 1,
-    "catch_rate": 45.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/solight.json
+++ b/mods/tuxemon/db/monster/solight.json
@@ -63,7 +63,7 @@
     "txmn_id": 230,
     "height": 55,
     "weight": 17,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/spighter.json
+++ b/mods/tuxemon/db/monster/spighter.json
@@ -62,7 +62,7 @@
     "txmn_id": 121,
     "height": 30,
     "weight": 2,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/spoilurm.json
+++ b/mods/tuxemon/db/monster/spoilurm.json
@@ -62,7 +62,7 @@
     "txmn_id": 214,
     "height": 41,
     "weight": 4,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/spycozeus.json
+++ b/mods/tuxemon/db/monster/spycozeus.json
@@ -63,7 +63,7 @@
     "txmn_id": 222,
     "height": 60,
     "weight": 18,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/squabbit.json
+++ b/mods/tuxemon/db/monster/squabbit.json
@@ -45,7 +45,7 @@
     "txmn_id": 44,
     "height": 60,
     "weight": 10,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/squink.json
+++ b/mods/tuxemon/db/monster/squink.json
@@ -49,7 +49,7 @@
     "txmn_id": 270,
     "height": 70,
     "weight": 24,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/statursus.json
+++ b/mods/tuxemon/db/monster/statursus.json
@@ -51,7 +51,7 @@
     "txmn_id": 191,
     "height": 190,
     "weight": 160,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/strella.json
+++ b/mods/tuxemon/db/monster/strella.json
@@ -51,7 +51,7 @@
     "txmn_id": 49,
     "height": 80,
     "weight": 8,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/sumchon.json
+++ b/mods/tuxemon/db/monster/sumchon.json
@@ -64,7 +64,7 @@
     "txmn_id": 59,
     "height": 150,
     "weight": 125,
-    "catch_rate": 85.0,
+    "catch_rate": 35.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/tadcool.json
+++ b/mods/tuxemon/db/monster/tadcool.json
@@ -57,7 +57,7 @@
     "txmn_id": 268,
     "height": 25,
     "weight": 1,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/tarpeur.json
+++ b/mods/tuxemon/db/monster/tarpeur.json
@@ -45,7 +45,7 @@
     "txmn_id": 217,
     "height": 19,
     "weight": 1,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/taupypus.json
+++ b/mods/tuxemon/db/monster/taupypus.json
@@ -62,7 +62,7 @@
     "txmn_id": 219,
     "height": 60,
     "weight": 3,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/teddisun.json
+++ b/mods/tuxemon/db/monster/teddisun.json
@@ -62,7 +62,7 @@
     "txmn_id": 170,
     "height": 110,
     "weight": 60,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/tetrchimp.json
+++ b/mods/tuxemon/db/monster/tetrchimp.json
@@ -45,7 +45,7 @@
     "txmn_id": 196,
     "height": 45,
     "weight": 4,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/tigrock.json
+++ b/mods/tuxemon/db/monster/tigrock.json
@@ -55,7 +55,7 @@
     "txmn_id": 94,
     "height": 200,
     "weight": 220,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/tikoal.json
+++ b/mods/tuxemon/db/monster/tikoal.json
@@ -46,7 +46,7 @@
     "txmn_id": 79,
     "height": 68,
     "weight": 11,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/tikorch.json
+++ b/mods/tuxemon/db/monster/tikorch.json
@@ -52,7 +52,7 @@
     "txmn_id": 80,
     "height": 136,
     "weight": 44,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/tobishimi.json
+++ b/mods/tuxemon/db/monster/tobishimi.json
@@ -68,7 +68,7 @@
     "txmn_id": 187,
     "height": 180,
     "weight": 169,
-    "catch_rate": 85.0,
+    "catch_rate": 35.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/toufigel.json
+++ b/mods/tuxemon/db/monster/toufigel.json
@@ -63,7 +63,7 @@
     "txmn_id": 122,
     "height": 40,
     "weight": 3,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/tourbidi.json
+++ b/mods/tuxemon/db/monster/tourbidi.json
@@ -62,7 +62,7 @@
     "txmn_id": 123,
     "height": 42,
     "weight": 14,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/trapsnap.json
+++ b/mods/tuxemon/db/monster/trapsnap.json
@@ -45,7 +45,7 @@
     "txmn_id": 85,
     "height": 120,
     "weight": 60,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/tsushimi.json
+++ b/mods/tuxemon/db/monster/tsushimi.json
@@ -57,7 +57,7 @@
     "txmn_id": 186,
     "height": 136,
     "weight": 85,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/tumblebee.json
+++ b/mods/tuxemon/db/monster/tumblebee.json
@@ -51,7 +51,7 @@
     "txmn_id": 96,
     "height": 66,
     "weight": 23,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/tumbledillo.json
+++ b/mods/tuxemon/db/monster/tumbledillo.json
@@ -67,7 +67,7 @@
     "txmn_id": 231,
     "height": 64,
     "weight": 14,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/tumblequill.json
+++ b/mods/tuxemon/db/monster/tumblequill.json
@@ -61,7 +61,7 @@
     "txmn_id": 220,
     "height": 27,
     "weight": 2,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/tumbleworm.json
+++ b/mods/tuxemon/db/monster/tumbleworm.json
@@ -45,7 +45,7 @@
     "txmn_id": 95,
     "height": 21,
     "weight": 5,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/turnipper.json
+++ b/mods/tuxemon/db/monster/turnipper.json
@@ -45,7 +45,7 @@
     "txmn_id": 198,
     "height": 65,
     "weight": 25,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/tux.json
+++ b/mods/tuxemon/db/monster/tux.json
@@ -62,7 +62,7 @@
     "txmn_id": 254,
     "height": 115,
     "weight": 55,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/tweesher.json
+++ b/mods/tuxemon/db/monster/tweesher.json
@@ -49,7 +49,7 @@
     "txmn_id": 7,
     "height": 45,
     "weight": 1,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/uf0.json
+++ b/mods/tuxemon/db/monster/uf0.json
@@ -62,7 +62,7 @@
     "txmn_id": 267,
     "height": 80,
     "weight": 7,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/uglip.json
+++ b/mods/tuxemon/db/monster/uglip.json
@@ -62,7 +62,7 @@
     "txmn_id": 246,
     "height": 30,
     "weight": 2,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/uneye.json
+++ b/mods/tuxemon/db/monster/uneye.json
@@ -69,7 +69,7 @@
     "txmn_id": 240,
     "height": 45,
     "weight": 3.5,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/urcheedle.json
+++ b/mods/tuxemon/db/monster/urcheedle.json
@@ -62,7 +62,7 @@
     "txmn_id": 243,
     "height": 30,
     "weight": 0.5,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/urcine.json
+++ b/mods/tuxemon/db/monster/urcine.json
@@ -62,7 +62,7 @@
     "txmn_id": 216,
     "height": 115,
     "weight": 45,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/vamporm.json
+++ b/mods/tuxemon/db/monster/vamporm.json
@@ -49,7 +49,7 @@
     "txmn_id": 36,
     "height": 17,
     "weight": 1,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/velocitile.json
+++ b/mods/tuxemon/db/monster/velocitile.json
@@ -67,7 +67,7 @@
     "txmn_id": 67,
     "height": 150,
     "weight": 75,
-    "catch_rate": 45.0,
+    "catch_rate": 35.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/vigueur.json
+++ b/mods/tuxemon/db/monster/vigueur.json
@@ -51,7 +51,7 @@
     "txmn_id": 218,
     "height": 38,
     "weight": 4,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/vivicinder.json
+++ b/mods/tuxemon/db/monster/vivicinder.json
@@ -51,7 +51,7 @@
     "txmn_id": 133,
     "height": 95,
     "weight": 6,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/vividactil.json
+++ b/mods/tuxemon/db/monster/vividactil.json
@@ -51,7 +51,7 @@
     "txmn_id": 138,
     "height": 97,
     "weight": 10,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/vivipere.json
+++ b/mods/tuxemon/db/monster/vivipere.json
@@ -117,7 +117,7 @@
     "txmn_id": 132,
     "height": 85,
     "weight": 8,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/viviphyta.json
+++ b/mods/tuxemon/db/monster/viviphyta.json
@@ -51,7 +51,7 @@
     "txmn_id": 134,
     "height": 87,
     "weight": 9,
-    "catch_rate": 45.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/vivisource.json
+++ b/mods/tuxemon/db/monster/vivisource.json
@@ -51,7 +51,7 @@
     "txmn_id": 139,
     "height": 107,
     "weight": 9,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/viviteel.json
+++ b/mods/tuxemon/db/monster/viviteel.json
@@ -51,7 +51,7 @@
     "txmn_id": 135,
     "height": 102,
     "weight": 18,
-    "catch_rate": 170.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/vivitrans.json
+++ b/mods/tuxemon/db/monster/vivitrans.json
@@ -52,7 +52,7 @@
     "txmn_id": 136,
     "height": 98,
     "weight": 11,
-    "catch_rate": 85.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/vivitron.json
+++ b/mods/tuxemon/db/monster/vivitron.json
@@ -51,7 +51,7 @@
     "txmn_id": 137,
     "height": 92,
     "weight": 12,
-    "catch_rate": 45.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/volcoli.json
+++ b/mods/tuxemon/db/monster/volcoli.json
@@ -62,7 +62,7 @@
     "txmn_id": 124,
     "height": 53,
     "weight": 18,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/waysprite.json
+++ b/mods/tuxemon/db/monster/waysprite.json
@@ -64,7 +64,7 @@
     "txmn_id": 262,
     "height": 15,
     "weight": 1,
-    "catch_rate": 170.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/weavifly.json
+++ b/mods/tuxemon/db/monster/weavifly.json
@@ -67,7 +67,7 @@
     "txmn_id": 35,
     "height": 52,
     "weight": 17,
-    "catch_rate": 85.0,
+    "catch_rate": 35.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/windeye.json
+++ b/mods/tuxemon/db/monster/windeye.json
@@ -51,7 +51,7 @@
     "txmn_id": 180,
     "height": 300,
     "weight": 600,
-    "catch_rate": 120.0,
+    "catch_rate": 70.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/woodoor.json
+++ b/mods/tuxemon/db/monster/woodoor.json
@@ -57,7 +57,7 @@
     "txmn_id": 250,
     "height": 2040,
     "weight": 46,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/wrougon.json
+++ b/mods/tuxemon/db/monster/wrougon.json
@@ -53,7 +53,7 @@
     "txmn_id": 159,
     "height": 120,
     "weight": 96,
-    "catch_rate": 45.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.85,
     "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/xeon.json
+++ b/mods/tuxemon/db/monster/xeon.json
@@ -62,7 +62,7 @@
     "txmn_id": 0,
     "height": 0,
     "weight": 100,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/xeon_2.json
+++ b/mods/tuxemon/db/monster/xeon_2.json
@@ -62,7 +62,7 @@
     "txmn_id": 0,
     "height": 0,
     "weight": 100,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/yiinaang.json
+++ b/mods/tuxemon/db/monster/yiinaang.json
@@ -63,7 +63,7 @@
     "txmn_id": 146,
     "height": 200,
     "weight": 0,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/ziggurat.json
+++ b/mods/tuxemon/db/monster/ziggurat.json
@@ -62,7 +62,7 @@
     "txmn_id": 242,
     "height": 30,
     "weight": 1,
-    "catch_rate": 85.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.9,
     "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/zunna.json
+++ b/mods/tuxemon/db/monster/zunna.json
@@ -62,7 +62,7 @@
     "txmn_id": 131,
     "height": 90,
     "weight": 2,
-    "catch_rate": 120.0,
+    "catch_rate": 100.0,
     "lower_catch_resistance": 0.95,
     "upper_catch_resistance": 1.05
 }


### PR DESCRIPTION
as per discussion https://github.com/Tuxemon/Tuxemon/issues/1517#issuecomment-1575462937

the catch rate is the result of a copy paste, this PR defines precise catch rate.
As starting point the catch rate will be modified as:

> I'd say, set basic stage to 100, stage 1 to 70, stage 2 to 35 and very rare monsters (Altie, Drokoro, Snarlon are the ones I can think of) to 5.

@Sanglorian will change others once the PR has been merged.