### PR TITLE
refactor types (elements)

### DIFF
--- a/mods/tuxemon/db/element/aether.json
+++ b/mods/tuxemon/db/element/aether.json
@@ -1,0 +1,29 @@
+{
+  "slug": "aether",
+  "types": [
+    {
+      "against": "aether",
+      "multiplier": 1
+    },
+    {
+      "against": "earth",
+      "multiplier": 1
+    },
+    {
+      "against": "fire",
+      "multiplier": 1
+    },
+    {
+      "against": "metal",
+      "multiplier": 1
+    },
+    {
+      "against": "water",
+      "multiplier": 1
+    },
+    {
+      "against": "wood",
+      "multiplier": 1
+    }
+  ]
+}

--- a/mods/tuxemon/db/element/earth.json
+++ b/mods/tuxemon/db/element/earth.json
@@ -1,0 +1,29 @@
+{
+  "slug": "earth",
+  "types": [
+    {
+      "against": "aether",
+      "multiplier": 1
+    },
+    {
+      "against": "earth",
+      "multiplier": 1
+    },
+    {
+      "against": "fire",
+      "multiplier": 1
+    },
+    {
+      "against": "metal",
+      "multiplier": 0.5
+    },
+    {
+      "against": "water",
+      "multiplier": 2
+    },
+    {
+      "against": "wood",
+      "multiplier": 1
+    }
+  ]
+}

--- a/mods/tuxemon/db/element/fire.json
+++ b/mods/tuxemon/db/element/fire.json
@@ -1,0 +1,29 @@
+{
+  "slug": "fire",
+  "types": [
+    {
+      "against": "aether",
+      "multiplier": 1
+    },
+    {
+      "against": "earth",
+      "multiplier": 0.5
+    },
+    {
+      "against": "fire",
+      "multiplier": 1
+    },
+    {
+      "against": "metal",
+      "multiplier": 2
+    },
+    {
+      "against": "water",
+      "multiplier": 1
+    },
+    {
+      "against": "wood",
+      "multiplier": 1
+    }
+  ]
+}

--- a/mods/tuxemon/db/element/metal.json
+++ b/mods/tuxemon/db/element/metal.json
@@ -1,0 +1,29 @@
+{
+  "slug": "metal",
+  "types": [
+    {
+      "against": "aether",
+      "multiplier": 1
+    },
+    {
+      "against": "earth",
+      "multiplier": 1
+    },
+    {
+      "against": "fire",
+      "multiplier": 1
+    },
+    {
+      "against": "metal",
+      "multiplier": 1
+    },
+    {
+      "against": "water",
+      "multiplier": 0.5
+    },
+    {
+      "against": "wood",
+      "multiplier": 2
+    }
+  ]
+}

--- a/mods/tuxemon/db/element/water.json
+++ b/mods/tuxemon/db/element/water.json
@@ -1,0 +1,29 @@
+{
+  "slug": "water",
+  "types": [
+    {
+      "against": "aether",
+      "multiplier": 1
+    },
+    {
+      "against": "earth",
+      "multiplier": 1
+    },
+    {
+      "against": "fire",
+      "multiplier": 2
+    },
+    {
+      "against": "metal",
+      "multiplier": 1
+    },
+    {
+      "against": "water",
+      "multiplier": 1
+    },
+    {
+      "against": "wood",
+      "multiplier": 0.5
+    }
+  ]
+}

--- a/mods/tuxemon/db/element/wood.json
+++ b/mods/tuxemon/db/element/wood.json
@@ -1,0 +1,29 @@
+{
+  "slug": "wood",
+  "types": [
+    {
+      "against": "aether",
+      "multiplier": 1
+    },
+    {
+      "against": "earth",
+      "multiplier": 2
+    },
+    {
+      "against": "fire",
+      "multiplier": 0.5
+    },
+    {
+      "against": "metal",
+      "multiplier": 1
+    },
+    {
+      "against": "water",
+      "multiplier": 1
+    },
+    {
+      "against": "wood",
+      "multiplier": 1
+    }
+  ]
+}

--- a/mods/tuxemon/db/monster/d0llf1n.json
+++ b/mods/tuxemon/db/monster/d0llf1n.json
@@ -56,7 +56,6 @@
     "shape": "leviathan",
     "stage": "standalone",
     "types": [
-        "glitch",
         "water"
     ],
     "possible_genders": ["neuter"],

--- a/mods/tuxemon/db/monster/f7u1t3ra.json
+++ b/mods/tuxemon/db/monster/f7u1t3ra.json
@@ -56,7 +56,6 @@
     "shape": "flier",
     "stage": "standalone",
     "types": [
-        "glitch",
         "wood"
     ],
     "possible_genders": ["neuter"],

--- a/mods/tuxemon/db/monster/l3gk0.json
+++ b/mods/tuxemon/db/monster/l3gk0.json
@@ -56,7 +56,6 @@
     "shape": "serpent",
     "stage": "standalone",
     "types": [
-        "glitch",
         "wood"
     ],
     "possible_genders": ["neuter"],

--- a/mods/tuxemon/db/monster/r0ck1tt3n.json
+++ b/mods/tuxemon/db/monster/r0ck1tt3n.json
@@ -56,7 +56,6 @@
     "shape": "hunter",
     "stage": "standalone",
     "types": [
-        "glitch",
         "earth"
     ],
     "possible_genders": ["neuter"],

--- a/tuxemon/combat.py
+++ b/tuxemon/combat.py
@@ -273,18 +273,18 @@ def generic(
                 "combat_state_switch_both",
                 {
                     "user": attacker.name.upper(),
-                    "type1": T.translate(attacker.types[0]),
+                    "type1": T.translate(attacker.types[0].slug),
                     "target": defender.name.upper(),
-                    "type2": T.translate(defender.types[0]),
+                    "type2": T.translate(defender.types[0].slug),
                 },
             )
         else:
             if has_effect_param(tech, "switch", "target", "objective"):
                 monster = defender.name.upper()
-                _type = T.translate(defender.types[0])
+                _type = T.translate(defender.types[0].slug)
             if has_effect_param(tech, "switch", "user", "objective"):
                 monster = attacker.name.upper()
-                _type = T.translate(attacker.types[0])
+                _type = T.translate(attacker.types[0].slug)
             message = T.format(
                 "combat_state_switch",
                 {

--- a/tuxemon/element.py
+++ b/tuxemon/element.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from typing import Union
+
+from tuxemon.db import ElementType, db
+
+logger = logging.getLogger(__name__)
+
+
+class Element:
+    """An Element holds a list of types and multipliers."""
+
+    def __init__(self, slug: Union[str, None] = None) -> None:
+        if slug:
+            self.load(slug)
+
+    def load(self, slug: str) -> None:
+        """Loads an element."""
+
+        try:
+            results = db.lookup(slug, table="element")
+        except KeyError:
+            raise RuntimeError(f"Failed to find element with slug {slug}")
+
+        self.slug = results.slug
+        self.name = results.slug.name
+        self.types = results.types
+
+    def lookup_field(
+        self, element: ElementType, field: str
+    ) -> Union[float, None]:
+        """Looks up the element against for this element."""
+        for item in self.types:
+            if item.against == element and hasattr(item, field):
+                value = float(getattr(item, field))
+                return value
+        return None
+
+    def lookup_multiplier(self, element: ElementType) -> float:
+        """Looks up the element multiplier for this element."""
+        mult = self.lookup_field(element, "multiplier")
+
+        if mult is None:
+            mult = 1.0
+            logger.error(
+                f"Multiplier for element '{element}' not found in "
+                f"this element '{self.slug}'"
+            )
+        return mult

--- a/tuxemon/event/actions/spawn_monster.py
+++ b/tuxemon/event/actions/spawn_monster.py
@@ -85,28 +85,28 @@ class SpawnMonsterAction(EventAction):
         # matrix, it respects the types[0], strong against weak.
         # Mother (Water), Father (Earth)
         # Earth > Water => Child (Earth)
-        if mother.types[0].water:
-            if father.types[0].earth:
+        if mother.types[0].slug.water:
+            if father.types[0].slug.earth:
                 seed = father
             else:
                 seed = mother
-        elif mother.types[0].fire:
-            if father.types[0].water:
+        elif mother.types[0].slug.fire:
+            if father.types[0].slug.water:
                 seed = father
             else:
                 seed = mother
-        elif mother.types[0].wood:
-            if father.types[0].metal:
+        elif mother.types[0].slug.wood:
+            if father.types[0].slug.metal:
                 seed = father
             else:
                 seed = mother
-        elif mother.types[0].metal:
-            if father.types[0].fire:
+        elif mother.types[0].slug.metal:
+            if father.types[0].slug.fire:
                 seed = father
             else:
                 seed = mother
-        elif mother.types[0].earth:
-            if father.types[0].wood:
+        elif mother.types[0].slug.earth:
+            if father.types[0].slug.wood:
                 seed = father
             else:
                 seed = mother

--- a/tuxemon/event/conditions/monster_property.py
+++ b/tuxemon/event/conditions/monster_property.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+from tuxemon.db import ElementType
 from tuxemon.event import MapCondition
 from tuxemon.event.eventcondition import EventCondition
 from tuxemon.session import Session
@@ -83,7 +84,8 @@ class MonsterPropertyCondition(EventCondition):
                     return True
             # monster type (eg. earth, fire, etc)
             elif prop == "type":
-                if val in mon.types:
+                ele = ElementType(val)
+                if mon.has_type(ele):
                     return True
             # monster gender (eg. male, female or neuter)
             elif prop == "gender":

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -5,36 +5,20 @@ from __future__ import annotations
 import datetime as dt
 import logging
 import random
-from typing import TYPE_CHECKING, NamedTuple, Sequence, Tuple
+from typing import TYPE_CHECKING, Sequence, Tuple
 
 if TYPE_CHECKING:
-    from tuxemon.db import ElementType, MonsterModel
+    from tuxemon.db import MonsterModel
+    from tuxemon.element import Element
     from tuxemon.monster import Monster
     from tuxemon.technique.technique import Technique
 
 logger = logging.getLogger(__name__)
 
 
-class TypeChart(NamedTuple):
-    earth: float
-    fire: float
-    metal: float
-    water: float
-    wood: float
-
-
-TYPES = {
-    "earth": TypeChart(1, 1, 0.5, 2, 1),
-    "fire": TypeChart(0.5, 1, 2, 1, 1),
-    "metal": TypeChart(1, 1, 1, 0.5, 2),
-    "water": TypeChart(1, 2, 1, 1, 0.5),
-    "wood": TypeChart(2, 0.5, 1, 1, 1),
-}
-
-
 def simple_damage_multiplier(
-    attack_types: Sequence[ElementType],
-    target_types: Sequence[ElementType],
+    attack_types: Sequence[Element],
+    target_types: Sequence[Element],
 ) -> float:
     """
     Calculates damage multiplier based on strengths and weaknesses.
@@ -51,11 +35,12 @@ def simple_damage_multiplier(
     for attack_type in attack_types:
         for target_type in target_types:
             if target_type:
-                if attack_type == "aether" or target_type == "aether":
+                if (
+                    attack_type.slug == "aether"
+                    or target_type.slug == "aether"
+                ):
                     continue
-                body = TYPES.get(attack_type)
-                value = float(getattr(body, target_type))
-                m = value
+                m = attack_type.lookup_multiplier(target_type.slug)
 
     m = min(4, m)
     m = max(0.25, m)

--- a/tuxemon/item/conditions/type.py
+++ b/tuxemon/item/conditions/type.py
@@ -31,6 +31,6 @@ class TypeCondition(ItemCondition):
         else:
             elements.append(self.elements)
         for ele in target.types:
-            if ele in elements:
+            if ele.slug in elements:
                 ret = True
         return ret

--- a/tuxemon/item/effects/capture.py
+++ b/tuxemon/item/effects/capture.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import logging
 import random
+import uuid
 from dataclasses import dataclass
 from math import sqrt
 from typing import TYPE_CHECKING, Union
 
-from tuxemon.db import TasteWarm
+from tuxemon.db import ElementType, GenderType, TasteWarm
 from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
 
 if TYPE_CHECKING:
@@ -51,33 +52,33 @@ class CaptureEffect(ItemEffect):
                 if status.category == "positive":
                     status_category = "positive"
         # retrieves monster fighting (player)
-        iid = self.user.game_variables["iid_fighting_monster"]
+        iid = uuid.UUID(self.user.game_variables["iid_fighting_monster"])
         fighting_monster = self.user.find_monster_by_id(iid)
         # Check type tuxeball and address malus/bonus
         tuxeball_modifier = 1.0
         # type based tuxeball
         if item.slug == "tuxeball_earth":
-            if target.types[0] != "earth":
+            if target.types[0].slug != ElementType.earth:
                 tuxeball_modifier = 0.2
             else:
                 tuxeball_modifier = 1.5
         if item.slug == "tuxeball_fire":
-            if target.types[0] != "fire":
+            if target.types[0].slug != ElementType.fire:
                 tuxeball_modifier = 0.2
             else:
                 tuxeball_modifier = 1.5
         if item.slug == "tuxeball_metal":
-            if target.types[0] != "metal":
+            if target.types[0].slug != ElementType.metal:
                 tuxeball_modifier = 0.2
             else:
                 tuxeball_modifier = 1.5
         if item.slug == "tuxeball_water":
-            if target.types[0] != "water":
+            if target.types[0].slug != ElementType.water:
                 tuxeball_modifier = 0.2
             else:
                 tuxeball_modifier = 1.5
         if item.slug == "tuxeball_wood":
-            if target.types[0] != "wood":
+            if target.types[0].slug != ElementType.wood:
                 tuxeball_modifier = 0.2
             else:
                 tuxeball_modifier = 1.5
@@ -94,17 +95,17 @@ class CaptureEffect(ItemEffect):
             target.taste_warm = TasteWarm.zesty
         # gender based tuxeball
         if item.slug == "tuxeball_male":
-            if target.gender != "male":
+            if target.gender != GenderType.male:
                 tuxeball_modifier = 0.2
             else:
                 tuxeball_modifier = 1.5
         if item.slug == "tuxeball_female":
-            if target.gender != "female":
+            if target.gender != GenderType.female:
                 tuxeball_modifier = 0.2
             else:
                 tuxeball_modifier = 1.5
         if item.slug == "tuxeball_neuter":
-            if target.gender != "neuter":
+            if target.gender != GenderType.neuter:
                 tuxeball_modifier = 0.2
             else:
                 tuxeball_modifier = 1.5
@@ -120,12 +121,12 @@ class CaptureEffect(ItemEffect):
             tuxeball_modifier = crusher
         if fighting_monster:
             if item.slug == "tuxeball_xero":
-                if fighting_monster.types[0] != target.types[0]:
+                if fighting_monster.types[0].slug != target.types[0].slug:
                     tuxeball_modifier = 1.4
                 else:
                     tuxeball_modifier = 0.3
             if item.slug == "tuxeball_omni":
-                if fighting_monster.types[0] != target.types[0]:
+                if fighting_monster.types[0].slug != target.types[0].slug:
                     tuxeball_modifier = 0.3
                 else:
                     tuxeball_modifier = 1.4

--- a/tuxemon/item/effects/learn_mm.py
+++ b/tuxemon/item/effects/learn_mm.py
@@ -23,11 +23,12 @@ class LearnMmEffect(ItemEffect):
     """This effect teaches the target a random type technique."""
 
     name = "learn_mm"
-    element: ElementType
+    element: str
 
     def apply(
         self, item: Item, target: Union[Monster, None]
     ) -> LearnMmEffectResult:
+        ele = ElementType(self.element)
         assert target
         techs = list(db.database["technique"])
         # type moves
@@ -35,7 +36,7 @@ class LearnMmEffect(ItemEffect):
         for mov in techs:
             results = db.lookup(mov, table="technique")
             if results.randomly:
-                if self.element in results.types:
+                if ele in results.types:
                     filters.append(results.slug)
         # monster moves
         moves = []

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -25,6 +25,7 @@ from tuxemon.db import (
     TasteWarm,
     db,
 )
+from tuxemon.element import Element
 from tuxemon.locale import T
 from tuxemon.sprite import Sprite
 from tuxemon.technique.technique import Technique, decode_moves, encode_moves
@@ -240,8 +241,8 @@ class Monster:
         self.experience_modifier = 1
         self.total_experience = 0
 
-        self.types: List[ElementType] = []
-        self._types: List[ElementType] = []
+        self.types: List[Element] = []
+        self._types: List[Element] = []
         self.shape = MonsterShape.landrace
         self.randomly = True
 
@@ -319,9 +320,11 @@ class Monster:
         self.stage = results.stage or EvolutionStage.standalone
         self.taste_cold = self.set_taste_cold(self.taste_cold)
         self.taste_warm = self.set_taste_warm(self.taste_warm)
-        self.types = list(results.types)
-        # backup types
-        self._types = list(results.types)
+        # types
+        for _ele in results.types:
+            _element = Element(_ele)
+            self.types.append(_element)
+            self._types.append(_element)
 
         self.randomly = results.randomly or self.randomly
 
@@ -377,8 +380,8 @@ class Monster:
             self.combat_call = results.sounds.combat_call
             self.faint_call = results.sounds.faint_call
         else:
-            self.combat_call = f"sound_{self.types[0]}_call"
-            self.faint_call = f"sound_{self.types[0]}_faint"
+            self.combat_call = f"sound_{self.types[0].slug}_call"
+            self.faint_call = f"sound_{self.types[0].slug}_faint"
 
     def learn(
         self,
@@ -430,6 +433,17 @@ class Monster:
             return self.speed
         else:
             return value
+
+    def has_type(self, element: Optional[ElementType]) -> bool:
+        """
+        Returns TRUE if there is the type among the types.
+        """
+        ret: bool = False
+        if element:
+            eles = [ele for ele in self.types if ele.slug == element]
+            if eles:
+                ret = True
+        return ret
 
     def give_experience(self, amount: int = 1) -> None:
         """

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -905,16 +905,15 @@ class NPC(Entity[NPCState]):
     def has_type(self, element: Optional[ElementType]) -> bool:
         """
         Returns TRUE if there is the type in the party.
-
-        Parameters:
-            type: The slug name of the type.
         """
-        for mon in self.monsters:
-            if element in mon.types:
-                return True
-            else:
-                return False
-        return False
+        ret: bool = False
+        if element:
+            eles = []
+            for mon in self.monsters:
+                eles = [ele for ele in mon.types if ele.slug == element]
+            if eles:
+                ret = True
+        return ret
 
     def check_max_moves(self, session: Session, monster: Monster) -> None:
         """

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -398,7 +398,7 @@ class CombatState(CombatAnimations):
                 var = self.players[0].game_variables
                 var["battle_last_monster_name"] = monster_record.name
                 var["battle_last_monster_level"] = monster_record.level
-                var["battle_last_monster_type"] = monster_record.types[0]
+                var["battle_last_monster_type"] = monster_record.types[0].slug
                 var["battle_last_monster_category"] = monster_record.category
                 var["battle_last_monster_shape"] = monster_record.shape
                 # Avoid reset string to seen if monster has already been caught

--- a/tuxemon/states/combat/combat_menus.py
+++ b/tuxemon/states/combat/combat_menus.py
@@ -433,7 +433,7 @@ class CombatTargetMenuState(Menu[Monster]):
         self.targeting_map: DefaultDict[str, List[Monster]] = defaultdict(list)
         # avoid choosing multiple targets (aether type tech)
         if (
-            ElementType.aether in self.tech.types
+            self.tech.has_type(ElementType.aether)
             or self.tech.sort == TechSort.meta
         ):
             sprite = self.combat._monster_sprite_map[self.monster]

--- a/tuxemon/states/journal/__init__.py
+++ b/tuxemon/states/journal/__init__.py
@@ -266,12 +266,12 @@ class JournalInfoState(PygameMenuState):
         # types
         types = ""
         if len(monster.types) == 1:
-            types = T.translate(monster.types[0])
+            types = T.translate(monster.types[0].name)
         else:
             types = (
-                T.translate(monster.types[0])
+                T.translate(monster.types[0].name)
                 + " "
-                + T.translate(monster.types[1])
+                + T.translate(monster.types[1].name)
             )
         # weight and height
         unit = local_session.player.game_variables["unit_measure"]
@@ -521,12 +521,12 @@ class MonsterInfoState(PygameMenuState):
         # types
         types = ""
         if len(monster.types) == 1:
-            types = T.translate(monster.types[0])
+            types = T.translate(monster.types[0].slug)
         else:
             types = (
-                T.translate(monster.types[0])
+                T.translate(monster.types[0].slug)
                 + " "
-                + T.translate(monster.types[1])
+                + T.translate(monster.types[1].slug)
             )
         # weight and height
         results = db.lookup(monster.slug, table="monster")

--- a/tuxemon/states/techniques/__init__.py
+++ b/tuxemon/states/techniques/__init__.py
@@ -144,12 +144,12 @@ class TechniqueMenuState(Menu[Technique]):
             name = tech.name
             types = ""
             if len(tech.types) == 1:
-                types = T.translate(tech.types[0])
+                types = T.translate(tech.types[0].slug)
             else:
                 types = (
-                    T.translate(tech.types[0])
+                    T.translate(tech.types[0].slug)
                     + " "
-                    + T.translate(tech.types[1])
+                    + T.translate(tech.types[1].slug)
                 )
             image = self.shadow_text(name, bg=(128, 128, 128))
             if tech.counter == 0:

--- a/tuxemon/technique/effects/switch.py
+++ b/tuxemon/technique/effects/switch.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from tuxemon.db import ElementType
+from tuxemon.element import Element
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
 
 if TYPE_CHECKING:
@@ -39,8 +40,8 @@ class SwitchEffect(TechEffect):
     ) -> SwitchEffectResult:
         done: bool = False
         elements = list(ElementType)
-        if self.element in elements:
-            ele = ElementType(self.element)
+        if self.element != "random":
+            ele = Element(self.element)
             if ele not in target.types:
                 if self.objective == "user":
                     user.types = [ele]
@@ -52,17 +53,19 @@ class SwitchEffect(TechEffect):
                     user.types = [ele]
                     target.types = [ele]
                     done = True
-        if self.element == "random":
+        else:
             _user = random.choice(elements)
             _target = random.choice(elements)
+            ele_u = Element(_user)
+            ele_t = Element(_target)
             if self.objective == "user":
-                user.types = [_user]
+                user.types = [ele_u]
                 done = True
             elif self.objective == "target":
-                target.types = [_target]
+                target.types = [ele_t]
                 done = True
             elif self.objective == "both":
-                user.types = [_user]
-                target.types = [_target]
+                user.types = [ele_u]
+                target.types = [ele_t]
                 done = True
         return {"success": done}

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -25,6 +25,7 @@ from tuxemon.db import (
     db,
     process_targets,
 )
+from tuxemon.element import Element
 from tuxemon.graphics import animation_frame_files
 from tuxemon.locale import T
 from tuxemon.technique.techcondition import TechCondition
@@ -88,7 +89,7 @@ class Technique:
         self.sort = ""
         self.slug = ""
         self.target: Sequence[str] = []
-        self.types: List[ElementType] = []
+        self.types: List[Element] = []
         self.usable_on = False
         self.use_success = ""
         self.use_failure = ""
@@ -133,7 +134,10 @@ class Technique:
         self.icon = results.icon
         self.counter = self.counter
         self.counter_success = self.counter_success
-        self.types = list(results.types)
+        # types
+        for _ele in results.types:
+            _element = Element(_ele)
+            self.types.append(_element)
         # technique stats
         self.accuracy = results.accuracy or self.accuracy
         self.potency = results.potency or self.potency
@@ -349,6 +353,17 @@ class Technique:
         self.next_use = self.recharge_length
 
         return meta_result
+
+    def has_type(self, element: Optional[ElementType]) -> bool:
+        """
+        Returns TRUE if there is the type among the types.
+        """
+        ret: bool = False
+        if element:
+            eles = [ele for ele in self.types if ele.slug == element]
+            if eles:
+                ret = True
+        return ret
 
     def set_stats(self) -> None:
         """


### PR DESCRIPTION
PR refactors types (related to #1852 expansion of types)

At the moment types were listed inside the db.py.

This PR creates a folder in **DB** called **Element** where there is a JSON for each element.

eg earth.json
```
  "slug": "earth", <---- name of the element
  "types": [
    {
      "against": "aether", 
      "multiplier": 1
    },
    {
      "against": "earth",
      "multiplier": 1
    },
    {
      "against": "fire",
      "multiplier": 1
    },
    {
      "against": "metal",
      "multiplier": 0.5
    },
    {
      "against": "water", <-- if technique earth targets a water monster, then multiplier is 2
      "multiplier": 2
    },
    {
      "against": "wood",
      "multiplier": 1
    }
```
in this way elements will not be hardcoded inside the code, modders can add / remove elements, modders can change multiplier, they can do what they want. It'll make easier to expand elements.

Why? @freshreplicant wanted it, he talked about modules and how we needed it (@Sanglorian too)
(it looks like there are a bunch of modders stopped only by this, honestly I don't know)

my first thought was to create a separate self.elements (eg monster.elements and technique.elements), but at the end it was possible to integrate it inside the original monster.types / technique.types. I needed to fix a couple of things, but I'm satisfied by the result.