### PR TITLE
refactor shape

### DIFF
--- a/mods/tuxemon/db/shape/shapes.json
+++ b/mods/tuxemon/db/shape/shapes.json
@@ -1,0 +1,128 @@
+[
+    {
+      "slug": "blob",
+      "armour": 8,
+      "dodge": 4,
+      "hp": 8,
+      "melee": 4,
+      "ranged": 8,
+      "speed": 4
+    },
+    {
+      "slug": "brute",
+      "armour": 7,
+      "dodge": 5,
+      "hp": 7,
+      "melee": 8,
+      "ranged": 4,
+      "speed": 5
+    },
+    {
+      "slug": "dragon",
+      "armour": 7,
+      "dodge": 5,
+      "hp": 6,
+      "melee": 6,
+      "ranged": 6,
+      "speed": 6
+    },
+    {
+      "slug": "flier",
+      "armour": 5,
+      "dodge": 7,
+      "hp": 4,
+      "melee": 8,
+      "ranged": 4,
+      "speed": 8
+    },
+    {
+      "slug": "grub",
+      "armour": 7,
+      "dodge": 5,
+      "hp": 7,
+      "melee": 4,
+      "ranged": 8,
+      "speed": 5
+    },
+    {
+      "slug": "humanoid",
+      "armour": 5,
+      "dodge": 7,
+      "hp": 4,
+      "melee": 4,
+      "ranged": 8,
+      "speed": 8
+    },
+    {
+      "slug": "hunter",
+      "armour": 4,
+      "dodge": 8,
+      "hp": 5,
+      "melee": 8,
+      "ranged": 4,
+      "speed": 7
+    },
+    {
+      "slug": "landrace",
+      "armour": 8,
+      "dodge": 4,
+      "hp": 8,
+      "melee": 8,
+      "ranged": 4,
+      "speed": 4
+    },
+    {
+      "slug": "leviathan",
+      "armour": 8,
+      "dodge": 4,
+      "hp": 8,
+      "melee": 6,
+      "ranged": 6,
+      "speed": 4
+    },
+    {
+      "slug": "piscine",
+      "armour": 6,
+      "dodge": 6,
+      "hp": 8,
+      "melee": 6,
+      "ranged": 6,
+      "speed": 4
+    },
+    {
+      "slug": "polliwog",
+      "armour": 4,
+      "dodge": 8,
+      "hp": 5,
+      "melee": 4,
+      "ranged": 8,
+      "speed": 7
+    },
+    {
+      "slug": "serpent",
+      "armour": 6,
+      "dodge": 6,
+      "hp": 6,
+      "melee": 4,
+      "ranged": 8,
+      "speed": 6
+    },
+    {
+      "slug": "sprite",
+      "armour": 6,
+      "dodge": 6,
+      "hp": 4,
+      "melee": 6,
+      "ranged": 6,
+      "speed": 8
+    },
+    {
+      "slug": "varmint",
+      "armour": 6,
+      "dodge": 6,
+      "hp": 6,
+      "melee": 8,
+      "ranged": 4,
+      "speed": 6
+    }
+  ]

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -113,6 +113,7 @@ class OutputBattle(str, Enum):
 
 
 class MonsterShape(str, Enum):
+    default = "default"
     blob = "blob"
     brute = "brute"
     dragon = "dragon"
@@ -237,6 +238,22 @@ class ItemModel(BaseModel):
         if has.file(v):
             return v
         raise ValueError(f"the sprite {v} doesn't exist in the db")
+
+
+class ShapeModel(BaseModel):
+    slug: MonsterShape = Field(..., description="Slug of the shape")
+    armour: int = Field(..., description="Armour value")
+    dodge: int = Field(..., description="Dodge value")
+    hp: int = Field(..., description="HP value")
+    melee: int = Field(..., description="Melee value")
+    ranged: int = Field(..., description="Ranged value")
+    speed: int = Field(..., description="Speed value")
+
+    @validator("slug")
+    def translation_exists_shape(cls: ShapeModel, v: Any) -> Any:
+        if has.translation(v):
+            return v
+        raise ValueError(f"no translation exists with msgid: {v}")
 
 
 class MonsterMovesetItemModel(BaseModel):
@@ -756,6 +773,7 @@ class SoundModel(BaseModel):
 TableName = Literal[
     "economy",
     "element",
+    "shape",
     "template",
     "encounter",
     "environment",
@@ -770,6 +788,7 @@ TableName = Literal[
 DataModel = Union[
     EconomyModel,
     ElementModel,
+    ShapeModel,
     TemplateModel,
     EncounterModel,
     EnvironmentModel,
@@ -829,6 +848,7 @@ class JSONDatabase:
             "music",
             "economy",
             "element",
+            "shape",
             "template",
         ]
         self.preloaded: Dict[TableName, Dict[str, Any]] = {}
@@ -955,6 +975,9 @@ class JSONDatabase:
             elif table == "element":
                 element = ElementModel(**item)
                 self.database[table][element.slug] = element
+            elif table == "shape":
+                shape = ShapeModel(**item)
+                self.database[table][shape.slug] = shape
             elif table == "template":
                 template = TemplateModel(**item)
                 self.database[table][template.slug] = template
@@ -1019,6 +1042,10 @@ class JSONDatabase:
 
     @overload
     def lookup(self, slug: str, table: Literal["element"]) -> ElementModel:
+        pass
+
+    @overload
+    def lookup(self, slug: str, table: Literal["shape"]) -> ShapeModel:
         pass
 
     @overload
@@ -1107,6 +1134,7 @@ class JSONDatabase:
         table: Literal[
             "economy",
             "element",
+            "shape",
             "template",
             "encounter",
             "environment",

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -27,6 +27,7 @@ from tuxemon.db import (
 )
 from tuxemon.element import Element
 from tuxemon.locale import T
+from tuxemon.shape import Shape
 from tuxemon.sprite import Sprite
 from tuxemon.technique.technique import Technique, decode_moves, encode_moves
 
@@ -61,121 +62,6 @@ SIMPLE_PERSISTANCE_ATTRIBUTES = (
     "mod_hp",
     "plague",
 )
-
-SHAPES = {
-    MonsterShape.blob: {
-        "armour": 8,
-        "dodge": 4,
-        "hp": 8,
-        "melee": 4,
-        "ranged": 8,
-        "speed": 4,
-    },
-    MonsterShape.brute: {
-        "armour": 7,
-        "dodge": 5,
-        "hp": 7,
-        "melee": 8,
-        "ranged": 4,
-        "speed": 5,
-    },
-    MonsterShape.dragon: {
-        "armour": 7,
-        "dodge": 5,
-        "hp": 6,
-        "melee": 6,
-        "ranged": 6,
-        "speed": 6,
-    },
-    MonsterShape.flier: {
-        "armour": 5,
-        "dodge": 7,
-        "hp": 4,
-        "melee": 8,
-        "ranged": 4,
-        "speed": 8,
-    },
-    MonsterShape.grub: {
-        "armour": 7,
-        "dodge": 5,
-        "hp": 7,
-        "melee": 4,
-        "ranged": 8,
-        "speed": 5,
-    },
-    MonsterShape.humanoid: {
-        "armour": 5,
-        "dodge": 7,
-        "hp": 4,
-        "melee": 4,
-        "ranged": 8,
-        "speed": 8,
-    },
-    MonsterShape.hunter: {
-        "armour": 4,
-        "dodge": 8,
-        "hp": 5,
-        "melee": 8,
-        "ranged": 4,
-        "speed": 7,
-    },
-    MonsterShape.landrace: {
-        "armour": 8,
-        "dodge": 4,
-        "hp": 8,
-        "melee": 8,
-        "ranged": 4,
-        "speed": 4,
-    },
-    MonsterShape.leviathan: {
-        "armour": 8,
-        "dodge": 4,
-        "hp": 8,
-        "melee": 6,
-        "ranged": 6,
-        "speed": 4,
-    },
-    MonsterShape.piscine: {
-        "armour": 6,
-        "dodge": 6,
-        "hp": 8,
-        "melee": 6,
-        "ranged": 6,
-        "speed": 4,
-    },
-    MonsterShape.polliwog: {
-        "armour": 4,
-        "dodge": 8,
-        "hp": 5,
-        "melee": 4,
-        "ranged": 8,
-        "speed": 7,
-    },
-    MonsterShape.serpent: {
-        "armour": 6,
-        "dodge": 6,
-        "hp": 6,
-        "melee": 4,
-        "ranged": 8,
-        "speed": 6,
-    },
-    MonsterShape.sprite: {
-        "armour": 6,
-        "dodge": 6,
-        "hp": 4,
-        "melee": 6,
-        "ranged": 6,
-        "speed": 8,
-    },
-    MonsterShape.varmint: {
-        "armour": 6,
-        "dodge": 6,
-        "hp": 6,
-        "melee": 8,
-        "ranged": 4,
-        "speed": 6,
-    },
-}
 
 MAX_LEVEL = 999
 MAX_MOVES = 4
@@ -243,7 +129,7 @@ class Monster:
 
         self.types: List[Element] = []
         self._types: List[Element] = []
-        self.shape = MonsterShape.landrace
+        self.shape = MonsterShape.default
         self.randomly = True
 
         self.status: List[Technique] = []
@@ -316,7 +202,7 @@ class Monster:
         self.cat = results.category
         self.category = T.translate(f"cat_{self.cat}")
         self.plague = self.plague
-        self.shape = results.shape or MonsterShape.landrace
+        self.shape = results.shape or MonsterShape.default
         self.stage = results.stage or EvolutionStage.standalone
         self.taste_cold = self.set_taste_cold(self.taste_cold)
         self.taste_warm = self.set_taste_warm(self.taste_warm)
@@ -519,14 +405,13 @@ class Monster:
         level = self.level
 
         multiplier = level + 7
-        shape = SHAPES[self.shape]
-        self.armour = (shape["armour"] * multiplier) + self.mod_armour
-        self.dodge = (shape["dodge"] * multiplier) + self.mod_dodge
-        self.hp = (shape["hp"] * multiplier) + self.mod_hp
-        self.melee = (shape["melee"] * multiplier) + self.mod_melee
-        self.ranged = (shape["ranged"] * multiplier) + self.mod_ranged
-        self.speed = (shape["speed"] * multiplier) + self.mod_speed
-
+        shape = Shape(self.shape)
+        self.armour = (shape.armour * multiplier) + self.mod_armour
+        self.dodge = (shape.dodge * multiplier) + self.mod_dodge
+        self.hp = (shape.hp * multiplier) + self.mod_hp
+        self.melee = (shape.melee * multiplier) + self.mod_melee
+        self.ranged = (shape.ranged * multiplier) + self.mod_ranged
+        self.speed = (shape.speed * multiplier) + self.mod_speed
         # tastes
         self.armour += formula.check_taste(self, "armour")
         self.dodge += formula.check_taste(self, "dodge")

--- a/tuxemon/shape.py
+++ b/tuxemon/shape.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from typing import Union
+
+from tuxemon.db import MonsterShape, db
+
+logger = logging.getLogger(__name__)
+
+
+class Shape:
+    """A shape holds all the values (speed, ranged, etc.)."""
+
+    def __init__(self, slug: Union[str, None] = None) -> None:
+        self.slug = MonsterShape.landrace
+        self.armour: int = 1
+        self.dodge: int = 1
+        self.hp: int = 1
+        self.melee: int = 1
+        self.ranged: int = 1
+        self.speed: int = 1
+        if slug:
+            if slug == MonsterShape.default:
+                pass
+            else:
+                self.load(slug)
+
+    def load(self, slug: str) -> None:
+        """Loads shape."""
+
+        if slug == MonsterShape.default:
+            pass
+        else:
+            results = db.lookup(slug, table="shape")
+
+        self.slug = results.slug or self.slug
+        self.armour = results.armour or self.armour
+        self.dodge = results.dodge or self.dodge
+        self.hp = results.hp or self.hp
+        self.melee = results.melee or self.melee
+        self.ranged = results.ranged or self.ranged
+        self.speed = results.speed or self.speed


### PR DESCRIPTION
PR refactors shape and it creates a folder in the DB called **shape**, here inside a single, simple and easy to understand JSON called **shapes.json**

Why this? Because @Sanglorian was considering to add new body shapes. This will make everything easier for modders, they can add/remove shapes as well as correct values (speed, ranged, etc.) without being forced to edit the actual code.

Moreover it removes hardcoded things in monster.py

I was forced to add MonsterShape.default as well as this piece inside shape.py:
```
        if slug == MonsterShape.default:
            pass
        else:
            results = db.lookup(slug, table="shape")
```
because if not `test_catch_release.py` and `test_monster.py` were failing (unable to load the table)


tested, black, isort, no new typehints