### PR TITLE
fix dante and release

### DIFF
--- a/mods/tuxemon/maps/spyder_paper_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_paper_scoop.tmx
@@ -78,6 +78,7 @@
   <object id="62" name="Talk Dante" type="event" x="16" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_papertown_danteresting"/>
+    <property name="act2" value="set_variable dantefirst:yes"/>
     <property name="behav1" value="talk spyder_dante"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_paper_town.tmx
+++ b/mods/tuxemon/maps/spyder_paper_town.tmx
@@ -273,6 +273,7 @@
     <property name="act70" value="unlock_controls"/>
     <property name="cond1" value="is player_at"/>
     <property name="cond2" value="is party_size less_than,1"/>
+    <property name="cond3" value="is variable_set dantefirst:yes"/>
    </properties>
   </object>
   <object id="219" name="Chosen - Rockitten" type="event" x="512" y="128" width="16" height="16">

--- a/tuxemon/states/world/world_menus.py
+++ b/tuxemon/states/world/world_menus.py
@@ -177,7 +177,7 @@ class WorldMenuState(PygameMenuState):
                         partial(positive_answer, monster),
                     ),
                 ),
-                escape_key_exits=True,
+                escape_key_exits=False,
             )
 
         def open_monster_techs(monster: Monster) -> None:
@@ -191,33 +191,33 @@ class WorldMenuState(PygameMenuState):
             original = monster_menu.get_selected_item()
             if original:
                 monster = original.game_object
-                assert monster
-                open_choice_dialog(
-                    local_session,
-                    menu=(
-                        (
-                            "info",
-                            T.translate("monster_menu_info").upper(),
-                            partial(open_monster_stats, monster),
+                if monster:
+                    open_choice_dialog(
+                        local_session,
+                        menu=(
+                            (
+                                "info",
+                                T.translate("monster_menu_info").upper(),
+                                partial(open_monster_stats, monster),
+                            ),
+                            (
+                                "tech",
+                                T.translate("monster_menu_tech").upper(),
+                                partial(open_monster_techs, monster),
+                            ),
+                            (
+                                "move",
+                                T.translate("monster_menu_move").upper(),
+                                partial(select_first_monster, monster),
+                            ),
+                            (
+                                "release",
+                                T.translate("monster_menu_release").upper(),
+                                partial(release_monster_from_party, monster),
+                            ),
                         ),
-                        (
-                            "tech",
-                            T.translate("monster_menu_tech").upper(),
-                            partial(open_monster_techs, monster),
-                        ),
-                        (
-                            "move",
-                            T.translate("monster_menu_move").upper(),
-                            partial(select_first_monster, monster),
-                        ),
-                        (
-                            "release",
-                            T.translate("monster_menu_release").upper(),
-                            partial(release_monster_from_party, monster),
-                        ),
-                    ),
-                    escape_key_exits=True,
-                )
+                        escape_key_exits=True,
+                    )
 
         def handle_selection(menu_item: MenuItem[WorldMenuGameObj]) -> None:
             if "monster" in context:


### PR DESCRIPTION
fix #1908 

introduce variable, if the player doesn't talk with Dante, then it doesn't start the bin scene.

fixed a bug related to release, because it didn't update the hook, and if someone was trying to click as much as keys possible to speed up. Like pressing 100x the elevator button thinking it goes faster, then it would result in a crash.