### PR TITLE
fix hacker cotton town

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -6957,6 +6957,9 @@ msgstr "Hey, cool tuxemon! Can I see the receipt? \n ... \n Just kidding, I had 
 msgid "spyder_cottontown_stopthere"
 msgstr "Hey, that's not cool! You have to come to my talk at the cafe before you run off!"
 
+msgid "spyder_cottontown_followme"
+msgstr "The Cafe is located on the other side of these houses."
+
 msgid "spyder_cottontown_mom"
 msgstr "Well hello stranger! What are you doing going into a Cafe? \n You know caffeine is bad for you. I'm kidding! \n You're a grown up of 12 years old, you can do whatever you like! ... No alcohol .... \n But you should call home more often. I want someone to tell about my inventions. \n ... Oh, I forget, you haven't got a phone yet. Here's one I invented. I call it the Nu Phone! \n You can install all sorts of apps on it. It already has the Map App, so you'll never get lost!"
 

--- a/mods/tuxemon/maps/spyder_cotton_town.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_town.tmx
@@ -243,18 +243,22 @@
   </object>
   <object id="548" name="Stop! Cotton" type="event" x="608" y="448" width="16" height="32">
    <properties>
-    <property name="act1" value="player_stop"/>
+    <property name="act10" value="player_stop"/>
     <property name="act11" value="lock_controls"/>
-    <property name="act20" value="create_npc spyder_cottontown_hacker,35,35"/>
-    <property name="act21" value="pathfind spyder_cottontown_hacker,35,29"/>
-    <property name="act30" value="pathfind spyder_cottontown_hacker,36,29"/>
+    <property name="act20" value="create_npc spyder_cottontown_hacker,23,23"/>
+    <property name="act30" value="pathfind_to_player spyder_cottontown_hacker,left"/>
     <property name="act40" value="translated_dialog spyder_cottontown_stopthere"/>
-    <property name="act50" value="pathfind player,36,28"/>
-    <property name="act60" value="pathfind spyder_cottontown_hacker,35,35"/>
+    <property name="act50" value="pathfind player,33,29"/>
+    <property name="act51" value="wait 0.5"/>
+    <property name="act52" value="pathfind_to_player spyder_cottontown_hacker,left"/>
+    <property name="act53" value="wait 0.5"/>
+    <property name="act54" value="translated_dialog spyder_cottontown_followme"/>
+    <property name="act55" value="wait 0.5"/>
+    <property name="act60" value="pathfind spyder_cottontown_hacker,23,23"/>
     <property name="act80" value="remove_npc spyder_cottontown_hacker"/>
     <property name="act90" value="unlock_controls"/>
     <property name="cond1" value="is player_at"/>
-    <property name="cond3" value="not variable_set visitedcottoncafe:yes"/>
+    <property name="cond2" value="not variable_set visitedcottoncafe:yes"/>
    </properties>
   </object>
   <object id="551" name="Teleport to Art Shop" type="event" x="256" y="256" width="16" height="16">


### PR DESCRIPTION
fix #1912 (moved my reply here)

PR fixes event (stop) in Cotton Town
- changes coordinates (original coordinates where 35,35, while the right ones are 23,23 - in this way the player can see the hacker going north);
- removes double pathfind;
- fixes numeration;
- adds dialogue (the hacker before disappearing stops again close to the player and says - see below - just to make sure the player can find the cafe);
- adds movements and pauses;

before:
```
    <property name="act1" value="player_stop"/>
    <property name="act11" value="lock_controls"/>
    <property name="act20" value="create_npc spyder_cottontown_hacker,35,35"/>
    <property name="act21" value="pathfind spyder_cottontown_hacker,35,29"/>
    <property name="act30" value="pathfind spyder_cottontown_hacker,36,29"/>
    <property name="act40" value="translated_dialog spyder_cottontown_stopthere"/>
    <property name="act50" value="pathfind player,36,28"/>
    <property name="act60" value="pathfind spyder_cottontown_hacker,35,35"/>
    <property name="act80" value="remove_npc spyder_cottontown_hacker"/>
    <property name="act90" value="unlock_controls"/>
    <property name="cond1" value="is player_at"/>
    <property name="cond3" value="not variable_set visitedcottoncafe:yes"/>
```
after:
```
    <property name="act10" value="player_stop"/>
    <property name="act11" value="lock_controls"/>
    <property name="act20" value="create_npc spyder_cottontown_hacker,23,23"/>
    <property name="act30" value="pathfind_to_player spyder_cottontown_hacker,left"/>
    <property name="act40" value="translated_dialog spyder_cottontown_stopthere"/>
    <property name="act50" value="pathfind player,33,29"/>
    <property name="act51" value="wait 0.5"/>
    <property name="act52" value="pathfind_to_player spyder_cottontown_hacker,left"/>
    <property name="act53" value="wait 0.5"/>
    <property name="act54" value="translated_dialog spyder_cottontown_followme"/>
    <property name="act55" value="wait 0.5"/>
    <property name="act60" value="pathfind spyder_cottontown_hacker,23,23"/>
    <property name="act80" value="remove_npc spyder_cottontown_hacker"/>
    <property name="act90" value="unlock_controls"/>
    <property name="cond1" value="is player_at"/>
    <property name="cond2" value="not variable_set visitedcottoncafe:yes"/>
```
it cleans up the event (double pathfinding was pointless) and it adds an additional dialogue:
`The Cafe is located on the other side of these houses.`

@Sanglorian if you have a better dialogue, then feel free to tell me.