### PR TITLE
lock change bg

### DIFF
--- a/mods/tuxemon/maps/debug.tmx
+++ b/mods/tuxemon/maps/debug.tmx
@@ -1,31 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="4" height="4" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="11">
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="8" height="8" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="11">
  <properties>
   <property name="scenario" value="debug"/>
   <property name="slug" value="debug"/>
   <property name="types" value="notype"/>
  </properties>
- <layer id="1" name="Tile Layer 1" width="4" height="4">
+ <layer id="1" name="Tile Layer 1" width="8" height="8">
   <data encoding="base64" compression="zlib">
-   eAFjYKAMAAAAQAAB
+   eAFjYBjZAAABAAAB
   </data>
  </layer>
- <layer id="2" name="Tile Layer 2" width="4" height="4">
+ <layer id="2" name="Tile Layer 2" width="8" height="8">
   <data encoding="base64" compression="zlib">
-   eAFjYKAMAAAAQAAB
+   eAFjYBjZAAABAAAB
   </data>
  </layer>
- <layer id="3" name="Tile Layer 3" width="4" height="4">
+ <layer id="3" name="Tile Layer 3" width="8" height="8">
   <data encoding="base64" compression="zlib">
-   eAFjYKAMAAAAQAAB
+   eAFjYBjZAAABAAAB
   </data>
  </layer>
- <objectgroup color="#ff0000" id="4" name="Collisions">
-  <object id="3" type="collision" x="0" y="0" width="16" height="64"/>
-  <object id="4" type="collision" x="48" y="0" width="16" height="64"/>
-  <object id="5" type="collision" x="16" y="0" width="32" height="16"/>
-  <object id="6" type="collision" x="16" y="48" width="32" height="16"/>
- </objectgroup>
+ <objectgroup color="#ff0000" id="4" name="Collisions"/>
  <objectgroup color="#ffff00" id="5" name="Event">
   <object id="7" name="Scenario" type="event" x="0" y="0" width="16" height="16">
    <properties>

--- a/tuxemon/states/bg/__init__.py
+++ b/tuxemon/states/bg/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Callable
+from typing import Callable, Optional
 
 import pygame_menu
 from pygame_menu import locals
@@ -12,6 +12,7 @@ from pygame_menu.locals import POSITION_CENTER
 from tuxemon import prepare, tools
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.menu.theme import get_theme
+from tuxemon.platform.events import PlayerInput
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +21,10 @@ MenuGameObj = Callable[[], object]
 
 
 class BgState(PygameMenuState):
-    """Menu for the change of backgroun"""
+    """Menu for the change of background"""
+
+    def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
+        return None
 
     def __init__(self, background: str) -> None:
         width, height = prepare.SCREEN_SIZE


### PR DESCRIPTION
In #1909 it could be that the cause of wrong teleport was caused by a sequence of keys.
I noticed some points (when the bg changes) during the first phases where someone can "click".
When I say click, I mean furiously clicking, maybe thinking to speed up things.

For this reason I have added:
```
    def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
        return None
```
to the change bg, when it changes then it's automatically locked (exactly as by using lock_controls)

tested by furiously pressing enter+esc+shit for all the intro sequence (+ Mart scene in Spyder).
Nothing happens.