### PR TITLE
change day and night

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -2654,6 +2654,15 @@ msgstr "Cancel Key"
 msgid "menu_back_key"
 msgstr "Back Key"
 
+msgid "menu_music_daynight"
+msgstr "Day / Night"
+
+msgid "enable"
+msgstr "Enable"
+
+msgid "disable"
+msgstr "Disable"
+
 msgid "menu_music_volume"
 msgstr "Music Volume"
 

--- a/mods/tuxemon/maps/debug.tmx
+++ b/mods/tuxemon/maps/debug.tmx
@@ -42,6 +42,7 @@
     <property name="act4" value="transition_teleport spyder_bedroom.tmx,4,4,0.3"/>
     <property name="act5" value="set_money player,250"/>
     <property name="act6" value="set_variable spyder_starting_money:yes"/>
+    <property name="act7" value="set_variable change_day_night:Enable"/>
     <property name="cond1" value="is variable_set scenario_choice:spyder_campaign"/>
     <property name="cond2" value="not variable_set spyder_starting_money:yes"/>
     <property name="cond3" value="not variable_set gender_choice:gender_male"/>
@@ -56,6 +57,7 @@
     <property name="act4" value="transition_teleport player_house_bedroom.tmx,4,4,0.3"/>
     <property name="act5" value="set_money player,500"/>
     <property name="act6" value="set_variable xero_starting_money:yes"/>
+    <property name="act7" value="set_variable change_day_night:Disable"/>
     <property name="cond1" value="is variable_set scenario_choice:xero_campaign"/>
     <property name="cond2" value="not variable_set xero_starting_money:yes"/>
     <property name="cond3" value="not variable_set gender_choice:gender_male"/>

--- a/tuxemon/save_upgrader.py
+++ b/tuxemon/save_upgrader.py
@@ -70,6 +70,8 @@ def upgrade_save(save_data: Dict[str, Any]) -> SaveData:
         save_data["game_variables"]["sound_volume"] = 0.2
     if "unit_measure" not in save_data["game_variables"]:
         save_data["game_variables"]["unit_measure"] = "Metric"
+    if "change_day_night" not in save_data["game_variables"]:
+        save_data["game_variables"]["change_day_night"] = "Disable"
     if "hemisphere" not in save_data["game_variables"]:
         save_data["game_variables"]["hemisphere"] = "Northern"
     if "gender_choice" not in save_data["game_variables"]:

--- a/tuxemon/states/control/__init__.py
+++ b/tuxemon/states/control/__init__.py
@@ -156,6 +156,7 @@ class ControlState(PygameMenuState):
                 self.client.push_state, state, **change_state_kwargs
             )
 
+        player = local_session.player
         display_buttons = {}
         key_names = config.get_custom_pygame_keyboard_controls_names(
             tuxe_config.cfg
@@ -217,25 +218,26 @@ class ControlState(PygameMenuState):
         default_sound: int = 20
         default_unit: int = 0
         default_hemi: int = 0
-        if local_session.player:
+        default_dn: int = 0
+        if player:
             default_music = int(
-                float(local_session.player.game_variables["music_volume"])
-                * 100
+                float(player.game_variables["music_volume"]) * 100
             )
             default_sound = int(
-                float(local_session.player.game_variables["sound_volume"])
-                * 100
+                float(player.game_variables["sound_volume"]) * 100
             )
-            if local_session.player.game_variables["unit_measure"] == METRIC:
+            if player.game_variables["unit_measure"] == METRIC:
                 default_unit = 0
-            elif (
-                local_session.player.game_variables["unit_measure"] == IMPERIAL
-            ):
+            elif player.game_variables["unit_measure"] == IMPERIAL:
                 default_unit = 1
-            if local_session.player.game_variables["hemisphere"] == NORTHERN:
+            if player.game_variables["hemisphere"] == NORTHERN:
                 default_hemi = 0
-            elif local_session.player.game_variables["hemisphere"] == SOUTHERN:
+            elif player.game_variables["hemisphere"] == SOUTHERN:
                 default_hemi = 1
+            if player.game_variables["change_day_night"] == "Disable":
+                default_dn = 0
+            elif player.game_variables["change_day_night"] == "Enable":
+                default_dn = 1
 
         music = menu.add.range_slider(
             title=T.translate("menu_music_volume").upper(),
@@ -260,19 +262,15 @@ class ControlState(PygameMenuState):
             """
             Updates the value.
             """
-            if local_session.player:
-                local_session.player.game_variables["music_volume"] = round(
-                    val / 100, 1
-                )
+            if player:
+                player.game_variables["music_volume"] = round(val / 100, 1)
 
         def on_change_sound(val: int) -> None:
             """
             Updates the value.
             """
-            if local_session.player:
-                local_session.player.game_variables["sound_volume"] = round(
-                    val / 100, 1
-                )
+            if player:
+                player.game_variables["sound_volume"] = round(val / 100, 1)
 
         music.set_onchange(on_change_music)
         sound.set_onchange(on_change_sound)
@@ -281,8 +279,8 @@ class ControlState(PygameMenuState):
             """
             Updates the value.
             """
-            if local_session.player:
-                local_session.player.game_variables["unit_measure"] = label
+            if player:
+                player.game_variables["unit_measure"] = label
 
         metric = T.translate("menu_units_metric")
         imperial = T.translate("menu_units_imperial")
@@ -302,8 +300,8 @@ class ControlState(PygameMenuState):
             """
             Updates the value.
             """
-            if local_session.player:
-                local_session.player.game_variables["hemisphere"] = label
+            if player:
+                player.game_variables["hemisphere"] = label
 
         north_hemi = T.translate("menu_hemisphere_north")
         south_hemi = T.translate("menu_hemisphere_south")
@@ -316,6 +314,27 @@ class ControlState(PygameMenuState):
             default=default_hemi,
             style="fancy",
             onchange=on_change_hemisphere,
+            font_size=20,
+        )
+
+        def on_change_daynight(value: Any, label: str) -> None:
+            """
+            Updates the value.
+            """
+            if player:
+                player.game_variables["change_day_night"] = label
+
+        off = T.translate("disable")
+        on = T.translate("enable")
+        dayandnight: List[Tuple[Any, ...]] = []
+        dayandnight = [(off, off), (on, on)]
+        menu.add.selector(
+            title=T.translate("menu_music_daynight").upper(),
+            items=dayandnight,
+            selector_id="dayandnight",
+            default=default_dn,
+            style="fancy",
+            onchange=on_change_daynight,
             font_size=20,
         )
 

--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -556,6 +556,19 @@ class WorldState(state.State):
         if prepare.CONFIG.collision_map:
             self.debug_drawing(surface)
 
+        # If triggers night color only at night (2200-0400) outside
+        game_variable = self.player.game_variables
+        if not self.client.map_inside:
+            if (
+                game_variable["stage_of_day"] == "night"
+                and game_variable["change_day_night"] == "Enable"
+            ):
+                game_surf = pygame.surface.Surface(
+                    surface.get_size(), pygame.SRCALPHA
+                )
+                game_surf.fill([0, 0, 128, 128])
+                surface.blit(game_surf, (0, 0))
+
     ####################################################
     #            Pathfinding and Collisions            #
     ####################################################


### PR DESCRIPTION
fix #1823

PR adds the change of graphics between day and night.

The option is set as DISABLED at the beginning, but it can be ENABLED, see below the menu options screen, last line:
![Screenshot from 2023-06-07 11-02-05](https://github.com/Tuxemon/Tuxemon/assets/64643719/67d3b102-0711-4b6a-b516-17db282712f5)
if enabled, this is the results, it's simply a BLUE (0, 0, 128) with a transparency.
![Screenshot from 2023-06-07 10-26-36](https://github.com/Tuxemon/Tuxemon/assets/64643719/7f1dc186-4679-4d48-a0da-65cbcd227f66)

NB: if ENABLED the change of color will happen only FROM 20:00 TO 04:00. It can be DISABLED any time. Moreover the darkness will touch only the maps OUTSIDE, so all the maps with this `<property name="inside" type="bool" value="true"/>` will stay normal color (eg centers, shops, caves, etc.)

@Sanglorian Spyder is ok. Eventually we can enable it by default at the beginning. Let me know.

@Qiangong2 if these maps are inside: **taba_ba_br_1**, **taba_ba_foyer**, **taba_ba_main** and **taba_ba_passageway_1** then we can add this `<property name="inside" type="bool" value="true"/>` in the tmx files. So we can fix Xero, alternatively I can hide the menu day/night for Xero. Let me know, eventually I have the PR ready for both.