### PR TITLE
additions capturing process

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -1044,8 +1044,17 @@ msgstr "Wrong!"
 msgid "attempting_capture"
 msgstr "Attempting capture..."
 
+msgid "captured_failed"
+msgstr "Not this time! The capture failed!"
+
 msgid "gotcha"
 msgstr "Gotcha!"
+
+msgid "gotcha_kennel"
+msgstr "{name} has been put in the kennel!"
+
+msgid "gotcha_team"
+msgstr "{name} has joined the team!"
 
 msgid "not_implemented"
 msgstr "This feature is not yet implemented."

--- a/tuxemon/states/combat/combat_animations.py
+++ b/tuxemon/states/combat/combat_animations.py
@@ -747,20 +747,38 @@ class CombatAnimations(ABC, Menu[None]):
             # leave a 0.6s wait between each shake
             shake_ball(1.8 + i * 1.0)
 
+        combat._captured_mon = monster
         if is_captured:
             self.task(kill, 2 + num_shakes)
             action_time = num_shakes + 1.8
             # Tuxepedia: set monster as caught (2)
+            if self.players[0].tuxepedia[monster.slug] == SeenStatus.seen:
+                combat._new_tuxepedia = True
             self.players[0].tuxepedia[monster.slug] = SeenStatus.caught
             # Display 'Gotcha!' first.
-            self.task(combat.end_combat, action_time + 0.5)
+            self.task(combat.end_combat, action_time + 4)
             gotcha = T.translate("gotcha")
+            combat._captured = True
+            info = None
+            # if party
+            if len(combat.players[0].monsters) >= 6:
+                info = T.format(
+                    "gotcha_kennel",
+                    {"name": monster.name.upper()},
+                )
+            else:
+                info = T.format(
+                    "gotcha_team",
+                    {"name": monster.name.upper()},
+                )
+            if info:
+                gotcha += "\n" + info
+                action_time += len(gotcha) * 0.02
             self.task(
                 partial(self.alert, gotcha),
                 action_time,
             )
             self._animation_in_progress = True
-            return
         else:
             breakout_delay = 1.8 + num_shakes * 1.0
             self.task(  # make the monster appear again!


### PR DESCRIPTION
fix #1922 

> When a monster escapes the tuxeball, a message like "Not this time! The capture failed." would explain what had happened.

Done

> When the monster is captured, as well as "Gotcha!", if it could say either: "SPECIES NAME has been put in the kennel" or "SPECIES NAME has joined the team".

Done

> If the monster hasn't already been captured or otherwise acquired, it could say: "You add a page for SPECIES NAME to Tuxepedia" and then show the monster's Tuxepedia entry until the player presses enter.

Done, but the player needs to press return.
This is a general rule, because monster info is a state and as all the stats, enter opens (enter), return closes (shift).

> This is getting even more ambitious, but would it be possible to give monsters nicknames when they're acquired? Something like "Would you like to nickname your new SPECIES NAME?" and then a keyboard like that for naming the player?

We can, but I didn't implement it.
It sounds like something other mods don't need and having something popping up after each capture can be annoying.
Eventually we can implement the renaming app for the Spyder campaign.
Let me know.