### PR TITLE
sync daytime + maps fixes

### DIFF
--- a/mods/tuxemon/maps/37707_tower.tmx
+++ b/mods/tuxemon/maps/37707_tower.tmx
@@ -32,7 +32,7 @@
    eAFbrs1AM7AcaDYI0woQaz42N2ATQ3fnqPnoIYLKxxY+2MKVXLFR8zHDG1lkNHyQQwOzrCE2fFBNwc1DT8ej5qOG1UgJH1i8k0MjhxhMP7IYNdnDxXyYP2hBAwBC723t
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="30" type="collision" x="16" y="0" width="128" height="48"/>
   <object id="31" type="collision" x="240" y="0" width="128" height="48"/>
   <object id="32" type="collision" x="144" y="0" width="96" height="32"/>

--- a/mods/tuxemon/maps/37707_town.tmx
+++ b/mods/tuxemon/maps/37707_town.tmx
@@ -50,7 +50,7 @@
    eAHt0MEJwDAMA0BDM072SLNNm/0f8QyBPlxOoKdAXIQQIECAAAECBAj8UWBcEXd2Zivmyd9vdhX9X9HcZwIECBAgQIAAgTOB3s52VgS+FtgUrwJu
   </data>
  </layer>
- <objectgroup color="#ff0000" id="6" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collisions">
   <properties>
    <property name="Collision" value=""/>
   </properties>

--- a/mods/tuxemon/maps/37707_town_missing.tmx
+++ b/mods/tuxemon/maps/37707_town_missing.tmx
@@ -302,7 +302,7 @@
    eAHt0LENACAMA8E0DA/UwLpkjURn6XvrIowAAQIECBAgQKCjwBwRK9tZxZ38fbNX9H9Fc58JECBAgAABAgQIEOgl8AHnqwN/
   </data>
  </layer>
- <objectgroup color="#ff0000" id="6" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collisions">
   <properties>
    <property name="Collision" value=""/>
   </properties>

--- a/mods/tuxemon/maps/candy_town.tmx
+++ b/mods/tuxemon/maps/candy_town.tmx
@@ -36,7 +36,7 @@
    eAHt2EkOgkAUANHvuBGXxpuoeAv1Xk6ndFqJunIqr2AQbVM/eUvopOiGhIjfmFo3oo4GmmihDccCZRRwf5VR0Xt8qsAmi9hihz0OcCyQQoFJJ2L6hhnX/MsMOK9DjJBjDMcCFkijwJx30QJLrLCGYwELpFHgyPe2wAlnXOBYwAJpFLhyXm+44/E6u/77q/zB9XuVL+mCFvhqgSczIxjC
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="118" type="collision" x="0" y="416" width="80" height="224"/>
   <object id="119" type="collision" x="224" y="624" width="416" height="16"/>
   <object id="120" type="collision" x="32" y="0" width="384" height="32"/>

--- a/mods/tuxemon/maps/city1_mart_junkyard.tmx
+++ b/mods/tuxemon/maps/city1_mart_junkyard.tmx
@@ -29,7 +29,7 @@
    eAFjYBgFoyEwGgKjITAaAqMhMBoCoyEwGgL0CAFLRgYGKyAeBSM3BAD2YgB2
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="1" type="collision" x="32" y="96" width="48" height="16"/>
   <object id="2" type="collision" x="16" y="144" width="16" height="16"/>
   <object id="3" type="collision" x="128" y="224" width="48" height="32"/>

--- a/mods/tuxemon/maps/citypark.tmx
+++ b/mods/tuxemon/maps/citypark.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="124">
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="126">
  <properties>
   <property name="east" value="leather_town"/>
   <property name="edges" value="clamped"/>
@@ -38,7 +38,7 @@
    eAHt1LEJACAQA8DUjuD+89mI1jqF8nCB9OEePpHKAqNXXm87AQIVBfydilezmQABAgQIECBAgACBHwKzJet23woBAgQIvBc46kcFDQ==
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="1" type="collision" x="0" y="0" width="32" height="640"/>
   <object id="2" type="collision" x="32" y="0" width="496" height="32"/>
   <object id="4" type="collision" x="64" y="32" width="192" height="32"/>
@@ -472,6 +472,18 @@
     <property name="act20" value="player_face right"/>
     <property name="cond10" value="is player_at"/>
     <property name="cond20" value="is player_facing right"/>
+   </properties>
+  </object>
+  <object id="124" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_variable environment:grass"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
+   </properties>
+  </object>
+  <object id="125" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_variable environment:night_grass"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/cotton_cathedral.tmx
+++ b/mods/tuxemon/maps/cotton_cathedral.tmx
@@ -36,7 +36,7 @@
    eAFjYBje4LYcA8MdJHwXyB4F1AkBAH4YBOM=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="5" type="collision" x="32" y="112" width="32" height="32"/>
   <object id="6" type="collision" x="160" y="48" width="32" height="16"/>
   <object id="7" type="collision" x="144" y="48" width="16" height="32"/>

--- a/mods/tuxemon/maps/dojo2.tmx
+++ b/mods/tuxemon/maps/dojo2.tmx
@@ -61,7 +61,7 @@
   </object>
   <object id="19" name="Player Spawn" type="event" x="192" y="160" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ff0000" id="6" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collisions">
   <object id="1" type="collision" x="32" y="80" width="16" height="112"/>
   <object id="2" type="collision" x="32" y="80" width="48" height="32"/>
   <object id="3" type="collision" x="64" y="16" width="16" height="96"/>

--- a/mods/tuxemon/maps/dojo3.tmx
+++ b/mods/tuxemon/maps/dojo3.tmx
@@ -48,7 +48,7 @@
   </object>
   <object id="19" name="Player Spawn" type="event" x="176" y="144" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="1" type="collision" x="32" y="80" width="16" height="112"/>
   <object id="2" type="collision" x="32" y="80" width="48" height="32"/>
   <object id="3" type="collision" x="64" y="16" width="16" height="96"/>

--- a/mods/tuxemon/maps/dragonscave.tmx
+++ b/mods/tuxemon/maps/dragonscave.tmx
@@ -34,7 +34,7 @@
    eAHtlNENwjAMRCuxEDANMA0wDWwDG+ETnHocdpoiJH4aKaSJk2f74rBfDcP+D33oaHPiOkQOrbabmePCe1dz0a/9Tm5RX5uib2N9rn6t2kdtVrz3W+ufVTz4Whd5Vfli/R49y6EVe7Z/au2XvEvEfI5+jH4t4p+Kh3ay9Aa+ZWYs3EmlMWLwxrgwQjNtGUvt+IYubK6P87yWsvjJ4qhn8JbwZtCy2OgPNtYg9z9Pfb4PnlE/0IKxuZ/eGJRHFmLQdWoPZvU2GJ/eKdc8NvJaI856DOT5eotDm/M0V2qejTzvo/NU74yDNa87ZToPNuZb8Somc3N/PTFmTMaR3WMvU+8MvIxFPdQf3wdGfSPO0zk40OD06nj7mT/6Qc56Hus6p57Yh5ax/L70vPp5EsbfjDVax69enu6jDvrfB6L7vEW+qu3odVqH6v8gY7pf1cVtrAUdwdR6uMfc7cijh6XnWt9eC773AXz85d8=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="2" type="collision" x="240" y="336">
    <polygon points="0,0 0,16 16,16 16,0"/>
   </object>

--- a/mods/tuxemon/maps/dryadsgrove.tmx
+++ b/mods/tuxemon/maps/dryadsgrove.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="41">
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="43">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="xero"/>
@@ -169,5 +169,17 @@
    </properties>
   </object>
   <object id="39" name="Player Spawn" type="event" x="32" y="112" width="16" height="16"/>
+  <object id="41" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_variable environment:grass"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
+   </properties>
+  </object>
+  <object id="42" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_variable environment:night_grass"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
+   </properties>
+  </object>
  </objectgroup>
 </map>

--- a/mods/tuxemon/maps/flower_city.tmx
+++ b/mods/tuxemon/maps/flower_city.tmx
@@ -38,7 +38,7 @@
    eAHNWElOAzEQdBA7EnBGkOQKF7Y/AC8g24n1J3DmxCbEL4ATPwGJwB+AI9VKSrHM2HjJELdU6rHd7W5XSs4kSik1vqTUBGAzc51j3dtyzXmpwzxZ05/N8Wq/J/Frjv7MdY51b/ZhG0sd5r3WBs/sk2sc08t+Eq/b/qQ+KveZfbEKx/Sc1/3ZP/an1+WzcJezCXe5GnVHn1uf1B19bv1JP6PQ392iPxPCnete9t8pLNKnR+rOdS+HVfWL9ulNdqLucuVPehQOy+CvMaVUE2gBbaAD0Hz5k/ic9Xex0DtRKH8H4OIQOAKOgRPgFLBZw/iODOFP9ixbf+dGf1KTPdq8xNCEP/O9hWs+PvYdx9Yb53m/mPy9zSrVBXytrHcc3i+h+vur71B9uvYjhxLzAM4egacA7lx7D2ONHIbsdQm9XwHXwA1wC7gsVp/kztSfq1bRWndeqXfgAyiyWH2SO+ov+vPFPVoBxvr3aVGPsXPkMDY/NE+u8WlgBhCZzwEuI4eumGGurWOzDWAT2AK2AZuRO+ov+vO1FSiYb2CuCbSANtABbEbuqD9b3CjnyWFKD/cB7+uhdchhaJ4e/1xSf+SO+tNr5vBM7srQ3ycO+AV8Jx6UHCZu8yu9WlGqBtSBFCOHKXsU5e6gr11gL7G/F/yflqv+Vuq9k5ehP5PTWB1V0eN/8BejI/7mEP5izyc8MbcsLzVCzsdzLdclc5DLPYbtpYbv2dkbteublxrne2Y5i26+eSlxP45tYoE=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="6" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collisions">
   <object id="120" type="collision" x="0" y="608" width="640" height="32"/>
   <object id="121" type="collision" x="0" y="96" width="32" height="32"/>
   <object id="122" type="collision" x="0" y="128" width="16" height="480"/>

--- a/mods/tuxemon/maps/gadget_store1.tmx
+++ b/mods/tuxemon/maps/gadget_store1.tmx
@@ -29,7 +29,7 @@
    eAFjYBgFgyUE3BUGi0tG3TFSQwAABxsAaA==
   </data>
  </layer>
- <objectgroup color="#ff0000" id="6" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collisions">
   <object id="3" type="collision" x="0" y="192" width="112" height="16"/>
   <object id="4" type="collision" x="144" y="192" width="176" height="16"/>
   <object id="5" type="collision" x="0" y="0" width="320" height="48"/>

--- a/mods/tuxemon/maps/healing_center.tmx
+++ b/mods/tuxemon/maps/healing_center.tmx
@@ -36,7 +36,7 @@
    eAFjYBje4LYcA8MdJHwXyB4F1AkBAH4YBOM=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="5" type="collision" x="144" y="128" width="32" height="32"/>
   <object id="6" type="collision" x="160" y="48" width="32" height="16"/>
   <object id="7" type="collision" x="144" y="48" width="16" height="32"/>

--- a/mods/tuxemon/maps/leather_shaft1.tmx
+++ b/mods/tuxemon/maps/leather_shaft1.tmx
@@ -48,7 +48,7 @@
    </properties>
   </object>
  </objectgroup>
- <objectgroup color="#ff0000" id="6" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collisions">
   <object id="5" type="collision" x="0" y="32" width="240" height="16"/>
   <object id="6" type="collision" x="160" y="48" width="16" height="144"/>
   <object id="7" type="collision" x="0" y="176" width="128" height="16"/>

--- a/mods/tuxemon/maps/leather_shaft2.tmx
+++ b/mods/tuxemon/maps/leather_shaft2.tmx
@@ -39,7 +39,7 @@
    eJxjYBgeII+fgSGfn752dgsQp24hkepAAAAUyQJI
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="62" type="collision" x="0" y="96" width="64" height="16"/>
   <object id="63" type="collision" x="80" y="48" width="80" height="32"/>
   <object id="64" type="collision" x="0" y="32" width="160" height="16"/>

--- a/mods/tuxemon/maps/mansion.tmx
+++ b/mods/tuxemon/maps/mansion.tmx
@@ -42,7 +42,7 @@
    eAFjYBgFoyEwGgL0CoFpMtSxiVrmUMc1pJsyg0rhQLrN+HUAAIAqAhk=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="1" type="collision" x="48" y="0" width="16" height="128"/>
   <object id="2" type="collision" x="64" y="0" width="224" height="32"/>
   <object id="3" type="collision" x="64" y="96" width="80" height="32"/>

--- a/mods/tuxemon/maps/mansion_basement.tmx
+++ b/mods/tuxemon/maps/mansion_basement.tmx
@@ -40,7 +40,7 @@
    eAFjYBgFwyEE5IGeAGGl4eCZUT+MhsBoCIyGwDALgeFYNgMAj/oAgw==
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="1" type="collision" x="0" y="0" width="16" height="224"/>
   <object id="2" type="collision" x="16" y="0" width="368" height="32"/>
   <object id="3" type="collision" x="368" y="32" width="16" height="320"/>

--- a/mods/tuxemon/maps/mansion_top.tmx
+++ b/mods/tuxemon/maps/mansion_top.tmx
@@ -69,7 +69,7 @@
   </object>
   <object id="28" name="Player Spawn" type="event" x="32" y="224" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="1" type="collision" x="0" y="0" width="16" height="304"/>
   <object id="2" type="collision" x="352" y="0" width="16" height="304"/>
   <object id="3" type="collision" x="16" y="176" width="160" height="32"/>

--- a/mods/tuxemon/maps/maple_bedroom.tmx
+++ b/mods/tuxemon/maps/maple_bedroom.tmx
@@ -39,7 +39,7 @@
    eAFjYCAfvOIjrFecn7CagVIBANIHAR8=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="1" type="collision" x="0" y="16" width="144" height="16"/>
   <object id="6" type="collision" x="96" y="48" width="32" height="16"/>
   <object id="7" type="collision" x="64" y="32" width="48" height="16"/>

--- a/mods/tuxemon/maps/maple_house.tmx
+++ b/mods/tuxemon/maps/maple_house.tmx
@@ -34,7 +34,7 @@
    eAFjYMAPJjIzMEwGYkLAgIWBwRCIQWAKUP00IvT4A9UHQPVAdA4tUgvodm0g1qGxH44DzYdhfCEEUkNPAADosAck
   </data>
  </layer>
- <objectgroup color="#ff0000" id="4" name="Collision">
+ <objectgroup color="#ff0000" id="4" name="Collisions">
   <object id="4" type="collision" x="0" y="0" width="176" height="32"/>
   <object id="10" type="collision" x="16" y="102" width="48" height="26"/>
   <object id="16" type="collision" x="0" y="32" width="80" height="32"/>

--- a/mods/tuxemon/maps/omnichannel1.tmx
+++ b/mods/tuxemon/maps/omnichannel1.tmx
@@ -26,7 +26,7 @@
    eAHNUjkOwkAM9BegBHE08CR4C0eX/AXxDK73IKigYwatpWG1cSIasDRa2+tJZm2bmR0Hn7hkcX4PytvWQzPFHTyNc995+UneN/avPO/XKb2rq07vl9f72dabRd9sCUwxD1pXXgVODWwTb4RzDOxTzG/tUo75Jlvhjto3UuM55n9lj57ZEzgE++wzUo0z9GQOXIN9vhV2lj0iJsGbSzyfu/ZP9dAv8fIaxmfRxdlFWpSvO8PZRVqaeJpv8/V/pdoXWiZAOA==
   </data>
  </layer>
- <objectgroup color="#ff0000" id="3" name="Collision">
+ <objectgroup color="#ff0000" id="3" name="Collisions">
   <object id="1" type="collision" x="0" y="0" width="16" height="336"/>
   <object id="2" type="collision" x="16" y="0" width="208" height="16"/>
   <object id="4" type="collision" x="208" y="16" width="16" height="320"/>

--- a/mods/tuxemon/maps/omnichannel2.tmx
+++ b/mods/tuxemon/maps/omnichannel2.tmx
@@ -26,7 +26,7 @@
    eAHFUkkKAkEQyxf0qAe96JP0LS43/Yv4DEXfI4gHvZkWAiEM2jMoFhRdRVd6UskAwHHQLgl5xXIItEnhvn2eyL9LXH+Ek57n0PVm39tRO82Ju7QsvFSX03kuTHPhZn1gzvS5cpe95nVuiNkyx3zTI3u/83oduOx99h/1vQc8mIfwYW+8m3yYUJMp8xI+rAzX5IP8HNlczd7y2t9PXO0/nrvWcnm3a3LxvuC6xCfcE1CRRWE=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="3" name="Collision">
+ <objectgroup color="#ff0000" id="3" name="Collisions">
   <object id="1" type="collision" x="0" y="0" width="224" height="32"/>
   <object id="2" type="collision-line" x="0" y="336">
    <polyline points="0,0 224,0"/>

--- a/mods/tuxemon/maps/omnichannel3.tmx
+++ b/mods/tuxemon/maps/omnichannel3.tmx
@@ -26,7 +26,7 @@
    eAG1UUsKQkEMyxV0qQhu9Eh6Fj+7513EYyh6HkFd6M5UWwiPN2/GAQOdFkraTgIAp1E6Lh09Uj5Yj4FU3Mhr94LXl6ecWYNtIe/Mu2pg/ymF6vkQ3pG19qKOuaqX7ruSp72og7cYAkuGQfUzXh8acnbOU/1yvNTMWt7ddTm4h3tm0yaH0GXjvBWzaRN4DoAXw6C+5+6cUZO569L24Tut+w0/LavvuX3hp+Vf9ukV6vuEc+yGEj3V99Avpafu+3f9Bv8oR8c=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="4" name="Collision">
+ <objectgroup color="#ff0000" id="4" name="Collisions">
   <object id="1" type="collision" x="0" y="336">
    <polygon points="0,0 0,-336 224,-336 224,0 208,0 208,-32 176,-32 176,-64 208,-64 208,-128 176,-128 176,-160 208,-160 208,-208 128,-208 128,-160 160,-160 160,-128 128,-128 128,-64 160,-64 160,-32 112,-32 112,-240 208,-240 208,-304 144,-304 144,-272 128,-272 128,-304 16,-304 16,-240 64,-240 64,-272 80,-272 80,-176 64,-176 64,-208 48,-208 16,-208 16,-96 64,-96 64,-128 80,-128 80,-32 64,-32 64,-64 16,-64 16,0 0,0"/>
   </object>

--- a/mods/tuxemon/maps/player_house_bedroom.tmx
+++ b/mods/tuxemon/maps/player_house_bedroom.tmx
@@ -39,7 +39,7 @@
    eAFjYCAffBEnrFdRgrAaaquYqk3YxC1ANQAM/gLk
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="1" type="collision" x="0" y="16" width="144" height="16"/>
   <object id="5" type="collision" x="0" y="32" width="16" height="32"/>
   <object id="6" type="collision" x="96" y="48" width="32" height="16"/>

--- a/mods/tuxemon/maps/player_house_downstairs.tmx
+++ b/mods/tuxemon/maps/player_house_downstairs.tmx
@@ -39,7 +39,7 @@
    eAFjYKAveKhNH/um6jEwTAPi6UCMCwAA3E8DWQ==
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="1" type="collision" x="96" y="64" width="32" height="16"/>
   <object id="2" type="collision" x="16" y="16" width="128" height="16"/>
   <object id="4" type="collision" x="0" y="96" width="48" height="16"/>

--- a/mods/tuxemon/maps/professor_lab.tmx
+++ b/mods/tuxemon/maps/professor_lab.tmx
@@ -41,7 +41,7 @@
    eAFjYBgFoyEwGgKDPQQAA6gAAQ==
   </data>
  </layer>
- <objectgroup color="#ff0000" id="6" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collisions">
   <object id="43" type="collision" x="144" y="112" width="48" height="32"/>
   <object id="56" type="collision" x="144" y="48" width="48" height="16"/>
   <object id="85" type="collision" x="0" y="0" width="208" height="48"/>

--- a/mods/tuxemon/maps/route1.tmx
+++ b/mods/tuxemon/maps/route1.tmx
@@ -38,7 +38,7 @@
    eAHtkkFuQzEIRP8RerjkMO1h2qvWWczmKcQYcCyqRorQYOYxtLl9XNd9fG+H6oXP58jxNb7eCvtLeepG7WU49XfUHUzP70T/N96qvrfS/0qfuvV7/E5/xtf66H1WLf+z/qlbn2XZ3ZvdGtk/Yz7eT3xmuSoycUcFM8JgDuoIk54dTO7waOag9jA4Q4al6dutrRzqV+wXS7WCGWFov1UjTHrI5vu7NHNQV+QgU7qCvcLQXquusKxZsq05q0//Lm3tX+kz24q3cpY5qCt2kSldwV5haK9VV1jWLNnW3O4+c1BX7M8y6V/VumHm01ymWjsyzIjXyqF+hEmPWKp8n2n5olX8mV9zmcodGVbGyxzUGba8ZErr3aqay1bxZxzNZSp3ZFgZL3NQZ9jyrjI5v6q1l3XG4XxEWzsirIzHyqF+hi2vWKrqs+o9W8mVnnE1l6nckWFlvMxBnWHLS6a03t9VtdeqFTnIrmBGGMxBHWHSs4PJHR7NHNQeRpcZ3kbd5Q5PTt5G7WF0meFt1F3u8OTkbdQeRpcZ3kbd5Q5PTt5G7WF0meFt1F3u8OTkbdQeRpcZ3kbd5Q5PTt7WVXtu/Z/5m3+BX7PEMNw=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="1" type="collision" x="656" y="272" width="96" height="160"/>
   <object id="2" type="collision" x="720" y="128" width="48" height="48"/>
   <object id="3" type="collision" x="592" y="128" width="16" height="208"/>
@@ -841,13 +841,13 @@
   <object id="153" name="Environment Day" type="event" x="0" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
-    <property name="cond1" value="is variable_set daytime:true"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="154" name="Environment Night" type="event" x="16" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
-    <property name="cond1" value="is variable_set daytime:false"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="155" name="Default" type="event" x="16" y="16" width="16" height="16">

--- a/mods/tuxemon/maps/route1_sanglorian.tmx
+++ b/mods/tuxemon/maps/route1_sanglorian.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="161">
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="163">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="north" value="cotton_town"/>
@@ -246,6 +246,18 @@
     <property name="act20" value="player_face down"/>
     <property name="cond10" value="is player_at"/>
     <property name="cond20" value="is player_facing down"/>
+   </properties>
+  </object>
+  <object id="161" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_variable environment:grass"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
+   </properties>
+  </object>
+  <object id="162" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_variable environment:night_grass"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/route2.tmx
+++ b/mods/tuxemon/maps/route2.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="1" nextobjectid="137">
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="1" nextobjectid="139">
  <properties>
   <property name="east" value="cotton_town"/>
   <property name="edges" value="clamped"/>
@@ -537,6 +537,18 @@
     <property name="cond20" value="is player_facing left"/>
     <property name="cond30" value="is button_pressed K_RETURN"/>
     <property name="cond40" value="is variable_set leavemealone:yes"/>
+   </properties>
+  </object>
+  <object id="137" name="Environment Day" type="event" x="0" y="16" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_variable environment:grass"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
+   </properties>
+  </object>
+  <object id="138" name="Environment Night" type="event" x="16" y="16" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_variable environment:night_grass"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/route3.tmx
+++ b/mods/tuxemon/maps/route3.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="178">
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="180">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="north" value="route4"/>
@@ -360,5 +360,17 @@
    </properties>
   </object>
   <object id="177" name="Player Spawn" type="event" x="512" y="608" width="16" height="16"/>
+  <object id="178" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_variable environment:grass"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
+   </properties>
+  </object>
+  <object id="179" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_variable environment:night_grass"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
+   </properties>
+  </object>
  </objectgroup>
 </map>

--- a/mods/tuxemon/maps/route4.tmx
+++ b/mods/tuxemon/maps/route4.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="37">
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="39">
  <properties>
   <property name="east" value="flower_city"/>
   <property name="edges" value="clamped"/>
@@ -25,7 +25,7 @@
    eAFjYBgFoyEwGgKjITAaAqMhMBoCoyEwMCFwgouB4SQQUwu8BZr1jormUctdo+aMhsBoCCBCAACenwOV
   </data>
  </layer>
- <objectgroup color="#ff0000" id="4" name="Collision">
+ <objectgroup color="#ff0000" id="4" name="Collisions">
   <object id="1" type="collision" x="0" y="0" width="32" height="640"/>
   <object id="2" type="collision" x="272" y="112" width="48" height="416"/>
   <object id="3" type="collision" x="32" y="0" width="288" height="32"/>
@@ -94,5 +94,17 @@
    </properties>
   </object>
   <object id="36" name="Player Spawn" type="event" x="272" y="48" width="16" height="16"/>
+  <object id="37" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_variable environment:grass"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
+   </properties>
+  </object>
+  <object id="38" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_variable environment:night_grass"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
+   </properties>
+  </object>
  </objectgroup>
 </map>

--- a/mods/tuxemon/maps/route5.tmx
+++ b/mods/tuxemon/maps/route5.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="20">
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="22">
  <properties>
   <property name="east" value="timber_town"/>
   <property name="edges" value="clamped"/>
@@ -78,5 +78,17 @@
    </properties>
   </object>
   <object id="19" name="Player Spawn" type="event" x="32" y="240" width="16" height="16"/>
+  <object id="20" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_variable environment:grass"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
+   </properties>
+  </object>
+  <object id="21" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_variable environment:night_grass"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
+   </properties>
+  </object>
  </objectgroup>
 </map>

--- a/mods/tuxemon/maps/route6.tmx
+++ b/mods/tuxemon/maps/route6.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="5" nextobjectid="71">
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="5" nextobjectid="73">
  <properties>
   <property name="east" value="tunnel"/>
   <property name="edges" value="clamped"/>
@@ -20,6 +20,86 @@
    eAG9kzFugjEMRt2VgYm5cA4OAByjPUmHqpwNDkPHlrF2pSdZVmIntIBkOXbyfXkJ+UVELguRT42TxlnjZSnyqpH9WMsa6ug1W+MTs+2D14eyHTt86Fj73zW+MbMP99HL6Jjv1W/6P1j05lt6GHxmHH3Qf+ngW+NKI8l4wUamn0h/p2DwmXFP+/wkstbYaFQ/vCIX/UrfmrfvITvfKB8esFn2XMy3GLKefbfeJ64d5cs8zDPOrzrfX9y/OtcoX/SdqbM3Hs8VfXf67vYah4H3F7WjdXUHrTt8/+P9+3dYcVZ81R1m/l7LOT0b48wj48Mz01dzeMAKE31q86HnPVt8rMOT2utGx3jYenyMib6N6dPz3q03HtfF2utnxvjAQ6Y/42Va9DM6W7stvh94yLP+tt606G/lvGXfTMO54SHDmWkfOQcPGc5HMlR7GRNcPU7mY8ab/j1qY4pcvZo+Ga571z/QswMw
   </data>
  </layer>
+ <objectgroup color="#ff0000" id="4" name="Collisions">
+  <object id="2" type="collision" x="0" y="304" width="640" height="16"/>
+  <object id="3" type="collision" x="560" y="0" width="80" height="64"/>
+  <object id="4" type="collision" x="624" y="176" width="16" height="128"/>
+  <object id="5" type="collision" x="0" y="0" width="48" height="64"/>
+  <object id="6" type="collision" x="0" y="64" width="32" height="240"/>
+  <object id="7" type="collision" x="32" y="80" width="16" height="32"/>
+  <object id="8" type="collision" x="32" y="144" width="16" height="32"/>
+  <object id="9" type="collision" x="48" y="32" width="16" height="32"/>
+  <object id="10" type="collision" x="48" y="0" width="32" height="32"/>
+  <object id="11" type="collision" x="32" y="192" width="32" height="32"/>
+  <object id="12" type="collision" x="32" y="240" width="32" height="64"/>
+  <object id="13" type="collision" x="64" y="288" width="32" height="16"/>
+  <object id="14" type="collision" x="256" y="288" width="32" height="16"/>
+  <object id="15" type="collision" x="320" y="288" width="32" height="16"/>
+  <object id="16" type="collision" x="384" y="288" width="32" height="16"/>
+  <object id="17" type="collision" x="448" y="288" width="32" height="16"/>
+  <object id="18" type="collision" x="512" y="288" width="32" height="16"/>
+  <object id="19" type="collision" x="576" y="288" width="32" height="16"/>
+  <object id="20" type="collision" x="608" y="176" width="16" height="32"/>
+  <object id="21" type="collision" x="608" y="240" width="16" height="32"/>
+  <object id="22" type="collision" x="576" y="240" width="16" height="16"/>
+  <object id="23" type="collision" x="224" y="224" width="16" height="16"/>
+  <object id="24" type="collision" x="96" y="144" width="16" height="16"/>
+  <object id="25" type="collision" x="80" y="0" width="32" height="32"/>
+  <object id="26" type="collision" x="224" y="0" width="336" height="32"/>
+  <object id="27" type="collision" x="192" y="16" width="32" height="32"/>
+  <object id="28" type="collision" x="256" y="144" width="32" height="32"/>
+  <object id="29" type="collision" x="352" y="208" width="64" height="32"/>
+  <object id="30" type="collision" x="320" y="208" width="128" height="16"/>
+  <object id="31" type="collision" x="416" y="192" width="64" height="16"/>
+  <object id="32" type="collision" x="272" y="176" width="64" height="16"/>
+  <object id="33" type="collision" x="304" y="160" width="32" height="16"/>
+  <object id="34" type="collision" x="272" y="192" width="32" height="16"/>
+  <object id="35" type="collision" x="448" y="176" width="32" height="16"/>
+  <object id="36" type="collision" x="368" y="176" width="32" height="32"/>
+  <object id="37" type="collision" x="320" y="192" width="32" height="16"/>
+  <object id="38" type="collision" x="256" y="32" width="32" height="16"/>
+  <object id="39" type="collision" x="320" y="32" width="32" height="16"/>
+  <object id="40" type="collision" x="384" y="32" width="32" height="16"/>
+  <object id="41" type="collision" x="448" y="32" width="32" height="16"/>
+  <object id="42" type="collision" x="512" y="32" width="32" height="16"/>
+  <object id="43" type="collision" x="304" y="48" width="32" height="32"/>
+  <object id="44" type="collision" x="288" y="80" width="32" height="32"/>
+  <object id="46" type="collision" x="368" y="64" width="32" height="32"/>
+  <object id="47" type="collision" x="400" y="48" width="32" height="32"/>
+  <object id="48" type="collision" x="416" y="80" width="32" height="32"/>
+  <object id="49" type="collision" x="560" y="144" width="80" height="32">
+   <properties>
+    <property name="key" value="water"/>
+   </properties>
+  </object>
+  <object id="50" type="collision" x="416" y="144" width="128" height="32">
+   <properties>
+    <property name="key" value="water"/>
+   </properties>
+  </object>
+  <object id="51" type="collision" x="240" y="112" width="208" height="32">
+   <properties>
+    <property name="key" value="water"/>
+   </properties>
+  </object>
+  <object id="52" type="collision" x="160" y="80" width="112" height="32">
+   <properties>
+    <property name="key" value="water"/>
+   </properties>
+  </object>
+  <object id="53" type="collision" x="80" y="80" width="64" height="32">
+   <properties>
+    <property name="key" value="water"/>
+   </properties>
+  </object>
+  <object id="54" type="collision" x="80" y="32" width="32" height="48">
+   <properties>
+    <property name="key" value="water"/>
+   </properties>
+  </object>
+  <object id="55" type="collision" x="128" y="288" width="96" height="16"/>
+  <object id="69" type="collision" x="480" y="96" width="16" height="16"/>
+ </objectgroup>
  <objectgroup color="#ffff00" id="3" name="Events">
   <object id="1" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
@@ -124,85 +204,17 @@
    </properties>
   </object>
   <object id="70" name="Player Spawn" type="event" x="144" y="32" width="16" height="16"/>
- </objectgroup>
- <objectgroup color="#ff0000" id="4" name="Collision">
-  <object id="2" type="collision" x="0" y="304" width="640" height="16"/>
-  <object id="3" type="collision" x="560" y="0" width="80" height="64"/>
-  <object id="4" type="collision" x="624" y="176" width="16" height="128"/>
-  <object id="5" type="collision" x="0" y="0" width="48" height="64"/>
-  <object id="6" type="collision" x="0" y="64" width="32" height="240"/>
-  <object id="7" type="collision" x="32" y="80" width="16" height="32"/>
-  <object id="8" type="collision" x="32" y="144" width="16" height="32"/>
-  <object id="9" type="collision" x="48" y="32" width="16" height="32"/>
-  <object id="10" type="collision" x="48" y="0" width="32" height="32"/>
-  <object id="11" type="collision" x="32" y="192" width="32" height="32"/>
-  <object id="12" type="collision" x="32" y="240" width="32" height="64"/>
-  <object id="13" type="collision" x="64" y="288" width="32" height="16"/>
-  <object id="14" type="collision" x="256" y="288" width="32" height="16"/>
-  <object id="15" type="collision" x="320" y="288" width="32" height="16"/>
-  <object id="16" type="collision" x="384" y="288" width="32" height="16"/>
-  <object id="17" type="collision" x="448" y="288" width="32" height="16"/>
-  <object id="18" type="collision" x="512" y="288" width="32" height="16"/>
-  <object id="19" type="collision" x="576" y="288" width="32" height="16"/>
-  <object id="20" type="collision" x="608" y="176" width="16" height="32"/>
-  <object id="21" type="collision" x="608" y="240" width="16" height="32"/>
-  <object id="22" type="collision" x="576" y="240" width="16" height="16"/>
-  <object id="23" type="collision" x="224" y="224" width="16" height="16"/>
-  <object id="24" type="collision" x="96" y="144" width="16" height="16"/>
-  <object id="25" type="collision" x="80" y="0" width="32" height="32"/>
-  <object id="26" type="collision" x="224" y="0" width="336" height="32"/>
-  <object id="27" type="collision" x="192" y="16" width="32" height="32"/>
-  <object id="28" type="collision" x="256" y="144" width="32" height="32"/>
-  <object id="29" type="collision" x="352" y="208" width="64" height="32"/>
-  <object id="30" type="collision" x="320" y="208" width="128" height="16"/>
-  <object id="31" type="collision" x="416" y="192" width="64" height="16"/>
-  <object id="32" type="collision" x="272" y="176" width="64" height="16"/>
-  <object id="33" type="collision" x="304" y="160" width="32" height="16"/>
-  <object id="34" type="collision" x="272" y="192" width="32" height="16"/>
-  <object id="35" type="collision" x="448" y="176" width="32" height="16"/>
-  <object id="36" type="collision" x="368" y="176" width="32" height="32"/>
-  <object id="37" type="collision" x="320" y="192" width="32" height="16"/>
-  <object id="38" type="collision" x="256" y="32" width="32" height="16"/>
-  <object id="39" type="collision" x="320" y="32" width="32" height="16"/>
-  <object id="40" type="collision" x="384" y="32" width="32" height="16"/>
-  <object id="41" type="collision" x="448" y="32" width="32" height="16"/>
-  <object id="42" type="collision" x="512" y="32" width="32" height="16"/>
-  <object id="43" type="collision" x="304" y="48" width="32" height="32"/>
-  <object id="44" type="collision" x="288" y="80" width="32" height="32"/>
-  <object id="46" type="collision" x="368" y="64" width="32" height="32"/>
-  <object id="47" type="collision" x="400" y="48" width="32" height="32"/>
-  <object id="48" type="collision" x="416" y="80" width="32" height="32"/>
-  <object id="49" type="collision" x="560" y="144" width="80" height="32">
+  <object id="71" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
    <properties>
-    <property name="key" value="water"/>
+    <property name="act1" value="set_variable environment:grass"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
    </properties>
   </object>
-  <object id="50" type="collision" x="416" y="144" width="128" height="32">
+  <object id="72" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
-    <property name="key" value="water"/>
+    <property name="act1" value="set_variable environment:night_grass"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
    </properties>
   </object>
-  <object id="51" type="collision" x="240" y="112" width="208" height="32">
-   <properties>
-    <property name="key" value="water"/>
-   </properties>
-  </object>
-  <object id="52" type="collision" x="160" y="80" width="112" height="32">
-   <properties>
-    <property name="key" value="water"/>
-   </properties>
-  </object>
-  <object id="53" type="collision" x="80" y="80" width="64" height="32">
-   <properties>
-    <property name="key" value="water"/>
-   </properties>
-  </object>
-  <object id="54" type="collision" x="80" y="32" width="32" height="48">
-   <properties>
-    <property name="key" value="water"/>
-   </properties>
-  </object>
-  <object id="55" type="collision" x="128" y="288" width="96" height="16"/>
-  <object id="69" type="collision" x="480" y="96" width="16" height="16"/>
  </objectgroup>
 </map>

--- a/mods/tuxemon/maps/routea.tmx
+++ b/mods/tuxemon/maps/routea.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="57">
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="59">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="xero"/>
@@ -118,6 +118,18 @@
     <property name="act20" value="player_face down"/>
     <property name="cond10" value="is player_at"/>
     <property name="cond20" value="is player_facing down"/>
+   </properties>
+  </object>
+  <object id="57" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_variable environment:grass"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
+   </properties>
+  </object>
+  <object id="58" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_variable environment:night_grass"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/rubberduck_city_01.tmx
+++ b/mods/tuxemon/maps/rubberduck_city_01.tmx
@@ -47,7 +47,7 @@
    eAHt1NEJgCAQANCjCZqlJdqh/lulBqr98qcPiRDEn+odiCjnwT3FCEGAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIEAgYoRAgACBRgJD16jQR8pMfcSchsgF1mSycclR0mpPJgeXm4uNssBSTvllhj/4l9de1fT1Vp7mqqIvPnQCUd4ImA==
   </data>
  </layer>
- <objectgroup color="#ff0000" id="6" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collisions">
   <object id="3" type="collision" x="0" y="0" width="96" height="912"/>
   <object id="5" type="collision" x="96" y="880" width="672" height="32"/>
   <object id="6" type="collision" x="96" y="0" width="896" height="32"/>

--- a/mods/tuxemon/maps/rubberduck_route_01.tmx
+++ b/mods/tuxemon/maps/rubberduck_route_01.tmx
@@ -35,7 +35,7 @@
    eAHtWMFtwzAM9L/JLk0nawdKt+mnnaK/jFEeigMMArTJgFTEwAIEmhJ1dzpLcJDLeVku0m+n//gmz+hfkp8lztpeRRs6dCNiD9CNfOYGnfSWPp9kbGav4Sc1Qj99n9lnaoNW+IxI3zk3c4Rm9tnP9NpHnI9uZwT6O91F7Xen80Htne4iNSN29Bq6Z/++QOPM7f1lWT6kH22MA4ffY3wmy+E3nThixIFf+b3XqXU951f59nw2/P58i+afhro7neln09r1jnZ8D/Taih33tKeZe92rq5gntxUrOB+NqfdarUfzbeURLRonsnZk7Widmm8rj/qgsaLrq+u1PuYVvMSOxKgOC9vCYb01nz1OPh2zeYCnOTx5VIeFGcWpqB+tzeLbGo/s28KJYGTVUgvxmOvI+YqouTy5V8celhenos7SVsG1xrR4t8bX663nrfX4z5rz1vrqcfLrmMmrse/NPZq82B6srJr1e7b0ZXBZ2PeOezR5sT1YWTUj/PbuO1Ln2b8Xz4OVVfPMfmd5lInzBy03vY0=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="6" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collisions">
   <object id="1" type="collision" x="128" y="640" width="176" height="208"/>
   <object id="4" type="collision" x="608" y="208" width="96" height="640"/>
   <object id="5" type="collision" x="64" y="240" width="80" height="400"/>

--- a/mods/tuxemon/maps/scoop2.tmx
+++ b/mods/tuxemon/maps/scoop2.tmx
@@ -59,7 +59,7 @@
   </object>
   <object id="14" name="Player Spawn" type="event" x="32" y="64" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ff0000" id="3" name="Collision">
+ <objectgroup color="#ff0000" id="3" name="Collisions">
   <object id="4" type="collision" x="0" y="16" width="32" height="48"/>
   <object id="5" type="collision" x="32" y="0" width="48" height="48"/>
   <object id="6" type="collision" x="80" y="16" width="32" height="48"/>

--- a/mods/tuxemon/maps/scoop3.tmx
+++ b/mods/tuxemon/maps/scoop3.tmx
@@ -66,7 +66,7 @@
   </object>
   <object id="13" name="Player Spawn" type="event" x="80" y="160" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ff0000" id="6" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collisions">
   <object id="4" type="collision" x="0" y="0" width="80" height="48"/>
   <object id="5" type="collision" x="80" y="0" width="112" height="32"/>
   <object id="6" type="collision" x="112" y="32" width="80" height="16"/>

--- a/mods/tuxemon/maps/scoop4.tmx
+++ b/mods/tuxemon/maps/scoop4.tmx
@@ -52,7 +52,7 @@
   </object>
   <object id="29" name="Player Spawn" type="event" x="160" y="320" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#ff0000" id="7" name="Collision">
+ <objectgroup color="#ff0000" id="7" name="Collisions">
   <object id="4" type="collision" x="0" y="0" width="192" height="48"/>
   <object id="5" type="collision" x="112" y="160" width="80" height="16"/>
   <object id="7" type="collision-line" x="0" y="352">

--- a/mods/tuxemon/maps/sphalian_center.tmx
+++ b/mods/tuxemon/maps/sphalian_center.tmx
@@ -36,7 +36,7 @@
    eAFjYBje4LYcA8MdJHwXyB4F1AkBAH4YBOM=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="5" type="collision" x="144" y="128" width="32" height="32"/>
   <object id="6" type="collision" x="160" y="48" width="32" height="16"/>
   <object id="7" type="collision" x="144" y="48" width="16" height="32"/>

--- a/mods/tuxemon/maps/sphalian_town.tmx
+++ b/mods/tuxemon/maps/sphalian_town.tmx
@@ -36,7 +36,7 @@
    eAHt1LsNgDAQBNFtypVjQ+RfP4BdgqcEAkSAdqWXXjDBSd9sC1JEwo4Dngu4gAu4wH8LZP58QUVDx1s7uXXhxsCE5wJPCyz+ig8G
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="12" type="collision" x="272" y="304" width="48" height="64"/>
   <object id="14" type="collision" x="240" y="352" width="16" height="16"/>
   <object id="15" type="collision" x="336" y="304" width="16" height="64"/>

--- a/mods/tuxemon/maps/sphalian_town_house.tmx
+++ b/mods/tuxemon/maps/sphalian_town_house.tmx
@@ -36,7 +36,7 @@
    eAFjYBh8wEGOgcERiOkB7OUZGByAGBcAAHyqAXs=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="1" type="collision" x="96" y="80" width="32" height="32"/>
   <object id="2" type="collision" x="0" y="32" width="144" height="16"/>
   <object id="4" type="collision" x="16" y="112" width="32" height="16"/>

--- a/mods/tuxemon/maps/spyder_bedroom.tmx
+++ b/mods/tuxemon/maps/spyder_bedroom.tmx
@@ -39,7 +39,7 @@
    eAFjYCAffBEnrFdRgrAaaquYqk3YxC1ANQAM/gLk
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="1" type="collision" x="0" y="16" width="144" height="16"/>
   <object id="5" type="collision" x="0" y="32" width="16" height="32"/>
   <object id="6" type="collision" x="96" y="48" width="32" height="16"/>

--- a/mods/tuxemon/maps/spyder_candy_center.tmx
+++ b/mods/tuxemon/maps/spyder_candy_center.tmx
@@ -39,7 +39,7 @@
    eAFjYBgF1AyBw/wMDEeQ8FEgGxmclkPwdgPZ6HyE7ChrOIYAAHvuB6Q=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="5" type="collision" x="144" y="128" width="32" height="32"/>
   <object id="6" type="collision" x="160" y="48" width="32" height="16"/>
   <object id="7" type="collision" x="144" y="48" width="16" height="32"/>

--- a/mods/tuxemon/maps/spyder_candy_house1.tmx
+++ b/mods/tuxemon/maps/spyder_candy_house1.tmx
@@ -36,7 +36,7 @@
    eAFjYBh4EMvDwBAHxIRALlBNHhHq8JmzmoOBYQ0Q4wKE5NH1AQDSvwSV
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="61" type="collision" x="0" y="0" width="160" height="32"/>
   <object id="72" type="collision" x="64" y="80" width="16" height="16"/>
   <object id="73" type="collision" x="0" y="112" width="32" height="16"/>

--- a/mods/tuxemon/maps/spyder_candy_house2.tmx
+++ b/mods/tuxemon/maps/spyder_candy_house2.tmx
@@ -33,7 +33,7 @@
    eJxjYBgFlAAAAUAAAQ==
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="62" type="collision" x="32" y="80" width="32" height="32"/>
   <object id="63" type="collision" x="96" y="64" width="32" height="32"/>
   <object id="64" type="collision" x="0" y="16" width="160" height="16"/>

--- a/mods/tuxemon/maps/spyder_candy_house3.tmx
+++ b/mods/tuxemon/maps/spyder_candy_house3.tmx
@@ -36,7 +36,7 @@
    eAFjYBg4YMXJwGANxCBwGkifAeKzQHwOiM8D8QUgpjdYzcHAsAaIiQUAEmwG9g==
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="61" type="collision" x="64" y="0" width="96" height="32"/>
   <object id="73" type="collision" x="16" y="64" width="32" height="16"/>
   <object id="74" type="collision" x="128" y="112" width="32" height="16"/>

--- a/mods/tuxemon/maps/spyder_candy_town.tmx
+++ b/mods/tuxemon/maps/spyder_candy_town.tmx
@@ -37,7 +37,7 @@
    eAHtlklOw0AQRUuITXaAxDoMKwisEsKOIYTpCBwi8wBLlsAtyCVCLkC4RpBIrsHbtNQyjmPZxG3F9aWntttl9/e3S7aIatUTyG+J7MAu7ME+qMInMMiFr3VROU6xv3e8pT2/sM/se12eJxC2/r/qapsidWhAE1qgWv0EPvMiY/gCVwrq3x98TWGWoL/S2t8krrdFbuAW7uAeXMnPXxc/PejDIzyBK/n5c+XFb91l+3vZEHldwBvH5+nB5/2bVxtlfsjaHwsYBfjzrhnUv97aLO3P+IYWLILu/YD/5UMowBEcg0oTSCIB7d/4KRfp1xKcQBlOweiMb/E5XFjjJdsVuLLmTE2VuSRVY706NKyxyXYL2tacqekwp0pPAtq/8Z6Fyc+M8a6WvbNNbt4xe0lEu2NvbmY/2tX0rLQl8AtVvEGl
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="108" type="collision" x="96" y="0" width="128" height="64"/>
   <object id="109" type="collision" x="320" y="0" width="160" height="64"/>
   <object id="110" type="collision" x="496" y="0" width="32" height="32"/>
@@ -420,14 +420,14 @@
   <object id="212" name="Environment Day" type="event" x="112" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
-    <property name="cond1" value="is variable_set daytime:true"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
     <property name="cond2" value="not has_sprite swimmer"/>
    </properties>
   </object>
   <object id="221" name="Environment Night" type="event" x="96" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
-    <property name="cond1" value="is variable_set daytime:false"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
     <property name="cond2" value="not has_sprite swimmer"/>
    </properties>
   </object>
@@ -541,7 +541,7 @@
     <property name="act1" value="set_variable environment:sea"/>
     <property name="act2" value="random_encounter routec"/>
     <property name="cond1" value="is has_sprite swimmer"/>
-    <property name="cond2" value="is variable_set daytime:true"/>
+    <property name="cond2" value="not variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="225" name="Swim Encounters Night" type="event" x="624" y="384" width="16" height="16">
@@ -549,7 +549,7 @@
     <property name="act1" value="set_variable environment:night_sea"/>
     <property name="act2" value="random_encounter routec"/>
     <property name="cond1" value="is has_sprite swimmer"/>
-    <property name="cond2" value="is variable_set daytime:false"/>
+    <property name="cond2" value="is variable_set stage_of_day:night"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_citypark.tmx
+++ b/mods/tuxemon/maps/spyder_citypark.tmx
@@ -36,7 +36,7 @@
    eAHt0LENgEAMA0AvQcOKMCniV/kZyAgUqaKz5NaSLxECBAgQIDBTYJ8zf3lFgAABAgS6Ba4avLtH7REg8FvgOZK3uqpCgAABAgQI9Al8WiQEgg==
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="177" type="collision" x="0" y="224" width="32" height="416"/>
   <object id="178" type="collision" x="32" y="0" width="496" height="32"/>
   <object id="179" type="collision" x="64" y="32" width="192" height="32"/>
@@ -531,13 +531,13 @@
   <object id="81" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
-    <property name="cond1" value="is variable_set daytime:true"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="82" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
-    <property name="cond1" value="is variable_set daytime:false"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="83" name="Talk Bobette" type="event" x="208" y="272" width="48" height="16">

--- a/mods/tuxemon/maps/spyder_cotton_house1.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_house1.tmx
@@ -36,7 +36,7 @@
    eAFjYBgFlIQAAAFAAAE=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="63" type="collision" x="0" y="0" width="160" height="32"/>
   <object id="64" type="collision" x="96" y="48" width="32" height="32"/>
   <object id="66" type="collision" x="0" y="96" width="16" height="32"/>

--- a/mods/tuxemon/maps/spyder_cotton_house2.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_house2.tmx
@@ -36,7 +36,7 @@
    eAFjYBgFlIQAAAFAAAE=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="59" type="collision" x="0" y="0" width="160" height="32"/>
   <object id="61" type="collision" x="112" y="32" width="32" height="32"/>
   <object id="62" type="collision" x="16" y="48" width="16" height="48"/>

--- a/mods/tuxemon/maps/spyder_cotton_town.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_town.tmx
@@ -372,13 +372,13 @@
   <object id="580" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
-    <property name="cond1" value="is variable_set daytime:true"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="582" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
-    <property name="cond1" value="is variable_set daytime:false"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="587" name="Nu Phone Mom" type="event" x="496" y="272" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_dojo2.tmx
+++ b/mods/tuxemon/maps/spyder_dojo2.tmx
@@ -36,7 +36,7 @@
    eAFjYBgFoyEwGgIkh4AQyTpGNWAJAQAbfgAT
   </data>
  </layer>
- <objectgroup color="#ff0000" id="6" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collisions">
   <object id="1" type="collision" x="32" y="80" width="16" height="112"/>
   <object id="2" type="collision" x="32" y="80" width="48" height="32"/>
   <object id="3" type="collision" x="64" y="16" width="16" height="96"/>

--- a/mods/tuxemon/maps/spyder_dojo3.tmx
+++ b/mods/tuxemon/maps/spyder_dojo3.tmx
@@ -36,7 +36,7 @@
    eAFjYBgFoyEwGgIkh4AQyTpGNWAJAQAbfgAT
   </data>
  </layer>
- <objectgroup color="#ff0000" id="6" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collisions">
   <object id="1" type="collision" x="32" y="80" width="16" height="112"/>
   <object id="2" type="collision" x="32" y="80" width="48" height="32"/>
   <object id="3" type="collision" x="64" y="16" width="16" height="96"/>

--- a/mods/tuxemon/maps/spyder_dojo4.tmx
+++ b/mods/tuxemon/maps/spyder_dojo4.tmx
@@ -31,7 +31,7 @@
    eAFjYBgFoyEwGgKjITAwIQAABIAAAQ==
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="1" type="collision" x="32" y="80" width="16" height="112"/>
   <object id="2" type="collision" x="32" y="80" width="48" height="32"/>
   <object id="3" type="collision" x="64" y="16" width="16" height="96"/>

--- a/mods/tuxemon/maps/spyder_downstairs.tmx
+++ b/mods/tuxemon/maps/spyder_downstairs.tmx
@@ -39,7 +39,7 @@
    eAFjYKAveKhNH/um6jEwTAPi6UCMCwAA3E8DWQ==
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="1" type="collision" x="96" y="64" width="32" height="16"/>
   <object id="2" type="collision" x="16" y="16" width="128" height="16"/>
   <object id="4" type="collision" x="0" y="96" width="48" height="16"/>

--- a/mods/tuxemon/maps/spyder_dragonscave.tmx
+++ b/mods/tuxemon/maps/spyder_dragonscave.tmx
@@ -34,7 +34,7 @@
    eAHtlNENwjAMRCuxEDANMA0wDWwDG+ETnHocdpoiJH4aKaSJk2f74rBfDcP+D33oaHPiOkQOrbabmePCe1dz0a/9Tm5RX5uib2N9rn6t2kdtVrz3W+ufVTz4Whd5Vfli/R49y6EVe7Z/au2XvEvEfI5+jH4t4p+Kh3ay9Aa+ZWYs3EmlMWLwxrgwQjNtGUvt+IYubK6P87yWsvjJ4qhn8JbwZtCy2OgPNtYg9z9Pfb4PnlE/0IKxuZ/eGJRHFmLQdWoPZvU2GJ/eKdc8NvJaI856DOT5eotDm/M0V2qejTzvo/NU74yDNa87ZToPNuZb8Somc3N/PTFmTMaR3WMvU+8MvIxFPdQf3wdGfSPO0zk40OD06nj7mT/6Qc56Hus6p57Yh5ax/L70vPp5EsbfjDVax69enu6jDvrfB6L7vEW+qu3odVqH6v8gY7pf1cVtrAUdwdR6uMfc7cijh6XnWt9eC773AXz85d8=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="2" type="collision" x="240" y="336">
    <polygon points="0,0 0,16 16,16 16,0"/>
   </object>

--- a/mods/tuxemon/maps/spyder_dryadsgrove.tmx
+++ b/mods/tuxemon/maps/spyder_dryadsgrove.tmx
@@ -788,13 +788,13 @@
   <object id="219" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
-    <property name="cond1" value="is variable_set daytime:true"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="224" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
-    <property name="cond1" value="is variable_set daytime:false"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="220" name="Talk Aquemini" type="event" x="544" y="192" width="16" height="48">

--- a/mods/tuxemon/maps/spyder_flower_center.tmx
+++ b/mods/tuxemon/maps/spyder_flower_center.tmx
@@ -36,7 +36,7 @@
    eAFjYBje4LYcA8MdJHwXyB4F1AkBAH4YBOM=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="5" type="collision" x="144" y="128" width="32" height="32"/>
   <object id="6" type="collision" x="160" y="48" width="32" height="16"/>
   <object id="7" type="collision" x="144" y="48" width="16" height="32"/>

--- a/mods/tuxemon/maps/spyder_flower_city.tmx
+++ b/mods/tuxemon/maps/spyder_flower_city.tmx
@@ -38,7 +38,7 @@
    eAHtlktKA0EQhmuh+MgZjCsR88DXTvAcvrbZJ5qQa7jwCmpcqfGxVlEvoJ4jeoR8QQoyGXVm0t2xYbrgo6ieTteff5qhRLLFQ1nkMYEnnk9viUzBcNZOuq61zdyj92cCXzwvoW0FhrPq0HWtbea0+tL2rFWiO9vb3/W4Hi9wXjGBxZGeUQXR6uSXvS49jioI1X84MO79m5TWcP8m5XTo48KBS76rV3ANXbiBEPYcqFdFGnAIR9CEFoTIrwO9NWZLsBF5ul/PePYCrz9453JOOOWbeAbn0IELyBou5oTbJZE7uAcf4w1d7/CRUt9f7zfp/82wYRbmYB4K4FOsImZwbddhAzbBp9hBzC7swT4cgO0web+2tfh0XmPZJzVxLcee64srDivBgeBAnhzQ+c9VNvVS5z9X2VTf4PeuvNNzTTW68k7PNdHXB5B/bvw=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="6" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collisions">
   <object id="302" type="collision" x="0" y="512" width="64" height="48">
    <properties>
     <property name="key" value="water"/>
@@ -524,13 +524,13 @@
   <object id="466" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
-    <property name="cond1" value="is variable_set daytime:true"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="467" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
-    <property name="cond1" value="is variable_set daytime:false"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="468" name="Sign: Flower Scoop" type="event" x="352" y="368" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_flower_house1.tmx
+++ b/mods/tuxemon/maps/spyder_flower_house1.tmx
@@ -33,7 +33,7 @@
    eAFjYBgFlIQAAAFAAAE=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="61" type="collision" x="0" y="0" width="160" height="32"/>
   <object id="62" type="collision" x="96" y="64" width="32" height="32"/>
   <object id="63" type="collision" x="32" y="80" width="32" height="32"/>

--- a/mods/tuxemon/maps/spyder_flower_house2.tmx
+++ b/mods/tuxemon/maps/spyder_flower_house2.tmx
@@ -36,7 +36,7 @@
    eAFjYBh84KXi4HMTLhcBALPXAQs=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="60" type="collision" x="0" y="0" width="160" height="32"/>
   <object id="61" type="collision" x="0" y="32" width="16" height="16"/>
   <object id="62" type="collision" x="144" y="32" width="16" height="16"/>

--- a/mods/tuxemon/maps/spyder_flower_petshop.tmx
+++ b/mods/tuxemon/maps/spyder_flower_petshop.tmx
@@ -38,7 +38,7 @@
    eAFjYBgFIzEEAAH4AAE=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="3" name="Collision">
+ <objectgroup color="#ff0000" id="3" name="Collisions">
   <object id="14" type="collision" x="0" y="32" width="224" height="16"/>
   <object id="15" type="collision" x="0" y="48" width="16" height="48"/>
   <object id="16" type="collision" x="208" y="32" width="16" height="112"/>

--- a/mods/tuxemon/maps/spyder_healing_center.tmx
+++ b/mods/tuxemon/maps/spyder_healing_center.tmx
@@ -36,7 +36,7 @@
    eAFjYBje4LYcA8MdJHwXyB4F1AkBAH4YBOM=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="5" type="collision" x="144" y="128" width="32" height="32"/>
   <object id="6" type="collision" x="160" y="48" width="32" height="16"/>
   <object id="7" type="collision" x="144" y="48" width="16" height="32"/>

--- a/mods/tuxemon/maps/spyder_leather_center.tmx
+++ b/mods/tuxemon/maps/spyder_leather_center.tmx
@@ -36,7 +36,7 @@
    eAFjYBje4LYcA8MdJHwXyB4F1AkBAH4YBOM=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="5" type="collision" x="144" y="128" width="32" height="32"/>
   <object id="6" type="collision" x="160" y="48" width="32" height="16"/>
   <object id="7" type="collision" x="144" y="48" width="16" height="32"/>

--- a/mods/tuxemon/maps/spyder_leather_house1.tmx
+++ b/mods/tuxemon/maps/spyder_leather_house1.tmx
@@ -42,7 +42,7 @@
    eAFjYCAeNHIyMDQBMSEwEahmEhHqCJkzFOQBRCICSw==
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="19" type="collision" x="0" y="0" width="160" height="32"/>
   <object id="20" type="collision" x="112" y="80" width="32" height="32"/>
   <object id="25" type="collision" x="16" y="32" width="32" height="16"/>

--- a/mods/tuxemon/maps/spyder_leather_house2.tmx
+++ b/mods/tuxemon/maps/spyder_leather_house2.tmx
@@ -36,7 +36,7 @@
    eAFjYBgFlIQAAAFAAAE=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="60" type="collision" x="0" y="0" width="160" height="32"/>
   <object id="61" type="collision" x="32" y="64" width="48" height="16"/>
   <object id="70" type="collision" x="48" y="32" width="32" height="16"/>

--- a/mods/tuxemon/maps/spyder_leather_shaft1.tmx
+++ b/mods/tuxemon/maps/spyder_leather_shaft1.tmx
@@ -104,7 +104,7 @@
    </properties>
   </object>
  </objectgroup>
- <objectgroup color="#ff0000" id="6" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collisions">
   <object id="5" type="collision" x="0" y="32" width="240" height="16"/>
   <object id="6" type="collision" x="160" y="48" width="16" height="144"/>
   <object id="7" type="collision" x="0" y="176" width="128" height="16"/>

--- a/mods/tuxemon/maps/spyder_leather_shaft2.tmx
+++ b/mods/tuxemon/maps/spyder_leather_shaft2.tmx
@@ -39,7 +39,7 @@
    eAFjYBgeII+fgSEfiOkJugWIs20hkepApgEAFMkCSA==
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="62" type="collision" x="0" y="96" width="64" height="16"/>
   <object id="63" type="collision" x="80" y="48" width="80" height="32"/>
   <object id="64" type="collision" x="0" y="32" width="160" height="16"/>

--- a/mods/tuxemon/maps/spyder_leather_town.tmx
+++ b/mods/tuxemon/maps/spyder_leather_town.tmx
@@ -441,13 +441,13 @@
   <object id="301" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
-    <property name="cond1" value="is variable_set daytime:true"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="304" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
-    <property name="cond1" value="is variable_set daytime:false"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="303" name="Auto Healing Teleported" type="event" x="0" y="16" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_lion_mountain.tmx
+++ b/mods/tuxemon/maps/spyder_lion_mountain.tmx
@@ -315,13 +315,13 @@
   <object id="5" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:snow"/>
-    <property name="cond1" value="is variable_set daytime:true"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="6" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_snow"/>
-    <property name="cond1" value="is variable_set daytime:false"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="7" name="Player Spawn" type="event" x="64" y="1440" width="16" height="16"/>

--- a/mods/tuxemon/maps/spyder_mansion.tmx
+++ b/mods/tuxemon/maps/spyder_mansion.tmx
@@ -42,7 +42,7 @@
    eAFjYBgFoyEwGgL0CoFpMtSxiVrmUMc1pJsyg0rhQLrN+HUAAIAqAhk=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="1" type="collision" x="48" y="0" width="16" height="128"/>
   <object id="2" type="collision" x="64" y="0" width="224" height="32"/>
   <object id="3" type="collision" x="64" y="96" width="80" height="32"/>

--- a/mods/tuxemon/maps/spyder_mansion_basement.tmx
+++ b/mods/tuxemon/maps/spyder_mansion_basement.tmx
@@ -40,7 +40,7 @@
    eAFjYBgFwyEE5IGeAGGl4eCZUT+MhsBoCIyGwDALgeFYNgMAj/oAgw==
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="1" type="collision" x="0" y="0" width="16" height="224"/>
   <object id="2" type="collision" x="16" y="0" width="368" height="32"/>
   <object id="3" type="collision" x="368" y="32" width="16" height="320"/>

--- a/mods/tuxemon/maps/spyder_mansion_top.tmx
+++ b/mods/tuxemon/maps/spyder_mansion_top.tmx
@@ -44,7 +44,7 @@
    eJxjYBgFo2AUjALsQFlpoF0wCkYBaQAAwTYARg==
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="1" type="collision" x="0" y="0" width="16" height="304"/>
   <object id="2" type="collision" x="352" y="0" width="16" height="304"/>
   <object id="3" type="collision" x="16" y="176" width="160" height="32"/>

--- a/mods/tuxemon/maps/spyder_omnichannel1.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel1.tmx
@@ -34,7 +34,7 @@
    eAHNkjtuAjEQhicsSEC6UHIUHneAcAcCXQScACREUiXQIppchSYcIIkUIBwAkHi2+SxsyVq87BYUjPTJ43/mH1uWRUS+7kS+4QcaoCLmiXjwy34KM5jr2qlDZMl+BWvo6doDngxs2G9hB3v4BBNeTCQOCRhZuqon0VKQhnv489XNjLD1EOLrMHsAJtpWbjTX+kbfB7xr+hF9rlm3oiVC3ironlmfz55j50F+o9tz7NzUr7HmGJKHAhRB/ceJ7/7IZ1FCKcMjVED9x0UEX5XeJ6hBHdR/PEbw0XrVeHac2eCElqbpOG0cF+k6fD16XzUvDp+Shg5fQOtF+R9TICXb
   </data>
  </layer>
- <objectgroup color="#ff0000" id="3" name="Collision">
+ <objectgroup color="#ff0000" id="3" name="Collisions">
   <object id="1" type="collision" x="0" y="32" width="16" height="304"/>
   <object id="2" type="collision" x="0" y="0" width="224" height="32"/>
   <object id="4" type="collision" x="208" y="32" width="16" height="304"/>

--- a/mods/tuxemon/maps/spyder_omnichannel2.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel2.tmx
@@ -31,7 +31,7 @@
    eAGlkzlOg0EMRs0iKJK07BSElrVCHCDJIaCEK7CEK7BegeUwQM3SJdQsggJoeZ80I/2y/AcRLD15xvY3nkVjZlarmd1VzO7hAR5B1qiaNeEWIptH90ztC7zCW9JtUL8JT0n3Tvwj5bTOOroBcoMwBMOpLvf4TvMR/KjLjaMdS0zgI5tBM+t0i9QuJJZKdNFa/43pbrdg2/VU/Jo93rh95n662zYcOJ3iHTTdEp3u9hTOnE7xTzRfJbrcV77itMVcr/Fcn7q1PnW99uJzO/TYhT3YD/rpPSI7JH4Ex3DiaqrM9R6RnRO/gEu4cjV15nqPbP5/5PhvPvof0ugskzAF04U+eb3ofyinsyzDCqwGuqz3XmdpQBNaf9D5dYrzH0tjJ98=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="3" name="Collision">
+ <objectgroup color="#ff0000" id="3" name="Collisions">
   <object id="1" type="collision" x="0" y="0" width="224" height="32"/>
   <object id="16" type="collision" x="0" y="32" width="16" height="304"/>
   <object id="17" type="collision" x="112" y="48" width="16" height="128"/>

--- a/mods/tuxemon/maps/spyder_omnichannel3.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel3.tmx
@@ -31,7 +31,7 @@
    eAFjYEAF/kBuABA3MTIwNANxCxJuBbLbgBgbSAUKpmGToKLYSqDdK6B4FQ53YLNuP1DtPig+QII+bGZRIvaGiYFBH2i/AYlusGZmYHAF6nED4lygGf1AegIRZoD0RQPVxUDVLgXSy4jUR44/QfaRA2itLwnNXcTah64OnY/u19VAgTXogkA+IX0HgWoOATEobpFBMpK7QWmnEBh3LmhqkNXD2N1I+kB2twP15aDpI5SXQHbPxZJWCOUlZLth7iGHBgB0nSFG
   </data>
  </layer>
- <objectgroup color="#ff0000" id="4" name="Collision">
+ <objectgroup color="#ff0000" id="4" name="Collisions">
   <object id="15" type="collision" x="0" y="0" width="16" height="336"/>
   <object id="16" type="collision" x="16" y="0" width="208" height="32"/>
   <object id="17" type="collision" x="208" y="32" width="16" height="304"/>

--- a/mods/tuxemon/maps/spyder_paper_manor.tmx
+++ b/mods/tuxemon/maps/spyder_paper_manor.tmx
@@ -36,7 +36,7 @@
    eJxjYBhZ4KQiddTAAAByVgHV
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="60" type="collision" x="32" y="64" width="32" height="32"/>
   <object id="63" type="collision" x="0" y="112" width="16" height="16"/>
   <object id="64" type="collision" x="144" y="112" width="16" height="16"/>

--- a/mods/tuxemon/maps/spyder_paper_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_paper_scoop.tmx
@@ -41,7 +41,7 @@
    eAHlzLENgCAARNFbA6HQdXASmVFxEMVBEBL+BlTY+JPXXU76V36WdhyIONFrY3PhRsKDEa38ZrwoqOgV2JhFmmDh8FUNeNsOrQ==
   </data>
  </layer>
- <objectgroup color="#ff0000" id="6" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collisions">
   <object id="11" type="collision" x="0" y="16" width="208" height="32"/>
   <object id="21" type="collision" x="32" y="48" width="16" height="64"/>
   <object id="22" type="collision" x="0" y="112" width="48" height="16"/>

--- a/mods/tuxemon/maps/spyder_paper_town.tmx
+++ b/mods/tuxemon/maps/spyder_paper_town.tmx
@@ -42,7 +42,7 @@
    eAHt06sNgEAQRdFXAiiQVMO3JH4eaARokitJFhSIFW+SY3bM5CYreVzgvUCRvu+8CQu4V9jEL/8XKHOpQo0GLTo8TZ9JA0ZMmBHDLIm0YkMsc/+/O3cdOCO6L5ZOvsMFXMAFvha4ALfJCbo=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="6" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collisions">
   <properties>
    <property name="Collision" value=""/>
   </properties>
@@ -455,14 +455,14 @@
   <object id="246" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
-    <property name="cond1" value="is variable_set daytime:true"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
     <property name="cond2" value="not has_sprite swimmer"/>
    </properties>
   </object>
   <object id="251" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
-    <property name="cond1" value="is variable_set daytime:false"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
     <property name="cond2" value="not has_sprite swimmer"/>
    </properties>
   </object>
@@ -532,7 +532,7 @@
     <property name="act1" value="set_variable environment:sea"/>
     <property name="act2" value="random_encounter routec"/>
     <property name="cond1" value="is has_sprite swimmer"/>
-    <property name="cond2" value="is variable_set daytime:true"/>
+    <property name="cond2" value="not variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="234" name="Swim Encounters Night" type="event" x="176" y="304" width="16" height="16">
@@ -540,7 +540,7 @@
     <property name="act1" value="set_variable environment:night_sea"/>
     <property name="act2" value="random_encounter routec"/>
     <property name="cond1" value="is has_sprite swimmer"/>
-    <property name="cond2" value="is variable_set daytime:false"/>
+    <property name="cond2" value="is variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="272" name="Teleport to Daycare Back" type="event" x="352" y="48" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_route1.tmx
+++ b/mods/tuxemon/maps/spyder_route1.tmx
@@ -247,13 +247,13 @@
   <object id="190" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
-    <property name="cond1" value="is variable_set daytime:true"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="191" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
-    <property name="cond1" value="is variable_set daytime:false"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="192" name="Exhausted" type="event" x="0" y="16" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_route2.tmx
+++ b/mods/tuxemon/maps/spyder_route2.tmx
@@ -578,13 +578,13 @@
   <object id="187" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
-    <property name="cond1" value="is variable_set daytime:true"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="192" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
-    <property name="cond1" value="is variable_set daytime:false"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="188" name="Talk roddick" type="event" x="80" y="64" width="16" height="80">

--- a/mods/tuxemon/maps/spyder_route3.tmx
+++ b/mods/tuxemon/maps/spyder_route3.tmx
@@ -743,13 +743,13 @@
   <object id="676" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:sand"/>
-    <property name="cond1" value="is variable_set daytime:true"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="687" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_sand"/>
-    <property name="cond1" value="is variable_set daytime:false"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="679" name="Enforcer Talk" type="event" x="272" y="144" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_route4.tmx
+++ b/mods/tuxemon/maps/spyder_route4.tmx
@@ -25,7 +25,7 @@
    eAFjYBgFoyEwGgKjITAaAqMhMBoCoyEwMCFwgouB4SQQUwu8BZr1jormUctdo+aMhsBoCCBCAACenwOV
   </data>
  </layer>
- <objectgroup color="#ff0000" id="4" name="Collision">
+ <objectgroup color="#ff0000" id="4" name="Collisions">
   <object id="3" type="collision" x="32" y="0" width="288" height="32"/>
   <object id="4" type="collision" x="32" y="608" width="176" height="32"/>
   <object id="5" type="collision" x="32" y="512" width="32" height="96"/>
@@ -368,13 +368,13 @@
   <object id="81" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
-    <property name="cond1" value="is variable_set daytime:true"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="87" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
-    <property name="cond1" value="is variable_set daytime:false"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="82" name="Talk Marshall" type="event" x="48" y="464" width="48" height="16">

--- a/mods/tuxemon/maps/spyder_route5.tmx
+++ b/mods/tuxemon/maps/spyder_route5.tmx
@@ -354,13 +354,13 @@
   <object id="61" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
-    <property name="cond1" value="is variable_set daytime:true"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="67" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
-    <property name="cond1" value="is variable_set daytime:false"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="62" name="Talk Sara" type="event" x="384" y="128" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_route6.tmx
+++ b/mods/tuxemon/maps/spyder_route6.tmx
@@ -20,7 +20,7 @@
    eAHNlT1ORDEMhENLQbU1cA4OANyKlbjcchgogRJP8UnWKD8OzdtI1sTJjD0JecvltrWPiMuV4mf4+oq4VvR7awcN90Hu93aQveHfD5/gUf7oiw9w5/7QrJBeGZ/ucjaeux/vNVbWv6FZjdWe+3G/v62dfyK+I6jlGq2/xTfPYN7jwami+zmlPqrxeNPODxH3EdR0jfzgSRxy56HfwdUZe/569fGU0WuT9/SjtdUZq/5UP3tT7rXJtTcb7/HtcJYRot/xh2YXe2+cs4yQHq/x7l4intP7Y6+CnH/Gnd0BenBWh71T8bdLfM6Ptoczf+jBnl5r+B9h1uV36PzMYz7zV9GrDv5HSC+h/DGcz3rGmT/Xu99qnvtpvqObvXGv436rufv7r25Vx/1Wc+ry9sh39HDRClkDq+d2nmrhDdSa80Z55mquof+1zv8D6q5wNQ==
   </data>
  </layer>
- <objectgroup color="#ff0000" id="4" name="Collision">
+ <objectgroup color="#ff0000" id="4" name="Collisions">
   <object id="145" type="collision" x="0" y="0" width="64" height="128"/>
   <object id="146" type="collision" x="64" y="0" width="576" height="32"/>
   <object id="147" type="collision" x="544" y="32" width="32" height="32"/>
@@ -433,13 +433,13 @@
   <object id="212" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
-    <property name="cond1" value="is variable_set daytime:true"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="219" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
-    <property name="cond1" value="is variable_set daytime:false"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="213" name="Talk Maxwell" type="event" x="64" y="80" width="96" height="16">

--- a/mods/tuxemon/maps/spyder_route7.tmx
+++ b/mods/tuxemon/maps/spyder_route7.tmx
@@ -112,13 +112,13 @@
   <object id="7" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:cliff"/>
-    <property name="cond1" value="is variable_set daytime:true"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="8" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_cliff"/>
-    <property name="cond1" value="is variable_set daytime:false"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="9" name="Sign" type="event" x="80" y="560" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_routea.tmx
+++ b/mods/tuxemon/maps/spyder_routea.tmx
@@ -179,13 +179,13 @@
   <object id="66" name="Environment Day" type="event" x="96" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
-    <property name="cond1" value="is variable_set daytime:true"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="68" name="Environment Night" type="event" x="80" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
-    <property name="cond1" value="is variable_set daytime:false"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="67" name="Exhausted" type="event" x="112" y="0" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_routec.tmx
+++ b/mods/tuxemon/maps/spyder_routec.tmx
@@ -246,13 +246,13 @@
   <object id="221" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:ocean"/>
-    <property name="cond1" value="is variable_set daytime:true"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="228" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_ocean"/>
-    <property name="cond1" value="is variable_set daytime:false"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="222" name="Talk Rutherford" type="event" x="544" y="144" width="16" height="48">

--- a/mods/tuxemon/maps/spyder_routee.tmx
+++ b/mods/tuxemon/maps/spyder_routee.tmx
@@ -17,7 +17,7 @@
    eAGtzkEKwzAMRFFvepfkMOn9j1Nv3maCsQsTCJ+R5C9dnzHu+V+HHPHlu2d6vvM/Zehe77KfOff/28/5vHvXz/2ydzKqozrmftm8jOqojrxJ86v6qs+bNL+qr/q5Xza/o3nM/fLOo28eeVvkbbF1F0/rLh7eFnlbbN3F07qLh7dF3hZ/cRpRAQ==
   </data>
  </layer>
- <objectgroup color="#ff0000" id="6" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collisions">
   <object id="151" type="collision" x="0" y="0" width="192" height="32"/>
   <object id="152" type="collision" x="128" y="32" width="64" height="96"/>
   <object id="153" type="collision" x="0" y="80" width="80" height="240"/>

--- a/mods/tuxemon/maps/spyder_scoop2.tmx
+++ b/mods/tuxemon/maps/spyder_scoop2.tmx
@@ -26,7 +26,7 @@
    eAFjYCAebBfAr/YaUJ5PAqIGl1prqDxILQjsJGAmADZLBJ0=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="3" name="Collision">
+ <objectgroup color="#ff0000" id="3" name="Collisions">
   <object id="4" type="collision" x="0" y="16" width="32" height="48"/>
   <object id="5" type="collision" x="32" y="0" width="48" height="48"/>
   <object id="6" type="collision" x="80" y="16" width="32" height="48"/>

--- a/mods/tuxemon/maps/spyder_scoop3.tmx
+++ b/mods/tuxemon/maps/spyder_scoop3.tmx
@@ -37,7 +37,7 @@
    eAFjYBgF1AyBZ9IMDMRgkJ0gdUMdAAB7DgsM
   </data>
  </layer>
- <objectgroup color="#ff0000" id="6" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collisions">
   <object id="4" type="collision" x="0" y="0" width="80" height="48"/>
   <object id="5" type="collision" x="80" y="0" width="112" height="32"/>
   <object id="6" type="collision" x="112" y="32" width="80" height="16"/>

--- a/mods/tuxemon/maps/spyder_scoop4.tmx
+++ b/mods/tuxemon/maps/spyder_scoop4.tmx
@@ -42,7 +42,7 @@
    eAFjYBgFwykEFIeTZwahX0Za+AIAb2AAQw==
   </data>
  </layer>
- <objectgroup color="#ff0000" id="7" name="Collision">
+ <objectgroup color="#ff0000" id="7" name="Collisions">
   <object id="4" type="collision" x="0" y="0" width="192" height="48"/>
   <object id="5" type="collision" x="112" y="160" width="80" height="16"/>
   <object id="7" type="collision-line" x="0" y="352">

--- a/mods/tuxemon/maps/spyder_timber_center.tmx
+++ b/mods/tuxemon/maps/spyder_timber_center.tmx
@@ -36,7 +36,7 @@
    eAFjYBje4LYcA8MdJHwXyB4F1AkBAH4YBOM=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="5" type="collision" x="144" y="128" width="32" height="32"/>
   <object id="6" type="collision" x="160" y="48" width="32" height="16"/>
   <object id="7" type="collision" x="144" y="48" width="16" height="32"/>

--- a/mods/tuxemon/maps/spyder_timber_house.tmx
+++ b/mods/tuxemon/maps/spyder_timber_house.tmx
@@ -36,7 +36,7 @@
    eJxjYBhZ4KQiddTAAAByVgHV
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="60" type="collision" x="32" y="64" width="32" height="32"/>
   <object id="63" type="collision" x="0" y="112" width="16" height="16"/>
   <object id="64" type="collision" x="144" y="112" width="16" height="16"/>

--- a/mods/tuxemon/maps/spyder_timber_town.tmx
+++ b/mods/tuxemon/maps/spyder_timber_town.tmx
@@ -45,7 +45,7 @@
    eAHt00sOwVAYhuFvD6hEgrAiu3GbdA8tFuM2oqXdCDbhHRo0JhJOju9PnsmZ9D/vSSXPPxY49aUzCpS4wOMCLvC+wJb/ZIc9DjjiG9PiO210kKCL17kmUoUaIc6Nve54BLpfiM280+cFspGUY4U1NvC4gAu4gAu4gAu4gAu4gAvEUWA6kGaYY4ElxlLadD7pSU3ncZSI7xZD3jG+W/lGvyzwBOReHWY=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="6" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collisions">
   <object id="245" type="collision" x="288" y="16" width="144" height="224"/>
   <object id="246" type="collision" x="96" y="0" width="192" height="32"/>
   <object id="247" type="collision" x="80" y="0" width="16" height="16"/>
@@ -331,13 +331,13 @@
   <object id="357" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
-    <property name="cond1" value="is variable_set daytime:true"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="358" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
-    <property name="cond1" value="is variable_set daytime:false"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="356" name="Destination - Timber" type="event" x="80" y="288" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_tunnel.tmx
+++ b/mods/tuxemon/maps/spyder_tunnel.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="359">
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="361">
  <properties>
   <property name="east" value="route6"/>
   <property name="edges" value="clamped"/>
@@ -254,12 +254,6 @@
     <property name="cond1" value="not variable_set tunnelbtommy:yes"/>
    </properties>
   </object>
-  <object id="340" name="Environment" type="event" x="16" y="0" width="16" height="16">
-   <properties>
-    <property name="act1" value="set_variable environment:cave"/>
-    <property name="cond1" value="not variable_set environment:cave"/>
-   </properties>
-  </object>
   <object id="341" name="Talk Greta" type="event" x="208" y="576" width="16" height="32">
    <properties>
     <property name="act00" value="pathfind_to_player spyder_tunnelb_greta"/>
@@ -350,6 +344,18 @@
    <properties>
     <property name="act1" value="remove_collision water"/>
     <property name="cond1" value="is variable_set swimming:yes"/>
+   </properties>
+  </object>
+  <object id="359" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_variable environment:grass"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
+   </properties>
+  </object>
+  <object id="360" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_variable environment:night_grass"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/taba_town.tmx
+++ b/mods/tuxemon/maps/taba_town.tmx
@@ -32,7 +32,7 @@
    eAHt2ksOwVAYhuGfiEQ7IrZgXTbhNrAFt0247sUG6jLHzAZ8s0qjkVST4/S8f/JGSVT7aGiKWfHpN9PnHt+W00dZQqA8gWlc3rp+XdPT8fE+65jN1UIt1UoxCCCAwD8LJG2zkzqri7qq7PDZlhWpxv1P39+3yOyuHirEaemcJlKxo3ObWsOsrsq+DfG9ZJ8RQAABBBBAAAEEEEAAAQQQQAABBBAIRaDo9cRQfNhPBBBAAAEEEMgXGHTNhmqkxmqiQp+efq9lEEAAAQQQQKC6Amv9r3ujtmqn9uqgGAQQQMA3gW/XhX3bH7bXjUDeceRma3hVBPwUeAGhuxmc
   </data>
  </layer>
- <objectgroup color="#ff0000" id="6" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collisions">
   <properties>
    <property name="Collision" value=""/>
   </properties>
@@ -961,13 +961,13 @@
   <object id="179" name="Environment Day" type="event" x="8.88178e-16" y="16" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
-    <property name="cond1" value="is variable_set daytime:true"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
    </properties>
   </object>
   <object id="180" name="Environment Night" type="event" x="16" y="16" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
-    <property name="cond1" value="is variable_set daytime:false"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/taba_town_house1.tmx
+++ b/mods/tuxemon/maps/taba_town_house1.tmx
@@ -36,7 +36,7 @@
    eAFjYBgF1AwBAAFQAAE=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="28" type="collision" x="160" y="48" width="16" height="16"/>
   <object id="29" type="collision" x="128" y="96" width="16" height="16"/>
   <object id="30" type="collision" x="32" y="64" width="48" height="32"/>

--- a/mods/tuxemon/maps/taba_town_house2.tmx
+++ b/mods/tuxemon/maps/taba_town_house2.tmx
@@ -36,7 +36,7 @@
    eAFjYBgF1AwBAAFQAAE=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="29" type="collision" x="1.42109e-14" y="32" width="144" height="16"/>
   <object id="39" type="collision" x="128" y="48" width="64" height="16"/>
   <object id="40" type="collision" x="16" y="64" width="32" height="32"/>

--- a/mods/tuxemon/maps/taba_town_house3.tmx
+++ b/mods/tuxemon/maps/taba_town_house3.tmx
@@ -36,7 +36,7 @@
    eAFjYBgF1AwBAAFQAAE=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="29" type="collision" x="80" y="96" width="16" height="16"/>
   <object id="33" type="collision" x="0" y="16" width="192" height="16"/>
   <object id="39" type="collision" x="144" y="32" width="16" height="64"/>

--- a/mods/tuxemon/maps/taba_town_house4.tmx
+++ b/mods/tuxemon/maps/taba_town_house4.tmx
@@ -36,7 +36,7 @@
    eAFjYBgF1AwBAAFQAAE=
   </data>
  </layer>
- <objectgroup color="#ff0000" id="5" name="Collision">
+ <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="29" type="collision" x="128" y="32" width="16" height="64"/>
   <object id="33" type="collision" x="0" y="16" width="192" height="16"/>
   <object id="39" type="collision" x="144" y="32" width="32" height="16"/>

--- a/mods/tuxemon/maps/timber_town.tmx
+++ b/mods/tuxemon/maps/timber_town.tmx
@@ -40,78 +40,7 @@
    eAHtl0kOgkAQRWvntHQ6jV5LEcT5LkbjCZxWTrfydVzXgoAJhP+TRyfV1VB56Q1migwUa+AxMnvCC97wAUUG6mbgzL2/wBVucIcqpsvcPejDAIagZDcQldzbvuTzZTde7IkGr2tCC9rQAUUGZEAGZEAGZEAGZEAGZOC/BiZjsylEMIMYQlasa9jAFnYQkrDOIYUFLCHE6//t1uOZOv98iVOPnbrXn9fiyfne0akfnLrXn3c+na+2gS/MMyKo
   </data>
  </layer>
- <objectgroup color="#ffff00" id="5" name="Events">
-  <object id="118" name="Teleport to Route 5" type="event" x="0" y="464" width="16" height="16">
-   <properties>
-    <property name="act10" value="transition_teleport route5.tmx,39,9,0.3"/>
-    <property name="act20" value="player_face left"/>
-    <property name="cond10" value="is player_at"/>
-    <property name="cond20" value="is player_facing left"/>
-   </properties>
-  </object>
-  <object id="172" name="Teleport to Tunnel" type="event" x="528" y="0" width="16" height="16">
-   <properties>
-    <property name="act10" value="transition_teleport tunnel.tmx,13,39,0.3"/>
-    <property name="act20" value="player_face up"/>
-    <property name="cond10" value="is player_at"/>
-    <property name="cond20" value="is player_facing up"/>
-   </properties>
-  </object>
-  <object id="173" name="Teleport to Tunnel" type="event" x="544" y="0" width="16" height="16">
-   <properties>
-    <property name="act10" value="transition_teleport tunnel.tmx,14,39,0.3"/>
-    <property name="act20" value="player_face up"/>
-    <property name="cond10" value="is player_at"/>
-    <property name="cond20" value="is player_facing up"/>
-   </properties>
-  </object>
-  <object id="174" name="Teleport to Tunnel" type="event" x="560" y="0" width="16" height="16">
-   <properties>
-    <property name="act10" value="transition_teleport tunnel.tmx,15,39,0.3"/>
-    <property name="act20" value="player_face up"/>
-    <property name="cond10" value="is player_at"/>
-    <property name="cond20" value="is player_facing up"/>
-   </properties>
-  </object>
-  <object id="175" name="Teleport to Tunnel" type="event" x="576" y="0" width="16" height="16">
-   <properties>
-    <property name="act10" value="transition_teleport tunnel.tmx,16,39,0.3"/>
-    <property name="act20" value="player_face up"/>
-    <property name="cond10" value="is player_at"/>
-    <property name="cond20" value="is player_facing up"/>
-   </properties>
-  </object>
-  <object id="176" name="Play Music" type="event" x="0" y="0" width="16" height="16">
-   <properties>
-    <property name="act10" value="play_music music_town_theme"/>
-    <property name="cond10" value="not music_playing music_town_theme"/>
-   </properties>
-  </object>
-  <object id="180" name="Teleport to Scoop" type="event" x="160" y="352" width="16" height="16">
-   <properties>
-    <property name="act10" value="transition_teleport scoop1.tmx,0,3,0.3"/>
-    <property name="act20" value="player_face right"/>
-    <property name="cond10" value="is player_at"/>
-    <property name="cond20" value="is player_facing up"/>
-   </properties>
-  </object>
-  <object id="181" name="Player Spawn" type="event" x="560" y="48" width="16" height="16"/>
-  <object id="184" name="Sign: Timber Town" type="event" x="32" y="448" width="16" height="16">
-   <properties>
-    <property name="act1" value="translated_dialog welcome_location_town"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
-   </properties>
-  </object>
-  <object id="185" name="Sign: Timber North" type="event" x="528" y="16" width="16" height="16">
-   <properties>
-    <property name="act1" value="translated_dialog here_to_north"/>
-    <property name="cond1" value="is player_facing_tile"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
-   </properties>
-  </object>
- </objectgroup>
- <objectgroup color="#ff0000" id="6" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collisions">
   <object id="119" type="collision" x="0" y="0" width="32" height="464"/>
   <object id="120" type="collision" x="0" y="608" width="640" height="32"/>
   <object id="121" type="collision" x="608" y="0" width="32" height="608"/>
@@ -205,5 +134,76 @@
   <object id="177" type="collision" x="32" y="448" width="16" height="16"/>
   <object id="178" type="collision" x="208" y="16" width="16" height="16"/>
   <object id="179" type="collision" x="144" y="368" width="16" height="16"/>
+ </objectgroup>
+ <objectgroup color="#ffff00" id="5" name="Events">
+  <object id="118" name="Teleport to Route 5" type="event" x="0" y="464" width="16" height="16">
+   <properties>
+    <property name="act10" value="transition_teleport route5.tmx,39,9,0.3"/>
+    <property name="act20" value="player_face left"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing left"/>
+   </properties>
+  </object>
+  <object id="172" name="Teleport to Tunnel" type="event" x="528" y="0" width="16" height="16">
+   <properties>
+    <property name="act10" value="transition_teleport tunnel.tmx,13,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+   </properties>
+  </object>
+  <object id="173" name="Teleport to Tunnel" type="event" x="544" y="0" width="16" height="16">
+   <properties>
+    <property name="act10" value="transition_teleport tunnel.tmx,14,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+   </properties>
+  </object>
+  <object id="174" name="Teleport to Tunnel" type="event" x="560" y="0" width="16" height="16">
+   <properties>
+    <property name="act10" value="transition_teleport tunnel.tmx,15,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+   </properties>
+  </object>
+  <object id="175" name="Teleport to Tunnel" type="event" x="576" y="0" width="16" height="16">
+   <properties>
+    <property name="act10" value="transition_teleport tunnel.tmx,16,39,0.3"/>
+    <property name="act20" value="player_face up"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+   </properties>
+  </object>
+  <object id="176" name="Play Music" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act10" value="play_music music_town_theme"/>
+    <property name="cond10" value="not music_playing music_town_theme"/>
+   </properties>
+  </object>
+  <object id="180" name="Teleport to Scoop" type="event" x="160" y="352" width="16" height="16">
+   <properties>
+    <property name="act10" value="transition_teleport scoop1.tmx,0,3,0.3"/>
+    <property name="act20" value="player_face right"/>
+    <property name="cond10" value="is player_at"/>
+    <property name="cond20" value="is player_facing up"/>
+   </properties>
+  </object>
+  <object id="181" name="Player Spawn" type="event" x="560" y="48" width="16" height="16"/>
+  <object id="184" name="Sign: Timber Town" type="event" x="32" y="448" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog welcome_location_town"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+   </properties>
+  </object>
+  <object id="185" name="Sign: Timber North" type="event" x="528" y="16" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog here_to_north"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+   </properties>
+  </object>
  </objectgroup>
 </map>

--- a/mods/tuxemon/maps/tt_paper_town.tmx
+++ b/mods/tuxemon/maps/tt_paper_town.tmx
@@ -14,7 +14,7 @@
    eAFjYBgFgzEErgEdhQvT273lzAwMFUi4EsjGBcQYcckMDnFquo+UcCHW99R0H7F2YlOHK+2BxEcyMB7k6Xskxw0pfkfPu6DyDV+5RorZpKgVIEXxAKg1GAA7SbXSkgQNA5F/SXEfCV4ZVTqEQgCUzwci7REbRIM5n4PyTyQQRxHrmRGkDgC7VBYk
   </data>
  </layer>
- <objectgroup color="#ff0000" id="6" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collisions">
   <properties>
    <property name="Collision" value=""/>
   </properties>

--- a/mods/tuxemon/maps/tunnel.tmx
+++ b/mods/tuxemon/maps/tunnel.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="103">
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="109">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="xero"/>
@@ -22,6 +22,111 @@
    eAGVlttNJDEQRRskVohIeKQCiDT4BoJhg1ktsSD44JEDPjBHupTKPTOWempcLh9flx/dp0fLcjae02KXUs4OluU8novxvytXg3M9nmpr/+vS/2bDrly0WdRI/W7E3x4uy/2wf0a94xEHNwvaLGq0roU1452PIPLw79jo7XaNZ++qU39n4TF/5m1RF9rI4b48OHD/j3k9lbnBWuO5LlpzA+9lsF735LkuWucKLwvjsJwPW/TRR232N4fuHzj8h0WZzff95KddbT+13/sFvXJsl5c63jYsY7LNOduW1jnjqzoyrrY9l3UwVm3U8y6wfWZnGpOXd8GMk/66xrQlL3OU/Wb/0cg9kWcleTVHM071p87k7ZO/ZCbvb6zTrvmr9+tFwFPfLvl7HOOnHlH1jODfNX8dL3U5Rt73+joLL+c8u/Pyvu84+uClRrR1+nbJ38PIH/mvvHpHM/a2/DFH1xJetwZw1Lq2/2SZN7j2g5FF/9r+Q49M+9IPjbMzt5Y/eJkz7zm13Me50LeWv8qzjzbH0re2/zqeGpl/nlt53f7jvfX9nh59qgb7watt+Lr8GdethbyuDV6XP3la4pgbLHm+42mjsLc5g13+5Gi/O4yf5GWb3yC0d/kzVruN5zeI2on/2Lx7mZcc3hV+DxCT+rp3XfKI/9ww5eGjWE8e/m48/LXUOOv1u8fzkeNVVtaNSx93Vy3G1fnWOHRdDmc+9TuIPqn/C3uEZj8=
   </data>
  </layer>
+ <objectgroup color="#ff0000" id="5" name="Collisions">
+  <object id="1" type="collision" x="112" y="400" width="96" height="240"/>
+  <object id="2" type="collision" x="272" y="512" width="48" height="128"/>
+  <object id="3" type="collision" x="80" y="480" width="32" height="128"/>
+  <object id="4" type="collision" x="64" y="560" width="16" height="16"/>
+  <object id="5" type="collision" x="160" y="288" width="96" height="112"/>
+  <object id="6" type="collision" x="240" y="368" width="64" height="224"/>
+  <object id="7" type="collision" x="224" y="496" width="16" height="80"/>
+  <object id="8" type="collision" x="208" y="400" width="16" height="80"/>
+  <object id="9" type="collision" x="224" y="400" width="16" height="16"/>
+  <object id="10" type="collision" x="32" y="560" width="16" height="16"/>
+  <object id="11" type="collision" x="48" y="576" width="16" height="16"/>
+  <object id="12" type="collision" x="160" y="0" width="160" height="192"/>
+  <object id="13" type="collision" x="176" y="192" width="144" height="32"/>
+  <object id="14" type="collision" x="192" y="224" width="128" height="16"/>
+  <object id="15" type="collision" x="224" y="240" width="96" height="176"/>
+  <object id="16" type="collision" x="192" y="240" width="16" height="16"/>
+  <object id="17" type="collision" x="0" y="0" width="160" height="32"/>
+  <object id="18" type="collision" x="0" y="32" width="16" height="32"/>
+  <object id="19" type="collision" x="48" y="32" width="32" height="32"/>
+  <object id="20" type="collision" x="96" y="32" width="16" height="16"/>
+  <object id="21" type="collision" x="128" y="32" width="32" height="16"/>
+  <object id="22" type="collision" x="144" y="48" width="16" height="96"/>
+  <object id="23" type="collision" x="80" y="112" width="64" height="32"/>
+  <object id="24" type="collision" x="48" y="176" width="16" height="16"/>
+  <object id="25" type="collision" x="64" y="160" width="16" height="16"/>
+  <object id="26" type="collision" x="96" y="144" width="32" height="32"/>
+  <object id="27" type="collision" x="112" y="176" width="32" height="32"/>
+  <object id="28" type="collision" x="144" y="304" width="16" height="16"/>
+  <object id="29" type="collision" x="144" y="368" width="16" height="32"/>
+  <object id="30" type="collision" x="128" y="384" width="16" height="16"/>
+  <object id="31" type="collision" x="0" y="176" width="32" height="160"/>
+  <object id="32" type="collision" x="32" y="208" width="16" height="32"/>
+  <object id="33" type="collision" x="32" y="272" width="16" height="32"/>
+  <object id="34" type="collision" x="0" y="336" width="16" height="224"/>
+  <object id="35" type="collision" x="16" y="368" width="16" height="96"/>
+  <object id="36" type="collision" x="32" y="400" width="16" height="32"/>
+  <object id="73" type="collision" x="16" y="496" width="16" height="32"/>
+  <object id="74" type="collision" x="0" y="144" width="80" height="32">
+   <properties>
+    <property name="key" value="water"/>
+   </properties>
+  </object>
+  <object id="75" type="collision" x="48" y="176" width="32" height="64">
+   <properties>
+    <property name="key" value="water"/>
+   </properties>
+  </object>
+  <object id="76" type="collision" x="64" y="208" width="48" height="64">
+   <properties>
+    <property name="key" value="water"/>
+   </properties>
+  </object>
+  <object id="77" type="collision" x="32" y="432" width="32" height="160">
+   <properties>
+    <property name="key" value="water"/>
+   </properties>
+  </object>
+  <object id="78" type="collision" x="0" y="560" width="32" height="32">
+   <properties>
+    <property name="key" value="water"/>
+   </properties>
+  </object>
+  <object id="79" type="collision" x="64" y="336" width="32" height="128">
+   <properties>
+    <property name="key" value="water"/>
+   </properties>
+  </object>
+  <object id="80" type="collision" x="112" y="240" width="32" height="112">
+   <properties>
+    <property name="key" value="water"/>
+   </properties>
+  </object>
+  <object id="81" type="collision" x="32" y="336" width="96" height="32">
+   <properties>
+    <property name="key" value="water"/>
+   </properties>
+  </object>
+  <object id="82" type="collision" x="48" y="368" width="64" height="16">
+   <properties>
+    <property name="key" value="water"/>
+   </properties>
+  </object>
+  <object id="83" type="collision" x="48" y="272" width="16" height="32">
+   <properties>
+    <property name="key" value="water"/>
+   </properties>
+  </object>
+  <object id="84" type="collision" x="32" y="304" width="16" height="32">
+   <properties>
+    <property name="key" value="water"/>
+   </properties>
+  </object>
+  <object id="85" type="collision" x="240" y="592" width="16" height="16"/>
+  <object id="86" type="collision" x="96" y="224" width="32" height="64">
+   <properties>
+    <property name="key" value="water"/>
+   </properties>
+  </object>
+  <object id="87" type="collision" x="96" y="320" width="16" height="16">
+   <properties>
+    <property name="key" value="water"/>
+   </properties>
+  </object>
+ </objectgroup>
  <objectgroup color="#ffff00" id="4" name="Events">
   <object id="88" name="Play Music" type="event" x="0" y="0" width="16" height="16">
    <properties>
@@ -126,109 +231,16 @@
    </properties>
   </object>
   <object id="102" name="Player Spawn" type="event" x="112" y="64" width="16" height="16"/>
- </objectgroup>
- <objectgroup color="#ff0000" id="5" name="Collisions">
-  <object id="1" type="collision" x="112" y="400" width="96" height="240"/>
-  <object id="2" type="collision" x="272" y="512" width="48" height="128"/>
-  <object id="3" type="collision" x="80" y="480" width="32" height="128"/>
-  <object id="4" type="collision" x="64" y="560" width="16" height="16"/>
-  <object id="5" type="collision" x="160" y="288" width="96" height="112"/>
-  <object id="6" type="collision" x="240" y="368" width="64" height="224"/>
-  <object id="7" type="collision" x="224" y="496" width="16" height="80"/>
-  <object id="8" type="collision" x="208" y="400" width="16" height="80"/>
-  <object id="9" type="collision" x="224" y="400" width="16" height="16"/>
-  <object id="10" type="collision" x="32" y="560" width="16" height="16"/>
-  <object id="11" type="collision" x="48" y="576" width="16" height="16"/>
-  <object id="12" type="collision" x="160" y="0" width="160" height="192"/>
-  <object id="13" type="collision" x="176" y="192" width="144" height="32"/>
-  <object id="14" type="collision" x="192" y="224" width="128" height="16"/>
-  <object id="15" type="collision" x="224" y="240" width="96" height="176"/>
-  <object id="16" type="collision" x="192" y="240" width="16" height="16"/>
-  <object id="17" type="collision" x="0" y="0" width="160" height="32"/>
-  <object id="18" type="collision" x="0" y="32" width="16" height="32"/>
-  <object id="19" type="collision" x="48" y="32" width="32" height="32"/>
-  <object id="20" type="collision" x="96" y="32" width="16" height="16"/>
-  <object id="21" type="collision" x="128" y="32" width="32" height="16"/>
-  <object id="22" type="collision" x="144" y="48" width="16" height="96"/>
-  <object id="23" type="collision" x="80" y="112" width="64" height="32"/>
-  <object id="24" type="collision" x="48" y="176" width="16" height="16"/>
-  <object id="25" type="collision" x="64" y="160" width="16" height="16"/>
-  <object id="26" type="collision" x="96" y="144" width="32" height="32"/>
-  <object id="27" type="collision" x="112" y="176" width="32" height="32"/>
-  <object id="28" type="collision" x="144" y="304" width="16" height="16"/>
-  <object id="29" type="collision" x="144" y="368" width="16" height="32"/>
-  <object id="30" type="collision" x="128" y="384" width="16" height="16"/>
-  <object id="31" type="collision" x="0" y="176" width="32" height="160"/>
-  <object id="32" type="collision" x="32" y="208" width="16" height="32"/>
-  <object id="33" type="collision" x="32" y="272" width="16" height="32"/>
-  <object id="34" type="collision" x="0" y="336" width="16" height="224"/>
-  <object id="35" type="collision" x="16" y="368" width="16" height="96"/>
-  <object id="36" type="collision" x="32" y="400" width="16" height="32"/>
-  <object id="73" type="collision" x="16" y="496" width="16" height="32"/>
-  <object id="74" type="collision" x="0" y="144" width="80" height="32">
+  <object id="107" name="Environment Day" type="event" x="32" y="0" width="16" height="16">
    <properties>
-    <property name="key" value="water"/>
+    <property name="act1" value="set_variable environment:grass"/>
+    <property name="cond1" value="not variable_set stage_of_day:night"/>
    </properties>
   </object>
-  <object id="75" type="collision" x="48" y="176" width="32" height="64">
+  <object id="108" name="Environment Night" type="event" x="16" y="0" width="16" height="16">
    <properties>
-    <property name="key" value="water"/>
-   </properties>
-  </object>
-  <object id="76" type="collision" x="64" y="208" width="48" height="64">
-   <properties>
-    <property name="key" value="water"/>
-   </properties>
-  </object>
-  <object id="77" type="collision" x="32" y="432" width="32" height="160">
-   <properties>
-    <property name="key" value="water"/>
-   </properties>
-  </object>
-  <object id="78" type="collision" x="0" y="560" width="32" height="32">
-   <properties>
-    <property name="key" value="water"/>
-   </properties>
-  </object>
-  <object id="79" type="collision" x="64" y="336" width="32" height="128">
-   <properties>
-    <property name="key" value="water"/>
-   </properties>
-  </object>
-  <object id="80" type="collision" x="112" y="240" width="32" height="112">
-   <properties>
-    <property name="key" value="water"/>
-   </properties>
-  </object>
-  <object id="81" type="collision" x="32" y="336" width="96" height="32">
-   <properties>
-    <property name="key" value="water"/>
-   </properties>
-  </object>
-  <object id="82" type="collision" x="48" y="368" width="64" height="16">
-   <properties>
-    <property name="key" value="water"/>
-   </properties>
-  </object>
-  <object id="83" type="collision" x="48" y="272" width="16" height="32">
-   <properties>
-    <property name="key" value="water"/>
-   </properties>
-  </object>
-  <object id="84" type="collision" x="32" y="304" width="16" height="32">
-   <properties>
-    <property name="key" value="water"/>
-   </properties>
-  </object>
-  <object id="85" type="collision" x="240" y="592" width="16" height="16"/>
-  <object id="86" type="collision" x="96" y="224" width="32" height="64">
-   <properties>
-    <property name="key" value="water"/>
-   </properties>
-  </object>
-  <object id="87" type="collision" x="96" y="320" width="16" height="16">
-   <properties>
-    <property name="key" value="water"/>
+    <property name="act1" value="set_variable environment:night_grass"/>
+    <property name="cond1" value="is variable_set stage_of_day:night"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/tuxe_mart_taba.tmx
+++ b/mods/tuxemon/maps/tuxe_mart_taba.tmx
@@ -41,7 +41,7 @@
    eAFjYBhZwEuBgQGE9wDxXiDeB8SEQCZQDQjfBuI7QHwXiGkBfgHN9YbiP0D6LxATApKKDAxZQHUgLA1kywAxvQAAFrkNYg==
   </data>
  </layer>
- <objectgroup color="#ff0000" id="6" name="Collision">
+ <objectgroup color="#ff0000" id="6" name="Collisions">
   <object id="11" type="collision" x="0" y="16" width="208" height="32"/>
   <object id="21" type="collision" x="32" y="48" width="16" height="64"/>
   <object id="22" type="collision" x="0" y="112" width="48" height="16"/>


### PR DESCRIPTION
PR follows #1920 and sync daytime, now the background (during battles) will change following the day/night cycle (before was 18:00 to 06:00, now it's only night 20:00 to 04:00)

Moreover:
- adds the missing environment variables where those weren't present;
- fixes a couple of maps where the collision layer was above the event layer;
- renames the "collision" label into "collisions", so everything is standardized;