### PR TITLE
update actions + new actions (random_item and set_random_variable)

### DIFF
--- a/mods/tuxemon/db/item/booster_tech.json
+++ b/mods/tuxemon/db/item/booster_tech.json
@@ -4,7 +4,7 @@
     "is has_path booster_tech"
   ],
   "effects": [
-    "evolve random"
+    "evolve"
   ],
   "slug": "booster_tech",
   "sort": "utility",

--- a/tuxemon/element.py
+++ b/tuxemon/element.py
@@ -21,12 +21,9 @@ class Element:
 
     def load(self, slug: str) -> None:
         """Loads an element."""
-
-        try:
-            results = db.lookup(slug, table="element")
-        except KeyError:
-            raise RuntimeError(f"Failed to find element with slug {slug}")
-
+        results = db.lookup(slug, table="element")
+        if results is None:
+            raise RuntimeError(f"element {slug} is not found")
         self.slug = results.slug
         self.name = results.slug.name
         self.types = results.types

--- a/tuxemon/event/actions/add_monster.py
+++ b/tuxemon/event/actions/add_monster.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional, Union, final
 
-from tuxemon import formula, monster
+from tuxemon import formula
 from tuxemon.db import SeenStatus, db
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
+from tuxemon.monster import Monster
 from tuxemon.npc import NPC
 
 
@@ -66,7 +67,7 @@ class AddMonsterAction(EventAction):
         else:
             _monster = self.monster_slug
 
-        current_monster = monster.Monster()
+        current_monster = Monster()
         current_monster.load_from_db(_monster)
         current_monster.set_level(self.monster_level)
         current_monster.set_moves(self.monster_level)

--- a/tuxemon/event/actions/random_item.py
+++ b/tuxemon/event/actions/random_item.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import List, Union, final
+
+from tuxemon.event.actions.add_item import AddItemAction
+from tuxemon.event.eventaction import EventAction
+
+
+@final
+@dataclass
+class RandomItemAction(EventAction):
+    """
+    Pick a random item from a list and add it to the trainer's inventory.
+
+    Script usage:
+        .. code-block::
+
+            random_item <item_slug>[,quantity][,trainer_slug]
+
+    Script parameters:
+        item_slug: Item name to look up in the item database (multiple items
+        separate by ":").
+        quantity: Quantity of the item to add or to reduce. By default it is 1.
+        trainer_slug: Slug of the trainer that will receive the item. It
+            defaults to the current player.
+
+    """
+
+    name = "random_item"
+    item_slug: str
+    quantity: Union[int, None] = None
+    trainer_slug: Union[str, None] = None
+
+    def start(self) -> None:
+        # check if multiple items
+        item: str = ""
+        items: List[str] = []
+        if self.item_slug.find(":"):
+            items = self.item_slug.split(":")
+            item = random.choice(items)
+        else:
+            item = self.item_slug
+
+        AddItemAction(
+            item_slug=item,
+            quantity=self.quantity,
+            trainer_slug=self.trainer_slug,
+        ).start()

--- a/tuxemon/event/actions/set_random_variable.py
+++ b/tuxemon/event/actions/set_random_variable.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import List, final
+
+from tuxemon import formula
+from tuxemon.event.eventaction import EventAction
+
+
+@final
+@dataclass
+class SetRandomVariableAction(EventAction):
+    """
+    Set the key in the player.game_variables dictionary
+    with a random value.
+
+    Script usage:
+        .. code-block::
+
+            set_random_variable <variable>,<value>:<value>
+
+    Script parameters:
+        variable: Name of the variable.
+        values: Multiple values of the variable separated
+        with ":".
+
+    """
+
+    name = "set_random_variable"
+    var_key: str
+    var_value: str
+
+    def start(self) -> None:
+        player = self.session.player
+
+        # Split the values
+        value: str = ""
+        values: List[str] = []
+        if self.var_value.find(":"):
+            values = self.var_value.split(":")
+            value = random.choice(values)
+        else:
+            value = self.var_value
+
+        # replaces today value with ordinal
+        if value == "today":
+            value = str(formula.today_ordinal())
+
+        # Append the game_variables dictionary with the key: value pair
+        player.game_variables[self.var_key] = value

--- a/tuxemon/item/effects/evolve.py
+++ b/tuxemon/item/effects/evolve.py
@@ -22,25 +22,24 @@ class EvolveEffect(ItemEffect):
     """This effect evolves the target into the monster in the parameters."""
 
     name = "evolve"
-    value: Union[str, None]
 
     def apply(
         self, item: Item, target: Union[Monster, None]
     ) -> EvolveEffectResult:
         assert target
-        if self.value:
-            if self.value == "random":
-                choices = [d for d in target.evolutions if d.path == "item"]
-                evolution = random.choice(choices).monster_slug
-                self.user.evolve_monster(target, evolution)
-                return {"success": True}
+        evolve: bool = False
+        if item.slug == "booster_tech":
+            choices = [d for d in target.evolutions if d.path == "item"]
+            evolution = random.choice(choices).monster_slug
+            self.user.evolve_monster(target, evolution)
+            evolve = True
         else:
             choices = [d for d in target.evolutions if d.item == item.slug]
             if len(choices) == 1:
                 self.user.evolve_monster(target, choices[0].monster_slug)
-                return {"success": True}
+                evolve = True
             elif len(choices) > 1:
                 evolution = random.choice(choices).monster_slug
                 self.user.evolve_monster(target, evolution)
-                return {"success": True}
-        return {"success": False}
+                evolve = True
+        return {"success": evolve}

--- a/tuxemon/shape.py
+++ b/tuxemon/shape.py
@@ -34,6 +34,8 @@ class Shape:
             pass
         else:
             results = db.lookup(slug, table="shape")
+            if results is None:
+                raise RuntimeError(f"shape {slug} is not found")
 
         self.slug = results.slug or self.slug
         self.armour = results.armour or self.armour

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -766,10 +766,10 @@ class CombatState(CombatAnimations):
             if removed.current_hp <= 0:
                 faint = Technique()
                 faint.load("status_faint")
-                monster.current_hp = 0
-                if monster.status:
-                    monster.status[0].nr_turn = 0
-                monster.status = [faint]
+                removed.current_hp = 0
+                if removed.status:
+                    removed.status[0].nr_turn = 0
+                removed.status = [faint]
         self.alert(message)
         # save iid monster fighting
         if player is self.players[0]:


### PR DESCRIPTION
PR updates actions and fixes small issue:

small issue:
- "evolve random" into "evolve".

updates:
- updates **add_monster** from monster.Monster() to **Monster()**;
- updates **add_item** from item.Item() to **Item()**;
- updates **random_monster** by calling AddMonster and avoiding pointless repetition, the same will happen for random_item;
- **add_item** will accept variables too, variable "alpha" as "potion" as value, when by using `add_item alpha`, the player gets a potion;

new actions:
- **random_item** will pick a random item among the listed ones;

`random_item potion:tea:revive:rhincus_fossil` it'll pick a random items among those 4 and add it to the player's inventory;

- **set_random_variable** will pick a random value among the listed ones;

`set_random_variable alpha,one:two:three` it'll pick a random value among those 3, it could be alpha:one or alpha:two or alpha:three;