### PR TITLE
Update org.tuxemon.Tuxemon.desktop generic name

### DIFF
--- a/buildconfig/flatpak/org.tuxemon.Tuxemon.desktop
+++ b/buildconfig/flatpak/org.tuxemon.Tuxemon.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Tuxemon
 Name[de_AT]=Tuxemon
-GenericName=c
+GenericName=Open source monster-fighting RPG
 GenericName[de]=Tuxemon
 Comment=
 Exec=org.tuxemon.Tuxemon


### PR DESCRIPTION
Right now the .desktop entry for the Tuxemon Flatpak just has 'c' in the GenericName field, so if you mouse over the shortcut, it will say 'Tuxemon' and beneath that 'c'. 

Based on the [Arch Wiki's Desktop Entries entry](https://wiki.archlinux.org/title/Desktop_entries#Key_definition): "GenericName should state what you would generally call an application that does what this specific application offers (i.e. Firefox is a "Web Browser")."

I just took a part of the description for Tuxemon that is given in the README.md file for the repo: "Open source monster-fighting RPG".

Alternative suggestions are also welcome.