### PR TITLE
fix config

### DIFF
--- a/tuxemon/config.py
+++ b/tuxemon/config.py
@@ -26,8 +26,7 @@ class TuxemonConfig:
 
         # update with customized values
         if config_path:
-            temp = configparser.ConfigParser()
-            temp.read(config_path)
+            cfg.read(config_path)
 
         # [display]
         resolution_x = cfg.getint("display", "resolution_x")


### PR DESCRIPTION
PR could fix #1910 

I tested with my native language
before the PR, it was impossible to change language.
after the PR, I succeeded.

Some issues:
```
  File "/home/robespierreni/Tuxemon/tuxemon/config.py", line 32, in __init__
    resolution_x = cfg.getint("display", "resolution_x")
  File "/usr/lib/python3.10/configparser.py", line 819, in getint
    return self._get_conv(section, option, int, raw=raw, vars=vars,
  File "/usr/lib/python3.10/configparser.py", line 809, in _get_conv
    return self._get(section, conv, option, raw=raw, vars=vars,
  File "/usr/lib/python3.10/configparser.py", line 804, in _get
    return conv(self.get(section, option, **kwargs))
  File "/usr/lib/python3.10/configparser.py", line 782, in get
    d = self._unify_values(section, vars)
  File "/usr/lib/python3.10/configparser.py", line 1153, in _unify_values
    raise NoSectionError(section) from None
configparser.NoSectionError: No section: 'display'
```
it's something completely new for me