### PR TITLE
sold out (shop)

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -2508,6 +2508,9 @@ msgstr "Release"
 msgid "shop_buy_free"
 msgstr "FREE!"
 
+msgid "shop_buy_soldout"
+msgstr "Sold Out!"
+
 #Release notifications
 msgid "cant_release"
 msgstr "Can't release only Tuxemon in party."

--- a/tests/tuxemon/item/test_economy.py
+++ b/tests/tuxemon/item/test_economy.py
@@ -50,7 +50,7 @@ class GetDefaultPriceAndCost(EconomyTestBase):
     def test_missing_inventory(self):
         economy = self.economy
         inventory = economy.lookup_item_inventory("revive")
-        self.assertEqual(inventory, 0)
+        self.assertEqual(inventory, -1)
 
     def test_unknown_item_price(self):
         economy = self.economy

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -752,7 +752,8 @@ class EconomyItemModel(BaseModel):
     item_name: str = Field(..., description="Name of the item")
     price: int = Field(0, description="Price of the item")
     cost: int = Field(0, description="Cost of the item")
-    inventory: int = Field(0, description="Quantity of the item")
+    inventory: int = Field(-1, description="Quantity of the item")
+    variable: Optional[str] = Field(None, description="Variable of the item")
 
     @validator("item_name")
     def item_exists(cls: EconomyItemModel, v: Any) -> Any:

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -34,7 +34,7 @@ SIMPLE_PERSISTANCE_ATTRIBUTES = (
     "slug",
     "quantity",
 )
-INFINITE_ITEMS = 0
+INFINITE_ITEMS = -1
 # eg 5 capture devices, 1 type and 5 items
 MAX_TYPES_BAG = 99
 

--- a/tuxemon/menu/quantity.py
+++ b/tuxemon/menu/quantity.py
@@ -134,6 +134,8 @@ class QuantityAndPriceMenu(QuantityMenu):
             price_tag = T.translate("shop_buy_free")
         else:
             price_tag = str(price)
+            if self.quantity == 0:
+                price_tag = T.translate("shop_buy_soldout")
 
         formatted_name = label_format(price_tag, count_len=count_len)
         image = self.shadow_text(formatted_name, bg=(128, 128, 128))

--- a/tuxemon/states/items/__init__.py
+++ b/tuxemon/states/items/__init__.py
@@ -401,13 +401,18 @@ class ShopBuyMenuState(ShopMenuState):
         inventory = self.economy.lookup_item_inventory(item.slug)
         if inventory == INFINITE_ITEMS:
             inventory = 99999
+
+        quantity: int = 1
         max_quantity = min(inventory, qty_can_afford)
+        if item.quantity == 0:
+            quantity = 0
+            max_quantity = 0
 
         self.client.push_state(
             QuantityAndPriceMenu(
                 callback=partial(buy_item, item),
                 max_quantity=max_quantity,
-                quantity=1,
+                quantity=quantity,
                 shrink_to_items=True,
                 price=price,
             )


### PR DESCRIPTION
PR fix #430

when it's sold out, the player can exit and reenter in the store to find it replenished.

@kerizane it was the only thing missing

![Screenshot from 2023-06-11 10-37-52](https://github.com/Tuxemon/Tuxemon/assets/64643719/e3038159-9670-40c5-b803-5d193850cd28)

I added the following feature:

> Or for vendors who only sell items once a season. Or some other thing. Not a high priority.

now modders can set variables to make appear items inside the shops:
```
    {
      "item_name": "tm_blossom",
      "price": 1000,
      "cost": 200,
      "inventory": 20,
      "variable": "season:spring"
    },
```
the new optional field is called variable and accept strings in this format xxx:yyy, exactly like the one we use for set_variable, in this case this item will appear inside the shop only in spring, but it can be done with any variable.


tested, black, isort, no new typehints