### PR TITLE
fix hp bar behavior

### DIFF
--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -1284,21 +1284,6 @@ class CombatState(CombatAnimations):
                         if mex:
                             message += "\n" + mex
                             action_time += len(message) * letter_time
-                        # updates hud graphics player
-                        if len(self.monsters_in_play_human) > 1:
-                            self.build_hud(
-                                self._layout[self.players[0]]["hud0"][0],
-                                self.monsters_in_play_human[0],
-                            )
-                            self.build_hud(
-                                self._layout[self.players[0]]["hud1"][0],
-                                self.monsters_in_play_human[1],
-                            )
-                        else:
-                            self.build_hud(
-                                self._layout[self.players[0]]["hud"][0],
-                                self.monsters_in_play_human[0],
-                            )
                 if winners in self.players[0].monsters:
                     m = T.format(
                         "combat_gain_exp",


### PR DESCRIPTION
fix #1952 

@kerizane you marked it as important and liked it, but this was implemented for a specific reason #1581

I'm looking into to find another way to update the level, but feel free to raise an equal important issue

_before there was no update in combat (if the monster leveled up) and the only way to know it: switch out and switch in or at the end checking the monster menu -> now the hub will refresh, the number lv XX will update;_