### PR TITLE
remove state (event action) + update (change state - event action)

### DIFF
--- a/tuxemon/event/actions/remove_state.py
+++ b/tuxemon/event/actions/remove_state.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Union, final
+
+from tuxemon.event.eventaction import EventAction
+
+
+@final
+@dataclass
+class RemoveStateAction(EventAction):
+    """
+    Remove the specified state.
+
+    Script usage:
+        .. code-block::
+
+            remove_state <state_name>
+
+    Script parameters:
+        state_name: The state name to remove (e.g. PCState)
+
+    """
+
+    name = "remove_state"
+    state_name: Union[str, None] = None
+
+    def start(self) -> None:
+        # Don't override previous state if we are still in the state.
+        current_state = self.session.client.current_state
+        if current_state is None:
+            # obligatory "should not happen"
+            raise RuntimeError
+        if not self.state_name:
+            for ele in self.session.client.active_states:
+                if ele.name != "WorldState" and ele.name != "BackgroundState":
+                    self.session.client.remove_state(ele)
+        if current_state.name == self.state_name:
+            self.session.client.pop_state()

--- a/tuxemon/states/journal/__init__.py
+++ b/tuxemon/states/journal/__init__.py
@@ -372,11 +372,10 @@ class JournalInfoState(PygameMenuState):
         assert not isinstance(lab6, List)
         lab6.translate(fix_width(width, 0.50), fix_height(height, 0.40))
         # species
-        species = (
-            T.translate("monster_menu_species")
-            + ": "
-            + T.translate(f"cat_{monster.category}")
-        )
+        spec = T.translate(f"cat_{monster.category}")
+        if monster.category:
+            spec = T.translate(monster.category)
+        species = T.translate("monster_menu_species") + ": " + spec
         lab7 = menu.add.label(
             title=species,
             label_id="species",


### PR DESCRIPTION
PR:
- adds event to remove state;
- updates change state to show monster menu info;

no changes, I need these actions for other PRs

eg
```
    <property name="act40" value="change_state JournalInfoState,rockitten"/>
    <property name="act45" value="remove_state"/>
```


tested, black, isort, no new typehints