### PR TITLE
fix preview complaints (Spyder)

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -6928,25 +6928,28 @@ msgid "spyder_papertown_myfirstmon1"
 msgstr "*rummages* *rumages* "
 
 msgid "spyder_papertown_myfirstmon2"
-msgstr "Here we go, five tuxemon! Which would you like?"
+msgstr "Here we go, looks like there's monsters in most of these bins. \n Sounds like my boss is calling. Good luck!"
 
-msgid "spyder_papertown_rockittenchosen"
-msgstr "An excellent choice! Rockitten is an Earth tuxemon."
+msgid "spyder_papertown_thereis"
+msgstr "There is something here..."
 
-msgid "spyder_papertown_lambertchosen"
-msgstr "A fine choice! Lambert is a Wood tuxemon."
+msgid "spyder_papertown_trash"
+msgstr "Just trash"
 
-msgid "spyder_papertown_nutchosen"
-msgstr "A magnificent choice! Nut is a Metal tuxemon."
+msgid "spyder_papertown_rockitten"
+msgstr "Do you want ROCKITTEN?"
 
-msgid "spyder_papertown_tweesherchosen"
-msgstr "An inspired choice! Tweesher is a Water tuxemon."
+msgid "spyder_papertown_lambert"
+msgstr "Do you want LAMBERT?"
 
-msgid "spyder_papertown_agnitechosen"
-msgstr "A great choice! Agnite is a Fire tuxemon."
+msgid "spyder_papertown_nut"
+msgstr "Do you want NUT?"
 
-msgid "spyder_papertown_wrapup"
-msgstr "I'll give the rest of these to other kids who missed out on their own tuxemon! \n And I might keep one for myself. "
+msgid "spyder_papertown_tweesher"
+msgstr "Do you want TWEESHER?"
+
+msgid "spyder_papertown_agnite"
+msgstr "Do you want AGNITE?"
 
 msgid "spyder_papertown_firstfight"
 msgstr "Hey, what are you doing rummaging in bins? That's gross - and it's against the rules! \n ... \n What, they were throwing out perfectly good tuxemon? \n ... \n Well, if they were perfectly good, they wouldn't throw them out, would they? \n They must be inferior to the new models. Here, I'll show you! "

--- a/mods/tuxemon/maps/spyder_paper_town.tmx
+++ b/mods/tuxemon/maps/spyder_paper_town.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="274">
+<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="280">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="north" value="route1"/>
@@ -253,94 +253,94 @@
     <property name="cond2" value="is player_facing left"/>
    </properties>
   </object>
-  <object id="218" name="My First Mon" type="event" x="368" y="176" width="144" height="16">
+  <object id="218" name="My First Mon" type="event" x="400" y="208" width="112" height="16">
    <properties>
     <property name="act10" value="player_stop"/>
     <property name="act11" value="lock_controls"/>
-    <property name="act20" value="create_npc spyder_dante,18,14"/>
+    <property name="act20" value="create_npc spyder_dante,19,13"/>
     <property name="act30" value="pathfind_to_player spyder_dante,down"/>
-    <property name="act31" value="npc_face player,down"/>
+    <property name="act31" value="npc_face spyder_dante,up"/>
+    <property name="act32" value="npc_face player,down"/>
     <property name="act40" value="translated_dialog spyder_papertown_myfirstmon"/>
     <property name="act45" value="pathfind spyder_dante,26,9"/>
     <property name="act46" value="npc_face spyder_dante,right"/>
     <property name="act47" value="npc_face player,up"/>
     <property name="act48" value="translated_dialog spyder_papertown_myfirstmon1"/>
-    <property name="act49" value="pathfind player,26,10"/>
-    <property name="act50" value="npc_face player,up"/>
-    <property name="act51" value="translated_dialog spyder_papertown_myfirstmon2"/>
-    <property name="act55" value="npc_face spyder_dante,down"/>
-    <property name="act60" value="translated_dialog_choice rockitten:nut:tweesher:agnite:lambert,mymonchoice"/>
+    <property name="act49" value="wait 1.0"/>
+    <property name="act50" value="translated_dialog spyder_papertown_myfirstmon2"/>
+    <property name="act51" value="pathfind spyder_dante,19,13"/>
+    <property name="act52" value="remove_npc spyder_dante"/>
+    <property name="act60" value="set_variable dantebin:yes"/>
     <property name="act70" value="unlock_controls"/>
     <property name="cond1" value="is player_at"/>
     <property name="cond2" value="is party_size less_than,1"/>
     <property name="cond3" value="is variable_set dantefirst:yes"/>
+    <property name="cond4" value="not variable_set dantebin:yes"/>
    </properties>
   </object>
   <object id="219" name="Chosen - Rockitten" type="event" x="512" y="128" width="16" height="16">
    <properties>
     <property name="act1" value="add_monster rockitten,5"/>
-    <property name="act2" value="translated_dialog spyder_papertown_rockittenchosen"/>
     <property name="act3" value="set_variable firstfightdue:yes"/>
-    <property name="cond1" value="is variable_set mymonchoice:rockitten"/>
+    <property name="act4" value="set_variable mymonchoice:rockitten"/>
+    <property name="cond1" value="is variable_set rockittenchosen:yes"/>
     <property name="cond2" value="is party_size less_than,1"/>
    </properties>
   </object>
   <object id="220" name="Chosen - Lambert" type="event" x="512" y="160" width="16" height="16">
    <properties>
     <property name="act1" value="add_monster lambert,5"/>
-    <property name="act2" value="translated_dialog spyder_papertown_lambertchosen"/>
     <property name="act3" value="set_variable firstfightdue:yes"/>
-    <property name="cond1" value="is variable_set mymonchoice:lambert"/>
+    <property name="act4" value="set_variable mymonchoice:lambert"/>
+    <property name="cond1" value="is variable_set lambertchosen:yes"/>
     <property name="cond2" value="is party_size less_than,1"/>
    </properties>
   </object>
   <object id="221" name="Chosen - Nut" type="event" x="512" y="192" width="16" height="16">
    <properties>
     <property name="act1" value="add_monster nut,5"/>
-    <property name="act2" value="translated_dialog spyder_papertown_nutchosen"/>
     <property name="act3" value="set_variable firstfightdue:yes"/>
-    <property name="cond1" value="is variable_set mymonchoice:nut"/>
+    <property name="act4" value="set_variable mymonchoice:nut"/>
+    <property name="cond1" value="is variable_set nutchosen:yes"/>
     <property name="cond2" value="is party_size less_than,1"/>
    </properties>
   </object>
   <object id="222" name="Chosen - Tweesher" type="event" x="512" y="224" width="16" height="16">
    <properties>
     <property name="act1" value="add_monster tweesher,5"/>
-    <property name="act2" value="translated_dialog spyder_papertown_tweesherchosen"/>
     <property name="act3" value="set_variable firstfightdue:yes"/>
-    <property name="cond1" value="is variable_set mymonchoice:tweesher"/>
+    <property name="act4" value="set_variable mymonchoice:tweesher"/>
+    <property name="cond1" value="is variable_set tweesherchosen:yes"/>
     <property name="cond2" value="is party_size less_than,1"/>
    </properties>
   </object>
   <object id="223" name="Chosen - Agnite" type="event" x="512" y="256" width="16" height="16">
    <properties>
     <property name="act1" value="add_monster agnite,5"/>
-    <property name="act2" value="translated_dialog spyder_papertown_agnitechosen"/>
     <property name="act3" value="set_variable firstfightdue:yes"/>
-    <property name="cond1" value="is variable_set mymonchoice:agnite"/>
+    <property name="act4" value="set_variable mymonchoice:agnite"/>
+    <property name="cond1" value="is variable_set agnitechosen:yes"/>
     <property name="cond2" value="is party_size less_than,1"/>
    </properties>
   </object>
-  <object id="224" name="First Fight - Start" type="event" x="400" y="160" width="16" height="16">
+  <object id="224" name="First Fight - Start" type="event" x="400" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="lock_controls"/>
-    <property name="act10" value="translated_dialog spyder_papertown_wrapup"/>
-    <property name="act20" value="remove_npc spyder_dante"/>
-    <property name="act30" value="screen_transition 1"/>
+    <property name="act10" value="lock_controls"/>
+    <property name="act20" value="create_npc spyder_billie,13,14"/>
+    <property name="act30" value="pathfind spyder_billie,25,13"/>
     <property name="act40" value="wait 1.0"/>
-    <property name="act50" value="create_npc spyder_billie,13,14"/>
-    <property name="act60" value="pathfind spyder_billie,26,12"/>
-    <property name="act61" value="npc_face player,down"/>
-    <property name="act70" value="translated_dialog spyder_papertown_firstfight"/>
-    <property name="act71" value="add_monster billie_choice,5,spyder_billie,5,10"/>
-    <property name="act80" value="start_battle spyder_billie"/>
-    <property name="act90" value="set_variable firstfightdue:no"/>
-    <property name="act91" value="set_variable teleport_faint:spyder_bedroom.tmx 3 4"/>
-    <property name="act92" value="set_variable firstfightend:yes"/>
+    <property name="act50" value="pathfind_to_player spyder_billie"/>
+    <property name="act51" value="npc_face spyder_billie,player"/>
+    <property name="act60" value="translated_dialog spyder_papertown_firstfight"/>
+    <property name="act61" value="add_monster billie_choice,5,spyder_billie,5,10"/>
+    <property name="act70" value="start_battle spyder_billie"/>
+    <property name="act80" value="set_variable firstfightdue:no"/>
+    <property name="act81" value="set_variable teleport_faint:spyder_bedroom.tmx 3 4"/>
+    <property name="act82" value="set_variable firstfightend:yes"/>
     <property name="cond1" value="is variable_set firstfightdue:yes"/>
    </properties>
   </object>
-  <object id="225" name="First Fight - Win" type="event" x="384" y="144" width="16" height="16">
+  <object id="225" name="First Fight - Win" type="event" x="384" y="128" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog spyder_papertown_firstfight_win"/>
     <property name="act11" value="pathfind spyder_billie,25,14"/>
@@ -357,7 +357,7 @@
     <property name="cond2" value="is variable_set firstfightend:yes"/>
    </properties>
   </object>
-  <object id="226" name="First Fight - Lose" type="event" x="416" y="144" width="16" height="16">
+  <object id="226" name="First Fight - Lose" type="event" x="416" y="128" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog spyder_papertown_firstfight_lose"/>
     <property name="act11" value="pathfind spyder_billie,25,14"/>
@@ -551,27 +551,97 @@
     <property name="cond2" value="is player_facing left"/>
    </properties>
   </object>
-  <object id="273" name="My First Mon - Not Met" type="event" x="368" y="176" width="144" height="16">
+  <object id="273" name="My First Mon - Not Met" type="event" x="400" y="208" width="112" height="16">
    <properties>
     <property name="act10" value="player_stop"/>
     <property name="act11" value="lock_controls"/>
-    <property name="act20" value="create_npc spyder_dante,18,14"/>
+    <property name="act20" value="create_npc spyder_dante,19,13"/>
     <property name="act30" value="pathfind_to_player spyder_dante,down"/>
-    <property name="act31" value="npc_face player,down"/>
+    <property name="act31" value="npc_face spyder_dante,up"/>
+    <property name="act32" value="npc_face player,down"/>
     <property name="act40" value="translated_dialog spyder_papertown_myfirstmon_notmet"/>
     <property name="act45" value="pathfind spyder_dante,26,9"/>
     <property name="act46" value="npc_face spyder_dante,right"/>
     <property name="act47" value="npc_face player,up"/>
     <property name="act48" value="translated_dialog spyder_papertown_myfirstmon1"/>
-    <property name="act49" value="pathfind player,26,10"/>
-    <property name="act50" value="npc_face player,up"/>
-    <property name="act51" value="translated_dialog spyder_papertown_myfirstmon2"/>
-    <property name="act55" value="npc_face spyder_dante,down"/>
-    <property name="act60" value="translated_dialog_choice rockitten:nut:tweesher:agnite:lambert,mymonchoice"/>
+    <property name="act49" value="wait 1.0"/>
+    <property name="act50" value="translated_dialog spyder_papertown_myfirstmon2"/>
+    <property name="act51" value="pathfind spyder_dante,19,13"/>
+    <property name="act52" value="remove_npc spyder_dante"/>
+    <property name="act60" value="set_variable dantefirst:yes"/>
+    <property name="act61" value="set_variable dantebin:yes"/>
     <property name="act70" value="unlock_controls"/>
     <property name="cond1" value="is player_at"/>
     <property name="cond2" value="is party_size less_than,1"/>
     <property name="cond3" value="not variable_set dantefirst:yes"/>
+    <property name="cond4" value="not variable_set dantebin:yes"/>
+   </properties>
+  </object>
+  <object id="274" name="Rockitten" type="event" x="352" y="144" width="16" height="32">
+   <properties>
+    <property name="act05" value="translated_dialog spyder_papertown_thereis"/>
+    <property name="act10" value="change_state JournalInfoState,rockitten"/>
+    <property name="act20" value="remove_state"/>
+    <property name="act25" value="translated_dialog spyder_papertown_rockitten"/>
+    <property name="act30" value="translated_dialog_choice yes:no,rockittenchosen"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is party_size less_than,1"/>
+   </properties>
+  </object>
+  <object id="275" name="Lambert" type="event" x="352" y="176" width="16" height="32">
+   <properties>
+    <property name="act05" value="translated_dialog spyder_papertown_thereis"/>
+    <property name="act10" value="change_state JournalInfoState,lambert"/>
+    <property name="act20" value="remove_state"/>
+    <property name="act25" value="translated_dialog spyder_papertown_lambert"/>
+    <property name="act30" value="translated_dialog_choice yes:no,lambertchosen"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is party_size less_than,1"/>
+   </properties>
+  </object>
+  <object id="276" name="Nut" type="event" x="432" y="144" width="32" height="16">
+   <properties>
+    <property name="act05" value="translated_dialog spyder_papertown_thereis"/>
+    <property name="act10" value="change_state JournalInfoState,nut"/>
+    <property name="act20" value="remove_state"/>
+    <property name="act25" value="translated_dialog spyder_papertown_nut"/>
+    <property name="act30" value="translated_dialog_choice yes:no,nutchosen"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is party_size less_than,1"/>
+   </properties>
+  </object>
+  <object id="277" name="Tweesher" type="event" x="464" y="144" width="32" height="16">
+   <properties>
+    <property name="act05" value="translated_dialog spyder_papertown_thereis"/>
+    <property name="act10" value="change_state JournalInfoState,tweesher"/>
+    <property name="act20" value="remove_state"/>
+    <property name="act25" value="translated_dialog spyder_papertown_tweesher"/>
+    <property name="act30" value="translated_dialog_choice yes:no,tweesherchosen"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is party_size less_than,1"/>
+   </properties>
+  </object>
+  <object id="278" name="Agnite" type="event" x="480" y="176" width="16" height="32">
+   <properties>
+    <property name="act05" value="translated_dialog spyder_papertown_thereis"/>
+    <property name="act10" value="change_state JournalInfoState,agnite"/>
+    <property name="act20" value="remove_state"/>
+    <property name="act25" value="translated_dialog spyder_papertown_agnite"/>
+    <property name="act30" value="translated_dialog_choice yes:no,agnitechosen"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is party_size less_than,1"/>
+   </properties>
+  </object>
+  <object id="279" name="Trash" type="event" x="368" y="208" width="32" height="16">
+   <properties>
+    <property name="act25" value="translated_dialog spyder_papertown_trash"/>
+    <property name="cond1" value="is player_facing_tile"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
  </objectgroup>

--- a/tuxemon/event/actions/remove_state.py
+++ b/tuxemon/event/actions/remove_state.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Union, final
+
+from tuxemon.event.eventaction import EventAction
+
+
+@final
+@dataclass
+class RemoveStateAction(EventAction):
+    """
+    Remove the specified state.
+
+    Script usage:
+        .. code-block::
+
+            remove_state <state_name>
+
+    Script parameters:
+        state_name: The state name to remove (e.g. PCState)
+
+    """
+
+    name = "remove_state"
+    state_name: Union[str, None] = None
+
+    def start(self) -> None:
+        # Don't override previous state if we are still in the state.
+        current_state = self.session.client.current_state
+        if current_state is None:
+            # obligatory "should not happen"
+            raise RuntimeError
+        if not self.state_name:
+            for ele in self.session.client.active_states:
+                if ele.name != "WorldState" and ele.name != "BackgroundState":
+                    self.session.client.remove_state(ele)
+        if current_state.name == self.state_name:
+            self.session.client.pop_state()

--- a/tuxemon/states/journal/__init__.py
+++ b/tuxemon/states/journal/__init__.py
@@ -372,11 +372,10 @@ class JournalInfoState(PygameMenuState):
         assert not isinstance(lab6, List)
         lab6.translate(fix_width(width, 0.50), fix_height(height, 0.40))
         # species
-        species = (
-            T.translate("monster_menu_species")
-            + ": "
-            + T.translate(f"cat_{monster.category}")
-        )
+        spec = T.translate(f"cat_{monster.category}")
+        if monster.category:
+            spec = T.translate(monster.category)
+        species = T.translate("monster_menu_species") + ": " + spec
         lab7 = menu.add.label(
             title=species,
             label_id="species",


### PR DESCRIPTION
I wasted some time to fix #1950 

@Sanglorian this change modifies the Spyder Dante scene in the bins, because it allows to check more carefully the monsters.

everything goes on as usual, Dante starts rummaging and then:
![Screenshot from 2023-06-14 14-01-15](https://github.com/Tuxemon/Tuxemon/assets/64643719/2474fe96-b650-40e8-a7df-61d417718b14)
he goes back inside the shop, then the player can rummage
![Screenshot from 2023-06-14 14-02-49](https://github.com/Tuxemon/Tuxemon/assets/64643719/364af686-138e-4ada-a70f-0736b1524359)
5/6 bins contain a monster, 1/6 trash
![Screenshot from 2023-06-14 14-02-57](https://github.com/Tuxemon/Tuxemon/assets/64643719/78aa11e7-d138-44b4-b0fd-267fe564d659)
it appears the complained screen
![Screenshot from 2023-06-14 14-03-06](https://github.com/Tuxemon/Tuxemon/assets/64643719/7c6466e5-7c79-4eaf-86af-d08b693c4eb9)
question
![Screenshot from 2023-06-14 14-03-15](https://github.com/Tuxemon/Tuxemon/assets/64643719/fdbc3319-0377-4a85-a3d7-9bd4d685c63b)
Y/N
![Screenshot from 2023-06-14 14-03-24](https://github.com/Tuxemon/Tuxemon/assets/64643719/4bf1ed98-7fb4-4795-800e-ee26a44a93d6)
then it arrives Billie

let me know, it would help to solve the complaints