### PR TITLE
variable (item effect)

### DIFF
--- a/tuxemon/item/effects/variable.py
+++ b/tuxemon/item/effects/variable.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, List, Union
+
+from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
+
+if TYPE_CHECKING:
+    from tuxemon.item.item import Item
+    from tuxemon.monster import Monster
+
+
+class VariableEffectResult(ItemEffectResult):
+    pass
+
+
+@dataclass
+class VariableEffect(ItemEffect):
+    """
+    Creates a game variable, format xx:yy.
+    If the value "yy" is "step", then the game
+    variable will be xx_steps:yy where yy are
+    the exact number of the player's step.
+
+    variable key:value
+    variable key:steps > key_steps:nr_steps
+
+    """
+
+    name = "variable"
+    optional: str
+
+    def apply(
+        self, item: Item, target: Union[Monster, None]
+    ) -> VariableEffectResult:
+        player = self.session.player
+        ret: bool = False
+        elements: List[str] = []
+        if self.optional.find(":"):
+            elements = self.optional.split(":")
+        if elements:
+            if elements[1] == "steps":
+                player.game_variables[
+                    f"{elements[0]}_steps"
+                ] = player.game_variables["steps"]
+                ret = True
+            else:
+                player.game_variables[elements[0]] = elements[1]
+                ret = True
+
+        return {"success": ret}

--- a/tuxemon/player.py
+++ b/tuxemon/player.py
@@ -50,6 +50,21 @@ class Player(NPC):
         diff_y = abs(after.y - before.y)
 
         self.game_variables["steps"] += diff_x + diff_y
+
+        # check variables with steps
+        result: float = 0.0
+        save_key: str = ""
+        for ele in self.game_variables.keys():
+            if ele.endswith("_steps"):
+                save_key = ele
+                output = float(self.game_variables[ele])
+                result = self.game_variables["steps"] - output
+
+        if save_key in self.game_variables:
+            splitted = save_key.split("_")
+            if result >= float(splitted[0]):
+                del self.game_variables[ele]
+
         """
         %H - Hour 00-23
         %j - Day number of year 001-366


### PR DESCRIPTION
I started to waste some time on it some weeks ago. It's an effect for items really simple and useful, it creates game_variable.

```
  "effects": [
    "variable hello:world"
  ],
```
when the item is used, then it'll create a game variable `hello:world`, moreover the really "cool" thing is this format:
```
  "effects": [
    "variable 50:steps"
  ],
```
it'll create a game_variable `50_steps:nr_steps` where nr_steps are the steps of the player. It's completely automatized and in player.py checks for the difference between step and the saved steps, and when the counter meets the difference (50 in this case), it'll delete the game variable.
```
        # check variables with steps
        result: float = 0.0
        save_key: str = ""
        for ele in self.game_variables.keys():
            if ele.endswith("_steps"):
                save_key = ele
                output = float(self.game_variables[ele])
                result = self.game_variables["steps"] - output

        if save_key in self.game_variables:
            splitted = save_key.split("_")
            if result >= float(splitted[0]):
                del self.game_variables[ele]
```
We needed this to set up an effective `repellent` item.

@Sanglorian if you thought about a repellent item/items, maybe with different range (eg something that lasts 50 steps, 250 steps, etc. then it's the right time to tell me, so we can set up the items after this gets merged).

Why? Omnichannel HQ and Datacenter are really tough with wild monster, so the player needs to buy a repellent probably.

tested, black, isort, no new typehints