### PR TITLE
fix npc_face (event action) - player

### DIFF
--- a/tuxemon/event/actions/npc_face.py
+++ b/tuxemon/event/actions/npc_face.py
@@ -42,6 +42,9 @@ class NpcFaceAction(EventAction):
         if direction not in dirs2:
             if direction == "player":
                 target = self.session.player
+                # the player looks at the NPC
+                inverse = get_direction(target.tile_pos, npc.tile_pos)
+                target.facing = cast(Direction, inverse)
             else:
                 maybe_target = get_npc(self.session, direction)
                 assert maybe_target


### PR DESCRIPTION
Right now if a modder uses `npc_face knight1,player` the knight moves his face towards the player.

It's good, but what's missing is reciprocity, so I added a couple of lines.

Now by using `npc_face knight1,player` not only the knight moves his face towards the player, but the player sprite moves the face towards the NPC too.