### PR TITLE
fix menu

### DIFF
--- a/tuxemon/states/world/world_menus.py
+++ b/tuxemon/states/world/world_menus.py
@@ -58,7 +58,7 @@ class WorldMenuState(PygameMenuState):
         self.animation_offset = 0
 
         def change_state(state: str, **kwargs: Any) -> Callable[[], object]:
-            return partial(self.client.replace_state, state, **kwargs)
+            return partial(self.client.push_state, state, **kwargs)
 
         def exit_game() -> None:
             self.client.event_engine.execute_action("quit")


### PR DESCRIPTION
fix #1953 after the explanation here: https://github.com/Tuxemon/Tuxemon/pull/1956#issuecomment-1590961746

the issue: worldstate was using **replace_state** instead of **push_state**

this means that when someone clicks on save, then the menu doesn't disappear. 
![Screenshot from 2023-06-15 11-30-02](https://github.com/Tuxemon/Tuxemon/assets/64643719/c5fcacbd-32e7-4dea-b388-e0009bb7c7ad)
If this is "acceptable", then it's done.