### PR TITLE
Initialize MonsterModel.sprites to None

### DIFF
--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -385,7 +385,7 @@ class MonsterModel(BaseModel):
     )
 
     # Optional fields
-    sprites: Optional[MonsterSpritesModel]
+    sprites: Optional[MonsterSpritesModel] = None
     shape: MonsterShape = Field(..., description="The shape of the monster")
     types: Sequence[ElementType] = Field(
         [], description="The type(s) of this monster"


### PR DESCRIPTION
Somehow `MonsterModel.sprites` is failing validation (probably due to pydantic being 2.0.2 here, while it probably is 1.x.x for people that don't have this issue). This causes the monster db to be empty, causing all sorts of issues. 

This fixes #1973, #1972 and #1971. 

Edit: I've confirmed that with pydantic==1.9.2 this problem doesn't exist. So the fix could either be this PR or updating `requirements.txt` to avoid pydantic>=2.0.0.