### PR TITLE
Fix game lock up by avoiding two events firing at once (fix #1976)

### DIFF
--- a/mods/tuxemon/maps/spyder_cotton_cafe.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_cafe.tmx
@@ -74,6 +74,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_cottoncafe_hackerchat"/>
     <property name="behav1" value="talk spyder_cottontown_hacker"/>
+    <property name="cond1" value="is variable_set visitedcottoncafe:yes"/>
    </properties>
   </object>
   <object id="19" name="Talk Barmaid" type="event" x="0" y="80" width="16" height="16">


### PR DESCRIPTION
The issue in #1976 is that two events are firing at once when the player talks to Hacker. So we add a condition check that makes event "Talk Hacker" only fire after event "First Visit to Cotton Cafe".