### PR TITLE
Reorder end of combat messages & improve animations engine

### DIFF
--- a/tests/tuxemon/test_animation.py
+++ b/tests/tuxemon/test_animation.py
@@ -1,0 +1,106 @@
+import unittest
+from typing import Callable
+from unittest.mock import Mock, call
+
+import pygame
+
+from tuxemon.animation import Task
+
+DEFAULT_INTERVAL = 1.0
+
+
+class TestAnimation(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mock_callback = Mock(spec=Callable)
+        self.other_mock_callback = Mock(spec=Callable)
+
+    def test_task_run_callback_after_interval(self):
+        task = Task(self.mock_callback, DEFAULT_INTERVAL)
+
+        task.update(0.5)
+        self.mock_callback.assert_not_called()
+
+        task.update(0.5)
+        self.mock_callback.assert_called()
+
+    def test_raise_value_error_when_times_is_0(self):
+        times = 0
+        with self.assertRaises(ValueError):
+            Task(self.mock_callback, DEFAULT_INTERVAL, times)
+
+    def test_raise_value_error_when_callback_is_not_callable(self):
+        with self.assertRaises(ValueError):
+            Task("not callable", DEFAULT_INTERVAL)
+
+    def test_task_run_callback_immediately_when_no_interval(self):
+        task = Task(self.mock_callback, 0)
+
+        task.update(0)
+
+        self.mock_callback.assert_called()
+
+    def test_task_run_callback_twice_when_times_is_2(self):
+        times = 2
+        task = Task(self.mock_callback, DEFAULT_INTERVAL, times)
+
+        task.update(DEFAULT_INTERVAL)
+        task.update(DEFAULT_INTERVAL)
+
+        self.mock_callback.assert_has_calls([call(), call()])
+
+    def test_raise_runtime_error_when_calling_update_after_task_finished(self):
+        task = Task(self.mock_callback, DEFAULT_INTERVAL)
+
+        task.update(DEFAULT_INTERVAL)
+        with self.assertRaises(RuntimeError):
+            task.update(DEFAULT_INTERVAL)
+
+    def test_add_chained_callback_to_group_when_original_task_finished(self):
+        task = Task(self.mock_callback, DEFAULT_INTERVAL)
+        task.chain(self.other_mock_callback, DEFAULT_INTERVAL)
+        task_group = pygame.sprite.Group()
+        task_group.add(task)
+
+        task_group.update(DEFAULT_INTERVAL)
+        self.mock_callback.assert_called()
+        self.other_mock_callback.assert_not_called()
+
+        task_group.update(DEFAULT_INTERVAL)
+        self.other_mock_callback.assert_called()
+
+    def test_is_finish_return_true_when_task_finished(self):
+        task = Task(self.mock_callback, DEFAULT_INTERVAL)
+
+        task.update(DEFAULT_INTERVAL)
+        self.assertTrue(task.is_finish())
+
+    def test_is_finish_return_false_when_task_in_progress(self):
+        task = Task(self.mock_callback, DEFAULT_INTERVAL)
+
+        task.update(0.5)
+        self.assertFalse(task.is_finish())
+
+    def test_reset_delay_when_new_delay_is_greater_than_interval(self):
+        task = Task(self.mock_callback, DEFAULT_INTERVAL)
+        greater_delay = DEFAULT_INTERVAL * 2
+
+        task.reset_delay(greater_delay)
+
+        self.assertEqual(greater_delay, task._interval)
+
+    def test_reset_delay_when_new_delay_is_greater_than_time_left(self):
+        task = Task(self.mock_callback, DEFAULT_INTERVAL)
+        same_delay = DEFAULT_INTERVAL
+        task.update(0.5)  # Time left is decreasing
+
+        task.reset_delay(same_delay)
+
+        self.assertEqual(same_delay, task._interval)
+
+    def test_dont_change_delay_when_new_delay_is_lower_than_time_left(self):
+        task = Task(self.mock_callback, DEFAULT_INTERVAL)
+        lower_delay = DEFAULT_INTERVAL / 2
+
+        task.reset_delay(lower_delay)
+
+        self.assertEqual(DEFAULT_INTERVAL, task._interval)

--- a/tuxemon/animation.py
+++ b/tuxemon/animation.py
@@ -290,7 +290,8 @@ class Task(TaskBase):
 
     def reset_delay(self, new_delay: float) -> None:
         """
-        Reset the delay before starting the task to make sure the time left is equal or bigger to the provided value
+        Reset the delay before starting task to make sure time left is
+        equal or bigger to the provided value
 
         Parameters:
             new_delay: the updated delay that should be respected
@@ -299,7 +300,6 @@ class Task(TaskBase):
         if new_delay > time_left:
             self._interval = new_delay
             self._duration = 0
-            return
 
     def abort(self) -> None:
         """Force task to finish, without executing callbacks."""

--- a/tuxemon/animation.py
+++ b/tuxemon/animation.py
@@ -281,6 +281,26 @@ class Task(TaskBase):
             self._execute_chain()
             self._cleanup()
 
+    def is_finish(self) -> bool:
+        """
+        Returns:
+            Whether the task is finished or not.
+        """
+        return self._state is ANIMATION_FINISHED
+
+    def reset_delay(self, new_delay: float) -> None:
+        """
+        Reset the delay before starting the task to make sure the time left is equal or bigger to the provided value
+
+        Parameters:
+            new_delay: the updated delay that should be respected
+        """
+        time_left = self._interval - self._duration
+        if new_delay > time_left:
+            self._interval = new_delay
+            self._duration = 0
+            return
+
     def abort(self) -> None:
         """Force task to finish, without executing callbacks."""
         self._state = ANIMATION_FINISHED

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -137,7 +137,7 @@ MULT_MAP = {
 # This is the time, in seconds, that the text takes to display.
 LETTER_TIME: float = 0.02
 # This is the time, in seconds, that the animation takes to finish.
-ACTION_TIME: float = 3.0
+ACTION_TIME: float = 2.0
 
 
 class TechniqueAnimationCache:
@@ -1007,7 +1007,7 @@ class CombatState(CombatAnimations):
 
     def suppress_phase_change(
         self,
-        delay: float = 3.0,
+        delay: float = 2.0,
     ) -> Optional[Task]:
         """
         Prevent the combat phase from changing for a limited time.

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -247,6 +247,7 @@ class CombatState(CombatAnimations):
         self._new_tuxepedia: bool = False
         self._lost_status: Optional[str] = None
         self._lost_monster: Optional[Monster] = None
+        self._post_animation_task: Optional[Task] = None
 
         super().__init__(players, graphics)
         self.is_trainer_battle = combat_type == "trainer"
@@ -1018,14 +1019,15 @@ class CombatState(CombatAnimations):
 
         """
         if self._animation_in_progress:
-            logger.debug("double suppress: bug?")
-            return None
+            self._post_animation_task.reset_delay(delay)
+            return self._post_animation_task
 
         self._animation_in_progress = True
-        return self.task(
+        self._post_animation_task: Task = self.task(
             partial(setattr, self, "_animation_in_progress", False),
             delay,
         )
+        return self._post_animation_task
 
     def perform_action(
         self,

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -248,6 +248,7 @@ class CombatState(CombatAnimations):
         self._lost_status: Optional[str] = None
         self._lost_monster: Optional[Monster] = None
         self._post_animation_task: Optional[Task] = None
+        self._xp_message = None
 
         super().__init__(players, graphics)
         self.is_trainer_battle = combat_type == "trainer"


### PR DESCRIPTION
This PR addresses first bullet point of #1967 

XP message is now between "Opponent is KO message" and "win message".

But in order to do this properly, I reworked the battle animation system to fix two flaws:

1. Unfinished `Task` were not preventing the game to move to the next combat phase, which was sometimes resulting to animation tasks planned during previous turn to run during next turn.

A method to check if a task is finished has been added (` def is_finished(self) -> bool`) and is now called for every task in `CombatState._animations`: if any task is not finished, then the game is not moving to the next phase.

2. No delay before moving to the next phase was added if some delay was still there when calling `suppress_phase_change`. As a result, let's imagine 1 second was left before moving to the next phase, and a new animation requires 10 seconds ; no time was added and the animation was closing after 1 second.

A method to reset the delay before starting the task has been added (`def reset_delay(self, new_delay: float) -> None`) and is called inside of `suppress_phase_change` to make sure the boolean for running animation is not going to change back to False before the additional animation is finished.

**Next step**

If think the battle animation system is still clunky, I suggest to introduce a queue of animations as a next step to prevent new text animation to override the currently running one (sometimes, next message is displayed even if the previous one didn't finish rendering).

**Notes**

This is my first contribution to the project, so I hope I followed all rules correctly, don't hesitate to tell me if anything looks wrong so I could avoid doing it again.
I also added tests for `Task` class: 12 in total, because I love tests. 😄 