### PR TITLE
get current git hash

### DIFF
--- a/tuxemon/log.py
+++ b/tuxemon/log.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import logging
 import os
+import subprocess
 import sys
 import time
 import warnings
@@ -35,6 +36,17 @@ def configure() -> None:
         warnings.filterwarnings("default")
 
         for logger_name in config.loggers:
+            # Get the current git hash
+            try:
+                githash = (
+                    subprocess.check_output(["git", "describe", "--always"])
+                    .strip()
+                    .decode()
+                )
+                print(f"Git Hash: {githash}")
+            except:
+                print("No Git Hash")
+
             # Enable logging for all modules if specified.
             if logger_name == "all":
                 print("Enabling logging of all modules.")


### PR DESCRIPTION
https://github.com/Tuxemon/Tuxemon/issues/1989#issuecomment-1686722935 by @Grimmys 

I read your reply, did you mean something like this? Now at the start it'll print:

```
robespierre@robespierre-M11AD:~/Tuxemon$ python3 run_tuxemon.py
pygame-ce 2.2.1 (SDL 2.26.4, Python 3.10.12)
pygame-menu 4.4.3
Git Hash: 163ad3a86
Enabling logging of all modules.
[2023-08-22 08:30:39,119] tuxemon.rumble - ERROR - No rumble backends available.
```
~~I put also the git hash in the menu too, because some people can never see the terminal~~
~~https://github.com/Tuxemon/Tuxemon/assets/64643719/087d4278-074c-4a7d-a826-bc8e140abbbc~~

tested, black, isort, no new typehints
