### PR TITLE
Add animation queue

### DIFF
--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -295,10 +295,7 @@ class CombatState(CombatAnimations):
         """
         super().update(time_delta)
         self._text_animation_time_left -= time_delta
-        if (
-            self.no_ongoing_text_animation()
-            and self.text_animations_queue
-        ):
+        if self.no_ongoing_text_animation() and self.text_animations_queue:
             (
                 next_animation,
                 self._text_animation_time_left,
@@ -1339,9 +1336,7 @@ class CombatState(CombatAnimations):
                         mex = check_moves(winners, diff)
                         if mex:
                             message += "\n" + mex
-                            action_time += compute_text_animation_time(
-                                message
-                            )
+                            action_time += compute_text_animation_time(message)
                         # updates hud graphics player
                         if len(self.monsters_in_play_human) > 1:
                             self.build_hud(

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -297,7 +297,7 @@ class CombatState(CombatAnimations):
         self._text_animation_time_left -= time_delta
         if (
             self.no_ongoing_text_animation()
-            and len(self.text_animations_queue) > 0
+            and self.text_animations_queue
         ):
             (
                 next_animation,

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -1573,7 +1573,6 @@ class CombatState(CombatAnimations):
         return False
 
     def evolve(self) -> None:
-        self.client.pop_state()
         for monster in self.players[0].monsters:
             for evolution in monster.evolutions:
                 evolved = Monster()
@@ -1696,4 +1695,5 @@ class CombatState(CombatAnimations):
                 MonsterInfoState(monster=self._captured_mon)
             )
         else:
+            self.phase = None
             self.client.push_state(FadeOutTransition(caller=self))

--- a/tuxemon/states/combat/combat_animations.py
+++ b/tuxemon/states/combat/combat_animations.py
@@ -44,7 +44,7 @@ logger = logging.getLogger(__name__)
 
 sprite_layer = 0
 hud_layer = 100
-TimedCallable = tuple[Callable, float]
+TimedCallable = Tuple[Callable, float]
 
 
 def toggle_visible(sprite: Sprite) -> None:

--- a/tuxemon/states/combat/combat_animations.py
+++ b/tuxemon/states/combat/combat_animations.py
@@ -13,12 +13,12 @@ from collections import defaultdict
 from functools import partial
 from typing import (
     TYPE_CHECKING,
+    Callable,
     List,
     Literal,
     MutableMapping,
     Optional,
     Tuple,
-    Callable,
 )
 
 import pygame

--- a/tuxemon/states/combat/combat_animations.py
+++ b/tuxemon/states/combat/combat_animations.py
@@ -17,7 +17,7 @@ from typing import (
     Literal,
     MutableMapping,
     Optional,
-    Tuple,
+    Tuple, Callable,
 )
 
 import pygame
@@ -44,6 +44,7 @@ logger = logging.getLogger(__name__)
 
 sprite_layer = 0
 hud_layer = 100
+TimedCallable = tuple[Callable, float]
 
 
 def toggle_visible(sprite: Sprite) -> None:
@@ -83,6 +84,8 @@ class CombatAnimations(ABC, Menu[None]):
         self.hud: MutableMapping[Monster, Sprite] = {}
         self.is_trainer_battle = False
         self.capdevs: List[CaptureDeviceSprite] = []
+        self.text_animations_queue: List[TimedCallable] = []
+        self._text_animation_time_left: float = 0
         self._hp_bars: MutableMapping[Monster, HpBar] = {}
         self._exp_bars: MutableMapping[Monster, ExpBar] = {}
         self._status_icons: defaultdict[Monster, List[Sprite]] = defaultdict(

--- a/tuxemon/states/combat/combat_animations.py
+++ b/tuxemon/states/combat/combat_animations.py
@@ -121,13 +121,6 @@ class CombatAnimations(ABC, Menu[None]):
             player: layout[index] for index, player in enumerate(self.players)
         }
 
-    @abstractmethod
-    def suppress_phase_change(
-        self,
-        delay: float = 3.0,
-    ) -> Optional[Task]:
-        raise NotImplementedError
-
     def animate_open(self) -> None:
         self.transition_none_normal()
 
@@ -284,7 +277,6 @@ class CombatAnimations(ABC, Menu[None]):
             del self.hud[monster]
 
         self.animate_monster_leave(monster)
-        self.suppress_phase_change()
         self.task(kill, 2)
 
         for monsters in self.monsters_in_play.values():
@@ -789,7 +781,6 @@ class CombatAnimations(ABC, Menu[None]):
                 partial(self.alert, gotcha),
                 action_time,
             )
-            self._animation_in_progress = True
         else:
             breakout_delay = 1.8 + num_shakes * 1.0
             self.task(  # make the monster appear again!

--- a/tuxemon/states/combat/combat_animations.py
+++ b/tuxemon/states/combat/combat_animations.py
@@ -8,7 +8,7 @@ notably, the use of self.game
 from __future__ import annotations
 
 import logging
-from abc import ABC, abstractmethod
+from abc import ABC
 from collections import defaultdict
 from functools import partial
 from typing import (
@@ -34,7 +34,6 @@ from tuxemon.surfanim import SurfaceAnimation
 from tuxemon.tools import scale, scale_sequence
 
 if TYPE_CHECKING:
-    from tuxemon.animation import Task
     from tuxemon.db import BattleGraphicsModel
     from tuxemon.item.item import Item
     from tuxemon.monster import Monster

--- a/tuxemon/states/combat/combat_animations.py
+++ b/tuxemon/states/combat/combat_animations.py
@@ -17,7 +17,8 @@ from typing import (
     Literal,
     MutableMapping,
     Optional,
-    Tuple, Callable,
+    Tuple,
+    Callable,
 )
 
 import pygame

--- a/tuxemon/technique/effects/swap.py
+++ b/tuxemon/technique/effects/swap.py
@@ -58,6 +58,5 @@ class SwapEffect(TechEffect):
 
         # give a slight delay
         combat_state.task(partial(swap_add, original_monster), 0.75)
-        combat_state.suppress_phase_change(0.75)
 
         return {"success": True}


### PR DESCRIPTION
Following #1987, this PR introduces a text animation queue to be able to schedule displaying of text on the screen without replacing the already running text animation.

Example: at the end of the combat, in case of victory, multiple messages should be displayed (enemy defeated, xp earned, victory), but they should not be animating in parallel (but rather sequentially).

Also, it fixes an issue about fade out animation not running at the end of combat when it should (it was working fine only in case of successful capture). I can map this PR to a new issue or find the existing one (if any) if you want.

From technical perspective, I got rid of `suppress_phase_change` method that (imo) should not be used because it's error prone.
We should rather rely on tangible events happening on the state (such as running Tasks and text animations) than delay the state update with some arbitrary values.