### PR TITLE
migrate pydantic v2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ natsort
 PyYAML>=5.4.1
 prompt_toolkit
 pygame-menu-ce>=4.4.1
-pydantic>=1.9.1
+pydantic>=2.3

--- a/scripts/schema.py
+++ b/scripts/schema.py
@@ -19,29 +19,29 @@ from tuxemon.db import (
 def write_json_schema(output_dir):
     print(f"Writing JSON schemas to '{output_dir}'...")
     with open(os.path.join(output_dir, "economy-schema.json"), "w") as f:
-        f.write(EconomyModel.schema_json(indent=2))
+        f.write(EconomyModel.model_json_schema(indent=2))
     with open(
         os.path.join(output_dir, "encounter-schema.json"), "w"
     ) as f:
-        f.write(EncounterModel.schema_json(indent=2))
+        f.write(EncounterModel.model_json_schema(indent=2))
     with open(
         os.path.join(output_dir, "environment-schema.json"), "w"
     ) as f:
-        f.write(EnvironmentModel.schema_json(indent=2))
+        f.write(EnvironmentModel.model_json_schema(indent=2))
     with open(os.path.join(output_dir, "item-schema.json"), "w") as f:
-        f.write(ItemModel.schema_json(indent=2))
+        f.write(ItemModel.model_json_schema(indent=2))
     with open(os.path.join(output_dir, "monster-schema.json"), "w") as f:
-        f.write(MonsterModel.schema_json(indent=2))
+        f.write(MonsterModel.model_json_schema(indent=2))
     with open(os.path.join(output_dir, "music-schema.json"), "w") as f:
-        f.write(MusicModel.schema_json(indent=2))
+        f.write(MusicModel.model_json_schema(indent=2))
     with open(os.path.join(output_dir, "npc-schema.json"), "w") as f:
-        f.write(NpcModel.schema_json(indent=2))
+        f.write(NpcModel.model_json_schema(indent=2))
     with open(os.path.join(output_dir, "sound-schema.json"), "w") as f:
-        f.write(SoundModel.schema_json(indent=2))
+        f.write(SoundModel.model_json_schema(indent=2))
     with open(
         os.path.join(output_dir, "technique-schema.json"), "w"
     ) as f:
-        f.write(TechniqueModel.schema_json(indent=2))
+        f.write(TechniqueModel.model_json_schema(indent=2))
 
 
 if __name__ == "__main__":

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -837,7 +837,7 @@ class NPC(Entity[NPCState]):
         for npc_monster_details in npc_party:
             # This seems slightly wrong. The only usable element in
             # npc_monsters_details, which is a PartyMemberModel, is "slug"
-            monster = Monster(save_data=npc_monster_details.dict())
+            monster = Monster(save_data=npc_monster_details.model_dump())
             monster.money_modifier = npc_monster_details.money_mod
             monster.experience_modifier = npc_monster_details.exp_req_mod
             monster.set_level(monster.level)
@@ -854,7 +854,7 @@ class NPC(Entity[NPCState]):
         self.items = []
         npc_bag = npc_details.items
         for npc_itm_details in npc_bag:
-            itm = Item(save_data=npc_itm_details.dict())
+            itm = Item(save_data=npc_itm_details.model_dump())
             itm.quantity = npc_itm_details.quantity
 
         # load NPC template
@@ -863,7 +863,7 @@ class NPC(Entity[NPCState]):
         self.template = []
         npc_template = npc_details.template
         for npc_template_details in npc_template:
-            tmp = Template(save_data=npc_template_details.dict())
+            tmp = Template(save_data=npc_template_details.model_dump())
             tmp.sprite_name = npc_template_details.sprite_name
             tmp.combat_front = npc_template_details.combat_front
             self.template.append(tmp)


### PR DESCRIPTION
By looking at the tests/actions of #2000 (tox_unite), I noticed a bunch of warnings similar to:
```
/home/runner/work/Tuxemon/Tuxemon/tuxemon/db.py:759:
PydanticDeprecatedSince20: Pydantic V1 style @validator validators are deprecated.
You should migrate to Pydantic V2 style @field_validator validators, see the migration guide for more details.
Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.3/migration/
```
so I updated pydantic `pip install -U pydantic`

This PR removes all the warnings as well as migrates Pydantic from v1 to v2:
- replace all the `@validator` with `@field_validator`;
- update the requirements.txt from 1.9.1 to 2.3 (is it ok? do you prefer only 2.0?);
- replace `dict()` with `model_dump` (DeprecationWarning);
- replace `schema_json` with `model_json_schema` (DeprecationWarning);

tested, black, isort, no new typehints