### PR TITLE
items effects typehints

### DIFF
--- a/tuxemon/item/effects/buff.py
+++ b/tuxemon/item/effects/buff.py
@@ -53,4 +53,4 @@ class BuffEffect(ItemEffect):
         else:
             raise ValueError(f"{self.stat} must be a stat.")
 
-        return {"success": True}
+        return {"success": True, "num_shakes": 0, "extra": None}

--- a/tuxemon/item/effects/capture.py
+++ b/tuxemon/item/effects/capture.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 class CaptureEffectResult(ItemEffectResult):
-    num_shakes: int
+    pass
 
 
 @dataclass
@@ -191,7 +191,7 @@ class CaptureEffect(ItemEffect):
                     if tuxeball:
                         tuxeball.quantity += 1
 
-                return {"success": False, "num_shakes": i + 1}
+                return {"success": False, "num_shakes": i + 1, "extra": None}
 
         # it increases the level +1 upon capture
         if item.slug == "tuxeball_candy":
@@ -205,4 +205,4 @@ class CaptureEffect(ItemEffect):
         self.user.add_monster(target, len(self.user.monsters))
 
         # TODO: remove monster from the other party
-        return {"success": True, "num_shakes": 4}
+        return {"success": True, "num_shakes": 4, "extra": None}

--- a/tuxemon/item/effects/evolve.py
+++ b/tuxemon/item/effects/evolve.py
@@ -42,4 +42,4 @@ class EvolveEffect(ItemEffect):
                 evolution = random.choice(choices).monster_slug
                 self.user.evolve_monster(target, evolution)
                 evolve = True
-        return {"success": evolve}
+        return {"success": evolve, "num_shakes": 0, "extra": None}

--- a/tuxemon/item/effects/fishing.py
+++ b/tuxemon/item/effects/fishing.py
@@ -29,6 +29,7 @@ class FishingEffect(ItemEffect):
         self, item: Item, target: Union[Monster, None]
     ) -> FishingEffectResult:
         # define random encounters
+        fishing: bool = False
         bas = []
         adv = []
         pro = []
@@ -68,9 +69,7 @@ class FishingEffect(ItemEffect):
                 WildEncounterAction(
                     monster_slug=mon_slug, monster_level=level, env="ocean"
                 ).start()
-                return {"success": True}
-            else:
-                return {"success": False}
+                fishing = True
         elif item.slug == "neptune":
             if bait <= 65:
                 mon_slug = random.choice(adv)
@@ -78,9 +77,7 @@ class FishingEffect(ItemEffect):
                 WildEncounterAction(
                     monster_slug=mon_slug, monster_level=level, env="ocean"
                 ).start()
-                return {"success": True}
-            else:
-                return {"success": False}
+                fishing = True
         elif item.slug == "poseidon":
             if bait <= 85:
                 mon_slug = random.choice(pro)
@@ -88,7 +85,5 @@ class FishingEffect(ItemEffect):
                 WildEncounterAction(
                     monster_slug=mon_slug, monster_level=level, env="ocean"
                 ).start()
-                return {"success": True}
-            else:
-                return {"success": False}
-        return {"success": False}
+                fishing = True
+        return {"success": fishing, "num_shakes": 0, "extra": None}

--- a/tuxemon/item/effects/gain_xp.py
+++ b/tuxemon/item/effects/gain_xp.py
@@ -30,4 +30,4 @@ class GainXpEffect(ItemEffect):
     ) -> GainXpEffectResult:
         assert target
         target.give_experience(self.amount)
-        return {"success": True}
+        return {"success": True, "num_shakes": 0, "extra": None}

--- a/tuxemon/item/effects/heal.py
+++ b/tuxemon/item/effects/heal.py
@@ -53,4 +53,4 @@ class HealEffect(ItemEffect):
         if target.current_hp > target.hp:
             target.current_hp = target.hp
 
-        return {"success": True}
+        return {"success": True, "num_shakes": 0, "extra": None}

--- a/tuxemon/item/effects/increase.py
+++ b/tuxemon/item/effects/increase.py
@@ -53,4 +53,4 @@ class IncreaseEffect(ItemEffect):
         else:
             raise ValueError(f"{self.stat} must be a stat.")
         target.set_stats()
-        return {"success": True}
+        return {"success": True, "num_shakes": 0, "extra": None}

--- a/tuxemon/item/effects/learn_mm.py
+++ b/tuxemon/item/effects/learn_mm.py
@@ -28,6 +28,7 @@ class LearnMmEffect(ItemEffect):
     def apply(
         self, item: Item, target: Union[Monster, None]
     ) -> LearnMmEffectResult:
+        learn: bool = False
         ele = ElementType(self.element)
         assert target
         techs = list(db.database["technique"])
@@ -51,6 +52,6 @@ class LearnMmEffect(ItemEffect):
             self.user.game_variables["overwrite_technique"] = random.choice(
                 res
             )
-            return {"success": True}
-        else:
-            return {"success": False}
+            learn = True
+
+        return {"success": learn, "num_shakes": 0, "extra": None}

--- a/tuxemon/item/effects/learn_tm.py
+++ b/tuxemon/item/effects/learn_tm.py
@@ -26,6 +26,7 @@ class LearnTmEffect(ItemEffect):
     def apply(
         self, item: Item, target: Union[Monster, None]
     ) -> LearnTmEffectResult:
+        learn: bool = False
         assert target
         # monster moves
         moves = []
@@ -36,12 +37,9 @@ class LearnTmEffect(ItemEffect):
         res = list(set_moves)
         # continue operation
         if res:
-            if self.technique in res:
-                return {"success": False}
-            else:
+            if self.technique not in res:
                 self.user.game_variables[
                     "overwrite_technique"
                 ] = self.technique
-                return {"success": True}
-        else:
-            return {"success": False}
+                learn = True
+        return {"success": learn, "num_shakes": 0, "extra": None}

--- a/tuxemon/item/effects/remove.py
+++ b/tuxemon/item/effects/remove.py
@@ -29,6 +29,7 @@ class RemoveEffect(ItemEffect):
     def apply(
         self, item: Item, target: Union[Monster, None]
     ) -> RemoveEffectResult:
+        remove: bool = False
         coords: Tuple[int, int] = (0, 0)
         player = self.session.player
         facing = player.facing
@@ -51,6 +52,5 @@ class RemoveEffect(ItemEffect):
         if npc:
             RemoveNpcAction(npc_slug=npc.slug).start()
             self.session.player.game_variables[npc.slug] = self.name
-            return {"success": True}
-        else:
-            return {"success": False}
+            remove = True
+        return {"success": remove, "num_shakes": 0, "extra": None}

--- a/tuxemon/item/effects/restore.py
+++ b/tuxemon/item/effects/restore.py
@@ -57,4 +57,4 @@ class RestoreEffect(ItemEffect):
         else:
             target.status.clear()
 
-        return {"success": True}
+        return {"success": True, "num_shakes": 0, "extra": None}

--- a/tuxemon/item/effects/revive.py
+++ b/tuxemon/item/effects/revive.py
@@ -32,4 +32,4 @@ class ReviveEffect(ItemEffect):
         target.status = []
         target.current_hp = self.hp
 
-        return {"success": True}
+        return {"success": True, "num_shakes": 0, "extra": None}

--- a/tuxemon/item/effects/switch.py
+++ b/tuxemon/item/effects/switch.py
@@ -50,4 +50,4 @@ class SwitchEffect(ItemEffect):
                 ele = Element(_target)
                 target.types = [ele]
                 done = True
-        return {"success": done}
+        return {"success": done, "num_shakes": 0, "extra": None}

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -239,8 +239,8 @@ class Item:
         meta_result: ItemEffectResult = {
             "name": self.name,
             "num_shakes": 0,
-            "should_tackle": False,
             "success": False,
+            "extra": None,
         }
 
         # Loop through all the effects of this technique and execute the effect's function.

--- a/tuxemon/item/itemeffect.py
+++ b/tuxemon/item/itemeffect.py
@@ -18,6 +18,8 @@ logger = logging.getLogger(__name__)
 
 class ItemEffectResult(TypedDict):
     success: bool
+    num_shakes: int
+    extra: Union[str, None]
 
 
 @dataclass
@@ -73,4 +75,4 @@ class ItemEffect:
     def apply(
         self, item: Item, target: Union[Monster, None]
     ) -> ItemEffectResult:
-        return {"success": True}
+        return {"success": True, "num_shakes": 0, "extra": None}


### PR DESCRIPTION
PR
- removes `"should_tackle": False` from item.py (no used and cause of typehints);
- adds `"num_shakes"` to the other effects (the missing of this element was causing typehints);
- adds `"extra"` to the effects, in this way it'll be possible to carry messages without hardcoding in combat.py;

First step to remove item harcoded from combat.py (same task as for #1998 and following).

black, isort, tested, -4 typehints