### PR TITLE
fix mom destination (spyder)

### DIFF
--- a/mods/tuxemon/maps/spyder_cotton_town.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_town.tmx
@@ -388,7 +388,7 @@
     <property name="act11" value="player_stop"/>
     <property name="act12" value="lock_controls"/>
     <property name="act13" value="create_npc spyder_papertown_mom,23,23"/>
-    <property name="act14" value="pathfind spyder_papertown_mom,28,18"/>
+    <property name="act14" value="pathfind spyder_papertown_mom,31,18"/>
     <property name="act15" value="unlock_controls"/>
     <property name="act16" value="npc_face player,down"/>
     <property name="act20" value="translated_dialog spyder_cottontown_mom"/>


### PR DESCRIPTION
PR fixes mom destination. When arriving in Cotton Town, before entering the cafe, there is an event where the player's mom comes up. Well, before she was stopping at 28,18 (wrong coordinates), now she is stopping at 31,18, exactly in front of the player.