### PR TITLE
npc_wander_range

### DIFF
--- a/tuxemon/event/actions/npc_wander.py
+++ b/tuxemon/event/actions/npc_wander.py
@@ -22,7 +22,7 @@ class NpcWanderAction(EventAction):
     Script usage:
         .. code-block::
 
-            npc_wander <npc_slug>[,frequency][,c_v1][,c_v2]
+            npc_wander <npc_slug>[,frequency][,t_bound][,b_bound]
 
     Script parameters:
         npc_slug: Either "player" or npc slug name (e.g. "npc_maple").

--- a/tuxemon/event/actions/npc_wander.py
+++ b/tuxemon/event/actions/npc_wander.py
@@ -58,9 +58,8 @@ class NpcWanderAction(EventAction):
         if self.b_bound_x is not None and self.b_bound_y is not None:
             bottom_bound = (self.b_bound_x, self.b_bound_y)
         if top_bound and bottom_bound:
-            v = [top_bound, bottom_bound]
-            x_coords = [x for x in range(v[0][0], v[1][0] + 1)]
-            y_coords = [y for y in range(v[0][1], v[1][1] + 1)]
+            x_coords = [x for x in range(top_bound[0], bottom_bound[0] + 1)]
+            y_coords = [y for y in range(top_bound[1], bottom_bound[1] + 1)]
             output = list(itertools.product(x_coords, y_coords))
 
         def move(world: WorldState, npc: NPC) -> None:
@@ -93,10 +92,6 @@ class NpcWanderAction(EventAction):
                     if not output or path in output:
                         npc.path = [path]
                         npc.next_waypoint()
-                    else:
-                        return
-                else:
-                    return
 
         def schedule() -> None:
             # The timer is randomized between 0.5 and 1.0 of the frequency


### PR DESCRIPTION
@Sanglorian asked for this here #799

PR expands **npc_wander** with new fields (default None), so by using:
`npc_wander spyder_shopassistant,,5,7,7,9`
the npc will wander only between coordinates 5,7 and 7,9 (black dots)
_if the npc isn't in the "black square", it'll not move_

![spyder_cotton_scoop](https://github.com/Tuxemon/Tuxemon/assets/64643719/4e945f18-2d8e-4596-b6f3-d981e346e665)

black, isort, tested, no new typehints
fix #799