### PR TITLE
remove default effect

### DIFF
--- a/mods/tuxemon/db/condition/charging.json
+++ b/mods/tuxemon/db/condition/charging.json
@@ -2,7 +2,6 @@
   "animation": null,
   "category": "positive",
   "effects": [
-    "default",
     "charging"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/db/condition/festering.json
+++ b/mods/tuxemon/db/condition/festering.json
@@ -2,7 +2,7 @@
   "animation": null,
   "category": "negative",
   "effects": [
-    "default"
+    "festering"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_festering.png",

--- a/mods/tuxemon/db/condition/lockdown.json
+++ b/mods/tuxemon/db/condition/lockdown.json
@@ -2,7 +2,7 @@
   "animation": null,
   "category": "negative",
   "effects": [
-    "default"
+    "lockdown"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_lockdown.png",

--- a/mods/tuxemon/db/condition/noddingoff.json
+++ b/mods/tuxemon/db/condition/noddingoff.json
@@ -2,7 +2,7 @@
   "animation": null,
   "category": "negative",
   "effects": [
-    "default"
+    "noddingoff"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_noddingoff.png",

--- a/tuxemon/condition/effects/festering.py
+++ b/tuxemon/condition/effects/festering.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from tuxemon.condition.condeffect import CondEffect, CondEffectResult
+
+if TYPE_CHECKING:
+    from tuxemon.condition.condition import Condition
+    from tuxemon.monster import Monster
+
+
+class FesteringEffectResult(CondEffectResult):
+    pass
+
+
+@dataclass
+class FesteringEffect(CondEffect):
+    """
+    This effect has a chance to apply the festering status effect.
+    """
+
+    name = "festering"
+
+    def apply(self, tech: Condition, target: Monster) -> FesteringEffectResult:
+        return {
+            "success": True,
+            "condition": None,
+            "technique": None,
+            "extra": None,
+        }

--- a/tuxemon/condition/effects/lockdown.py
+++ b/tuxemon/condition/effects/lockdown.py
@@ -12,20 +12,19 @@ if TYPE_CHECKING:
     from tuxemon.monster import Monster
 
 
-class DefaultEffectResult(CondEffectResult):
+class LockdownEffectResult(CondEffectResult):
     pass
 
 
 @dataclass
-class DefaultEffect(CondEffect):
+class LockdownEffect(CondEffect):
     """
-    Default allows conditions without effects to manifest.
-
+    This effect has a chance to apply the lockdown status effect.
     """
 
-    name = "default"
+    name = "lockdown"
 
-    def apply(self, tech: Condition, target: Monster) -> DefaultEffectResult:
+    def apply(self, tech: Condition, target: Monster) -> LockdownEffectResult:
         return {
             "success": True,
             "condition": None,

--- a/tuxemon/condition/effects/noddingoff.py
+++ b/tuxemon/condition/effects/noddingoff.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from tuxemon.condition.condeffect import CondEffect, CondEffectResult
+
+if TYPE_CHECKING:
+    from tuxemon.condition.condition import Condition
+    from tuxemon.monster import Monster
+
+
+class NoddingOffEffectResult(CondEffectResult):
+    pass
+
+
+@dataclass
+class NoddingOffEffect(CondEffect):
+    """
+    This effect has a chance to apply the nodding off status effect.
+    """
+
+    name = "noddingoff"
+
+    def apply(
+        self, tech: Condition, target: Monster
+    ) -> NoddingOffEffectResult:
+        return {
+            "success": True,
+            "condition": None,
+            "technique": None,
+            "extra": None,
+        }


### PR DESCRIPTION
it follows #1998 

PR:
- removes completely the effect **default** from three status: lockdown, noddingoff and festering;
- creates a single file for each one of these;

black, isort, tested, no new typehints