### PR TITLE
type in db.py + typehint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,8 +9,8 @@ version: 2
 sphinx:
   configuration: docs/conf.py
 
-# 3.8 is required, anything lower will fail to build the actions
+# 3.9 is required, anything lower will fail to build the actions
 python:
-    version: 3.8
+    version: 3.9
     install:
     - requirements: docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ often out of date.
 
 ### Windows Source
 
-Requires Python 3.8+ and git.
+Requires Python 3.9+ and git.
 
 Install the latest version of Python 3 from
 [here](https://www.python.org/downloads/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,13 +18,12 @@ classifiers = [
         "Intended Audience :: End Users/Desktop",
         "Development Status :: 3 - Alpha",
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Topic :: Games/Entertainment",
         "Topic :: Games/Entertainment :: Role-Playing"
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dynamic = ["dependencies"]
 
 [project.urls]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,7 +2,7 @@ Tools to get/manipulate game files or config should go here.
 
 * Scripts should have documentation at the top of the file
 * Do not add script dependencies to requirements.txt or setup.py
-* New python scripts should be written for python 3.8+
+* New python scripts should be written for python 3.9+
 * Scripts do not require unit testing
 * Do not modify project if your script requires another language/runtime
 

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -255,7 +255,7 @@ class CombatState(CombatAnimations):
         self._new_tuxepedia: bool = False
         self._run: bool = False
         self._post_animation_task: Optional[Task] = None
-        self._xp_message = None
+        self._xp_message: Optional[str] = None
 
         super().__init__(players, graphics)
         self.is_trainer_battle = combat_type == "trainer"

--- a/tuxemon/states/combat/combat_animations.py
+++ b/tuxemon/states/combat/combat_animations.py
@@ -13,7 +13,6 @@ from collections import defaultdict
 from functools import partial
 from typing import (
     TYPE_CHECKING,
-    Callable,
     List,
     Literal,
     MutableMapping,
@@ -44,7 +43,7 @@ logger = logging.getLogger(__name__)
 
 sprite_layer = 0
 hud_layer = 100
-TimedCallable = Tuple[Callable, float]
+TimedCallable = Tuple[partial[None], float]
 
 
 def toggle_visible(sprite: Sprite) -> None:


### PR DESCRIPTION
PR:
- fixes type and return type in db.py
- 1 typehint in combat.py

@bitcraft you suggested it in the other PR, I took the initiative to fix all validators

I checked with mypy --strict last version (1.6) and I got rid of this typehint:
`tuxemon/states/combat/combat.py:1307: error: Incompatible types in assignment (expression has type "str", variable has type "None")  [assignment]`

black, isort, tested, -2 typehints) #1211 