### PR TITLE
fix indexerror

### DIFF
--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -66,7 +66,6 @@ from tuxemon.combat import (
     defeated,
     fainted,
     get_awake_monsters,
-    has_status,
     has_status_bond,
 )
 from tuxemon.condition.condition import Condition
@@ -1363,9 +1362,7 @@ class CombatState(CombatAnimations):
                         self.text_animations_queue.append(
                             (partial(self.alert, extra), action_time)
                         )
-                if monster.current_hp <= 0 and not has_status(
-                    monster, "faint"
-                ):
+                if monster.current_hp <= 0:
                     self.remove_monster_actions_from_queue(monster)
                     self.faint_monster(monster)
 


### PR DESCRIPTION
fix #2023 as reported by @spollard (thanks man for reporting).
The issue was caused by `not has_status(monster, "faint")` inside **check_party_hp**

```
A (human), B (ai)
B attacks A
A faints
A attacks B (this doesn't need to happen since A is fainted) (1)
crash
```
(1) this happened because the monster **A** was unable to overcome `not has_status(monster, "faint")` and get to `remove_monster_actions_from_queue` where the move would have been removed -> no crash 

Simply **A** got the faint status before.

black, isort, tested, no new typehints