### PR TITLE
proportional damage effect (technique)

### DIFF
--- a/mods/tuxemon/db/technique/panjandrum.json
+++ b/mods/tuxemon/db/technique/panjandrum.json
@@ -3,7 +3,7 @@
   "accuracy": 0.75,
   "animation": "explosion_mushroom_128",
   "effects": [
-    "local_damage"
+    "prop_damage target,0.25"
   ],
   "flip_axes": "",
   "is_fast": false,

--- a/tuxemon/technique/effects/prop_damage.py
+++ b/tuxemon/technique/effects/prop_damage.py
@@ -40,7 +40,6 @@ class PropDamageEffect(TechEffect):
     ) -> PropDamageEffectResult:
         player = self.session.player
         value = float(player.game_variables["random_tech_hit"])
-        mult = 1.0
         hit = tech.accuracy >= value
         if hit:
             tech.hit = True
@@ -54,7 +53,7 @@ class PropDamageEffect(TechEffect):
 
         return {
             "damage": damage,
-            "element_multiplier": mult,
+            "element_multiplier": 0.0,
             "should_tackle": bool(damage),
             "success": bool(damage),
             "extra": None,

--- a/tuxemon/technique/effects/prop_damage.py
+++ b/tuxemon/technique/effects/prop_damage.py
@@ -43,14 +43,11 @@ class PropDamageEffect(TechEffect):
         mult = 1.0
         hit = tech.accuracy >= value
         if hit:
-            damage = None
             tech.hit = True
             tech.advance_counter_success()
-            if self.objective == "target":
-                damage = target.hp * self.proportional
-            else:
-                damage = user.hp * self.proportional
-            target.current_hp -= int(damage)
+            reference_hp = target.hp if self.objective == "target" else user.hp
+            damage = int(reference_hp * self.proportional)
+            target.current_hp -= damage
         else:
             tech.hit = False
             damage = 0

--- a/tuxemon/technique/effects/prop_damage.py
+++ b/tuxemon/technique/effects/prop_damage.py
@@ -53,7 +53,7 @@ class PropDamageEffect(TechEffect):
             damage = 0
 
         return {
-            "damage": int(damage),
+            "damage": damage,
             "element_multiplier": mult,
             "should_tackle": bool(damage),
             "success": bool(damage),

--- a/tuxemon/technique/effects/prop_damage.py
+++ b/tuxemon/technique/effects/prop_damage.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from tuxemon import formula
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
 
 if TYPE_CHECKING:
@@ -13,50 +12,51 @@ if TYPE_CHECKING:
     from tuxemon.technique.technique import Technique
 
 
-class LocalDamageEffectResult(TechEffectResult):
+class PropDamageEffectResult(TechEffectResult):
     pass
 
 
 @dataclass
-class LocalDamageEffect(TechEffect):
+class PropDamageEffect(TechEffect):
     """
-    Apply damage, but it allows different output depending on the
-    technique used. Originally "particular_damage", but it was
-    too verbose.
+    Proportional Damage:
+    This effect does damage to the enemy equal
+    to % of the target's / user's maximum HP.
 
     Parameters:
-        user: The Monster object that used this technique.
-        target: The Monster object that we are using this technique on.
+        objective: User HP or target HP.
+        proportional: The percentage of the max HP
 
-    Returns:
-        Dict summarizing the result.
+    eg prop_damage target,0.25 (1/4 max enemy HP)
 
     """
 
-    name = "local_damage"
+    name = "prop_damage"
+    objective: str
+    proportional: float
 
     def apply(
         self, tech: Technique, user: Monster, target: Monster
-    ) -> LocalDamageEffectResult:
+    ) -> PropDamageEffectResult:
         player = self.session.player
         value = float(player.game_variables["random_tech_hit"])
+        mult = 1.0
         hit = tech.accuracy >= value
         if hit:
+            damage = None
             tech.hit = True
             tech.advance_counter_success()
-            damage, mult = formula.simple_damage_calculate(tech, user, target)
-            # land of ifs
-            # tech: panjandrum
-            if tech.slug == "panjandrum":
-                damage = formula.damage_full_hp(target, 4)
-            target.current_hp -= damage
+            if self.objective == "target":
+                damage = target.hp * self.proportional
+            else:
+                damage = user.hp * self.proportional
+            target.current_hp -= int(damage)
         else:
             tech.hit = False
             damage = 0
-            mult = 1.0
 
         return {
-            "damage": damage,
+            "damage": int(damage),
             "element_multiplier": mult,
             "should_tackle": bool(damage),
             "success": bool(damage),


### PR DESCRIPTION
PR follows #1998 

This effect does damage to the enemy equal to % of the target's / user's maximum HP, defined by @Sanglorian 

PR updates **local_damage** into **prop_damage** (proportional damage) and it removes the hardcoded part, moreover it allows to define the percentage (float value) and the objective (user max HP or target max HP).

the previous effect was only used by 1 technique. Other techniques will come with this mechanism.

eg `"prop_damage target,0.25"`

black, isort, tested, no new typehints