### PR TITLE
multi attack effect

### DIFF
--- a/tuxemon/technique/effects/multiattack.py
+++ b/tuxemon/technique/effects/multiattack.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from tuxemon.technique.techeffect import TechEffect, TechEffectResult
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
+    from tuxemon.technique.technique import Technique
+
+
+class MultiAttackEffectResult(TechEffectResult):
+    pass
+
+
+@dataclass
+class MultiAttackEffect(TechEffect):
+    """
+    Multiattack #: Do # attacks.
+
+    Parameters:
+        times: how many times multiattack
+
+    eg effects ["multiattack 3", "damage"]
+
+    """
+
+    name = "multiattack"
+    times: int
+
+    def apply(
+        self, tech: Technique, user: Monster, target: Monster
+    ) -> MultiAttackEffectResult:
+        player = self.session.player
+        value = random.random()
+        player.game_variables["random_tech_hit"] = value
+        done: bool = True
+        _track: int = 0
+        assert tech.combat_state
+        combat = tech.combat_state
+        log = combat._log_action
+        turn = combat._turn
+        track = [
+            action
+            for action in log
+            if turn == action[0]
+            and action[1].technique == tech
+            and action[1].user == user
+            and action[1].target == target
+        ]
+        if track:
+            _track = len(track)
+
+        if _track == self.times:
+            done = False
+
+        if done:
+            combat.enqueue_action(user, tech, target)
+
+        return {
+            "damage": 0,
+            "element_multiplier": 0.0,
+            "should_tackle": bool(done),
+            "success": bool(done),
+            "extra": None,
+        }

--- a/tuxemon/technique/effects/multiattack.py
+++ b/tuxemon/technique/effects/multiattack.py
@@ -58,7 +58,10 @@ class MultiAttackEffect(TechEffect):
         if _track == self.times:
             done = False
 
-        if done:
+        # check if technique hits
+        hit = tech.accuracy >= value
+
+        if done and hit:
             combat.enqueue_action(user, tech, target)
 
         return {


### PR DESCRIPTION
PR implements multiattack effect @Sanglorian 

Multiattack #: Do # attacks.

tested with **Ram**:
```
  "effects": [
    "multiattack 3",
    "damage"
  ],
```
in this scenario, it makes 3 attacks in a row, but if it misses one of these, then it stops; 
if it misses the first, then no second and third;
if it misses the second, then no third;
etc.

I don't know if the multi attack must stop if misses, let me know if it's correct
eventually we can add a flag to activate or deactivate ((if misses, then...)

black, isort, tested, no new typehints