### PR TITLE
fix fishing crash

### DIFF
--- a/tuxemon/states/items/__init__.py
+++ b/tuxemon/states/items/__init__.py
@@ -112,7 +112,7 @@ class ItemMenuState(Menu[Item]):
 
         """
         item = menu_item.game_object
-        state = self.determine_state_called_from()
+        states = [a.name for a in self.client.active_states]
 
         if not any(item.validate(m) for m in local_session.player.monsters):
             self.on_menu_selection_change()
@@ -139,7 +139,7 @@ class ItemMenuState(Menu[Item]):
                 elif i.name == "facing_tile" or i.name == "facing_sprite":
                     msg = T.format("item_cannot_use_here", {"name": item.name})
             tools.open_dialog(local_session, [msg])
-        elif State[state] not in item.usable_in:
+        elif not any(state.name in states for state in item.usable_in):
             msg = T.format("item_cannot_use_here", {"name": item.name})
             tools.open_dialog(local_session, [msg])
         else:

--- a/tuxemon/states/items/__init__.py
+++ b/tuxemon/states/items/__init__.py
@@ -112,7 +112,7 @@ class ItemMenuState(Menu[Item]):
 
         """
         item = menu_item.game_object
-        states = [a.name for a in self.client.active_states]
+        active_state_names = [a.name for a in self.client.active_states]
 
         if not any(item.validate(m) for m in local_session.player.monsters):
             self.on_menu_selection_change()
@@ -139,7 +139,7 @@ class ItemMenuState(Menu[Item]):
                 elif i.name == "facing_tile" or i.name == "facing_sprite":
                     msg = T.format("item_cannot_use_here", {"name": item.name})
             tools.open_dialog(local_session, [msg])
-        elif not any(state.name in states for state in item.usable_in):
+        elif not any(s.name in active_state_names for s in item.usable_in):
             msg = T.format("item_cannot_use_here", {"name": item.name})
             tools.open_dialog(local_session, [msg])
         else:


### PR DESCRIPTION
fix #2032

PR fixes the crash when a player uses the rod.

specifically regarding fishing:
`self.determine_state_called_from()` gives back a single state (**worldmenustate**).
**worldmenustate** wasn't recognized here `State[state] not in item.usable_in`
since this **State** comes from **db.py** and it hardcodes only (combat, world and none).
conclusion: crash

now it checks if both the list have the parameter

black, isort, tested, no new typehints

the alternative could have been simply adding **worldmenustate** in db.py, but I don't want to hardcode