### PR TITLE
fix evolution

### DIFF
--- a/tuxemon/event/actions/evolution.py
+++ b/tuxemon/event/actions/evolution.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import partial
+from typing import final
+
+from tuxemon.db import EvolutionType
+from tuxemon.event.eventaction import EventAction
+from tuxemon.locale import T
+from tuxemon.monster import Monster
+from tuxemon.tools import open_choice_dialog, open_dialog
+
+
+@final
+@dataclass
+class EvolutionAction(EventAction):
+    """
+    Checks, asks and evolves.
+
+    """
+
+    name = "evolution"
+
+    def start(self) -> None:
+        # this function cleans up the previous state without crashing
+        if len(self.session.client.state_manager.active_states) > 2:
+            self.session.client.pop_state()
+
+        player = self.session.player
+
+        def positive_answer(monster: Monster, evolved: Monster) -> None:
+            self.session.client.pop_state()
+            self.session.client.pop_state()
+            self.session.player.evolve_monster(monster, evolved.slug)
+
+        def negative_answer() -> None:
+            self.session.client.pop_state()
+            self.session.client.pop_state()
+
+        def question_evolution(monster: Monster, evolved: Monster) -> None:
+            open_dialog(
+                self.session,
+                [
+                    T.format(
+                        "evolution_confirmation",
+                        {
+                            "name": monster.name.upper(),
+                            "evolve": evolved.name.upper(),
+                        },
+                    )
+                ],
+            )
+            open_choice_dialog(
+                self.session,
+                menu=(
+                    (
+                        "yes",
+                        T.translate("yes"),
+                        partial(
+                            positive_answer,
+                            monster,
+                            evolved,
+                        ),
+                    ),
+                    (
+                        "no",
+                        T.translate("no"),
+                        negative_answer,
+                    ),
+                ),
+            )
+
+        for monster in player.monsters:
+            for evolution in monster.evolutions:
+                evolved = Monster()
+                evolved.load_from_db(evolution.monster_slug)
+                if evolution.path == EvolutionType.standard:
+                    if evolution.at_level <= monster.level:
+                        question_evolution(monster, evolved)
+                elif evolution.path == EvolutionType.gender:
+                    if evolution.at_level <= monster.level:
+                        if evolution.gender == monster.gender:
+                            question_evolution(monster, evolved)
+                elif evolution.path == EvolutionType.element:
+                    if evolution.at_level <= monster.level:
+                        if player.has_type(evolution.element):
+                            question_evolution(monster, evolved)
+                elif evolution.path == EvolutionType.tech:
+                    if evolution.at_level <= monster.level:
+                        if player.has_tech(evolution.tech):
+                            question_evolution(monster, evolved)
+                elif evolution.path == EvolutionType.location:
+                    if evolution.at_level <= monster.level:
+                        if evolution.inside == self.session.client.map_inside:
+                            question_evolution(monster, evolved)
+                elif evolution.path == EvolutionType.stat:
+                    if evolution.at_level <= monster.level:
+                        if monster.return_stat(
+                            evolution.stat1
+                        ) >= monster.return_stat(evolution.stat2):
+                            question_evolution(monster, evolved)
+                elif evolution.path == EvolutionType.season:
+                    if evolution.at_level <= monster.level:
+                        if evolution.season == player.game_variables["season"]:
+                            question_evolution(monster, evolved)
+                elif evolution.path == EvolutionType.daytime:
+                    if evolution.at_level <= monster.level:
+                        if (
+                            evolution.daytime
+                            == player.game_variables["daytime"]
+                        ):
+                            question_evolution(monster, evolved)

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -72,12 +72,12 @@ from tuxemon.combat import (
 from tuxemon.condition.condition import Condition
 from tuxemon.db import (
     BattleGraphicsModel,
-    EvolutionType,
     ItemCategory,
     OutputBattle,
     PlagueType,
     SeenStatus,
 )
+from tuxemon.event.actions.evolution import EvolutionAction
 from tuxemon.item.item import Item
 from tuxemon.locale import T
 from tuxemon.menu.interface import MenuItem
@@ -606,7 +606,6 @@ class CombatState(CombatAnimations):
         elif phase == "end combat":
             self.players[0].set_party_status()
             self.end_combat()
-            self.evolve()
 
         else:
             assert_never(phase)
@@ -1448,93 +1447,6 @@ class CombatState(CombatAnimations):
         # instead of player/trainer
         return [p for p in self.players if not defeated(p)]
 
-    def evolve(self) -> None:
-        for monster in self.players[0].monsters:
-            for evolution in monster.evolutions:
-                evolved = Monster()
-                evolved.load_from_db(evolution.monster_slug)
-                if evolution.path == EvolutionType.standard:
-                    if evolution.at_level <= monster.level:
-                        self.question_evolution(monster, evolved)
-                elif evolution.path == EvolutionType.gender:
-                    if evolution.at_level <= monster.level:
-                        if evolution.gender == monster.gender:
-                            self.question_evolution(monster, evolved)
-                elif evolution.path == EvolutionType.element:
-                    if evolution.at_level <= monster.level:
-                        if self.players[0].has_type(evolution.element):
-                            self.question_evolution(monster, evolved)
-                elif evolution.path == EvolutionType.tech:
-                    if evolution.at_level <= monster.level:
-                        if self.players[0].has_tech(evolution.tech):
-                            self.question_evolution(monster, evolved)
-                elif evolution.path == EvolutionType.location:
-                    if evolution.at_level <= monster.level:
-                        if evolution.inside == self.client.map_inside:
-                            self.question_evolution(monster, evolved)
-                elif evolution.path == EvolutionType.stat:
-                    if evolution.at_level <= monster.level:
-                        if monster.return_stat(
-                            evolution.stat1
-                        ) >= monster.return_stat(evolution.stat2):
-                            self.question_evolution(monster, evolved)
-                elif evolution.path == EvolutionType.season:
-                    if evolution.at_level <= monster.level:
-                        if (
-                            evolution.season
-                            == self.players[0].game_variables["season"]
-                        ):
-                            self.question_evolution(monster, evolved)
-                elif evolution.path == EvolutionType.daytime:
-                    if evolution.at_level <= monster.level:
-                        if (
-                            evolution.daytime
-                            == self.players[0].game_variables["daytime"]
-                        ):
-                            self.question_evolution(monster, evolved)
-
-    def question_evolution(self, monster: Monster, evolved: Monster) -> None:
-        tools.open_dialog(
-            local_session,
-            [
-                T.format(
-                    "evolution_confirmation",
-                    {
-                        "name": monster.name.upper(),
-                        "evolve": evolved.name.upper(),
-                    },
-                )
-            ],
-        )
-        tools.open_choice_dialog(
-            local_session,
-            menu=(
-                (
-                    "yes",
-                    T.translate("yes"),
-                    partial(
-                        self.positive_answer,
-                        monster,
-                        evolved,
-                    ),
-                ),
-                (
-                    "no",
-                    T.translate("no"),
-                    self.negative_answer,
-                ),
-            ),
-        )
-
-    def positive_answer(self, monster: Monster, evolved: Monster) -> None:
-        self.client.pop_state()
-        self.client.pop_state()
-        self.players[0].evolve_monster(monster, evolved.slug)
-
-    def negative_answer(self) -> None:
-        self.client.pop_state()
-        self.client.pop_state()
-
     def clean_combat(self) -> None:
         """Clean combat."""
         for player in self.players:
@@ -1573,3 +1485,4 @@ class CombatState(CombatAnimations):
         else:
             self.phase = None
             self.client.push_state(FadeOutTransition(caller=self))
+            EvolutionAction().start()


### PR DESCRIPTION
fix #2035 

PR fixes evolution crash. The crash was caused by the FadingState. Luckily it happened while I was working at this.

PR
- moves all the `evolve(`) code outside **combat.py**
- creates a brand new event action called **evolution**

the action will trigger at the end of the combat, so same output, no more hardcoded things in combat.py

black, isort, tested, no new typehints