### PR TITLE
fix set_monster_level and move update_moves

### DIFF
--- a/tuxemon/combat.py
+++ b/tuxemon/combat.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import logging
 import random
-from typing import TYPE_CHECKING, Generator, List, Sequence, Union
+from typing import TYPE_CHECKING, Generator, List, Optional, Sequence
 
 from tuxemon.db import PlagueType
 from tuxemon.locale import T
@@ -165,21 +165,9 @@ def defeated(player: NPC) -> bool:
     return fainted_party(player.monsters)
 
 
-def check_moves(monster: Monster, levels: int) -> Union[str, None]:
-    tech: Union[Technique, None] = None
-    for move in monster.moveset:
-        # monster levels up 1 level
-        if levels == 1:
-            if move.level_learned == monster.level:
-                tech = learn(monster, move.technique)
-        # monster levels up multiple levels
-        else:
-            level_before = monster.level - levels
-            # if there are techniques in this range
-            if level_before < move.level_learned <= monster.level:
-                tech = learn(monster, move.technique)
+def check_moves(monster: Monster, levels: int) -> Optional[str]:
+    tech = monster.update_moves(levels)
     if tech:
-        monster.learn(tech)
         message = T.format(
             "tuxemon_new_tech",
             {
@@ -188,15 +176,4 @@ def check_moves(monster: Monster, levels: int) -> Union[str, None]:
             },
         )
         return message
-    else:
-        return None
-
-
-def learn(monster: Monster, tech: str) -> Union[Technique, None]:
-    technique = Technique()
-    technique.load(tech)
-    duplicate = [mov for mov in monster.moves if mov.slug == technique.slug]
-    if duplicate:
-        return None
-    else:
-        return technique
+    return None

--- a/tuxemon/event/actions/set_monster_level.py
+++ b/tuxemon/event/actions/set_monster_level.py
@@ -49,7 +49,7 @@ class SetMonsterLevelAction(EventAction):
         monster_slot = self.slot
         monster_level = self.level
 
-        if monster_slot:
+        if monster_slot is not None:
             if len(self.session.player.monsters) < int(monster_slot):
                 return
 

--- a/tuxemon/item/effects/gain_xp.py
+++ b/tuxemon/item/effects/gain_xp.py
@@ -29,5 +29,6 @@ class GainXpEffect(ItemEffect):
         self, item: Item, target: Union[Monster, None]
     ) -> GainXpEffectResult:
         assert target
-        target.give_experience(self.amount)
+        levels = target.give_experience(self.amount)
+        target.update_moves(levels)
         return {"success": True, "num_shakes": 0, "extra": None}

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -335,7 +335,7 @@ class Monster:
                 ret = True
         return ret
 
-    def give_experience(self, amount: int = 1) -> None:
+    def give_experience(self, amount: int = 1) -> int:
         """
         Increase experience.
 
@@ -345,16 +345,22 @@ class Monster:
         Parameters:
             amount: The amount of experience to add to the monster.
 
+        Returns:
+            int: the amount of levels earned.
+
         Example:
 
         >>> bulbatux.give_experience(20)
 
         """
+        levels = 0
         self.total_experience += amount
 
         # Level up worthy monsters
         while self.total_experience >= self.experience_required(1):
             self.level_up()
+            levels += 1
+        return levels
 
     def apply_status(self, status: Condition) -> None:
         """
@@ -548,6 +554,32 @@ class Monster:
                 tech = Technique()
                 tech.load(ele)
                 self.learn(tech)
+
+    def update_moves(self, levels_earned: int) -> Optional[Technique]:
+        """
+        Set monster moves according to the levels increased.
+        Excludes the moves already learned.
+
+        Parameters:
+            levels_earned: Number of levels earned.
+
+        Returns:
+            technique: if there is a technique, then it returns
+            a technique, otherwise none
+
+        """
+        technique = None
+        for move in self.moveset:
+            if (
+                move.technique not in (m.slug for m in self.moves)
+                and (self.level - levels_earned)
+                < move.level_learned
+                <= self.level
+            ):
+                technique = Technique()
+                technique.load(move.technique)
+                self.learn(technique)
+        return technique
 
     def experience_required(self, level_ofs: int = 0) -> int:
         """

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -1268,36 +1268,32 @@ class CombatState(CombatAnimations):
             awarded_mon = monster.level * monster.money_modifier
             for winners in self._damage_map[monster]:
                 # check before giving exp
-                self._level_before = winners.level
-                winners.give_experience(awarded_exp)
+                levels = winners.give_experience(awarded_exp)
                 # check after giving exp
-                self._level_after = winners.level
                 if self.is_trainer_battle:
                     self._prize += awarded_mon
                 # it checks if there is a "level up"
-                if self._level_before != self._level_after:
-                    diff = self._level_after - self._level_before
-                    if winners in self.players[0].monsters:
-                        # checks and eventually teaches move/moves
-                        mex = check_moves(winners, diff)
-                        if mex:
-                            message += "\n" + mex
-                            action_time += compute_text_animation_time(message)
-                        # updates hud graphics player
-                        if len(self.monsters_in_play_human) > 1:
-                            self.build_hud(
-                                self._layout[self.players[0]]["hud0"][0],
-                                self.monsters_in_play_human[0],
-                            )
-                            self.build_hud(
-                                self._layout[self.players[0]]["hud1"][0],
-                                self.monsters_in_play_human[1],
-                            )
-                        else:
-                            self.build_hud(
-                                self._layout[self.players[0]]["hud"][0],
-                                self.monsters_in_play_human[0],
-                            )
+                if levels >= 1 and winners in self.players[0].monsters:
+                    # checks and eventually teaches move/moves
+                    mex = check_moves(winners, levels)
+                    if mex:
+                        message += "\n" + mex
+                        action_time += compute_text_animation_time(message)
+                    # updates hud graphics player
+                    if len(self.monsters_in_play_human) > 1:
+                        self.build_hud(
+                            self._layout[self.players[0]]["hud0"][0],
+                            self.monsters_in_play_human[0],
+                        )
+                        self.build_hud(
+                            self._layout[self.players[0]]["hud1"][0],
+                            self.monsters_in_play_human[1],
+                        )
+                    else:
+                        self.build_hud(
+                            self._layout[self.players[0]]["hud"][0],
+                            self.monsters_in_play_human[0],
+                        )
                 if winners in self.players[0].monsters:
                     m = T.format(
                         "combat_gain_exp",


### PR DESCRIPTION
PR:
- fixes a small bug noticed while testing #2035 > `set_monster_level 30,0` add 30 levels to the monster in slot 0, it was missing a ` is not None`
- moves **update_moves** into monster.py;
- removes some lines of code from combat.py;
- adds a return to **update_moves** (Technique) > the technique that has been learned;
- adds a return to **give_experience** (int) > the number of levels;
- updates the effect **give_xp**;

black, isort, tested, no new typehints