### PR TITLE
traded field + messages (monster)

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -2588,6 +2588,9 @@ msgstr "Seen {param} out of {all} Tuxemon"
 msgid "tuxepedia_data_caught"
 msgstr "Caught {param} out of {all} Tuxemon"
 
+msgid "player_start_adventure_today"
+msgstr "The adventure began today."
+
 msgid "player_start_adventure"
 msgstr "The adventure began {date} days ago."
 
@@ -2611,8 +2614,17 @@ msgstr "Evolution"
 msgid "yes_evolutions"
 msgstr "Evolutions"
 
+msgid "tuxepedia_capture_today"
+msgstr "Captured today"
+
+msgid "tuxepedia_trade_today"
+msgstr "Traded today"
+
 msgid "tuxepedia_capture"
 msgstr "Captured {doc} days ago"
+
+msgid "tuxepedia_trade"
+msgstr "Traded {doc} days ago"
 
 msgid "tuxepedia_exp"
 msgstr "{exp_lv}xp to Lv {lv}"

--- a/tuxemon/event/actions/trading.py
+++ b/tuxemon/event/actions/trading.py
@@ -56,6 +56,7 @@ class TradingAction(EventAction):
         new.set_moves(trading.level)
         new.set_capture(formula.today_ordinal())
         new.current_hp = new.hp
+        new.traded = True
         self.player.remove_monster(trading)
         self.player.add_monster(new, slot)
         self.player.tuxepedia[self.add] = SeenStatus.caught

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -58,6 +58,7 @@ SIMPLE_PERSISTANCE_ATTRIBUTES = (
     "weight",
     "taste_cold",
     "taste_warm",
+    "traded",
     "mod_armour",
     "mod_dodge",
     "mod_melee",
@@ -135,6 +136,7 @@ class Monster:
         self._types: List[Element] = []
         self.shape = MonsterShape.default
         self.randomly = True
+        self.traded = False
 
         self.status: List[Condition] = []
         self.plague = PlagueType.healthy
@@ -217,6 +219,7 @@ class Monster:
             self._types.append(_element)
 
         self.randomly = results.randomly or self.randomly
+        self.traded = self.traded
 
         self.txmn_id = results.txmn_id
         self.capture = self.set_capture(self.capture)

--- a/tuxemon/states/journal/__init__.py
+++ b/tuxemon/states/journal/__init__.py
@@ -634,8 +634,20 @@ class MonsterInfoState(PygameMenuState):
         lab9.translate(fix_width(width, 0.50), fix_height(height, 0.45))
         # capture
         doc = formula.today_ordinal() - monster.capture
+        if doc >= 1:
+            ref = (
+                T.format("tuxepedia_trade", {"doc": doc})
+                if monster.traded
+                else T.format("tuxepedia_capture", {"doc": doc})
+            )
+        else:
+            ref = (
+                T.translate("tuxepedia_trade_today")
+                if monster.traded
+                else T.translate("tuxepedia_capture_today")
+            )
         lab10 = menu.add.label(
-            title=T.format("tuxepedia_capture", {"doc": doc}),
+            title=ref,
             label_id="capture",
             font_size=15,
             align=locals.ALIGN_LEFT,

--- a/tuxemon/states/player/__init__.py
+++ b/tuxemon/states/player/__init__.py
@@ -75,9 +75,10 @@ class PlayerState(PygameMenuState):
         date_begin = formula.today_ordinal() - int(
             player.game_variables["date_start_game"]
         )
-        msg_begin = T.format(
-            "player_start_adventure",
-            {"date": str(date_begin)},
+        msg_begin = (
+            T.format("player_start_adventure", {"date": date_begin})
+            if date_begin >= 1
+            else T.translate("player_start_adventure_today")
         )
         tot = len(player.battles)
         won = sum(


### PR DESCRIPTION
PR completes the trading (exchange of monster) by adding a field called **traded** (simple boolean), in this way it'll possible to define different behaviors for traded monsters.

I updated the message too:
![Screenshot_2023-10-22_09-23-50](https://github.com/Tuxemon/Tuxemon/assets/64643719/3cc9f5de-6560-4c92-a97a-e02117d80c7e)
now it'll show traded instead of captured, moreover:
- on the same day "traded or capture today"
- on the following day "traded or capture X days ago"

black, isort, tested, no new typehints