### PR TITLE
update get_player_monster (event action)

### DIFF
--- a/tuxemon/event/actions/get_player_monster.py
+++ b/tuxemon/event/actions/get_player_monster.py
@@ -4,8 +4,17 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import final
+from operator import eq, ge, gt, le, lt, ne
+from typing import Optional, final
 
+from tuxemon.db import (
+    ElementType,
+    EvolutionStage,
+    GenderType,
+    MonsterShape,
+    TasteCold,
+    TasteWarm,
+)
 from tuxemon.event.eventaction import EventAction
 from tuxemon.menu.interface import MenuItem
 from tuxemon.monster import Monster
@@ -20,33 +29,169 @@ logger = logging.getLogger(__name__)
 class GetPlayerMonsterAction(EventAction):
     """
     Select a monster in the player party and store its id in a variable.
+    It allows filtering: slug, gender, evolution_stage, element, shape,
+    taste_warm, taste_cold, level, weight, height, max_hp, current_hp,
+    armour, dodge, melee, ranged and speed.
+
+    eg "get_player_monster name_variable,shape,serpent"
+    eg "get_player_monster name_variable,shape,serpent"
+
+    For the definition: level, weight, height, max_hp, current_hp, armour, dodge,
+    melee, ranged and speed (all numeric values) is necessary to use a numeric
+    comparison operator. Accepted values are "less_than", "less_or_equal",
+    "greater_than", "greater_or_equal", "equals" and "not_equals".
+
+    eg "get_player_monster name_variable,speed,more_than,50"
+    eg "get_player_monster name_variable,level,less_than,15"
+
+    Note:
+    let's say a player doesn't has no options, then the variable
+    will result as: name_variable:no_option
+    let's say a player has options, but clicks return, then the
+    variable will result as: name_variable:no_choice
 
     Script usage:
         .. code-block::
 
-            get_player_monster <variable_name>
+            get_player_monster <variable_name>,<filter_name>,<value_name>[,extra]
 
     Script parameters:
         variable_name: Name of the variable where to store the monster id.
+        filter
+        filter_name: the name of the first filter
+        value_name: the actual value to filter
+        extra: used to filter more
 
     """
 
     name = "get_player_monster"
     variable_name: str
+    filter_name: Optional[str] = None
+    value_name: Optional[str] = None
+    extra: Optional[str] = None
+
+    def validate(self, target: Optional[Monster]) -> bool:
+        filter_name = self.filter_name
+        value_name = self.value_name
+
+        if filter_name is None and value_name is None:
+            self.result = True
+
+        if target:
+            # filter slug
+            if filter_name == "slug" and target.slug == value_name:
+                self.result = True
+            # filter genders
+            if (
+                filter_name == "gender"
+                and value_name in list(GenderType)
+                and target.gender == value_name
+            ):
+                self.result = True
+            # filter evolution stages
+            if (
+                filter_name == "evolution_stage"
+                and value_name in list(EvolutionStage)
+                and target.stage == value_name
+            ):
+                self.result = True
+            # filter element / type
+            if (
+                filter_name == "element"
+                and value_name in list(ElementType)
+                and target.has_type(ElementType(value_name))
+            ):
+                self.result = True
+            # filter shape
+            if (
+                filter_name == "shape"
+                and value_name in list(MonsterShape)
+                and target.shape == value_name
+            ):
+                self.result = True
+            # filter taste warm
+            if (
+                filter_name == "taste_warm"
+                and value_name in list(TasteWarm)
+                and target.taste_warm == value_name
+            ):
+                self.result = True
+            # filter taste cold
+            if (
+                filter_name == "taste_cold"
+                and value_name in list(TasteCold)
+                and target.taste_cold == value_name
+            ):
+                self.result = True
+
+            # filter numeric fields
+            if self.extra is not None:
+                field = 0
+                if filter_name == "level":
+                    field = target.level
+                elif filter_name == "weight":
+                    field = int(target.weight)
+                elif filter_name == "height":
+                    field = int(target.height)
+                elif filter_name == "max_hp":
+                    field = target.hp
+                elif filter_name == "current_hp":
+                    field = target.current_hp
+                elif filter_name == "armour":
+                    field = target.armour
+                elif filter_name == "dodge":
+                    field = target.dodge
+                elif filter_name == "melee":
+                    field = target.melee
+                elif filter_name == "ranged":
+                    field = target.ranged
+                elif filter_name == "speed":
+                    field = target.speed
+                extra = int(self.extra)
+                if value_name == "less_than" and bool(lt(field, extra)):
+                    self.result = True
+                elif value_name == "less_or_equal" and bool(le(field, extra)):
+                    self.result = True
+                elif value_name == "greater_than" and bool(gt(field, extra)):
+                    self.result = True
+                elif value_name == "greater_or_equal" and bool(
+                    ge(field, extra)
+                ):
+                    self.result = True
+                elif value_name == "equals" and bool(eq(field, extra)):
+                    self.result = True
+                elif value_name == "not_equals" and bool(ne(field, extra)):
+                    self.result = True
+
+        return self.result
 
     def set_var(self, menu_item: MenuItem[Monster]) -> None:
-        self.session.player.game_variables[self.variable_name] = str(
-            menu_item.game_object.instance_id.hex
+        self.choose = True
+        player = self.session.player
+        monster = menu_item.game_object
+
+        player.game_variables[self.variable_name] = str(
+            monster.instance_id.hex
         )
         self.session.client.pop_state()
 
     def start(self) -> None:
+        self.result = False
+        self.choose = False
         # pull up the monster menu so we know which one we are saving
         menu = self.session.client.push_state(MonsterMenuState())
+        menu.is_valid_entry = self.validate  # type: ignore[assignment]
         menu.on_menu_selection = self.set_var  # type: ignore[assignment]
 
     def update(self) -> None:
         try:
             self.session.client.get_state_by_name(MonsterMenuState)
         except ValueError:
+            player = self.session.player
+            if self.result and not self.choose:
+                # the player can choose, but returns
+                player.game_variables[self.variable_name] = "no_choice"
+            if not self.result:
+                # the player can't choose (eg no females in the party)
+                player.game_variables[self.variable_name] = "no_options"
             self.stop()


### PR DESCRIPTION
PR updates `get_player_monster`, it allows more filtering.

It's possible to filter for numeric and not numeric fields, such as evolution_stage, shape, level, speed, armour, etc.

Moreover it offers two additional variables:
- let's say a player doesn't has no options, then the variable will result as: name_variable:no_option
- let's say a player has options, but clicks return, then the variable will result as: name_variable:no_choice

this is very important for modders, because it can simplify the work of "actions", especially if the player doesn't possess the monster in the party.

`"get_player_monster name_variable,speed,more_than,50"`
or
`"get_player_monster name_variable,shape,serpent"`

black, isort, tested, no new typehints