### PR TITLE
sacrifice effect (technique)

### DIFF
--- a/mods/tuxemon/db/technique/undertaker.json
+++ b/mods/tuxemon/db/technique/undertaker.json
@@ -4,13 +4,13 @@
   "animation": "x_attack",
   "effects": [
     "give prickly,target",
-    "enhance"
+    "sacrifice 2"
   ],
   "flip_axes": "",
   "is_fast": false,
   "potency": 1,
-  "power": 0,
-  "range": "special",
+  "power": 1,
+  "range": "melee",
   "recharge": 1,
   "sfx": "sfx_blaster",
   "slug": "undertaker",
@@ -24,7 +24,7 @@
     "own trainer": 0
   },
   "types": [
-    "aether"
+    "earth"
   ],
   "use_failure": "combat_miss",
   "use_success": null,

--- a/tuxemon/technique/effects/sacrifice.py
+++ b/tuxemon/technique/effects/sacrifice.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from tuxemon.technique.techeffect import TechEffect, TechEffectResult
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
+    from tuxemon.technique.technique import Technique
+
+
+class SacrificeEffectResult(TechEffectResult):
+    pass
+
+
+@dataclass
+class SacrificeEffect(TechEffect):
+    """
+    Sacrifice:
+    Monster takes damage equal to its current HP,
+    and does damage equal to double that amount.
+
+    Parameters:
+        multiplier: The percentage of the current HP
+
+    eg user 35/50 HP uses:
+        sacrifice 2
+    inflicts a damage of 70 HP (enemy)
+    inflicts a damage of 35 HP (user) > faints
+
+    """
+
+    name = "sacrifice"
+    multiplier: float
+
+    def apply(
+        self, tech: Technique, user: Monster, target: Monster
+    ) -> SacrificeEffectResult:
+        player = self.session.player
+        value = float(player.game_variables["random_tech_hit"])
+        hit = tech.accuracy >= value
+        if hit:
+            tech.hit = True
+            tech.advance_counter_success()
+            damage = int(user.current_hp * self.multiplier)
+            user.current_hp -= user.current_hp
+            target.current_hp -= damage
+        else:
+            tech.hit = False
+            damage = 0
+
+        return {
+            "damage": damage,
+            "element_multiplier": 0.0,
+            "should_tackle": bool(damage),
+            "success": bool(damage),
+            "extra": None,
+        }


### PR DESCRIPTION
PR introduces the effect sacrifice.

It was a concept developed by @Sanglorian and it was related to autodestruction types techniques.
These techniques can damage both the user as well as the enemy and they intact the current_hp of the user.
A sacrifice.

M (42/100) - E (69/100).
M uses technique XYZ (with sacrifice effect) against E
`sacrifice 1`
M (0/100) faints - E (27/100).

regarding we can assign the "sacrifice" to assign it to:
- https://wiki.tuxemon.org/Undertaker

we need to change some parameters like type, category, accuracy, potency, power and recharge.

black, isort, tested, no new typehints