### PR TITLE
enable replacing var (locale - PO files)

### DIFF
--- a/tuxemon/locale.py
+++ b/tuxemon/locale.py
@@ -224,6 +224,9 @@ def replace_text(session: Session, text: str) -> str:
     text = text.replace("${{currency}}", "$")
     text = text.replace(r"\n", "\n")
     text = text.replace("${{money}}", str(player.money["player"]))
+    # replace variables
+    for key, value in player.game_variables.items():
+        text = text.replace("${{var:" + str(key) + "}}", str(value))
     # distance (metric / imperial)
     if player.game_variables["unit_measure"] == "Metric":
         text = text.replace("${{length}}", "km")


### PR DESCRIPTION
PR enables replacing variables inside the PO files. It uses the same method:

eg `${{name}} is running away!` gives back `Richard is running away!`

this will help to pass data without being forced to hardcode, especially numbers as well as names, etc. 

Example:
eg `you chose nr. {{var:xyz}} back then!` gives back `you chose nr. 3 back then!`

black, isort, tested, no new typehints