### PR TITLE
competition (event action)

### DIFF
--- a/tuxemon/event/actions/competition.py
+++ b/tuxemon/event/actions/competition.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import random
+import uuid
+from dataclasses import dataclass
+from typing import List, final
+
+from tuxemon.db import StatType
+from tuxemon.event.eventaction import EventAction
+from tuxemon.monster import Monster
+
+
+@final
+@dataclass
+class CompetitionAction(EventAction):
+    """
+    A selected monster will compete against others based on a specific stat.
+
+    Script usage:
+        .. code-block::
+
+            competition <instance_id>,<stat>,<adversaries>
+
+    Script parameters:
+        instance_id: Variable where is saved
+        stat: Statistic to use (eg speed, armour, etc.)
+        adversaries: Slug monsters
+
+    eg "competition name_variable,speed,tumbleworm:apeoro:rockitten"
+
+    """
+
+    name = "competition"
+    instance_id: str
+    stat: StatType
+    adversaries: str
+
+    def start(self) -> None:
+        player = self.session.player
+
+        iid = uuid.UUID(player.game_variables[self.instance_id])
+        participant = player.find_monster_by_id(iid)
+        assert participant
+
+        adversaries: List[str] = []
+        if self.adversaries.find(":"):
+            adversaries = self.adversaries.split(":")
+        else:
+            adversaries.append(self.adversaries)
+
+        monsters: List[Monster] = []
+        for m in adversaries:
+            mon = Monster()
+            mon.load_from_db(m)
+            mon.set_level(participant.level)
+            monsters.append(mon)
+
+        # add us
+        monsters.append(participant)
+
+        results = []
+        for mon in monsters:
+            stat = mon.return_stat(self.stat)
+            res = sum(random.randint(1, stat) for x in range(10))
+            results.append((res, mon.name.upper(), str(mon.instance_id.hex)))
+            results.sort(key=lambda x: x[0], reverse=True)
+
+        for i, name in enumerate(results, 1):
+            # save ranking variables
+            player.game_variables[f"comp_rank_{i}"] = f"{name[1]} ({name[0]})"
+            # replace the variable with iid with the ranking
+            if name[2] == player.game_variables[self.instance_id]:
+                player.game_variables[self.instance_id] = i

--- a/tuxemon/locale.py
+++ b/tuxemon/locale.py
@@ -224,6 +224,9 @@ def replace_text(session: Session, text: str) -> str:
     text = text.replace("${{currency}}", "$")
     text = text.replace(r"\n", "\n")
     text = text.replace("${{money}}", str(player.money["player"]))
+    # replace variables
+    for key, value in player.game_variables.items():
+        text = text.replace("${{var:" + str(key) + "}}", str(value))
     # distance (metric / imperial)
     if player.game_variables["unit_measure"] == "Metric":
         text = text.replace("${{length}}", "km")

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -307,6 +307,9 @@ class Monster:
 
         Parameters:
             stat: The stat for the monster to return.
+
+        Returns:
+            int: The value of the requested stat.
         """
         value = 0
         if stat == StatType.armour:


### PR DESCRIPTION
depends on #2045 (and ideally #2041 but not mandatory)

PR adds the competition event action, it'll allow to a selected monster to compete against others.
```
    <property name="act1" value="get_player_monster top_flier"/>
    <property name="act2" value="competition top_flier,speed,av8r:tweesher:cherubat"/>
```
the action will generate a series of variables in this format:
`comp_rank_{i} : MONSTER (POINTS)`
where `i` is the rank (eg 1, 2, 3, etc), moreover it'll generate also:
`top_flier : i"`
where `i` is the rank of the monster selected (eg if the player chooses Pairagrin, then it'll refer to the rank of the monster)
so it'll be `top_flier : 2` because it's second.
in this way the modder can recall and create a precise output depending on the ranking.
eg:
```
<property name="cond1" value="is variable_set top_flier:1"/> -> well done, etc.
<property name="cond1" value="is variable_set top_flier:2"/> -> you can ameliorate, etc.
```
in this way we can recycle the variable

black, isort, tested, no new typehints