### PR TITLE
steps countdown

### DIFF
--- a/tuxemon/event/conditions/variable_is.py
+++ b/tuxemon/event/conditions/variable_is.py
@@ -42,6 +42,11 @@ class VariableIsCondition(EventCondition):
             Result of the operation over the variable.
 
         """
+        game_variables = session.player.game_variables
+        if condition.parameters[0] not in game_variables:
+            return False
+        if condition.parameters[2] not in game_variables:
+            return False
 
         # Read the parameters
         operand1 = number_or_variable(session, condition.parameters[0])
@@ -49,17 +54,17 @@ class VariableIsCondition(EventCondition):
         operand2 = number_or_variable(session, condition.parameters[2])
 
         # Check if the condition is true
-        if operation == "==":
+        if operation == "==" or operation == "equals":
             return operand1 == operand2
-        elif operation == "!=":
+        elif operation == "!=" or operation == "not_equals":
             return operand1 != operand2
-        elif operation == ">":
+        elif operation == ">" or operation == "greater_than":
             return operand1 > operand2
-        elif operation == ">=":
+        elif operation == ">=" or operation == "greater_or_equal":
             return operand1 >= operand2
-        elif operation == "<":
+        elif operation == "<" or operation == "less_than":
             return operand1 < operand2
-        elif operation == "<=":
+        elif operation == "<=" or operation == "less_or_equal":
             return operand1 <= operand2
         else:
             raise ValueError(f"invalid operation type {operation}")

--- a/tuxemon/player.py
+++ b/tuxemon/player.py
@@ -50,6 +50,14 @@ class Player(NPC):
         diff_y = abs(after.y - before.y)
 
         self.game_variables["steps"] += diff_x + diff_y
+
+        for key, value in self.game_variables.items():
+            if key.startswith("steps_"):
+                if float(value) > 0.0:
+                    self.game_variables[key] = float(value) - (diff_x + diff_y)
+                else:
+                    self.game_variables[key] = 0.0
+
         """
         %H - Hour 00-23
         %j - Day number of year 001-366


### PR DESCRIPTION
PR:
- introduces the possibility to set a countdown for steps;
- adds check returning Flase in `variable_is` because if not the game is going to crash (not finding the game variable);
- adds alternative labels in `variable_is`, especially considering <=, that in game needs to be written as `&lt`, so better offer an alternative like `less_than`;

set this
`<property name="act1" value="set_variable steps_park:200"/>`
the in another action 
`<property name="cond1" value="is variable_is steps_park,equals,0.0"/>`

black, isort, tested, no new typehints