### PR TITLE
faint monster (centralization)

### DIFF
--- a/mods/tuxemon/db/condition/faint.json
+++ b/mods/tuxemon/db/condition/faint.json
@@ -1,8 +1,8 @@
 {
   "animation": null,
+  "category": "neutral",
   "effects": [],
   "flip_axes": "",
-  "power": 10,
   "sfx": "sfx_faint",
   "slug": "faint",
   "range": "special",

--- a/tuxemon/condition/effects/harpooned.py
+++ b/tuxemon/condition/effects/harpooned.py
@@ -6,9 +6,9 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from tuxemon.condition.condeffect import CondEffect, CondEffectResult
-from tuxemon.condition.condition import Condition
 
 if TYPE_CHECKING:
+    from tuxemon.condition.condition import Condition
     from tuxemon.monster import Monster
 
 
@@ -26,19 +26,11 @@ class HarpoonedEffect(CondEffect):
     name = "harpooned"
 
     def apply(self, tech: Condition, target: Monster) -> HarpoonedEffectResult:
-        player = self.session.player
         if tech.phase == "add_monster_into_play":
             if tech.slug == "harpooned":
                 target.current_hp -= target.hp // 8
                 if target.current_hp <= 0:
-                    faint = Condition()
-                    faint.load("faint")
-                    faint.link = target
-                    faint.steps = player.game_variables["steps"]
-                    target.current_hp = 0
-                    if target.status:
-                        target.status[0].nr_turn = 0
-                    target.apply_status(faint)
+                    target.faint()
         return {
             "success": True,
             "condition": None,

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -509,6 +509,7 @@ class TechSort(str, Enum):
 class CategoryCondition(str, Enum):
     negative = "negative"
     positive = "positive"
+    neutral = "neutral"
 
 
 class ResponseCondition(str, Enum):

--- a/tuxemon/event/actions/teleport_faint.py
+++ b/tuxemon/event/actions/teleport_faint.py
@@ -31,6 +31,10 @@ class TeleportFaintAction(EventAction):
 
     def start(self) -> None:
         player = self.session.player
+        client = self.session.client
+        # this function cleans up the previous state without crashing
+        if len(client.state_manager.active_states) > 2:
+            return
 
         # If game variable exists, then teleport:
         if "teleport_faint" in player.game_variables:
@@ -45,4 +49,4 @@ class TeleportFaintAction(EventAction):
         # self.game.event_engine.execute_action("screen_transition", [.3])
 
         # Call the teleport action
-        self.session.client.event_engine.execute_action("teleport", teleport)
+        client.event_engine.execute_action("teleport", teleport)

--- a/tuxemon/event/conditions/player_defeated.py
+++ b/tuxemon/event/conditions/player_defeated.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from tuxemon.combat import has_status
-from tuxemon.condition.condition import Condition
 from tuxemon.event import MapCondition
 from tuxemon.event.eventcondition import EventCondition
 from tuxemon.session import Session
@@ -42,10 +41,7 @@ class PlayerDefeatedCondition(EventCondition):
         if player.monsters:
             for mon in player.monsters:
                 if mon.current_hp <= 0 and not has_status(mon, "faint"):
-                    mon.status = list()
-                    fainted = Condition()
-                    fainted.load("faint")
-                    mon.status = [fainted]
+                    mon.faint()
                 if "faint" not in (s.slug for s in mon.status):
                     return False
             return True

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -384,6 +384,7 @@ class Monster:
             # if the status doesn't exist.
             else:
                 # start counting nr turns
+                self.status[0].nr_turn = 0
                 status.nr_turn = 1
                 if self.status[0].category == CategoryCondition.positive:
                     if status.repl_pos == ResponseCondition.replaced:
@@ -404,7 +405,7 @@ class Monster:
                         # chargedup, charging and dozing
                         return
                 else:
-                    # spyderbite and eliminated
+                    self.status.clear()
                     self.status.append(status)
 
     def set_stats(self) -> None:
@@ -743,14 +744,24 @@ class Monster:
 
         self.load_sprites()
 
+    def faint(self) -> None:
+        """
+        Kills the monster, sets 0 HP and applies faint status.
+        """
+        faint = Condition()
+        faint.load("faint")
+        self.current_hp = 0
+        self.apply_status(faint)
+
     def end_combat(self) -> None:
+        """
+        Ends combat, recharges all moves and heals statuses.
+        """
         for move in self.moves:
             move.full_recharge()
 
         if "faint" in (s.slug for s in self.status):
-            faint = Condition()
-            faint.load("faint")
-            self.status = [faint]
+            self.faint()
         else:
             self.status = []
 

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -1261,12 +1261,7 @@ class CombatState(CombatAnimations):
             monster: Monster that will faint.
 
         """
-        faint = Condition()
-        faint.load("faint")
-        monster.current_hp = 0
-        if monster.status:
-            monster.status[0].nr_turn = 0
-        monster.status = [faint]
+        monster.faint()
 
         """
         Experience is earned when the target monster is fainted.

--- a/tuxemon/technique/effects/forfeit.py
+++ b/tuxemon/technique/effects/forfeit.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from tuxemon.condition.condition import Condition
 from tuxemon.db import OutputBattle
 from tuxemon.locale import T
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
@@ -51,10 +50,7 @@ class ForfeitEffect(TechEffect):
             combat.players.remove(remove)
         # kill monsters -> teleport center
         for mon in player.monsters:
-            faint = Condition()
-            faint.load("faint")
-            mon.current_hp = 0
-            mon.status = [faint]
+            mon.faint()
 
         return {
             "success": True,


### PR DESCRIPTION
While I was working on #2053, I noticed this in **faint_monster** (**combat.py**):
```
        faint = Condition()
        faint.load("faint")
        monster.current_hp = 0
        if monster.status:
            monster.status[0].nr_turn = 0
        monster.status = [faint]
```
and by looking at the code I noticed similar patterns.

Reason why I created the def **faint** in **monster.py**, so it can be called through the monster. It kills it, it sets 0 HP and it assigns the status faint. Assigned **neutral** category to **CategoryCondition** and added the checking for states in **teleport_faint** (exactly as we did for evolution, since it follows combat).

black, isort, tested, no new typehints