### PR TITLE
upgrade (Dict into dict, List into list, etc) [1/2]

### DIFF
--- a/tuxemon/condition/condition.py
+++ b/tuxemon/condition/condition.py
@@ -4,16 +4,8 @@ from __future__ import annotations
 
 import logging
 import uuid
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    ClassVar,
-    List,
-    Mapping,
-    Optional,
-    Sequence,
-    Type,
-)
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
 from tuxemon import plugin, prepare
 from tuxemon.condition.condcondition import CondCondition
@@ -47,8 +39,8 @@ class Condition:
 
     """
 
-    effects_classes: ClassVar[Mapping[str, Type[CondEffect[Any]]]] = {}
-    conditions_classes: ClassVar[Mapping[str, Type[CondCondition[Any]]]] = {}
+    effects_classes: ClassVar[Mapping[str, type[CondEffect[Any]]]] = {}
+    conditions_classes: ClassVar[Mapping[str, type[CondCondition[Any]]]] = {}
 
     def __init__(self, save_data: Optional[Mapping[str, Any]] = None) -> None:
         if save_data is None:
@@ -332,7 +324,7 @@ class Condition:
 
 def decode_condition(
     json_data: Optional[Sequence[Mapping[str, Any]]],
-) -> List[Condition]:
+) -> list[Condition]:
     return [Condition(save_data=cond) for cond in json_data or {}]
 
 

--- a/tuxemon/condition/conditions/current_hp.py
+++ b/tuxemon/condition/conditions/current_hp.py
@@ -2,9 +2,10 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from operator import eq, ge, gt, le, lt
-from typing import TYPE_CHECKING, Callable, Mapping, Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from tuxemon.condition.condcondition import CondCondition
 

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -7,19 +7,10 @@ import json
 import logging
 import os
 import sys
+from collections.abc import Mapping, Sequence
 from enum import Enum
 from operator import itemgetter
-from typing import (
-    Any,
-    Dict,
-    List,
-    Literal,
-    Mapping,
-    Optional,
-    Sequence,
-    Union,
-    overload,
-)
+from typing import Any, Literal, Optional, Union, overload
 
 from pydantic import (
     BaseModel,
@@ -982,7 +973,7 @@ class JSONDatabase:
     """
 
     def __init__(self, dir: str = "all") -> None:
-        self._tables: List[TableName] = [
+        self._tables: list[TableName] = [
             "item",
             "monster",
             "npc",
@@ -997,8 +988,8 @@ class JSONDatabase:
             "shape",
             "template",
         ]
-        self.preloaded: Dict[TableName, Dict[str, Any]] = {}
-        self.database: Dict[TableName, Dict[str, Any]] = {}
+        self.preloaded: dict[TableName, dict[str, Any]] = {}
+        self.database: dict[TableName, dict[str, Any]] = {}
         self.path = ""
         for table in self._tables:
             self.preloaded[table] = {}

--- a/tuxemon/event/__init__.py
+++ b/tuxemon/event/__init__.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import logging
-from collections import namedtuple
-from typing import TYPE_CHECKING, NamedTuple, Optional, Sequence, Tuple
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, NamedTuple, Optional
 
 from tuxemon.session import Session
 
@@ -69,7 +69,7 @@ def get_npc(session: Session, slug: str) -> Optional[NPC]:
     return world.get_entity(slug)
 
 
-def get_npc_pos(session: Session, pos: Tuple[int, int]) -> Optional[NPC]:
+def get_npc_pos(session: Session, pos: tuple[int, int]) -> Optional[NPC]:
     """
     Gets an NPC object by its position.
 

--- a/tuxemon/event/actions/dialog.py
+++ b/tuxemon/event/actions/dialog.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import logging
 import warnings
+from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Any, Optional, Sequence, final
+from typing import Any, Optional, final
 
 from tuxemon.db import db
 from tuxemon.event.eventaction import EventAction

--- a/tuxemon/event/actions/dialog_chain.py
+++ b/tuxemon/event/actions/dialog_chain.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import logging
 import warnings
+from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Any, Optional, Sequence, final
+from typing import Any, Optional, final
 
 from tuxemon.db import db
 from tuxemon.event.eventaction import EventAction

--- a/tuxemon/event/actions/npc_move.py
+++ b/tuxemon/event/actions/npc_move.py
@@ -2,8 +2,9 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+from collections.abc import Generator, Sequence
 from dataclasses import dataclass, field
-from typing import Any, Generator, Sequence, Tuple, cast, final
+from typing import Any, cast, final
 
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
@@ -12,10 +13,10 @@ from tuxemon.math import Vector2
 
 
 def simple_path(
-    origin: Tuple[int, int],
+    origin: tuple[int, int],
     direction: Direction,
     tiles: int,
-) -> Generator[Tuple[int, int], None, None]:
+) -> Generator[tuple[int, int], None, None]:
     origin_vec = Vector2(origin)
     for _ in range(tiles):
         origin_vec += dirs2[direction]
@@ -23,9 +24,9 @@ def simple_path(
 
 
 def parse_path_parameters(
-    origin: Tuple[int, int],
+    origin: tuple[int, int],
     move_list: Sequence[str],
-) -> Generator[Tuple[int, int], None, None]:
+) -> Generator[tuple[int, int], None, None]:
     for move in move_list:
         try:
             direction, tiles = move.strip().split()

--- a/tuxemon/event/actions/random_encounter.py
+++ b/tuxemon/event/actions/random_encounter.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import logging
 import random
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Optional, Sequence, Union, final
+from typing import Optional, Union, final
 
 from tuxemon import formula, monster, prepare
 from tuxemon.combat import check_battle_legal

--- a/tuxemon/event/actions/random_item.py
+++ b/tuxemon/event/actions/random_item.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import random
 from dataclasses import dataclass
-from typing import List, Union, final
+from typing import Union, final
 
 from tuxemon.event.actions.add_item import AddItemAction
 from tuxemon.event.eventaction import EventAction
@@ -38,7 +38,7 @@ class RandomItemAction(EventAction):
     def start(self) -> None:
         # check if multiple items
         item: str = ""
-        items: List[str] = []
+        items: list[str] = []
         if self.item_slug.find(":"):
             items = self.item_slug.split(":")
             item = random.choice(items)

--- a/tuxemon/event/actions/set_random_variable.py
+++ b/tuxemon/event/actions/set_random_variable.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import random
 from dataclasses import dataclass
-from typing import List, final
+from typing import final
 
 from tuxemon import formula
 from tuxemon.event.eventaction import EventAction
@@ -38,7 +38,7 @@ class SetRandomVariableAction(EventAction):
 
         # Split the values
         value: str = ""
-        values: List[str] = []
+        values: list[str] = []
         if self.var_value.find(":"):
             values = self.var_value.split(":")
             value = random.choice(values)

--- a/tuxemon/event/actions/translated_dialog.py
+++ b/tuxemon/event/actions/translated_dialog.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Any, Optional, Sequence, final
+from typing import Any, Optional, final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.graphics import get_avatar

--- a/tuxemon/event/actions/translated_dialog_chain.py
+++ b/tuxemon/event/actions/translated_dialog_chain.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Any, Optional, Sequence, final
+from typing import Any, Optional, final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.graphics import get_avatar

--- a/tuxemon/event/conditions/player_moved.py
+++ b/tuxemon/event/conditions/player_moved.py
@@ -2,8 +2,6 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-from typing import Tuple
-
 from tuxemon.event import MapCondition
 from tuxemon.event.eventcondition import EventCondition
 from tuxemon.npc import NPC
@@ -11,7 +9,7 @@ from tuxemon.session import Session
 
 
 # TODO: move to some other place?
-def collide(condition: MapCondition, tile_position: Tuple[int, int]) -> bool:
+def collide(condition: MapCondition, tile_position: tuple[int, int]) -> bool:
     """
     Check collision of a tile position with the map condition position.
 

--- a/tuxemon/event/eventcondition.py
+++ b/tuxemon/event/eventcondition.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-from typing import Any, ClassVar, Dict
+from typing import Any, ClassVar
 
 from tuxemon.event import MapCondition
 from tuxemon.session import Session
@@ -28,7 +28,7 @@ class EventCondition:
         """
         return True
 
-    def get_persist(self, session: Session) -> Dict[str, Any]:
+    def get_persist(self, session: Session) -> dict[str, Any]:
         """
         Return dictionary for this event class's data.
 
@@ -44,7 +44,7 @@ class EventCondition:
         try:
             return session.client.event_persist[self.name]
         except KeyError:
-            persist: Dict[str, Any] = {}
+            persist: dict[str, Any] = {}
             session.client.event_persist[self.name] = persist
             return persist
 

--- a/tuxemon/event/eventengine.py
+++ b/tuxemon/event/eventengine.py
@@ -3,20 +3,10 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Generator, Iterable, Sequence
 from contextlib import contextmanager
 from textwrap import dedent
-from typing import (
-    Any,
-    Dict,
-    Generator,
-    Iterable,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import Any, Optional, Union
 
 from tuxemon import plugin, prepare
 from tuxemon.constants import paths
@@ -63,7 +53,7 @@ class RunningEvent:
 
     def __init__(self, map_event: EventObject) -> None:
         self.map_event = map_event
-        self.context: Dict[str, Any] = dict()
+        self.context: dict[str, Any] = dict()
         self.action_index = 0
         self.current_action: Optional[EventAction[Any]] = None
         self.current_map_action = None
@@ -115,7 +105,7 @@ class EventEngine:
     def __init__(self, session: Session) -> None:
         self.session = session
 
-        self.running_events: Dict[int, RunningEvent] = dict()
+        self.running_events: dict[int, RunningEvent] = dict()
         self.name = "Event"
         self.current_map: Optional[TuxemonMap] = None
         self.timer = 0.0
@@ -123,7 +113,7 @@ class EventEngine:
         self.button = None
 
         # debug
-        self.partial_events: List[Sequence[Tuple[bool, MapCondition]]] = list()
+        self.partial_events: list[Sequence[tuple[bool, MapCondition]]] = list()
 
         self.conditions = plugin.load_plugins(
             paths.CONDITIONS_PATH,
@@ -189,7 +179,7 @@ class EventEngine:
             )
             return None
 
-    def get_actions(self) -> List[Type[EventAction]]:
+    def get_actions(self) -> list[type[EventAction]]:
         """
         Return list of EventActions.
 
@@ -224,7 +214,7 @@ class EventEngine:
         else:
             return condition()
 
-    def get_conditions(self) -> List[Type[EventCondition]]:
+    def get_conditions(self) -> list[type[EventCondition]]:
         """
         Return list of EventConditions.
 

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import datetime as dt
 import logging
 import random
-from typing import TYPE_CHECKING, Sequence, Tuple
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from tuxemon.db import MonsterModel
@@ -51,7 +52,7 @@ def simple_damage_calculate(
     technique: Technique,
     user: Monster,
     target: Monster,
-) -> Tuple[int, float]:
+) -> tuple[int, float]:
     """
     Calculates the damage of a technique based on stats and multiplier.
 
@@ -289,7 +290,7 @@ def convert_mi(steps: float) -> float:
 
 def weight_height_diff(
     monster: Monster, db: MonsterModel
-) -> Tuple[float, float]:
+) -> tuple[float, float]:
     weight = round(((monster.weight - db.weight) / db.weight) * 100, 1)
     height = round(((monster.height - db.height) / db.height) * 100, 1)
     return weight, height

--- a/tuxemon/item/conditions/category.py
+++ b/tuxemon/item/conditions/category.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
 
 from tuxemon.item.itemcondition import ItemCondition
 
@@ -26,7 +26,7 @@ class CategoryCondition(ItemCondition):
     cat: str
 
     def test(self, target: Monster) -> bool:
-        categories: List[str] = []
+        categories: list[str] = []
         if self.cat.find(":"):
             categories = self.cat.split(":")
         else:

--- a/tuxemon/item/conditions/current_hp.py
+++ b/tuxemon/item/conditions/current_hp.py
@@ -2,9 +2,10 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from operator import eq, ge, gt, le, lt
-from typing import TYPE_CHECKING, Callable, Mapping, Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from tuxemon.item.itemcondition import ItemCondition
 

--- a/tuxemon/item/conditions/facing_sprite.py
+++ b/tuxemon/item/conditions/facing_sprite.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING
 
 from tuxemon.event import get_npc_pos
 from tuxemon.item.itemcondition import ItemCondition
@@ -24,7 +24,7 @@ class FacingSpriteCondition(ItemCondition):
     sprite: str
 
     def test(self, target: Monster) -> bool:
-        coords: Tuple[int, int] = (0, 0)
+        coords: tuple[int, int] = (0, 0)
         player = self.session.player
         facing = player.facing
         player_x = player.tile_pos[0]

--- a/tuxemon/item/conditions/level.py
+++ b/tuxemon/item/conditions/level.py
@@ -2,9 +2,10 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from operator import eq, ge, gt, le, lt
-from typing import TYPE_CHECKING, Callable, Mapping, Optional
+from typing import TYPE_CHECKING, Optional
 
 from tuxemon.item.itemcondition import ItemCondition
 

--- a/tuxemon/item/conditions/shape.py
+++ b/tuxemon/item/conditions/shape.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
 
 from tuxemon.item.itemcondition import ItemCondition
 
@@ -24,7 +24,7 @@ class ShapeCondition(ItemCondition):
     shapes: str
 
     def test(self, target: Monster) -> bool:
-        shapes: List[str] = []
+        shapes: list[str] = []
         if self.shapes.find(":"):
             shapes = self.shapes.split(":")
         else:

--- a/tuxemon/item/conditions/type.py
+++ b/tuxemon/item/conditions/type.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
 
 from tuxemon.item.itemcondition import ItemCondition
 
@@ -25,7 +25,7 @@ class TypeCondition(ItemCondition):
 
     def test(self, target: Monster) -> bool:
         ret: bool = False
-        elements: List[str] = []
+        elements: list[str] = []
         if self.elements.find(":"):
             elements = self.elements.split(":")
         else:

--- a/tuxemon/item/effects/remove.py
+++ b/tuxemon/item/effects/remove.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Tuple, Union
+from typing import TYPE_CHECKING, Union
 
 from tuxemon.event import get_npc_pos
 from tuxemon.event.actions.remove_npc import RemoveNpcAction
@@ -30,7 +30,7 @@ class RemoveEffect(ItemEffect):
         self, item: Item, target: Union[Monster, None]
     ) -> RemoveEffectResult:
         remove: bool = False
-        coords: Tuple[int, int] = (0, 0)
+        coords: tuple[int, int] = (0, 0)
         player = self.session.player
         facing = player.facing
         player_x = player.tile_pos[0]

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -4,16 +4,8 @@ from __future__ import annotations
 
 import logging
 import uuid
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    ClassVar,
-    List,
-    Mapping,
-    Optional,
-    Sequence,
-    Type,
-)
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
 import pygame
 
@@ -44,8 +36,8 @@ MAX_TYPES_BAG = 99
 class Item:
     """An item object is an item that can be used either in or out of combat."""
 
-    effects_classes: ClassVar[Mapping[str, Type[ItemEffect[Any]]]] = {}
-    conditions_classes: ClassVar[Mapping[str, Type[ItemCondition[Any]]]] = {}
+    effects_classes: ClassVar[Mapping[str, type[ItemEffect[Any]]]] = {}
+    conditions_classes: ClassVar[Mapping[str, type[ItemCondition[Any]]]] = {}
 
     def __init__(self, save_data: Optional[Mapping[str, Any]] = None) -> None:
         if save_data is None:
@@ -309,7 +301,7 @@ class Item:
 
 def decode_items(
     json_data: Optional[Sequence[Mapping[str, Any]]],
-) -> List[Item]:
+) -> list[Item]:
     return [Item(save_data=itm) for itm in json_data or {}]
 
 

--- a/tuxemon/states/bg/__init__.py
+++ b/tuxemon/states/bg/__init__.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import logging
-from typing import Callable, Optional
+from collections.abc import Callable
+from typing import Optional
 
 import pygame_menu
 from pygame_menu import locals

--- a/tuxemon/states/choice/__init__.py
+++ b/tuxemon/states/choice/__init__.py
@@ -2,7 +2,8 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-from typing import Any, Callable, Sequence, Tuple
+from collections.abc import Callable, Sequence
+from typing import Any
 
 from tuxemon.animation import Animation
 from tuxemon.menu.menu import PygameMenuState
@@ -22,7 +23,7 @@ class ChoiceState(PygameMenuState):
 
     def __init__(
         self,
-        menu: Sequence[Tuple[str, str, Callable[[], None]]] = (),
+        menu: Sequence[tuple[str, str, Callable[[], None]]] = (),
         escape_key_exits: bool = False,
         **kwargs: Any,
     ) -> None:

--- a/tuxemon/states/control/__init__.py
+++ b/tuxemon/states/control/__init__.py
@@ -3,8 +3,9 @@
 """This module contains the Options state"""
 from __future__ import annotations
 
+from collections.abc import Callable
 from functools import partial
-from typing import Any, Callable, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 import pygame
 import pygame_menu
@@ -72,7 +73,7 @@ class SetKeyState(PygameMenuState):
 
         # to prevent a KeyError from happening, the game won't let you
         # input a key if that key has already been set a value
-        invalid_keys: List[int] = []
+        invalid_keys: list[int] = []
         invalid_keys = [
             pygame.K_UP,
             pygame.K_DOWN,
@@ -284,7 +285,7 @@ class ControlState(PygameMenuState):
 
         metric = T.translate("menu_units_metric")
         imperial = T.translate("menu_units_imperial")
-        units: List[Tuple[Any, ...]] = []
+        units: list[tuple[Any, ...]] = []
         units = [(metric, metric), (imperial, imperial)]
         menu.add.selector(
             title=T.translate("menu_units").upper(),
@@ -305,7 +306,7 @@ class ControlState(PygameMenuState):
 
         north_hemi = T.translate("menu_hemisphere_north")
         south_hemi = T.translate("menu_hemisphere_south")
-        hemispheres: List[Tuple[Any, ...]] = []
+        hemispheres: list[tuple[Any, ...]] = []
         hemispheres = [(north_hemi, north_hemi), (south_hemi, south_hemi)]
         menu.add.selector(
             title=T.translate("menu_hemisphere").upper(),
@@ -326,7 +327,7 @@ class ControlState(PygameMenuState):
 
         off = T.translate("disable")
         on = T.translate("enable")
-        dayandnight: List[Tuple[Any, ...]] = []
+        dayandnight: list[tuple[Any, ...]] = []
         dayandnight = [(off, off), (on, on)]
         menu.add.selector(
             title=T.translate("menu_music_daynight").upper(),

--- a/tuxemon/states/dialog/__init__.py
+++ b/tuxemon/states/dialog/__init__.py
@@ -2,7 +2,8 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-from typing import Any, Callable, Optional, Sequence, Tuple
+from collections.abc import Callable, Sequence
+from typing import Any, Optional
 
 from tuxemon.menu.menu import PopUpMenu
 from tuxemon.platform.const import buttons
@@ -29,7 +30,7 @@ class DialogState(PopUpMenu):
         self,
         text: Sequence[str] = (),
         avatar: Optional[Sprite] = None,
-        menu: Optional[Sequence[Tuple[str, str, Callable[[], None]]]] = None,
+        menu: Optional[Sequence[tuple[str, str, Callable[[], None]]]] = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)

--- a/tuxemon/states/items/__init__.py
+++ b/tuxemon/states/items/__init__.py
@@ -2,8 +2,9 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+from collections.abc import Generator, Sequence
 from functools import partial
-from typing import TYPE_CHECKING, Generator, Sequence, Tuple
+from typing import TYPE_CHECKING
 
 import pygame
 
@@ -43,7 +44,7 @@ def sort_inventory(
 
     """
 
-    def rank_item(item: Item) -> Tuple[int, str]:
+    def rank_item(item: Item) -> tuple[int, str]:
         primary_order = sort_order.index(item.sort)
         return primary_order, item.name
 

--- a/tuxemon/states/minigame/__init__.py
+++ b/tuxemon/states/minigame/__init__.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import random
+from collections.abc import Callable
 from functools import partial
-from typing import Callable
 
 import pygame_menu
 from pygame_menu import locals

--- a/tuxemon/states/monster/__init__.py
+++ b/tuxemon/states/monster/__init__.py
@@ -2,7 +2,8 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-from typing import Generator, Optional
+from collections.abc import Generator
+from typing import Optional
 
 import pygame
 from pygame.rect import Rect

--- a/tuxemon/states/pc/__init__.py
+++ b/tuxemon/states/pc/__init__.py
@@ -5,8 +5,9 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable, Generator, Sequence
 from functools import partial
-from typing import Any, Callable, Generator, Sequence, Tuple
+from typing import Any
 
 from tuxemon.locale import T
 from tuxemon.menu.input import InputMenu
@@ -27,7 +28,7 @@ LOCKER = "Locker"
 
 def add_menu_items(
     state: Menu[MenuGameObj],
-    items: Sequence[Tuple[str, MenuGameObj]],
+    items: Sequence[tuple[str, MenuGameObj]],
 ) -> None:
     for key, callback in items:
         label = T.translate(key).upper()

--- a/tuxemon/states/pc_kennel/__init__.py
+++ b/tuxemon/states/pc_kennel/__init__.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import logging
 import math
 import uuid
+from collections.abc import Callable, Sequence
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Any, Optional
 
 import pygame_menu
 from pygame_menu import locals
@@ -298,7 +299,7 @@ class MonsterBoxChooseState(PygameMenuState):
     def add_menu_items(
         self,
         menu: pygame_menu.Menu,
-        items: Sequence[Tuple[str, MenuGameObj]],
+        items: Sequence[tuple[str, MenuGameObj]],
     ) -> None:
         menu.add.vertical_fill()
         for key, callback in items:
@@ -318,7 +319,7 @@ class MonsterBoxChooseState(PygameMenuState):
             position=(width + b_width, b_height, False),
         )
 
-    def get_menu_items_map(self) -> Sequence[Tuple[str, MenuGameObj]]:
+    def get_menu_items_map(self) -> Sequence[tuple[str, MenuGameObj]]:
         """
         Return a list of menu options and callbacks, to be overridden by
         class descendants.
@@ -365,7 +366,7 @@ class MonsterBoxChooseState(PygameMenuState):
 class MonsterBoxChooseStorageState(MonsterBoxChooseState):
     """Menu to choose a box, which you can then take a tuxemon from."""
 
-    def get_menu_items_map(self) -> Sequence[Tuple[str, MenuGameObj]]:
+    def get_menu_items_map(self) -> Sequence[tuple[str, MenuGameObj]]:
         player = local_session.player
         menu_items_map = []
         for box_name, monsters in player.monster_boxes.items():
@@ -387,7 +388,7 @@ class MonsterBoxChooseStorageState(MonsterBoxChooseState):
 class MonsterBoxChooseDropOffState(MonsterBoxChooseState):
     """Menu to choose a box, which you can then drop off a tuxemon into."""
 
-    def get_menu_items_map(self) -> Sequence[Tuple[str, MenuGameObj]]:
+    def get_menu_items_map(self) -> Sequence[tuple[str, MenuGameObj]]:
         player = local_session.player
         menu_items_map = []
         for box_name, monsters in player.monster_boxes.items():

--- a/tuxemon/states/pc_locker/__init__.py
+++ b/tuxemon/states/pc_locker/__init__.py
@@ -5,16 +5,9 @@ from __future__ import annotations
 import logging
 import math
 import uuid
+from collections.abc import Callable, Sequence
 from functools import partial
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-)
+from typing import TYPE_CHECKING, Any, Optional
 
 import pygame_menu
 from pygame_menu import locals
@@ -327,7 +320,7 @@ class ItemBoxChooseState(PygameMenuState):
     def add_menu_items(
         self,
         menu: pygame_menu.Menu,
-        items: Sequence[Tuple[str, MenuGameObj]],
+        items: Sequence[tuple[str, MenuGameObj]],
     ) -> None:
         menu.add.vertical_fill()
         for key, callback in items:
@@ -349,7 +342,7 @@ class ItemBoxChooseState(PygameMenuState):
             position=(width + b_width, b_height, False),
         )
 
-    def get_menu_items_map(self) -> Sequence[Tuple[str, MenuGameObj]]:
+    def get_menu_items_map(self) -> Sequence[tuple[str, MenuGameObj]]:
         """
         Return a list of menu options and callbacks, to be overridden by
         class descendants.
@@ -396,7 +389,7 @@ class ItemBoxChooseState(PygameMenuState):
 class ItemBoxChooseStorageState(ItemBoxChooseState):
     """Menu to choose a box, which you can then take an item from."""
 
-    def get_menu_items_map(self) -> Sequence[Tuple[str, MenuGameObj]]:
+    def get_menu_items_map(self) -> Sequence[tuple[str, MenuGameObj]]:
         player = local_session.player
         menu_items_map = []
         for box_name, items in player.item_boxes.items():
@@ -418,7 +411,7 @@ class ItemBoxChooseStorageState(ItemBoxChooseState):
 class ItemBoxChooseDropOffState(ItemBoxChooseState):
     """Menu to choose a box, which you can then drop off an item into."""
 
-    def get_menu_items_map(self) -> Sequence[Tuple[str, MenuGameObj]]:
+    def get_menu_items_map(self) -> Sequence[tuple[str, MenuGameObj]]:
         player = local_session.player
         menu_items_map = []
         for box_name, items in player.item_boxes.items():
@@ -458,7 +451,7 @@ class ItemDropOffState(ItemMenuState):
 
             box = player.item_boxes[self.box_name]
 
-            def find_monster_box(itm: Item, box: List[Item]) -> Optional[Item]:
+            def find_monster_box(itm: Item, box: list[Item]) -> Optional[Item]:
                 for ele in box:
                     if ele.slug == itm.slug:
                         return ele

--- a/tuxemon/states/phone/__init__.py
+++ b/tuxemon/states/phone/__init__.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Callable, Sequence
 from functools import partial
-from typing import Any, Callable, List, Sequence
+from typing import Any
 
 import pygame_menu
 from pygame_menu import locals
@@ -424,7 +425,7 @@ class NuPhoneMap(PygameMenuState):
             font_size=20,
             background_color=(232, 48, 48),
         )
-        assert not isinstance(lab1, List)
+        assert not isinstance(lab1, list)
         lab1.translate(
             fix_width(menu._width, 0.20), fix_height(menu._height, -0.03)
         )
@@ -438,7 +439,7 @@ class NuPhoneMap(PygameMenuState):
             font_size=20,
             background_color=(232, 48, 48),
         )
-        assert not isinstance(lab2, List)
+        assert not isinstance(lab2, list)
         lab2.translate(
             fix_width(menu._width, 0.20), fix_height(menu._height, 0.08)
         )
@@ -452,7 +453,7 @@ class NuPhoneMap(PygameMenuState):
             font_size=20,
             background_color=(232, 48, 48),
         )
-        assert not isinstance(lab3, List)
+        assert not isinstance(lab3, list)
         lab3.translate(
             fix_width(menu._width, 0.20), fix_height(menu._height, 0.18)
         )
@@ -466,7 +467,7 @@ class NuPhoneMap(PygameMenuState):
             font_size=20,
             background_color=(232, 48, 48),
         )
-        assert not isinstance(lab4, List)
+        assert not isinstance(lab4, list)
         lab4.translate(
             fix_width(menu._width, -0.20), fix_height(menu._height, 0.18)
         )
@@ -480,7 +481,7 @@ class NuPhoneMap(PygameMenuState):
             font_size=20,
             background_color=(232, 48, 48),
         )
-        assert not isinstance(lab5, List)
+        assert not isinstance(lab5, list)
         lab5.translate(
             fix_width(menu._width, -0.20), fix_height(menu._height, -0.03)
         )
@@ -494,7 +495,7 @@ class NuPhoneMap(PygameMenuState):
             font_size=20,
             background_color=(232, 48, 48),
         )
-        assert not isinstance(lab6, List)
+        assert not isinstance(lab6, list)
         lab6.translate(
             fix_width(menu._width, -0.15), fix_height(menu._height, -0.15)
         )

--- a/tuxemon/states/player/__init__.py
+++ b/tuxemon/states/player/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-from typing import Callable, List
+from collections.abc import Callable
 
 import pygame_menu
 from pygame_menu import locals
@@ -131,7 +131,7 @@ class PlayerState(PygameMenuState):
             underline=True,
             float=True,
         )
-        assert not isinstance(lab1, List)
+        assert not isinstance(lab1, list)
         lab1.translate(fix_width(width, 0.45), fix_height(height, 0.15))
         # money
         money = player.money["player"]
@@ -142,7 +142,7 @@ class PlayerState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        assert not isinstance(lab2, List)
+        assert not isinstance(lab2, list)
         lab2.translate(fix_width(width, 0.45), fix_height(height, 0.25))
         # seen
         lab3 = menu.add.label(
@@ -152,7 +152,7 @@ class PlayerState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        assert not isinstance(lab3, List)
+        assert not isinstance(lab3, list)
         lab3.translate(fix_width(width, 0.45), fix_height(height, 0.30))
         # caught
         lab4 = menu.add.label(
@@ -162,7 +162,7 @@ class PlayerState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        assert not isinstance(lab4, List)
+        assert not isinstance(lab4, list)
         lab4.translate(fix_width(width, 0.45), fix_height(height, 0.35))
         # begin adventure
         lab5 = menu.add.label(
@@ -172,7 +172,7 @@ class PlayerState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        assert not isinstance(lab5, List)
+        assert not isinstance(lab5, list)
         lab5.translate(fix_width(width, 0.45), fix_height(height, 0.40))
         # walked
         lab6 = menu.add.label(
@@ -182,7 +182,7 @@ class PlayerState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        assert not isinstance(lab6, List)
+        assert not isinstance(lab6, list)
         lab6.translate(fix_width(width, 0.45), fix_height(height, 0.45))
         # battles
         lab7 = menu.add.label(
@@ -192,7 +192,7 @@ class PlayerState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        assert not isinstance(lab7, List)
+        assert not isinstance(lab7, list)
         lab7.translate(fix_width(width, 0.45), fix_height(height, 0.50))
         # % tuxepedia
         lab8 = menu.add.label(
@@ -202,7 +202,7 @@ class PlayerState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        assert not isinstance(lab8, List)
+        assert not isinstance(lab8, list)
         lab8.translate(fix_width(width, 0.45), fix_height(height, 0.10))
         # image
         combat_front = ""

--- a/tuxemon/states/splash/__init__.py
+++ b/tuxemon/states/splash/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Optional
+from typing import Optional
 
 import pygame
 

--- a/tuxemon/states/start/__init__.py
+++ b/tuxemon/states/start/__init__.py
@@ -5,8 +5,9 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from functools import partial
-from typing import Any, Callable, Union
+from typing import Any, Union
 
 import pygame
 import pygame_menu

--- a/tuxemon/states/techniques/__init__.py
+++ b/tuxemon/states/techniques/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-from typing import Generator, List
+from collections.abc import Generator
 
 import pygame
 
@@ -136,7 +136,7 @@ class TechniqueMenuState(Menu[Technique]):
             layer=100,
         )
 
-        moveset: List[Technique] = []
+        moveset: list[Technique] = []
         moveset = self.mon.moves
         output = sorted(moveset, key=lambda x: x.tech_id)
 

--- a/tuxemon/states/world/world_menus.py
+++ b/tuxemon/states/world/world_menus.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable, Sequence
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, Dict, Sequence, Tuple
+from typing import TYPE_CHECKING, Any
 
 import pygame_menu
 
@@ -29,7 +30,7 @@ WorldMenuGameObj = Callable[[], object]
 
 def add_menu_items(
     menu: pygame_menu.Menu,
-    items: Sequence[Tuple[str, WorldMenuGameObj]],
+    items: Sequence[tuple[str, WorldMenuGameObj]],
 ) -> None:
     menu.add.vertical_fill()
     for key, callback in items:
@@ -225,7 +226,7 @@ class WorldMenuState(PygameMenuState):
             else:
                 open_monster_submenu(menu_item)
 
-        context: Dict[
+        context: dict[
             str, Any
         ] = dict()  # dict passed around to hold info between menus/callbacks
         monster_menu = self.client.push_state(MonsterMenuState())

--- a/tuxemon/technique/conditions/current_hp.py
+++ b/tuxemon/technique/conditions/current_hp.py
@@ -2,9 +2,10 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from operator import eq, ge, gt, le, lt
-from typing import TYPE_CHECKING, Callable, Mapping, Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from tuxemon.technique.techcondition import TechCondition
 

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -4,16 +4,8 @@ from __future__ import annotations
 
 import logging
 import uuid
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    ClassVar,
-    List,
-    Mapping,
-    Optional,
-    Sequence,
-    Type,
-)
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
 from tuxemon import plugin, prepare
 from tuxemon.constants import paths
@@ -43,8 +35,8 @@ class Technique:
 
     """
 
-    effects_classes: ClassVar[Mapping[str, Type[TechEffect[Any]]]] = {}
-    conditions_classes: ClassVar[Mapping[str, Type[TechCondition[Any]]]] = {}
+    effects_classes: ClassVar[Mapping[str, type[TechEffect[Any]]]] = {}
+    conditions_classes: ClassVar[Mapping[str, type[TechCondition[Any]]]] = {}
 
     def __init__(self, save_data: Optional[Mapping[str, Any]] = None) -> None:
         if save_data is None:
@@ -78,7 +70,7 @@ class Technique:
         self.sort = ""
         self.slug = ""
         self.target: Sequence[str] = []
-        self.types: List[Element] = []
+        self.types: list[Element] = []
         self.usable_on = False
         self.use_success = ""
         self.use_failure = ""
@@ -388,7 +380,7 @@ class Technique:
 
 def decode_moves(
     json_data: Optional[Sequence[Mapping[str, Any]]],
-) -> List[Technique]:
+) -> list[Technique]:
     return [Technique(save_data=tech) for tech in json_data or {}]
 
 


### PR DESCRIPTION
PR upgrades:
List into **list**, Dict into **dict**, Type into **type**, Tuple into **tuple**;
it moves Callable, Mapping, Generator from **typing** to **collections.abc**

at the moment I targeted only:
- formula.py
- db.py
- event (+subfolders actions and conditions)
- technique (+ subfolders effects and conditions)
- item (+ subfolders effects and conditions)
- condition (+ subfolders effects and conditions)
- most of the states > world menu is done
- rest of the files #2060 

Since I was already working on these files (avoid merging conflicts):
- combat.py, combat_menu.py and combat.animations.py have been integrated #2053 (tested, no issues);
- sprite.py in #2057 (tested, no issues);
- graphics.py in #2059 (tested, no issues);
- state (journal) in #2062 (tested, no issues);

all the files have been upgraded




black, isort, tested, no new typehints