### PR TITLE
remove hardcode items

### DIFF
--- a/mods/tuxemon/db/item/app_banking.json
+++ b/mods/tuxemon/db/item/app_banking.json
@@ -8,6 +8,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "visible": false,
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/app_contacts.json
+++ b/mods/tuxemon/db/item/app_contacts.json
@@ -8,6 +8,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "visible": false,
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/app_map.json
+++ b/mods/tuxemon/db/item/app_map.json
@@ -8,6 +8,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "visible": false,
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/app_tuxepedia.json
+++ b/mods/tuxemon/db/item/app_tuxepedia.json
@@ -8,6 +8,8 @@
   "usable_in": [
     "WorldState"
   ],
+  "menu": ["0","menu_tuxepedia","JournalChoice"],
+  "visible": false,
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/nu_phone.json
+++ b/mods/tuxemon/db/item/nu_phone.json
@@ -8,6 +8,8 @@
   "usable_in": [
     "WorldState"
   ],
+  "menu": ["3","nu_phone","NuPhone"],
+  "visible": false,
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -229,6 +229,13 @@ class ItemModel(BaseModel):
     animation: Optional[str] = Field(
         None, description="Animation to play for this technique"
     )
+    menu: tuple[int, str, str] = Field(
+        None,
+        description="Item has a menu (position, label -inside the PO -,state, eg. 3:nu_phone:PhoneState)",
+    )
+    visible: bool = Field(
+        True, description="Whether or not this item is visible."
+    )
 
     class Config:
         title = "Item"

--- a/tuxemon/event/conditions/has_bag.py
+++ b/tuxemon/event/conditions/has_bag.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from operator import eq, ge, gt, le, lt, ne
 
-from tuxemon.db import ItemCategory
 from tuxemon.event import MapCondition
 from tuxemon.event.eventcondition import EventCondition
 from tuxemon.session import Session
@@ -35,8 +34,7 @@ class HasBagCondition(EventCondition):
         player = session.player
         sum_total = []
         for itm in player.items:
-            # excludes the phone + apps
-            if itm.category != ItemCategory.phone:
+            if itm.visible:
                 sum_total.append(itm.quantity)
         bag_size = sum(sum_total)
         if check == "less_than":

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -116,6 +116,8 @@ class Item:
         self.use_failure = T.translate(results.use_failure)
 
         # misc attributes (not translated!)
+        self.visible = results.visible
+        self.menu = results.menu
         self.sort = results.sort
         self.category = results.category or ItemCategory.none
         self.type = results.type or ItemType.consumable

--- a/tuxemon/states/items/__init__.py
+++ b/tuxemon/states/items/__init__.py
@@ -234,12 +234,10 @@ class ItemMenuState(Menu[Item]):
                 for item in local_session.player.items
                 if State[state] in item.usable_in
             ]
-        # shows all items (excluded phone category)
+        # shows all items (only visible)
         else:
             inventory = [
-                item
-                for item in local_session.player.items
-                if item.category != "phone"
+                item for item in local_session.player.items if item.visible
             ]
 
         # required because the max() below will fail if inv empty

--- a/tuxemon/states/world/world_menus.py
+++ b/tuxemon/states/world/world_menus.py
@@ -73,13 +73,12 @@ class WorldMenuState(PygameMenuState):
             ("menu_options", change_state("ControlState")),
             ("exit", exit_game),
         ]
-        if local_session.player.find_item("nu_phone"):
-            menu_items_map.insert(3, ("nu_phone", change_state("NuPhone")))
-        if local_session.player.find_item("app_tuxepedia"):
-            menu_items_map.insert(
-                0,
-                ("menu_tuxepedia", change_state("JournalChoice")),
-            )
+        player = local_session.player
+        for itm in player.items:
+            if itm.menu:
+                menu_items_map.insert(
+                    itm.menu[0], (itm.menu[1], change_state(itm.menu[2]))
+                )
         add_menu_items(self.menu, tuple(menu_items_map))
 
     def open_monster_menu(self) -> None:


### PR DESCRIPTION
PR removes two hardcoded part inside the code.

the first one was in init (Item):
```
            # excludes the phone + apps
            if itm.category != ItemCategory.phone:
```
the phone was hidden in this way, I replaced it by a new field called `visible` (bool, default True), in this way the modder can decide to hide an item by putting `"visible": false,` inside the JSON.

the second one was in world_menu.py and it was related to the menu. Until now:
```
        if local_session.player.find_item("nu_phone"):
            menu_items_map.insert(3, ("nu_phone", change_state("NuPhone")))
```
it was hardcoded, now with a new field called `menu` (tuple(int,str,str)), in this way in the `nu_phone` JSON will appear `"menu": ["3","nu_phone","NuPhone"],` where **3** is the position inside the menu, **nu_phone** is the label inside the PO and **NuPhone** is the State to invoke.
```
        player = local_session.player
        for itm in player.items:
            if itm.menu:
                menu_items_map.insert(
                    itm.menu[0], (itm.menu[1], change_state(itm.menu[2]))
                )
```

black, isort, tested, no new typehints