### PR TITLE
fishing (execute_action) + others

### DIFF
--- a/tuxemon/event/actions/random_item.py
+++ b/tuxemon/event/actions/random_item.py
@@ -6,7 +6,6 @@ import random
 from dataclasses import dataclass
 from typing import Union, final
 
-from tuxemon.event.actions.add_item import AddItemAction
 from tuxemon.event.eventaction import EventAction
 
 
@@ -45,8 +44,6 @@ class RandomItemAction(EventAction):
         else:
             item = self.item_slug
 
-        AddItemAction(
-            item_slug=item,
-            quantity=self.quantity,
-            trainer_slug=self.trainer_slug,
-        ).start()
+        self.session.client.event_engine.execute_action(
+            "add_item", [item, self.quantity, self.trainer_slug], True
+        )

--- a/tuxemon/event/actions/random_monster.py
+++ b/tuxemon/event/actions/random_monster.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from typing import Union, final
 
 from tuxemon.db import EvolutionStage, MonsterShape, db
-from tuxemon.event.actions.add_monster import AddMonsterAction
 from tuxemon.event.eventaction import EventAction
 
 
@@ -88,10 +87,14 @@ class RandomMonsterAction(EventAction):
 
         monster_slug = rd.choice(filters)
 
-        AddMonsterAction(
-            monster_slug=monster_slug,
-            monster_level=self.monster_level,
-            trainer_slug=self.trainer_slug,
-            exp=self.exp,
-            money=self.money,
-        ).start()
+        self.session.client.event_engine.execute_action(
+            "add_monster",
+            [
+                monster_slug,
+                self.monster_level,
+                self.trainer_slug,
+                self.exp,
+                self.money,
+            ],
+            True,
+        )

--- a/tuxemon/event/eventaction.py
+++ b/tuxemon/event/eventaction.py
@@ -83,6 +83,7 @@ class EventAction(ABC):
     name: ClassVar[str]
     session: Session = field(init=False, repr=False)
     _done: bool = field(default=False, init=False)
+    _skip: bool = field(default=False, init=False)
 
     def __post_init__(self) -> None:
         self.session = local_session
@@ -145,7 +146,10 @@ class EventAction(ABC):
 
         """
         while not self.done:
-            self.update()
+            if self._skip:
+                return
+            else:
+                self.update()
 
     @property
     def done(self) -> bool:

--- a/tuxemon/event/eventengine.py
+++ b/tuxemon/event/eventengine.py
@@ -254,6 +254,7 @@ class EventEngine:
         self,
         action_name: str,
         parameters: Optional[Sequence[Any]] = None,
+        skip: bool = False,
     ) -> None:
         """
         Load and execute an action.
@@ -273,6 +274,8 @@ class EventEngine:
             error_msg = f'Map action "{action_name}" is not loaded'
             logger.warning(error_msg)
             raise ValueError(error_msg)
+
+        action._skip = skip
 
         return action.execute()
 

--- a/tuxemon/item/effects/fishing.py
+++ b/tuxemon/item/effects/fishing.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Union
 
 from tuxemon.db import EvolutionStage, MonsterShape, db
-from tuxemon.event.actions.wild_encounter import WildEncounterAction
 from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
 
 if TYPE_CHECKING:
@@ -29,10 +28,12 @@ class FishingEffect(ItemEffect):
         self, item: Item, target: Union[Monster, None]
     ) -> FishingEffectResult:
         # define random encounters
+        mon_slug: str = ""
+        level: int = 0
         fishing: bool = False
-        bas = []
-        adv = []
-        pro = []
+        bas: list[str] = []
+        adv: list[str] = []
+        pro: list[str] = []
         monsters = list(db.database["monster"])
         for mon in monsters:
             results = db.lookup(mon, table="monster")
@@ -66,24 +67,30 @@ class FishingEffect(ItemEffect):
             if bait <= 35:
                 mon_slug = random.choice(bas)
                 level = random.randint(5, 15)
-                WildEncounterAction(
-                    monster_slug=mon_slug, monster_level=level, env="ocean"
-                ).start()
                 fishing = True
         elif item.slug == "neptune":
             if bait <= 65:
                 mon_slug = random.choice(adv)
                 level = random.randint(15, 25)
-                WildEncounterAction(
-                    monster_slug=mon_slug, monster_level=level, env="ocean"
-                ).start()
                 fishing = True
         elif item.slug == "poseidon":
             if bait <= 85:
                 mon_slug = random.choice(pro)
                 level = random.randint(25, 35)
-                WildEncounterAction(
-                    monster_slug=mon_slug, monster_level=level, env="ocean"
-                ).start()
                 fishing = True
+
+        client = self.session.client
+        player = self.session.player
+        environment = (
+            "night_ocean"
+            if player.game_variables["stage_of_day"] == "night"
+            else "ocean"
+        )
+        rgb = "0:105:148"
+        if fishing:
+            client.event_engine.execute_action(
+                "wild_encounter",
+                [mon_slug, level, None, None, environment, rgb],
+                True,
+            )
         return {"success": fishing, "num_shakes": 0, "extra": None}

--- a/tuxemon/item/effects/remove.py
+++ b/tuxemon/item/effects/remove.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Union
 
 from tuxemon.event import get_npc_pos
-from tuxemon.event.actions.remove_npc import RemoveNpcAction
 from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
 
 if TYPE_CHECKING:
@@ -50,7 +49,9 @@ class RemoveEffect(ItemEffect):
 
         npc = get_npc_pos(self.session, coords)
         if npc:
-            RemoveNpcAction(npc_slug=npc.slug).start()
+            self.session.client.event_engine.execute_action(
+                "remove_npc", [npc.slug], True
+            )
             self.session.player.game_variables[npc.slug] = self.name
             remove = True
         return {"success": remove, "num_shakes": 0, "extra": None}


### PR DESCRIPTION
PR replaces the `actions` action with `execute_action`:
- item effect `fishing`
- item effect `remove_npc`
- action `random_monster`
- action `random_item`

all the listed have been tested, no issues

using actions with `self.update() `in `execute_action` provokes a freeze, this is why I added a third field in `execute_action` for skipping the update part, in this way it'll be possible to use the action without freezing.