### PR TITLE
current state instead of combat_state

### DIFF
--- a/tuxemon/event/conditions/current_state.py
+++ b/tuxemon/event/conditions/current_state.py
@@ -7,22 +7,25 @@ from tuxemon.event.eventcondition import EventCondition
 from tuxemon.session import Session
 
 
-class CombatStartedCondition(EventCondition):
+class CurrentStateCondition(EventCondition):
     """
-    Check to see if combat has been started or not.
+    Check to see if the state has been started or not.
 
     Script usage:
         .. code-block::
 
-            is combat_started
+            is current_state <state>
+
+    Script parameters:
+        state: Either "CombatState", "DialogState", etc
 
     """
 
-    name = "combat_started"
+    name = "current_state"
 
     def test(self, session: Session, condition: MapCondition) -> bool:
         """
-        Check to see if combat has been started or not.
+        Check to see if the state has been started or not.
 
         Parameters:
             session: The session object
@@ -34,4 +37,4 @@ class CombatStartedCondition(EventCondition):
         """
         current_state = session.client.current_state
         assert current_state
-        return current_state.name == "CombatState"
+        return current_state.name == condition.parameters[0]


### PR DESCRIPTION
PR proposes to replace the unused **combat_state** (event condition) with a more generic **current_state** (event condition)