### PR TITLE
fix nodding off

### DIFF
--- a/mods/tuxemon/db/condition/noddingoff.json
+++ b/mods/tuxemon/db/condition/noddingoff.json
@@ -7,7 +7,6 @@
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_noddingoff.png",
   "range": "special",
-  "repl_neg": "replaced",
   "sfx": "sfx_pulse",
   "slug": "noddingoff",
   "sort": "meta",
@@ -21,6 +20,6 @@
   },
   "cond_id": 6,
   "use_failure": null,
-  "use_success": "combat_state_noddingoff_get",
-  "gain_cond": null
+  "use_success": "combat_state_dozing_get",
+  "gain_cond": "combat_state_noddingoff_get"
 }

--- a/mods/tuxemon/db/technique/petrify.json
+++ b/mods/tuxemon/db/technique/petrify.json
@@ -3,7 +3,7 @@
   "accuracy": 1,
   "animation": "shield_rock",
   "effects": [
-    "give dozing,target",
+    "give noddingoff,target",
     "enhance"
   ],
   "flip_axes": "",

--- a/tuxemon/condition/effects/noddingoff.py
+++ b/tuxemon/condition/effects/noddingoff.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from tuxemon.condition.condeffect import CondEffect, CondEffectResult
+from tuxemon.locale import T
+from tuxemon.technique.technique import Technique
 
 if TYPE_CHECKING:
     from tuxemon.condition.condition import Condition
@@ -27,9 +29,24 @@ class NoddingOffEffect(CondEffect):
     def apply(
         self, tech: Condition, target: Monster
     ) -> NoddingOffEffectResult:
+        extra: Optional[str] = None
+        skip: Optional[Technique] = None
+        if tech.phase == "pre_checking":
+            if tech.slug == "noddingoff":
+                skip = Technique()
+                skip.load("empty")
+        if tech.phase == "perform_action_tech" and tech.nr_turn > 0:
+            if tech.slug == "noddingoff":
+                extra = T.format(
+                    "combat_state_dozing_end",
+                    {
+                        "target": target.name.upper(),
+                    },
+                )
+                target.status.clear()
         return {
             "success": True,
             "condition": None,
-            "technique": None,
-            "extra": None,
+            "technique": skip,
+            "extra": extra,
         }


### PR DESCRIPTION
PR fixes nodding off (fix 1854)

@Sanglorian I have merged the nodding off and dozing off status. So all the messages and alerts are maintained in one single status, because at the end involves falling asleep and waking up. This will give you the opportunity to decide how long the monster is going to sleep (eg nr min and max of turns, etc). Let me know, so eventually we can remove or transform dozing off in something else. 