### PR TITLE
typehints (worldstate.py)

### DIFF
--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -472,16 +472,16 @@ class WorldState(state.State):
             s, c, l = frame
 
             # project to pixel/screen coords
-            c = self.get_pos_from_tilepos(c)
+            _c = self.get_pos_from_tilepos((int(c.x), int(c.y)))
 
             # TODO: better handling of tall sprites
             # handle tall sprites
             h = s.get_height()
             if h > prepare.TILE_SIZE[1]:
                 # offset for center and image height
-                c = (c[0], c[1] - h // 2)
+                _c = (_c[0], _c[1] - h // 2)
 
-            r = Rect(c, s.get_size())
+            r = Rect(_c, s.get_size())
             screen_surfaces.append((s, r, l))
 
         # draw the map and sprites
@@ -731,7 +731,7 @@ class WorldState(state.State):
         position: tuple[int, int],
         tile: Union[RegionProperties, EntityCollision],
         skip_nodes: Optional[set[tuple[int, int]]] = None,
-    ) -> Optional[Sequence[tuple[int, int]]]:
+    ) -> Optional[list[tuple[float, ...]]]:
         """
         Check for exits from tile which are defined in the map.
 
@@ -760,7 +760,7 @@ class WorldState(state.State):
             adjacent_tiles = list()
             for direction in tile["exit"]:
                 exit_tile = tuple(dirs2[direction] + position)
-                if exit_tile in skip_nodes:
+                if skip_nodes and exit_tile in skip_nodes:
                     continue
 
                 adjacent_tiles.append(exit_tile)
@@ -985,7 +985,9 @@ class WorldState(state.State):
 
     def _npc_to_pgrect(self, npc: NPC) -> pygame.rect.Rect:
         """Returns a Rect (in screen-coords) version of an NPC's bounding box."""
-        pos = self.get_pos_from_tilepos(proj(npc.position3))
+        vector = proj(npc.position3)
+        _vector = (int(vector.x), int(vector.y))
+        pos = self.get_pos_from_tilepos(_vector)
         return Rect(pos, self.tile_size)
 
     ####################################################


### PR DESCRIPTION
now
```
tuxemon/states/world/worldstate.py:754: error: TypedDict "EntityCollision" has no key "continue"  [typeddict-item]
tuxemon/states/world/worldstate.py:761: error: TypedDict "EntityCollision" has no key "exit"  [typeddict-item]
tuxemon/states/world/worldstate.py:855: error: TypedDict "EntityCollision" has no key "enter"  [typeddict-item]
```
before
```
tuxemon/states/world/worldstate.py:475: error: Incompatible types in assignment (expression has type "tuple[int, int]", variable has type "Vector2")  [assignment]
tuxemon/states/world/worldstate.py:475: error: Argument 1 to "get_pos_from_tilepos" of "WorldState" has incompatible type "Vector2"; expected "tuple[int, int]"  [arg-type]
tuxemon/states/world/worldstate.py:482: error: Incompatible types in assignment (expression has type "tuple[float, float]", variable has type "Vector2")  [assignment]
tuxemon/states/world/worldstate.py:484: error: No overload variant of "Rect" matches argument types "Vector2", "tuple[int, int]"  [call-overload]
tuxemon/states/world/worldstate.py:484: note: Possible overload variants:
tuxemon/states/world/worldstate.py:484: note:     def Rect(self, left: float, top: float, width: float, height: float) -> Rect
tuxemon/states/world/worldstate.py:484: note:     def Rect(self, left_top: Sequence[float], width_height: Sequence[float]) -> Rect
tuxemon/states/world/worldstate.py:484: note:     def Rect(self, single_arg: Sequence[float | Sequence[float]] | _HasRectAttribute) -> Rect
tuxemon/states/world/worldstate.py:754: error: List item 0 has incompatible type "tuple[float, ...]"; expected "tuple[int, int]"  [list-item]
tuxemon/states/world/worldstate.py:754: error: TypedDict "EntityCollision" has no key "continue"  [typeddict-item]
tuxemon/states/world/worldstate.py:761: error: TypedDict "EntityCollision" has no key "exit"  [typeddict-item]
tuxemon/states/world/worldstate.py:763: error: Unsupported right operand type for in ("set[tuple[int, int]] | None")  [operator]
tuxemon/states/world/worldstate.py:767: error: Incompatible return value type (got "list[tuple[float, ...]]", expected "Sequence[tuple[int, int]] | None")  [return-value]
tuxemon/states/world/worldstate.py:855: error: TypedDict "EntityCollision" has no key "enter"  [typeddict-item]
tuxemon/states/world/worldstate.py:988: error: Argument 1 to "get_pos_from_tilepos" of "WorldState" has incompatible type "Vector2"; expected "tuple[int, int]"  [arg-type]
```
