### PR TITLE
bump pygame-ce to 2.3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ babel
 cbor
 neteria
 pillow
-pygame-ce==2.2.0
+pygame-ce==2.3.2
 pyscroll>=2.31
 pytmx==3.31
 requests>=2.19.1

--- a/tuxemon/menu/menu.py
+++ b/tuxemon/menu/menu.py
@@ -487,7 +487,7 @@ class Menu(Generic[T], state.State):
         size = [int(math.ceil(a + b)) for a, b in zip(offset, top.get_size())]
         image = pygame.Surface(size, pygame.SRCALPHA)
 
-        image.blit(shadow, offset)
+        image.blit(shadow, tuple(offset))
         image.blit(top, (0, 0))
         return image
 

--- a/tuxemon/save.py
+++ b/tuxemon/save.py
@@ -79,8 +79,8 @@ def get_save_data(session: Session) -> SaveData:
     npc_state = session.player.get_state(session)
     save_data: SaveData = {
         "screenshot": base64.b64encode(
-            pygame.image.tostring(screenshot, "RGB")
-        ).decode("utf-8"),
+            pygame.image.tobytes(screenshot, "RGB")
+        ).decode(),
         "screenshot_width": screenshot.get_width(),
         "screenshot_height": screenshot.get_height(),
         "time": datetime.datetime.now().strftime(TIME_FORMAT),

--- a/tuxemon/sprite.py
+++ b/tuxemon/sprite.py
@@ -18,7 +18,6 @@ from typing import (
     overload,
 )
 
-import pygame
 from pygame.rect import Rect
 from pygame.sprite import DirtySprite, Group, LayeredUpdates
 from pygame.sprite import Sprite as PySprite
@@ -44,7 +43,7 @@ dummy_image: Final = Surface((0, 0))
 class Sprite(DirtySprite):
     _original_image: Optional[Surface]
     _image: Optional[Surface]
-    _rect: pygame.rect.Rect
+    _rect: Rect
 
     def __init__(
         self,
@@ -73,8 +72,8 @@ class Sprite(DirtySprite):
     def draw(
         self,
         surface: Surface,
-        rect: Optional[pygame.rect.Rect] = None,
-    ) -> pygame.rect.Rect:
+        rect: Optional[Rect] = None,
+    ) -> Rect:
         """
         Draw the sprite to the surface.
 
@@ -97,8 +96,8 @@ class Sprite(DirtySprite):
     def _draw(
         self,
         surface: Surface,
-        rect: pygame.rect.Rect,
-    ) -> pygame.rect.Rect:
+        rect: Rect,
+    ) -> Rect:
         return surface.blit(self.image, rect)
 
     @property
@@ -328,11 +327,11 @@ class SpriteGroup(LayeredUpdates, Generic[_GroupElement]):
         # patch in indexing / slicing support
         return self.sprites()[item]
 
-    def calc_bounding_rect(self) -> pygame.rect.Rect:
+    def calc_bounding_rect(self) -> Rect:
         """A rect object that contains all sprites of this group."""
         sprites = self.sprites()
         if len(sprites) == 1:
-            return pygame.rect.Rect(sprites[0].rect)
+            return Rect(sprites[0].rect)
         else:
             return sprites[0].rect.unionall([s.rect for s in sprites[1:]])
 
@@ -402,12 +401,12 @@ class RelativeGroup(MenuSpriteGroup[_MenuElement]):
     Drawing operations are relative to the group's rect.
     """
 
-    rect = pygame.rect.Rect(0, 0, 0, 0)
+    rect = Rect(0, 0, 0, 0)
 
     def __init__(
         self,
         *,
-        parent: Union[RelativeGroup[Any], Callable[[], pygame.rect.Rect]],
+        parent: Union[RelativeGroup[Any], Callable[[], Rect]],
         **kwargs: Any,
     ) -> None:
         self.parent = parent
@@ -415,8 +414,8 @@ class RelativeGroup(MenuSpriteGroup[_MenuElement]):
 
     def calc_absolute_rect(
         self,
-        rect: pygame.rect.Rect,
-    ) -> pygame.rect.Rect:
+        rect: Rect,
+    ) -> Rect:
         self.update_rect_from_parent()
         return rect.move(self.rect.topleft)
 
@@ -424,14 +423,14 @@ class RelativeGroup(MenuSpriteGroup[_MenuElement]):
         if callable(self.parent):
             self.rect = self.parent()
         else:
-            self.rect = pygame.rect.Rect(self.parent.rect)
+            self.rect = Rect(self.parent.rect)
 
     def draw(
         self,
         surface: Surface,
         bgsurf: Any = None,
         special_flags: int = 0,
-    ) -> list[pygame.rect.Rect]:
+    ) -> list[Rect]:
         self.update_rect_from_parent()
         topleft = self.rect.topleft
 
@@ -479,7 +478,7 @@ class VisualSpriteList(RelativeGroup[_MenuElement]):
         self._columns = value
         self._needs_arrange = True
 
-    def calc_bounding_rect(self) -> pygame.rect.Rect:
+    def calc_bounding_rect(self) -> Rect:
         if self._needs_arrange:
             self.arrange_menu_items()
         return super().calc_bounding_rect()

--- a/tuxemon/ui/draw.py
+++ b/tuxemon/ui/draw.py
@@ -179,7 +179,7 @@ def shadow_text(
     size = [int(math.ceil(a + b)) for a, b in zip(offset, top.get_size())]
     image = pygame.Surface(size, pygame.SRCALPHA)
 
-    image.blit(shadow, offset)
+    image.blit(shadow, tuple(offset))
     image.blit(top, (0, 0))
     return image
 


### PR DESCRIPTION
PR proposes to bump pygame-ce, there are no issues, but there are a few new typehints:
- fixes deprecation, from **tostring** to **tobytes**, I remove "utf-8" because it's already defined `encoding: str = "utf-8"`
```
/home/julesverne/Tuxemon/tuxemon/save.py:82: DeprecationWarning: pygame.image.tostring deprecated since 2.3.0
  pygame.image.tostring(screenshot, "RGB")
```
- fixes the following typehints:
```
tuxemon/menu/menu.py:490: note: Following member(s) of "Sequence[float]" have conflicts:
tuxemon/menu/menu.py:490: note:     Expected:
tuxemon/menu/menu.py:490: note:         def __getitem__(self, SupportsIndex, /) -> float
tuxemon/menu/menu.py:490: note:     Got:
tuxemon/menu/menu.py:490: note:         @overload
tuxemon/menu/menu.py:490: note:         def __getitem__(self, int, /) -> float
tuxemon/menu/menu.py:490: note:         @overload
tuxemon/menu/menu.py:490: note:         def __getitem__(self, slice, /) -> Sequence[float]
```

and the following related to this change


