### PR TITLE
fix scenario YAML  + fix probability (Spyder)

### DIFF
--- a/mods/tuxemon/maps/spyder.yaml
+++ b/mods/tuxemon/maps/spyder.yaml
@@ -18,6 +18,7 @@ events:
     - set_variable teleport_clinic:none
     - variable_math cathedral_ads,+,1
     conditions:
+    - is location_type clinic
     - is variable_set teleport_clinic:lost
     height: 1
     width: 1
@@ -27,6 +28,9 @@ events:
   Teleport Exception 1:
     actions:
     - transition_teleport spyder_wayfarer_inn1.tmx,9,6,0.3
+    - set_monster_health
+    - set_monster_status
+    - set_variable teleport_clinic:none
     conditions:
     - is player_defeated
     - is location_name wayfarer_inn1:wayfarer_inn2
@@ -38,6 +42,9 @@ events:
   Teleport Exception 2:
     actions:
     - transition_teleport spyder_scoop2.tmx,9,6,0.3
+    - set_monster_health
+    - set_monster_status
+    - set_variable teleport_clinic:none
     conditions:
     - is player_defeated
     - is location_name scoop3:scoop4
@@ -51,6 +58,7 @@ events:
     - evolution
     conditions:
     - is check_evolution all
+    - is current_state WorldState
     height: 1
     width: 1
     x: 0

--- a/mods/tuxemon/maps/spyder_cotton_tunnel.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_tunnel.tmx
@@ -126,7 +126,7 @@
   </object>
   <object id="65" name="Encounters" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter cotton_tunnel,11"/>
+    <property name="act1" value="random_encounter cotton_tunnel,0.6"/>
    </properties>
   </object>
   <object id="84" name="Create Petrified Dung" type="event" x="384" y="240" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_datacenter.tmx
+++ b/mods/tuxemon/maps/spyder_datacenter.tmx
@@ -347,7 +347,7 @@
   </object>
   <object id="102" name="Wild" type="event" x="304" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter datacenter"/>
+    <property name="act1" value="random_encounter datacenter,0.6"/>
     <property name="cond1" value="not variable_set kernelquest:done"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_dragonscave.tmx
+++ b/mods/tuxemon/maps/spyder_dragonscave.tmx
@@ -482,7 +482,7 @@
   </object>
   <object id="89" name="Encounters" type="event" x="16" y="208" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter dragonscave,6"/>
+    <property name="act1" value="random_encounter dragonscave,0.6"/>
     <property name="cond1" value="not variable_set dragonscavebenden:yes"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_omnichannel1.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel1.tmx
@@ -188,7 +188,7 @@
   </object>
   <object id="48" name="Threats" type="event" x="0" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter omnichannel,6"/>
+    <property name="act1" value="random_encounter omnichannel,0.6"/>
     <property name="cond1" value="is variable_set omnichannel1wall:yes"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_omnichannel2.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel2.tmx
@@ -203,7 +203,7 @@
   </object>
   <object id="42" name="Threats" type="event" x="0" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter omnichannel,6"/>
+    <property name="act1" value="random_encounter omnichannel,0.6"/>
     <property name="cond1" value="is variable_set omnichannel1wall:yes"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_omnichannel3.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel3.tmx
@@ -166,7 +166,7 @@
   </object>
   <object id="50" name="Threats" type="event" x="0" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter omnichannel,6"/>
+    <property name="act1" value="random_encounter omnichannel,0.6"/>
     <property name="cond1" value="is variable_set omnichannel1wall:yes"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_omnichannel4.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel4.tmx
@@ -106,7 +106,7 @@
   </object>
   <object id="40" name="Threats" type="event" x="0" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter omnichannel,6"/>
+    <property name="act1" value="random_encounter omnichannel,0.6"/>
     <property name="cond1" value="is variable_set omnichannel1wall:yes"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_tunnel_below.tmx
+++ b/mods/tuxemon/maps/spyder_tunnel_below.tmx
@@ -181,7 +181,7 @@
   </object>
   <object id="42" name="Encounters" type="event" x="0" y="64" width="16" height="16">
    <properties>
-    <property name="act1" value="random_encounter routeb,6"/>
+    <property name="act1" value="random_encounter routeb,0.6"/>
    </properties>
   </object>
   <object id="54" name="Create Shammer" type="event" x="32" y="608" width="16" height="16">


### PR DESCRIPTION
PR fixes some parts of scenario YAML after testing

PR fixes some probability too, similar to percentages. These places are different because there is a random_encounter event on all the map (eg. cave, datacenter when a virus is released, omnichannel treats, etc.)