### PR TITLE
change call_event (event action) + id (load_events) from maps

### DIFF
--- a/tuxemon/event/actions/call_event.py
+++ b/tuxemon/event/actions/call_event.py
@@ -12,25 +12,25 @@ from tuxemon.event.eventaction import EventAction
 @dataclass
 class CallEventAction(EventAction):
     """
-    Execute the specified event's actions by id.
+    Execute the specified event's actions by name.
 
     Script usage:
         .. code-block::
 
-            call_event <event_id>
+            call_event <event_name>
 
     Script parameters:
-        event_id: The id of the event whose actions will be executed.
+        event_name: The name of the event whose actions will be executed.
 
     """
 
     name = "call_event"
-    event_id: int
+    event_name: str
 
     def start(self) -> None:
         event_engine = self.session.client.event_engine
         events = self.session.client.events
 
         for e in events:
-            if e.id == self.event_id:
+            if e.name == self.event_name:
                 event_engine.start_event(e)

--- a/tuxemon/map_loader.py
+++ b/tuxemon/map_loader.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import logging
+import uuid
 from collections.abc import Generator, Iterator, Mapping
 from math import cos, pi, sin
 from typing import Any, Optional
@@ -379,6 +380,7 @@ class TMXMapLoader:
             Loaded event.
 
         """
+        _id = uuid.uuid4().int
         conds = []
         acts = []
         x = int(obj.x / tile_size[0])
@@ -434,4 +436,4 @@ class TMXMapLoader:
             logger.debug(cond_data)
             conds.append(cond_data)
 
-        return EventObject(obj.id, obj.name, x, y, w, h, conds, acts)
+        return EventObject(_id, obj.name, x, y, w, h, conds, acts)


### PR DESCRIPTION
PR:
- proposes to delete the **call_event** event action, it's unused and calling an event from the id is really tricky, considering the fact the ids in Tiled are progressively assigned;
- proposes to set **uuid** as id as well as for events loaded from maps (as well as I proposed here for #2092 for events from YAML);

