### PR TITLE
menu (event action)

### DIFF
--- a/tuxemon/event/actions/menu.py
+++ b/tuxemon/event/actions/menu.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, final
+
+from tuxemon.event.eventaction import EventAction
+
+
+@final
+@dataclass
+class MenuAction(EventAction):
+    """
+    Enable/disable one or more menu.
+
+    Script usage:
+        .. code-block::
+
+            menu <act>[,menu]
+
+    Script parameters:
+        act: enable or disable
+        menu: specific menu (menu_monster, menu_bag, menu_player,
+            exit, menu_options, menu_save, menu_load)
+            without specification, everything disabled
+
+    eg. menu disable,menu_bag
+    eg. menu enable,menu_player
+
+    """
+
+    name = "menu"
+    act: str
+    menu: Optional[str] = None
+
+    def start(self) -> None:
+        player = self.session.player
+        result = True if self.act == "enable" else False
+
+        if self.menu is None:
+            player.menu_bag = result
+            player.menu_load = result
+            player.menu_monsters = result
+            player.menu_save = result
+            player.menu_player = result
+        else:
+            if self.menu == "menu_bag":
+                player.menu_bag = result
+            elif self.menu == "menu_load":
+                player.menu_load = result
+            elif self.menu == "menu_monsters":
+                player.menu_monsters = result
+            elif self.menu == "menu_save":
+                player.menu_save = result
+            elif self.menu == "menu_player":
+                player.menu_player = result
+            else:
+                raise ValueError(f"{self.menu} isn't valid.")

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -130,6 +130,12 @@ class NPC(Entity[NPCState]):
             str
         ] = []  # list of ways player can interact with the Npc
         self.isplayer: bool = False  # used for various tests, idk
+        # menu labels (world menu)
+        self.menu_save: bool = True
+        self.menu_load: bool = True
+        self.menu_player: bool = True
+        self.menu_monsters: bool = True
+        self.menu_bag: bool = True
         # This is a list of tuxemon the npc has. Do not modify directly
         self.monsters: list[Monster] = []
         # The player's items.


### PR DESCRIPTION
PR:
-implements menu (event action);
-adds a series of bool in npc.py;
-edits world_menu.py, so it'll be possible to hide the labels;
-renames **menu_items_map** into **menu** and  **change_state** into **change** (more compact and less_long_text)

**menu** (event action) will be able to enable or disable certain label of the menu

Maybe a modder for a quest needs to disable the monster or bag menu:
`<property name="act1" value="menu disable,menu_monsters"/>`
or
`<property name="act1" value="menu enable,menu_bag"/>`
![Screenshot_2023-11-16_21-21-04](https://github.com/Tuxemon/Tuxemon/assets/64643719/6c4ddaac-fcbf-4e70-b3d6-37dc8abc277b)

