### PR TITLE
fix npc_wander and npc_look

### DIFF
--- a/tuxemon/event/actions/npc_look.py
+++ b/tuxemon/event/actions/npc_look.py
@@ -43,7 +43,6 @@ class NpcLookAction(EventAction):
     directions: Optional[str] = None
 
     def start(self) -> None:
-        player = self.session.player
         npc = get_npc(self.session, self.npc_slug)
         world = self.session.client.get_state_by_name(WorldState)
         self.limit_direction = []
@@ -54,11 +53,11 @@ class NpcLookAction(EventAction):
             directions: list[str] = ["up", "down", "right", "left"]
             # Suspend looking around if a dialog window is open
             for state in self.session.client.active_states:
-                if state.name == "DialogState":
-                    # retrieve NPC talking to
-                    if player.facing in directions:
-                        return
-                elif state.name == "WorldMenuState":
+                if state.name in (
+                    "WorldMenuState",
+                    "DialogState",
+                    "ChoiceState",
+                ):
                     return
 
             # Choose a random direction

--- a/tuxemon/event/actions/npc_wander.py
+++ b/tuxemon/event/actions/npc_wander.py
@@ -69,22 +69,22 @@ class NpcWanderAction(EventAction):
 
             # Suspend wandering if a dialog window is open
             coords = (0, 0)
+            # retrieve NPC talking to
+            if player.facing == "down":
+                coords = (player.tile_pos[0], player.tile_pos[1] + 1)
+            elif player.facing == "up":
+                coords = (player.tile_pos[0], player.tile_pos[1] - 1)
+            elif player.facing == "left":
+                coords = (player.tile_pos[0] - 1, player.tile_pos[1])
+            elif player.facing == "right":
+                coords = (player.tile_pos[0] + 1, player.tile_pos[1])
+
             for state in self.session.client.active_states:
-                if state.name == "DialogState":
-                    # retrieve NPC talking to
-                    if player.facing == "down":
-                        coords = (player.tile_pos[0], player.tile_pos[1] + 1)
-                    elif player.facing == "up":
-                        coords = (player.tile_pos[0], player.tile_pos[1] - 1)
-                    elif player.facing == "left":
-                        coords = (player.tile_pos[0] - 1, player.tile_pos[1])
-                    elif player.facing == "right":
-                        coords = (player.tile_pos[0] + 1, player.tile_pos[1])
-                elif state.name == "WorldMenuState":
+                if state.name == "WorldMenuState":
                     return
 
             # Choose a random direction that is free and walk toward it
-            origin = (int(npc.tile_pos[0]), int(npc.tile_pos[1]))
+            origin = (npc.tile_pos[0], npc.tile_pos[1])
             exits = world.get_exits(origin)
             if exits:
                 if origin != coords:


### PR DESCRIPTION
PR fixes an issue with **npc_wander** and update **npc_look**
While working on #2105, where the NPC is a npc_wander, I noticed some things really annoying.

I initially noticed that the NPC was stopping with DialogState, but not **ChoiceState**, reason why I add **ChoiceState** to **npc_look**, so the NPC stops looking around.

Looking deeply inside **npc_wander**, I noticed something amiss, I started tracking **coords**, but I realized that the value was always (0,0) because it was inside the loop (the `origin != coords` was pointless) , so I removed the coords from the loop (I left only the block for WorldStateMenu - the main menu -), and everything is fine.

Now if you look at a NPC wandering, it stops, so you can interact, then as soon as you look away from it, it starts again to wander.