### PR TITLE
update PCState (state)

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -2783,9 +2783,6 @@ msgstr "This shelter is empty, there are no monsters to take."
 msgid "menu_storage_full_kennel"
 msgstr "This shelter is full."
 
-msgid "menu_storage_hidden_kennel"
-msgstr "Unable to access the hidden storage."
-
 msgid "menu_storage_empty_locker"
 msgstr "This locker is empty, there are no items to take."
 
@@ -2794,9 +2791,6 @@ msgstr "Disband"
 
 msgid "item_disbanded"
 msgstr "{nr} {name} have been disbanded."
-
-msgid "menu_dropoff_no_monsters"
-msgstr "Can't drop off the last Tuxemon in your party."
 
 msgid "pick_up"
 msgstr "pick up"

--- a/tuxemon/states/idle/image_state.py
+++ b/tuxemon/states/idle/image_state.py
@@ -15,7 +15,7 @@ from tuxemon.platform.events import PlayerInput
 
 class ImageState(PygameMenuState):
     """
-    It imposes an image over the world, where it'll be possible to 
+    It imposes an image over the world, where it'll be possible to
     dispay dialogues, etc.
     """
 

--- a/tuxemon/states/multiplayer/__init__.py
+++ b/tuxemon/states/multiplayer/__init__.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from collections.abc import Callable, Generator
+
+import pygame_menu
+
+from tuxemon.animation import Animation
+from tuxemon.locale import T
+from tuxemon.menu.input import InputMenu
+from tuxemon.menu.interface import MenuItem
+from tuxemon.menu.menu import PopUpMenu, PygameMenuState
+from tuxemon.session import local_session
+from tuxemon.tools import open_dialog
+
+MenuGameObj = Callable[[], object]
+
+
+def add_menu_items(
+    menu: pygame_menu.Menu,
+    items: list[tuple[str, MenuGameObj]],
+) -> None:
+    for key, callback in items:
+        label = T.translate(key).upper()
+        menu.add.button(label, callback)
+
+
+class MultiplayerMenu(PygameMenuState):
+    """MP Menu
+
+    code salvaged from commit 6fa20da714c7b794cbe1e8a22168fa66cda13a9e
+    """
+
+    shrink_to_items = True
+
+    def __init__(self) -> None:
+        super().__init__()
+
+        menu: list[tuple[str, MenuGameObj]] = []
+        menu.append(("multiplayer_host_game", self.host_game))
+        menu.append(("multiplayer_scan_games", self.scan_for_games))
+        menu.append(("multiplayer_join_game", self.join_by_ip))
+
+        add_menu_items(self.menu, menu)
+
+    def update_animation_size(self) -> None:
+        widgets_size = self.menu.get_size(widget=True)
+        self.menu.resize(
+            max(1, int(widgets_size[0] * self.animation_size)),
+            max(1, int(widgets_size[1] * self.animation_size)),
+        )
+
+    def animate_open(self) -> Animation:
+        """
+        Animate the menu popping in.
+
+        Returns:
+            Popping in animation.
+
+        """
+        self.animation_size = 0.0
+
+        ani = self.animate(self, animation_size=1.0, duration=0.2)
+        ani.update_callback = self.update_animation_size
+
+        return ani
+
+    def host_game(self) -> None:
+        # check if server is already hosting a game
+        if self.client.server.listening:
+            self.client.pop_state(self)
+            open_dialog(
+                local_session, [T.translate("multiplayer_already_hosting")]
+            )
+
+        # not hosting, so start the process
+        elif not self.client.isclient:
+            # Configure this game to host
+            self.client.ishost = True
+            self.client.server.server.listen()
+            self.client.server.listening = True
+
+            # Enable the game, so we can connect to self
+            self.client.client.enable_join_multiplayer = True
+            self.client.client.client.listen()
+            self.client.client.listening = True
+
+            # connect to self
+            while not self.client.client.client.registered:
+                self.client.client.client.autodiscover(autoregister=False)
+                for game in self.client.client.client.discovered_servers:
+                    self.client.client.client.register(game)
+
+            # close this menu
+            self.client.pop_state(self)
+
+            # inform player that hosting is ready
+            open_dialog(
+                local_session, [T.translate("multiplayer_hosting_ready")]
+            )
+
+    def scan_for_games(self) -> None:
+        # start the game scanner
+        if not self.client.ishost:
+            self.client.client.enable_join_multiplayer = True
+            self.client.client.listening = True
+            self.client.client.client.listen()
+
+        # open menu to select games
+        self.client.push_state(MultiplayerSelect())
+
+    def join_by_ip(self) -> None:
+        self.client.push_state(
+            InputMenu(prompt=T.translate("multiplayer_join_prompt"))
+        )
+
+    def join(self) -> None:
+        if self.client.ishost:
+            return
+        else:
+            self.client.client.enable_join_multiplayer = True
+            self.client.client.listening = True
+            # self.client.client.game.listen()  # "LocalPygameClient" has no attribute "listen"
+
+
+class MultiplayerSelect(PopUpMenu[None]):
+    """Menu to show games found by the network game scanner"""
+
+    shrink_to_items = True
+
+    def __init__(self) -> None:
+        super().__init__()
+
+        # make a timer to refresh the menu items every second
+        self.task(self.reload_items, 1, -1)
+
+    def initialize_items(self) -> Generator[MenuItem[None], None, None]:
+        servers = self.client.client.server_list
+        if servers:
+            for server in servers:
+                label = self.shadow_text(server)
+                yield MenuItem(label, None, None, None)
+        else:
+            label = self.shadow_text(T.translate("multiplayer_no_servers"))
+            item = MenuItem(label, None, None, None)
+            item.enabled = False
+            yield item

--- a/tuxemon/states/pc/__init__.py
+++ b/tuxemon/states/pc/__init__.py
@@ -1,24 +1,21 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
-""" This module contains the PCState state.
-"""
 from __future__ import annotations
 
-import logging
-from collections.abc import Callable, Generator, Sequence
+from collections.abc import Callable
 from functools import partial
 from typing import Any
 
+import pygame_menu
+
+from tuxemon.animation import Animation
 from tuxemon.locale import T
-from tuxemon.menu.input import InputMenu
-from tuxemon.menu.interface import MenuItem
-from tuxemon.menu.menu import Menu, PopUpMenu
+from tuxemon.menu.menu import PygameMenuState
 from tuxemon.session import local_session
 from tuxemon.state import State
+from tuxemon.states.pc_kennel import HIDDEN_LIST
+from tuxemon.states.pc_locker import HIDDEN_LIST_LOCKER
 from tuxemon.tools import open_dialog
-
-logger = logging.getLogger(__name__)
-
 
 MenuGameObj = Callable[[], object]
 
@@ -27,182 +24,106 @@ LOCKER = "Locker"
 
 
 def add_menu_items(
-    state: Menu[MenuGameObj],
-    items: Sequence[tuple[str, MenuGameObj]],
+    menu: pygame_menu.Menu,
+    items: list[tuple[str, MenuGameObj]],
 ) -> None:
     for key, callback in items:
         label = T.translate(key).upper()
-
-        state.build_item(label, callback)
+        menu.add.button(label, callback)
 
 
 def not_implemented_dialog() -> None:
     open_dialog(local_session, [T.translate("not_implemented")])
 
 
-class PCState(PopUpMenu[MenuGameObj]):
-    """The state responsible in game settings."""
-
-    shrink_to_items = True
+class PCState(PygameMenuState):
+    """The PC State: deposit monster, deposit item, etc."""
 
     def __init__(self) -> None:
         super().__init__()
+        player = local_session.player
 
         # it creates the kennel and locker (new players)
-        if KENNEL not in local_session.player.monster_boxes.keys():
-            local_session.player.monster_boxes[KENNEL] = []
-        if LOCKER not in local_session.player.item_boxes.keys():
-            local_session.player.item_boxes[LOCKER] = []
+        if KENNEL not in player.monster_boxes.keys():
+            player.monster_boxes[KENNEL] = []
+        if LOCKER not in player.item_boxes.keys():
+            player.item_boxes[LOCKER] = []
 
         def change_state(state: str, **kwargs: Any) -> partial[State]:
             return partial(self.client.replace_state, state, **kwargs)
 
         # monster boxes
-        if len(local_session.player.monsters) == 6:
-            storage_callback = partial(
+        if len(player.monsters) == 6:
+            storage = partial(
                 open_dialog,
                 local_session,
                 [T.translate("menu_storage_monsters_full")],
             )
         else:
-            storage_callback = change_state("MonsterBoxChooseStorageState")
+            storage = change_state("MonsterStorageState")
 
-        if len(local_session.player.monsters) <= 1:
-            dropoff_callback = partial(
-                open_dialog,
-                local_session,
-                [T.translate("menu_dropoff_no_monsters")],
-            )
-        else:
-            dropoff_callback = change_state("MonsterBoxChooseDropOffState")
+        dropoff = change_state("MonsterDropOffState")
 
         # item boxes
-        if len(local_session.player.items) == 30:
-            storage_callback = partial(
+        if len(player.items) == 30:
+            storage = partial(
                 open_dialog,
                 local_session,
                 [T.translate("menu_storage_items_full")],
             )
         else:
-            item_storage_callback = change_state("ItemBoxChooseStorageState")
+            item_storage = change_state("ItemStorageState")
 
-        item_dropoff_callback = change_state("ItemBoxChooseDropOffState")
+        item_dropoff = change_state("ItemDropOffState")
 
-        add_menu_items(
-            self,
-            (
-                ("menu_storage", storage_callback),
-                ("menu_dropoff", dropoff_callback),
-                ("bank", change_state("NuPhoneBanking")),
-                ("menu_item_storage", item_storage_callback),
-                ("menu_item_dropoff", item_dropoff_callback),
-                (
-                    "menu_multiplayer",
-                    not_implemented_dialog,
-                ),  # change_state("MultiplayerMenu")),
-                ("log_off", self.client.pop_state),
-            ),
+        multiplayer = change_state("MultiplayerMenu")
+
+        _nr_monsters = [
+            len(mons)
+            for box, mons in player.monster_boxes.items()
+            if box not in HIDDEN_LIST
+        ]
+        nr_monsters = sum(_nr_monsters)
+        _nr_items = [
+            len(itm)
+            for box, itm in player.item_boxes.items()
+            if box not in HIDDEN_LIST_LOCKER
+        ]
+        nr_items = sum(_nr_items)
+
+        menu: list[tuple[str, MenuGameObj]] = []
+        if nr_monsters > 0:
+            menu.append(("menu_storage", storage))
+        if len(player.monsters) > 1:
+            menu.append(("menu_dropoff", dropoff))
+        if nr_items > 0:
+            menu.append(("menu_item_storage", item_storage))
+        if len(player.items) > 1:
+            menu.append(("menu_item_dropoff", item_dropoff))
+        # replace multiplayer when fixed
+        menu.append(("menu_multiplayer", not_implemented_dialog))
+        menu.append(("log_off", self.client.pop_state))
+
+        add_menu_items(self.menu, menu)
+
+    def update_animation_size(self) -> None:
+        widgets_size = self.menu.get_size(widget=True)
+        self.menu.resize(
+            max(1, int(widgets_size[0] * self.animation_size)),
+            max(1, int(widgets_size[1] * self.animation_size)),
         )
 
+    def animate_open(self) -> Animation:
+        """
+        Animate the menu popping in.
 
-# unused
-class MultiplayerMenu(PopUpMenu[MenuGameObj]):
-    """MP Menu
+        Returns:
+            Popping in animation.
 
-    code salvaged from commit 6fa20da714c7b794cbe1e8a22168fa66cda13a9e
-    """
+        """
+        self.animation_size = 0.0
 
-    shrink_to_items = True
+        ani = self.animate(self, animation_size=1.0, duration=0.2)
+        ani.update_callback = self.update_animation_size
 
-    def __init__(self) -> None:
-        super().__init__()
-
-        add_menu_items(
-            self,
-            (
-                ("multiplayer_host_game", self.host_game),
-                ("multiplayer_scan_games", self.scan_for_games),
-                ("multiplayer_join_game", self.join_by_ip),
-            ),
-        )
-
-    def host_game(self) -> None:
-        # check if server is already hosting a game
-        if self.client.server.listening:
-            self.client.pop_state(self)
-            open_dialog(
-                local_session, [T.translate("multiplayer_already_hosting")]
-            )
-
-        # not hosting, so start the process
-        elif not self.client.isclient:
-            # Configure this game to host
-            self.client.ishost = True
-            self.client.server.server.listen()
-            self.client.server.listening = True
-
-            # Enable the game, so we can connect to self
-            self.client.client.enable_join_multiplayer = True
-            self.client.client.client.listen()
-            self.client.client.listening = True
-
-            # connect to self
-            while not self.client.client.client.registered:
-                self.client.client.client.autodiscover(autoregister=False)
-                for game in self.client.client.client.discovered_servers:
-                    self.client.client.client.register(game)
-
-            # close this menu
-            self.client.pop_state(self)
-
-            # inform player that hosting is ready
-            open_dialog(
-                local_session, [T.translate("multiplayer_hosting_ready")]
-            )
-
-    def scan_for_games(self) -> None:
-        # start the game scanner
-        if not self.client.ishost:
-            self.client.client.enable_join_multiplayer = True
-            self.client.client.listening = True
-            self.client.client.client.listen()
-
-        # open menu to select games
-        self.client.push_state(MultiplayerSelect())
-
-    def join_by_ip(self) -> None:
-        self.client.push_state(
-            InputMenu(prompt=T.translate("multiplayer_join_prompt"))
-        )
-
-    def join(self) -> None:
-        if self.client.ishost:
-            return
-        else:
-            self.client.client.enable_join_multiplayer = True
-            self.client.client.listening = True
-            # self.client.client.game.listen()  # "LocalPygameClient" has no attribute "listen"
-
-
-class MultiplayerSelect(PopUpMenu[None]):
-    """Menu to show games found by the network game scanner"""
-
-    shrink_to_items = True
-
-    def __init__(self) -> None:
-        super().__init__()
-
-        # make a timer to refresh the menu items every second
-        self.task(self.reload_items, 1, -1)
-
-    def initialize_items(self) -> Generator[MenuItem[None], None, None]:
-        servers = self.client.client.server_list
-        if servers:
-            for server in servers:
-                label = self.shadow_text(server)
-                yield MenuItem(label, None, None, None)
-        else:
-            label = self.shadow_text(T.translate("multiplayer_no_servers"))
-            item = MenuItem(label, None, None, None)
-            item.enabled = False
-            yield item
+        return ani

--- a/tuxemon/states/pc_kennel/__init__.py
+++ b/tuxemon/states/pc_kennel/__init__.py
@@ -68,8 +68,12 @@ class MonsterTakeState(PygameMenuState):
             iid = uuid.UUID(instance_id)
             mon = self.player.find_monster_in_storage(iid)
 
-            # list with all the kennels and removes where we are
-            kennels = list(local_session.player.monster_boxes.keys())
+            # all kennels available with less than max value
+            kennels = [
+                key
+                for key, value in self.player.monster_boxes.items()
+                if len(value) < MAX_BOX and key not in HIDDEN_LIST
+            ]
             kennels.remove(self.box_name)
 
             # updates the kennel and executes operation
@@ -282,7 +286,7 @@ class MonsterTakeState(PygameMenuState):
         theme.title = False
 
 
-class MonsterBoxChooseState(PygameMenuState):
+class MonsterBoxState(PygameMenuState):
     """Menu to choose a tuxemon box."""
 
     def __init__(self) -> None:
@@ -302,7 +306,8 @@ class MonsterBoxChooseState(PygameMenuState):
     ) -> None:
         menu.add.vertical_fill()
         for key, callback in items:
-            num_mons = local_session.player.monster_boxes[key]
+            player = local_session.player
+            num_mons = player.monster_boxes[key]
             label = T.format(
                 f"{T.translate(key).upper()}: {len(num_mons)}/{MAX_BOX}"
             )
@@ -362,7 +367,7 @@ class MonsterBoxChooseState(PygameMenuState):
         return ani
 
 
-class MonsterBoxChooseStorageState(MonsterBoxChooseState):
+class MonsterStorageState(MonsterBoxState):
     """Menu to choose a box, which you can then take a tuxemon from."""
 
     def get_menu_items_map(self) -> Sequence[tuple[str, MenuGameObj]]:
@@ -384,7 +389,7 @@ class MonsterBoxChooseStorageState(MonsterBoxChooseState):
         return menu_items_map
 
 
-class MonsterBoxChooseDropOffState(MonsterBoxChooseState):
+class MonsterDropOffState(MonsterBoxState):
     """Menu to choose a box, which you can then drop off a tuxemon into."""
 
     def get_menu_items_map(self) -> Sequence[tuple[str, MenuGameObj]]:
@@ -392,9 +397,9 @@ class MonsterBoxChooseDropOffState(MonsterBoxChooseState):
         menu_items_map = []
         for box_name, monsters in player.monster_boxes.items():
             if box_name not in HIDDEN_LIST:
-                if len(monsters) <= MAX_BOX:
+                if len(monsters) < MAX_BOX:
                     menu_callback = self.change_state(
-                        "MonsterDropOffState", box_name=box_name
+                        "MonsterDropOff", box_name=box_name
                     )
                 else:
                     menu_callback = partial(
@@ -402,17 +407,11 @@ class MonsterBoxChooseDropOffState(MonsterBoxChooseState):
                         local_session,
                         [T.translate("menu_storage_full_kennel")],
                     )
-            else:
-                menu_callback = partial(
-                    open_dialog,
-                    local_session,
-                    [T.translate("menu_storage_hidden_kennel")],
-                )
-            menu_items_map.append((box_name, menu_callback))
+                menu_items_map.append((box_name, menu_callback))
         return menu_items_map
 
 
-class MonsterDropOffState(MonsterMenuState):
+class MonsterDropOff(MonsterMenuState):
     """Shows all Tuxemon in player's party, puts it into box if selected."""
 
     def __init__(self, box_name: str) -> None:

--- a/tuxemon/states/pc_locker/__init__.py
+++ b/tuxemon/states/pc_locker/__init__.py
@@ -68,7 +68,11 @@ class ItemTakeState(PygameMenuState):
             itm = self.player.find_item_in_storage(iid)
 
             # list with all the lockers and removes where we are
-            lockers = list(local_session.player.item_boxes.keys())
+            lockers = [
+                key
+                for key in self.player.item_boxes
+                if key not in HIDDEN_LIST_LOCKER
+            ]
             lockers.remove(self.box_name)
 
             # updates the kennel and executes operation
@@ -299,7 +303,7 @@ class ItemTakeState(PygameMenuState):
         theme.title = False
 
 
-class ItemBoxChooseState(PygameMenuState):
+class ItemBoxState(PygameMenuState):
     """Menu to choose an item box."""
 
     def __init__(self) -> None:
@@ -381,7 +385,7 @@ class ItemBoxChooseState(PygameMenuState):
         return ani
 
 
-class ItemBoxChooseStorageState(ItemBoxChooseState):
+class ItemStorageState(ItemBoxState):
     """Menu to choose a box, which you can then take an item from."""
 
     def get_menu_items_map(self) -> Sequence[tuple[str, MenuGameObj]]:
@@ -403,7 +407,7 @@ class ItemBoxChooseStorageState(ItemBoxChooseState):
         return menu_items_map
 
 
-class ItemBoxChooseDropOffState(ItemBoxChooseState):
+class ItemDropOffState(ItemBoxState):
     """Menu to choose a box, which you can then drop off an item into."""
 
     def get_menu_items_map(self) -> Sequence[tuple[str, MenuGameObj]]:
@@ -412,13 +416,13 @@ class ItemBoxChooseDropOffState(ItemBoxChooseState):
         for box_name, items in player.item_boxes.items():
             if box_name not in HIDDEN_LIST_LOCKER:
                 menu_callback = self.change_state(
-                    "ItemDropOffState", box_name=box_name
+                    "ItemDropOff", box_name=box_name
                 )
-            menu_items_map.append((box_name, menu_callback))
+                menu_items_map.append((box_name, menu_callback))
         return menu_items_map
 
 
-class ItemDropOffState(ItemMenuState):
+class ItemDropOff(ItemMenuState):
     """Shows all items in player's bag, puts it into box if selected."""
 
     def __init__(self, box_name: str) -> None:


### PR DESCRIPTION
PR:
- updates PcState (now PyGameMenu);
- splits PcState and MultiplayerMenu (separate files);
- updates MultiplayerMenu (now PyGameMenu);
- edits some names (too long)
- fix bug (it was possible to move monsters between boxes even above the limit);
- fix bug (it was possible to drop off monsters in full boxes);
- fix bug (it was possible to see and interact with hidden boxes, now the boxes will not appear anymore, neither during picking up or dropping off);

regarding names too long from:
`class MonsterBoxChooseStorageState(MonsterBoxChooseState):`
to
`class MonsterStorageState(MonsterBoxState):`

no monsters/items inside the boxes? then menu storage doesn't appear;
player has only 1 monster or not monster at all? then menu dropoff doesn't appear;

![Screenshot_2023-11-19_10-06-28](https://github.com/Tuxemon/Tuxemon/assets/64643719/b805717f-f360-4407-8f6c-44b4921613e7)
