### PR TITLE
update shop

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -46,7 +46,7 @@ msgid "imperial_potion_description"
 msgstr "Heals a monster by 500 HP."
 
 msgid "mega_potion"
-msgstr "Imperial Potion"
+msgstr "Mega Potion"
 
 msgid "mega_potion_description"
 msgstr "Heals a monster by 200 HP."
@@ -2555,6 +2555,12 @@ msgstr "FREE!"
 
 msgid "shop_buy_soldout"
 msgstr "Sold Out!"
+
+msgid "buy"
+msgstr "Buy"
+
+msgid "sell"
+msgstr "Sell"
 
 #Release notifications
 msgid "cant_release"

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -895,6 +895,14 @@ class EconomyItemModel(BaseModel):
             return v
         raise ValueError(f"the item {v} doesn't exist in the db")
 
+    @field_validator("variable")
+    def variable_exists(
+        cls: EconomyItemModel, v: Optional[str]
+    ) -> Optional[str]:
+        if not v or v.find(":") > 1:
+            return v
+        raise ValueError(f"the variable {v} isn't formatted correctly")
+
 
 class EconomyModel(BaseModel):
     slug: str = Field(..., description="Slug uniquely identifying the economy")

--- a/tuxemon/event/actions/open_shop.py
+++ b/tuxemon/event/actions/open_shop.py
@@ -9,6 +9,7 @@ from typing import Optional, final
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.item.economy import Economy
+from tuxemon.locale import T
 from tuxemon.npc import NPC
 from tuxemon.states.choice.choice_state import ChoiceState
 from tuxemon.states.items.shop_menu import ShopBuyMenuState, ShopSellMenuState
@@ -62,29 +63,30 @@ class OpenShopAction(EventAction):
                 )
             )
 
+        def buy_menu(npc: NPC) -> None:
+            self.session.client.pop_state()
+            push_buy_menu(npc)
+
+        def sell_menu(npc: NPC) -> None:
+            self.session.client.pop_state()
+            push_sell_menu(npc)
+
+        buy = T.translate("buy")
+        sell = T.translate("sell")
+
+        var_menu = [
+            (buy, buy, partial(buy_menu, npc)),
+            (sell, sell, partial(sell_menu, npc)),
+        ]
+
         menu = self.menu or "both"
         if menu == "both":
-
-            def buy_menu(npc: NPC) -> None:
-                self.session.client.pop_state()
-                push_buy_menu(npc)
-
-            def sell_menu(npc: NPC) -> None:
-                self.session.client.pop_state()
-                push_sell_menu(npc)
-
-            var_menu = [
-                ("Buy", "Buy", partial(buy_menu, npc)),
-                ("Sell", "Sell", partial(sell_menu, npc)),
-            ]
-
             self.session.client.push_state(
                 ChoiceState(
                     menu=var_menu,
                     escape_key_exits=True,
                 )
             )
-
         elif menu == "buy":
             push_buy_menu(npc)
         elif menu == "sell":

--- a/tuxemon/menu/menu.py
+++ b/tuxemon/menu/menu.py
@@ -182,6 +182,7 @@ class Menu(Generic[T], state.State):
     background_color: ColorLike = BACKGROUND_COLOR
     # Font color when the action is unavailable
     unavailable_color: ColorLike = (220, 220, 220)
+    unavailable_color_shop: ColorLike = (51, 51, 51)
     # File to load for image background
     background_filename: Optional[str] = None
     menu_select_sound_filename = "sound_menu_select"

--- a/tuxemon/menu/quantity.py
+++ b/tuxemon/menu/quantity.py
@@ -76,8 +76,8 @@ class QuantityMenu(Menu[None]):
             elif event.button == buttons.LEFT:
                 self.quantity -= 10
 
-            if self.quantity < 0:
-                self.quantity = 0
+            if self.quantity <= 0:
+                self.quantity = 1
             elif (
                 self.max_quantity is not None
                 and self.quantity > self.max_quantity
@@ -89,25 +89,15 @@ class QuantityMenu(Menu[None]):
         return None
 
     def initialize_items(self) -> Generator[MenuItem[None], None, None]:
-        # TODO: move this and other format strings to a locale or config file
-        label_format = "x {:>{count_len}}".format
-        count_len = 3
-
-        formatted_name = label_format(self.quantity, count_len=count_len)
-        image = self.shadow_text(formatted_name, bg=(128, 128, 128))
-        yield MenuItem(image, formatted_name, None, None)
+        label = f"{'x':1} {self.quantity}"
+        image = self.shadow_text(label)
+        yield MenuItem(image, label, None, None)
 
     def show_money(self) -> Generator[MenuItem[None], None, None]:
-        # Show the money in the buying/selling menu
-        count_len = 3
-        label_format_money = "Money {:>{count_len}}".format
-        money = str(local_session.player.money["player"])
-
-        formatted_name_money = label_format_money(money, count_len=count_len)
-        image_money = self.shadow_text(
-            formatted_name_money, bg=(128, 128, 128)
-        )
-        yield MenuItem(image_money, formatted_name_money, None, None)
+        money = local_session.player.money["player"]
+        label = f"{T.translate('wallet')}: {money}"
+        image_money = self.shadow_text(label)
+        yield MenuItem(image_money, label, None, None)
 
 
 class QuantityAndPriceMenu(QuantityMenu):
@@ -125,25 +115,13 @@ class QuantityAndPriceMenu(QuantityMenu):
         # Show the quantity by using the method from the parent class:
         yield from super().initialize_items()
 
-        # Now, show the price:
-        wallet = local_session.player.money["player"]
-        label_format = "$ {:>{count_len}}".format
-        count_len = 3
         price = (
             self.price if self.quantity == 0 else self.quantity * self.price
         )
-        if int(price) == 0:
-            price_tag = T.translate("shop_buy_free")
-        else:
-            price_tag = str(price)
-            if self.quantity == 0 and price > wallet:
-                price_tag = T.translate("shop_buy_soldout")
-            if price > wallet:
-                self.quantity = 0
-
-        formatted_name = label_format(price_tag, count_len=count_len)
-        image = self.shadow_text(formatted_name, bg=(128, 128, 128))
-        yield MenuItem(image, formatted_name, None, None)
+        price_tag = T.translate("shop_buy_free") if price == 0 else price
+        label = f"{'$':1} {price_tag}"
+        image = self.shadow_text(label)
+        yield MenuItem(image, label, None, None)
 
 
 class QuantityAndCostMenu(QuantityMenu):
@@ -161,16 +139,7 @@ class QuantityAndCostMenu(QuantityMenu):
         # Show the quantity by using the method from the parent class:
         yield from super().initialize_items()
 
-        # Now, show the cost:
-        label_format = "$ {:>{count_len}}".format
-        count_len = 3
-
         cost = self.cost if self.quantity == 0 else self.quantity * self.cost
-        if int(cost) == 0:
-            cost_tag = T.translate("shop_buy_free")
-        else:
-            cost_tag = str(cost)
-
-        formatted_name = label_format(cost_tag, count_len=count_len)
-        image = self.shadow_text(formatted_name, bg=(128, 128, 128))
-        yield MenuItem(image, formatted_name, None, None)
+        label = f"{'$':1} {cost}"
+        image = self.shadow_text(label)
+        yield MenuItem(image, label, None, None)


### PR DESCRIPTION
PR updates shop:
- if **no money** in the wallet, then it'll **not be possible to select** certain items;
- the items will be displayed by **price sorting** (from lower to higher);
- **prices** will be displayed in the main window;
- adds **buy** and **sell** inside the PO files, previously both were hardcoded > no translation;
- saves quantities of shop items inside **variables**;
- if a **quantity = 0**, then it'll appear **soldout** label  (see below);
- adds a **field_validator** inside **db.py** for checking if the variable is in the correct format (months ago I added this possibility, so modders can make appear certain items after quests, etc.)
- some edits in **set_economy**, it removes the default shop (it doesn't exist), it removes the raise (since there is the check inside db.py);
- corrects **Mega** Potion name, before it was Imperial, but Imperial exists already;

![Screenshot_2023-11-21_12-25-05](https://github.com/Tuxemon/Tuxemon/assets/64643719/da1cb3a8-b4c8-4d67-bd39-e0170fc949e0)
![Screenshot_2023-11-21_13-48-07](https://github.com/Tuxemon/Tuxemon/assets/64643719/c68cc39d-770f-46aa-ab9b-1f59dc84ad43)
![Screenshot_2023-11-22_15-03-57](https://github.com/Tuxemon/Tuxemon/assets/64643719/38a8046b-1a5d-42aa-a70f-dad1f5e0e30c)

