### PR TITLE
test_npcs.tmx + test_npcs.yaml + 2 tests + fix 2 bugs

### DIFF
--- a/mods/tuxemon/db/npc/test_npcs.json
+++ b/mods/tuxemon/db/npc/test_npcs.json
@@ -1,0 +1,5002 @@
+[
+  {
+    "slug": "test_npc001",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc002",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc003",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc004",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc005",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc006",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc007",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc008",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc009",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc010",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc011",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc012",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc013",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc014",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc015",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc016",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc017",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc018",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc019",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc020",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc021",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc022",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc023",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc024",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc025",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc026",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc027",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc028",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc029",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc030",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc031",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc032",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc033",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc034",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc035",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc036",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc037",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc038",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc039",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc040",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc041",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc042",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc043",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc044",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc045",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc046",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc047",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc048",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc049",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc050",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc051",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc052",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc053",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc054",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc055",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc056",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc057",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc058",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc059",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc060",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc061",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc062",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc063",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc064",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc065",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc066",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc067",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc068",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc069",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc070",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc071",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc072",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc073",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc074",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc075",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc076",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc077",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc078",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc079",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc080",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc081",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc082",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc083",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc084",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc085",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc086",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc087",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc088",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc089",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc090",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc091",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc092",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc093",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc094",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc095",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc096",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc097",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc098",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc099",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc100",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc101",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc102",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc103",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc104",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc105",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc106",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc107",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc108",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc109",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc110",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc111",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc112",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc113",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc114",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc115",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc116",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc117",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc118",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc119",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc120",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc121",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc122",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc123",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc124",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc125",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc126",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc127",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc128",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc129",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc130",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc131",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc132",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc133",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc134",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc135",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc136",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc137",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc138",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc139",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc140",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc141",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc142",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc143",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc144",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc145",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc146",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc147",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc148",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc149",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc150",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc151",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc152",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc153",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc154",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc155",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc156",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc157",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc158",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc159",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc160",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc161",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc162",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc163",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc164",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc165",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc166",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc167",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc168",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc169",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc170",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc171",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc172",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc173",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc174",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc175",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc176",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc177",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc178",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc179",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc180",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc181",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc182",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc183",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc184",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc185",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc186",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc187",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc188",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc189",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc190",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc191",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc192",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc193",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc194",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc195",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc196",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc197",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc198",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc199",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc200",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc201",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc202",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc203",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc204",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc205",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc206",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc207",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc208",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc209",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc210",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc211",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc212",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc213",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc214",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc215",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc216",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc217",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc218",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc219",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc220",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc221",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc222",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc223",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc224",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc225",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc226",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc227",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc228",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc229",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc230",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc231",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc232",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc233",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc234",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc235",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc236",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc237",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc238",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc239",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc240",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc241",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc242",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc243",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc244",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc245",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc246",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc247",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc248",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc249",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc250",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc251",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc252",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc253",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc254",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc255",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc256",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc257",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc258",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc259",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc260",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc261",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc262",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc263",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc264",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc265",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc266",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc267",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc268",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc269",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc270",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc271",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc272",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc273",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc274",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc275",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc276",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc277",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc278",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc279",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc280",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc281",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc282",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc283",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc284",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc285",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc286",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc287",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc288",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc289",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc290",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc291",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc292",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc293",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc294",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc295",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc296",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc297",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc298",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc299",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc300",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc301",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc302",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc303",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc304",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc305",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc306",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc307",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc308",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc309",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc310",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc311",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc312",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc313",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc314",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc315",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc316",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc317",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc318",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc319",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc320",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc321",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc322",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc323",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc324",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc325",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc326",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc327",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc328",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc329",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc330",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc331",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc332",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc333",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc334",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc335",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc336",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc337",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc338",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc339",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc340",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc341",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc342",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc343",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc344",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc345",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc346",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc347",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc348",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc349",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc350",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc351",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc352",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc353",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc354",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc355",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc356",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc357",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc358",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc359",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc360",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc361",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc362",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc363",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc364",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc365",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc366",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc367",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc368",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc369",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc370",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc371",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc372",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc373",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc374",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc375",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc376",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc377",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc378",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc379",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc380",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc381",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc382",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc383",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc384",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc385",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc386",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc387",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc388",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc389",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc390",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc391",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc392",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc393",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc394",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc395",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc396",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc397",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc398",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc399",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc400",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc401",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc402",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc403",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc404",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc405",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc406",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc407",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc408",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc409",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc410",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc411",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc412",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc413",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc414",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc415",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc416",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc417",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc418",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc419",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc420",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc421",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc422",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc423",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc424",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc425",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc426",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc427",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc428",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc429",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc430",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc431",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc432",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc433",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc434",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc435",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc436",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc437",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc438",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc439",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc440",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc441",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc442",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc443",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc444",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc445",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc446",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc447",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc448",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc449",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc450",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc451",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc452",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc453",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc454",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc455",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc456",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc457",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc458",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc459",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc460",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc461",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc462",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc463",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc464",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc465",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc466",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc467",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc468",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc469",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc470",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc471",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc472",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc473",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc474",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc475",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc476",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc477",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc478",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc479",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc480",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc481",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc482",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc483",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc484",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc485",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc486",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc487",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc488",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc489",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc490",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc491",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc492",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc493",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc494",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc495",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc496",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc497",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc498",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc499",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  },
+  {
+    "slug": "test_npc500",
+    "template": [
+      {
+        "sprite_name": "professor",
+        "combat_front": "professor",
+        "slug": "professor"
+      }
+    ]
+  }
+]

--- a/mods/tuxemon/maps/test_npcs.tmx
+++ b/mods/tuxemon/maps/test_npcs.tmx
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="594">
+ <properties>
+  <property name="edges" value="clamped"/>
+  <property name="slug" value="test_npcs"/>
+  <property name="types" value="notype"/>
+ </properties>
+ <tileset firstgid="1" source="../gfx/tilesets/core_outdoor.tsx"/>
+ <layer id="1" name="Tile Layer 1" width="40" height="40">
+  <data encoding="base64" compression="zlib">
+   eAHtV0FywzAIdK7JZ31J+pcmf4n7mOYdhYNmtppdi9iyWnt0YOQQBKsFgzUOwzAeVK52rtsGUouvT8N230Ae5pNhzPn4EHZpb0t8ju1y+s3H2X7PYWyJT8Waw6j2rM055jfVd84dxkD7lFtfW+BDHOr5L/FNxoPLy+Q/4kv5Urn6NtxfJskOV7VHnTOqZ/lSsZhtwqj2RHEoOxbzaRxNRBR3jrElvsTJO2vHx+s+ymHnbx/85d8taeaV1rmZqHpHRJ/3l63qKIKF2ewZn88z1qdb6vKZgPnNuY32mi3tOr56fazn930uj1p/S+dOaS75/3ivXcof7mNzYI0O3wOMg/pST8N9a7CwvYgD4/h9PMK/2+D3gZo7eC9UNmw24QxBfOwsER2eF3lH38oG7dkz+ohgYTYqNvpWNgwT6tTdjfGudJgP9F0DH/qr/bwnfOrdw15Xm5+SP+SP1a3rltZlKXbk/0htq9qN+O82898zP94ARYI=
+  </data>
+ </layer>
+ <layer id="2" name="Tile Layer 2" width="40" height="40">
+  <data encoding="base64" compression="zlib">
+   eAHtWAsKwjAM7USv4ucqbnoVETyKel4T8EEIkyaxazdYoSRrX9LXl85tdtuUNtS7jE3UesIM1Gu2Pa13oJ6zzAl7qMkPmuQsc8IeavI77lI6Ubc07MGCLYW5ELerkV+L+nr0a1Ffj34t6us5Jy3q6+HXor6e89eivp7z59G6FNajX6k1PXmWoh90zFnP3ktgoZ/VlljTkyOnl5735C6BteoGXIk1PTmgjyemJraVLtY9Lk2/M70L9oY+GN8ZrTr9wmn9brSuHpOxmLtX4qfPH/PTY5If5mrxgx7gwPwsrRY/6AFOc+O36ofKxOyqX0w3RGn9nnT/vr4dGGkx9zbe5zI24uv7N5Jjqhj+DdP6TbVWJC/zg34leOL7/UH/18HXvOS49DWOr6V+4DmGs47h+535wdexclz6GsfXUr+xee8Yvt+ZH3ydQ45LX+P4mvnNuS2Bn+Vd9F9MtEZL0C+6t2gcnj8Wy8+oDy41S4c=
+  </data>
+ </layer>
+ <layer id="6" name="Above Player" width="40" height="40">
+  <data encoding="base64" compression="zlib">
+   eAHt0AENAAAAwqD3T20PBxEoDBgwYMCAAQMGDBgwYMCAAQMGDBgwYMCAAQNfAwMZAAAB
+  </data>
+ </layer>
+ <objectgroup color="#ff0000" id="4" name="Collisions">
+  <object id="441" type="collision" x="0" y="144" width="32" height="416"/>
+  <object id="442" type="collision" x="0" y="592" width="400" height="16"/>
+  <object id="444" type="collision" x="624" y="480" width="16" height="160"/>
+  <object id="474" type="collision" x="304" y="512" width="80" height="48"/>
+  <object id="475" type="collision" x="448" y="512" width="32" height="48"/>
+  <object id="476" type="collision" x="496" y="512" width="32" height="48"/>
+  <object id="479" type="collision" x="64" y="320" width="16" height="160"/>
+  <object id="480" type="collision" x="80" y="320" width="160" height="16"/>
+  <object id="481" type="collision" x="224" y="336" width="16" height="144"/>
+  <object id="482" type="collision" x="192" y="464" width="32" height="16"/>
+  <object id="485" type="collision" x="192" y="336" width="32" height="32"/>
+  <object id="486" type="collision" x="80" y="336" width="32" height="32"/>
+  <object id="489" type="collision" x="32" y="208" width="160" height="64"/>
+  <object id="491" type="collision" x="176" y="0" width="32" height="160"/>
+  <object id="492" type="collision" x="0" y="0" width="176" height="48"/>
+  <object id="493" type="collision" x="0" y="48" width="32" height="64"/>
+  <object id="553" type="collision" x="448" y="624" width="176" height="16"/>
+  <object id="569" type="collision" x="32" y="512" width="32" height="32"/>
+  <object id="581" type="collision" x="80" y="464" width="32" height="16"/>
+ </objectgroup>
+ <objectgroup color="#ffff00" id="5" name="Events">
+  <object id="562" name="Play Music" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="play_music music_town_theme"/>
+    <property name="cond1" value="not music_playing music_town_theme"/>
+   </properties>
+  </object>
+ </objectgroup>
+</map>

--- a/mods/tuxemon/maps/test_npcs.yaml
+++ b/mods/tuxemon/maps/test_npcs.yaml
@@ -1,0 +1,1505 @@
+events:
+  NPCs:
+    actions:
+    - create_npc test_npc001,16,2
+    - create_npc test_npc002,17,2
+    - create_npc test_npc003,18,2
+    - create_npc test_npc004,19,2
+    - create_npc test_npc005,20,2
+    - create_npc test_npc006,21,2
+    - create_npc test_npc007,22,2
+    - create_npc test_npc008,23,2
+    - create_npc test_npc009,24,2
+    - create_npc test_npc010,25,2
+    - create_npc test_npc011,26,2
+    - create_npc test_npc012,27,2
+    - create_npc test_npc013,28,2
+    - create_npc test_npc014,29,2
+    - create_npc test_npc015,30,2
+    - create_npc test_npc016,31,2
+    - create_npc test_npc017,32,2
+    - create_npc test_npc018,33,2
+    - create_npc test_npc019,34,2
+    - create_npc test_npc020,35,2
+    - create_npc test_npc021,36,2
+    - create_npc test_npc022,16,4
+    - create_npc test_npc023,17,4
+    - create_npc test_npc024,18,4
+    - create_npc test_npc025,19,4
+    - create_npc test_npc026,20,4
+    - create_npc test_npc027,21,4
+    - create_npc test_npc028,22,4
+    - create_npc test_npc029,23,4
+    - create_npc test_npc030,24,4
+    - create_npc test_npc031,25,4
+    - create_npc test_npc032,26,4
+    - create_npc test_npc033,27,4
+    - create_npc test_npc034,28,4
+    - create_npc test_npc035,29,4
+    - create_npc test_npc036,30,4
+    - create_npc test_npc037,31,4
+    - create_npc test_npc038,32,4
+    - create_npc test_npc039,33,4
+    - create_npc test_npc040,34,4
+    - create_npc test_npc041,35,4
+    - create_npc test_npc042,36,4
+    - create_npc test_npc043,16,6
+    - create_npc test_npc044,17,6
+    - create_npc test_npc045,18,6
+    - create_npc test_npc046,19,6
+    - create_npc test_npc047,20,6
+    - create_npc test_npc048,21,6
+    - create_npc test_npc049,22,6
+    - create_npc test_npc050,23,6
+    - create_npc test_npc051,24,6
+    - create_npc test_npc052,25,6
+    - create_npc test_npc053,26,6
+    - create_npc test_npc054,27,6
+    - create_npc test_npc055,28,6
+    - create_npc test_npc056,29,6
+    - create_npc test_npc057,30,6
+    - create_npc test_npc058,31,6
+    - create_npc test_npc059,32,6
+    - create_npc test_npc060,33,6
+    - create_npc test_npc061,34,6
+    - create_npc test_npc062,35,6
+    - create_npc test_npc063,36,6
+    - create_npc test_npc064,16,8
+    - create_npc test_npc065,17,8
+    - create_npc test_npc066,18,8
+    - create_npc test_npc067,19,8
+    - create_npc test_npc068,20,8
+    - create_npc test_npc069,21,8
+    - create_npc test_npc070,22,8
+    - create_npc test_npc071,23,8
+    - create_npc test_npc072,24,8
+    - create_npc test_npc073,25,8
+    - create_npc test_npc074,26,8
+    - create_npc test_npc075,27,8
+    - create_npc test_npc076,28,8
+    - create_npc test_npc077,29,8
+    - create_npc test_npc078,30,8
+    - create_npc test_npc079,31,8
+    - create_npc test_npc080,32,8
+    - create_npc test_npc081,33,8
+    - create_npc test_npc082,34,8
+    - create_npc test_npc083,35,8
+    - create_npc test_npc084,36,8
+    - create_npc test_npc085,16,10
+    - create_npc test_npc086,17,10
+    - create_npc test_npc087,18,10
+    - create_npc test_npc088,19,10
+    - create_npc test_npc089,20,10
+    - create_npc test_npc090,21,10
+    - create_npc test_npc091,22,10
+    - create_npc test_npc092,23,10
+    - create_npc test_npc093,24,10
+    - create_npc test_npc094,25,10
+    - create_npc test_npc095,26,10
+    - create_npc test_npc096,27,10
+    - create_npc test_npc097,28,10
+    - create_npc test_npc098,29,10
+    - create_npc test_npc099,30,10
+    - create_npc test_npc100,31,10
+    - create_npc test_npc101,32,10
+    - create_npc test_npc102,33,10
+    - create_npc test_npc103,34,10
+    - create_npc test_npc104,35,10
+    - create_npc test_npc105,36,10
+    - create_npc test_npc106,16,12
+    - create_npc test_npc107,17,12
+    - create_npc test_npc108,18,12
+    - create_npc test_npc109,19,12
+    - create_npc test_npc110,20,12
+    - create_npc test_npc111,21,12
+    - create_npc test_npc112,22,12
+    - create_npc test_npc113,23,12
+    - create_npc test_npc114,24,12
+    - create_npc test_npc115,25,12
+    - create_npc test_npc116,26,12
+    - create_npc test_npc117,27,12
+    - create_npc test_npc118,28,12
+    - create_npc test_npc119,29,12
+    - create_npc test_npc120,30,12
+    - create_npc test_npc121,31,12
+    - create_npc test_npc122,32,12
+    - create_npc test_npc123,33,12
+    - create_npc test_npc124,34,12
+    - create_npc test_npc125,35,12
+    - create_npc test_npc126,36,12
+    - create_npc test_npc127,16,14
+    - create_npc test_npc128,17,14
+    - create_npc test_npc129,18,14
+    - create_npc test_npc130,19,14
+    - create_npc test_npc131,20,14
+    - create_npc test_npc132,21,14
+    - create_npc test_npc133,22,14
+    - create_npc test_npc134,23,14
+    - create_npc test_npc135,24,14
+    - create_npc test_npc136,25,14
+    - create_npc test_npc137,26,14
+    - create_npc test_npc138,27,14
+    - create_npc test_npc139,28,14
+    - create_npc test_npc140,29,14
+    - create_npc test_npc141,30,14
+    - create_npc test_npc142,31,14
+    - create_npc test_npc143,32,14
+    - create_npc test_npc144,33,14
+    - create_npc test_npc145,34,14
+    - create_npc test_npc146,35,14
+    - create_npc test_npc147,36,14
+    - create_npc test_npc148,16,16
+    - create_npc test_npc149,17,16
+    - create_npc test_npc150,18,16
+    - create_npc test_npc151,19,16
+    - create_npc test_npc152,20,16
+    - create_npc test_npc153,21,16
+    - create_npc test_npc154,22,16
+    - create_npc test_npc155,23,16
+    - create_npc test_npc156,24,16
+    - create_npc test_npc157,25,16
+    - create_npc test_npc158,26,16
+    - create_npc test_npc159,27,16
+    - create_npc test_npc160,28,16
+    - create_npc test_npc161,29,16
+    - create_npc test_npc162,30,16
+    - create_npc test_npc163,31,16
+    - create_npc test_npc164,32,16
+    - create_npc test_npc165,33,16
+    - create_npc test_npc166,34,16
+    - create_npc test_npc167,35,16
+    - create_npc test_npc168,36,16
+    - create_npc test_npc169,16,18
+    - create_npc test_npc170,17,18
+    - create_npc test_npc171,18,18
+    - create_npc test_npc172,19,18
+    - create_npc test_npc173,20,18
+    - create_npc test_npc174,21,18
+    - create_npc test_npc175,22,18
+    - create_npc test_npc176,23,18
+    - create_npc test_npc177,24,18
+    - create_npc test_npc178,25,18
+    - create_npc test_npc179,26,18
+    - create_npc test_npc180,27,18
+    - create_npc test_npc181,28,18
+    - create_npc test_npc182,29,18
+    - create_npc test_npc183,30,18
+    - create_npc test_npc184,31,18
+    - create_npc test_npc185,32,18
+    - create_npc test_npc186,33,18
+    - create_npc test_npc187,34,18
+    - create_npc test_npc188,35,18
+    - create_npc test_npc189,36,18
+    - create_npc test_npc190,3,4
+    - create_npc test_npc191,4,4
+    - create_npc test_npc192,5,4
+    - create_npc test_npc193,6,4
+    - create_npc test_npc194,7,4
+    - create_npc test_npc195,8,4
+    - create_npc test_npc196,9,4
+    - create_npc test_npc197,10,4
+    - create_npc test_npc198,3,6
+    - create_npc test_npc199,4,6
+    - create_npc test_npc200,5,6
+    - create_npc test_npc201,6,6
+    - create_npc test_npc202,7,6
+    - create_npc test_npc203,8,6
+    - create_npc test_npc204,9,6
+    - create_npc test_npc205,10,6
+    - create_npc test_npc206,3,8
+    - create_npc test_npc207,4,8
+    - create_npc test_npc208,5,8
+    - create_npc test_npc209,6,8
+    - create_npc test_npc210,7,8
+    - create_npc test_npc211,8,8
+    - create_npc test_npc212,9,8
+    - create_npc test_npc213,10,8
+    - create_npc test_npc214,3,10
+    - create_npc test_npc215,4,10
+    - create_npc test_npc216,5,10
+    - create_npc test_npc217,6,10
+    - create_npc test_npc218,7,10
+    - create_npc test_npc219,8,10
+    - create_npc test_npc220,9,10
+    - create_npc test_npc221,10,10
+    - create_npc test_npc222,3,12
+    - create_npc test_npc223,4,12
+    - create_npc test_npc224,5,12
+    - create_npc test_npc225,6,12
+    - create_npc test_npc226,7,12
+    - create_npc test_npc227,8,12
+    - create_npc test_npc228,9,12
+    - create_npc test_npc229,10,12
+    - create_npc test_npc230,13,0
+    - create_npc test_npc231,14,0
+    - create_npc test_npc232,15,0
+    - create_npc test_npc233,16,0
+    - create_npc test_npc234,17,0
+    - create_npc test_npc235,18,0
+    - create_npc test_npc236,19,0
+    - create_npc test_npc237,20,0
+    - create_npc test_npc238,21,0
+    - create_npc test_npc239,22,0
+    - create_npc test_npc240,23,0
+    - create_npc test_npc241,24,0
+    - create_npc test_npc242,25,0
+    - create_npc test_npc243,26,0
+    - create_npc test_npc244,27,0
+    - create_npc test_npc245,28,0
+    - create_npc test_npc246,29,0
+    - create_npc test_npc247,30,0
+    - create_npc test_npc248,31,0
+    - create_npc test_npc249,32,0
+    - create_npc test_npc250,33,0
+    - create_npc test_npc251,34,0
+    - create_npc test_npc252,35,0
+    - create_npc test_npc253,36,0
+    - create_npc test_npc254,37,0
+    - create_npc test_npc255,38,0
+    - create_npc test_npc256,39,0
+    - create_npc test_npc257,39,1
+    - create_npc test_npc258,39,2
+    - create_npc test_npc259,39,3
+    - create_npc test_npc260,39,4
+    - create_npc test_npc261,39,5
+    - create_npc test_npc262,39,6
+    - create_npc test_npc263,39,7
+    - create_npc test_npc264,39,8
+    - create_npc test_npc265,39,9
+    - create_npc test_npc266,39,10
+    - create_npc test_npc267,39,11
+    - create_npc test_npc268,39,12
+    - create_npc test_npc269,39,13
+    - create_npc test_npc270,39,14
+    - create_npc test_npc271,39,15
+    - create_npc test_npc272,39,16
+    - create_npc test_npc273,39,17
+    - create_npc test_npc274,39,18
+    - create_npc test_npc275,7,21
+    - create_npc test_npc276,8,21
+    - create_npc test_npc277,9,21
+    - create_npc test_npc278,10,21
+    - create_npc test_npc279,37,30
+    - create_npc test_npc280,38,30
+    - create_npc test_npc281,33,32
+    - create_npc test_npc282,34,32
+    - create_npc test_npc283,35,32
+    - create_npc test_npc284,36,32
+    - create_npc test_npc285,37,32
+    - create_npc test_npc286,38,32
+    - create_npc test_npc287,33,34
+    - create_npc test_npc288,34,34
+    - create_npc test_npc289,35,34
+    - create_npc test_npc290,36,34
+    - create_npc test_npc291,37,34
+    - create_npc test_npc292,38,34
+    - create_npc test_npc293,33,36
+    - create_npc test_npc294,34,36
+    - create_npc test_npc295,35,36
+    - create_npc test_npc296,36,36
+    - create_npc test_npc297,37,36
+    - create_npc test_npc298,38,36
+    - create_npc test_npc299,33,38
+    - create_npc test_npc300,34,38
+    - create_npc test_npc301,35,38
+    - create_npc test_npc302,36,38
+    - create_npc test_npc303,37,38
+    - create_npc test_npc304,38,38
+    - create_npc test_npc305,4,30
+    - create_npc test_npc306,5,30
+    - create_npc test_npc307,6,30
+    - create_npc test_npc308,7,30
+    - create_npc test_npc309,8,30
+    - create_npc test_npc310,9,30
+    - create_npc test_npc311,10,30
+    - create_npc test_npc312,11,30
+    - create_npc test_npc313,12,30
+    - create_npc test_npc314,13,30
+    - create_npc test_npc315,14,30
+    - create_npc test_npc316,15,30
+    - create_npc test_npc317,11,21
+    - create_npc test_npc318,24,32
+    - create_npc test_npc319,27,32
+    - create_npc test_npc320,4,32
+    - create_npc test_npc321,5,32
+    - create_npc test_npc322,6,32
+    - create_npc test_npc323,7,32
+    - create_npc test_npc324,8,32
+    - create_npc test_npc325,9,32
+    - create_npc test_npc326,10,32
+    - create_npc test_npc327,11,32
+    - create_npc test_npc328,12,32
+    - create_npc test_npc329,13,32
+    - create_npc test_npc330,14,32
+    - create_npc test_npc331,15,32
+    - create_npc test_npc332,16,32
+    - create_npc test_npc333,17,32
+    - create_npc test_npc334,18,32
+    - create_npc test_npc335,4,34
+    - create_npc test_npc336,5,34
+    - create_npc test_npc337,6,34
+    - create_npc test_npc338,7,34
+    - create_npc test_npc339,8,34
+    - create_npc test_npc340,9,34
+    - create_npc test_npc341,10,34
+    - create_npc test_npc342,11,34
+    - create_npc test_npc343,12,34
+    - create_npc test_npc344,13,34
+    - create_npc test_npc345,14,34
+    - create_npc test_npc346,15,34
+    - create_npc test_npc347,16,34
+    - create_npc test_npc348,17,34
+    - create_npc test_npc349,18,34
+    - create_npc test_npc350,4,36
+    - create_npc test_npc351,5,36
+    - create_npc test_npc352,6,36
+    - create_npc test_npc353,7,36
+    - create_npc test_npc354,8,36
+    - create_npc test_npc355,9,36
+    - create_npc test_npc356,10,36
+    - create_npc test_npc357,11,36
+    - create_npc test_npc358,12,36
+    - create_npc test_npc359,13,36
+    - create_npc test_npc360,14,36
+    - create_npc test_npc361,15,36
+    - create_npc test_npc362,16,36
+    - create_npc test_npc363,17,36
+    - create_npc test_npc364,18,36
+    - create_npc test_npc365,16,20
+    - create_npc test_npc366,17,20
+    - create_npc test_npc367,18,20
+    - create_npc test_npc368,19,20
+    - create_npc test_npc369,20,20
+    - create_npc test_npc370,21,20
+    - create_npc test_npc371,22,20
+    - create_npc test_npc372,23,20
+    - create_npc test_npc373,24,20
+    - create_npc test_npc374,25,20
+    - create_npc test_npc375,26,20
+    - create_npc test_npc376,27,20
+    - create_npc test_npc377,28,20
+    - create_npc test_npc378,29,20
+    - create_npc test_npc379,30,20
+    - create_npc test_npc380,31,20
+    - create_npc test_npc381,32,20
+    - create_npc test_npc382,33,20
+    - create_npc test_npc383,34,20
+    - create_npc test_npc384,35,20
+    - create_npc test_npc385,36,20
+    - create_npc test_npc386,16,22
+    - create_npc test_npc387,17,22
+    - create_npc test_npc388,18,22
+    - create_npc test_npc389,19,22
+    - create_npc test_npc390,20,22
+    - create_npc test_npc391,21,22
+    - create_npc test_npc392,22,22
+    - create_npc test_npc393,23,22
+    - create_npc test_npc394,24,22
+    - create_npc test_npc395,25,22
+    - create_npc test_npc396,26,22
+    - create_npc test_npc397,27,22
+    - create_npc test_npc398,28,22
+    - create_npc test_npc399,29,22
+    - create_npc test_npc400,30,22
+    - create_npc test_npc401,31,22
+    - create_npc test_npc402,32,22
+    - create_npc test_npc403,33,22
+    - create_npc test_npc404,34,22
+    - create_npc test_npc405,35,22
+    - create_npc test_npc406,36,22
+    - create_npc test_npc407,16,24
+    - create_npc test_npc408,17,24
+    - create_npc test_npc409,18,24
+    - create_npc test_npc410,19,24
+    - create_npc test_npc411,20,24
+    - create_npc test_npc412,21,24
+    - create_npc test_npc413,22,24
+    - create_npc test_npc414,23,24
+    - create_npc test_npc415,24,24
+    - create_npc test_npc416,25,24
+    - create_npc test_npc417,26,24
+    - create_npc test_npc418,27,24
+    - create_npc test_npc419,28,24
+    - create_npc test_npc420,29,24
+    - create_npc test_npc421,30,24
+    - create_npc test_npc422,31,24
+    - create_npc test_npc423,32,24
+    - create_npc test_npc424,33,24
+    - create_npc test_npc425,34,24
+    - create_npc test_npc426,35,24
+    - create_npc test_npc427,36,24
+    - create_npc test_npc428,16,26
+    - create_npc test_npc429,17,26
+    - create_npc test_npc430,18,26
+    - create_npc test_npc431,19,26
+    - create_npc test_npc432,20,26
+    - create_npc test_npc433,21,26
+    - create_npc test_npc434,22,26
+    - create_npc test_npc435,23,26
+    - create_npc test_npc436,24,26
+    - create_npc test_npc437,25,26
+    - create_npc test_npc438,26,26
+    - create_npc test_npc439,27,26
+    - create_npc test_npc440,28,26
+    - create_npc test_npc441,29,26
+    - create_npc test_npc442,30,26
+    - create_npc test_npc443,31,26
+    - create_npc test_npc444,32,26
+    - create_npc test_npc445,33,26
+    - create_npc test_npc446,34,26
+    - create_npc test_npc447,35,26
+    - create_npc test_npc448,36,26
+    - create_npc test_npc449,16,28
+    - create_npc test_npc450,17,28
+    - create_npc test_npc451,18,28
+    - create_npc test_npc452,19,28
+    - create_npc test_npc453,20,28
+    - create_npc test_npc454,21,28
+    - create_npc test_npc455,22,28
+    - create_npc test_npc456,23,28
+    - create_npc test_npc457,24,28
+    - create_npc test_npc458,25,28
+    - create_npc test_npc459,26,28
+    - create_npc test_npc460,27,28
+    - create_npc test_npc461,28,28
+    - create_npc test_npc462,29,28
+    - create_npc test_npc463,30,28
+    - create_npc test_npc464,31,28
+    - create_npc test_npc465,32,28
+    - create_npc test_npc466,33,28
+    - create_npc test_npc467,34,28
+    - create_npc test_npc468,35,28
+    - create_npc test_npc469,36,28
+    - create_npc test_npc470,16,30
+    - create_npc test_npc471,17,30
+    - create_npc test_npc472,18,30
+    - create_npc test_npc473,19,30
+    - create_npc test_npc474,20,30
+    - create_npc test_npc475,21,30
+    - create_npc test_npc476,22,30
+    - create_npc test_npc477,23,30
+    - create_npc test_npc478,24,30
+    - create_npc test_npc479,25,30
+    - create_npc test_npc480,26,30
+    - create_npc test_npc481,27,30
+    - create_npc test_npc482,28,30
+    - create_npc test_npc483,29,30
+    - create_npc test_npc484,30,30
+    - create_npc test_npc485,31,30
+    - create_npc test_npc486,32,30
+    - create_npc test_npc487,33,30
+    - create_npc test_npc488,34,30
+    - create_npc test_npc489,35,30
+    - create_npc test_npc490,36,30
+    - create_npc test_npc491,5,23
+    - create_npc test_npc492,5,24
+    - create_npc test_npc493,5,25
+    - create_npc test_npc494,5,26
+    - create_npc test_npc495,5,27
+    - create_npc test_npc496,13,23
+    - create_npc test_npc497,13,24
+    - create_npc test_npc498,13,25
+    - create_npc test_npc499,13,26
+    - create_npc test_npc500,13,27
+    - npc_wander test_npc001
+    - npc_wander test_npc002
+    - npc_wander test_npc003
+    - npc_wander test_npc004
+    - npc_wander test_npc005
+    - npc_wander test_npc006
+    - npc_wander test_npc007
+    - npc_wander test_npc008
+    - npc_wander test_npc009
+    - npc_wander test_npc010
+    - npc_wander test_npc011
+    - npc_wander test_npc012
+    - npc_wander test_npc013
+    - npc_wander test_npc014
+    - npc_wander test_npc015
+    - npc_wander test_npc016
+    - npc_wander test_npc017
+    - npc_wander test_npc018
+    - npc_wander test_npc019
+    - npc_wander test_npc020
+    - npc_wander test_npc021
+    - npc_wander test_npc022
+    - npc_wander test_npc023
+    - npc_wander test_npc024
+    - npc_wander test_npc025
+    - npc_wander test_npc026
+    - npc_wander test_npc027
+    - npc_wander test_npc028
+    - npc_wander test_npc029
+    - npc_wander test_npc030
+    - npc_wander test_npc031
+    - npc_wander test_npc032
+    - npc_wander test_npc033
+    - npc_wander test_npc034
+    - npc_wander test_npc035
+    - npc_wander test_npc036
+    - npc_wander test_npc037
+    - npc_wander test_npc038
+    - npc_wander test_npc039
+    - npc_wander test_npc040
+    - npc_wander test_npc041
+    - npc_wander test_npc042
+    - npc_wander test_npc043
+    - npc_wander test_npc044
+    - npc_wander test_npc045
+    - npc_wander test_npc046
+    - npc_wander test_npc047
+    - npc_wander test_npc048
+    - npc_wander test_npc049
+    - npc_wander test_npc050
+    - npc_wander test_npc051
+    - npc_wander test_npc052
+    - npc_wander test_npc053
+    - npc_wander test_npc054
+    - npc_wander test_npc055
+    - npc_wander test_npc056
+    - npc_wander test_npc057
+    - npc_wander test_npc058
+    - npc_wander test_npc059
+    - npc_wander test_npc060
+    - npc_wander test_npc061
+    - npc_wander test_npc062
+    - npc_wander test_npc063
+    - npc_wander test_npc064
+    - npc_wander test_npc065
+    - npc_wander test_npc066
+    - npc_wander test_npc067
+    - npc_wander test_npc068
+    - npc_wander test_npc069
+    - npc_wander test_npc070
+    - npc_wander test_npc071
+    - npc_wander test_npc072
+    - npc_wander test_npc073
+    - npc_wander test_npc074
+    - npc_wander test_npc075
+    - npc_wander test_npc076
+    - npc_wander test_npc077
+    - npc_wander test_npc078
+    - npc_wander test_npc079
+    - npc_wander test_npc080
+    - npc_wander test_npc081
+    - npc_wander test_npc082
+    - npc_wander test_npc083
+    - npc_wander test_npc084
+    - npc_wander test_npc085
+    - npc_wander test_npc086
+    - npc_wander test_npc087
+    - npc_wander test_npc088
+    - npc_wander test_npc089
+    - npc_wander test_npc090
+    - npc_wander test_npc091
+    - npc_wander test_npc092
+    - npc_wander test_npc093
+    - npc_wander test_npc094
+    - npc_wander test_npc095
+    - npc_wander test_npc096
+    - npc_wander test_npc097
+    - npc_wander test_npc098
+    - npc_wander test_npc099
+    - npc_wander test_npc100
+    - npc_wander test_npc101
+    - npc_wander test_npc102
+    - npc_wander test_npc103
+    - npc_wander test_npc104
+    - npc_wander test_npc105
+    - npc_wander test_npc106
+    - npc_wander test_npc107
+    - npc_wander test_npc108
+    - npc_wander test_npc109
+    - npc_wander test_npc110
+    - npc_wander test_npc111
+    - npc_wander test_npc112
+    - npc_wander test_npc113
+    - npc_wander test_npc114
+    - npc_wander test_npc115
+    - npc_wander test_npc116
+    - npc_wander test_npc117
+    - npc_wander test_npc118
+    - npc_wander test_npc119
+    - npc_wander test_npc120
+    - npc_wander test_npc121
+    - npc_wander test_npc122
+    - npc_wander test_npc123
+    - npc_wander test_npc124
+    - npc_wander test_npc125
+    - npc_wander test_npc126
+    - npc_wander test_npc127
+    - npc_wander test_npc128
+    - npc_wander test_npc129
+    - npc_wander test_npc130
+    - npc_wander test_npc131
+    - npc_wander test_npc132
+    - npc_wander test_npc133
+    - npc_wander test_npc134
+    - npc_wander test_npc135
+    - npc_wander test_npc136
+    - npc_wander test_npc137
+    - npc_wander test_npc138
+    - npc_wander test_npc139
+    - npc_wander test_npc140
+    - npc_wander test_npc141
+    - npc_wander test_npc142
+    - npc_wander test_npc143
+    - npc_wander test_npc144
+    - npc_wander test_npc145
+    - npc_wander test_npc146
+    - npc_wander test_npc147
+    - npc_wander test_npc148
+    - npc_wander test_npc149
+    - npc_wander test_npc150
+    - npc_wander test_npc151
+    - npc_wander test_npc152
+    - npc_wander test_npc153
+    - npc_wander test_npc154
+    - npc_wander test_npc155
+    - npc_wander test_npc156
+    - npc_wander test_npc157
+    - npc_wander test_npc158
+    - npc_wander test_npc159
+    - npc_wander test_npc160
+    - npc_wander test_npc161
+    - npc_wander test_npc162
+    - npc_wander test_npc163
+    - npc_wander test_npc164
+    - npc_wander test_npc165
+    - npc_wander test_npc166
+    - npc_wander test_npc167
+    - npc_wander test_npc168
+    - npc_wander test_npc169
+    - npc_wander test_npc170
+    - npc_wander test_npc171
+    - npc_wander test_npc172
+    - npc_wander test_npc173
+    - npc_wander test_npc174
+    - npc_wander test_npc175
+    - npc_wander test_npc176
+    - npc_wander test_npc177
+    - npc_wander test_npc178
+    - npc_wander test_npc179
+    - npc_wander test_npc180
+    - npc_wander test_npc181
+    - npc_wander test_npc182
+    - npc_wander test_npc183
+    - npc_wander test_npc184
+    - npc_wander test_npc185
+    - npc_wander test_npc186
+    - npc_wander test_npc187
+    - npc_wander test_npc188
+    - npc_wander test_npc189
+    - npc_wander test_npc190
+    - npc_wander test_npc191
+    - npc_wander test_npc192
+    - npc_wander test_npc193
+    - npc_wander test_npc194
+    - npc_wander test_npc195
+    - npc_wander test_npc196
+    - npc_wander test_npc197
+    - npc_wander test_npc198
+    - npc_wander test_npc199
+    - npc_wander test_npc200
+    - npc_wander test_npc201
+    - npc_wander test_npc202
+    - npc_wander test_npc203
+    - npc_wander test_npc204
+    - npc_wander test_npc205
+    - npc_wander test_npc206
+    - npc_wander test_npc207
+    - npc_wander test_npc208
+    - npc_wander test_npc209
+    - npc_wander test_npc210
+    - npc_wander test_npc211
+    - npc_wander test_npc212
+    - npc_wander test_npc213
+    - npc_wander test_npc214
+    - npc_wander test_npc215
+    - npc_wander test_npc216
+    - npc_wander test_npc217
+    - npc_wander test_npc218
+    - npc_wander test_npc219
+    - npc_wander test_npc220
+    - npc_wander test_npc221
+    - npc_wander test_npc222
+    - npc_wander test_npc223
+    - npc_wander test_npc224
+    - npc_wander test_npc225
+    - npc_wander test_npc226
+    - npc_wander test_npc227
+    - npc_wander test_npc228
+    - npc_wander test_npc229
+    - npc_wander test_npc230
+    - npc_wander test_npc231
+    - npc_wander test_npc232
+    - npc_wander test_npc233
+    - npc_wander test_npc234
+    - npc_wander test_npc235
+    - npc_wander test_npc236
+    - npc_wander test_npc237
+    - npc_wander test_npc238
+    - npc_wander test_npc239
+    - npc_wander test_npc240
+    - npc_wander test_npc241
+    - npc_wander test_npc242
+    - npc_wander test_npc243
+    - npc_wander test_npc244
+    - npc_wander test_npc245
+    - npc_wander test_npc246
+    - npc_wander test_npc247
+    - npc_wander test_npc248
+    - npc_wander test_npc249
+    - npc_wander test_npc250
+    - npc_wander test_npc251
+    - npc_wander test_npc252
+    - npc_wander test_npc253
+    - npc_wander test_npc254
+    - npc_wander test_npc255
+    - npc_wander test_npc256
+    - npc_wander test_npc257
+    - npc_wander test_npc258
+    - npc_wander test_npc259
+    - npc_wander test_npc260
+    - npc_wander test_npc261
+    - npc_wander test_npc262
+    - npc_wander test_npc263
+    - npc_wander test_npc264
+    - npc_wander test_npc265
+    - npc_wander test_npc266
+    - npc_wander test_npc267
+    - npc_wander test_npc268
+    - npc_wander test_npc269
+    - npc_wander test_npc270
+    - npc_wander test_npc271
+    - npc_wander test_npc272
+    - npc_wander test_npc273
+    - npc_wander test_npc274
+    - npc_wander test_npc275
+    - npc_wander test_npc276
+    - npc_wander test_npc277
+    - npc_wander test_npc278
+    - npc_wander test_npc279
+    - npc_wander test_npc280
+    - npc_wander test_npc281
+    - npc_wander test_npc282
+    - npc_wander test_npc283
+    - npc_wander test_npc284
+    - npc_wander test_npc285
+    - npc_wander test_npc286
+    - npc_wander test_npc287
+    - npc_wander test_npc288
+    - npc_wander test_npc289
+    - npc_wander test_npc290
+    - npc_wander test_npc291
+    - npc_wander test_npc292
+    - npc_wander test_npc293
+    - npc_wander test_npc294
+    - npc_wander test_npc295
+    - npc_wander test_npc296
+    - npc_wander test_npc297
+    - npc_wander test_npc298
+    - npc_wander test_npc299
+    - npc_wander test_npc300
+    - npc_wander test_npc301
+    - npc_wander test_npc302
+    - npc_wander test_npc303
+    - npc_wander test_npc304
+    - npc_wander test_npc305
+    - npc_wander test_npc306
+    - npc_wander test_npc307
+    - npc_wander test_npc308
+    - npc_wander test_npc309
+    - npc_wander test_npc310
+    - npc_wander test_npc311
+    - npc_wander test_npc312
+    - npc_wander test_npc313
+    - npc_wander test_npc314
+    - npc_wander test_npc315
+    - npc_wander test_npc316
+    - npc_wander test_npc317
+    - npc_wander test_npc318
+    - npc_wander test_npc319
+    - npc_wander test_npc320
+    - npc_wander test_npc321
+    - npc_wander test_npc322
+    - npc_wander test_npc323
+    - npc_wander test_npc324
+    - npc_wander test_npc325
+    - npc_wander test_npc326
+    - npc_wander test_npc327
+    - npc_wander test_npc328
+    - npc_wander test_npc329
+    - npc_wander test_npc330
+    - npc_wander test_npc331
+    - npc_wander test_npc332
+    - npc_wander test_npc333
+    - npc_wander test_npc334
+    - npc_wander test_npc335
+    - npc_wander test_npc336
+    - npc_wander test_npc337
+    - npc_wander test_npc338
+    - npc_wander test_npc339
+    - npc_wander test_npc340
+    - npc_wander test_npc341
+    - npc_wander test_npc342
+    - npc_wander test_npc343
+    - npc_wander test_npc344
+    - npc_wander test_npc345
+    - npc_wander test_npc346
+    - npc_wander test_npc347
+    - npc_wander test_npc348
+    - npc_wander test_npc349
+    - npc_wander test_npc350
+    - npc_wander test_npc351
+    - npc_wander test_npc352
+    - npc_wander test_npc353
+    - npc_wander test_npc354
+    - npc_wander test_npc355
+    - npc_wander test_npc356
+    - npc_wander test_npc357
+    - npc_wander test_npc358
+    - npc_wander test_npc359
+    - npc_wander test_npc360
+    - npc_wander test_npc361
+    - npc_wander test_npc362
+    - npc_wander test_npc363
+    - npc_wander test_npc364
+    - npc_wander test_npc365
+    - npc_wander test_npc366
+    - npc_wander test_npc367
+    - npc_wander test_npc368
+    - npc_wander test_npc369
+    - npc_wander test_npc370
+    - npc_wander test_npc371
+    - npc_wander test_npc372
+    - npc_wander test_npc373
+    - npc_wander test_npc374
+    - npc_wander test_npc375
+    - npc_wander test_npc376
+    - npc_wander test_npc377
+    - npc_wander test_npc378
+    - npc_wander test_npc379
+    - npc_wander test_npc380
+    - npc_wander test_npc381
+    - npc_wander test_npc382
+    - npc_wander test_npc383
+    - npc_wander test_npc384
+    - npc_wander test_npc385
+    - npc_wander test_npc386
+    - npc_wander test_npc387
+    - npc_wander test_npc388
+    - npc_wander test_npc389
+    - npc_wander test_npc390
+    - npc_wander test_npc391
+    - npc_wander test_npc392
+    - npc_wander test_npc393
+    - npc_wander test_npc394
+    - npc_wander test_npc395
+    - npc_wander test_npc396
+    - npc_wander test_npc397
+    - npc_wander test_npc398
+    - npc_wander test_npc399
+    - npc_wander test_npc400
+    - npc_wander test_npc401
+    - npc_wander test_npc402
+    - npc_wander test_npc403
+    - npc_wander test_npc404
+    - npc_wander test_npc405
+    - npc_wander test_npc406
+    - npc_wander test_npc407
+    - npc_wander test_npc408
+    - npc_wander test_npc409
+    - npc_wander test_npc410
+    - npc_wander test_npc411
+    - npc_wander test_npc412
+    - npc_wander test_npc413
+    - npc_wander test_npc414
+    - npc_wander test_npc415
+    - npc_wander test_npc416
+    - npc_wander test_npc417
+    - npc_wander test_npc418
+    - npc_wander test_npc419
+    - npc_wander test_npc420
+    - npc_wander test_npc421
+    - npc_wander test_npc422
+    - npc_wander test_npc423
+    - npc_wander test_npc424
+    - npc_wander test_npc425
+    - npc_wander test_npc426
+    - npc_wander test_npc427
+    - npc_wander test_npc428
+    - npc_wander test_npc429
+    - npc_wander test_npc430
+    - npc_wander test_npc431
+    - npc_wander test_npc432
+    - npc_wander test_npc433
+    - npc_wander test_npc434
+    - npc_wander test_npc435
+    - npc_wander test_npc436
+    - npc_wander test_npc437
+    - npc_wander test_npc438
+    - npc_wander test_npc439
+    - npc_wander test_npc440
+    - npc_wander test_npc441
+    - npc_wander test_npc442
+    - npc_wander test_npc443
+    - npc_wander test_npc444
+    - npc_wander test_npc445
+    - npc_wander test_npc446
+    - npc_wander test_npc447
+    - npc_wander test_npc448
+    - npc_wander test_npc449
+    - npc_wander test_npc450
+    - npc_wander test_npc451
+    - npc_wander test_npc452
+    - npc_wander test_npc453
+    - npc_wander test_npc454
+    - npc_wander test_npc455
+    - npc_wander test_npc456
+    - npc_wander test_npc457
+    - npc_wander test_npc458
+    - npc_wander test_npc459
+    - npc_wander test_npc460
+    - npc_wander test_npc461
+    - npc_wander test_npc462
+    - npc_wander test_npc463
+    - npc_wander test_npc464
+    - npc_wander test_npc465
+    - npc_wander test_npc466
+    - npc_wander test_npc467
+    - npc_wander test_npc468
+    - npc_wander test_npc469
+    - npc_wander test_npc470
+    - npc_wander test_npc471
+    - npc_wander test_npc472
+    - npc_wander test_npc473
+    - npc_wander test_npc474
+    - npc_wander test_npc475
+    - npc_wander test_npc476
+    - npc_wander test_npc477
+    - npc_wander test_npc478
+    - npc_wander test_npc479
+    - npc_wander test_npc480
+    - npc_wander test_npc481
+    - npc_wander test_npc482
+    - npc_wander test_npc483
+    - npc_wander test_npc484
+    - npc_wander test_npc485
+    - npc_wander test_npc486
+    - npc_wander test_npc487
+    - npc_wander test_npc488
+    - npc_wander test_npc489
+    - npc_wander test_npc490
+    - npc_wander test_npc491
+    - npc_wander test_npc492
+    - npc_wander test_npc493
+    - npc_wander test_npc494
+    - npc_wander test_npc495
+    - npc_wander test_npc496
+    - npc_wander test_npc497
+    - npc_wander test_npc498
+    - npc_wander test_npc499
+    - npc_wander test_npc500
+    conditions:
+    - not npc_exists test_npc001
+    - not npc_exists test_npc002
+    - not npc_exists test_npc003
+    - not npc_exists test_npc004
+    - not npc_exists test_npc005
+    - not npc_exists test_npc006
+    - not npc_exists test_npc007
+    - not npc_exists test_npc008
+    - not npc_exists test_npc009
+    - not npc_exists test_npc010
+    - not npc_exists test_npc011
+    - not npc_exists test_npc012
+    - not npc_exists test_npc013
+    - not npc_exists test_npc014
+    - not npc_exists test_npc015
+    - not npc_exists test_npc016
+    - not npc_exists test_npc017
+    - not npc_exists test_npc018
+    - not npc_exists test_npc019
+    - not npc_exists test_npc020
+    - not npc_exists test_npc021
+    - not npc_exists test_npc022
+    - not npc_exists test_npc023
+    - not npc_exists test_npc024
+    - not npc_exists test_npc025
+    - not npc_exists test_npc026
+    - not npc_exists test_npc027
+    - not npc_exists test_npc028
+    - not npc_exists test_npc029
+    - not npc_exists test_npc030
+    - not npc_exists test_npc031
+    - not npc_exists test_npc032
+    - not npc_exists test_npc033
+    - not npc_exists test_npc034
+    - not npc_exists test_npc035
+    - not npc_exists test_npc036
+    - not npc_exists test_npc037
+    - not npc_exists test_npc038
+    - not npc_exists test_npc039
+    - not npc_exists test_npc040
+    - not npc_exists test_npc041
+    - not npc_exists test_npc042
+    - not npc_exists test_npc043
+    - not npc_exists test_npc044
+    - not npc_exists test_npc045
+    - not npc_exists test_npc046
+    - not npc_exists test_npc047
+    - not npc_exists test_npc048
+    - not npc_exists test_npc049
+    - not npc_exists test_npc050
+    - not npc_exists test_npc051
+    - not npc_exists test_npc052
+    - not npc_exists test_npc053
+    - not npc_exists test_npc054
+    - not npc_exists test_npc055
+    - not npc_exists test_npc056
+    - not npc_exists test_npc057
+    - not npc_exists test_npc058
+    - not npc_exists test_npc059
+    - not npc_exists test_npc060
+    - not npc_exists test_npc061
+    - not npc_exists test_npc062
+    - not npc_exists test_npc063
+    - not npc_exists test_npc064
+    - not npc_exists test_npc065
+    - not npc_exists test_npc066
+    - not npc_exists test_npc067
+    - not npc_exists test_npc068
+    - not npc_exists test_npc069
+    - not npc_exists test_npc070
+    - not npc_exists test_npc071
+    - not npc_exists test_npc072
+    - not npc_exists test_npc073
+    - not npc_exists test_npc074
+    - not npc_exists test_npc075
+    - not npc_exists test_npc076
+    - not npc_exists test_npc077
+    - not npc_exists test_npc078
+    - not npc_exists test_npc079
+    - not npc_exists test_npc080
+    - not npc_exists test_npc081
+    - not npc_exists test_npc082
+    - not npc_exists test_npc083
+    - not npc_exists test_npc084
+    - not npc_exists test_npc085
+    - not npc_exists test_npc086
+    - not npc_exists test_npc087
+    - not npc_exists test_npc088
+    - not npc_exists test_npc089
+    - not npc_exists test_npc090
+    - not npc_exists test_npc091
+    - not npc_exists test_npc092
+    - not npc_exists test_npc093
+    - not npc_exists test_npc094
+    - not npc_exists test_npc095
+    - not npc_exists test_npc096
+    - not npc_exists test_npc097
+    - not npc_exists test_npc098
+    - not npc_exists test_npc099
+    - not npc_exists test_npc100
+    - not npc_exists test_npc101
+    - not npc_exists test_npc102
+    - not npc_exists test_npc103
+    - not npc_exists test_npc104
+    - not npc_exists test_npc105
+    - not npc_exists test_npc106
+    - not npc_exists test_npc107
+    - not npc_exists test_npc108
+    - not npc_exists test_npc109
+    - not npc_exists test_npc110
+    - not npc_exists test_npc111
+    - not npc_exists test_npc112
+    - not npc_exists test_npc113
+    - not npc_exists test_npc114
+    - not npc_exists test_npc115
+    - not npc_exists test_npc116
+    - not npc_exists test_npc117
+    - not npc_exists test_npc118
+    - not npc_exists test_npc119
+    - not npc_exists test_npc120
+    - not npc_exists test_npc121
+    - not npc_exists test_npc122
+    - not npc_exists test_npc123
+    - not npc_exists test_npc124
+    - not npc_exists test_npc125
+    - not npc_exists test_npc126
+    - not npc_exists test_npc127
+    - not npc_exists test_npc128
+    - not npc_exists test_npc129
+    - not npc_exists test_npc130
+    - not npc_exists test_npc131
+    - not npc_exists test_npc132
+    - not npc_exists test_npc133
+    - not npc_exists test_npc134
+    - not npc_exists test_npc135
+    - not npc_exists test_npc136
+    - not npc_exists test_npc137
+    - not npc_exists test_npc138
+    - not npc_exists test_npc139
+    - not npc_exists test_npc140
+    - not npc_exists test_npc141
+    - not npc_exists test_npc142
+    - not npc_exists test_npc143
+    - not npc_exists test_npc144
+    - not npc_exists test_npc145
+    - not npc_exists test_npc146
+    - not npc_exists test_npc147
+    - not npc_exists test_npc148
+    - not npc_exists test_npc149
+    - not npc_exists test_npc150
+    - not npc_exists test_npc151
+    - not npc_exists test_npc152
+    - not npc_exists test_npc153
+    - not npc_exists test_npc154
+    - not npc_exists test_npc155
+    - not npc_exists test_npc156
+    - not npc_exists test_npc157
+    - not npc_exists test_npc158
+    - not npc_exists test_npc159
+    - not npc_exists test_npc160
+    - not npc_exists test_npc161
+    - not npc_exists test_npc162
+    - not npc_exists test_npc163
+    - not npc_exists test_npc164
+    - not npc_exists test_npc165
+    - not npc_exists test_npc166
+    - not npc_exists test_npc167
+    - not npc_exists test_npc168
+    - not npc_exists test_npc169
+    - not npc_exists test_npc170
+    - not npc_exists test_npc171
+    - not npc_exists test_npc172
+    - not npc_exists test_npc173
+    - not npc_exists test_npc174
+    - not npc_exists test_npc175
+    - not npc_exists test_npc176
+    - not npc_exists test_npc177
+    - not npc_exists test_npc178
+    - not npc_exists test_npc179
+    - not npc_exists test_npc180
+    - not npc_exists test_npc181
+    - not npc_exists test_npc182
+    - not npc_exists test_npc183
+    - not npc_exists test_npc184
+    - not npc_exists test_npc185
+    - not npc_exists test_npc186
+    - not npc_exists test_npc187
+    - not npc_exists test_npc188
+    - not npc_exists test_npc189
+    - not npc_exists test_npc190
+    - not npc_exists test_npc191
+    - not npc_exists test_npc192
+    - not npc_exists test_npc193
+    - not npc_exists test_npc194
+    - not npc_exists test_npc195
+    - not npc_exists test_npc196
+    - not npc_exists test_npc197
+    - not npc_exists test_npc198
+    - not npc_exists test_npc199
+    - not npc_exists test_npc200
+    - not npc_exists test_npc201
+    - not npc_exists test_npc202
+    - not npc_exists test_npc203
+    - not npc_exists test_npc204
+    - not npc_exists test_npc205
+    - not npc_exists test_npc206
+    - not npc_exists test_npc207
+    - not npc_exists test_npc208
+    - not npc_exists test_npc209
+    - not npc_exists test_npc210
+    - not npc_exists test_npc211
+    - not npc_exists test_npc212
+    - not npc_exists test_npc213
+    - not npc_exists test_npc214
+    - not npc_exists test_npc215
+    - not npc_exists test_npc216
+    - not npc_exists test_npc217
+    - not npc_exists test_npc218
+    - not npc_exists test_npc219
+    - not npc_exists test_npc220
+    - not npc_exists test_npc221
+    - not npc_exists test_npc222
+    - not npc_exists test_npc223
+    - not npc_exists test_npc224
+    - not npc_exists test_npc225
+    - not npc_exists test_npc226
+    - not npc_exists test_npc227
+    - not npc_exists test_npc228
+    - not npc_exists test_npc229
+    - not npc_exists test_npc230
+    - not npc_exists test_npc231
+    - not npc_exists test_npc232
+    - not npc_exists test_npc233
+    - not npc_exists test_npc234
+    - not npc_exists test_npc235
+    - not npc_exists test_npc236
+    - not npc_exists test_npc237
+    - not npc_exists test_npc238
+    - not npc_exists test_npc239
+    - not npc_exists test_npc240
+    - not npc_exists test_npc241
+    - not npc_exists test_npc242
+    - not npc_exists test_npc243
+    - not npc_exists test_npc244
+    - not npc_exists test_npc245
+    - not npc_exists test_npc246
+    - not npc_exists test_npc247
+    - not npc_exists test_npc248
+    - not npc_exists test_npc249
+    - not npc_exists test_npc250
+    - not npc_exists test_npc251
+    - not npc_exists test_npc252
+    - not npc_exists test_npc253
+    - not npc_exists test_npc254
+    - not npc_exists test_npc255
+    - not npc_exists test_npc256
+    - not npc_exists test_npc257
+    - not npc_exists test_npc258
+    - not npc_exists test_npc259
+    - not npc_exists test_npc260
+    - not npc_exists test_npc261
+    - not npc_exists test_npc262
+    - not npc_exists test_npc263
+    - not npc_exists test_npc264
+    - not npc_exists test_npc265
+    - not npc_exists test_npc266
+    - not npc_exists test_npc267
+    - not npc_exists test_npc268
+    - not npc_exists test_npc269
+    - not npc_exists test_npc270
+    - not npc_exists test_npc271
+    - not npc_exists test_npc272
+    - not npc_exists test_npc273
+    - not npc_exists test_npc274
+    - not npc_exists test_npc275
+    - not npc_exists test_npc276
+    - not npc_exists test_npc277
+    - not npc_exists test_npc278
+    - not npc_exists test_npc279
+    - not npc_exists test_npc280
+    - not npc_exists test_npc281
+    - not npc_exists test_npc282
+    - not npc_exists test_npc283
+    - not npc_exists test_npc284
+    - not npc_exists test_npc285
+    - not npc_exists test_npc286
+    - not npc_exists test_npc287
+    - not npc_exists test_npc288
+    - not npc_exists test_npc289
+    - not npc_exists test_npc290
+    - not npc_exists test_npc291
+    - not npc_exists test_npc292
+    - not npc_exists test_npc293
+    - not npc_exists test_npc294
+    - not npc_exists test_npc295
+    - not npc_exists test_npc296
+    - not npc_exists test_npc297
+    - not npc_exists test_npc298
+    - not npc_exists test_npc299
+    - not npc_exists test_npc300
+    - not npc_exists test_npc301
+    - not npc_exists test_npc302
+    - not npc_exists test_npc303
+    - not npc_exists test_npc304
+    - not npc_exists test_npc305
+    - not npc_exists test_npc306
+    - not npc_exists test_npc307
+    - not npc_exists test_npc308
+    - not npc_exists test_npc309
+    - not npc_exists test_npc310
+    - not npc_exists test_npc311
+    - not npc_exists test_npc312
+    - not npc_exists test_npc313
+    - not npc_exists test_npc314
+    - not npc_exists test_npc315
+    - not npc_exists test_npc316
+    - not npc_exists test_npc317
+    - not npc_exists test_npc318
+    - not npc_exists test_npc319
+    - not npc_exists test_npc320
+    - not npc_exists test_npc321
+    - not npc_exists test_npc322
+    - not npc_exists test_npc323
+    - not npc_exists test_npc324
+    - not npc_exists test_npc325
+    - not npc_exists test_npc326
+    - not npc_exists test_npc327
+    - not npc_exists test_npc328
+    - not npc_exists test_npc329
+    - not npc_exists test_npc330
+    - not npc_exists test_npc331
+    - not npc_exists test_npc332
+    - not npc_exists test_npc333
+    - not npc_exists test_npc334
+    - not npc_exists test_npc335
+    - not npc_exists test_npc336
+    - not npc_exists test_npc337
+    - not npc_exists test_npc338
+    - not npc_exists test_npc339
+    - not npc_exists test_npc340
+    - not npc_exists test_npc341
+    - not npc_exists test_npc342
+    - not npc_exists test_npc343
+    - not npc_exists test_npc344
+    - not npc_exists test_npc345
+    - not npc_exists test_npc346
+    - not npc_exists test_npc347
+    - not npc_exists test_npc348
+    - not npc_exists test_npc349
+    - not npc_exists test_npc350
+    - not npc_exists test_npc351
+    - not npc_exists test_npc352
+    - not npc_exists test_npc353
+    - not npc_exists test_npc354
+    - not npc_exists test_npc355
+    - not npc_exists test_npc356
+    - not npc_exists test_npc357
+    - not npc_exists test_npc358
+    - not npc_exists test_npc359
+    - not npc_exists test_npc360
+    - not npc_exists test_npc361
+    - not npc_exists test_npc362
+    - not npc_exists test_npc363
+    - not npc_exists test_npc364
+    - not npc_exists test_npc365
+    - not npc_exists test_npc366
+    - not npc_exists test_npc367
+    - not npc_exists test_npc368
+    - not npc_exists test_npc369
+    - not npc_exists test_npc370
+    - not npc_exists test_npc371
+    - not npc_exists test_npc372
+    - not npc_exists test_npc373
+    - not npc_exists test_npc374
+    - not npc_exists test_npc375
+    - not npc_exists test_npc376
+    - not npc_exists test_npc377
+    - not npc_exists test_npc378
+    - not npc_exists test_npc379
+    - not npc_exists test_npc380
+    - not npc_exists test_npc381
+    - not npc_exists test_npc382
+    - not npc_exists test_npc383
+    - not npc_exists test_npc384
+    - not npc_exists test_npc385
+    - not npc_exists test_npc386
+    - not npc_exists test_npc387
+    - not npc_exists test_npc388
+    - not npc_exists test_npc389
+    - not npc_exists test_npc390
+    - not npc_exists test_npc391
+    - not npc_exists test_npc392
+    - not npc_exists test_npc393
+    - not npc_exists test_npc394
+    - not npc_exists test_npc395
+    - not npc_exists test_npc396
+    - not npc_exists test_npc397
+    - not npc_exists test_npc398
+    - not npc_exists test_npc399
+    - not npc_exists test_npc400
+    - not npc_exists test_npc401
+    - not npc_exists test_npc402
+    - not npc_exists test_npc403
+    - not npc_exists test_npc404
+    - not npc_exists test_npc405
+    - not npc_exists test_npc406
+    - not npc_exists test_npc407
+    - not npc_exists test_npc408
+    - not npc_exists test_npc409
+    - not npc_exists test_npc410
+    - not npc_exists test_npc411
+    - not npc_exists test_npc412
+    - not npc_exists test_npc413
+    - not npc_exists test_npc414
+    - not npc_exists test_npc415
+    - not npc_exists test_npc416
+    - not npc_exists test_npc417
+    - not npc_exists test_npc418
+    - not npc_exists test_npc419
+    - not npc_exists test_npc420
+    - not npc_exists test_npc421
+    - not npc_exists test_npc422
+    - not npc_exists test_npc423
+    - not npc_exists test_npc424
+    - not npc_exists test_npc425
+    - not npc_exists test_npc426
+    - not npc_exists test_npc427
+    - not npc_exists test_npc428
+    - not npc_exists test_npc429
+    - not npc_exists test_npc430
+    - not npc_exists test_npc431
+    - not npc_exists test_npc432
+    - not npc_exists test_npc433
+    - not npc_exists test_npc434
+    - not npc_exists test_npc435
+    - not npc_exists test_npc436
+    - not npc_exists test_npc437
+    - not npc_exists test_npc438
+    - not npc_exists test_npc439
+    - not npc_exists test_npc440
+    - not npc_exists test_npc441
+    - not npc_exists test_npc442
+    - not npc_exists test_npc443
+    - not npc_exists test_npc444
+    - not npc_exists test_npc445
+    - not npc_exists test_npc446
+    - not npc_exists test_npc447
+    - not npc_exists test_npc448
+    - not npc_exists test_npc449
+    - not npc_exists test_npc450
+    - not npc_exists test_npc451
+    - not npc_exists test_npc452
+    - not npc_exists test_npc453
+    - not npc_exists test_npc454
+    - not npc_exists test_npc455
+    - not npc_exists test_npc456
+    - not npc_exists test_npc457
+    - not npc_exists test_npc458
+    - not npc_exists test_npc459
+    - not npc_exists test_npc460
+    - not npc_exists test_npc461
+    - not npc_exists test_npc462
+    - not npc_exists test_npc463
+    - not npc_exists test_npc464
+    - not npc_exists test_npc465
+    - not npc_exists test_npc466
+    - not npc_exists test_npc467
+    - not npc_exists test_npc468
+    - not npc_exists test_npc469
+    - not npc_exists test_npc470
+    - not npc_exists test_npc471
+    - not npc_exists test_npc472
+    - not npc_exists test_npc473
+    - not npc_exists test_npc474
+    - not npc_exists test_npc475
+    - not npc_exists test_npc476
+    - not npc_exists test_npc477
+    - not npc_exists test_npc478
+    - not npc_exists test_npc479
+    - not npc_exists test_npc480
+    - not npc_exists test_npc481
+    - not npc_exists test_npc482
+    - not npc_exists test_npc483
+    - not npc_exists test_npc484
+    - not npc_exists test_npc485
+    - not npc_exists test_npc486
+    - not npc_exists test_npc487
+    - not npc_exists test_npc488
+    - not npc_exists test_npc489
+    - not npc_exists test_npc490
+    - not npc_exists test_npc491
+    - not npc_exists test_npc492
+    - not npc_exists test_npc493
+    - not npc_exists test_npc494
+    - not npc_exists test_npc495
+    - not npc_exists test_npc496
+    - not npc_exists test_npc497
+    - not npc_exists test_npc498
+    - not npc_exists test_npc499
+    - not npc_exists test_npc500
+    type: "event"

--- a/mods/tuxemon/maps/test_spyder_cotton_scoop.yaml
+++ b/mods/tuxemon/maps/test_spyder_cotton_scoop.yaml
@@ -1,0 +1,44 @@
+events:
+  NPCs:
+    actions:
+    - create_npc test_npc038,3,4
+    - create_npc test_npc039,4,4
+    - create_npc test_npc040,5,4
+    - create_npc test_npc041,6,4
+    - create_npc test_npc042,7,4
+    - create_npc test_npc043,8,4
+    - create_npc test_npc044,9,4
+    - create_npc test_npc045,10,4
+    - create_npc test_npc046,11,4
+    - create_npc test_npc047,12,4
+    - create_npc test_npc048,1,8
+    - create_npc test_npc049,1,9
+    - create_npc test_npc050,1,10    
+    - npc_wander test_npc038
+    - npc_wander test_npc039
+    - npc_wander test_npc040
+    - npc_wander test_npc041
+    - npc_wander test_npc042
+    - npc_wander test_npc043
+    - npc_wander test_npc044
+    - npc_wander test_npc045
+    - npc_wander test_npc046
+    - npc_wander test_npc047
+    - npc_wander test_npc048
+    - npc_wander test_npc049
+    - npc_wander test_npc050
+    conditions:
+    - not npc_exists test_npc038
+    - not npc_exists test_npc039
+    - not npc_exists test_npc040
+    - not npc_exists test_npc041
+    - not npc_exists test_npc042
+    - not npc_exists test_npc043
+    - not npc_exists test_npc044
+    - not npc_exists test_npc045
+    - not npc_exists test_npc046
+    - not npc_exists test_npc047
+    - not npc_exists test_npc048
+    - not npc_exists test_npc049
+    - not npc_exists test_npc050
+    type: "event"

--- a/mods/tuxemon/maps/test_spyder_cotton_town.yaml
+++ b/mods/tuxemon/maps/test_spyder_cotton_town.yaml
@@ -1,0 +1,642 @@
+events:
+  test_npc001:
+    actions:
+    - create_npc test_npc001,7,21
+    - npc_wander test_npc001
+    conditions:
+    - not npc_exists test_npc001
+    type: "event"
+  test_npc002:
+    actions:
+    - create_npc test_npc002,8,21
+    - npc_wander test_npc002
+    conditions:
+    - not npc_exists test_npc002
+    type: "event"
+  test_npc003:
+    actions:
+    - create_npc test_npc003,9,21
+    - npc_wander test_npc003
+    conditions:
+    - not npc_exists test_npc003
+    type: "event"
+  test_npc004:
+    actions:
+    - create_npc test_npc004,10,21
+    - npc_wander test_npc004
+    conditions:
+    - not npc_exists test_npc004
+    type: "event"
+  test_npc005:
+    actions:
+    - create_npc test_npc005,11,21
+    - npc_wander test_npc005
+    conditions:
+    - not npc_exists test_npc005
+    type: "event"
+  test_npc006:
+    actions:
+    - create_npc test_npc006,5,23
+    - npc_wander test_npc006
+    conditions:
+    - not npc_exists test_npc006
+    type: "event"
+  test_npc007:
+    actions:
+    - create_npc test_npc007,5,24
+    - npc_wander test_npc007
+    conditions:
+    - not npc_exists test_npc007
+    type: "event"
+  test_npc008:
+    actions:
+    - create_npc test_npc008,5,25
+    - npc_wander test_npc008
+    conditions:
+    - not npc_exists test_npc008
+    type: "event"
+  test_npc009:
+    actions:
+    - create_npc test_npc009,5,26
+    - npc_wander test_npc009
+    conditions:
+    - not npc_exists test_npc009
+    type: "event"
+  test_npc010:
+    actions:
+    - create_npc test_npc010,5,27
+    - npc_wander test_npc010
+    conditions:
+    - not npc_exists test_npc010
+    type: "event"
+  test_npc011:
+    actions:
+    - create_npc test_npc011,5,28
+    - npc_wander test_npc011
+    conditions:
+    - not npc_exists test_npc011
+    type: "event"
+  test_npc012:
+    actions:
+    - create_npc test_npc012,13,23
+    - npc_wander test_npc012
+    conditions:
+    - not npc_exists test_npc012
+    type: "event"
+  test_npc013:
+    actions:
+    - create_npc test_npc013,13,24
+    - npc_wander test_npc013
+    conditions:
+    - not npc_exists test_npc013
+    type: "event"
+  test_npc014:
+    actions:
+    - create_npc test_npc014,13,25
+    - npc_wander test_npc014
+    conditions:
+    - not npc_exists test_npc014
+    type: "event"
+  test_npc015:
+    actions:
+    - create_npc test_npc015,13,26
+    - npc_wander test_npc015
+    conditions:
+    - not npc_exists test_npc015
+    type: "event"
+  test_npc016:
+    actions:
+    - create_npc test_npc016,13,27
+    - npc_wander test_npc016
+    conditions:
+    - not npc_exists test_npc016
+    type: "event"
+  test_npc017:
+    actions:
+    - create_npc test_npc017,13,28
+    - npc_wander test_npc017
+    conditions:
+    - not npc_exists test_npc017
+    type: "event"
+  test_npc018:
+    actions:
+    - create_npc test_npc018,4,36
+    - npc_wander test_npc018
+    conditions:
+    - not npc_exists test_npc018
+    type: "event"
+  test_npc019:
+    actions:
+    - create_npc test_npc019,5,36
+    - npc_wander test_npc019
+    conditions:
+    - not npc_exists test_npc019
+    type: "event"
+  test_npc020:
+    actions:
+    - create_npc test_npc020,6,36
+    - npc_wander test_npc020
+    conditions:
+    - not npc_exists test_npc020
+    type: "event"
+  test_npc021:
+    actions:
+    - create_npc test_npc021,7,36
+    - npc_wander test_npc021
+    conditions:
+    - not npc_exists test_npc021
+    type: "event"
+  test_npc022:
+    actions:
+    - create_npc test_npc022,8,36
+    - npc_wander test_npc022
+    conditions:
+    - not npc_exists test_npc022
+    type: "event"
+  test_npc023:
+    actions:
+    - create_npc test_npc023,9,36
+    - npc_wander test_npc023
+    conditions:
+    - not npc_exists test_npc023
+    type: "event"
+  test_npc024:
+    actions:
+    - create_npc test_npc024,10,36
+    - npc_wander test_npc024
+    conditions:
+    - not npc_exists test_npc024
+    type: "event"
+  test_npc025:
+    actions:
+    - create_npc test_npc025,11,36
+    - npc_wander test_npc025
+    conditions:
+    - not npc_exists test_npc025
+    type: "event"
+  test_npc026:
+    actions:
+    - create_npc test_npc026,12,36
+    - npc_wander test_npc026
+    conditions:
+    - not npc_exists test_npc026
+    type: "event"
+  test_npc027:
+    actions:
+    - create_npc test_npc027,13,36
+    - npc_wander test_npc027
+    conditions:
+    - not npc_exists test_npc027
+    type: "event"
+  test_npc028:
+    actions:
+    - create_npc test_npc028,14,36
+    - npc_wander test_npc028
+    conditions:
+    - not npc_exists test_npc028
+    type: "event"
+  test_npc029:
+    actions:
+    - create_npc test_npc029,15,36
+    - npc_wander test_npc029
+    conditions:
+    - not npc_exists test_npc029
+    type: "event"
+  test_npc030:
+    actions:
+    - create_npc test_npc030,16,36
+    - npc_wander test_npc030
+    conditions:
+    - not npc_exists test_npc030
+    type: "event"
+  test_npc031:
+    actions:
+    - create_npc test_npc031,17,36
+    - npc_wander test_npc031
+    conditions:
+    - not npc_exists test_npc031
+    type: "event"
+  test_npc032:
+    actions:
+    - create_npc test_npc032,18,36
+    - npc_wander test_npc032
+    conditions:
+    - not npc_exists test_npc032
+    type: "event"
+  test_npc033:
+    actions:
+    - create_npc test_npc033,19,36
+    - npc_wander test_npc033
+    conditions:
+    - not npc_exists test_npc033
+    type: "event"
+  test_npc034:
+    actions:
+    - create_npc test_npc034,20,36
+    - npc_wander test_npc034
+    conditions:
+    - not npc_exists test_npc034
+    type: "event"
+  test_npc035:
+    actions:
+    - create_npc test_npc035,21,36
+    - npc_wander test_npc035
+    conditions:
+    - not npc_exists test_npc035
+    type: "event"
+  test_npc036:
+    actions:
+    - create_npc test_npc036,22,36
+    - npc_wander test_npc036
+    conditions:
+    - not npc_exists test_npc036
+    type: "event"
+  test_npc037:
+    actions:
+    - create_npc test_npc037,23,36
+    - npc_wander test_npc037
+    conditions:
+    - not npc_exists test_npc037
+    type: "event"
+  test_npc038:
+    actions:
+    - create_npc test_npc038,24,36
+    - npc_wander test_npc038
+    conditions:
+    - not npc_exists test_npc038
+    type: "event"
+  test_npc038:
+    actions:
+    - create_npc test_npc038,2,17
+    - create_npc test_npc039,3,17
+    - create_npc test_npc040,4,17
+    - create_npc test_npc041,5,17
+    - create_npc test_npc042,6,17
+    - create_npc test_npc043,7,17
+    - create_npc test_npc044,8,17
+    - create_npc test_npc045,9,17
+    - create_npc test_npc046,10,17
+    - create_npc test_npc047,11,17
+    - create_npc test_npc048,12,17
+    - create_npc test_npc049,13,17
+    - create_npc test_npc050,14,17
+    - create_npc test_npc051,15,17
+    - create_npc test_npc052,16,17
+    - create_npc test_npc053,17,17
+    - create_npc test_npc054,18,17
+    - create_npc test_npc055,19,17
+    - create_npc test_npc056,20,17
+    - create_npc test_npc057,21,17
+    - create_npc test_npc058,22,17
+    - create_npc test_npc059,23,17
+    - create_npc test_npc060,24,17
+    - create_npc test_npc061,25,17
+    - create_npc test_npc062,26,17
+    - create_npc test_npc063,27,17
+    - create_npc test_npc064,28,17
+    - create_npc test_npc065,29,17
+    - create_npc test_npc066,30,17
+    - create_npc test_npc067,31,17
+    - create_npc test_npc068,32,17
+    - create_npc test_npc069,28,38
+    - create_npc test_npc070,29,38
+    - create_npc test_npc071,30,38
+    - create_npc test_npc072,31,38
+    - create_npc test_npc073,32,38
+    - create_npc test_npc074,33,38
+    - create_npc test_npc075,34,38
+    - create_npc test_npc076,35,38
+    - create_npc test_npc077,36,38
+    - create_npc test_npc078,37,38
+    - create_npc test_npc079,38,38
+    - create_npc test_npc080,10,10
+    - create_npc test_npc081,11,10
+    - create_npc test_npc082,12,10
+    - create_npc test_npc083,13,10
+    - create_npc test_npc084,14,10
+    - create_npc test_npc085,15,10
+    - create_npc test_npc086,16,10
+    - create_npc test_npc087,17,10
+    - create_npc test_npc088,18,10
+    - create_npc test_npc089,19,10
+    - create_npc test_npc090,20,10
+    - create_npc test_npc091,21,10
+    - create_npc test_npc092,22,10
+    - create_npc test_npc093,23,10
+    - create_npc test_npc094,24,10
+    - create_npc test_npc095,25,10
+    - create_npc test_npc096,26,10
+    - create_npc test_npc097,27,10
+    - create_npc test_npc098,28,10
+    - create_npc test_npc099,29,10
+    - create_npc test_npc100,30,10
+    - create_npc test_npc101,31,10
+    - create_npc test_npc102,32,10
+    - create_npc test_npc103,33,10
+    - create_npc test_npc104,34,10
+    - create_npc test_npc105,35,10
+    - create_npc test_npc119,2,18
+    - create_npc test_npc106,2,19
+    - create_npc test_npc107,2,20
+    - create_npc test_npc108,2,21
+    - create_npc test_npc109,2,22
+    - create_npc test_npc110,2,23
+    - create_npc test_npc111,2,24
+    - create_npc test_npc112,2,25
+    - create_npc test_npc113,2,26
+    - create_npc test_npc114,2,27
+    - create_npc test_npc115,2,28
+    - create_npc test_npc116,2,29
+    - create_npc test_npc117,2,30
+    - create_npc test_npc118,2,31
+    - create_npc test_npc119,10,3
+    - create_npc test_npc120,10,4
+    - create_npc test_npc121,10,5
+    - create_npc test_npc122,10,6
+    - create_npc test_npc123,10,7
+    - create_npc test_npc124,10,8
+    - create_npc test_npc125,10,9
+    - create_npc test_npc126,3,12
+    - create_npc test_npc127,4,12
+    - create_npc test_npc128,5,12
+    - create_npc test_npc129,6,12
+    - create_npc test_npc130,7,12
+    - create_npc test_npc131,8,12
+    - create_npc test_npc132,9,12
+    - create_npc test_npc133,10,12
+    - create_npc test_npc134,13,12
+    - create_npc test_npc135,14,12
+    - create_npc test_npc136,15,12
+    - create_npc test_npc137,16,12
+    - create_npc test_npc138,17,12
+    - create_npc test_npc139,18,12
+    - create_npc test_npc140,19,12
+    - create_npc test_npc141,20,12
+    - create_npc test_npc142,21,12
+    - create_npc test_npc143,22,12
+    - create_npc test_npc144,23,12
+    - create_npc test_npc145,24,12
+    - create_npc test_npc146,25,12
+    - create_npc test_npc147,26,12
+    - create_npc test_npc148,27,12
+    - create_npc test_npc149,28,12
+    - create_npc test_npc150,29,12
+    - create_npc test_npc151,30,12
+    - create_npc test_npc152,31,12
+    - create_npc test_npc153,15,24
+    - create_npc test_npc154,15,25
+    - create_npc test_npc155,15,26
+    - create_npc test_npc156,15,27
+    - create_npc test_npc157,15,28
+    - create_npc test_npc158,15,29
+    - create_npc test_npc159,31,26
+    - create_npc test_npc160,33,26
+    - npc_wander test_npc038
+    - npc_wander test_npc039
+    - npc_wander test_npc040
+    - npc_wander test_npc041
+    - npc_wander test_npc042
+    - npc_wander test_npc043
+    - npc_wander test_npc044
+    - npc_wander test_npc045
+    - npc_wander test_npc046
+    - npc_wander test_npc047
+    - npc_wander test_npc048
+    - npc_wander test_npc049
+    - npc_wander test_npc050
+    - npc_wander test_npc051
+    - npc_wander test_npc052
+    - npc_wander test_npc053
+    - npc_wander test_npc054
+    - npc_wander test_npc055
+    - npc_wander test_npc056
+    - npc_wander test_npc057
+    - npc_wander test_npc058
+    - npc_wander test_npc059
+    - npc_wander test_npc060
+    - npc_wander test_npc061
+    - npc_wander test_npc062
+    - npc_wander test_npc063
+    - npc_wander test_npc064
+    - npc_wander test_npc065
+    - npc_wander test_npc066
+    - npc_wander test_npc067
+    - npc_wander test_npc068
+    - npc_wander test_npc069
+    - npc_wander test_npc070
+    - npc_wander test_npc071
+    - npc_wander test_npc072
+    - npc_wander test_npc073
+    - npc_wander test_npc074
+    - npc_wander test_npc075
+    - npc_wander test_npc076
+    - npc_wander test_npc077
+    - npc_wander test_npc078
+    - npc_wander test_npc079
+    - npc_wander test_npc080
+    - npc_wander test_npc081
+    - npc_wander test_npc082
+    - npc_wander test_npc083
+    - npc_wander test_npc084
+    - npc_wander test_npc085
+    - npc_wander test_npc086
+    - npc_wander test_npc087
+    - npc_wander test_npc088
+    - npc_wander test_npc089
+    - npc_wander test_npc090
+    - npc_wander test_npc091
+    - npc_wander test_npc092
+    - npc_wander test_npc093
+    - npc_wander test_npc094
+    - npc_wander test_npc095
+    - npc_wander test_npc096
+    - npc_wander test_npc097
+    - npc_wander test_npc098
+    - npc_wander test_npc099
+    - npc_wander test_npc100
+    - npc_wander test_npc101
+    - npc_wander test_npc102
+    - npc_wander test_npc103
+    - npc_wander test_npc104
+    - npc_wander test_npc105
+    - npc_wander test_npc106
+    - npc_wander test_npc107
+    - npc_wander test_npc108
+    - npc_wander test_npc109
+    - npc_wander test_npc110
+    - npc_wander test_npc111
+    - npc_wander test_npc112
+    - npc_wander test_npc113
+    - npc_wander test_npc114
+    - npc_wander test_npc115
+    - npc_wander test_npc116
+    - npc_wander test_npc117
+    - npc_wander test_npc118
+    - npc_wander test_npc119
+    - npc_wander test_npc120
+    - npc_wander test_npc121
+    - npc_wander test_npc122
+    - npc_wander test_npc123
+    - npc_wander test_npc124
+    - npc_wander test_npc125
+    - npc_wander test_npc126
+    - npc_wander test_npc127
+    - npc_wander test_npc128
+    - npc_wander test_npc129
+    - npc_wander test_npc130
+    - npc_wander test_npc131
+    - npc_wander test_npc132
+    - npc_wander test_npc133
+    - npc_wander test_npc134
+    - npc_wander test_npc135
+    - npc_wander test_npc136
+    - npc_wander test_npc137
+    - npc_wander test_npc138
+    - npc_wander test_npc139
+    - npc_wander test_npc140
+    - npc_wander test_npc141
+    - npc_wander test_npc142
+    - npc_wander test_npc143
+    - npc_wander test_npc144
+    - npc_wander test_npc145
+    - npc_wander test_npc146
+    - npc_wander test_npc147
+    - npc_wander test_npc148
+    - npc_wander test_npc149
+    - npc_wander test_npc150
+    - npc_wander test_npc151
+    - npc_wander test_npc152
+    - npc_wander test_npc153
+    - npc_wander test_npc154
+    - npc_wander test_npc155
+    - npc_wander test_npc156
+    - npc_wander test_npc157
+    - npc_wander test_npc158
+    - npc_wander test_npc159
+    - npc_wander test_npc160
+    conditions:
+    - not npc_exists test_npc038
+    - not npc_exists test_npc039
+    - not npc_exists test_npc040
+    - not npc_exists test_npc041
+    - not npc_exists test_npc042
+    - not npc_exists test_npc043
+    - not npc_exists test_npc044
+    - not npc_exists test_npc045
+    - not npc_exists test_npc046
+    - not npc_exists test_npc047
+    - not npc_exists test_npc048
+    - not npc_exists test_npc049
+    - not npc_exists test_npc050
+    - not npc_exists test_npc051
+    - not npc_exists test_npc052
+    - not npc_exists test_npc053
+    - not npc_exists test_npc054
+    - not npc_exists test_npc055
+    - not npc_exists test_npc056
+    - not npc_exists test_npc057
+    - not npc_exists test_npc058
+    - not npc_exists test_npc059
+    - not npc_exists test_npc060
+    - not npc_exists test_npc061
+    - not npc_exists test_npc062
+    - not npc_exists test_npc063
+    - not npc_exists test_npc064
+    - not npc_exists test_npc065
+    - not npc_exists test_npc066
+    - not npc_exists test_npc067
+    - not npc_exists test_npc068
+    - not npc_exists test_npc069
+    - not npc_exists test_npc070
+    - not npc_exists test_npc071
+    - not npc_exists test_npc072
+    - not npc_exists test_npc073
+    - not npc_exists test_npc074
+    - not npc_exists test_npc075
+    - not npc_exists test_npc076
+    - not npc_exists test_npc077
+    - not npc_exists test_npc078
+    - not npc_exists test_npc079
+    - not npc_exists test_npc080
+    - not npc_exists test_npc081
+    - not npc_exists test_npc082
+    - not npc_exists test_npc083
+    - not npc_exists test_npc084
+    - not npc_exists test_npc085
+    - not npc_exists test_npc086
+    - not npc_exists test_npc087
+    - not npc_exists test_npc088
+    - not npc_exists test_npc089
+    - not npc_exists test_npc090
+    - not npc_exists test_npc091
+    - not npc_exists test_npc092
+    - not npc_exists test_npc093
+    - not npc_exists test_npc094
+    - not npc_exists test_npc095
+    - not npc_exists test_npc096
+    - not npc_exists test_npc097
+    - not npc_exists test_npc098
+    - not npc_exists test_npc099
+    - not npc_exists test_npc100
+    - not npc_exists test_npc101
+    - not npc_exists test_npc102
+    - not npc_exists test_npc103
+    - not npc_exists test_npc104
+    - not npc_exists test_npc105
+    - not npc_exists test_npc106
+    - not npc_exists test_npc107
+    - not npc_exists test_npc108
+    - not npc_exists test_npc109
+    - not npc_exists test_npc110
+    - not npc_exists test_npc111
+    - not npc_exists test_npc112
+    - not npc_exists test_npc113
+    - not npc_exists test_npc114
+    - not npc_exists test_npc115
+    - not npc_exists test_npc116
+    - not npc_exists test_npc117
+    - not npc_exists test_npc118
+    - not npc_exists test_npc119
+    - not npc_exists test_npc120
+    - not npc_exists test_npc121
+    - not npc_exists test_npc122
+    - not npc_exists test_npc123
+    - not npc_exists test_npc124
+    - not npc_exists test_npc125
+    - not npc_exists test_npc126
+    - not npc_exists test_npc127
+    - not npc_exists test_npc128
+    - not npc_exists test_npc129
+    - not npc_exists test_npc130
+    - not npc_exists test_npc131
+    - not npc_exists test_npc132
+    - not npc_exists test_npc133
+    - not npc_exists test_npc134
+    - not npc_exists test_npc135
+    - not npc_exists test_npc136
+    - not npc_exists test_npc137
+    - not npc_exists test_npc138
+    - not npc_exists test_npc139
+    - not npc_exists test_npc140
+    - not npc_exists test_npc140
+    - not npc_exists test_npc141
+    - not npc_exists test_npc142
+    - not npc_exists test_npc143
+    - not npc_exists test_npc144
+    - not npc_exists test_npc145
+    - not npc_exists test_npc146
+    - not npc_exists test_npc147
+    - not npc_exists test_npc148
+    - not npc_exists test_npc149
+    - not npc_exists test_npc150
+    - not npc_exists test_npc151
+    - not npc_exists test_npc152
+    - not npc_exists test_npc153
+    - not npc_exists test_npc154
+    - not npc_exists test_npc155
+    - not npc_exists test_npc156
+    - not npc_exists test_npc157
+    - not npc_exists test_npc158
+    - not npc_exists test_npc159
+    - not npc_exists test_npc160
+    type: "event"

--- a/tuxemon/map.py
+++ b/tuxemon/map.py
@@ -407,6 +407,7 @@ class TuxemonMap:
         self.surfable_map = surfable_map
         self.collision_lines_map = collisions_lines_map
         self.size = tiled_map.width, tiled_map.height
+        self.area = tiled_map.width * tiled_map.height
         self.inits = inits
         self.events = events
         self.renderer: Optional[pyscroll.BufferedRenderer] = None

--- a/tuxemon/states/persistance/load_menu.py
+++ b/tuxemon/states/persistance/load_menu.py
@@ -30,6 +30,7 @@ class LoadMenuState(SaveMenuState):
                 # when game is loaded from world menu
                 self.client.pop_state(self)
                 self.client.pop_state(old_world)
+                self.client.pop_state()
             except ValueError:
                 # when game is loaded from the start menu
                 self.client.pop_state()

--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -1073,6 +1073,7 @@ class WorldState(state.State):
         self.surfable_map = map_data.surfable_map
         self.collision_lines_map = map_data.collision_lines_map
         self.map_size = map_data.size
+        self.map_area = map_data.area
 
         # The first coordinates that are out of bounds.
         self.invalid_x = (-1, self.map_size[0])
@@ -1107,17 +1108,20 @@ class WorldState(state.State):
         """
         txmn_map = TMXMapLoader().load(path)
         yaml_path = path[:-4] + ".yaml"
-        scenario_path = prepare.fetch("maps", txmn_map.scenario + ".yaml")
         # TODO: merge the events from both sources
         if os.path.exists(yaml_path):
             new_events = list(txmn_map.events)
             new_events.extend(YAMLEventLoader().load_events(yaml_path))
             txmn_map.events = new_events
-        # specific YAML, scenario based
-        if os.path.exists(scenario_path):
-            new_events = list(txmn_map.events)
-            new_events.extend(YAMLEventLoader().load_events(scenario_path))
-            txmn_map.events = new_events
+        # scenario YAML, try because not all maps have a scenario
+        try:
+            scenario_path = prepare.fetch("maps", txmn_map.scenario + ".yaml")
+            if os.path.exists(scenario_path):
+                new_events = list(txmn_map.events)
+                new_events.extend(YAMLEventLoader().load_events(scenario_path))
+                txmn_map.events = new_events
+        except:
+            pass
         return txmn_map
 
     @no_type_check  # only used by multiplayer which is disabled


### PR DESCRIPTION
PR:
- creates the **test_npcs.json** where there are 500 NPCs called test_npc001, test_npc002, etc.
- creates a new map called **test_npcs** that will host all the 500 NPCs (testing purpose);
- creates the **test_spyder_cotton_town**.yaml, the file that creates 160 NPCs inside the town, if someone wants to test it, then he/she needs to rename it: **spyder_cotton_town.yaml** (spyder_cotton_town has an area of 1600 tiles);
- creates the **test_spyder_cotton_scoop**.yaml, the file that creates 13 NPCs inside the scoop, if someone wants to test it, then he/she needs to rename it: **spyder_cotton_scoop.yaml** (spyder_cotton_scoop has an area of 143 tiles, but only 73 without collisions, it means 13/71 tiles (18.3% occupancy);
- fixes a bug (crash) if someone tries to load a map without indicating a scenario;
- fixes a bug related to the loading of the game; how to reproduce the bug, save in Paper Town, enter the Player house, see mom happily wandering, load the game, reenter the house, mom is stuck
- adds a new parameter in worldstate called **map_area** and it's nothing more than the area of the map (it exists **map_size** but it returns a tuple(40,40), **map_area** will return 1600)