### PR TITLE
remove BackgroundState (State)

### DIFF
--- a/tuxemon/event/actions/change_bg.py
+++ b/tuxemon/event/actions/change_bg.py
@@ -43,30 +43,27 @@ class ChangeBgAction(EventAction):
     background: Optional[str] = None
 
     def start(self) -> None:
+        client = self.session.client
         # don't override previous state if we are still in the state.
-        current_state = self.session.client.current_state
+        current_state = client.current_state
         if current_state is None:
             # obligatory "should not happen"
             raise RuntimeError
 
         # this function cleans up the previous state without crashing
-        if len(self.session.client.state_manager.active_states) > 2:
-            self.session.client.pop_state()
+        if len(client.state_manager.active_states) > 1:
+            client.pop_state()
 
         if current_state.name != str(ImageState):
             if self.background is None:
-                self.session.client.pop_state()
+                client.pop_state()
                 return
             else:
                 _background = self.background.split(":")
                 if len(_background) == 1:
-                    self.session.client.push_state(
-                        ImageState(background=self.background)
-                    )
+                    client.push_state(ImageState(background=self.background))
                 else:
-                    self.session.client.push_state(
-                        ColorState(color=self.background)
-                    )
+                    client.push_state(ColorState(color=self.background))
 
     def cleanup(self) -> None:
         theme = get_theme()

--- a/tuxemon/event/actions/evolution.py
+++ b/tuxemon/event/actions/evolution.py
@@ -31,7 +31,7 @@ class EvolutionAction(EventAction):
         player = self.session.player
         client = self.session.client
         # this function cleans up the previous state without crashing
-        if len(client.state_manager.active_states) > 2:
+        if len(client.state_manager.active_states) > 1:
             return
 
         def positive_answer(monster: Monster, evolved: Monster) -> None:

--- a/tuxemon/event/actions/remove_state.py
+++ b/tuxemon/event/actions/remove_state.py
@@ -35,7 +35,7 @@ class RemoveStateAction(EventAction):
             raise RuntimeError
         if not self.state_name:
             for ele in self.session.client.active_states:
-                if ele.name != "WorldState" and ele.name != "BackgroundState":
+                if ele.name != "WorldState":
                     self.session.client.remove_state(ele)
         if current_state.name == self.state_name:
             self.session.client.pop_state()

--- a/tuxemon/main.py
+++ b/tuxemon/main.py
@@ -9,7 +9,7 @@ from tuxemon import log, prepare
 from tuxemon.session import local_session
 from tuxemon.states.persistance.load_menu import LoadMenuState
 from tuxemon.states.splash import SplashState
-from tuxemon.states.start import BackgroundState, StartState
+from tuxemon.states.start import StartState
 from tuxemon.states.transition.fade import FadeInTransition
 from tuxemon.states.world.worldstate import WorldState
 
@@ -45,13 +45,6 @@ def main(
     # WIP.  Will be more complete with game-view
     local_session.client = client
 
-    # background state is used to prevent other states from
-    # being required to track dirty screen areas.  for example,
-    # in the start state, there is a menu on a blank background,
-    # since menus do not clean up dirty areas, the blank,
-    # "Background state" will do that.  The alternative is creating
-    # a system for states to clean up their dirty screen areas.
-    client.push_state(BackgroundState())
     if not config.skip_titlescreen:
         client.push_state(StartState())
 

--- a/tuxemon/states/start/__init__.py
+++ b/tuxemon/states/start/__init__.py
@@ -9,7 +9,6 @@ from collections.abc import Callable
 from functools import partial
 from typing import Any, Union
 
-import pygame
 import pygame_menu
 from pygame_menu import locals
 from pygame_menu.locals import POSITION_CENTER
@@ -25,22 +24,6 @@ from tuxemon.state import State
 logger = logging.getLogger(__name__)
 
 StartGameObj = Callable[[], object]
-
-
-class BackgroundState(State):
-    """
-    Background state is used to prevent other states from
-    being required to track dirty screen areas. For example,
-    in the start state, there is a menu on a blank background,
-    since menus do not clean up dirty areas, the blank,
-    "Background state" will do that. The alternative is creating
-    a system for states to clean up their dirty screen areas.
-
-    Eventually the need for this will be phased out.
-    """
-
-    def draw(self, surface: pygame.surface.Surface) -> None:
-        surface.fill((0, 0, 0, 0))
 
 
 class StartState(PygameMenuState):
@@ -60,7 +43,7 @@ class StartState(PygameMenuState):
             local_session.player.game_variables[
                 "date_start_game"
             ] = formula.today_ordinal()
-            self.client.pop_state(self)
+            self.client.remove_state(self)
 
         def change_state(
             state: Union[State, str],


### PR DESCRIPTION
everything started after discovering the bug in #2122 (bug related to stuck NPCs after loading from menu - in game)

by tracking the states I discovered that when loading the savegame from the menu (in game), the game loses **BackgroundState** without any issue, this is why I opened the PR.

PR proposes to remove **BackgroundState**, from my knowledge BackgroundState was created because of some issue with the background color (exclusively during the starting process, but without getting removed (?) after the loading or the starting of a new game).
This issue doesn't exist anymore since the menu (Start) has its own background.

By the way, after removing it I didn't notice anything weird, neither in the black background behind the map, neither in other contexts.

Remember:
_if there are no bugs from removing the background state, thats fine to remove it.  the reason it existed was to allow all states to draw to the screen and not draw the background.  without the state, then the screen doesn't get cleared, so you would see the old menu graphics if it changed.  there was a check if a state draws to the entire screen, like the world state, then the next state (ususally the background state) would not get drawn.  so it was never actually used unless a menu is on top.
i haven't checked the state of the code in a while, but my only concern would be that menus would need to be aware of what they are drawn over._ (@bitcraft )

update: tried to track the surface, but nothing happens, it seems active only during the splash screen + starting menu