### PR TITLE
class EntityFacing

### DIFF
--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -177,6 +177,13 @@ class MissionStatus(str, Enum):
     failed = "failed"
 
 
+class EntityFacing(str, Enum):
+    front = "front"
+    back = "back"
+    left = "left"
+    right = "right"
+
+
 # TODO: Automatically generate state enum through discovery
 State = Enum(
     "State",
@@ -785,7 +792,10 @@ class NpcTemplateModel(BaseModel):
 
     @field_validator("sprite_name")
     def sprite_exists(cls: NpcTemplateModel, v: str) -> str:
-        sprite: str = f"sprites/{v}_front.png"
+        sprite = f"sprites/{v}_{EntityFacing.front}.png"
+        sprite = f"sprites/{v}_{EntityFacing.back}.png"
+        sprite = f"sprites/{v}_{EntityFacing.right}.png"
+        sprite = f"sprites/{v}_{EntityFacing.left}.png"
         sprite_obj: str = f"sprites_obj/{v}.png"
         if has.file(sprite) or has.file(sprite_obj):
             return v

--- a/tuxemon/map.py
+++ b/tuxemon/map.py
@@ -61,9 +61,6 @@ short_dirs = {d[0]: dirs2[d] for d in dirs2}
 # complimentary directions
 pairs = {"up": "down", "down": "up", "left": "right", "right": "left"}
 
-# what directions entities can face
-facing = "front", "back", "left", "right"
-
 
 def translate_short_path(
     path: str,

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -13,12 +13,12 @@ from typing import TYPE_CHECKING, Any, Optional, TypedDict
 from tuxemon import surfanim
 from tuxemon.battle import Battle, decode_battle, encode_battle
 from tuxemon.compat import Rect
-from tuxemon.db import ElementType, PlagueType, SeenStatus, db
+from tuxemon.db import ElementType, EntityFacing, PlagueType, SeenStatus, db
 from tuxemon.entity import Entity
 from tuxemon.graphics import load_and_scale
 from tuxemon.item.item import MAX_TYPES_BAG, Item, decode_items, encode_items
 from tuxemon.locale import T
-from tuxemon.map import Direction, dirs2, dirs3, facing, get_direction, proj
+from tuxemon.map import Direction, dirs2, dirs3, get_direction, proj
 from tuxemon.math import Vector2
 from tuxemon.mission import Mission, decode_mission, encode_mission
 from tuxemon.monster import (
@@ -291,7 +291,7 @@ class NPC(Entity[NPCState]):
                     self.interactive_obj = True
 
         self.standing = {}
-        for standing_type in facing:
+        for standing_type in list(EntityFacing):
             # if the template slug is interactive_obj, then it needs _front
             if self.interactive_obj:
                 filename = f"{self.sprite_name}.png"
@@ -301,14 +301,16 @@ class NPC(Entity[NPCState]):
                 path = os.path.join("sprites", filename)
             self.standing[standing_type] = load_and_scale(path)
         # The player's sprite size in pixels
-        self.playerWidth, self.playerHeight = self.standing["front"].get_size()
+        self.playerWidth, self.playerHeight = self.standing[
+            EntityFacing.front
+        ].get_size()
 
         # avoid cutoff frames when steps don't line up with tile movement
         n_frames = 3
         frame_duration = (1000 / CONFIG.player_walkrate) / n_frames / 1000 * 2
 
         # Load all of the player's sprite animations
-        anim_types = ["front_walk", "back_walk", "left_walk", "right_walk"]
+        anim_types = [f"{facing}_walk" for facing in list(EntityFacing)]
         for anim_type in anim_types:
             if not self.interactive_obj:
                 images = [


### PR DESCRIPTION
While working on #2121 I noticed: `facing = "front", "back", "left", "right"`
out of curiosity I looked for all the reference and I got only 3, map.py itself as well as npc.py;

PR:
- replaces the **facing** with a class **EntityFacing**, it deletes it from map.py and creates it in db.py;
- upgrades the validator checking in db.py, before it was checking only front, now it's going to check front, back, left and right;

it replaces: 
`anim_types = ["front_walk", "back_walk", "left_walk", "right_walk"]`
with
`anim_types = [f"{facing}_walk" for facing in list(EntityFacing)]`

initially I thought about creating a separate class called **EntityWalking**, but I wasn't sure about, since the "front_walk" references are not many as well as it wasn't much different from **EntityFacing**, only with a **_walk** added.

There is one last piece that needs to be addresses in worldstate.py, but it's connected to #2121 (there are some up, down, left and right), if this gets merged, then it'll be completed there.