### PR TITLE
get coords (map.py)

### DIFF
--- a/tuxemon/client.py
+++ b/tuxemon/client.py
@@ -156,6 +156,8 @@ class LocalPygameClient:
         self.map_name = map_data.name
         self.map_desc = map_data.description
         self.map_inside = map_data.inside
+        self.map_area = map_data.area
+        self.map_size = map_data.size
 
         # Check if the map type exists
         types = [maps.value for maps in MapType]

--- a/tuxemon/event/conditions/npc_facing_tile.py
+++ b/tuxemon/event/conditions/npc_facing_tile.py
@@ -6,6 +6,7 @@ import logging
 
 from tuxemon.event import MapCondition, get_npc
 from tuxemon.event.eventcondition import EventCondition
+from tuxemon.map import get_coords, get_direction
 from tuxemon.session import Session
 
 logger = logging.getLogger(__name__)
@@ -52,31 +53,18 @@ class NPCFacingTileCondition(EventCondition):
             for h in range(0, condition.height)
         ]
         tile_location = None
+        # get all the coordinates around the npc
+        client = session.client
+        npc_tiles = get_coords(npc.tile_pos, client.map_size)
+        # return common coordinates
+        tiles = list(set(tiles).intersection(npc_tiles))
 
-        for coordinates in tiles:
-            # Next, we check the npc position and see if we're one tile away
-            # from the tile.
-            if coordinates[1] == npc.tile_pos[1]:
-                # Check to see if the tile is to the left of the npc
-                if coordinates[0] == npc.tile_pos[0] - 1:
-                    logger.debug("Tile is to the left of the NPC")
-                    tile_location = "left"
-                # Check to see if the tile is to the right of the npc
-                elif coordinates[0] == npc.tile_pos[0] + 1:
-                    logger.debug("Tile is to the right of the NPC")
-                    tile_location = "right"
-
-            if coordinates[0] == npc.tile_pos[0]:
-                # Check to see if the tile is above the npc
-                if coordinates[1] == npc.tile_pos[1] - 1:
-                    logger.debug("Tile is above the NPC")
-                    tile_location = "up"
-                elif coordinates[1] == npc.tile_pos[1] + 1:
-                    logger.debug("Tile is below the NPC")
-                    tile_location = "down"
-
+        for coords in tiles:
+            # Look through the remaining tiles and get directions
+            tile_location = get_direction(npc.tile_pos, coords)
             # Then we check to see the npc is facing the Tile
             if npc.facing == tile_location:
+                logger.debug(f"{npc.slug} is facing {tile_location}")
                 return True
 
         return False

--- a/tuxemon/event/conditions/player_facing_npc.py
+++ b/tuxemon/event/conditions/player_facing_npc.py
@@ -6,6 +6,7 @@ import logging
 
 from tuxemon.event import MapCondition, get_npc
 from tuxemon.event.eventcondition import EventCondition
+from tuxemon.map import get_coords, get_direction
 from tuxemon.session import Session
 
 logger = logging.getLogger(__name__)
@@ -39,32 +40,22 @@ class PlayerFacingNPCCondition(EventCondition):
             Whether the player is facing the chosen character.
 
         """
+        player = session.player
+        client = session.client
         npc_location = None
 
         npc = get_npc(session, condition.parameters[0])
         if not npc:
             return False
 
-        # Next, we check the player position and see if we're one tile away
-        # from the NPC.
-        if npc.tile_pos[1] == session.player.tile_pos[1]:
-            # Check to see if the NPC is to the left of the player
-            if npc.tile_pos[0] == session.player.tile_pos[0] - 1:
-                logger.debug("NPC is to the left of the player")
-                npc_location = "left"
-            # Check to see if the NPC is to the right of the player
-            elif npc.tile_pos[0] == session.player.tile_pos[0] + 1:
-                logger.debug("NPC is to the right of the player")
-                npc_location = "right"
+        # get all the coordinates around the npc
+        npc_tiles = get_coords(npc.tile_pos, client.map_size)
+        npc_location = get_direction(player.tile_pos, npc.tile_pos)
 
-        if npc.tile_pos[0] == session.player.tile_pos[0]:
-            # Check to see if the NPC is above the player
-            if npc.tile_pos[1] == session.player.tile_pos[1] - 1:
-                logger.debug("NPC is above the player")
-                npc_location = "up"
-            elif npc.tile_pos[1] == session.player.tile_pos[1] + 1:
-                logger.debug("NPC is below the player")
-                npc_location = "down"
+        if player.tile_pos in npc_tiles:
+            logger.debug(
+                f"{player.name} is facing {npc_location} at {npc.slug}"
+            )
+            return player.facing == npc_location
 
-        # Then we check to see if we're facing the NPC
-        return session.player.facing == npc_location
+        return False

--- a/tuxemon/event/conditions/player_facing_tile.py
+++ b/tuxemon/event/conditions/player_facing_tile.py
@@ -6,6 +6,7 @@ import logging
 
 from tuxemon.event import MapCondition
 from tuxemon.event.eventcondition import EventCondition
+from tuxemon.map import get_coords, get_direction
 from tuxemon.session import Session
 from tuxemon.states.world.worldstate import WorldState
 
@@ -47,38 +48,28 @@ class PlayerFacingTileCondition(EventCondition):
             for h in range(0, condition.height)
         ]
         tile_location = None
+        player = session.player
+        client = session.client
+        # get all the coordinates around the player
+        player_tiles = get_coords(player.tile_pos, client.map_size)
 
         # check if the NPC is facing a specific set of tiles
         world = session.client.get_state_by_name(WorldState)
         if condition.parameters:
             prop = condition.parameters[0]
             if prop == "surfable":
-                tiles = list(world.surfable_map)
+                surf = list(world.surfable_map)
+                tiles = list(set(player_tiles).intersection(surf))
 
-        # Next, we check the player position and see if we're one tile
-        # away from the tile.
-        for coordinates in tiles:
-            if coordinates[1] == session.player.tile_pos[1]:
-                # Check to see if the tile is to the left of the player
-                if coordinates[0] == session.player.tile_pos[0] - 1:
-                    logger.debug("Tile is to the left of the player")
-                    tile_location = "left"
-                # Check to see if the tile is to the right of the player
-                elif coordinates[0] == session.player.tile_pos[0] + 1:
-                    logger.debug("Tile is to the right of the player")
-                    tile_location = "right"
+        # return common coordinates
+        tiles = list(set(tiles).intersection(player_tiles))
 
-            elif coordinates[0] == session.player.tile_pos[0]:
-                # Check to see if the tile is above the player
-                if coordinates[1] == session.player.tile_pos[1] - 1:
-                    logger.debug("Tile is above the player")
-                    tile_location = "up"
-                elif coordinates[1] == session.player.tile_pos[1] + 1:
-                    logger.debug("Tile is below the player")
-                    tile_location = "down"
-
+        for coords in tiles:
+            # Look through the remaining tiles and get directions
+            tile_location = get_direction(player.tile_pos, coords)
             # Then we check to see if we're facing the Tile
-            if session.player.facing == tile_location:
+            if player.facing == tile_location:
+                logger.debug(f"Player is facing {tile_location}")
                 return True
 
         return False

--- a/tuxemon/item/conditions/facing_sprite.py
+++ b/tuxemon/item/conditions/facing_sprite.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from tuxemon.event import get_npc_pos
 from tuxemon.item.itemcondition import ItemCondition
+from tuxemon.map import get_coords, get_direction
 
 if TYPE_CHECKING:
     from tuxemon.monster import Monster
@@ -24,29 +25,14 @@ class FacingSpriteCondition(ItemCondition):
     sprite: str
 
     def test(self, target: Monster) -> bool:
-        coords: tuple[int, int] = (0, 0)
         player = self.session.player
-        facing = player.facing
-        player_x = player.tile_pos[0]
-        player_y = player.tile_pos[1]
-        if facing == "down":
-            y = player_y - 1
-            coords = player_x, y
-        elif facing == "up":
-            y = player_y + 1
-            coords = player_x, y
-        elif facing == "right":
-            x = player_x + 1
-            coords = x, player_y
-        elif facing == "left":
-            x = player_x - 1
-            coords = x, player_y
+        client = self.session.client
+        tiles = get_coords(player.tile_pos, client.map_size)
 
-        npc = get_npc_pos(self.session, coords)
-        if npc:
-            if npc.sprite_name == self.sprite:
-                return True
-            else:
-                return False
-        else:
-            return False
+        for coords in tiles:
+            npc = get_npc_pos(self.session, coords)
+            if npc and npc.sprite_name == self.sprite:
+                facing = get_direction(player.tile_pos, npc.tile_pos)
+                return player.facing == facing
+
+        return False

--- a/tuxemon/item/conditions/facing_tile.py
+++ b/tuxemon/item/conditions/facing_tile.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from tuxemon.item.itemcondition import ItemCondition
+from tuxemon.map import get_coords, get_direction
 from tuxemon.states.world.worldstate import WorldState
 
 if TYPE_CHECKING:
@@ -25,34 +26,19 @@ class FacingTileCondition(ItemCondition):
     def test(self, target: Monster) -> bool:
         player = self.session.player
         client = self.session.client
-        tiles = []
+        # get all the coordinates around the player
+        tiles = get_coords(player.tile_pos, client.map_size)
         tile_location = None
 
         # check if the NPC is facing a specific set of tiles
         world = client.get_state_by_name(WorldState)
         if self.facing_tile == "surfable":
-            tiles = list(world.surfable_map)
+            surf = list(world.surfable_map)
+            tiles = list(set(tiles).intersection(surf))
 
         # Next, we check the player position and see if we're one tile
         # away from the tile.
-        for coordinates in tiles:
-            if coordinates[1] == player.tile_pos[1]:
-                # Check to see if the tile is to the left of the player
-                if coordinates[0] == player.tile_pos[0] - 1:
-                    tile_location = "left"
-                # Check to see if the tile is to the right of the player
-                elif coordinates[0] == player.tile_pos[0] + 1:
-                    tile_location = "right"
+        for coords in tiles:
+            tile_location = get_direction(player.tile_pos, coords)
 
-            elif coordinates[0] == player.tile_pos[0]:
-                # Check to see if the tile is above the player
-                if coordinates[1] == player.tile_pos[1] - 1:
-                    tile_location = "up"
-                elif coordinates[1] == player.tile_pos[1] + 1:
-                    tile_location = "down"
-
-            # Then we check to see if we're facing the Tile
-            if player.facing == tile_location:
-                return True
-
-        return False
+        return player.facing == tile_location

--- a/tuxemon/item/effects/remove.py
+++ b/tuxemon/item/effects/remove.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Union
 
 from tuxemon.event import get_npc_pos
 from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
+from tuxemon.map import get_coords, get_direction
 
 if TYPE_CHECKING:
     from tuxemon.item.item import Item
@@ -29,29 +30,19 @@ class RemoveEffect(ItemEffect):
         self, item: Item, target: Union[Monster, None]
     ) -> RemoveEffectResult:
         remove: bool = False
-        coords: tuple[int, int] = (0, 0)
+        client = self.session.client
         player = self.session.player
-        facing = player.facing
-        player_x = player.tile_pos[0]
-        player_y = player.tile_pos[1]
-        if facing == "down":
-            y = player_y - 1
-            coords = player_x, y
-        elif facing == "up":
-            y = player_y + 1
-            coords = player_x, y
-        elif facing == "right":
-            x = player_x + 1
-            coords = x, player_y
-        elif facing == "left":
-            x = player_x - 1
-            coords = x, player_y
+        tiles = get_coords(player.tile_pos, client.map_size)
 
-        npc = get_npc_pos(self.session, coords)
-        if npc:
-            self.session.client.event_engine.execute_action(
-                "remove_npc", [npc.slug], True
-            )
-            self.session.player.game_variables[npc.slug] = self.name
-            remove = True
+        for coords in tiles:
+            npc = get_npc_pos(self.session, coords)
+            if npc:
+                facing = get_direction(player.tile_pos, npc.tile_pos)
+                if player.facing == facing:
+                    client.event_engine.execute_action(
+                        "remove_npc", [npc.slug], True
+                    )
+                    player.game_variables[npc.slug] = self.name
+                    remove = True
+
         return {"success": remove, "num_shakes": 0, "extra": None}

--- a/tuxemon/map.py
+++ b/tuxemon/map.py
@@ -89,10 +89,97 @@ def translate_short_path(
         yield (int(position_vec.x), int(position_vec.y))
 
 
+def get_coords(
+    tile: tuple[int, int], map_size: tuple[int, int], radius: int = 1
+) -> list[tuple[int, int]]:
+    """
+    Returns a list with the cardinal coordinates (down, right, up, and left),
+    Negative coordinates as well as the ones the exceed the map size will be
+    filtered out. If no valid coordinates, then it'll be raised a ValueError.
+
+     -  | 1,0 |  -
+    0,1 | 1,1 | 2,1 |
+     -  | 1,2 |  -
+
+    eg. radius = 1 (1,0),(0,1),(1,2),(2,1)
+
+    Parameters:
+        tile: Tile coordinates
+        map_size: Dimension of the map
+        radius: Radius, default 1
+
+    Returns:
+        List tile coordinates.
+    """
+    coords: list[tuple[int, int]] = []
+    coords.append((tile[0], tile[1] + radius))  # down
+    coords.append((tile[0] + radius, tile[1]))  # right
+    coords.append((tile[0], tile[1] - radius))  # up
+    coords.append((tile[0] - radius, tile[1]))  # left
+    _coords = [
+        _tile
+        for _tile in coords
+        if map_size[0] >= _tile[0] >= 0 and map_size[1] >= _tile[1] >= 0
+    ]
+    if not _coords:
+        raise ValueError(f"{coords} invalid coordinates")
+    return _coords
+
+
+def get_coord_direction(
+    tile: tuple[int, int],
+    direction: Direction,
+    map_size: tuple[int, int],
+    radius: int = 1,
+) -> tuple[int, int]:
+    """
+    Returns the coordinates for a specific side and radius.
+    Negative coordinates as well as the ones the exceed the map size will
+    raise a ValueError.
+
+    Parameters:
+        tile: Tile coordinates
+        side: Direction "up*, "dowm", "left", "right"
+        map_size: Dimension of the map
+        radius: Radius, default 1
+
+    Returns:
+        Tuple tile coordinates.
+    """
+    _tile: tuple[int, int] = (0, 0)
+    if direction == "down":
+        _tile = (tile[0], tile[1] + radius)
+    elif direction == "right":
+        _tile = (tile[0] + radius, tile[1])
+    elif direction == "up":
+        _tile = (tile[0], tile[1] - radius)
+    elif direction == "left":
+        _tile = (tile[0] - radius, tile[1])
+    else:
+        raise ValueError(f"{direction} doesn't exist")
+    if map_size[0] >= _tile[0] >= 0 and map_size[1] >= _tile[1] >= 0:
+        return _tile
+    else:
+        raise ValueError(f"{_tile} invalid coordinates")
+
+
 def get_direction(
     base: Union[Vector2, tuple[int, int]],
     target: Union[Vector2, tuple[int, int]],
 ) -> Direction:
+    """
+    Return the direction based on the coordinates position.
+
+    eg. base (1,3) - target (1,12) -> "down"
+
+    Parameters:
+        base: Base coordinates
+        target: Target coordinates
+
+    Returns:
+        Direction.
+
+    """
     y_offset = base[1] - target[1]
     x_offset = base[0] - target[0]
     # Is it further away vertically or horizontally?


### PR DESCRIPTION
while working on #2121 I was surprised by the amount of hardcoded "up", "down". Sure #2121 creates a class and centralize, but we can do better.  This is the main reason that drove me to code a def, a def that will allow us to get a list of all the coordinates around the player (at the moment only 4); to explain what I mean, see below:
```
     -  | 1,0 |  -
    0,1 | 1,1 | 2,1
     -  | 1,2 |  -
```
let's say our player is (1,1), there is no way to get a list with (1,0), (0,1), (1,2) and (2,2)

The results are encouraging, especially by seeing how much I was able to simplify certain actions/conditions (both event and item). The casting in **pathfind_to_player** will be removed in #2121, it was needed because of typehints.