### PR TITLE
typehints

### DIFF
--- a/tuxemon/condition/condition.py
+++ b/tuxemon/condition/condition.py
@@ -39,8 +39,8 @@ class Condition:
 
     """
 
-    effects_classes: ClassVar[Mapping[str, type[CondEffect[Any]]]] = {}
-    conditions_classes: ClassVar[Mapping[str, type[CondCondition[Any]]]] = {}
+    effects_classes: ClassVar[Mapping[str, type[CondEffect]]] = {}
+    conditions_classes: ClassVar[Mapping[str, type[CondCondition]]] = {}
 
     def __init__(self, save_data: Optional[Mapping[str, Any]] = None) -> None:
         if save_data is None:
@@ -54,9 +54,9 @@ class Condition:
         self.animation: Optional[str] = None
         self.category: Optional[CategoryCondition] = None
         self.combat_state: Optional[CombatState] = None
-        self.conditions: Sequence[CondCondition[Any]] = []
+        self.conditions: Sequence[CondCondition] = []
         self.description = ""
-        self.effects: Sequence[CondEffect[Any]] = []
+        self.effects: Sequence[CondEffect] = []
         self.flip_axes = ""
         self.gain_cond = ""
         self.icon = ""
@@ -156,7 +156,7 @@ class Condition:
     def parse_effects(
         self,
         raw: Sequence[str],
-    ) -> Sequence[CondEffect[Any]]:
+    ) -> Sequence[CondEffect]:
         """
         Convert effect strings to effect objects.
 
@@ -190,7 +190,7 @@ class Condition:
     def parse_conditions(
         self,
         raw: Sequence[str],
-    ) -> Sequence[CondCondition[Any]]:
+    ) -> Sequence[CondCondition]:
         """
         Convert condition strings to condition objects.
 

--- a/tuxemon/event/eventengine.py
+++ b/tuxemon/event/eventengine.py
@@ -55,7 +55,7 @@ class RunningEvent:
         self.map_event = map_event
         self.context: dict[str, Any] = dict()
         self.action_index = 0
-        self.current_action: Optional[EventAction[Any]] = None
+        self.current_action: Optional[EventAction] = None
         self.current_map_action = None
 
     def get_next_action(self) -> Optional[MapAction]:
@@ -143,7 +143,7 @@ class EventEngine:
         self,
         name: str,
         parameters: Optional[Sequence[Any]] = None,
-    ) -> Optional[EventAction[Any]]:
+    ) -> Optional[EventAction]:
         """
         Get an action that is loaded into the engine.
 

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -36,8 +36,8 @@ MAX_TYPES_BAG = 99
 class Item:
     """An item object is an item that can be used either in or out of combat."""
 
-    effects_classes: ClassVar[Mapping[str, type[ItemEffect[Any]]]] = {}
-    conditions_classes: ClassVar[Mapping[str, type[ItemCondition[Any]]]] = {}
+    effects_classes: ClassVar[Mapping[str, type[ItemEffect]]] = {}
+    conditions_classes: ClassVar[Mapping[str, type[ItemCondition]]] = {}
 
     def __init__(self, save_data: Optional[Mapping[str, Any]] = None) -> None:
         if save_data is None:
@@ -58,8 +58,8 @@ class Item:
         self.surface: Optional[pygame.surface.Surface] = None
         self.surface_size_original = (0, 0)
 
-        self.effects: Sequence[ItemEffect[Any]] = []
-        self.conditions: Sequence[ItemCondition[Any]] = []
+        self.effects: Sequence[ItemEffect] = []
+        self.conditions: Sequence[ItemCondition] = []
         self.combat_state: Optional[CombatState] = None
 
         self.sort = ""
@@ -134,7 +134,7 @@ class Item:
     def parse_effects(
         self,
         raw: Sequence[str],
-    ) -> Sequence[ItemEffect[Any]]:
+    ) -> Sequence[ItemEffect]:
         """
         Convert effect strings to effect objects.
 
@@ -168,7 +168,7 @@ class Item:
     def parse_conditions(
         self,
         raw: Sequence[str],
-    ) -> Sequence[ItemCondition[Any]]:
+    ) -> Sequence[ItemCondition]:
         """
         Convert condition strings to condition objects.
 

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -35,8 +35,8 @@ class Technique:
 
     """
 
-    effects_classes: ClassVar[Mapping[str, type[TechEffect[Any]]]] = {}
-    conditions_classes: ClassVar[Mapping[str, type[TechCondition[Any]]]] = {}
+    effects_classes: ClassVar[Mapping[str, type[TechEffect]]] = {}
+    conditions_classes: ClassVar[Mapping[str, type[TechCondition]]] = {}
 
     def __init__(self, save_data: Optional[Mapping[str, Any]] = None) -> None:
         if save_data is None:
@@ -49,9 +49,9 @@ class Technique:
         self.accuracy = 0.0
         self.animation: Optional[str] = None
         self.combat_state: Optional[CombatState] = None
-        self.conditions: Sequence[TechCondition[Any]] = []
+        self.conditions: Sequence[TechCondition] = []
         self.description = ""
-        self.effects: Sequence[TechEffect[Any]] = []
+        self.effects: Sequence[TechEffect] = []
         self.flip_axes = ""
         self.icon = ""
         self.images: Sequence[str] = []
@@ -157,7 +157,7 @@ class Technique:
     def parse_effects(
         self,
         raw: Sequence[str],
-    ) -> Sequence[TechEffect[Any]]:
+    ) -> Sequence[TechEffect]:
         """
         Convert effect strings to effect objects.
 
@@ -191,7 +191,7 @@ class Technique:
     def parse_conditions(
         self,
         raw: Sequence[str],
-    ) -> Sequence[TechCondition[Any]]:
+    ) -> Sequence[TechCondition]:
         """
         Convert condition strings to condition objects.
 


### PR DESCRIPTION
PR fixes the following typehints:
```
tuxemon/technique/technique.py:38: error: "TechEffect" expects no type arguments, but 1 given  [type-arg]
tuxemon/technique/technique.py:39: error: "TechCondition" expects no type arguments, but 1 given  [type-arg]
tuxemon/technique/technique.py:52: error: "TechCondition" expects no type arguments, but 1 given  [type-arg]
tuxemon/technique/technique.py:54: error: "TechEffect" expects no type arguments, but 1 given  [type-arg]
tuxemon/technique/technique.py:160: error: "TechEffect" expects no type arguments, but 1 given  [type-arg]
tuxemon/technique/technique.py:194: error: "TechCondition" expects no type arguments, but 1 given  [type-arg]
```
the same number for Condition (6) and Item (6) too (total 18) - same structure. 
+
```
tuxemon/event/eventengine.py:58: error: "EventAction" expects no type arguments, but 1 given  [type-arg]
tuxemon/event/eventengine.py:146: error: "EventAction" expects no type arguments, but 1 given  [type-arg]
```
everything works as usual, effects, techniques, etc.
