### PR TITLE
fix 727 (default name vs custom name) +  mini capture devices issue

### DIFF
--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -759,6 +759,7 @@ class Monster:
         faint = Condition()
         faint.load("faint")
         self.current_hp = 0
+        self.status.clear()
         self.apply_status(faint)
 
     def end_combat(self) -> None:

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -744,6 +744,11 @@ class NPC(Entity[NPCState]):
         new_monster.taste_cold = old_monster.taste_cold
         new_monster.taste_warm = old_monster.taste_warm
         new_monster.plague = old_monster.plague
+        new_monster.name = (
+            new_monster.name
+            if old_monster.name == T.translate(old_monster.slug)
+            else old_monster.name
+        )
         self.remove_monster(old_monster)
         self.add_monster(new_monster, slot)
 


### PR DESCRIPTION
PR fixes #727 as well as an issue with the small capture devices / tuxeball in the combat.

the issue was:
- someone renamed a Rockitten into Tequila;
- Tequila evolves into Rockat;
- Tequila is now named Rockat

added a check between the translated name (with the slug) vs the actual name, if different (Tequila != Rockitten), then it keeps the name (Tequila), on the contrary gets updated (Rockat).

The issue was no cleaning of the statuses just before fainting. It means that if the monster fainted, then the small tuxeball wasn't black but violet (if the monster fainted had a status). Now it's fixed. I remember there was an issue related to it, but I have never found the problem before.
