### PR TITLE
action consolidation (set_monster_flair / health / level / status / plague)

### DIFF
--- a/mods/tuxemon/maps/sphalian_center.tmx
+++ b/mods/tuxemon/maps/sphalian_center.tmx
@@ -69,8 +69,8 @@
   </object>
   <object id="23" name="Auto Healing Teleported" type="event" x="0" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="set_monster_health ,"/>
-    <property name="act2" value="set_monster_status ,"/>
+    <property name="act1" value="set_monster_health"/>
+    <property name="act2" value="set_monster_status"/>
     <property name="act3" value="set_variable battle_last_result:none"/>
     <property name="cond1" value="is variable_set battle_last_result:lost"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
+++ b/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
@@ -172,7 +172,7 @@
     <property name="act1" value="translated_dialog spyder_wayfarer1_maniac1"/>
     <property name="act2" value="add_monster botbot,10"/>
     <property name="act3" value="set_variable gotbotbot:yes"/>
-    <property name="act4" value="set_monster_plague infected"/>
+    <property name="act4" value="set_monster_plague ,infected"/>
     <property name="cond1" value="is variable_set wayfarer1_botbot:yes"/>
     <property name="cond2" value="is variable_set quebotbot:yes"/>
     <property name="cond3" value="not variable_set gotbotbot:yes"/>

--- a/tuxemon/event/actions/set_monster_flair.py
+++ b/tuxemon/event/actions/set_monster_flair.py
@@ -2,11 +2,15 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+import logging
+import uuid
 from dataclasses import dataclass
 from typing import final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.monster import Flair
+
+logger = logging.getLogger(__name__)
 
 
 @final
@@ -18,22 +22,31 @@ class SetMonsterFlairAction(EventAction):
     Script usage:
         .. code-block::
 
-            set_monster_flair <slot>,<category>,<flair>
+            set_monster_flair <variable>,<category>,<flair>
 
     Script parameters:
-        slot: Slot of the monster in the party.
+        variable: Name of the variable where to store the monster id. If no
+            variable is specified, all monsters are changed.
         category: Category of the monster flair.
         flair: Name of the monster flair.
 
     """
 
     name = "set_monster_flair"
-    slot: int
+    variable: str
     category: str
     flair: str
 
     def start(self) -> None:
-        monster = self.session.player.monsters[self.slot]
+        player = self.session.player
+        if self.variable not in player.game_variables:
+            logger.error(f"Game variable {self.variable} not found")
+            return
+        monster_id = uuid.UUID(player.game_variables[self.variable])
+        monster = player.find_monster_by_id(monster_id)
+        if monster is None:
+            logger.error("Monster not found in party")
+            return
         if self.category in monster.flairs:
             monster.flairs[self.category] = Flair(
                 self.category,


### PR DESCRIPTION
PR proposes to:
- update **set_monster_flair** (not used)
- update **set_monster_health** (used but always without the optional, excluded only once - fixed)
- update **set_monster_level** (not used)
- update **set_monster_plague** (used only once, related to Spyder campaign, fixed)
- update **set_monster_status** (used but always without the optional, excluded only once - fixed)

it'll replace the optional **int** **slot** value with an optional **str** value (**variable** containing the UUID, **instance_id** of the monster), this will allow to use all the actions above with **get_monster_player** (graphical tool for choosing the monsters), right now trying to pick the right slot isn't easy.

in the case of **set_monster_level**, I needed to invert the slot to put the variable in front:
`set_monster_level [levels_added][,slot]` > `set_monster_level [variable][,levels_added]`
but since it's not possible to have an optional followed by a string (attribution), then I set levels_added optional too, and by default there will be 1, so by using **set_monster_level** without values all the monster in the party with increase the level by 1. Same discourse applies to **set_monster_plague**, but default is **healthy**.