### PR TITLE
moverate (valid_movement) + fix pathfinding

### DIFF
--- a/mods/tuxemon/maps/route1.tmx
+++ b/mods/tuxemon/maps/route1.tmx
@@ -330,9 +330,9 @@
   </object>
   <object id="117" name="move husband" type="event" x="448" y="176" width="16" height="16">
    <properties>
-    <property name="act1" value="pathfind marissa,37,22"/>
+    <property name="act1" value="pathfind marissa,36,23"/>
     <property name="act2" value="npc_face marissa,left"/>
-    <property name="act3" value="pathfind tuxemart_keeper,37,21"/>
+    <property name="act3" value="pathfind tuxemart_keeper,36,24"/>
     <property name="act4" value="npc_face tuxemart_keeper,left"/>
     <property name="act5" value="set_variable getaway:weregone"/>
     <property name="cond1" value="is variable_set getaway:pls"/>
@@ -340,15 +340,17 @@
   </object>
   <object id="118" name="move bob" type="event" x="432" y="192" width="16" height="16">
    <properties>
-    <property name="act1" value="pathfind bob,36,23"/>
-    <property name="act2" value="npc_face bob,left"/>
+    <property name="act1" value="pathfind bob,33,22"/>
+    <property name="act2" value="pathfind bob,37,21"/>
+    <property name="act3" value="npc_face bob,left"/>
     <property name="cond1" value="is variable_set getaway:pls"/>
    </properties>
   </object>
   <object id="119" name="move liela" type="event" x="416" y="208" width="16" height="16">
    <properties>
-    <property name="act1" value="pathfind liela,36,24"/>
-    <property name="act2" value="npc_face liela,left"/>
+    <property name="act1" value="wait 1"/>
+    <property name="act2" value="pathfind liela,37,22"/>
+    <property name="act3" value="npc_face liela,left"/>
     <property name="cond1" value="is variable_set getaway:pls"/>
    </properties>
   </object>

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -509,16 +509,21 @@ class NPC(Entity[NPCState]):
             If the tile can be moved into.
 
         """
-        _direction: bool = True
         _map_size = self.world.map_size
         _exit = tile in self.world.get_exits(self.tile_pos)
 
+        _direction = []
         for neighbor in get_coords_ext(tile, _map_size):
             char = self.world.get_entity_pos(neighbor)
-            if char and char.moving and self.facing != char.facing:
-                _direction = False
+            if (
+                char
+                and char.moving
+                and char.moverate == CONFIG.player_walkrate
+                and self.facing != char.facing
+            ):
+                _direction.append(char)
 
-        return _exit and _direction or self.ignore_collisions
+        return _exit and not _direction or self.ignore_collisions
 
     @property
     def move_destination(self) -> Optional[tuple[int, int]]:


### PR DESCRIPTION
PR:
- adds: `char.moverate == CONFIG.player_walkrate` , regarding mostly the player; it helps when the player is running;
- changes the **valid_movement** structure, the NPCs will be added inside a list, to avoid remaining in the loop;
- fixes a series of pathfind that result in a crash for RecursionError (route1.tmx (Xero));

Why crash now and not before? #2123 happened and the tuxemart_keeper cannot overlap anymore. This doesn't mean that it wasn't an issue before, seeing alerts in the terminal isn't a good sign. Luckily now these alerts don't appear anymore.

The cause of the crash was the tile in front of the Xerogrunt (right side), as you can see multiple paths are supposed to pass from that point (the 4 NPCs start the pathfind at the same moment);
![Screenshot_2023-12-23_10-47-43](https://github.com/Tuxemon/Tuxemon/assets/64643719/0259f615-d780-40da-aeda-dc4dbee910c7)
Changes? Nothing much, bob (brown color) will pathfind until it's between the two Xerogrunts and then it'll pathfind to the final destination  (previous tuxemart_keeper) ; liela (yellow color) will wait 1 second and then it'll reach the destination (previous marissa, free path, no issues). Tuxemart_keeper and Marissa will end up at Liela and Bob position (closer). This simple change will make disappear all the pathfinding alerts (see below).

```
`[2023-12-18 21:23:31,745] tuxemon.npc - ERROR - tuxemart_keeper finding new path!`
and a double repetition each 745,745,746,746, etc.
[2023-12-18 21:23:32,042] tuxemon.npc - ERROR - tuxemart_keeper finding new path!
[2023-12-18 21:23:32,042] tuxemon.npc - ERROR - tuxemart_keeper finding new path!
Traceback (most recent call last):
<------------------------- hundreds of of these lines ------------------>
  File "/home/julesverne/Tuxemon/tuxemon/npc.py", line 570, in next_waypoint
    self.pathfind(self.pathfinding)
  File "/home/julesverne/Tuxemon/tuxemon/npc.py", line 357, in pathfind
    self.next_waypoint()
<------------------------- hundreds of of these lines ------------------>
  File "/home/julesverne/Tuxemon/tuxemon/npc.py", line 550, in next_waypoint
    if self.valid_movement(target):
  File "/home/julesverne/Tuxemon/tuxemon/npc.py", line 520, in valid_movement
    and char.moving
  File "/home/julesverne/Tuxemon/tuxemon/entity.py", line 121, in moving
    return not self.velocity3 == (0, 0, 0)
  File "/home/julesverne/Tuxemon/tuxemon/math.py", line 28, in __eq__
    if not isinstance(other, Sequence) or len(self) != len(other):
  File "/usr/lib/python3.10/abc.py", line 119, in __instancecheck__
    return _abc_instancecheck(cls, instance)
  File "/usr/lib/python3.10/abc.py", line 123, in __subclasscheck__
    return _abc_subclasscheck(cls, subclass)
RecursionError: maximum recursion depth exceeded in comparison
```
