### PR TITLE
stats (evolution parameter)

### DIFF
--- a/mods/tuxemon/db/monster/katacoon.json
+++ b/mods/tuxemon/db/monster/katacoon.json
@@ -32,15 +32,13 @@
             "path": "stat",
             "at_level": 12,
             "monster_slug": "bugnin",
-            "stat1": "melee",
-            "stat2": "armour"
+            "stats": "dodge:greater_than:speed"
         },
         {
             "path": "stat",
             "at_level": 12,
             "monster_slug": "sumchon",
-            "stat1": "armour",
-            "stat2": "melee"
+            "stats": "speed:greater_than:dodge"
         }
     ],
     "history": [

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -165,6 +165,7 @@ class EvolutionType(str, Enum):
     standard = "standard"
     stat = "stat"
     tech = "tech"
+    traded = "traded"
 
 
 class StatType(str, Enum):
@@ -194,6 +195,15 @@ class EntityFacing(str, Enum):
     back = "back"
     left = "left"
     right = "right"
+
+
+class Comparison(str, Enum):
+    less_than = "less_than"
+    less_or_equal = "less_or_equal"
+    greater_than = "greater_than"
+    greater_or_equal = "greater_or_equal"
+    equals = "equals"
+    not_equals = "not_equals"
 
 
 # TODO: Automatically generate state enum through discovery
@@ -360,16 +370,17 @@ class MonsterEvolutionItemModel(BaseModel):
     item: Optional[str] = Field(None, description="Item parameter.")
     inside: bool = Field(
         None,
-        description="Location parameter: inside true or inside false (outside).",
+        description="Location parameter: whether the monster is inside or not.",
+    )
+    traded: bool = Field(
+        None,
+        description="Traded parameter: whether the monster is traded or not.",
     )
     variable: Optional[str] = Field(
         None, description="Variable parameter based on game variables."
     )
-    stat1: Optional[StatType] = Field(
-        None, description="Stat parameter stat1 >= stat2."
-    )
-    stat2: Optional[StatType] = Field(
-        None, description="Stat parameter stat2 < stat1."
+    stats: Optional[str] = Field(
+        None, description="Stat parameter stat1:more_than:stat2."
     )
     tech: Optional[str] = Field(None, description="Technique parameter.")
 
@@ -402,6 +413,29 @@ class MonsterEvolutionItemModel(BaseModel):
         if not v or v.find(":") > 1:
             return v
         raise ValueError(f"the variable {v} isn't formatted correctly")
+
+    @field_validator("stats")
+    def stats_exists(
+        cls: MonsterEvolutionItemModel, v: Optional[str]
+    ) -> Optional[str]:
+        stats = list(StatType)
+        comparison = list(Comparison)
+        param = v.split(":") if v else []
+        if not v or len(param) == 3:
+            if param[1] not in comparison:
+                raise ValueError(
+                    f"the comparison {param[1]} doesn't exist among {comparison}"
+                )
+            if param[0] not in stats:
+                raise ValueError(
+                    f"the stat {param[0]} doesn't exist among {stats}"
+                )
+            if param[2] not in stats:
+                raise ValueError(
+                    f"the stat {param[2]} doesn't exist among {stats}"
+                )
+            return v
+        raise ValueError(f"the stats {v} isn't formatted correctly")
 
 
 class MonsterFlairItemModel(BaseModel):

--- a/tuxemon/event/actions/evolution.py
+++ b/tuxemon/event/actions/evolution.py
@@ -46,18 +46,12 @@ class EvolutionAction(EventAction):
             client.pop_state()
 
         def question_evolution(monster: Monster, evolved: Monster) -> None:
-            open_dialog(
-                self.session,
-                [
-                    T.format(
-                        "evolution_confirmation",
-                        {
-                            "name": monster.name.upper(),
-                            "evolve": evolved.name.upper(),
-                        },
-                    )
-                ],
-            )
+            params = {
+                "name": monster.name.upper(),
+                "evolve": evolved.name.upper(),
+            }
+            msg = T.format("evolution_confirmation", params)
+            open_dialog(self.session, [msg])
             open_choice_dialog(
                 self.session,
                 menu=(

--- a/tuxemon/event/conditions/check_evolution.py
+++ b/tuxemon/event/conditions/check_evolution.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-from tuxemon.db import EvolutionType
+from tuxemon.db import EvolutionType, StatType
 from tuxemon.event import MapCondition
 from tuxemon.event.eventcondition import EventCondition
 from tuxemon.monster import Monster
 from tuxemon.session import Session
+from tuxemon.tools import compare
 
 
 class CheckEvolutionCondition(EventCondition):
@@ -29,8 +30,8 @@ class CheckEvolutionCondition(EventCondition):
     ef. "is check_evolution standard:tech:stat"
     ef. "is check_evolution all"
 
-    Note: methods of evolution are element, gender,
-        location, variable, standard, stat and tech.
+    Note: methods of evolution are element, gender, location,
+        variable, standard, stat, traded and tech.
 
     """
 
@@ -46,13 +47,10 @@ class CheckEvolutionCondition(EventCondition):
         methods: list[str] = []
         evolution_type: list[EvolutionType] = []
         # recognize if single or multiple
-        if self.method.find(":") > 1:
-            methods = self.method.split(":")
+        if self.method == "all":
+            evolution_type = list(EvolutionType)
         else:
-            if self.method == "all":
-                evolution_type = list(EvolutionType)
-            else:
-                methods.append(self.method)
+            methods = self.method.split(":")
 
         # keep evolution type and remove not valid (+ debug)
         if methods:
@@ -62,7 +60,7 @@ class CheckEvolutionCondition(EventCondition):
                     evolution_type.append(method)
                 else:
                     raise ValueError(
-                        f"{method} isn't a valid method of evolution"
+                        f"{method} isn't among {list(EvolutionType)}"
                     )
 
         evolving: list[tuple[Monster, Monster]] = []
@@ -71,49 +69,64 @@ class CheckEvolutionCondition(EventCondition):
                 evolved = Monster()
                 for evolution in monster.evolutions:
                     evolved.load_from_db(evolution.monster_slug)
-                    for _method in evolution_type:
-                        if evolution.path == _method:
-                            if evolution.at_level <= monster.level:
+                    if evolution.at_level <= monster.level:
+                        for _method in evolution_type:
+                            if _method == EvolutionType.standard:
                                 evolving.append((monster, evolved))
                                 _evolution = True
-                        elif evolution.path == _method:
-                            if evolution.at_level <= monster.level:
-                                if evolution.gender == monster.gender:
-                                    evolving.append((monster, evolved))
-                                    _evolution = True
-                        elif evolution.path == _method:
-                            if evolution.at_level <= monster.level:
-                                if player.has_type(evolution.element):
-                                    evolving.append((monster, evolved))
-                                    _evolution = True
-                        elif evolution.path == _method:
-                            if evolution.at_level <= monster.level:
-                                if player.has_tech(evolution.tech):
-                                    evolving.append((monster, evolved))
-                                    _evolution = True
-                        elif evolution.path == _method:
-                            if evolution.at_level <= monster.level:
-                                if evolution.inside == client.map_inside:
-                                    evolving.append((monster, evolved))
-                                    _evolution = True
-                        elif evolution.path == _method:
-                            if evolution.at_level <= monster.level:
-                                if monster.return_stat(
-                                    evolution.stat1
-                                ) >= monster.return_stat(evolution.stat2):
-                                    evolving.append((monster, evolved))
-                                    _evolution = True
-                        elif evolution.path == _method:
-                            if (
-                                evolution.at_level <= monster.level
+                            elif (
+                                _method == EvolutionType.gender
+                                and evolution.gender == monster.gender
+                            ):
+                                evolving.append((monster, evolved))
+                                _evolution = True
+                            elif (
+                                _method == EvolutionType.element
+                                and player.has_type(evolution.element)
+                            ):
+                                evolving.append((monster, evolved))
+                                _evolution = True
+                            elif (
+                                _method == EvolutionType.tech
+                                and player.has_tech(evolution.tech)
+                            ):
+                                evolving.append((monster, evolved))
+                                _evolution = True
+                            elif (
+                                _method == EvolutionType.location
+                                and evolution.inside == client.map_inside
+                            ):
+                                evolving.append((monster, evolved))
+                                _evolution = True
+                            elif (
+                                _method == EvolutionType.traded
+                                and evolution.traded == monster.traded
+                            ):
+                                evolving.append((monster, evolved))
+                                _evolution = True
+                            elif (
+                                _method == EvolutionType.stat
+                                and evolution.stats
+                            ):
+                                params = evolution.stats.split(":")
+                                operator = params[1]
+                                stat1 = monster.return_stat(
+                                    StatType(params[0])
+                                )
+                                stat2 = monster.return_stat(
+                                    StatType(params[2])
+                                )
+                                evolving.append((monster, evolved))
+                                _evolution = compare(operator, stat1, stat2)
+                            elif (
+                                _method == EvolutionType.variable
                                 and evolution.variable
                             ):
                                 parts = evolution.variable.split(":")
                                 key = parts[0]
                                 value = parts[1]
-                                exists = key in player.game_variables
                                 if (
-                                    exists
+                                    key in player.game_variables
                                     and player.game_variables[key] == value
                                 ):
                                     evolving.append((monster, evolved))

--- a/tuxemon/item/effects/evolve.py
+++ b/tuxemon/item/effects/evolve.py
@@ -26,20 +26,15 @@ class EvolveEffect(ItemEffect):
     def apply(
         self, item: Item, target: Union[Monster, None]
     ) -> EvolveEffectResult:
-        assert target
+        assert target and target.owner
         evolve: bool = False
-        if item.slug == "booster_tech":
-            choices = [d for d in target.evolutions if d.path == "item"]
-            evolution = random.choice(choices).monster_slug
-            self.user.evolve_monster(target, evolution)
+        choices = [d for d in target.evolutions if d.item == item.slug]
+        if len(choices) == 1:
+            evolution = choices[0].monster_slug
             evolve = True
         else:
-            choices = [d for d in target.evolutions if d.item == item.slug]
-            if len(choices) == 1:
-                self.user.evolve_monster(target, choices[0].monster_slug)
-                evolve = True
-            elif len(choices) > 1:
-                evolution = random.choice(choices).monster_slug
-                self.user.evolve_monster(target, evolution)
-                evolve = True
+            evolution = random.choice(choices).monster_slug
+            evolve = True
+        if evolve and evolution:
+            target.owner.evolve_monster(target, evolution)
         return {"success": evolve, "num_shakes": 0, "extra": None}

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -295,15 +295,16 @@ class Monster:
         """
         self.types = self._types
 
-    def return_stat(
-        self,
-        stat: Optional[StatType],
-    ) -> int:
+    def return_stat(self, stat: StatType) -> int:
         """
         Returns a monster stat (eg. melee, armour, etc.).
 
         Parameters:
             stat: The stat for the monster to return.
+
+        Returns:
+            value: The stat.
+
         """
         value = 0
         if stat == StatType.armour:

--- a/tuxemon/tools.py
+++ b/tuxemon/tools.py
@@ -16,6 +16,7 @@ import logging
 import typing
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import fields
+from operator import eq, ge, gt, le, lt, ne
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -28,6 +29,7 @@ from typing import (
 
 from tuxemon import prepare
 from tuxemon.compat.rect import ReadOnlyRect
+from tuxemon.db import Comparison
 from tuxemon.locale import T, replace_text
 from tuxemon.math import Vector2
 
@@ -376,3 +378,39 @@ def assert_never(value: Never) -> NoReturn:
 
     """
     assert False, f"Unhandled value: {value} ({type(value).__name__})"
+
+
+def compare(
+    key: str, value1: Union[int, float], value2: Union[int, float]
+) -> bool:
+    """
+    It compares and it returns a boleean whether is greater_than or not.
+
+    It supports: less_than, less_or_equal, greater_than, greater_or_equal
+        equals and not_equals.
+
+    It raises a ValueError if the key isn't among the operators.
+
+    Parameters:
+        key: Key to check.
+        value1: First value to compare.
+        value2: Second value to compare.
+
+    Returns:
+        boolean: true / false
+
+    """
+    if key == Comparison.less_than:
+        return bool(lt(value1, value2))
+    elif key == Comparison.less_or_equal:
+        return bool(le(value1, value2))
+    elif key == Comparison.greater_than:
+        return bool(gt(value1, value2))
+    elif key == Comparison.greater_or_equal:
+        return bool(ge(value1, value2))
+    elif key == Comparison.equals:
+        return bool(eq(value1, value2))
+    elif key == Comparison.not_equals:
+        return bool(ne(value1, value2))
+    else:
+        raise ValueError(f"{key} isn't among {list(Comparison)}")


### PR DESCRIPTION
PR updates:
- **stat** evolution field;
- adds **compare** in **tools.py**;
- rewrites **check_evolution** by moving the check for evolution level above, in this way we can remove all ifs below as well as avoid to trigger a loop when there are no monster (below the level) able to evolve;

while I was working on #2166 I noticed a bottleneck here:
```
    "evolutions": [
        {
            "path": "stat",
            "at_level": 12,
            "monster_slug": "bugnin",
this:
            "stat1": "melee", <-----------
            "stat2": "armour" <-----------
replaced by:
            "stats": "melee:greater_than:armour"
        }
```
it was hardcoded that stat1 was greater or equal than stat2, too limited, not enough possibilities, so I have deleted both parameters and merged both into stats, in this way we can allow different comparison (not_equal, etc.); it includes a brand new validator to check that everything is formatted correctly

defined a class comparison too, so we have all the values centralized in db.py
-> next step #2168 

it changes melee and armour after a discussion with @Sanglorian because after multiple iterations (testing), the probability of getting a melee greater than armour was 0