### PR TITLE
fix 2172 and update pydantic (2.4)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ natsort
 PyYAML>=5.4.1
 prompt_toolkit
 pygame-menu-ce==4.4.2
-pydantic>=2.3
+pydantic>=2.4

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -15,8 +15,8 @@ from typing import Any, Literal, Optional, Union, overload
 from pydantic import (
     BaseModel,
     Field,
-    FieldValidationInfo,
     ValidationError,
+    ValidationInfo,
     field_validator,
 )
 from typing_extensions import Annotated
@@ -489,7 +489,7 @@ class MonsterModel(BaseModel):
     # because by default pydantic doesn't validate null fields.
     @field_validator("sprites")
     def set_default_sprites(
-        cls: MonsterModel, v: str, info: FieldValidationInfo
+        cls: MonsterModel, v: str, info: ValidationInfo
     ) -> Union[str, MonsterSpritesModel]:
         slug = info.data.get("slug")
         default = MonsterSpritesModel(
@@ -656,7 +656,7 @@ class TechniqueModel(BaseModel):
     # Custom validation for range
     @field_validator("range")
     def range_validation(
-        cls: TechniqueModel, v: Range, info: FieldValidationInfo
+        cls: TechniqueModel, v: Range, info: ValidationInfo
     ) -> Range:
         # Special indicates that we are not doing damage
         if v == Range.special and "damage" in info.data["effects"]:


### PR DESCRIPTION
fix #2172 

PR:
- upgrades the pydantic package from 2.3 to 2.4;
- replaces **FieldValidationInfo** with **ValidationInfo**;

They have deprecated **FieldValidationInfo** in 2.4 (https://docs.pydantic.dev/latest/concepts/validators/)