### PR TITLE
save_game and load_game (events action)

### DIFF
--- a/docs/handcrafted/action_list.rst
+++ b/docs/handcrafted/action_list.rst
@@ -23,6 +23,7 @@
 .. autoscriptinfoclass:: tuxemon.event.actions.get_party_monsters.GetPartyMonsterAction
 .. autoscriptinfoclass:: tuxemon.event.actions.get_player_monster.GetPlayerMonsterAction
 .. autoscriptinfoclass:: tuxemon.event.actions.kennel_print.KennelAction
+.. autoscriptinfoclass:: tuxemon.event.actions.load_game.LoadGameAction
 .. autoscriptinfoclass:: tuxemon.event.actions.menu.MenuAction
 .. autoscriptinfoclass:: tuxemon.event.actions.money_print.MoneyPrintAction
 .. autoscriptinfoclass:: tuxemon.event.actions.npc_face.NpcFaceAction
@@ -57,6 +58,7 @@
 .. autoscriptinfoclass:: tuxemon.event.actions.rename_monster.RenameMonsterAction
 .. autoscriptinfoclass:: tuxemon.event.actions.rename_player.RenamePlayerAction
 .. autoscriptinfoclass:: tuxemon.event.actions.rumble.RumbleAction
+.. autoscriptinfoclass:: tuxemon.event.actions.save_game.SaveGameAction
 .. autoscriptinfoclass:: tuxemon.event.actions.screen_transition.ScreenTransitionAction
 .. autoscriptinfoclass:: tuxemon.event.actions.set_battle.SetBattleAction
 .. autoscriptinfoclass:: tuxemon.event.actions.set_bubble.SetBubbleAction

--- a/tuxemon/event/actions/load_game.py
+++ b/tuxemon/event/actions/load_game.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2024 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional, final
+
+from tuxemon import prepare, save
+from tuxemon.event.eventaction import EventAction
+from tuxemon.states.world.worldstate import WorldState
+
+logger = logging.getLogger(__name__)
+
+
+@final
+@dataclass
+class LoadGameAction(EventAction):
+    """
+    Loads the game.
+
+    If the index parameter is absent, then it'll load
+    slot4.save
+
+    index = 0 > slot 1
+    index = 1 > slot 2
+    index = 2 > slot 3
+
+    Script usage:
+        .. code-block::
+
+            load_game [index]
+
+    Script parameters:
+        index: Selected index.
+
+    eg: "load_game" (slot4.save)
+    eg: "load_game 1"
+
+    """
+
+    name = "load_game"
+    index: Optional[int] = None
+
+    def start(self) -> None:
+        client = self.session.client
+        index = 4 if self.index is None else self.index + 1
+
+        logger.info("Loading!")
+        save_data = save.load(index)
+        if save_data and "error" not in save_data:
+            try:
+                old_world = client.get_state_by_name(WorldState)
+                # when game is loaded from world menu
+                client.pop_state()
+                client.pop_state(old_world)
+                client.pop_state()
+            except ValueError:
+                # when game is loaded from the start menu
+                client.pop_state()
+                # avoid crash save and load same action
+                if self.index is not None:
+                    client.pop_state()
+
+            map_path = prepare.fetch("maps", save_data["current_map"])
+            client.push_state(
+                WorldState(
+                    map_name=map_path,
+                )
+            )
+
+            # TODO: Get player from whatever place and use self.client in
+            # order to build a Session
+            self.session.player.set_state(self.session, save_data)
+
+            # teleport the player to the correct position using an event
+            # engine action
+            tele_x, tele_y = save_data["tile_pos"]
+            params = [save_data["current_map"], tele_x, tele_y]
+            client.event_engine.execute_action("teleport", params)

--- a/tuxemon/event/actions/save_game.py
+++ b/tuxemon/event/actions/save_game.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2024 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional, final
+
+from tuxemon import save
+from tuxemon.event.eventaction import EventAction
+from tuxemon.locale import T
+from tuxemon.tools import open_dialog
+
+logger = logging.getLogger(__name__)
+
+
+@final
+@dataclass
+class SaveGameAction(EventAction):
+    """
+    Saves the game.
+
+    If the index parameter is absent, then it'll create
+    slot4.save
+
+    index = 0 > slot 1
+    index = 1 > slot 2
+    index = 2 > slot 3
+
+    Script usage:
+        .. code-block::
+
+            save_game [index]
+
+    Script parameters:
+        index: Selected index.
+
+    eg: "save_game" (slot4.save)
+    eg: "save_game 1"
+
+    """
+
+    name = "save_game"
+    index: Optional[int] = None
+
+    def start(self) -> None:
+        index = 4 if self.index is None else self.index + 1
+        slot = 0 if self.index is None else self.index
+
+        logger.info("Saving!")
+        try:
+            save_data = save.get_save_data(
+                self.session,
+            )
+            save.save(
+                save_data,
+                index,
+            )
+            save.slot_number = slot
+        except Exception as e:
+            raise
+            logger.error("Unable to save game!!")
+            logger.error(e)
+            open_dialog(self.session, [T.translate("save_failure")])
+        else:
+            if self.index is not None:
+                open_dialog(self.session, [T.translate("save_success")])
+            else:
+                logger.info(T.translate("save_success"))

--- a/tuxemon/states/persistance/load_menu.py
+++ b/tuxemon/states/persistance/load_menu.py
@@ -5,10 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
-from tuxemon import prepare, save
 from tuxemon.menu.interface import MenuItem
-from tuxemon.session import local_session
-from tuxemon.states.world.worldstate import WorldState
 
 from .save_menu import SaveMenuState
 
@@ -23,32 +20,8 @@ class LoadMenuState(SaveMenuState):
             self.on_menu_selection(None)
 
     def on_menu_selection(self, menuitem: Optional[MenuItem[None]]) -> None:
-        save_data = save.load(self.selected_index + 1)
-        if save_data and "error" not in save_data:
-            try:
-                old_world = self.client.get_state_by_name(WorldState)
-                # when game is loaded from world menu
-                self.client.pop_state(self)
-                self.client.pop_state(old_world)
-                self.client.pop_state()
-            except ValueError:
-                # when game is loaded from the start menu
-                self.client.pop_state()
-                self.client.pop_state()
-
-            map_path = prepare.fetch("maps", save_data["current_map"])
-            self.client.push_state(
-                WorldState(
-                    map_name=map_path,
-                )
-            )
-
-            # TODO: Get player from whatever place and use self.client in
-            # order to build a Session
-            local_session.player.set_state(local_session, save_data)
-
-            # teleport the player to the correct position using an event
-            # engine action
-            tele_x, tele_y = save_data["tile_pos"]
-            params = [save_data["current_map"], tele_x, tele_y]
-            self.client.event_engine.execute_action("teleport", params)
+        self.client.event_engine.execute_action(
+            "load_game",
+            [self.selected_index],
+            True,
+        )

--- a/tuxemon/states/persistance/save_menu.py
+++ b/tuxemon/states/persistance/save_menu.py
@@ -16,7 +16,6 @@ from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.menu import PopUpMenu
 from tuxemon.save import get_save_path
 from tuxemon.session import local_session
-from tuxemon.tools import open_dialog
 from tuxemon.ui import text
 
 logger = logging.getLogger(__name__)
@@ -137,23 +136,11 @@ class SaveMenuState(PopUpMenu[None]):
         return slot_image
 
     def save(self) -> None:
-        logger.info("Saving!")
-        try:
-            save_data = save.get_save_data(
-                local_session,
-            )
-            save.save(
-                save_data,
-                self.selected_index + 1,
-            )
-            save.slot_number = self.selected_index
-        except Exception as e:
-            raise
-            logger.error("Unable to save game!!")
-            logger.error(e)
-            open_dialog(local_session, [T.translate("save_failure")])
-        else:
-            open_dialog(local_session, [T.translate("save_success")])
+        self.client.event_engine.execute_action(
+            "save_game",
+            [self.selected_index],
+            True,
+        )
 
     def on_menu_selection(self, menuitem: MenuItem[None]) -> None:
         def positive_answer() -> None:


### PR DESCRIPTION
PR proposes:
- to add the **save_game** and **load_game** events action;
- to remove the function from the **load_menu** and **save_menu** states and "ship" the action through client **event_engine.execute_action** (save and respectively load);

**save_game** can be used:
"save_game" without index (it'll save the game in slot4.save, invisible from the game, a sort of autosaving backup)
"save_game 1" with index (where 0 is slot 1, etc.)

the same for **load_game**

tested:
```
    <property name="act1" value="translated_dialog talkingwithjeff"/>
    <property name="act2" value="save_game"/>
    <property name="act3" value="load_game"/>
    <property name="behav1" value="talk mynameisjeff"/>
```
