### PR TITLE
constants to prepare.py + hardcoded values to JSONs (conditions)

### DIFF
--- a/mods/tuxemon/db/condition/burn.json
+++ b/mods/tuxemon/db/condition/burn.json
@@ -2,7 +2,7 @@
   "animation": null,
   "category": "negative",
   "effects": [
-    "burnt"
+    "burnt 8"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_burn.png",

--- a/mods/tuxemon/db/condition/confused.json
+++ b/mods/tuxemon/db/condition/confused.json
@@ -2,13 +2,14 @@
   "animation": null,
   "category": "negative",
   "effects": [
-    "confused"
+    "confused 0.5"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_confused.png",
   "range": "special",
   "repl_pos": "replaced",
   "repl_neg": "replaced",
+  "repl_tech": "empty",
   "sfx": "sfx_pulse",
   "slug": "confused",
   "sort": "meta",

--- a/mods/tuxemon/db/condition/diehard.json
+++ b/mods/tuxemon/db/condition/diehard.json
@@ -2,7 +2,7 @@
   "animation": null,
   "category": "positive",
   "effects": [
-    "diehard"
+    "diehard 1"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_diehard.png",

--- a/mods/tuxemon/db/condition/elementalshield.json
+++ b/mods/tuxemon/db/condition/elementalshield.json
@@ -2,7 +2,7 @@
   "animation": null,
   "category": "positive",
   "effects": [
-    "elemental_shield"
+    "elemental_shield 16,special"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_elementalshield.png",

--- a/mods/tuxemon/db/condition/feedback.json
+++ b/mods/tuxemon/db/condition/feedback.json
@@ -2,7 +2,7 @@
   "animation": null,
   "category": "positive",
   "effects": [
-    "feedback"
+    "feedback 8,ranged:reach"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_feedback.png",

--- a/mods/tuxemon/db/condition/flinching.json
+++ b/mods/tuxemon/db/condition/flinching.json
@@ -2,13 +2,14 @@
   "animation": null,
   "category": "negative",
   "effects": [
-    "flinching"
+    "flinching 0.5"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_flinching.png",
   "range": "special",
   "repl_pos": "replaced",
   "repl_neg": "replaced",
+  "repl_tech": "empty",
   "sfx": "sfx_pulse",
   "slug": "flinching",
   "sort": "meta",

--- a/mods/tuxemon/db/condition/grabbed.json
+++ b/mods/tuxemon/db/condition/grabbed.json
@@ -1,8 +1,11 @@
 {
   "animation": null,
   "category": "negative",
+	"conditions": [
+	  	"is current_hp >,0"
+	],
   "effects": [
-    "grabbed"
+    "grabbed 2,ranged:reach"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_grabbed.png",

--- a/mods/tuxemon/db/condition/harpooned.json
+++ b/mods/tuxemon/db/condition/harpooned.json
@@ -2,7 +2,7 @@
   "animation": null,
   "category": "negative",
   "effects": [
-    "harpooned"
+    "harpooned 8"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_harpooned.png",

--- a/mods/tuxemon/db/condition/lifeleech.json
+++ b/mods/tuxemon/db/condition/lifeleech.json
@@ -5,7 +5,7 @@
 	  	"is current_hp >,0"
 	],
   "effects": [
-    "lifeleech"
+    "lifeleech 16"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_lifeleech.png",

--- a/mods/tuxemon/db/condition/noddingoff.json
+++ b/mods/tuxemon/db/condition/noddingoff.json
@@ -2,11 +2,12 @@
   "animation": null,
   "category": "negative",
   "effects": [
-    "noddingoff"
+    "noddingoff 0.5"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_noddingoff.png",
   "range": "special",
+  "repl_tech": "empty",
   "sfx": "sfx_pulse",
   "slug": "noddingoff",
   "sort": "meta",

--- a/mods/tuxemon/db/condition/poison.json
+++ b/mods/tuxemon/db/condition/poison.json
@@ -2,7 +2,7 @@
   "animation": "drip_green",
   "category": "negative",
   "effects": [
-    "poisoned"
+    "poisoned 8"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_poison.png",

--- a/mods/tuxemon/db/condition/prickly.json
+++ b/mods/tuxemon/db/condition/prickly.json
@@ -2,7 +2,7 @@
   "animation": null,
   "category": "positive",
   "effects": [
-    "prickly"
+    "prickly 8,touch:melee"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_prickly.png",

--- a/mods/tuxemon/db/condition/recover.json
+++ b/mods/tuxemon/db/condition/recover.json
@@ -2,7 +2,7 @@
   "animation": null,
   "category": "positive",
   "effects": [
-    "recover"
+    "recover 16"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_recover.png",

--- a/mods/tuxemon/db/condition/stuck.json
+++ b/mods/tuxemon/db/condition/stuck.json
@@ -1,8 +1,11 @@
 {
   "animation": null,
   "category": "negative",
+	"conditions": [
+	  	"is current_hp >,0"
+	],
   "effects": [
-    "stuck"
+    "stuck 2,melee:touch"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_stuck.png",

--- a/mods/tuxemon/db/condition/wasting.json
+++ b/mods/tuxemon/db/condition/wasting.json
@@ -2,7 +2,7 @@
   "animation": null,
   "category": "negative",
   "effects": [
-    "wasting"
+    "wasting 16"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_wasting.png",

--- a/mods/tuxemon/db/condition/wild.json
+++ b/mods/tuxemon/db/condition/wild.json
@@ -2,13 +2,14 @@
   "animation": null,
   "category": "negative",
   "effects": [
-    "wild"
+    "wild 0.25,8"
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_wild.png",
   "range": "special",
   "repl_pos": "replaced",
   "repl_neg": "replaced",
+  "repl_tech": "empty",
   "sfx": "sfx_pulse",
   "slug": "wild",
   "sort": "meta",

--- a/mods/tuxemon/db/technique/avalanche.json
+++ b/mods/tuxemon/db/technique/avalanche.json
@@ -4,7 +4,7 @@
   "animation": "rockfall_193",
   "effects": [
     "give exhausted,target",
-    "splash"
+    "splash 2"
   ],
   "flip_axes": "",
   "is_fast": false,

--- a/mods/tuxemon/db/technique/chill_mist.json
+++ b/mods/tuxemon/db/technique/chill_mist.json
@@ -3,7 +3,7 @@
   "accuracy": 0.6,
   "animation": "waterspurt",
   "effects": [
-    "splash"
+    "splash 2"
   ],
   "flip_axes": "",
   "is_fast": false,

--- a/mods/tuxemon/db/technique/electrical_storm.json
+++ b/mods/tuxemon/db/technique/electrical_storm.json
@@ -3,7 +3,7 @@
   "accuracy": 0.75,
   "animation": "lightning_claw",
   "effects": [
-    "splash"
+    "splash 2"
   ],
   "flip_axes": "",
   "is_fast": false,

--- a/mods/tuxemon/db/technique/flood.json
+++ b/mods/tuxemon/db/technique/flood.json
@@ -3,7 +3,7 @@
   "accuracy": 0.6,
   "animation": "watershot",
   "effects": [
-    "splash"
+    "splash 2"
   ],
   "flip_axes": "x",
   "is_fast": false,

--- a/mods/tuxemon/db/technique/flow.json
+++ b/mods/tuxemon/db/technique/flow.json
@@ -3,7 +3,7 @@
   "accuracy": 0.6,
   "animation": "waterspurt",
   "effects": [
-    "splash"
+    "splash 2"
   ],
   "flip_axes": "",
   "is_fast": false,

--- a/mods/tuxemon/db/technique/frostbite.json
+++ b/mods/tuxemon/db/technique/frostbite.json
@@ -4,7 +4,7 @@
   "animation": "lance_ice",
   "effects": [
     "give poison,target",
-    "splash"
+    "splash 2"
   ],
   "flip_axes": "xy",
   "is_fast": false,

--- a/mods/tuxemon/db/technique/icicle_spear.json
+++ b/mods/tuxemon/db/technique/icicle_spear.json
@@ -3,7 +3,7 @@
   "accuracy": 0.75,
   "animation": "lance_ice",
   "effects": [
-    "splash"
+    "splash 2"
   ],
   "flip_axes": "xy",
   "is_fast": false,

--- a/mods/tuxemon/db/technique/panjandrum.json
+++ b/mods/tuxemon/db/technique/panjandrum.json
@@ -3,7 +3,7 @@
   "accuracy": 0.75,
   "animation": "explosion_mushroom_128",
   "effects": [
-    "prop_damage target,0.25"
+    "prop_damage target,4"
   ],
   "flip_axes": "",
   "is_fast": false,

--- a/mods/tuxemon/db/technique/proboscis.json
+++ b/mods/tuxemon/db/technique/proboscis.json
@@ -4,7 +4,7 @@
   "animation": "lance_ice",
   "effects": [
     "give lifeleech,target",
-    "splash"
+    "splash 2"
   ],
   "flip_axes": "xy",
   "is_fast": false,

--- a/mods/tuxemon/db/technique/ring.json
+++ b/mods/tuxemon/db/technique/ring.json
@@ -4,7 +4,7 @@
   "animation": "pulse_absorb",
   "effects": [
     "give recover,user",
-    "splash"
+    "splash 2"
   ],
   "flip_axes": "",
   "is_fast": false,

--- a/mods/tuxemon/db/technique/rust_bomb.json
+++ b/mods/tuxemon/db/technique/rust_bomb.json
@@ -4,7 +4,7 @@
   "animation": "smokebomb_puff_128",
   "effects": [
     "give poison,target",
-    "splash"
+    "splash 2"
   ],
   "flip_axes": "",
   "is_fast": false,

--- a/mods/tuxemon/db/technique/shrapnel.json
+++ b/mods/tuxemon/db/technique/shrapnel.json
@@ -3,7 +3,7 @@
   "accuracy": 0.6,
   "animation": "explosion_small",
   "effects": [
-    "splash"
+    "splash 2"
   ],
   "flip_axes": "",
   "is_fast": true,

--- a/mods/tuxemon/db/technique/snowstorm.json
+++ b/mods/tuxemon/db/technique/snowstorm.json
@@ -4,7 +4,7 @@
   "animation": "explosion_ice_112",
   "effects": [
     "give exhausted,target",
-    "splash"
+    "splash 2"
   ],
   "flip_axes": "",
   "is_fast": false,

--- a/mods/tuxemon/db/technique/surf.json
+++ b/mods/tuxemon/db/technique/surf.json
@@ -3,7 +3,7 @@
   "accuracy": 0.6,
   "animation": "waterfall",
   "effects": [
-    "splash"
+    "splash 2"
   ],
   "flip_axes": "",
   "is_fast": false,

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -1004,6 +1004,9 @@ msgstr "{target} wiped it off."
 msgid "combat_state_lockdown_get"
 msgstr "Items will not affect {target}."
 
+msgid "combat_state_lockdown_item"
+msgstr "Items cannot be used on {target} while it is locked down."
+
 msgid "combat_state_wasting_get"
 msgstr "{target} is afflicted by a wasting condition."
 

--- a/tuxemon/ai.py
+++ b/tuxemon/ai.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import random
 from typing import TYPE_CHECKING
 
-from tuxemon.combat import pre_checking
+from tuxemon.combat import pre_checking, recharging
 from tuxemon.db import ItemCategory
 from tuxemon.technique.technique import Technique
 
@@ -64,7 +64,7 @@ class AI:
         actions = []
         # it chooses among the last 4 moves
         for mov in self.monster.moves[-self.monster.max_moves :]:
-            if mov.next_use <= 0:
+            if not recharging(mov):
                 for opponent in self.opponents:
                     # it checks technique conditions
                     if mov.validate(opponent):

--- a/tuxemon/combat.py
+++ b/tuxemon/combat.py
@@ -110,7 +110,17 @@ def has_effect_param(
 
 
 def fainted(monster: Monster) -> bool:
+    """
+    Checks to see if the monster is fainted.
+    """
     return has_status(monster, "faint") or monster.current_hp <= 0
+
+
+def recharging(technique: Technique) -> bool:
+    """
+    Checks to see if a technique is recharging.
+    """
+    return technique.next_use > 0
 
 
 def get_awake_monsters(
@@ -159,13 +169,8 @@ def defeated(player: NPC) -> bool:
 def check_moves(monster: Monster, levels: int) -> Optional[str]:
     tech = monster.update_moves(levels)
     if tech:
-        message = T.format(
-            "tuxemon_new_tech",
-            {
-                "name": monster.name.upper(),
-                "tech": tech.name.upper(),
-            },
-        )
+        params = {"name": monster.name.upper(), "tech": tech.name.upper()}
+        message = T.format("tuxemon_new_tech", params)
         return message
     return None
 
@@ -372,15 +377,13 @@ def track_battles(
         if trainer_battle:
             winner.give_money(prize)
             for _loser in losers:
+                params = {
+                    "npc": _loser.name.upper(),
+                    "prize": prize,
+                    "currency": "$",
+                }
                 winner.game_variables["battle_last_trainer"] = _loser.slug
-                message = T.format(
-                    "combat_victory_trainer",
-                    {
-                        "npc": _loser.name,
-                        "prize": prize,
-                        "currency": "$",
-                    },
-                )
+                message = T.format("combat_victory_trainer", params)
                 register_battles(OutputBattle.won, winner, _loser)
             return message
         else:

--- a/tuxemon/condition/effects/burnt.py
+++ b/tuxemon/condition/effects/burnt.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from tuxemon import formula
 from tuxemon.condition.condeffect import CondEffect, CondEffectResult
 
 if TYPE_CHECKING:
@@ -21,20 +20,21 @@ class BurntEffectResult(CondEffectResult):
 class BurntEffect(CondEffect):
     """
     This effect has a chance to apply the burnt status.
+
+    Parameters:
+        divisor: The divisor.
+
     """
 
     name = "burnt"
+    divisor: int
 
     def apply(
         self, condition: Condition, target: Monster
     ) -> BurntEffectResult:
         burnt: bool = False
-        if (
-            condition.phase == "perform_action_status"
-            and condition.slug == "burn"
-        ):
-            damage = formula.damage_full_hp(target, 8)
-            target.current_hp -= damage
+        if condition.phase == "perform_action_status":
+            target.current_hp -= target.hp // self.divisor
             burnt = True
 
         return {

--- a/tuxemon/condition/effects/chargedup.py
+++ b/tuxemon/condition/effects/chargedup.py
@@ -31,10 +31,7 @@ class ChargedUpEffect(CondEffect):
         player = target.owner
         assert player
         cond: Optional[Condition] = None
-        if (
-            condition.phase == "perform_action_tech"
-            and condition.slug == "chargedup"
-        ):
+        if condition.phase == "perform_action_tech":
             target.status.clear()
             if condition.repl_tech:
                 cond = Condition()

--- a/tuxemon/condition/effects/charging.py
+++ b/tuxemon/condition/effects/charging.py
@@ -31,20 +31,14 @@ class ChargingEffect(CondEffect):
         player = target.owner
         assert player
         cond: Optional[Condition] = None
-        if (
-            condition.phase == "perform_action_tech"
-            and condition.slug == "charging"
-        ):
+        if condition.phase == "perform_action_tech":
             target.status.clear()
             if condition.repl_tech:
                 cond = Condition()
                 cond.load(condition.repl_tech)
                 cond.steps = player.steps
                 cond.link = target
-        if (
-            condition.phase == "perform_action_item"
-            and condition.slug == "charging"
-        ):
+        if condition.phase == "perform_action_item":
             target.status.clear()
             if condition.repl_item:
                 cond = Condition()

--- a/tuxemon/condition/effects/diehard.py
+++ b/tuxemon/condition/effects/diehard.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
+from tuxemon.combat import fainted
 from tuxemon.condition.condeffect import CondEffect, CondEffectResult
 from tuxemon.locale import T
 
@@ -20,34 +21,32 @@ class DieHardEffectResult(CondEffectResult):
 @dataclass
 class DieHardEffect(CondEffect):
     """
-    DieHard status
+    DieHard: When HP would fall below 1, set it to 1, remove this condition and
+    print "X fights through the pain."
+
+    A monster that is already on exactly 1 HP cannot gain the Diehard condition.
+
+    Parameters:
+        hp: The amount of HP to set.
 
     """
 
     name = "diehard"
+    hp: int
 
     def apply(
         self, condition: Condition, target: Monster
     ) -> DieHardEffectResult:
         extra: Optional[str] = None
-        if condition.phase == "check_party_hp" and condition.slug == "diehard":
-            if target.current_hp <= 0:
-                target.current_hp = 1
+        if condition.phase == "check_party_hp":
+            params = {"target": target.name.upper()}
+            if fainted(target):
+                target.current_hp = self.hp
                 target.status.clear()
-                extra = T.format(
-                    "combat_state_diehard_tech",
-                    {
-                        "target": target.name.upper(),
-                    },
-                )
-            elif target.current_hp == 1:
+                extra = T.format("combat_state_diehard_tech", params)
+            if target.current_hp == self.hp:
                 target.status.clear()
-                extra = T.format(
-                    "combat_state_diehard_end",
-                    {
-                        "target": target.name.upper(),
-                    },
-                )
+                extra = T.format("combat_state_diehard_end", params)
 
         return {
             "success": True,

--- a/tuxemon/condition/effects/enraged.py
+++ b/tuxemon/condition/effects/enraged.py
@@ -28,10 +28,7 @@ class EnragedEffect(CondEffect):
     def apply(
         self, condition: Condition, target: Monster
     ) -> EnragedEffectResult:
-        if (
-            condition.phase == "perform_action_tech"
-            and condition.slug == "enraged"
-        ):
+        if condition.phase == "perform_action_tech":
             target.status.clear()
         return {
             "success": True,

--- a/tuxemon/condition/effects/exhausted.py
+++ b/tuxemon/condition/effects/exhausted.py
@@ -31,10 +31,7 @@ class ExhaustedEffect(CondEffect):
         player = target.owner
         assert player
         cond: Optional[Condition] = None
-        if (
-            condition.phase == "perform_action_tech"
-            and condition.slug == "exhausted"
-        ):
+        if condition.phase == "perform_action_tech":
             target.status.clear()
             if condition.repl_tech:
                 cond = Condition()

--- a/tuxemon/condition/effects/flinching.py
+++ b/tuxemon/condition/effects/flinching.py
@@ -21,24 +21,28 @@ class FlinchingEffectResult(CondEffectResult):
 @dataclass
 class FlinchingEffect(CondEffect):
     """
-    Flinching status
+    Flinching: 50% chance to miss your next turn.
+    If you do miss your next turn, this condition ends.
+
+    Parameters:
+        chance: The chance.
 
     """
 
     name = "flinching"
+    chance: float
 
     def apply(
         self, condition: Condition, target: Monster
     ) -> FlinchingEffectResult:
         skip: Optional[Technique] = None
-        if condition.phase == "pre_checking" and condition.slug == "flinching":
-            flinching = random.randint(1, 2)
-            if flinching == 1:
-                user = condition.link
-                assert user
-                skip = Technique()
-                skip.load("empty")
-                user.status.clear()
+        if condition.phase == "pre_checking" and random.random() > self.chance:
+            user = condition.link
+            empty = condition.repl_tech
+            assert user and empty
+            skip = Technique()
+            skip.load(empty)
+            user.status.clear()
         return {
             "success": True,
             "condition": None,

--- a/tuxemon/condition/effects/grabbed.py
+++ b/tuxemon/condition/effects/grabbed.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from tuxemon import formula
 from tuxemon.condition.condeffect import CondEffect, CondEffectResult
 
 if TYPE_CHECKING:
@@ -21,20 +20,32 @@ class GrabbedEffectResult(CondEffectResult):
 class GrabbedEffect(CondEffect):
     """
     This effect has a chance to apply the grabbed status effect.
+
+    It applies an effect on ranged and reach techniques.
+
+    Parameters:
+        divisor: The divisor.
+        ranges: Technique range separated by ":".
+
     """
 
     name = "grabbed"
+    divisor: float
+    ranges: str
 
     def apply(
         self, condition: Condition, target: Monster
     ) -> GrabbedEffectResult:
         done: bool = False
-        if (
-            condition.phase == "perform_action_status"
-            and condition.slug == "grabbed"
-        ):
-            formula.simple_grabbed(target)
+        ranges = self.ranges.split(":")
+        moves = [tech for tech in target.moves if tech.range in ranges]
+        if condition.phase == "perform_action_status":
             done = True
+        # applies effect on techniques
+        if done and moves:
+            for move in moves:
+                move.potency = move.default_potency / self.divisor
+                move.power = move.default_power / self.divisor
         return {
             "success": done,
             "condition": None,

--- a/tuxemon/condition/effects/harpooned.py
+++ b/tuxemon/condition/effects/harpooned.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from tuxemon.combat import fainted
 from tuxemon.condition.condeffect import CondEffect, CondEffectResult
 
 if TYPE_CHECKING:
@@ -19,21 +20,22 @@ class HarpoonedEffectResult(CondEffectResult):
 @dataclass
 class HarpoonedEffect(CondEffect):
     """
-    Status harpooned.
+    Harpooned: If you swap out, take damage equal to 1/8th your maximum HP
+
+    Parameters:
+        divisor: The divisor.
 
     """
 
     name = "harpooned"
+    divisor: int
 
     def apply(
         self, condition: Condition, target: Monster
     ) -> HarpoonedEffectResult:
-        if (
-            condition.phase == "add_monster_into_play"
-            and condition.slug == "harpooned"
-        ):
-            target.current_hp -= target.hp // 8
-            if target.current_hp <= 0:
+        if condition.phase == "add_monster_into_play":
+            target.current_hp -= target.hp // self.divisor
+            if fainted(target):
                 target.faint()
         return {
             "success": True,

--- a/tuxemon/condition/effects/lifeleech.py
+++ b/tuxemon/condition/effects/lifeleech.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from tuxemon import formula
+from tuxemon.combat import fainted
 from tuxemon.condition.condeffect import CondEffect, CondEffectResult
+from tuxemon.formula import simple_lifeleech
 
 if TYPE_CHECKING:
     from tuxemon.condition.condition import Condition
@@ -23,30 +24,28 @@ class LifeLeechEffect(CondEffect):
     This effect has a chance to apply the lifeleech status effect.
 
     Parameters:
-        user: The Monster object that used this condition.
-        target: The Monster object that we are using this condition on.
-
-    Returns:
-        Dict summarizing the result.
+        user: The monster getting HPs.
+        target: The monster losing HPs.
+        divisor: The number by which target HP is to be divided.
 
     """
 
     name = "lifeleech"
+    divisor: int
 
     def apply(
         self, condition: Condition, target: Monster
     ) -> LifeLeechEffectResult:
         lifeleech: bool = False
-        if (
-            condition.phase == "perform_action_status"
-            and condition.slug == "lifeleech"
-        ):
-            user = condition.link
-            assert user
-            damage = formula.simple_lifeleech(user, target)
+        user = condition.link
+        assert user
+        if condition.phase == "perform_action_status" and not fainted(user):
+            damage = simple_lifeleech(user, target, self.divisor)
             target.current_hp -= damage
             user.current_hp += damage
             lifeleech = True
+        if fainted(user):
+            target.status.clear()
 
         return {
             "success": lifeleech,

--- a/tuxemon/condition/effects/lockdown.py
+++ b/tuxemon/condition/effects/lockdown.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from tuxemon.condition.condeffect import CondEffect, CondEffectResult
+from tuxemon.locale import T
 
 if TYPE_CHECKING:
     from tuxemon.condition.condition import Condition
@@ -27,9 +28,13 @@ class LockdownEffect(CondEffect):
     def apply(
         self, condition: Condition, target: Monster
     ) -> LockdownEffectResult:
+        extra: Optional[str] = None
+        if condition.phase == "enqueue_item":
+            params = {"target": target.name.upper()}
+            extra = T.format("combat_state_lockdown_item", params)
         return {
             "success": True,
             "condition": None,
             "technique": None,
-            "extra": None,
+            "extra": extra,
         }

--- a/tuxemon/condition/effects/noddingoff.py
+++ b/tuxemon/condition/effects/noddingoff.py
@@ -23,9 +23,18 @@ class NoddingOffEffectResult(CondEffectResult):
 class NoddingOffEffect(CondEffect):
     """
     This effect has a chance to apply the nodding off status effect.
+
+    Sleep lasts for a minimum of one turn.
+    It has a 50% chance to end after each turn.
+    If it has gone on for 5 turns, it ends.
+
+    Parameters:
+        chance: The chance.
+
     """
 
     name = "noddingoff"
+    chance: float
 
     def apply(
         self, condition: Condition, target: Monster
@@ -33,24 +42,15 @@ class NoddingOffEffect(CondEffect):
         extra: Optional[str] = None
         skip: Optional[Technique] = None
 
-        if (
-            condition.phase == "pre_checking"
-            and condition.slug == "noddingoff"
-        ):
+        if condition.phase == "pre_checking" and condition.repl_tech:
             skip = Technique()
-            skip.load("empty")
+            skip.load(condition.repl_tech)
 
-        if (
-            condition.phase == "perform_action_tech"
-            and condition.slug == "noddingoff"
-            and self.wake_up(condition)
+        if condition.phase == "perform_action_tech" and self.wake_up(
+            condition
         ):
-            extra = T.format(
-                "combat_state_dozing_end",
-                {
-                    "target": target.name.upper(),
-                },
-            )
+            params = {"target": target.name.upper()}
+            extra = T.format("combat_state_dozing_end", params)
             target.status.clear()
         return {
             "success": True,
@@ -60,8 +60,10 @@ class NoddingOffEffect(CondEffect):
         }
 
     def wake_up(self, condition: Condition) -> bool:
-        value = random.random()
-        if condition.duration >= condition.nr_turn > 0 and value > 0.5:
+        if (
+            condition.duration >= condition.nr_turn > 0
+            and random.random() > self.chance
+        ):
             return True
         if condition.nr_turn > condition.duration:
             return True

--- a/tuxemon/condition/effects/poisoned.py
+++ b/tuxemon/condition/effects/poisoned.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from tuxemon import formula
 from tuxemon.condition.condeffect import CondEffect, CondEffectResult
 
 if TYPE_CHECKING:
@@ -21,20 +20,21 @@ class PoisonedEffectResult(CondEffectResult):
 class PoisonedEffect(CondEffect):
     """
     This effect has a chance to apply the poisoned status.
+
+    Parameters:
+        divisor: The divisor.
+
     """
 
     name = "poisoned"
+    divisor: int
 
     def apply(
         self, condition: Condition, target: Monster
     ) -> PoisonedEffectResult:
         poisoned: bool = False
-        if (
-            condition.phase == "perform_action_status"
-            and condition.slug == "poison"
-        ):
-            damage = formula.damage_full_hp(target, 8)
-            target.current_hp -= damage
+        if condition.phase == "perform_action_status":
+            target.current_hp -= target.hp // self.divisor
             poisoned = True
 
         return {

--- a/tuxemon/condition/effects/prickly.py
+++ b/tuxemon/condition/effects/prickly.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Union
 
+from tuxemon.combat import fainted
 from tuxemon.condition.condeffect import CondEffect, CondEffectResult
 from tuxemon.condition.condition import Condition
-from tuxemon.db import Range
 from tuxemon.monster import Monster
 from tuxemon.technique.technique import Technique
 
@@ -24,9 +24,14 @@ class PricklyBackEffect(CondEffect):
     Each time you are hit by a Physical move
     the attacker takes 1/8th your maximum HP in damage
 
+    Parameters:
+        divisor: The divisor.
+
     """
 
     name = "prickly"
+    divisor: int
+    ranges: str
 
     def apply(
         self, condition: Condition, target: Monster
@@ -36,6 +41,7 @@ class PricklyBackEffect(CondEffect):
         combat = condition.combat_state
         log = combat._log_action
         turn = combat._turn
+        ranges = self.ranges.split(":")
         # check log actions
         attacker: Union[Monster, None] = None
         hit: bool = False
@@ -48,23 +54,19 @@ class PricklyBackEffect(CondEffect):
                     isinstance(method, Technique)
                     and isinstance(action.user, Monster)
                     and method.hit
+                    and method.range in ranges
+                    and action.target.instance_id == target.instance_id
                 ):
-                    if (
-                        method.range == Range.touch
-                        or method.range == Range.melee
-                    ):
-                        if action.target.instance_id == target.instance_id:
-                            attacker = action.user
-                            hit = True
+                    attacker = action.user
+                    hit = True
 
         if (
             condition.phase == "perform_action_status"
-            and condition.slug == "prickly"
             and attacker
             and hit
-            and attacker.current_hp > 0
+            and not fainted(attacker)
         ):
-            attacker.current_hp -= target.hp // 8
+            attacker.current_hp -= target.hp // self.divisor
             done = True
         return {
             "success": done,

--- a/tuxemon/condition/effects/retaliate.py
+++ b/tuxemon/condition/effects/retaliate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Union
 
+from tuxemon.combat import fainted
 from tuxemon.condition.condeffect import CondEffect, CondEffectResult
 from tuxemon.condition.condition import Condition
 from tuxemon.db import Range
@@ -54,24 +55,21 @@ class RetaliateEffect(CondEffect):
                     isinstance(method, Technique)
                     and isinstance(action.user, Monster)
                     and method.hit
+                    and action.target.instance_id == target.instance_id
+                    and method.range != Range.special
                 ):
-                    if (
-                        action.target.instance_id == target.instance_id
-                        and method.range != Range.special
-                    ):
-                        attacker = action.user
-                        hit = True
-                        dam, mul = simple_damage_calculate(
-                            method, attacker, target
-                        )
-                        damage = dam
+                    attacker = action.user
+                    hit = True
+                    dam, mul = simple_damage_calculate(
+                        method, attacker, target
+                    )
+                    damage = dam
 
         if (
             condition.phase == "perform_action_status"
-            and condition.slug == "retaliate"
             and attacker
             and hit
-            and attacker.current_hp > 0
+            and not fainted(attacker)
         ):
             attacker.current_hp -= damage
             done = True

--- a/tuxemon/condition/effects/revenge.py
+++ b/tuxemon/condition/effects/revenge.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Union
 
+from tuxemon.combat import fainted
 from tuxemon.condition.condeffect import CondEffect, CondEffectResult
 from tuxemon.db import Range
 from tuxemon.formula import simple_damage_calculate
@@ -53,24 +54,21 @@ class RevengeEffect(CondEffect):
                     isinstance(method, Technique)
                     and isinstance(action.user, Monster)
                     and method.hit
+                    and action.target.instance_id == target.instance_id
+                    and method.range != Range.special
                 ):
-                    if (
-                        action.target.instance_id == target.instance_id
-                        and method.range != Range.special
-                    ):
-                        attacker = action.user
-                        hit = True
-                        dam, mul = simple_damage_calculate(
-                            method, attacker, target
-                        )
-                        damage = dam
+                    attacker = action.user
+                    hit = True
+                    dam, mul = simple_damage_calculate(
+                        method, attacker, target
+                    )
+                    damage = dam
 
         if (
             condition.phase == "perform_action_status"
-            and condition.slug == "revenge"
             and attacker
             and hit
-            and attacker.current_hp > 0
+            and not fainted(attacker)
         ):
             attacker.current_hp -= damage
             target.current_hp += damage

--- a/tuxemon/condition/effects/sniping.py
+++ b/tuxemon/condition/effects/sniping.py
@@ -28,10 +28,7 @@ class SnipingEffect(CondEffect):
     def apply(
         self, condition: Condition, target: Monster
     ) -> SnipingEffectResult:
-        if (
-            condition.phase == "perform_action_tech"
-            and condition.slug == "sniping"
-        ):
+        if condition.phase == "perform_action_tech":
             target.status.clear()
         return {
             "success": True,

--- a/tuxemon/condition/effects/stuck.py
+++ b/tuxemon/condition/effects/stuck.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from tuxemon import formula
 from tuxemon.condition.condeffect import CondEffect, CondEffectResult
 
 if TYPE_CHECKING:
@@ -21,20 +20,32 @@ class StuckEffectResult(CondEffectResult):
 class StuckEffect(CondEffect):
     """
     This effect has a chance to apply the stuck status effect.
+
+    It applies an effect on melee and touch techniques.
+
+    Parameters:
+        divisor: The divisor.
+        ranges: Technique range separated by ":".
+
     """
 
     name = "stuck"
+    divisor: float
+    ranges: str
 
     def apply(
         self, condition: Condition, target: Monster
     ) -> StuckEffectResult:
         done: bool = False
-        if (
-            condition.phase == "perform_action_status"
-            and condition.slug == "stuck"
-        ):
-            formula.simple_stuck(target)
+        ranges = self.ranges.split(":")
+        moves = [tech for tech in target.moves if tech.range in ranges]
+        if condition.phase == "perform_action_status":
             done = True
+        # applies effect on techniques
+        if done and moves:
+            for move in moves:
+                move.potency = move.default_potency / self.divisor
+                move.power = move.default_power / self.divisor
         return {
             "success": done,
             "condition": None,

--- a/tuxemon/condition/effects/tired.py
+++ b/tuxemon/condition/effects/tired.py
@@ -30,16 +30,9 @@ class TiredEffect(CondEffect):
         self, condition: Condition, target: Monster
     ) -> TiredEffectResult:
         extra: Optional[str] = None
-        if (
-            condition.phase == "perform_action_tech"
-            and condition.slug == "tired"
-        ):
-            extra = T.format(
-                "combat_state_tired_end",
-                {
-                    "target": target.name.upper(),
-                },
-            )
+        if condition.phase == "perform_action_tech":
+            params = {"target": target.name.upper()}
+            extra = T.format("combat_state_tired_end", params)
             target.status.clear()
         return {
             "success": True,

--- a/tuxemon/condition/effects/wasting.py
+++ b/tuxemon/condition/effects/wasting.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from tuxemon.combat import fainted
 from tuxemon.condition.condeffect import CondEffect, CondEffectResult
 
 if TYPE_CHECKING:
@@ -21,20 +22,21 @@ class WastingEffect(CondEffect):
     """
     Wasting: Take #/16 of your maximum HP in damage each turn
     where # = the number of turns that you have had this condition.
+
+    Parameters:
+        divisor: The divisor.
+
     """
 
     name = "wasting"
+    divisor: int
 
     def apply(
         self, condition: Condition, target: Monster
     ) -> WastingEffectResult:
         done: bool = False
-        if (
-            condition.phase == "perform_action_status"
-            and condition.slug == "wasting"
-            and target.current_hp > 0
-        ):
-            damage = (target.hp // 16) * condition.nr_turn
+        if condition.phase == "perform_action_status" and not fainted(target):
+            damage = (target.hp // self.divisor) * condition.nr_turn
             target.current_hp -= damage
             done = True
         return {

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -769,11 +769,11 @@ class ConditionModel(BaseModel):
     )
     repl_tech: Optional[str] = Field(
         None,
-        description="With which status reply after a tech used",
+        description="With which status or technique reply after a tech used",
     )
     repl_item: Optional[str] = Field(
         None,
-        description="With which status reply after an item used",
+        description="With which status or technique reply after an item used",
     )
     gain_cond: Optional[str] = Field(
         None,
@@ -829,7 +829,11 @@ class ConditionModel(BaseModel):
 
     @field_validator("repl_tech", "repl_item")
     def status_exists(cls: ConditionModel, v: Optional[str]) -> Optional[str]:
-        if not v or has.db_entry("condition", v):
+        if (
+            not v
+            or has.db_entry("condition", v)
+            or has.db_entry("technique", v)
+        ):
             return v
         raise ValueError(f"the status {v} doesn't exist in the db")
 

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -129,7 +129,7 @@ class Monster:
         self.total_experience = 0
 
         self.types: list[Element] = []
-        self._types: list[Element] = []
+        self.default_types: list[Element] = []
         self.shape = MonsterShape.default
         self.randomly = True
         self.out_of_range = False
@@ -212,7 +212,7 @@ class Monster:
         for _ele in results.types:
             _element = Element(_ele)
             self.types.append(_element)
-            self._types.append(_element)
+            self.default_types.append(_element)
 
         self.randomly = results.randomly or self.randomly
         self.got_experience = self.got_experience
@@ -289,11 +289,11 @@ class Monster:
 
         self.moves.append(technique)
 
-    def return_types(self) -> None:
+    def reset_types(self) -> None:
         """
-        Returns a monster types.
+        Resets monster types to the default ones.
         """
-        self.types = self._types
+        self.types = self.default_types
 
     def return_stat(
         self,
@@ -421,12 +421,12 @@ class Monster:
         self.melee = (shape.melee * multiplier) + self.mod_melee
         self.ranged = (shape.ranged * multiplier) + self.mod_ranged
         self.speed = (shape.speed * multiplier) + self.mod_speed
-        # tastes
-        self.armour += formula.check_taste(self, "armour")
-        self.dodge += formula.check_taste(self, "dodge")
-        self.melee += formula.check_taste(self, "melee")
-        self.ranged += formula.check_taste(self, "ranged")
-        self.speed += formula.check_taste(self, "speed")
+        # updates stats based on additional parameters
+        self.armour += formula.update_armour(self)
+        self.dodge += formula.update_dodge(self)
+        self.melee += formula.update_melee(self)
+        self.ranged += formula.update_ranged(self)
+        self.speed += formula.update_speed(self)
 
     def set_taste_cold(self, taste_cold: TasteCold) -> TasteCold:
         """

--- a/tuxemon/prepare.py
+++ b/tuxemon/prepare.py
@@ -157,6 +157,14 @@ BG_MONSTERS: str = "gfx/ui/monster/monster_menu_bg.png"
 # used for scaling.
 NATIVE_RESOLUTION: tuple[int, int] = (240, 160)
 
+# Maps
+# 1 tile = 1 m (3.28 ft) large
+COEFF_TILE: float = 1.0
+# for converting metric into imperial (distance)
+COEFF_MILES: float = 0.6213711922
+COEFF_FEET: float = 0.032808399
+# for converting metric into imperial (weight)
+COEFF_POUNDS: float = 2.2046
 
 # Players
 PLAYER_NPC = CONFIG.player_npc
@@ -186,6 +194,11 @@ COEFF_STATS: int = 7
 # set experience required for levelling up
 # (level + level_ofs) ** coefficient) - level_ofs default 0
 COEFF_EXP: int = 3
+# weight and height (min and max) = -/+ 10%
+WEIGHT_RANGE: tuple[float, float] = (-0.1, 0.1)
+HEIGHT_RANGE: tuple[float, float] = (-0.1, 0.1)
+# tastes (malus and bonus)
+TASTE_RANGE: tuple[float, float] = (-0.1, 0.1)
 
 # Capture
 TOTAL_SHAKES: int = 4

--- a/tuxemon/states/combat/combat_menus.py
+++ b/tuxemon/states/combat/combat_menus.py
@@ -90,18 +90,12 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
         forfeit.load("menu_forfeit")
         forfeit.combat_state = self.combat
         if not forfeit.validate(self.monster):
-            tools.open_dialog(
-                local_session,
-                [
-                    T.format(
-                        "combat_player_forfeit_status",
-                        {
-                            "monster": self.monster.name,
-                            "status": self.monster.status[0].name.lower(),
-                        },
-                    )
-                ],
-            )
+            params = {
+                "monster": self.monster.name.upper(),
+                "status": self.monster.status[0].name.lower(),
+            }
+            msg = T.format("combat_player_forfeit_status", params)
+            tools.open_dialog(local_session, [msg])
             return
         self.client.pop_state(self)
         if not self.enemy.forfeit:
@@ -133,18 +127,12 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
         run.load("menu_run")
         run.combat_state = self.combat
         if not run.validate(self.monster):
-            tools.open_dialog(
-                local_session,
-                [
-                    T.format(
-                        "combat_player_run_status",
-                        {
-                            "monster": self.monster.name,
-                            "status": self.monster.status[0].name.lower(),
-                        },
-                    )
-                ],
-            )
+            params = {
+                "monster": self.monster.name.upper(),
+                "status": self.monster.status[0].name.lower(),
+            }
+            msg = T.format("combat_player_run_status", params)
+            tools.open_dialog(local_session, [msg])
             return
         self.client.pop_state(self)
         player = self.party[0]
@@ -158,33 +146,23 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
             added = menuitem.game_object
 
             if added in self.combat.active_monsters:
-                tools.open_dialog(
-                    local_session,
-                    [T.format("combat_isactive", {"name": added.name})],
-                )
+                msg = T.format("combat_isactive", {"name": added.name.upper()})
+                tools.open_dialog(local_session, [msg])
                 return
-            elif added.current_hp < 1:
-                tools.open_dialog(
-                    local_session,
-                    [T.format("combat_fainted", {"name": added.name})],
-                )
+            if combat.fainted(added):
+                msg = T.format("combat_fainted", {"name": added.name.upper()})
+                tools.open_dialog(local_session, [msg])
                 return
             swap = Technique()
             swap.load("swap")
             swap.combat_state = self.combat
             if not swap.validate(self.monster):
-                tools.open_dialog(
-                    local_session,
-                    [
-                        T.format(
-                            "combat_player_swap_status",
-                            {
-                                "monster": self.monster.name,
-                                "status": self.monster.status[0].name.lower(),
-                            },
-                        )
-                    ],
-                )
+                params = {
+                    "monster": self.monster.name.upper(),
+                    "status": self.monster.status[0].name.lower(),
+                }
+                msg = T.format("combat_player_swap_status", params)
+                tools.open_dialog(local_session, [msg])
                 return
             self.combat.enqueue_action(self.monster, swap, added)
             self.client.pop_state()  # close technique menu
@@ -223,13 +201,18 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
             target = menu_item.game_object
             # is the item valid to use?
             if not item.validate(target):
-                msg = T.format("cannot_use_item_monster", {"name": item.name})
+                params = {"name": item.name.upper()}
+                msg = T.format("cannot_use_item_monster", params)
                 tools.open_dialog(local_session, [msg])
                 return
-            if combat.has_status(target, "lockdown"):
-                msg = T.format("cannot_use_item_monster", {"name": item.name})
-                tools.open_dialog(local_session, [msg])
-                return
+            # check target status
+            if target.status:
+                target.status[0].combat_state = self.combat
+                target.status[0].phase = "enqueue_item"
+                result_status = target.status[0].use(target)
+                if result_status["extra"]:
+                    tools.open_dialog(local_session, [result_status["extra"]])
+                    return
 
             # enqueue the item
             self.combat.enqueue_action(self.character, item, target)
@@ -252,7 +235,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
             # add techniques to the menu
             filter_moves = []
             for tech in self.monster.moves:
-                if tech.next_use <= 0:
+                if not combat.recharging(tech):
                     image = self.shadow_text(tech.name)
                 else:
                     image = self.shadow_text(
@@ -278,12 +261,13 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
         def choose_target(menu_item: MenuItem[Technique]) -> None:
             # open menu to choose target of technique
             technique = menu_item.game_object
-            if technique.next_use > 0:
-                params = {"move": technique.name, "name": self.monster.name}
-                tools.open_dialog(
-                    local_session,
-                    [T.format("combat_recharging", params)],
-                )
+            if combat.recharging(technique):
+                params = {
+                    "move": technique.name.upper(),
+                    "name": self.monster.name.upper(),
+                }
+                msg = T.format("combat_recharging", params)
+                tools.open_dialog(local_session, [msg])
                 return
 
             # allow to choose target if 1 vs 2 or 2 vs 2
@@ -313,11 +297,10 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
             # enqueue the technique
             target = menu_item.game_object
 
+            params = {"name": self.monster.name.upper()}
             # can be used the technique?
             if not technique.validate(target):
-                msg = T.format(
-                    "cannot_use_tech_monster", {"name": technique.name}
-                )
+                msg = T.format("cannot_use_tech_monster", params)
                 tools.open_dialog(local_session, [msg])
                 return
 
@@ -325,7 +308,6 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                 combat.has_effect(technique, "damage")
                 and target == self.monster
             ):
-                params = {"name": self.monster.name}
                 msg = T.format("combat_target_itself", params)
                 tools.open_dialog(local_session, [msg])
                 return

--- a/tuxemon/states/monster_info/__init__.py
+++ b/tuxemon/states/monster_info/__init__.py
@@ -51,7 +51,8 @@ class MonsterInfoState(PygameMenuState):
         types = " ".join(map(lambda s: T.translate(s.slug), monster.types))
         # weight and height
         results = db.lookup(monster.slug, table="monster")
-        diff_weight, diff_height = formula.weight_height_diff(monster, results)
+        diff_weight = formula.diff_percentage(monster.weight, results.weight)
+        diff_height = formula.diff_percentage(monster.height, results.height)
         unit = local_session.player.game_variables["unit_measure"]
         if unit == "Metric":
             mon_weight = monster.weight

--- a/tuxemon/technique/effects/fly_off.py
+++ b/tuxemon/technique/effects/fly_off.py
@@ -51,12 +51,8 @@ class FlyOffEffect(TechEffect):
             # if it's already flying
             done = False
 
-        extra = T.format(
-            "combat_fly",
-            {
-                "name": user.name.upper(),
-            },
-        )
+        params = {"name": user.name.upper()}
+        extra = T.format("combat_fly", params)
 
         return {
             "success": done,

--- a/tuxemon/technique/effects/forfeit.py
+++ b/tuxemon/technique/effects/forfeit.py
@@ -37,12 +37,8 @@ class ForfeitEffect(TechEffect):
         var["battle_last_result"] = OutputBattle.forfeit
         var["teleport_clinic"] = OutputBattle.lost
         combat._run = True
-        extra = T.format(
-            "combat_forfeit",
-            {
-                "npc": combat.players[1].name,
-            },
-        )
+        params = {"npc": combat.players[1].name.upper()}
+        extra = T.format("combat_forfeit", params)
         # trigger forfeit
         for remove in combat.players:
             combat.clean_combat()

--- a/tuxemon/technique/effects/give.py
+++ b/tuxemon/technique/effects/give.py
@@ -82,6 +82,9 @@ class GiveEffect(TechEffect):
                     user.apply_status(status)
                     target.apply_status(status)
                     done = True
+        # show icons
+        if done:
+            combat.reset_status_icons()
         return {
             "success": done,
             "damage": 0,

--- a/tuxemon/technique/effects/healing.py
+++ b/tuxemon/technique/effects/healing.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
+from tuxemon.prepare import COEFF_DAMAGE
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
 
 if TYPE_CHECKING:
@@ -49,7 +50,7 @@ class HealingEffect(TechEffect):
             raise ValueError(f"{self.objective} must be user or target")
         # check healing power
         if isinstance(tech.healing_power, int):
-            heal = (7 + mon.level) * tech.healing_power
+            heal = (COEFF_DAMAGE + mon.level) * tech.healing_power
         diff = mon.hp - mon.current_hp
         if hit:
             tech.hit = True

--- a/tuxemon/technique/effects/money.py
+++ b/tuxemon/technique/effects/money.py
@@ -48,14 +48,8 @@ class MoneyEffect(TechEffect):
             tech.advance_counter_success()
             amount = int(damage * mult)
             player.give_money(amount)
-            extra = T.format(
-                "combat_state_gold",
-                {
-                    "name": user.name,
-                    "symbol": "$",
-                    "gold": damage,
-                },
-            )
+            params = {"name": user.name.upper(), "symbol": "$", "gold": amount}
+            extra = T.format("combat_state_gold", params)
         return {
             "success": done,
             "damage": 0,

--- a/tuxemon/technique/effects/prop_damage.py
+++ b/tuxemon/technique/effects/prop_damage.py
@@ -27,13 +27,13 @@ class PropDamageEffect(TechEffect):
         objective: User HP or target HP.
         proportional: The percentage of the max HP
 
-    eg prop_damage target,0.25 (1/4 max enemy HP)
+    eg prop_damage target,4 (1/4 max enemy HP)
 
     """
 
     name = "prop_damage"
     objective: str
-    proportional: float
+    proportional: int
 
     def apply(
         self, tech: Technique, user: Monster, target: Monster
@@ -45,8 +45,7 @@ class PropDamageEffect(TechEffect):
             tech.hit = True
             tech.advance_counter_success()
             reference_hp = target.hp if self.objective == "target" else user.hp
-            damage = int(reference_hp * self.proportional)
-            target.current_hp -= damage
+            target.current_hp -= reference_hp // self.proportional
         else:
             tech.hit = False
             damage = 0

--- a/tuxemon/technique/effects/remove.py
+++ b/tuxemon/technique/effects/remove.py
@@ -46,7 +46,7 @@ class RemoveEffect(TechEffect):
                 else:
                     if has_status(user, self.condition):
                         done = True
-                        target.status.clear()
+                        user.status.clear()
             elif self.objective == "target":
                 if self.condition == "all":
                     done = True

--- a/tuxemon/technique/effects/reverse.py
+++ b/tuxemon/technique/effects/reverse.py
@@ -34,14 +34,14 @@ class ReverseEffect(TechEffect):
     ) -> ReverseEffectResult:
         done: bool = False
         if self.objective == "user":
-            user.return_types()
+            user.reset_types()
             done = True
         elif self.objective == "target":
-            target.return_types()
+            target.reset_types()
             done = True
         elif self.objective == "both":
-            user.return_types()
-            target.return_types()
+            user.reset_types()
+            target.reset_types()
             done = True
         return {
             "success": done,

--- a/tuxemon/technique/effects/scope.py
+++ b/tuxemon/technique/effects/scope.py
@@ -29,16 +29,14 @@ class ScopeEffect(TechEffect):
     def apply(
         self, tech: Technique, user: Monster, target: Monster
     ) -> ScopeEffectResult:
-        extra = T.format(
-            "combat_scope",
-            {
-                "AR": target.armour,
-                "DE": target.dodge,
-                "ME": target.melee,
-                "RD": target.ranged,
-                "SD": target.speed,
-            },
-        )
+        params = {
+            "AR": target.armour,
+            "DE": target.dodge,
+            "ME": target.melee,
+            "RD": target.ranged,
+            "SD": target.speed,
+        }
+        extra = T.format("combat_scope", params)
         return {
             "success": True,
             "damage": 0,

--- a/tuxemon/technique/effects/splash.py
+++ b/tuxemon/technique/effects/splash.py
@@ -25,6 +25,7 @@ class SplashEffect(TechEffect):
     """
 
     name = "splash"
+    divisor: int
 
     def apply(
         self, tech: Technique, user: Monster, target: Monster
@@ -39,7 +40,7 @@ class SplashEffect(TechEffect):
             target.current_hp -= damage
         else:
             tech.hit = True
-            damage //= 2
+            damage //= self.divisor
             target.current_hp -= damage
         return {
             "success": bool(damage),

--- a/tuxemon/technique/effects/spyderbite.py
+++ b/tuxemon/technique/effects/spyderbite.py
@@ -37,20 +37,11 @@ class SpyderbiteEffect(TechEffect):
         ):
             target.plague = PlagueType.infected
 
+        params = {"target": target.name.upper()}
         if target.plague == PlagueType.infected:
-            extra = T.format(
-                "combat_state_plague3",
-                {
-                    "target": target.name.upper(),
-                },
-            )
+            extra = T.format("combat_state_plague3", params)
         else:
-            extra = T.format(
-                "combat_state_plague0",
-                {
-                    "target": target.name.upper(),
-                },
-            )
+            extra = T.format("combat_state_plague0", params)
 
         return {
             "success": True,

--- a/tuxemon/technique/effects/switch.py
+++ b/tuxemon/technique/effects/switch.py
@@ -74,15 +74,13 @@ class SwitchEffect(TechEffect):
             _type: str = ""
             _monster: str = ""
             if self.objective == "both":
-                extra = T.format(
-                    "combat_state_switch_both",
-                    {
-                        "user": user.name.upper(),
-                        "type1": T.translate(user.types[0].slug),
-                        "target": target.name.upper(),
-                        "type2": T.translate(target.types[0].slug),
-                    },
-                )
+                params = {
+                    "user": user.name.upper(),
+                    "type1": T.translate(user.types[0].slug),
+                    "target": target.name.upper(),
+                    "type2": T.translate(target.types[0].slug),
+                }
+                extra = T.format("combat_state_switch_both", params)
             else:
                 if self.objective == "target":
                     _monster = target.name.upper()
@@ -90,13 +88,8 @@ class SwitchEffect(TechEffect):
                 if self.objective == "user":
                     _monster = user.name.upper()
                     _type = T.translate(user.types[0].slug)
-                extra = T.format(
-                    "combat_state_switch",
-                    {
-                        "target": _monster,
-                        "types": _type,
-                    },
-                )
+                params = {"target": _monster, "types": _type}
+                extra = T.format("combat_state_switch", params)
         return {
             "success": done,
             "damage": 0,


### PR DESCRIPTION
everything started while cleaning up **formula.py**

PR:
- moves some **constants** from formula.py to **prepare.py**, mostly related with distance (meters, kilometers and miles) as well as weight (pounds and kilograms);
- gets rid of **check_taste** in formula.py and it replaces it with a stock of new defs (**update_speed**, **update_melee**, etc) with the only goal to update the stat; it's more simpler, it's more easier to read and it can be expanded if there is something else going on;
- removes **simple_stuck** and **simple_grabbed** from **formula.py**, both were really close, almost a duplicate, it was possible to move the code inside the respective condition files; it has been removed also the hardcoded 0.5 by integrating the parameter directly in the JSONs (it can be modified eventually);
- removes **damage_full_hp**, it was used only twice (burnt and poison effect), but there wasn't anything particular of tricky to "deserve" a formula in formula.py; nothing more than 1 liner;
- to avoid harcoding, moves multiple hardcoded values in the JSONs (techniques - only splash - and multiple conditions);
- removes the pointless `condition.slug == xxx`, these were inserted back when techniques and conditions shared files, luckily we refactored;
- replaces some `target.current_hp > 0` with `if not fainted(target)` (and viceversa), since we have it, we can use it;
- replaces **weight_height_diff** in **formula.py** with **diff_percentage**, this because the previous formula was too specific (almost hardcoded on some parameters), while the new one is more generic and it can be used in other contexts;
- renames **_types** into **default_types** (monster.py), this is a sort of backup, so if a technique or condition is going to change the type/elements, this one is going to reset the original;
- adds a def in combat.py (not the state) called **recharging**, it'll return a boolean if True is the technique is recharging; this because I noticed a handful of `next_use > 0` as well as `next_use <= 0`;
- moved the **reset_icons** inside the give.py effect, in this way the status icons will appear immediately;
- removes the hardcoded **lockdown** from combat_menu and moves it inside the condition file; it gets replaced by a a generic check for status;
- removes some lines by moving out the parameters of **T.format** and creating a dict;

