### PR TITLE
steps monsters

### DIFF
--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -59,6 +59,7 @@ SIMPLE_PERSISTANCE_ATTRIBUTES = (
     "taste_cold",
     "taste_warm",
     "traded",
+    "steps",
     "mod_armour",
     "mod_dodge",
     "mod_melee",
@@ -104,6 +105,7 @@ class Monster:
         self.current_hp = 0
         self.hp = 0
         self.level = 0
+        self.steps = 0.0
 
         # modifier values
         self.mod_armour = 0
@@ -208,6 +210,7 @@ class Monster:
         self.stage = results.stage or EvolutionStage.standalone
         self.taste_cold = self.set_taste_cold(self.taste_cold)
         self.taste_warm = self.set_taste_warm(self.taste_warm)
+        self.steps = self.steps
         # types
         for _ele in results.types:
             _element = Element(_ele)

--- a/tuxemon/player.py
+++ b/tuxemon/player.py
@@ -46,8 +46,14 @@ class Player(NPC):
         diff_x = abs(after.x - before.x)
         diff_y = abs(after.y - before.y)
 
+        # increases steps player
         self.steps += diff_x + diff_y
 
+        # increases steps party monsters
+        for monster in self.monsters:
+            monster.steps += diff_x + diff_y
+
+        # checks variables starting with steps_
         for key, value in self.game_variables.items():
             if key.startswith("steps_"):
                 if float(value) > 0.0:


### PR DESCRIPTION
PR introduces the parameter "steps" for monster, the temporal parameters (days) isn't enough to qualify how much a monster has been between us, but steps is a pretty good one; this implements only the parameter, something else will follow (where this can be viewed, etc.). Only the ones carried (party) will increase steps (so max 6, nothing more).