### PR TITLE
enable / disable hp/exp bar (JSON)

### DIFF
--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -932,6 +932,15 @@ class BattleHudModel(BaseModel):
     tray_opponent: str = Field(
         ..., description="Sprite used for tray opponent background"
     )
+    hp_bar_player: bool = Field(
+        True, description="Whether draw or not player HP Bar"
+    )
+    hp_bar_opponent: bool = Field(
+        True, description="Whether draw or not opponent HP Bar"
+    )
+    exp_bar_player: bool = Field(
+        True, description="Whether draw or not player EXP Bar"
+    )
 
     @field_validator(
         "hud_player",

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -307,19 +307,23 @@ class CombatState(CombatAnimations):
 
     def draw_hp_bars(self) -> None:
         """Go through the HP bars and redraw them."""
+        draw: bool = False
         for monster, hud in self.hud.items():
             rect = Rect(0, 0, tools.scale(70), tools.scale(8))
             rect.right = hud.image.get_width() - tools.scale(8)
-            if hud.player:
+            if hud.player and self.graphics.hud.hp_bar_player:
                 rect.top += tools.scale(18)
-            else:
+                draw = True
+            elif not hud.player and self.graphics.hud.hp_bar_opponent:
                 rect.top += tools.scale(12)
-            self._hp_bars[monster].draw(hud.image, rect)
+                draw = True
+            if draw:
+                self._hp_bars[monster].draw(hud.image, rect)
 
     def draw_exp_bars(self) -> None:
         """Go through the EXP bars and redraw them."""
         for monster, hud in self.hud.items():
-            if hud.player:
+            if hud.player and self.graphics.hud.exp_bar_player:
                 rect = Rect(0, 0, tools.scale(70), tools.scale(6))
                 rect.right = hud.image.get_width() - tools.scale(8)
                 rect.top += tools.scale(31)


### PR DESCRIPTION
PR proposes to add 3 parameters in the environment JSONs below the hud section:
- hp_bar_player
- hp_bar_opponent
- exp_bar_player

all the fields are True by default, but this will give to the modder the power to remove the bar in certain environments.