### PR TITLE
evolution (path) + evolution for steps

### DIFF
--- a/mods/tuxemon/db/monster/aardorn.json
+++ b/mods/tuxemon/db/monster/aardorn.json
@@ -41,7 +41,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "aardart"
         }

--- a/mods/tuxemon/db/monster/agnidon.json
+++ b/mods/tuxemon/db/monster/agnidon.json
@@ -49,7 +49,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 36,
             "monster_slug": "agnigon"
         }

--- a/mods/tuxemon/db/monster/agnite.json
+++ b/mods/tuxemon/db/monster/agnite.json
@@ -49,7 +49,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 24,
             "monster_slug": "agnidon"
         }

--- a/mods/tuxemon/db/monster/allagon.json
+++ b/mods/tuxemon/db/monster/allagon.json
@@ -53,7 +53,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 54,
             "monster_slug": "ferricran"
         }

--- a/mods/tuxemon/db/monster/angesnow.json
+++ b/mods/tuxemon/db/monster/angesnow.json
@@ -29,7 +29,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 32,
             "monster_slug": "seraphice"
         }

--- a/mods/tuxemon/db/monster/anoleaf.json
+++ b/mods/tuxemon/db/monster/anoleaf.json
@@ -49,7 +49,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "gectile"
         }

--- a/mods/tuxemon/db/monster/baoby.json
+++ b/mods/tuxemon/db/monster/baoby.json
@@ -41,7 +41,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "baobaraffe"
         }

--- a/mods/tuxemon/db/monster/bolt.json
+++ b/mods/tuxemon/db/monster/bolt.json
@@ -41,7 +41,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 12,
             "monster_slug": "arthrobolt"
         }

--- a/mods/tuxemon/db/monster/boltnu.json
+++ b/mods/tuxemon/db/monster/boltnu.json
@@ -37,7 +37,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "exclawvate"
         }

--- a/mods/tuxemon/db/monster/botbot.json
+++ b/mods/tuxemon/db/monster/botbot.json
@@ -25,31 +25,26 @@
     ],
     "evolutions": [
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "av8r",
             "item": "booster_tech"
         },
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "picc",
             "item": "booster_tech"
         },
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "mrmoswitch",
             "item": "booster_tech"
         },
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "k9",
             "item": "booster_tech"
         },
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "b_ver_1",
             "item": "booster_tech"

--- a/mods/tuxemon/db/monster/bricgard.json
+++ b/mods/tuxemon/db/monster/bricgard.json
@@ -49,7 +49,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 36,
             "monster_slug": "brickhemoth"
         }

--- a/mods/tuxemon/db/monster/budaye.json
+++ b/mods/tuxemon/db/monster/budaye.json
@@ -25,25 +25,21 @@
     ],
     "evolutions": [
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "bamboon",
             "item": "wood_booster"
         },
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "bamboon",
             "item": "lucky_bamboo"
         },
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "frondly",
             "item": "water_booster"
         },
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "frondly",
             "item": "peace_lily"

--- a/mods/tuxemon/db/monster/bumbulus.json
+++ b/mods/tuxemon/db/monster/bumbulus.json
@@ -53,7 +53,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 32,
             "monster_slug": "nimbulex"
         }

--- a/mods/tuxemon/db/monster/bursa.json
+++ b/mods/tuxemon/db/monster/bursa.json
@@ -41,7 +41,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 32,
             "monster_slug": "flambear"
         }

--- a/mods/tuxemon/db/monster/cairfrey.json
+++ b/mods/tuxemon/db/monster/cairfrey.json
@@ -53,7 +53,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 32,
             "monster_slug": "possessun"
         }

--- a/mods/tuxemon/db/monster/caper.json
+++ b/mods/tuxemon/db/monster/caper.json
@@ -45,7 +45,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 32,
             "monster_slug": "crankus"
         }

--- a/mods/tuxemon/db/monster/capiti.json
+++ b/mods/tuxemon/db/monster/capiti.json
@@ -65,7 +65,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 32,
             "monster_slug": "capinyah"
         }

--- a/mods/tuxemon/db/monster/cardiling.json
+++ b/mods/tuxemon/db/monster/cardiling.json
@@ -49,7 +49,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "cardiwing"
         }

--- a/mods/tuxemon/db/monster/cardiwing.json
+++ b/mods/tuxemon/db/monster/cardiwing.json
@@ -49,7 +49,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 36,
             "monster_slug": "cardinale"
         }

--- a/mods/tuxemon/db/monster/cataspike.json
+++ b/mods/tuxemon/db/monster/cataspike.json
@@ -49,7 +49,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 9,
             "monster_slug": "puparmor"
         }

--- a/mods/tuxemon/db/monster/chenipode.json
+++ b/mods/tuxemon/db/monster/chenipode.json
@@ -37,9 +37,9 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
-            "at_level": 18,
-            "monster_slug": "exapode"
+            "at_level": 0,
+            "monster_slug": "exapode",
+            "steps": "2500"
         }
     ],
     "history": [

--- a/mods/tuxemon/db/monster/chillimp.json
+++ b/mods/tuxemon/db/monster/chillimp.json
@@ -37,7 +37,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "snowrilla"
         }

--- a/mods/tuxemon/db/monster/chloragon.json
+++ b/mods/tuxemon/db/monster/chloragon.json
@@ -53,7 +53,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 32,
             "monster_slug": "sapragon"
         }

--- a/mods/tuxemon/db/monster/chromeye.json
+++ b/mods/tuxemon/db/monster/chromeye.json
@@ -25,25 +25,21 @@
     ],
     "evolutions": [
         {
-            "path": "variable",
             "at_level": 18,
             "monster_slug": "angrito",
             "variable": "season:winter"
         },
         {
-            "path": "variable",
             "at_level": 18,
             "monster_slug": "happito",
             "variable": "season:summer"
         },
         {
-            "path": "variable",
             "at_level": 18,
             "monster_slug": "neutrito",
             "variable": "season:spring"
         },
         {
-            "path": "variable",
             "at_level": 18,
             "monster_slug": "sadito",
             "variable": "season:autumn"

--- a/mods/tuxemon/db/monster/corvix.json
+++ b/mods/tuxemon/db/monster/corvix.json
@@ -49,7 +49,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 36,
             "monster_slug": "gryfix"
         }

--- a/mods/tuxemon/db/monster/dandicub.json
+++ b/mods/tuxemon/db/monster/dandicub.json
@@ -37,7 +37,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "dandylion"
         }

--- a/mods/tuxemon/db/monster/demosnow.json
+++ b/mods/tuxemon/db/monster/demosnow.json
@@ -29,7 +29,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 32,
             "monster_slug": "lucifice"
         }

--- a/mods/tuxemon/db/monster/dollfin.json
+++ b/mods/tuxemon/db/monster/dollfin.json
@@ -25,25 +25,21 @@
     ],
     "evolutions": [
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "bigfin",
             "item": "water_booster"
         },
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "bigfin",
             "item": "sweet_sand"
         },
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "sharpfin",
             "item": "metal_booster"
         },
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "sharpfin",
             "item": "sea_girdle"

--- a/mods/tuxemon/db/monster/dracune.json
+++ b/mods/tuxemon/db/monster/dracune.json
@@ -45,7 +45,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 12,
             "monster_slug": "fluttaflap"
         }

--- a/mods/tuxemon/db/monster/drashimi.json
+++ b/mods/tuxemon/db/monster/drashimi.json
@@ -49,7 +49,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "tsushimi"
         }

--- a/mods/tuxemon/db/monster/elofly.json
+++ b/mods/tuxemon/db/monster/elofly.json
@@ -49,7 +49,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "elowind"
         }

--- a/mods/tuxemon/db/monster/elowind.json
+++ b/mods/tuxemon/db/monster/elowind.json
@@ -49,7 +49,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 42,
             "monster_slug": "elostorm"
         }

--- a/mods/tuxemon/db/monster/embra.json
+++ b/mods/tuxemon/db/monster/embra.json
@@ -53,7 +53,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 32,
             "monster_slug": "ruption"
         }

--- a/mods/tuxemon/db/monster/eyenemy.json
+++ b/mods/tuxemon/db/monster/eyenemy.json
@@ -37,7 +37,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "eyesore"
         }

--- a/mods/tuxemon/db/monster/fancair.json
+++ b/mods/tuxemon/db/monster/fancair.json
@@ -33,7 +33,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 24,
             "monster_slug": "windeye"
         }

--- a/mods/tuxemon/db/monster/flacono.json
+++ b/mods/tuxemon/db/monster/flacono.json
@@ -49,7 +49,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "corvix"
         }

--- a/mods/tuxemon/db/monster/fluoresfin.json
+++ b/mods/tuxemon/db/monster/fluoresfin.json
@@ -49,7 +49,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "incandesfin"
         }

--- a/mods/tuxemon/db/monster/forturtle.json
+++ b/mods/tuxemon/db/monster/forturtle.json
@@ -37,7 +37,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "prophetoise"
         }

--- a/mods/tuxemon/db/monster/furnursus.json
+++ b/mods/tuxemon/db/monster/furnursus.json
@@ -37,7 +37,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "statursus"
         }

--- a/mods/tuxemon/db/monster/fuzzlet.json
+++ b/mods/tuxemon/db/monster/fuzzlet.json
@@ -53,7 +53,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 32,
             "monster_slug": "fuzzina"
         }

--- a/mods/tuxemon/db/monster/gectile.json
+++ b/mods/tuxemon/db/monster/gectile.json
@@ -49,7 +49,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 36,
             "monster_slug": "velocitile"
         }

--- a/mods/tuxemon/db/monster/glombroc.json
+++ b/mods/tuxemon/db/monster/glombroc.json
@@ -57,7 +57,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 50,
             "monster_slug": "conglolem"
         }

--- a/mods/tuxemon/db/monster/grimachin.json
+++ b/mods/tuxemon/db/monster/grimachin.json
@@ -41,7 +41,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 32,
             "monster_slug": "tigrock"
         }

--- a/mods/tuxemon/db/monster/grintot.json
+++ b/mods/tuxemon/db/monster/grintot.json
@@ -25,25 +25,21 @@
     ],
     "evolutions": [
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "grinflare",
             "item": "earth_booster"
         },
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "grinflare",
             "item": "flintstone"
         },
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "grintrock",
             "item": "metal_booster"
         },
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "grintrock",
             "item": "thunderstone"

--- a/mods/tuxemon/db/monster/hatchling.json
+++ b/mods/tuxemon/db/monster/hatchling.json
@@ -37,7 +37,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "birdling"
         }

--- a/mods/tuxemon/db/monster/heronquak.json
+++ b/mods/tuxemon/db/monster/heronquak.json
@@ -49,7 +49,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 36,
             "monster_slug": "eaglace"
         }

--- a/mods/tuxemon/db/monster/ignibus.json
+++ b/mods/tuxemon/db/monster/ignibus.json
@@ -25,25 +25,21 @@
     ],
     "evolutions": [
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "eruptibus",
             "item": "earth_booster"
         },
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "eruptibus",
             "item": "tectonic_drill"
         },
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "embazook",
             "item": "metal_booster"
         },
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "embazook",
             "item": "stovepipe"

--- a/mods/tuxemon/db/monster/imbrickcile.json
+++ b/mods/tuxemon/db/monster/imbrickcile.json
@@ -49,7 +49,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "bricgard"
         }

--- a/mods/tuxemon/db/monster/incandesfin.json
+++ b/mods/tuxemon/db/monster/incandesfin.json
@@ -49,7 +49,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 36,
             "monster_slug": "lightmare"
         }

--- a/mods/tuxemon/db/monster/katacoon.json
+++ b/mods/tuxemon/db/monster/katacoon.json
@@ -29,13 +29,11 @@
     ],
     "evolutions": [
         {
-            "path": "stat",
             "at_level": 12,
             "monster_slug": "bugnin",
             "stats": "dodge:greater_than:speed"
         },
         {
-            "path": "stat",
             "at_level": 12,
             "monster_slug": "sumchon",
             "stats": "speed:greater_than:dodge"

--- a/mods/tuxemon/db/monster/katapill.json
+++ b/mods/tuxemon/db/monster/katapill.json
@@ -29,7 +29,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 9,
             "monster_slug": "katacoon"
         }

--- a/mods/tuxemon/db/monster/komodraw.json
+++ b/mods/tuxemon/db/monster/komodraw.json
@@ -53,7 +53,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 32,
             "monster_slug": "komoduel"
         }

--- a/mods/tuxemon/db/monster/lambert.json
+++ b/mods/tuxemon/db/monster/lambert.json
@@ -49,7 +49,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 24,
             "monster_slug": "legko"
         }

--- a/mods/tuxemon/db/monster/legko.json
+++ b/mods/tuxemon/db/monster/legko.json
@@ -49,7 +49,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 36,
             "monster_slug": "moloch"
         }

--- a/mods/tuxemon/db/monster/lesmagu.json
+++ b/mods/tuxemon/db/monster/lesmagu.json
@@ -53,7 +53,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "shelagu"
         }

--- a/mods/tuxemon/db/monster/memnomnom.json
+++ b/mods/tuxemon/db/monster/memnomnom.json
@@ -25,37 +25,31 @@
     ],
     "evolutions": [
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "miaownolith",
             "item": "earth_booster"
         },
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "miaownolith",
             "item": "miaow_milk"
         },
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "pyraminx",
             "item": "metal_booster"
         },
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "pyraminx",
             "item": "pyramidion"
         },
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "mauai",
             "item": "fire_booster"
         },
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "mauai",
             "item": "pyramidion"

--- a/mods/tuxemon/db/monster/merlicun.json
+++ b/mods/tuxemon/db/monster/merlicun.json
@@ -45,7 +45,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 20,
             "monster_slug": "firomenis"
         }

--- a/mods/tuxemon/db/monster/metesaur.json
+++ b/mods/tuxemon/db/monster/metesaur.json
@@ -45,7 +45,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 40,
             "monster_slug": "qetzlrokilus"
         }

--- a/mods/tuxemon/db/monster/mk01_alpha.json
+++ b/mods/tuxemon/db/monster/mk01_alpha.json
@@ -41,12 +41,10 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 32,
             "monster_slug": "mk01_delta"
         },
         {
-            "path": "standard",
             "at_level": 32,
             "monster_slug": "mk01_gamma"
         }

--- a/mods/tuxemon/db/monster/mk01_beta.json
+++ b/mods/tuxemon/db/monster/mk01_beta.json
@@ -41,12 +41,10 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 32,
             "monster_slug": "mk01_delta"
         },
         {
-            "path": "standard",
             "at_level": 32,
             "monster_slug": "mk01_omega"
         }

--- a/mods/tuxemon/db/monster/mk01_proto.json
+++ b/mods/tuxemon/db/monster/mk01_proto.json
@@ -21,12 +21,10 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 10,
             "monster_slug": "mk01_alpha"
         },
         {
-            "path": "standard",
             "at_level": 10,
             "monster_slug": "mk01_beta"
         }

--- a/mods/tuxemon/db/monster/noctula.json
+++ b/mods/tuxemon/db/monster/noctula.json
@@ -37,7 +37,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "noctalo"
         }

--- a/mods/tuxemon/db/monster/nostray.json
+++ b/mods/tuxemon/db/monster/nostray.json
@@ -37,7 +37,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "shnark"
         }

--- a/mods/tuxemon/db/monster/nudiflot_female.json
+++ b/mods/tuxemon/db/monster/nudiflot_female.json
@@ -37,7 +37,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "nudimind"
         }

--- a/mods/tuxemon/db/monster/nudiflot_male.json
+++ b/mods/tuxemon/db/monster/nudiflot_male.json
@@ -37,7 +37,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "nudikill"
         }

--- a/mods/tuxemon/db/monster/nut.json
+++ b/mods/tuxemon/db/monster/nut.json
@@ -41,7 +41,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 9,
             "monster_slug": "bolt"
         }

--- a/mods/tuxemon/db/monster/pairagrin.json
+++ b/mods/tuxemon/db/monster/pairagrin.json
@@ -41,7 +41,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 26,
             "monster_slug": "pairagrim"
         }

--- a/mods/tuxemon/db/monster/pantherafira.json
+++ b/mods/tuxemon/db/monster/pantherafira.json
@@ -37,7 +37,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "criniotherme"
         }

--- a/mods/tuxemon/db/monster/pipis.json
+++ b/mods/tuxemon/db/monster/pipis.json
@@ -37,7 +37,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "strella"
         }

--- a/mods/tuxemon/db/monster/poinchin.json
+++ b/mods/tuxemon/db/monster/poinchin.json
@@ -25,7 +25,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "saurchin"
         }

--- a/mods/tuxemon/db/monster/potturmeist.json
+++ b/mods/tuxemon/db/monster/potturmeist.json
@@ -45,7 +45,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "potturney"
         }

--- a/mods/tuxemon/db/monster/puparmor.json
+++ b/mods/tuxemon/db/monster/puparmor.json
@@ -49,7 +49,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 12,
             "monster_slug": "weavifly"
         }

--- a/mods/tuxemon/db/monster/pythwire.json
+++ b/mods/tuxemon/db/monster/pythwire.json
@@ -25,13 +25,11 @@
     ],
     "evolutions": [
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "ouroboutlet",
             "item": "fire_booster"
         },
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "sockeserp",
             "item": "metal_booster"

--- a/mods/tuxemon/db/monster/rockat.json
+++ b/mods/tuxemon/db/monster/rockat.json
@@ -49,7 +49,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 36,
             "monster_slug": "jemuar"
         }

--- a/mods/tuxemon/db/monster/rockitten.json
+++ b/mods/tuxemon/db/monster/rockitten.json
@@ -49,7 +49,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 24,
             "monster_slug": "rockat"
         }

--- a/mods/tuxemon/db/monster/sapragon.json
+++ b/mods/tuxemon/db/monster/sapragon.json
@@ -53,7 +53,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 54,
             "monster_slug": "dragarbor"
         }

--- a/mods/tuxemon/db/monster/seirein.json
+++ b/mods/tuxemon/db/monster/seirein.json
@@ -37,7 +37,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "loliferno"
         }

--- a/mods/tuxemon/db/monster/selket.json
+++ b/mods/tuxemon/db/monster/selket.json
@@ -37,7 +37,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "selmatek"
         }

--- a/mods/tuxemon/db/monster/shybulb.json
+++ b/mods/tuxemon/db/monster/shybulb.json
@@ -37,7 +37,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "narcileaf"
         }

--- a/mods/tuxemon/db/monster/skwib.json
+++ b/mods/tuxemon/db/monster/skwib.json
@@ -41,7 +41,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "octabode"
         }

--- a/mods/tuxemon/db/monster/slichen.json
+++ b/mods/tuxemon/db/monster/slichen.json
@@ -57,7 +57,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 26,
             "monster_slug": "glombroc"
         }

--- a/mods/tuxemon/db/monster/snaki.json
+++ b/mods/tuxemon/db/monster/snaki.json
@@ -37,7 +37,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "snokari"
         }

--- a/mods/tuxemon/db/monster/snock.json
+++ b/mods/tuxemon/db/monster/snock.json
@@ -41,7 +41,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 24,
             "monster_slug": "pythock"
         }

--- a/mods/tuxemon/db/monster/squabbit.json
+++ b/mods/tuxemon/db/monster/squabbit.json
@@ -37,7 +37,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "rabbitosaur"
         }

--- a/mods/tuxemon/db/monster/squink.json
+++ b/mods/tuxemon/db/monster/squink.json
@@ -41,7 +41,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 20,
             "monster_slug": "hectapod"
         }

--- a/mods/tuxemon/db/monster/tadcool.json
+++ b/mods/tuxemon/db/monster/tadcool.json
@@ -45,7 +45,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 32,
             "monster_slug": "fribbit"
         }

--- a/mods/tuxemon/db/monster/tarpeur.json
+++ b/mods/tuxemon/db/monster/tarpeur.json
@@ -37,7 +37,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "vigueur"
         }

--- a/mods/tuxemon/db/monster/tetrchimp.json
+++ b/mods/tuxemon/db/monster/tetrchimp.json
@@ -37,7 +37,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "apeoro"
         }

--- a/mods/tuxemon/db/monster/tikoal.json
+++ b/mods/tuxemon/db/monster/tikoal.json
@@ -37,7 +37,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 32,
             "monster_slug": "tikorch"
         }

--- a/mods/tuxemon/db/monster/trapsnap.json
+++ b/mods/tuxemon/db/monster/trapsnap.json
@@ -37,7 +37,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 32,
             "monster_slug": "sapsnap"
         }

--- a/mods/tuxemon/db/monster/tsushimi.json
+++ b/mods/tuxemon/db/monster/tsushimi.json
@@ -49,7 +49,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 36,
             "monster_slug": "tobishimi"
         }

--- a/mods/tuxemon/db/monster/tumblequill.json
+++ b/mods/tuxemon/db/monster/tumblequill.json
@@ -53,7 +53,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 32,
             "monster_slug": "tumbledillo"
         }

--- a/mods/tuxemon/db/monster/tumbleworm.json
+++ b/mods/tuxemon/db/monster/tumbleworm.json
@@ -37,7 +37,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "tumblebee"
         }

--- a/mods/tuxemon/db/monster/turnipper.json
+++ b/mods/tuxemon/db/monster/turnipper.json
@@ -25,7 +25,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 18,
             "monster_slug": "beenstalker"
         }

--- a/mods/tuxemon/db/monster/tweesher.json
+++ b/mods/tuxemon/db/monster/tweesher.json
@@ -49,7 +49,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 24,
             "monster_slug": "heronquak"
         }

--- a/mods/tuxemon/db/monster/uneye.json
+++ b/mods/tuxemon/db/monster/uneye.json
@@ -53,7 +53,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 40,
             "monster_slug": "lendos"
         }

--- a/mods/tuxemon/db/monster/vamporm.json
+++ b/mods/tuxemon/db/monster/vamporm.json
@@ -45,7 +45,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 9,
             "monster_slug": "dracune"
         }

--- a/mods/tuxemon/db/monster/vivipere.json
+++ b/mods/tuxemon/db/monster/vivipere.json
@@ -25,54 +25,45 @@
     ],
     "evolutions": [
         {
-            "path": "tech",
             "at_level": 0,
             "monster_slug": "vivicinder",
             "tech": "flamethrower"
         },
         {
-            "path": "element",
             "at_level": 0,
             "monster_slug": "viviphyta",
             "element": "wood"
         },
         {
-            "path": "gender",
             "at_level": 24,
             "monster_slug": "viviteel",
             "gender": "female"
         },
         {
-            "path": "location",
             "at_level": 0,
             "monster_slug": "vivitrans",
             "inside": true
         },
         {
-            "path": "standard",
             "at_level": 26,
             "monster_slug": "vivitron"
         },
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "vividactil",
             "item": "petrified_dung"
         },
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "vividactil",
             "item": "shammer_fossil"
         },
         {
-            "path": "item",
             "at_level": 0,
             "monster_slug": "vividactil",
             "item": "rhincus_fossil"
         },
         {
-            "path": "gender",
             "at_level": 24,
             "monster_slug": "vivisource",
             "gender": "male"

--- a/mods/tuxemon/db/monster/waysprite.json
+++ b/mods/tuxemon/db/monster/waysprite.json
@@ -25,13 +25,11 @@
     ],
     "evolutions": [
         {
-            "path": "variable",
             "at_level": 14,
             "monster_slug": "angesnow",
             "variable": "daytime:true"
         },
         {
-            "path": "variable",
             "at_level": 14,
             "monster_slug": "demosnow",
             "variable": "daytime:false"

--- a/mods/tuxemon/db/monster/woodoor.json
+++ b/mods/tuxemon/db/monster/woodoor.json
@@ -45,7 +45,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 26,
             "monster_slug": "blasdoor"
         }

--- a/mods/tuxemon/db/monster/wrougon.json
+++ b/mods/tuxemon/db/monster/wrougon.json
@@ -53,7 +53,6 @@
     ],
     "evolutions": [
         {
-            "path": "standard",
             "at_level": 32,
             "monster_slug": "allagon"
         }

--- a/mods/tuxemon/maps/spyder.yaml
+++ b/mods/tuxemon/maps/spyder.yaml
@@ -55,9 +55,9 @@ events:
     type: "event"
   Evolution all:
     actions:
-    - evolution
+    - evolution player
     conditions:
-    - is check_evolution all
+    - is check_evolution player
     - is current_state WorldState
     type: "event"
   Choice Surf:

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -156,18 +156,6 @@ class MapType(str, Enum):
     dungeon = "dungeon"
 
 
-class EvolutionType(str, Enum):
-    element = "element"
-    gender = "gender"
-    item = "item"
-    location = "location"
-    variable = "variable"
-    standard = "standard"
-    stat = "stat"
-    tech = "tech"
-    traded = "traded"
-
-
 class StatType(str, Enum):
     armour = "armour"
     dodge = "dodge"
@@ -354,15 +342,14 @@ class MonsterHistoryItemModel(BaseModel):
 
 
 class MonsterEvolutionItemModel(BaseModel):
-    path: EvolutionType = Field(..., description="Paths to evolution")
-    at_level: int = Field(
-        ...,
-        description="The level at which this item can be used for evolution",
-    )
     monster_slug: str = Field(
         ..., description="The monster slug that this evolution item applies to"
     )
     # optional fields
+    at_level: int = Field(
+        ...,
+        description="The level at which this monster evolves",
+    )
     element: Optional[ElementType] = Field(
         None, description="Element parameter"
     )
@@ -382,6 +369,7 @@ class MonsterEvolutionItemModel(BaseModel):
     stats: Optional[str] = Field(
         None, description="Stat parameter stat1:more_than:stat2."
     )
+    steps: Optional[int] = Field(None, description="Steps parameter 50 steps.")
     tech: Optional[str] = Field(None, description="Technique parameter.")
 
     @field_validator("tech")

--- a/tuxemon/event/actions/evolution.py
+++ b/tuxemon/event/actions/evolution.py
@@ -2,14 +2,18 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from functools import partial
 from typing import final
 
+from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.locale import T
 from tuxemon.monster import Monster
 from tuxemon.tools import open_choice_dialog, open_dialog
+
+logger = logging.getLogger(__name__)
 
 
 @final
@@ -21,15 +25,22 @@ class EvolutionAction(EventAction):
     Script usage:
         .. code-block::
 
-            evolution
+            evolution <character>
+
+    Script parameters:
+        character: Either "player" or npc slug name (e.g. "npc_maple").
 
     """
 
     name = "evolution"
+    npc_slug: str
 
     def start(self) -> None:
-        player = self.session.player
         client = self.session.client
+        character = get_npc(self.session, self.npc_slug)
+        if character is None:
+            logger.error(f"{self.npc_slug} not found")
+            return
         # this function cleans up the previous state without crashing
         if len(client.state_manager.active_states) > 2:
             return
@@ -37,11 +48,13 @@ class EvolutionAction(EventAction):
         def positive_answer(monster: Monster, evolved: Monster) -> None:
             client.pop_state()
             client.pop_state()
-            player.evolve_monster(monster, evolved.slug)
+            logger.info(f"{monster.name} evolves into {evolved.name}!")
+            character.evolve_monster(monster, evolved.slug)
 
         def negative_answer() -> None:
             monster.got_experience = False
             monster.levelling_up = False
+            logger.info(f"{monster.name}'s evolution refused!")
             client.pop_state()
             client.pop_state()
 
@@ -72,9 +85,9 @@ class EvolutionAction(EventAction):
                 ),
             )
 
-        if player.pending_evolutions:
-            evolutions = set(player.pending_evolutions)
-            player.pending_evolutions.clear()
+        if character.pending_evolutions:
+            evolutions = set(character.pending_evolutions)
+            character.pending_evolutions.clear()
             for _monster in evolutions:
                 monster = _monster[0]
                 evolved = _monster[1]

--- a/tuxemon/event/conditions/check_evolution.py
+++ b/tuxemon/event/conditions/check_evolution.py
@@ -2,12 +2,16 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-from tuxemon.db import EvolutionType, StatType
-from tuxemon.event import MapCondition
+import logging
+
+from tuxemon.db import StatType
+from tuxemon.event import MapCondition, get_npc
 from tuxemon.event.eventcondition import EventCondition
 from tuxemon.monster import Monster
 from tuxemon.session import Session
 from tuxemon.tools import compare
+
+logger = logging.getLogger(__name__)
 
 
 class CheckEvolutionCondition(EventCondition):
@@ -19,118 +23,74 @@ class CheckEvolutionCondition(EventCondition):
     Script usage:
         .. code-block::
 
-            is check_evolution <method>
+            is check_evolution <character>
 
     Script parameters:
-        method: Method or methods of evolution.
-        "all" means all the existing methods.
+        character: Either "player" or npc slug name (e.g. "npc_maple").
 
-    eg. "is check_evolution standard"
-    eg. "is check_evolution standard"
-    ef. "is check_evolution standard:tech:stat"
-    ef. "is check_evolution all"
-
-    Note: methods of evolution are element, gender, location,
-        variable, standard, stat, traded and tech.
+    eg. "is check_evolution player"
 
     """
 
     name = "check_evolution"
 
     def test(self, session: Session, condition: MapCondition) -> bool:
-        player = session.player
+        _character = condition.parameters[0]
+        character = get_npc(session, _character)
+        if character is None:
+            logger.error(f"{_character} not found")
+            return False
+
         client = session.client
         _evolution: bool = False
 
-        self.method = condition.parameters[0]
-
-        methods: list[str] = []
-        evolution_type: list[EvolutionType] = []
-        # recognize if single or multiple
-        if self.method == "all":
-            evolution_type = list(EvolutionType)
-        else:
-            methods = self.method.split(":")
-
-        # keep evolution type and remove not valid (+ debug)
-        if methods:
-            for method in methods:
-                if method in list(EvolutionType):
-                    method = EvolutionType(method)
-                    evolution_type.append(method)
-                else:
-                    raise ValueError(
-                        f"{method} isn't among {list(EvolutionType)}"
-                    )
-
         evolving: list[tuple[Monster, Monster]] = []
-        for monster in player.monsters:
+        for monster in character.monsters:
             if monster.evolutions:
                 evolved = Monster()
                 for evolution in monster.evolutions:
                     evolved.load_from_db(evolution.monster_slug)
-                    if evolution.at_level <= monster.level:
-                        for _method in evolution_type:
-                            if _method == EvolutionType.standard:
-                                evolving.append((monster, evolved))
-                                _evolution = True
-                            elif (
-                                _method == EvolutionType.gender
-                                and evolution.gender == monster.gender
-                            ):
-                                evolving.append((monster, evolved))
-                                _evolution = True
-                            elif (
-                                _method == EvolutionType.element
-                                and player.has_type(evolution.element)
-                            ):
-                                evolving.append((monster, evolved))
-                                _evolution = True
-                            elif (
-                                _method == EvolutionType.tech
-                                and player.has_tech(evolution.tech)
-                            ):
-                                evolving.append((monster, evolved))
-                                _evolution = True
-                            elif (
-                                _method == EvolutionType.location
-                                and evolution.inside == client.map_inside
-                            ):
-                                evolving.append((monster, evolved))
-                                _evolution = True
-                            elif (
-                                _method == EvolutionType.traded
-                                and evolution.traded == monster.traded
-                            ):
-                                evolving.append((monster, evolved))
-                                _evolution = True
-                            elif (
-                                _method == EvolutionType.stat
-                                and evolution.stats
-                            ):
-                                params = evolution.stats.split(":")
-                                operator = params[1]
-                                stat1 = monster.return_stat(
-                                    StatType(params[0])
-                                )
-                                stat2 = monster.return_stat(
-                                    StatType(params[2])
-                                )
-                                evolving.append((monster, evolved))
-                                _evolution = compare(operator, stat1, stat2)
-                            elif (
-                                _method == EvolutionType.variable
-                                and evolution.variable
-                            ):
-                                parts = evolution.variable.split(":")
-                                key = parts[0]
-                                value = parts[1]
-                                if (
-                                    key in player.game_variables
-                                    and player.game_variables[key] == value
-                                ):
-                                    evolving.append((monster, evolved))
-                                    _evolution = True
+                    op = "greater_or_equal"
+                    if compare(op, monster.level, evolution.at_level):
+                        _evolution = True
+                    if evolution.gender == monster.gender:
+                        _evolution = True
+                    if character.has_type(evolution.element):
+                        _evolution = True
+                    if character.has_tech(evolution.tech):
+                        _evolution = True
+                    if evolution.inside == client.map_inside:
+                        _evolution = True
+                    if evolution.traded == monster.traded:
+                        _evolution = True
+                    if evolution.stats:
+                        params = evolution.stats.split(":")
+                        operator = params[1]
+                        stat1 = monster.return_stat(StatType(params[0]))
+                        stat2 = monster.return_stat(StatType(params[2]))
+                        _evolution = compare(operator, stat1, stat2)
+                    if evolution.variable:
+                        parts = evolution.variable.split(":")
+                        key = parts[0]
+                        value = parts[1]
+                        if (
+                            key in character.game_variables
+                            and character.game_variables[key] == value
+                        ):
+                            _evolution = True
+                    if evolution.steps:
+                        result = evolution.steps - int(monster.steps)
+                        if result == 0:
+                            _evolution = True
+                            monster.steps += 1
+                        monster.levelling_up = True
+                        monster.got_experience = True
+                    # use the item on the monster
+                    if evolution.item:
+                        _evolution = False
+                    if _evolution:
+                        evolving.append((monster, evolved))
+
         if evolving:
-            player.pending_evolutions = evolving
-        return _evolution
+            character.pending_evolutions = evolving
+        return len(evolving) > 0


### PR DESCRIPTION
PR:
- removes **path**;
- adds **steps** (trigger evolution if the monster has walked a certain amount of steps);

when working on monster I noticed a bottleneck with evolution, we can set:

```
            "path": "standard",
            "at_level": 36,
            "monster_slug": "agnigon"
```
but it doesn't allow to add multiple parameters, like
```
            "path": "standard",
            "at_level": 36,
            "monster_slug": "agnigon"
            "variable": "season:winter"
```
for doing this above, I would be obliged to set path "variable", so I decided to remove the path and doing a multiple check on booleans
```
            "at_level": 36, >true?
            "monster_slug": "agnigon" required parameter
            "variable": "season:winter" > true?
```
in this way we can simplify the code too in **check_evolution**