### PR TITLE
fix 2188

### DIFF
--- a/mods/tuxemon/maps/spyder_bedroom.yaml
+++ b/mods/tuxemon/maps/spyder_bedroom.yaml
@@ -103,3 +103,12 @@ events:
     conditions:
     - not music_playing music_home
     type: "event"
+  Auto healing teleported:
+    actions:
+    - set_monster_health
+    - set_monster_status
+    - set_variable teleport_clinic:none
+    conditions:
+    - is variable_set teleport_clinic:lost
+    - is current_state WorldState
+    type: "event"


### PR DESCRIPTION
PR fixes #2188 the player was unable to move after getting teleported in the bedroom (losing in route1 against a wild monster). The reason: it was missing an auto healing event inside the bedroom, this is why the player was completely stuck (I was able to reproduce it). 