### PR TITLE
pathfind check for npc

### DIFF
--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -563,9 +563,22 @@ class NPC(Entity[NPCState]):
             self.stop_moving()
 
             if self.pathfinding:
-                # since we are pathfinding, just try a new path
-                logger.error(f"{self.slug} finding new path!")
-                self.pathfind(self.pathfinding)
+                # check tile for npc
+                npc = self.world.get_entity_pos(self.pathfinding)
+                if npc:
+                    # since we are pathfinding, just try a new path
+                    logger.error(
+                        f"{npc.slug} on your way, {self.slug} finding new path!"
+                    )
+                    self.pathfind(self.pathfinding)
+                else:
+                    logger.warning(
+                        f"Possible issue of {self.slug} in {self.tile_pos}"
+                        f" in its way to {self.pathfinding}!"
+                        " Consider to postpone it (eg. 'wait 1') or to split"
+                        f" it (eg. 'pathfind {self.tile_pos}, stop then"
+                        f" pathfind {self.pathfinding})"
+                    )
 
             else:
                 # give up and wait until the target is clear again


### PR DESCRIPTION
PR proposes to add the following check before starting to look for a new path.

In this way we can know if the pathfind tile is blocked by a NPC or not. If not it simply  passes without starting with a new pathfind check and if there is one, then it precises which one (clarity).

If we got an issue with pathfind (related to NPCs), we need to understand which other NPC is causing the issue, otherwise we can make wait whoever is going to pathfind until the tile is free after adding a simple warning, because it can be solved by postponing it ( eg "wait 1" event action) or splitting it into two phases (from 1,1 to (coordinates_issue) and then from (coordinate_issue) to 3,3).