### PR TITLE
random encounter (replace daytime with variable)

### DIFF
--- a/mods/tuxemon/db/encounter/37707_town.json
+++ b/mods/tuxemon/db/encounter/37707_town.json
@@ -3,7 +3,7 @@
     "monsters": [
       {
         "encounter_rate": 0.5,
-        "daytime": true,
+        "variable": "daytime:true",
         "exp_req_mod": 1,
         "level_range": [
           1,
@@ -13,7 +13,7 @@
       },
       {
         "encounter_rate": 0.5,
-        "daytime": true,
+        "variable": "daytime:true",
         "exp_req_mod": 1,
         "level_range": [
           1,
@@ -23,7 +23,7 @@
       },
       {
         "encounter_rate": 0.5,
-        "daytime": false,
+        "variable": "daytime:false",
         "exp_req_mod": 1,
         "level_range": [
           1,
@@ -33,7 +33,7 @@
       },
       {
         "encounter_rate": 0.5,
-        "daytime": false,
+        "variable": "daytime:false",
         "exp_req_mod": 1,
         "level_range": [
           1,

--- a/mods/tuxemon/db/encounter/37707_town_missing.json
+++ b/mods/tuxemon/db/encounter/37707_town_missing.json
@@ -3,7 +3,7 @@
     "monsters": [
       {
         "encounter_rate": 0.5,
-        "daytime": false,
+        "variable": "daytime:false",
         "exp_req_mod": 1,
         "level_range": [
           1,
@@ -13,7 +13,7 @@
       },
       {
         "encounter_rate": 0.5,
-        "daytime": true,
+        "variable": "daytime:true",
         "exp_req_mod": 1,
         "level_range": [
           1
@@ -22,7 +22,7 @@
       },
       {
         "encounter_rate": 0.5,
-        "daytime": false,
+        "variable": "daytime:false",
         "exp_req_mod": 1,
         "level_range": [
           666
@@ -31,7 +31,7 @@
       },
       {
         "encounter_rate": 0.5,
-        "daytime": true,
+        "variable": "daytime:true",
         "exp_req_mod": 1,
         "level_range": [
           13,

--- a/mods/tuxemon/db/encounter/citypark.json
+++ b/mods/tuxemon/db/encounter/citypark.json
@@ -4,7 +4,7 @@
     {
       "monster": "cardiling",
       "encounter_rate": 3,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         5,
@@ -14,7 +14,7 @@
     {
       "monster": "cardiwing",
       "encounter_rate": 1,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         8,
@@ -24,7 +24,7 @@
     {
       "monster": "cataspike",
       "encounter_rate": 3,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         6,
@@ -34,7 +34,7 @@
     {
       "monster": "eyenemy",
       "encounter_rate": 3,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         5,
@@ -44,7 +44,7 @@
     {
       "monster": "axylightl",
       "encounter_rate": 3,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         8,
@@ -54,7 +54,7 @@
     {
       "monster": "tourbidi",
       "encounter_rate": 1,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         8,
@@ -64,7 +64,7 @@
     {
       "monster": "squabbit",
       "encounter_rate": 3,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         8,
@@ -74,7 +74,7 @@
     {
       "monster": "puparmor",
       "encounter_rate": 1,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         9,

--- a/mods/tuxemon/db/encounter/cotton_tunnel.json
+++ b/mods/tuxemon/db/encounter/cotton_tunnel.json
@@ -4,7 +4,7 @@
     {
       "monster": "dinoflop",
       "encounter_rate": 3.5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         35,
@@ -14,7 +14,7 @@
     {
       "monster": "furnursus",
       "encounter_rate": 3.5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         30,
@@ -24,7 +24,7 @@
     {
       "monster": "boltnu",
       "encounter_rate": 3.5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         25,
@@ -34,7 +34,7 @@
     {
       "monster": "metesaur",
       "encounter_rate": 3.5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         30,

--- a/mods/tuxemon/db/encounter/datacenter.json
+++ b/mods/tuxemon/db/encounter/datacenter.json
@@ -4,7 +4,7 @@
     {
       "monster": "pythwire",
       "encounter_rate": 0.5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         45,
@@ -14,7 +14,7 @@
     {
       "monster": "ouroboutlet",
       "encounter_rate": 0.5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         45,
@@ -24,7 +24,7 @@
     {
       "monster": "sockeserp",
       "encounter_rate": 0.5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         40,

--- a/mods/tuxemon/db/encounter/default_encounter.json
+++ b/mods/tuxemon/db/encounter/default_encounter.json
@@ -3,7 +3,7 @@
    "monsters": [
      {
        "encounter_rate": 0.5,
-       "daytime": true,
+       "variable": "daytime:true",
        "exp_req_mod": 1,
        "level_range": [
          2,
@@ -13,7 +13,7 @@
      },
      {
        "encounter_rate": 0.5,
-       "daytime": true,
+       "variable": "daytime:true",
        "exp_req_mod": 1,
        "level_range": [
          2,
@@ -23,7 +23,7 @@
      },
      {
        "encounter_rate": 0.5,
-       "daytime": true,
+       "variable": "daytime:true",
        "exp_req_mod": 1,
        "level_range": [
          2,
@@ -33,7 +33,7 @@
      },
      {
        "encounter_rate": 0.5,
-       "daytime": true,
+       "variable": "daytime:true",
        "exp_req_mod": 1,
        "level_range": [
          2,
@@ -43,7 +43,7 @@
      },
      {
        "encounter_rate": 0.5,
-       "daytime": true,
+       "variable": "daytime:true",
        "exp_req_mod": 1,
        "level_range": [
          2,
@@ -53,7 +53,7 @@
      },
      {
        "encounter_rate": 0.5,
-       "daytime": false,
+       "variable": "daytime:false",
        "exp_req_mod": 1,
        "level_range": [
          3,
@@ -63,7 +63,7 @@
      },
      {
        "encounter_rate": 0.5,
-       "daytime": false,
+       "variable": "daytime:false",
        "exp_req_mod": 1,
        "level_range": [
          3,
@@ -73,7 +73,7 @@
      },
      {
        "encounter_rate": 0.5,
-       "daytime": false,
+       "variable": "daytime:false",
        "exp_req_mod": 1,
        "level_range": [
          3,
@@ -83,7 +83,7 @@
      },
      {
        "encounter_rate": 0.5,
-       "daytime": false,
+       "variable": "daytime:false",
        "exp_req_mod": 1,
        "level_range": [
          3,
@@ -93,7 +93,7 @@
      },
      {
        "encounter_rate": 0.5,
-       "daytime": false,
+       "variable": "daytime:false",
        "exp_req_mod": 1,
        "level_range": [
          3,

--- a/mods/tuxemon/db/encounter/dragonscave.json
+++ b/mods/tuxemon/db/encounter/dragonscave.json
@@ -4,7 +4,7 @@
     {
       "monster": "agnite",
       "encounter_rate": 3,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         25,
@@ -14,7 +14,7 @@
     {
       "monster": "agnidon",
       "encounter_rate": 1,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         20,
@@ -24,7 +24,7 @@
     {
       "monster": "embra",
       "encounter_rate": 3,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         25,
@@ -34,7 +34,7 @@
     {
       "monster": "ruption",
       "encounter_rate": 1,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         20,
@@ -44,7 +44,7 @@
     {
       "monster": "agnite",
       "encounter_rate": 3,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         28,
@@ -54,7 +54,7 @@
     {
       "monster": "agnidon",
       "encounter_rate": 1,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         25,
@@ -64,7 +64,7 @@
     {
       "monster": "embra",
       "encounter_rate": 3,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         28,
@@ -74,7 +74,7 @@
     {
       "monster": "ruption",
       "encounter_rate": 1,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         25,

--- a/mods/tuxemon/db/encounter/dryadsgrove.json
+++ b/mods/tuxemon/db/encounter/dryadsgrove.json
@@ -4,7 +4,7 @@
     {
       "monster": "coleorus",
       "encounter_rate": 1,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         25,
@@ -14,7 +14,7 @@
     {
       "monster": "tourbidi",
       "encounter_rate": 1,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         20,
@@ -24,7 +24,7 @@
     {
       "monster": "shybulb",
       "encounter_rate": 3,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         25,
@@ -34,7 +34,7 @@
     {
       "monster": "narcileaf",
       "encounter_rate": 3,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         25,
@@ -44,7 +44,7 @@
     {
       "monster": "sapsnap",
       "encounter_rate": 3,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         28,
@@ -54,7 +54,7 @@
     {
       "monster": "lambert",
       "encounter_rate": 1,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         25,

--- a/mods/tuxemon/db/encounter/greenwash.json
+++ b/mods/tuxemon/db/encounter/greenwash.json
@@ -4,7 +4,7 @@
     {
       "monster": "cochini",
       "encounter_rate": 5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         15,
@@ -14,7 +14,7 @@
     {
       "monster": "cateye",
       "encounter_rate": 5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         15,
@@ -24,7 +24,7 @@
     {
       "monster": "sclairus",
       "encounter_rate": 5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         15,
@@ -34,7 +34,7 @@
     {
       "monster": "bursa",
       "encounter_rate": 5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         20,
@@ -44,7 +44,7 @@
     {
       "monster": "nut",
       "encounter_rate": 5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         20,

--- a/mods/tuxemon/db/encounter/lion_mountain.json
+++ b/mods/tuxemon/db/encounter/lion_mountain.json
@@ -4,7 +4,7 @@
     {
       "monster": "snowrilla",
       "encounter_rate": 3.5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         55,
@@ -14,7 +14,7 @@
     {
       "monster": "snowrilla",
       "encounter_rate": 3.5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         65,
@@ -24,7 +24,7 @@
     {
       "monster": "tadcool",
       "encounter_rate": 3.5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         55,
@@ -34,7 +34,7 @@
     {
       "monster": "bumbulus",
       "encounter_rate": 3.5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         65,
@@ -44,7 +44,7 @@
     {
       "monster": "chillimp",
       "encounter_rate": 3.5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         55,
@@ -54,7 +54,7 @@
     {
       "monster": "bumbulus",
       "encounter_rate": 3.5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         65,
@@ -64,7 +64,7 @@
     {
       "monster": "tux",
       "encounter_rate": 3.5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         55,
@@ -74,7 +74,7 @@
     {
       "monster": "tux",
       "encounter_rate": 3.5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         65,

--- a/mods/tuxemon/db/encounter/mansion.json
+++ b/mods/tuxemon/db/encounter/mansion.json
@@ -4,7 +4,7 @@
     {
       "monster": "cairfrey",
       "encounter_rate": 3,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         13,
@@ -14,7 +14,7 @@
     {
       "monster": "polyrock",
       "encounter_rate": 3,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         13,
@@ -24,7 +24,7 @@
     {
       "monster": "djinnbo",
       "encounter_rate": 1,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         14,
@@ -34,7 +34,7 @@
     {
       "monster": "pigabyte",
       "encounter_rate": 3,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         13,
@@ -44,7 +44,7 @@
     {
       "monster": "cairfrey",
       "encounter_rate": 3,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         14,
@@ -54,7 +54,7 @@
     {
       "monster": "polyrock",
       "encounter_rate": 3,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         14,
@@ -64,7 +64,7 @@
     {
       "monster": "djinnbo",
       "encounter_rate": 1,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         14,
@@ -74,7 +74,7 @@
     {
       "monster": "pigabyte",
       "encounter_rate": 3,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         14,

--- a/mods/tuxemon/db/encounter/new_txmn.json
+++ b/mods/tuxemon/db/encounter/new_txmn.json
@@ -3,7 +3,7 @@
     "monsters": [
       {
         "encounter_rate": 0.5,
-        "daytime": true,
+        "variable": "daytime:true",
         "exp_req_mod": 1,
         "level_range": [
           2,
@@ -13,7 +13,7 @@
       },
       {
         "encounter_rate": 0.5,
-        "daytime": true,
+        "variable": "daytime:true",
         "exp_req_mod": 1,
         "level_range": [
           2,
@@ -23,7 +23,7 @@
       },
       {
         "encounter_rate": 0.5,
-        "daytime": false,
+        "variable": "daytime:false",
         "exp_req_mod": 1,
         "level_range": [
           3,
@@ -33,7 +33,7 @@
       },
       {
         "encounter_rate": 0.5,
-        "daytime": false,
+        "variable": "daytime:false",
         "exp_req_mod": 1,
         "level_range": [
           3,
@@ -43,7 +43,7 @@
       },
       {
         "encounter_rate": 0.5,
-        "daytime": false,
+        "variable": "daytime:false",
         "exp_req_mod": 1,
         "level_range": [
           3,

--- a/mods/tuxemon/db/encounter/omnichannel.json
+++ b/mods/tuxemon/db/encounter/omnichannel.json
@@ -4,7 +4,7 @@
     {
       "monster": "dark_robo",
       "encounter_rate": 0.5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         30,
@@ -14,7 +14,7 @@
     {
       "monster": "dark_robo",
       "encounter_rate": 0.5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         30,
@@ -24,7 +24,7 @@
     {
       "monster": "xeon_2",
       "encounter_rate": 0.5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         30,
@@ -34,7 +34,7 @@
     {
       "monster": "xeon_2",
       "encounter_rate": 0.5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         30,

--- a/mods/tuxemon/db/encounter/propellercat.json
+++ b/mods/tuxemon/db/encounter/propellercat.json
@@ -4,7 +4,7 @@
      {
        "monster": "propellercat",
        "encounter_rate": 1,
-       "daytime": true,
+       "variable": "daytime:true",
        "exp_req_mod": 1,
        "level_range": [
          2,
@@ -14,7 +14,7 @@
      {
        "monster": "propellercat",
        "encounter_rate": 1,
-       "daytime": false,
+       "variable": "daytime:false",
        "exp_req_mod": 1,
        "level_range": [
          2,

--- a/mods/tuxemon/db/encounter/rare_txmn.json
+++ b/mods/tuxemon/db/encounter/rare_txmn.json
@@ -3,7 +3,7 @@
     "monsters": [
       {
         "encounter_rate": 0.5,
-        "daytime": true,
+        "variable": "daytime:true",
         "exp_req_mod": 1,
         "level_range": [
           18,
@@ -13,7 +13,7 @@
       },
       {
         "encounter_rate": 0.5,
-        "daytime": true,
+        "variable": "daytime:true",
         "exp_req_mod": 1,
         "level_range": [
           36,
@@ -23,7 +23,7 @@
       },
       {
         "encounter_rate": 0.5,
-        "daytime": true,
+        "variable": "daytime:true",
         "exp_req_mod": 1,
         "level_range": [
           18,
@@ -33,7 +33,7 @@
       },
       {
         "encounter_rate": 0.5,
-        "daytime": true,
+        "variable": "daytime:true",
         "exp_req_mod": 1,
         "level_range": [
           36,
@@ -43,7 +43,7 @@
       },
       {
         "encounter_rate": 0.5,
-        "daytime": true,
+        "variable": "daytime:true",
         "exp_req_mod": 1,
         "level_range": [
           18,
@@ -53,7 +53,7 @@
       },
       {
         "encounter_rate": 0.5,
-        "daytime": true,
+        "variable": "daytime:true",
         "exp_req_mod": 1,
         "level_range": [
           36,
@@ -63,7 +63,7 @@
       },
       {
         "encounter_rate": 0.5,
-        "daytime": true,
+        "variable": "daytime:true",
         "exp_req_mod": 1,
         "level_range": [
           18,
@@ -73,7 +73,7 @@
       },
       {
         "encounter_rate": 0.5,
-        "daytime": true,
+        "variable": "daytime:true",
         "exp_req_mod": 1,
         "level_range": [
           36,
@@ -83,7 +83,7 @@
       },
       {
         "encounter_rate": 0.5,
-        "daytime": true,
+        "variable": "daytime:true",
         "exp_req_mod": 1,
         "level_range": [
           18,
@@ -93,7 +93,7 @@
       },
       {
         "encounter_rate": 0.5,
-        "daytime": true,
+        "variable": "daytime:true",
         "exp_req_mod": 1,
         "level_range": [
           10,
@@ -103,7 +103,7 @@
       },
       {
         "encounter_rate": 0.5,
-        "daytime": false,
+        "variable": "daytime:false",
         "exp_req_mod": 1,
         "level_range": [
           18,
@@ -113,7 +113,7 @@
       },
       {
         "encounter_rate": 0.5,
-        "daytime": false,
+        "variable": "daytime:false",
         "exp_req_mod": 1,
         "level_range": [
           36,
@@ -123,7 +123,7 @@
       },
       {
         "encounter_rate": 0.5,
-        "daytime": false,
+        "variable": "daytime:false",
         "exp_req_mod": 1,
         "level_range": [
           18,
@@ -133,7 +133,7 @@
       },
       {
         "encounter_rate": 0.5,
-        "daytime": false,
+        "variable": "daytime:false",
         "exp_req_mod": 1,
         "level_range": [
           36,
@@ -143,7 +143,7 @@
       },
       {
         "encounter_rate": 0.5,
-        "daytime": false,
+        "variable": "daytime:false",
         "exp_req_mod": 1,
         "level_range": [
           10,
@@ -153,7 +153,7 @@
       },
       {
         "encounter_rate": 0.5,
-        "daytime": false,
+        "variable": "daytime:false",
         "exp_req_mod": 1,
         "level_range": [
           18,
@@ -163,7 +163,7 @@
       },
       {
         "encounter_rate": 0.5,
-        "daytime": false,
+        "variable": "daytime:false",
         "exp_req_mod": 1,
         "level_range": [
           36,
@@ -173,7 +173,7 @@
       },
       {
         "encounter_rate": 0.5,
-        "daytime": false,
+        "variable": "daytime:false",
         "exp_req_mod": 1,
         "level_range": [
           10,
@@ -183,7 +183,7 @@
       },
       {
         "encounter_rate": 0.5,
-        "daytime": false,
+        "variable": "daytime:false",
         "exp_req_mod": 1,
         "level_range": [
           10,
@@ -193,7 +193,7 @@
       },
       {
         "encounter_rate": 0.5,
-        "daytime": false,
+        "variable": "daytime:false",
         "exp_req_mod": 1,
         "level_range": [
           10,

--- a/mods/tuxemon/db/encounter/route1.json
+++ b/mods/tuxemon/db/encounter/route1.json
@@ -4,7 +4,7 @@
     {
       "monster": "pairagrin",
       "encounter_rate": 3.5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         2,
@@ -14,7 +14,7 @@
     {
       "monster": "aardorn",
       "encounter_rate": 3.5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         2,
@@ -24,7 +24,7 @@
     {
       "monster": "cataspike",
       "encounter_rate": 3.5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         2,
@@ -34,7 +34,7 @@
     {
       "monster": "pairagrin",
       "encounter_rate": 3.5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         3,
@@ -44,7 +44,7 @@
     {
       "monster": "aardorn",
       "encounter_rate": 3.5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         3,
@@ -54,7 +54,7 @@
     {
       "monster": "cataspike",
       "encounter_rate": 3.5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         3,

--- a/mods/tuxemon/db/encounter/route2.json
+++ b/mods/tuxemon/db/encounter/route2.json
@@ -4,7 +4,7 @@
     {
       "monster": "cardiling",
       "encounter_rate": 2.5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         3,
@@ -14,7 +14,7 @@
     {
       "monster": "aardorn",
       "encounter_rate": 2.5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         3,
@@ -24,7 +24,7 @@
     {
       "monster": "eyenemy",
       "encounter_rate": 2.5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         3,
@@ -34,7 +34,7 @@
     {
       "monster": "axylightl",
       "encounter_rate": 1,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         4,
@@ -44,7 +44,7 @@
     {
       "monster": "cataspike",
       "encounter_rate": 2.5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         3,
@@ -54,7 +54,7 @@
     {
       "monster": "cardiling",
       "encounter_rate": 2.5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         3,
@@ -64,7 +64,7 @@
     {
       "monster": "aardorn",
       "encounter_rate": 2.5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         4,
@@ -74,7 +74,7 @@
     {
       "monster": "eyenemy",
       "encounter_rate": 2.5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         4,
@@ -84,7 +84,7 @@
     {
       "monster": "axylightl",
       "encounter_rate": 1,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         5,
@@ -94,7 +94,7 @@
     {
       "monster": "cataspike",
       "encounter_rate": 2.5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         4,

--- a/mods/tuxemon/db/encounter/route3.json
+++ b/mods/tuxemon/db/encounter/route3.json
@@ -4,7 +4,7 @@
     {
       "monster": "cardiling",
       "encounter_rate": 3,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         7,
@@ -14,7 +14,7 @@
     {
       "monster": "elofly",
       "encounter_rate": 3,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         7,
@@ -24,7 +24,7 @@
     {
       "monster": "squabbit",
       "encounter_rate": 1,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         8,
@@ -34,7 +34,7 @@
     {
       "monster": "shybulb",
       "encounter_rate": 3,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         7,
@@ -44,7 +44,7 @@
     {
       "monster": "cardiling",
       "encounter_rate": 3,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         9,
@@ -54,7 +54,7 @@
     {
       "monster": "elofly",
       "encounter_rate": 3,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         9,
@@ -64,7 +64,7 @@
     {
       "monster": "squabbit",
       "encounter_rate": 1,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         9,
@@ -74,7 +74,7 @@
     {
       "monster": "shybulb",
       "encounter_rate": 3,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         9,

--- a/mods/tuxemon/db/encounter/route4.json
+++ b/mods/tuxemon/db/encounter/route4.json
@@ -4,7 +4,7 @@
     {
       "monster": "elofly",
       "encounter_rate": 3,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         11,
@@ -14,7 +14,7 @@
     {
       "monster": "sapsnap",
       "encounter_rate": 1,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         12,
@@ -24,7 +24,7 @@
     {
       "monster": "aardorn",
       "encounter_rate": 3,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         11,
@@ -34,7 +34,7 @@
     {
       "monster": "katapill",
       "encounter_rate": 3,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         11,
@@ -44,7 +44,7 @@
     {
       "monster": "elofly",
       "encounter_rate": 3,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         13,
@@ -54,7 +54,7 @@
     {
       "monster": "sapsnap",
       "encounter_rate": 1,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         13,
@@ -64,7 +64,7 @@
     {
       "monster": "aardorn",
       "encounter_rate": 3,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         13,
@@ -74,7 +74,7 @@
     {
       "monster": "katapill",
       "encounter_rate": 3,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         13,

--- a/mods/tuxemon/db/encounter/route5.json
+++ b/mods/tuxemon/db/encounter/route5.json
@@ -4,7 +4,7 @@
     {
       "monster": "foofle",
       "encounter_rate": 3,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         19,
@@ -14,7 +14,7 @@
     {
       "monster": "vamporm",
       "encounter_rate": 3,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         16,
@@ -24,7 +24,7 @@
     {
       "monster": "dracune",
       "encounter_rate": 1,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         18,
@@ -34,7 +34,7 @@
     {
       "monster": "anoleaf",
       "encounter_rate": 3,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         18,
@@ -44,7 +44,7 @@
     {
       "monster": "gectile",
       "encounter_rate": 1,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         22,

--- a/mods/tuxemon/db/encounter/route6.json
+++ b/mods/tuxemon/db/encounter/route6.json
@@ -4,7 +4,7 @@
     {
       "monster": "dandicub",
       "encounter_rate": 10,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         19,
@@ -14,7 +14,7 @@
     {
       "monster": "dandylion",
       "encounter_rate": 5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         21,
@@ -24,7 +24,7 @@
     {
       "monster": "capiti",
       "encounter_rate": 10,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         19,
@@ -34,7 +34,7 @@
     {
       "monster": "dandicub",
       "encounter_rate": 10,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         20,
@@ -44,7 +44,7 @@
     {
       "monster": "dandylion",
       "encounter_rate": 5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         22,
@@ -54,7 +54,7 @@
     {
       "monster": "capiti",
       "encounter_rate": 10,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         20,

--- a/mods/tuxemon/db/encounter/route7.json
+++ b/mods/tuxemon/db/encounter/route7.json
@@ -4,7 +4,7 @@
     {
       "monster": "pairagrim",
       "encounter_rate": 3.5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         35,
@@ -14,7 +14,7 @@
     {
       "monster": "aardart",
       "encounter_rate": 3.5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         35,
@@ -24,7 +24,7 @@
     {
       "monster": "weavifly",
       "encounter_rate": 3.5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         35,
@@ -34,7 +34,7 @@
     {
       "monster": "pantherafira",
       "encounter_rate": 3.5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         35,
@@ -44,7 +44,7 @@
     {
       "monster": "flacono",
       "encounter_rate": 3.5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         35,
@@ -54,7 +54,7 @@
     {
       "monster": "slichen",
       "encounter_rate": 3.5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         35,

--- a/mods/tuxemon/db/encounter/routea.json
+++ b/mods/tuxemon/db/encounter/routea.json
@@ -4,7 +4,7 @@
     {
       "monster": "shybulb",
       "encounter_rate": 3.5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         12,
@@ -14,7 +14,7 @@
     {
       "monster": "katapill",
       "encounter_rate": 3.5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         12,
@@ -24,7 +24,7 @@
     {
       "monster": "anoleaf",
       "encounter_rate": 1.5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         12,
@@ -34,7 +34,7 @@
     {
       "monster": "katapill",
       "encounter_rate": 3.5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         14,
@@ -44,7 +44,7 @@
     {
       "monster": "vamporm",
       "encounter_rate": 1.5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         14,
@@ -54,7 +54,7 @@
     {
       "monster": "anoleaf",
       "encounter_rate": 1.5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         14,

--- a/mods/tuxemon/db/encounter/routeb.json
+++ b/mods/tuxemon/db/encounter/routeb.json
@@ -4,7 +4,7 @@
     {
       "monster": "toufigel",
       "encounter_rate": 3,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         25,
@@ -14,7 +14,7 @@
     {
       "monster": "pipis",
       "encounter_rate": 3,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         20,
@@ -24,7 +24,7 @@
     {
       "monster": "strella",
       "encounter_rate": 1,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         25,
@@ -34,7 +34,7 @@
     {
       "monster": "noctula",
       "encounter_rate": 3,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         20,
@@ -44,7 +44,7 @@
     {
       "monster": "noctalo",
       "encounter_rate": 1,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         26,
@@ -54,7 +54,7 @@
     {
       "monster": "cairfrey",
       "encounter_rate": 3,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         26,
@@ -64,7 +64,7 @@
     {
       "monster": "possessun",
       "encounter_rate": 1,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         26,
@@ -74,7 +74,7 @@
     {
       "monster": "rockat",
       "encounter_rate": 1,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         26,

--- a/mods/tuxemon/db/encounter/routec.json
+++ b/mods/tuxemon/db/encounter/routec.json
@@ -4,7 +4,7 @@
     {
       "monster": "nudiflot_male",
       "encounter_rate": 3.5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         22,
@@ -14,7 +14,7 @@
     {
       "monster": "nudiflot_female",
       "encounter_rate": 3.5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         22,
@@ -24,7 +24,7 @@
     {
       "monster": "nudimind",
       "encounter_rate": 3.5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         22,
@@ -34,7 +34,7 @@
     {
       "monster": "nudikill",
       "encounter_rate": 3.5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         22,
@@ -44,7 +44,7 @@
     {
       "monster": "manosting",
       "encounter_rate": 3.5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         22,
@@ -54,7 +54,7 @@
     {
       "monster": "tweesher",
       "encounter_rate": 3.5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         22,
@@ -64,7 +64,7 @@
     {
       "monster": "nostray",
       "encounter_rate": 3.5,
-      "daytime": true,
+      "variable": "daytime:true",
       "exp_req_mod": 1,
       "level_range": [
         22,
@@ -74,7 +74,7 @@
     {
       "monster": "nudiflot_male",
       "encounter_rate": 3.5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         25,
@@ -84,7 +84,7 @@
     {
       "monster": "nudiflot_female",
       "encounter_rate": 3.5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         25,
@@ -94,7 +94,7 @@
     {
       "monster": "nudimind",
       "encounter_rate": 3.5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         25,
@@ -104,7 +104,7 @@
     {
       "monster": "nudikill",
       "encounter_rate": 3.5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         25,
@@ -114,7 +114,7 @@
     {
       "monster": "manosting",
       "encounter_rate": 3.5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         25,
@@ -124,7 +124,7 @@
     {
       "monster": "tweesher",
       "encounter_rate": 3.5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         25,
@@ -134,7 +134,7 @@
     {
       "monster": "nostray",
       "encounter_rate": 3.5,
-      "daytime": false,
+      "variable": "daytime:false",
       "exp_req_mod": 1,
       "level_range": [
         25,

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -1053,9 +1053,7 @@ class EncounterItemModel(BaseModel):
     level_range: Sequence[int] = Field(
         ..., description="Level range to encounter"
     )
-    daytime: bool = Field(
-        True, description="Options: day (true), night (false)"
-    )
+    variable: Optional[str] = Field(None, description="Variable encounter")
     exp_req_mod: int = Field(1, description="Exp modifier wild monster")
 
     @field_validator("monster")
@@ -1063,6 +1061,14 @@ class EncounterItemModel(BaseModel):
         if has.db_entry("monster", v):
             return v
         raise ValueError(f"the monster {v} doesn't exist in the db")
+
+    @field_validator("variable")
+    def variable_exists(
+        cls: EncounterItemModel, v: Optional[str]
+    ) -> Optional[str]:
+        if not v or v.find(":") > 1:
+            return v
+        raise ValueError(f"the variable {v} isn't formatted correctly")
 
 
 class EncounterModel(BaseModel):

--- a/tuxemon/event/actions/random_encounter.py
+++ b/tuxemon/event/actions/random_encounter.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import random
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Optional, final
 
@@ -50,53 +49,31 @@ class RandomEncounterAction(EventAction):
     def start(self) -> None:
         player = self.session.player
 
-        # Don't start a battle if we don't even have monsters in our party yet.
         if not check_battle_legal(player):
             logger.warning("battle is not legal, won't start")
             return
 
         slug = self.encounter_slug
         encounters = db.lookup(slug, table="encounter").monsters
+        filtered = list(encounters)
 
-        # Filter monsters based on daytime true / false
-        filtered = []
-        for ele in encounters:
-            if (
-                ele.daytime is True
-                and player.game_variables["daytime"] == "true"
-            ):
-                filtered.append(ele)
-            elif (
-                ele.daytime is False
-                and player.game_variables["daytime"] == "false"
-            ):
-                filtered.append(ele)
+        for meet in encounters:
+            if meet.variable:
+                part = meet.variable.split(":")
+                if player.game_variables[part[0]] != part[1]:
+                    filtered.remove(meet)
 
-        if filtered:
-            encounter = _choose_encounter(filtered, self.total_prob)
-        else:
-            # if no monster is set for nighttime, it loads all
-            encounter = _choose_encounter(encounters, self.total_prob)
+        if not filtered:
+            logger.info(f"no wild monsters, check encounter/{slug}.json")
+            return
 
-        # If a random encounter was successfully rolled, look up the monster
-        # and start the battle.
+        encounter = _choose_encounter(filtered, self.total_prob)
+
         if encounter:
             logger.info("Starting random encounter!")
-
-            # get wild monster level
             level = _get_level(encounter)
-
-            # Lookup the environment
-            environment = (
-                "grass"
-                if "environment" not in player.game_variables
-                else player.game_variables["environment"]
-            )
-
-            # flash color
+            environment = player.game_variables.get("environment", "grass")
             rgb = self.rgb if self.rgb else None
-
-            # starts the battle with wild_encounter
             self.session.client.event_engine.execute_action(
                 "wild_encounter",
                 [
@@ -112,7 +89,7 @@ class RandomEncounterAction(EventAction):
 
 
 def _choose_encounter(
-    encounters: Sequence[EncounterItemModel],
+    encounters: list[EncounterItemModel],
     total_prob: Optional[float],
 ) -> Optional[EncounterItemModel]:
     total = 0.0


### PR DESCRIPTION
PR proposes to replace **daytime field (boolean)** with **variable (optional string)**.

Originally daytime was added to guarantee a possible difference between the monster encountered in the night vs day, but daytime is a game variable, so I thought to allow directly to set a variable instead of forcing only 1. In this way it can offer literally infinite possibilities, spawning in seasons, precise hours, days, weekday, after certain quests, etc.

from
```
    "monsters": [
      {
        "encounter_rate": 0.5,
        "daytime": true,
        "exp_req_mod": 1,
```
to
```
    "monsters": [
      {
        "encounter_rate": 0.5,
        "variable": "daytime:true",
        "exp_req_mod": 1,
```