### PR TITLE
common checking, remove A (input) and cheat code

### DIFF
--- a/mods/tuxemon/maps/spyder.yaml
+++ b/mods/tuxemon/maps/spyder.yaml
@@ -183,3 +183,19 @@ events:
     - not variable_set nu_map_6:flower_city*-0.15*0.32
     - is location_name flower_city
     type: "event"
+  Cheat Code ApexPlayer:
+    actions:
+    - get_party_monster
+    - remove_monster iid_slot_0
+    - add_monster rockat,100
+    - add_monster moloch,100
+    - add_monster arthrobolt,100
+    - add_monster eaglace,100
+    - add_monster agnigon,100
+    - set_variable cheat_apex:enabled
+    conditions:
+    - is check_char_parameter player,name,ApexPlayer
+    - is party_size equals,1
+    - not variable_set cheat_apex:enabled
+    - is current_state WorldState
+    type: "event"

--- a/tuxemon/event/actions/rename_player.py
+++ b/tuxemon/event/actions/rename_player.py
@@ -32,7 +32,8 @@ class RenamePlayerAction(EventAction):
     random: Union[str, None] = None
 
     def set_player_name(self, name: str) -> None:
-        self.session.player.name = name
+        client = self.session.client
+        client.event_engine.execute_action("set_player_name", [name], True)
 
     def start(self) -> None:
         self.session.client.push_state(

--- a/tuxemon/event/actions/set_player_name.py
+++ b/tuxemon/event/actions/set_player_name.py
@@ -2,12 +2,15 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+import logging
 import random
 from dataclasses import dataclass
 from typing import final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.locale import T
+
+logger = logging.getLogger(__name__)
 
 
 @final
@@ -40,3 +43,4 @@ class SetPlayerNameAction(EventAction):
         else:
             name = self.choice
         self.session.player.name = T.translate(name)
+        logger.info(f"Player name is {T.translate(name)}")

--- a/tuxemon/event/conditions/check_char_parameter.py
+++ b/tuxemon/event/conditions/check_char_parameter.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2024 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import final
+
+from tuxemon.event import MapCondition, get_npc
+from tuxemon.event.conditions.common import CommonCondition
+from tuxemon.event.eventcondition import EventCondition
+from tuxemon.session import Session
+
+logger = logging.getLogger(__name__)
+
+
+@final
+@dataclass
+class CheckCharParameterCondition(EventCondition):
+    """
+    Check the parameter's value of the character against a given value.
+
+    Script usage:
+        .. code-block::
+
+            check_char_parameter <character>,<parameter>,<value>
+
+    Script parameters:
+        character: Either "player" or npc slug name (eg. "npc_maple").
+        parameter: Name of the parameter to check (eg. "name", "steps", etc.).
+        value: Given value to check.
+
+    eg. "player,name,alpha" -> is the player named alpha? true/false
+
+    """
+
+    name = "check_char_parameter"
+
+    def test(self, session: Session, condition: MapCondition) -> bool:
+        _character, _parameter, _value = condition.parameters[:3]
+        character = get_npc(session, _character)
+        if character is None:
+            logger.error(f"{_character} not found")
+            return False
+        return CommonCondition.check_character_parameter(
+            character, _parameter, _value
+        )

--- a/tuxemon/event/conditions/common.py
+++ b/tuxemon/event/conditions/common.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2024 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import logging
+
+from tuxemon.npc import NPC
+
+logger = logging.getLogger(__name__)
+
+
+class CommonCondition:
+    name = "Common"
+
+    @staticmethod
+    def check_character_parameter(
+        character: NPC,
+        parameter: str,
+        value: str,
+    ) -> bool:
+        """
+        Check a character's parameter against a given value.
+
+        Parameters:
+            character: The character to check.
+            parameter: The character's parameter (eg. "name", "steps", etc.)
+            value: Given value to check against the parameter's value.
+
+        eg. "player,name,alpha" -> is the player named alpha? true/false
+
+        """
+
+        # check for valid inputs
+        # trigger an AttributeError if the parameter doesn't already exist
+        attr = None
+        try:
+            attr = getattr(character, parameter)
+        except AttributeError:
+            logger.warning(
+                "Character parameter '{0}' specified does not exist.",
+                parameter,
+            )
+            return False
+
+        try:
+            val = type(attr)(value)
+        except TypeError:
+            logger.warning(
+                "The value given cannot be parsed into the correct type for '{0}'",
+                parameter,
+            )
+            return False
+        return attr == val  # type: ignore[no-any-return]

--- a/tuxemon/event/eventengine.py
+++ b/tuxemon/event/eventengine.py
@@ -262,6 +262,7 @@ class EventEngine:
         Parameters:
             action_name: Name of the action.
             parameters: Parameters of the action.
+            skip: Boolean for skipping the action.update().
 
         """
         if parameters is None:

--- a/tuxemon/menu/input.py
+++ b/tuxemon/menu/input.py
@@ -60,6 +60,7 @@ class InputMenu(Menu[InputMenuObj]):
 
         """
         super().__init__(**kwargs)
+        self.is_first_input = True
         self.input_string = initial
         self.chars = T.translate("menu_alphabet").replace(r"\0", "\0")
         self.n_columns = int(T.translate("menu_alphabet_n_columns"))
@@ -205,7 +206,9 @@ class InputMenu(Menu[InputMenuObj]):
             self.char_limit is None
             or len(self.input_string) <= self.char_limit
         ):
-            self.input_string += char
+            # removes A at the end of the name
+            self.input_string += char if not self.is_first_input else ""
+            self.is_first_input = False
             self.update_text_area()
         else:
             self.text_area.text = T.translate("alert_text")


### PR DESCRIPTION
PR:
- removes the A that appears by default at the end of the name. It adds a simple flag;
- **rename_player** event action instead of setting the name will ship it to **set_player_name** event action;
- adds a logger.info inside **set_player_name** to alert the player about the new name;
- adds **common** (event condition);
- adds **check_char_parameter** (event condition), inspired to the one of similar name (event action), this will simplify the checking for single parameters without the necessity to create an event condition for each one;
- adds a cheat code if the player is named **ApexPlayer**, it'll give to the player all starting monsters (max evolution: eg rockat instead of rockitten, eaglace, etc.) at lv 100; I talked about it with @Sanglorian after showing him this issue #2193  opened by @ultidonki , in this way someone can enjoy the game without bothering too much in levelling up (moreover it can help us to understand if there are bugs later in the game);
- adds the description of skip parameter (it was missing);

to complete after #2149 (add **check_char_parameter** to the conditions list + fix an event after **wayfarer inn**)

![Screenshot_2024-01-02_21-12-54](https://github.com/Tuxemon/Tuxemon/assets/64643719/3fe9db3a-4925-4793-a102-eb3aaf573d87)
