### PR TITLE
rename monster (event action)

### DIFF
--- a/mods/tuxemon/maps/healing_center.tmx
+++ b/mods/tuxemon/maps/healing_center.tmx
@@ -101,7 +101,8 @@
   </object>
   <object id="31" name="Rename Monster" type="event" x="176" y="128" width="16" height="16">
    <properties>
-    <property name="act10" value="rename_monster"/>
+    <property name="act10" value="get_player_monster rename"/>
+    <property name="act15" value="rename_monster rename"/>
     <property name="act20" value="translated_dialog happy_rename"/>
     <property name="act30" value="npc_face happy_guy,left"/>
     <property name="act40" value="set_variable happy:no"/>

--- a/tuxemon/event/actions/rename_monster.py
+++ b/tuxemon/event/actions/rename_monster.py
@@ -2,64 +2,55 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+import logging
+import uuid
 from dataclasses import dataclass
 from typing import final
 
+from tuxemon.event import get_monster_by_iid
 from tuxemon.event.eventaction import EventAction
 from tuxemon.locale import T
 from tuxemon.menu.input import InputMenu
-from tuxemon.menu.interface import MenuItem
-from tuxemon.monster import Monster
-from tuxemon.states.monster import MonsterMenuState
-from tuxemon.states.world.worldstate import WorldState
+
+logger = logging.getLogger(__name__)
 
 
 @final
 @dataclass
 class RenameMonsterAction(EventAction):
     """
-    Open the monster menu and text input screens to rename a selected monster.
+    Open the text input screen to rename the monster.
 
     Script usage:
         .. code-block::
 
-            rename_monster
+            rename_monster <variable>
+
+    Script parameters:
+        variable: Name of the variable where to store the monster id.
 
     """
 
     name = "rename_monster"
-
-    def start(self) -> None:
-        # Get a copy of the world state.
-        self.session.client.get_state_by_name(WorldState)
-
-        # pull up the monster menu so we know which one we are renaming
-        menu = self.session.client.push_state(MonsterMenuState())
-        menu.on_menu_selection = self.prompt_for_name  # type: ignore[assignment]
-
-    def update(self) -> None:
-        missing_monster_menu = False
-
-        try:
-            self.session.client.get_state_by_name(MonsterMenuState)
-        except ValueError:
-            missing_monster_menu = True
-
-        try:
-            self.session.client.get_state_by_name(InputMenu)
-        except ValueError:
-            if missing_monster_menu:
-                self.stop()
+    variable: str
 
     def set_monster_name(self, name: str) -> None:
         self.monster.name = name
-        monster_menu_state = self.session.client.get_state_by_name(
-            MonsterMenuState,
-        )
-        monster_menu_state.refresh_menu_items()
+        logger.info(f"Now {T.translate(self.monster.slug)} is {name}!")
 
-    def prompt_for_name(self, menu_item: MenuItem[Monster]) -> None:
-        self.monster = menu_item.game_object
+    def start(self) -> None:
+        player = self.session.player
+        if self.variable not in player.game_variables:
+            logger.error(f"Game variable {self.variable} not found")
+            return
+
+        monster_id = uuid.UUID(player.game_variables[self.variable])
+        monster = get_monster_by_iid(self.session, monster_id)
+        if monster is None:
+            logger.error("Monster not found")
+            return
+
+        self.monster = monster
 
         self.session.client.push_state(
             InputMenu(
@@ -69,3 +60,9 @@ class RenameMonsterAction(EventAction):
                 initial=T.translate(self.monster.slug),
             )
         )
+
+    def update(self) -> None:
+        try:
+            self.session.client.get_state_by_name(InputMenu)
+        except ValueError:
+            self.stop()


### PR DESCRIPTION
PR removes from the event action **rename_monster** the opening of the monster menu. The action needs to be single use, since we got **get_player_monster** to open the monster menu (which allows many filters). It fixes also the only **rename_monster** among all the maps.