### PR TITLE
fix asserts (journal + phone) + LEFT/RIGHT navigation (journal)

### DIFF
--- a/tuxemon/states/journal/journal_choice.py
+++ b/tuxemon/states/journal/journal_choice.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0
-# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+# Copyright (c) 2014-2024 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
 import math
@@ -57,34 +57,29 @@ class JournalChoice(PygameMenuState):
         for page in range(diff):
             maximum = (page * MAX_PAGE) + MAX_PAGE
             minimum = page * MAX_PAGE
-            _tuxepedia = [
-                ele
-                for ele in monsters
-                if page * MAX_PAGE < ele.txmn_id <= (page + 1) * MAX_PAGE
-                and ele.slug in player.tuxepedia
+            tuxepedia = [
+                mon
+                for mon in monsters
+                if minimum < mon.txmn_id <= maximum
+                and mon.slug in player.tuxepedia
             ]
-            tuxepedia = True if _tuxepedia else False
-            label = T.format(
-                "page_tuxepedia", {"a": str(minimum), "b": str(maximum)}
-            ).upper()
+            _label = {"a": str(minimum), "b": str(maximum)}
+            label = T.format("page_tuxepedia", _label).upper()
             if tuxepedia:
+                param = {"monsters": monsters, "page": page}
                 menu.add.button(
                     label,
-                    change_state(
-                        "JournalState",
-                        kwargs={"monsters": monsters, "page": page},
-                    ),
+                    change_state("JournalState", kwargs=param),
                     font_size=self.font_size_small,
                 ).translate(
                     fix_measure(width, 0.18), fix_measure(height, 0.01)
                 )
             else:
-                lab1 = menu.add.label(
+                lab1: Any = menu.add.label(
                     label,
                     font_color=prepare.DIMGRAY_COLOR,
                     font_size=self.font_size_small,
                 )
-                assert not isinstance(lab1, list)
                 lab1.translate(
                     fix_measure(width, 0.18), fix_measure(height, 0.01)
                 )

--- a/tuxemon/states/journal/journal_info.py
+++ b/tuxemon/states/journal/journal_info.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0
-# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+# Copyright (c) 2014-2024 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
 from typing import Any, Optional
@@ -9,7 +9,7 @@ from pygame_menu import locals
 from pygame_menu.locals import POSITION_CENTER
 
 from tuxemon import formula, prepare, tools
-from tuxemon.db import MonsterModel
+from tuxemon.db import MonsterModel, SeenStatus, db
 from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.menu.theme import get_theme
@@ -35,8 +35,6 @@ class JournalInfoState(PygameMenuState):
         height = menu._height
         menu._width = fix_measure(menu._width, 0.97)
 
-        name = T.translate(monster.slug).upper()
-        desc = T.translate(f"{monster.slug}_description")
         # history
         evo = ""
         if monster.history:
@@ -62,44 +60,44 @@ class JournalInfoState(PygameMenuState):
             unit_height = "ft"
         # name
         menu._auto_centering = False
-        lab1 = menu.add.label(
+        name = T.translate(monster.slug).upper()
+        lab1: Any = menu.add.label(
             title=name,
             label_id="name",
             font_size=self.font_size_big,
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        assert not isinstance(lab1, list)
         lab1.translate(fix_measure(width, 0.50), fix_measure(height, 0.15))
         # weight
-        lab2 = menu.add.label(
-            title=str(mon_weight) + " " + unit_weight,
+        _weight = f"{mon_weight} {unit_weight}"
+        lab2: Any = menu.add.label(
+            title=_weight,
             label_id="weight",
             font_size=self.font_size_small,
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        assert not isinstance(lab2, list)
         lab2.translate(fix_measure(width, 0.50), fix_measure(height, 0.25))
         # height
-        lab3 = menu.add.label(
-            title=str(mon_height) + " " + unit_height,
+        _height = f"{mon_height} {unit_height}"
+        lab3: Any = menu.add.label(
+            title=_height,
             label_id="height",
             font_size=self.font_size_small,
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        assert not isinstance(lab3, list)
         lab3.translate(fix_measure(width, 0.65), fix_measure(height, 0.25))
         # type
-        lab4 = menu.add.label(
-            title=T.translate("monster_menu_type"),
+        _type = T.translate("monster_menu_type")
+        lab4: Any = menu.add.label(
+            title=_type,
             label_id="type_label",
             font_size=self.font_size_small,
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        assert not isinstance(lab4, list)
         lab4.translate(fix_measure(width, 0.50), fix_measure(height, 0.30))
         type_image_1 = pygame_menu.BaseImage(
             tools.transform_resource_filename(
@@ -107,10 +105,9 @@ class JournalInfoState(PygameMenuState):
             ),
         )
         if len(monster.types) > 1:
+            path = f"gfx/ui/icons/element/{monster.types[1].name}_type.png"
             type_image_2 = pygame_menu.BaseImage(
-                tools.transform_resource_filename(
-                    f"gfx/ui/icons/element/{monster.types[1].name}_type.png"
-                ),
+                tools.transform_resource_filename(path),
             )
             menu.add.image(type_image_1, float=True).translate(
                 fix_measure(width, 0.17), fix_measure(height, 0.29)
@@ -122,54 +119,53 @@ class JournalInfoState(PygameMenuState):
             menu.add.image(type_image_1, float=True).translate(
                 fix_measure(width, 0.17), fix_measure(height, 0.29)
             )
-        lab5 = menu.add.label(
+        types = types if self.caught else "-----"
+        lab5: Any = menu.add.label(
             title=types,
             label_id="type_loaded",
             font_size=self.font_size_small,
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        assert not isinstance(lab5, list)
         lab5.translate(fix_measure(width, 0.50), fix_measure(height, 0.35))
         # shape
-        shape = (
-            T.translate("monster_menu_shape")
-            + ": "
-            + T.translate(monster.shape)
-        )
-        lab6 = menu.add.label(
+        menu_shape = T.translate("monster_menu_shape")
+        _shape = T.translate(monster.shape)
+        shape = f"{menu_shape}: {_shape}"
+        lab6: Any = menu.add.label(
             title=shape,
             label_id="shape",
             font_size=self.font_size_small,
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        assert not isinstance(lab6, list)
         lab6.translate(fix_measure(width, 0.50), fix_measure(height, 0.40))
         # species
         spec = T.translate(f"cat_{monster.category}")
+        spec = spec if self.caught else "-----"
         species = T.translate("monster_menu_species") + ": " + spec
-        lab7 = menu.add.label(
+        lab7: Any = menu.add.label(
             title=species,
             label_id="species",
             font_size=self.font_size_small,
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        assert not isinstance(lab7, list)
         lab7.translate(fix_measure(width, 0.50), fix_measure(height, 0.45))
         # txmn_id
-        lab8 = menu.add.label(
-            title="ID: " + str(monster.txmn_id),
+        _txmn_id = f"ID: {monster.txmn_id}"
+        lab8: Any = menu.add.label(
+            title=_txmn_id,
             label_id="txmn_id",
             font_size=self.font_size_small,
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        assert not isinstance(lab8, list)
         lab8.translate(fix_measure(width, 0.50), fix_measure(height, 0.10))
         # description
-        lab9 = menu.add.label(
+        desc = T.translate(f"{monster.slug}_description")
+        desc = desc if self.caught else "-----"
+        lab9: Any = menu.add.label(
             title=desc,
             label_id="description",
             font_size=self.font_size_small,
@@ -177,10 +173,10 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        assert not isinstance(lab9, list)
         lab9.translate(fix_measure(width, 0.01), fix_measure(height, 0.56))
         # history
-        lab10 = menu.add.label(
+        evo = evo if self.caught else "-----"
+        lab10: Any = menu.add.label(
             title=evo,
             label_id="history",
             font_size=self.font_size_small,
@@ -188,36 +184,36 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        assert not isinstance(lab10, list)
         lab10.translate(fix_measure(width, 0.01), fix_measure(height, 0.76))
 
         # history monsters
-        f = menu.add.frame_h(
-            float=True,
-            width=fix_measure(width, 0.95),
-            height=fix_measure(width, 0.05),
-            frame_id="histories",
-        )
-        f.translate(fix_measure(width, 0.02), fix_measure(height, 0.80))
-        f._relax = True
-        elements = []
-        for ele in monster.history:
-            elements.append(ele.mon_slug)
-        labels = [
-            menu.add.label(
-                title=f"{T.translate(ele).upper()}",
-                align=locals.ALIGN_LEFT,
-                font_size=self.font_size_smaller,
+        if self.caught:
+            f = menu.add.frame_h(
+                float=True,
+                width=fix_measure(width, 0.95),
+                height=fix_measure(width, 0.05),
+                frame_id="histories",
             )
-            for ele in elements
-        ]
-        for elements in labels:
-            f.pack(elements)
+            f.translate(fix_measure(width, 0.02), fix_measure(height, 0.80))
+            f._relax = True
+            elements = []
+            for ele in monster.history:
+                elements.append(ele.mon_slug)
+            labels = [
+                menu.add.label(
+                    title=f"{T.translate(ele).upper()}",
+                    align=locals.ALIGN_LEFT,
+                    font_size=self.font_size_smaller,
+                )
+                for ele in elements
+            ]
+            for elements in labels:
+                f.pack(elements)
         # image
+        _path = f"gfx/sprites/battle/{monster.slug}-front.png"
+        _path = _path if self.caught else prepare.MISSING_IMAGE
         new_image = pygame_menu.BaseImage(
-            tools.transform_resource_filename(
-                f"gfx/sprites/battle/{monster.slug}-front.png"
-            ),
+            tools.transform_resource_filename(_path),
         )
         new_image.scale(prepare.SCALE, prepare.SCALE)
         image_widget = menu.add.image(image_path=new_image.copy())
@@ -230,6 +226,8 @@ class JournalInfoState(PygameMenuState):
         monster: Optional[MonsterModel] = None
         for element in kwargs.values():
             monster = element["monster"]
+        if monster is None:
+            raise ValueError("No monster")
         width, height = prepare.SCREEN_SIZE
         background = pygame_menu.BaseImage(
             image_path=tools.transform_resource_filename(
@@ -244,7 +242,9 @@ class JournalInfoState(PygameMenuState):
 
         super().__init__(height=height, width=width)
 
-        assert monster
+        checks = local_session.player.tuxepedia.get(monster.slug)
+        self.caught = True if checks == SeenStatus.caught else False
+        self._monster = monster
         self.add_menu_items(self.menu, monster)
         self.repristinate()
 
@@ -256,10 +256,36 @@ class JournalInfoState(PygameMenuState):
         theme.widget_alignment = locals.ALIGN_LEFT
 
     def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
-        if (
+        client = self.client
+        monsters = list(local_session.player.tuxepedia)
+        box: list[MonsterModel] = []
+        for mov in monsters:
+            results = db.lookup(mov, table="monster")
+            box.append(results)
+        box = sorted(box, key=lambda x: x.txmn_id)
+        param: dict[str, Any] = {}
+        if event.button == buttons.RIGHT and event.pressed and box:
+            slot = box.index(self._monster)
+            if slot < (len(box) - 1):
+                slot += 1
+                param["monster"] = box[slot]
+                client.replace_state("JournalInfoState", kwargs=param)
+            else:
+                param["monster"] = box[0]
+                client.replace_state("JournalInfoState", kwargs=param)
+        elif event.button == buttons.LEFT and event.pressed and box:
+            slot = box.index(self._monster)
+            if slot > 0:
+                slot -= 1
+                param["monster"] = box[slot]
+                client.replace_state("JournalInfoState", kwargs=param)
+            else:
+                param["monster"] = box[len(box) - 1]
+                client.replace_state("JournalInfoState", kwargs=param)
+        elif (
             event.button == buttons.BACK
             or event.button == buttons.B
             or event.button == buttons.A
         ) and event.pressed:
-            self.client.pop_state()
+            client.pop_state()
         return None

--- a/tuxemon/states/phone/phone_map.py
+++ b/tuxemon/states/phone/phone_map.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0
-# Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+# Copyright (c) 2014-2024 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
 from collections.abc import Callable
@@ -76,15 +76,14 @@ class NuPhoneMap(PygameMenuState):
                     underline = True
                     selectable = False
 
-                place = menu.add.label(
+                lab: Any = menu.add.label(
                     title=T.translate(place),
                     selectable=selectable,
                     float=True,
                     underline=underline,
                     font_size=self.font_size_small,
                 )
-                assert not isinstance(place, list)
-                place.translate(
+                lab.translate(
                     fix_measure(menu._width, x), fix_measure(menu._height, y)
                 )
 


### PR DESCRIPTION
PR:
- removes a bunch of `assert not isinstance(lab, list)` , I put it to avoid a typehint (since the output was an annoying Union Any/List), but this approach is way better (journal + phone);
- allows to change screen by using RIGHT and LEFT arrows (screenshot below);
- hides the names of monsters (neither seen or caught);
- hides some info of monsters (seen vs caught);

eg if you have seen monster id 1,45,89 and you click RIGHT, it'll automatically jump from 1 to 45, then 89, then 1, same other direction (LEFT);

before
![Screenshot_2024-01-19_09-38-32](https://github.com/Tuxemon/Tuxemon/assets/64643719/161f8b6b-6237-44d4-bff4-de3ab9014bc6)
after
![Screenshot_2024-01-19_09-40-59](https://github.com/Tuxemon/Tuxemon/assets/64643719/32f1a52d-6851-4e30-94b8-8a86dee8019e)

monster seen
![Screenshot_2024-01-19_09-38-56](https://github.com/Tuxemon/Tuxemon/assets/64643719/54d92b8a-0e08-4b72-b969-c575b5e608be)
monster caught
![Screenshot_2024-01-19_09-38-44](https://github.com/Tuxemon/Tuxemon/assets/64643719/305aa7a0-e53d-4ef2-b1cf-47f2d871e69e)


split out PlayerState + MonsterInfo in #2202