### PR TITLE
pydantic warning

### DIFF
--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -14,6 +14,7 @@ from typing import Any, Literal, Optional, Union, overload
 
 from pydantic import (
     BaseModel,
+    ConfigDict,
     Field,
     ValidationError,
     ValidationInfo,
@@ -218,6 +219,7 @@ State = Enum(
 
 
 class ItemModel(BaseModel):
+    model_config = ConfigDict(title="Item")
     slug: str = Field(..., description="Slug to use")
     use_item: str = Field(
         ...,
@@ -262,9 +264,6 @@ class ItemModel(BaseModel):
     visible: bool = Field(
         True, description="Whether or not this item is visible."
     )
-
-    class Config:
-        title = "Item"
 
     # Validate fields that refer to translated text
     @field_validator("use_item", "use_success", "use_failure")
@@ -466,7 +465,8 @@ class MonsterSoundsModel(BaseModel):
     )
 
 
-class MonsterModel(BaseModel):
+# Validate assignment allows us to assign a default inside a validator
+class MonsterModel(BaseModel, validate_assignment=True):
     slug: str = Field(..., description="The slug of the monster")
     category: str = Field(..., description="The category of monster")
     txmn_id: int = Field(..., description="The id of the monster")
@@ -514,10 +514,6 @@ class MonsterModel(BaseModel):
         None,
         description="The sounds this monster has",
     )
-
-    class Config:
-        # Validate assignment allows us to assign a default inside a validator
-        validate_assignment = True
 
     # Set the default sprites based on slug. Specifying 'always' is needed
     # because by default pydantic doesn't validate null fields.


### PR DESCRIPTION
PR:
- replaces **Config** with **ConfigDict** (warning in the action, see below);

regarding Config, this was the warning, so I replaced it (https://docs.pydantic.dev/2.5/migration/#changes-to-config):
```
  /home/runner/work/Tuxemon/Tuxemon/.tox/py3/lib/python3.12/site-packages/pydantic/_internal/_config.py:271:
PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead.
Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.5/migration/
    warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)
```

question: is it necessary `model_config = ConfigDict(title="Item")`?
let's say the pydantic check finds something wrong inside an item, with config dict it'll print:
```
tuxemon.db - ERROR - validation failed for 'xxx': 1 validation error for Item <----
```
otherwise
```
tuxemon.db - ERROR - validation failed for 'xxx': 1 validation error for ItemModel <----
```
I ask because if it's necessary, then we can simply add it to all the models