### PR TITLE
fix imports

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,10 +17,10 @@ sys.path.insert(0, os.path.abspath('../'))
 
 
 # -- Project information -----------------------------------------------------
-from typing import Any, List
+from typing import Any
 
 project = 'Tuxemon'
-copyright = '2015-2021, William Edwards'
+copyright = '2015-2024, William Edwards'
 author = 'William Edwards'
 
 # The full version, including alpha/beta/rc tags
@@ -75,7 +75,7 @@ napoleon_custom_sections = [
 # Apidoc call to generate automatic reference docs. Taken from
 # https://github.com/readthedocs/readthedocs.org/issues/1139#issuecomment-398083449
 def run_apidoc(_: Any) -> None:
-    ignore_paths: List[str] = []
+    ignore_paths: list[str] = []
 
     argv = [
         "-f",

--- a/tuxemon/cli/commands/action.py
+++ b/tuxemon/cli/commands/action.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import sys
 import traceback
-from typing import TYPE_CHECKING, Iterable
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 from tuxemon.cli.clicommand import CLICommand
 from tuxemon.script.parser import parse_action_string

--- a/tuxemon/cli/commands/test.py
+++ b/tuxemon/cli/commands/test.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import sys
 import traceback
-from typing import TYPE_CHECKING, Iterable
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 from tuxemon.cli.clicommand import CLICommand
 from tuxemon.cli.exceptions import ParseError

--- a/tuxemon/event/eventaction.py
+++ b/tuxemon/event/eventaction.py
@@ -6,7 +6,7 @@ import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from types import TracebackType
-from typing import ClassVar, Optional, Type
+from typing import ClassVar, Optional
 
 from tuxemon.session import Session, local_session
 from tuxemon.tools import cast_dataclass_parameters
@@ -100,7 +100,7 @@ class EventAction(ABC):
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
+        exc_type: Optional[type[BaseException]],
         exc_val: Optional[BaseException],
         exc_tb: Optional[TracebackType],
     ) -> None:

--- a/tuxemon/sprite.py
+++ b/tuxemon/sprite.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 import logging
 import math
-from collections.abc import Container, Iterator, Sequence
+from collections.abc import Callable, Container, Iterator, Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     Final,
     Generic,
     Literal,
@@ -422,8 +421,6 @@ class RelativeGroup(MenuSpriteGroup[_MenuElement]):
     def draw(
         self,
         surface: Surface,
-        bgsurf: Any = None,
-        special_flags: int = 0,
     ) -> list[Rect]:
         self.update_rect_from_parent()
         topleft = self.rect.topleft
@@ -510,8 +507,6 @@ class VisualSpriteList(RelativeGroup[_MenuElement]):
     def draw(
         self,
         surface: Surface,
-        bgsurf: Any = None,
-        special_flags: int = 0,
     ) -> list[Rect]:
         if self._needs_arrange:
             self.arrange_menu_items()

--- a/tuxemon/technique/effects/area.py
+++ b/tuxemon/technique/effects/area.py
@@ -2,8 +2,9 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 from tuxemon import formula
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult

--- a/tuxemon/technique/effects/give.py
+++ b/tuxemon/technique/effects/give.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import random
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 from tuxemon.condition.condition import Condition
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult


### PR DESCRIPTION
I noticed some wrong imports  + typehint (by getting rid of bgsurf: Any = ..., special_flags: int = ...)

```
tuxemon/sprite.py:422: note:      Superclass:
tuxemon/sprite.py:422: note:          def draw(self, surface: Surface) -> list[FRect | Rect]
tuxemon/sprite.py:422: note:      Subclass:
tuxemon/sprite.py:422: note:          def draw(self, surface: Surface, bgsurf: Any = ..., special_flags: int = ...) -> list[Rect]
```
