### PR TITLE
party_size & party_infected (event conditions)

### DIFF
--- a/docs/handcrafted/condition_list.rst
+++ b/docs/handcrafted/condition_list.rst
@@ -9,6 +9,7 @@
 .. autoscriptinfoclass:: tuxemon.event.conditions.char_in.CharInCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.char_moved.CharMovedCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.char_sprite.CharSpriteCondition
+.. autoscriptinfoclass:: tuxemon.event.conditions.check_char_parameter.CheckCharParameterCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.check_evolution.CheckEvolutionCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.check_mission.CheckMissionCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.current_state.CurrentStateCondition

--- a/mods/tuxemon/maps/daycare.tmx
+++ b/mods/tuxemon/maps/daycare.tmx
@@ -86,7 +86,7 @@
     <property name="behav10" value="talk cotton_breeder"/>
     <property name="cond10" value="is variable_set breeder_state:1"/>
     <property name="cond30" value="not variable_set wannabreed"/>
-    <property name="cond40" value="is has_party_breeder"/>
+    <property name="cond40" value="is has_party_breeder player"/>
    </properties>
   </object>
   <object id="23" name="breeder state 2a" type="event" x="144" y="48" width="16" height="16">

--- a/mods/tuxemon/maps/healing_center.tmx
+++ b/mods/tuxemon/maps/healing_center.tmx
@@ -61,7 +61,7 @@
     <property name="act10" value="translated_dialog tabanurse_dialog_welcome"/>
     <property name="cond10" value="is char_facing_tile player"/>
     <property name="cond20" value="is button_pressed K_RETURN"/>
-    <property name="cond30" value="is party_size less_than,1"/>
+    <property name="cond30" value="is party_size player,less_than,1"/>
    </properties>
   </object>
   <object id="26" name="hello there" type="event" x="80" y="80" width="16" height="16">
@@ -71,7 +71,7 @@
     <property name="cond10" value="is char_facing_tile player"/>
     <property name="cond20" value="is button_pressed K_RETURN"/>
     <property name="cond30" value="not variable_set chooses:yes"/>
-    <property name="cond40" value="is party_size greater_than,0"/>
+    <property name="cond40" value="is party_size player,greater_than,0"/>
    </properties>
   </object>
   <object id="27" name="Heal Tuxemon" type="event" x="80" y="96" width="16" height="16">

--- a/mods/tuxemon/maps/player_house_downstairs.tmx
+++ b/mods/tuxemon/maps/player_house_downstairs.tmx
@@ -56,7 +56,7 @@
   <object id="24" name="Watch TV" type="event" x="16" y="80" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog xero_taba_tvwatch"/>
-    <property name="cond10" value="is party_size greater_than,0"/>
+    <property name="cond10" value="is party_size player,greater_than,0"/>
     <property name="cond20" value="is char_at player"/>
     <property name="cond30" value="is char_facing player,up"/>
     <property name="cond40" value="is button_pressed K_RETURN"/>

--- a/mods/tuxemon/maps/rubberduck_route_01.tmx
+++ b/mods/tuxemon/maps/rubberduck_route_01.tmx
@@ -202,7 +202,7 @@
     <property name="act20" value="play_map_animation grass,0.1,noloop,player"/>
     <property name="cond10" value="is char_moved player"/>
     <property name="cond20" value="is char_at player"/>
-    <property name="cond30" value="is party_size greater_than,0"/>
+    <property name="cond30" value="is party_size player,greater_than,0"/>
    </properties>
   </object>
   <object id="10" name="Random Battle 3" type="event" x="384" y="544" width="96" height="48">
@@ -211,7 +211,7 @@
     <property name="act20" value="play_map_animation grass,0.1,noloop,player"/>
     <property name="cond10" value="is char_moved player"/>
     <property name="cond20" value="is char_at player"/>
-    <property name="cond30" value="is party_size greater_than,0"/>
+    <property name="cond30" value="is party_size player,greater_than,0"/>
    </properties>
   </object>
   <object id="11" name="Random Battle 3" type="event" x="304" y="688" width="144" height="80">
@@ -220,7 +220,7 @@
     <property name="act20" value="play_map_animation grass,0.1,noloop,player"/>
     <property name="cond10" value="is char_moved player"/>
     <property name="cond20" value="is char_at player"/>
-    <property name="cond30" value="is party_size greater_than,0"/>
+    <property name="cond30" value="is party_size player,greater_than,0"/>
    </properties>
   </object>
   <object id="12" name="Random Battle 3" type="event" x="144" y="480" width="80" height="32">
@@ -229,7 +229,7 @@
     <property name="act20" value="play_map_animation grass,0.1,noloop,player"/>
     <property name="cond10" value="is char_moved player"/>
     <property name="cond20" value="is char_at player"/>
-    <property name="cond30" value="is party_size greater_than,0"/>
+    <property name="cond30" value="is party_size player,greater_than,0"/>
    </properties>
   </object>
   <object id="13" name="Random Battle 3" type="event" x="176" y="512" width="48" height="16">
@@ -238,7 +238,7 @@
     <property name="act20" value="play_map_animation grass,0.1,noloop,player"/>
     <property name="cond10" value="is char_moved player"/>
     <property name="cond20" value="is char_at player"/>
-    <property name="cond30" value="is party_size greater_than,0"/>
+    <property name="cond30" value="is party_size player,greater_than,0"/>
    </properties>
   </object>
   <object id="15" name="Random Battle 3" type="event" x="432" y="144" width="128" height="32">
@@ -247,7 +247,7 @@
     <property name="act20" value="play_map_animation grass,0.1,noloop,player"/>
     <property name="cond10" value="is char_moved player"/>
     <property name="cond20" value="is char_at player"/>
-    <property name="cond30" value="is party_size greater_than,0"/>
+    <property name="cond30" value="is party_size player,greater_than,0"/>
    </properties>
   </object>
   <object id="16" name="Random Battle 3" type="event" x="464" y="176" width="48" height="32">
@@ -256,7 +256,7 @@
     <property name="act20" value="play_map_animation grass,0.1,noloop,player"/>
     <property name="cond10" value="is char_moved player"/>
     <property name="cond20" value="is char_at player"/>
-    <property name="cond30" value="is party_size greater_than,0"/>
+    <property name="cond30" value="is party_size player,greater_than,0"/>
    </properties>
   </object>
   <object id="17" name="Random Battle 3" type="event" x="480" y="128" width="80" height="16">
@@ -265,7 +265,7 @@
     <property name="act20" value="play_map_animation grass,0.1,noloop,player"/>
     <property name="cond10" value="is char_moved player"/>
     <property name="cond20" value="is char_at player"/>
-    <property name="cond30" value="is party_size greater_than,0"/>
+    <property name="cond30" value="is party_size player,greater_than,0"/>
    </properties>
   </object>
   <object id="18" name="Random Battle 3" type="event" x="160" y="224" width="48" height="64">
@@ -274,7 +274,7 @@
     <property name="act20" value="play_map_animation grass,0.1,noloop,player"/>
     <property name="cond10" value="is char_moved player"/>
     <property name="cond20" value="is char_at player"/>
-    <property name="cond30" value="is party_size greater_than,0"/>
+    <property name="cond30" value="is party_size player,greater_than,0"/>
    </properties>
   </object>
   <object id="46" name="Teleport to map1 (lower)" type="event" x="304" y="800" width="96" height="16">

--- a/mods/tuxemon/maps/sphalian_town_house.tmx
+++ b/mods/tuxemon/maps/sphalian_town_house.tmx
@@ -61,7 +61,7 @@
   <object id="24" name="Watch TV" type="event" x="32" y="96" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog old_sphalian_house01"/>
-    <property name="cond10" value="is party_size greater_than,0"/>
+    <property name="cond10" value="is party_size player,greater_than,0"/>
     <property name="cond20" value="is char_facing_tile player"/>
     <property name="cond30" value="is button_pressed K_RETURN"/>
    </properties>

--- a/mods/tuxemon/maps/spyder.yaml
+++ b/mods/tuxemon/maps/spyder.yaml
@@ -187,7 +187,7 @@ events:
     - set_variable cheat_apex:enabled
     conditions:
     - is check_char_parameter player,name,ApexPlayer
-    - is party_size equals,1
+    - is party_size player,equals,1
     - not variable_set cheat_apex:enabled
     - is current_state WorldState
     type: "event"

--- a/mods/tuxemon/maps/spyder_bedroom.yaml
+++ b/mods/tuxemon/maps/spyder_bedroom.yaml
@@ -85,6 +85,7 @@ events:
     - translated_dialog spyder_intro03
     - set_variable spyder_intro:yes
     - transition_teleport spyder_paper_mart.tmx,4,8,0.3
+    - char_face player,right
     conditions:
     - is variable_set question_intro:no
     - not variable_set spyder_intro:yes
@@ -93,6 +94,7 @@ events:
     actions:
     - set_variable spyder_intro:yes
     - transition_teleport spyder_paper_mart.tmx,4,8,0.3
+    - char_face player,right
     conditions:
     - is variable_set question_intro:yes
     - not variable_set spyder_intro:yes

--- a/mods/tuxemon/maps/spyder_candy_cafe.tmx
+++ b/mods/tuxemon/maps/spyder_candy_cafe.tmx
@@ -54,7 +54,7 @@
     <property name="act2" value="char_face player,down"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,down"/>
-    <property name="cond3" value="is party_size less_than,1"/>
+    <property name="cond3" value="is party_size player,less_than,1"/>
    </properties>
   </object>
   <object id="28" name="Player Spawn" type="event" x="176" y="0" width="16" height="16"/>

--- a/mods/tuxemon/maps/spyder_candy_town.tmx
+++ b/mods/tuxemon/maps/spyder_candy_town.tmx
@@ -279,7 +279,7 @@
     <property name="act60" value="remove_npc spyder_candy_henrik"/>
     <property name="cond1" value="is variable_set confiscation_candy:yes"/>
     <property name="cond2" value="not variable_set party_all_sick:yes"/>
-    <property name="cond3" value="is party_infected all"/>
+    <property name="cond3" value="is party_infected player,all"/>
     <property name="cond4" value="not variable_set confiscation_done:yes"/>
    </properties>
   </object>
@@ -294,7 +294,7 @@
     <property name="act50" value="remove_npc spyder_candy_henrik"/>
     <property name="cond1" value="is variable_set confiscation_candy:yes"/>
     <property name="cond2" value="not variable_set party_healthy:yes"/>
-    <property name="cond3" value="is party_infected none"/>
+    <property name="cond3" value="is party_infected player,none"/>
     <property name="cond4" value="not variable_set confiscation_done:yes"/>
     <property name="cond5" value="not variable_set party_sick:yes"/>
    </properties>
@@ -313,7 +313,7 @@
     <property name="act60" value="remove_npc spyder_candy_henrik"/>
     <property name="cond1" value="is variable_set confiscation_candy:yes"/>
     <property name="cond2" value="not variable_set party_sick:yes"/>
-    <property name="cond3" value="is party_infected some"/>
+    <property name="cond3" value="is party_infected player,some"/>
     <property name="cond4" value="not variable_set confiscation_done:yes"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_downstairs.tmx
+++ b/mods/tuxemon/maps/spyder_downstairs.tmx
@@ -89,7 +89,7 @@
     <property name="act1" value="translated_dialog spyder_papertown_mom2"/>
     <property name="act2" value="set_variable spokenmom:yes"/>
     <property name="behav1" value="talk spyder_papertown_mom"/>
-    <property name="cond1" value="is party_size less_than,1"/>
+    <property name="cond1" value="is party_size player,less_than,1"/>
     <property name="cond2" value="is variable_set spokenmom:yes"/>
    </properties>
   </object>
@@ -124,7 +124,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_papertown_mom3"/>
     <property name="behav1" value="talk spyder_papertown_mom"/>
-    <property name="cond1" value="is party_size greater_than,0"/>
+    <property name="cond1" value="is party_size player,greater_than,0"/>
     <property name="cond2" value="is variable_set spokenmom:yes"/>
     <property name="cond3" value="not variable_set zoolanderdefeat:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_paper_mart.yaml
+++ b/mods/tuxemon/maps/spyder_paper_mart.yaml
@@ -9,7 +9,6 @@ events:
     actions:
     - change_bg
     - lock_controls
-    - char_face player,right
     - create_npc spyder_paperscoop_santino,7,6
     - char_face spyder_paperscoop_santino,left
     - create_npc spyder_dante,7,7

--- a/mods/tuxemon/maps/spyder_paper_town.tmx
+++ b/mods/tuxemon/maps/spyder_paper_town.tmx
@@ -206,7 +206,7 @@
     <property name="act80" value="remove_npc spyder_dante"/>
     <property name="act81" value="unlock_controls"/>
     <property name="cond1" value="is char_at player"/>
-    <property name="cond2" value="is party_size less_than,1"/>
+    <property name="cond2" value="is party_size player,less_than,1"/>
    </properties>
   </object>
   <object id="157" name="Sign for Daycare, After Opening" type="event" x="256" y="64" width="16" height="16">
@@ -273,7 +273,7 @@
     <property name="act60" value="set_variable dantebin:yes"/>
     <property name="act70" value="unlock_controls"/>
     <property name="cond1" value="is char_at player"/>
-    <property name="cond2" value="is party_size less_than,1"/>
+    <property name="cond2" value="is party_size player,less_than,1"/>
     <property name="cond3" value="is variable_set dantefirst:yes"/>
     <property name="cond4" value="not variable_set dantebin:yes"/>
    </properties>
@@ -284,7 +284,7 @@
     <property name="act3" value="set_variable firstfightdue:yes"/>
     <property name="act4" value="set_variable mymonchoice:rockitten"/>
     <property name="cond1" value="is variable_set rockittenchosen:yes"/>
-    <property name="cond2" value="is party_size less_than,1"/>
+    <property name="cond2" value="is party_size player,less_than,1"/>
    </properties>
   </object>
   <object id="220" name="Chosen - Lambert" type="event" x="512" y="160" width="16" height="16">
@@ -293,7 +293,7 @@
     <property name="act3" value="set_variable firstfightdue:yes"/>
     <property name="act4" value="set_variable mymonchoice:lambert"/>
     <property name="cond1" value="is variable_set lambertchosen:yes"/>
-    <property name="cond2" value="is party_size less_than,1"/>
+    <property name="cond2" value="is party_size player,less_than,1"/>
    </properties>
   </object>
   <object id="221" name="Chosen - Nut" type="event" x="512" y="192" width="16" height="16">
@@ -302,7 +302,7 @@
     <property name="act3" value="set_variable firstfightdue:yes"/>
     <property name="act4" value="set_variable mymonchoice:nut"/>
     <property name="cond1" value="is variable_set nutchosen:yes"/>
-    <property name="cond2" value="is party_size less_than,1"/>
+    <property name="cond2" value="is party_size player,less_than,1"/>
    </properties>
   </object>
   <object id="222" name="Chosen - Tweesher" type="event" x="512" y="224" width="16" height="16">
@@ -311,7 +311,7 @@
     <property name="act3" value="set_variable firstfightdue:yes"/>
     <property name="act4" value="set_variable mymonchoice:tweesher"/>
     <property name="cond1" value="is variable_set tweesherchosen:yes"/>
-    <property name="cond2" value="is party_size less_than,1"/>
+    <property name="cond2" value="is party_size player,less_than,1"/>
    </properties>
   </object>
   <object id="223" name="Chosen - Agnite" type="event" x="512" y="256" width="16" height="16">
@@ -320,7 +320,7 @@
     <property name="act3" value="set_variable firstfightdue:yes"/>
     <property name="act4" value="set_variable mymonchoice:agnite"/>
     <property name="cond1" value="is variable_set agnitechosen:yes"/>
-    <property name="cond2" value="is party_size less_than,1"/>
+    <property name="cond2" value="is party_size player,less_than,1"/>
    </properties>
   </object>
   <object id="224" name="First Fight - Start" type="event" x="400" y="128" width="16" height="16">
@@ -495,7 +495,7 @@
     <property name="act80" value="remove_npc spyder_dante"/>
     <property name="act81" value="unlock_controls"/>
     <property name="cond1" value="is char_at player"/>
-    <property name="cond2" value="is party_size less_than,1"/>
+    <property name="cond2" value="is party_size player,less_than,1"/>
    </properties>
   </object>
   <object id="244" name="Teleport to Daycare Back" type="event" x="336" y="48" width="16" height="16">
@@ -541,7 +541,7 @@
     <property name="act61" value="set_variable dantebin:yes"/>
     <property name="act70" value="unlock_controls"/>
     <property name="cond1" value="is char_at player"/>
-    <property name="cond2" value="is party_size less_than,1"/>
+    <property name="cond2" value="is party_size player,less_than,1"/>
     <property name="cond3" value="not variable_set dantefirst:yes"/>
     <property name="cond4" value="not variable_set dantebin:yes"/>
    </properties>
@@ -555,7 +555,7 @@
     <property name="act30" value="translated_dialog_choice yes:no,rockittenchosen"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
-    <property name="cond3" value="is party_size less_than,1"/>
+    <property name="cond3" value="is party_size player,less_than,1"/>
    </properties>
   </object>
   <object id="242" name="Lambert" type="event" x="352" y="176" width="16" height="32">
@@ -567,7 +567,7 @@
     <property name="act30" value="translated_dialog_choice yes:no,lambertchosen"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
-    <property name="cond3" value="is party_size less_than,1"/>
+    <property name="cond3" value="is party_size player,less_than,1"/>
    </properties>
   </object>
   <object id="243" name="Nut" type="event" x="432" y="144" width="32" height="16">
@@ -579,7 +579,7 @@
     <property name="act30" value="translated_dialog_choice yes:no,nutchosen"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
-    <property name="cond3" value="is party_size less_than,1"/>
+    <property name="cond3" value="is party_size player,less_than,1"/>
    </properties>
   </object>
   <object id="245" name="Tweesher" type="event" x="464" y="144" width="32" height="16">
@@ -591,7 +591,7 @@
     <property name="act30" value="translated_dialog_choice yes:no,tweesherchosen"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
-    <property name="cond3" value="is party_size less_than,1"/>
+    <property name="cond3" value="is party_size player,less_than,1"/>
    </properties>
   </object>
   <object id="246" name="Agnite" type="event" x="480" y="176" width="16" height="32">
@@ -603,7 +603,7 @@
     <property name="act30" value="translated_dialog_choice yes:no,agnitechosen"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
-    <property name="cond3" value="is party_size less_than,1"/>
+    <property name="cond3" value="is party_size player,less_than,1"/>
    </properties>
   </object>
   <object id="250" name="Trash" type="event" x="368" y="208" width="32" height="16">

--- a/mods/tuxemon/maps/taba_town.tmx
+++ b/mods/tuxemon/maps/taba_town.tmx
@@ -749,7 +749,7 @@
     <property name="act40" value="translated_dialog gotfivetuxeballs"/>
     <property name="act60" value="char_face taba_greeter,down"/>
     <property name="cond10" value="not has_item player,tuxeball"/>
-    <property name="cond20" value="is party_size greater_than,0"/>
+    <property name="cond20" value="is party_size player,greater_than,0"/>
     <property name="cond30" value="is char_at player"/>
     <property name="cond40" value="not variable_set greeter_greets:yes"/>
    </properties>
@@ -762,7 +762,7 @@
     <property name="act30" value="translated_dialog taba_greeting2b"/>
     <property name="act60" value="char_face taba_greeter,down"/>
     <property name="cond10" value="is has_item player,tuxeball"/>
-    <property name="cond20" value="is party_size greater_than,0"/>
+    <property name="cond20" value="is party_size player,greater_than,0"/>
     <property name="cond30" value="is char_at player"/>
     <property name="cond40" value="not variable_set greeter_greets:yes"/>
    </properties>

--- a/tuxemon/event/conditions/has_party_breeder.py
+++ b/tuxemon/event/conditions/has_party_breeder.py
@@ -1,48 +1,48 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2024 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-from tuxemon.event import MapCondition
+import logging
+
+from tuxemon.db import EvolutionStage, GenderType
+from tuxemon.event import MapCondition, get_npc
 from tuxemon.event.eventcondition import EventCondition
 from tuxemon.session import Session
+
+logger = logging.getLogger(__name__)
 
 
 class HasPartyBreederCondition(EventCondition):
     """
-    Check to see if the player has a male and female
-    monsters not basic (first evolution stage)
-    in the party.
+    Check to see if the character has a male and female
+    monsters not basic (first evolution stage) in the party.
 
     Script usage:
         .. code-block::
 
-            is has_party_breeder
+            is has_party_breeder <character>
+
+    Script parameters:
+        character: Either "player" or npc slug name (e.g. "npc_maple").
 
     """
 
     name = "has_party_breeder"
 
     def test(self, session: Session, condition: MapCondition) -> bool:
-        """
-        Check to see if the player has a technique in his party.
-
-        Parameters:
-            session: The session object
-            condition: The map condition object.
-
-        Returns:
-            Whether the player has a technique in his party.
-
-        """
-        player = session.player
-        if any(
-            t
-            for t in player.monsters
-            if t.stage != "basic" and t.gender == "male"
-        ):
-            if any(
-                t
-                for t in player.monsters
-                if t.stage != "basic" and t.gender == "female"
-            ):
-                return True
-
-        return False
+        _character = condition.parameters[0]
+        basic = EvolutionStage.basic
+        male = GenderType.male
+        female = GenderType.female
+        character = get_npc(session, _character)
+        if character is None:
+            logger.error(f"{_character} not found")
+            return False
+        party = character.monsters
+        var1 = [
+            mon for mon in party if mon.stage != basic and mon.gender == male
+        ]
+        var2 = [
+            mon for mon in party if mon.stage != basic and mon.gender == female
+        ]
+        return any(var1) and any(var2)

--- a/tuxemon/event/conditions/party_size.py
+++ b/tuxemon/event/conditions/party_size.py
@@ -2,22 +2,27 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-from tuxemon.event import MapCondition
+import logging
+
+from tuxemon.event import MapCondition, get_npc
 from tuxemon.event.eventcondition import EventCondition
 from tuxemon.session import Session
 from tuxemon.tools import compare
 
+logger = logging.getLogger(__name__)
+
 
 class PartySizeCondition(EventCondition):
     """
-    Check the party size.
+    Check the character's party size.
 
     Script usage:
         .. code-block::
 
-            is party_size <operator>,<value>
+            is party_size <character>,<operator>,<value>
 
     Script parameters:
+        character: Either "player" or npc slug name (e.g. "npc_maple").
         operator: Numeric comparison operator. Accepted values are "less_than",
             "less_or_equal", "greater_than", "greater_or_equal", "equals"
             and "not_equals".
@@ -28,6 +33,9 @@ class PartySizeCondition(EventCondition):
     name = "party_size"
 
     def test(self, session: Session, condition: MapCondition) -> bool:
-        operator, value = condition.parameters[:2]
-        party_size = len(session.player.monsters)
-        return compare(operator, party_size, int(value))
+        _character, _operator, _value = condition.parameters[:3]
+        character = get_npc(session, _character)
+        if character is None:
+            logger.error(f"{_character} not found")
+            return False
+        return compare(_operator, len(character.monsters), int(_value))


### PR DESCRIPTION
PR continues #2149 task and it:
- adds the parameter "player" to **party_size** (event condition), it was hardcoded on player, but now the condition can be used for no matter which character;
- updates the structure of **party_infected** (event condition), same as above, hardcoded on player;
- updates the structure of **has_party_breeder** (event condition), same as above, hardcoded on player;
- adds **CheckCharParameterCondition** to the condition list (reminder from #2195)

from: `<property name="cond40" value="is party_size greater_than,0"/>`
to: `<property name="cond40" value="is party_size player,greater_than,0"/>`