### PR TITLE
sort and order event actions/conditions (maps)

### DIFF
--- a/mods/tuxemon/maps/citypark.tmx
+++ b/mods/tuxemon/maps/citypark.tmx
@@ -475,12 +475,14 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:grass"/>
    </properties>
   </object>
   <object id="125" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
     <property name="cond1" value="is variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:night_grass"/>
    </properties>
   </object>
   <object id="126" name="Teleport to Maniac House" type="event" x="576" y="48" width="16" height="16">

--- a/mods/tuxemon/maps/dryadsgrove.tmx
+++ b/mods/tuxemon/maps/dryadsgrove.tmx
@@ -172,12 +172,14 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:grass"/>
    </properties>
   </object>
   <object id="42" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
     <property name="cond1" value="is variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:night_grass"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/route1.tmx
+++ b/mods/tuxemon/maps/route1.tmx
@@ -843,12 +843,14 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:grass"/>
    </properties>
   </object>
   <object id="154" name="Environment Night" type="event" x="16" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
     <property name="cond1" value="is variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:night_grass"/>
    </properties>
   </object>
   <object id="155" name="Default" type="event" x="16" y="16" width="16" height="16">

--- a/mods/tuxemon/maps/route1_sanglorian.tmx
+++ b/mods/tuxemon/maps/route1_sanglorian.tmx
@@ -187,12 +187,14 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:grass"/>
    </properties>
   </object>
   <object id="162" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
     <property name="cond1" value="is variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:night_grass"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/route2.tmx
+++ b/mods/tuxemon/maps/route2.tmx
@@ -534,12 +534,14 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:grass"/>
    </properties>
   </object>
   <object id="138" name="Environment Night" type="event" x="16" y="16" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
     <property name="cond1" value="is variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:night_grass"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/route3.tmx
+++ b/mods/tuxemon/maps/route3.tmx
@@ -362,12 +362,14 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:grass"/>
    </properties>
   </object>
   <object id="179" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
     <property name="cond1" value="is variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:night_grass"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/route4.tmx
+++ b/mods/tuxemon/maps/route4.tmx
@@ -96,12 +96,14 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:grass"/>
    </properties>
   </object>
   <object id="38" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
     <property name="cond1" value="is variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:night_grass"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/route5.tmx
+++ b/mods/tuxemon/maps/route5.tmx
@@ -80,12 +80,14 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:grass"/>
    </properties>
   </object>
   <object id="21" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
     <property name="cond1" value="is variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:night_grass"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/route6.tmx
+++ b/mods/tuxemon/maps/route6.tmx
@@ -206,12 +206,14 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:grass"/>
    </properties>
   </object>
   <object id="72" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
     <property name="cond1" value="is variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:night_grass"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/routea.tmx
+++ b/mods/tuxemon/maps/routea.tmx
@@ -123,12 +123,14 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:grass"/>
    </properties>
   </object>
   <object id="58" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
     <property name="cond1" value="is variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:night_grass"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder.yaml
+++ b/mods/tuxemon/maps/spyder.yaml
@@ -100,24 +100,41 @@ events:
     - remove_collision water
     conditions:
     - is variable_set swimming:yes
+    - is current_state WorldState
     type: "event"
   Swim Encounters Day:
     actions:
-    - set_variable environment:sea
     - random_encounter routec,0.25
     conditions:
     - is char_sprite player,swimmer
-    - not variable_set stage_of_day:night
     - is current_state WorldState
+    - is check_char_parameter player,moving,1
+    - is variable_set environment:ocean
     type: "event"
   Swim Encounters Night:
     actions:
-    - set_variable environment:night_sea
     - random_encounter routec,0.75
     conditions:
     - is char_sprite player,swimmer
-    - is variable_set stage_of_day:night
     - is current_state WorldState
+    - is check_char_parameter player,moving,1
+    - is variable_set environment:night_ocean
+    type: "event"
+  Swim Day Environment:
+    actions:
+    - set_variable environment:ocean
+    conditions:
+    - is char_sprite player,swimmer
+    - not variable_set stage_of_day:night
+    - not variable_set environment:ocean
+    type: "event"
+  Swim Night Environment:
+    actions:
+    - set_variable environment:night_ocean
+    conditions:
+    - is char_sprite player,swimmer
+    - is variable_set stage_of_day:night
+    - not variable_set environment:night_ocean
     type: "event"
   Night Day Cycle Outside:
     actions:
@@ -184,6 +201,7 @@ events:
     - add_monster arthrobolt,100
     - add_monster eaglace,100
     - add_monster agnigon,100
+    - set_monster_plague ,inoculated
     - set_variable cheat_apex:enabled
     conditions:
     - is check_char_parameter player,name,ApexPlayer

--- a/mods/tuxemon/maps/spyder_citypark.tmx
+++ b/mods/tuxemon/maps/spyder_citypark.tmx
@@ -492,12 +492,14 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:grass"/>
    </properties>
   </object>
   <object id="82" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
     <property name="cond1" value="is variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:night_grass"/>
    </properties>
   </object>
   <object id="83" name="Talk Bobette" type="event" x="208" y="272" width="48" height="16">

--- a/mods/tuxemon/maps/spyder_cotton_town.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_town.tmx
@@ -377,12 +377,14 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:grass"/>
    </properties>
   </object>
   <object id="582" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
     <property name="cond1" value="is variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:night_grass"/>
    </properties>
   </object>
   <object id="587" name="Nu Phone Mom" type="event" x="496" y="272" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_cotton_tunnel.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_tunnel.tmx
@@ -127,6 +127,7 @@
   <object id="65" name="Encounters" type="event" x="0" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="random_encounter cotton_tunnel,0.6"/>
+    <property name="cond1" value="is check_char_parameter player,moving,1"/>
    </properties>
   </object>
   <object id="84" name="Create Petrified Dung" type="event" x="384" y="240" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_datacenter.tmx
+++ b/mods/tuxemon/maps/spyder_datacenter.tmx
@@ -349,6 +349,7 @@
    <properties>
     <property name="act1" value="random_encounter datacenter,0.6"/>
     <property name="cond1" value="not variable_set kernelquest:done"/>
+    <property name="cond2" value="is check_char_parameter player,moving,1"/>
    </properties>
   </object>
   <object id="103" name="PC7 No" type="event" x="128" y="192" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_dragonscave.tmx
+++ b/mods/tuxemon/maps/spyder_dragonscave.tmx
@@ -484,6 +484,7 @@
    <properties>
     <property name="act1" value="random_encounter dragonscave,0.6"/>
     <property name="cond1" value="not variable_set dragonscavebenden:yes"/>
+    <property name="cond2" value="is check_char_parameter player,moving,1"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_dryadsgrove.tmx
+++ b/mods/tuxemon/maps/spyder_dryadsgrove.tmx
@@ -789,12 +789,14 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:grass"/>
    </properties>
   </object>
   <object id="224" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
     <property name="cond1" value="is variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:night_grass"/>
    </properties>
   </object>
   <object id="220" name="Talk Aquemini" type="event" x="544" y="192" width="16" height="48">

--- a/mods/tuxemon/maps/spyder_flower_city.tmx
+++ b/mods/tuxemon/maps/spyder_flower_city.tmx
@@ -529,12 +529,14 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:grass"/>
    </properties>
   </object>
   <object id="467" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
     <property name="cond1" value="is variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:night_grass"/>
    </properties>
   </object>
   <object id="468" name="Sign: Flower Scoop" type="event" x="352" y="368" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_leather_town.tmx
+++ b/mods/tuxemon/maps/spyder_leather_town.tmx
@@ -442,12 +442,14 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:grass"/>
    </properties>
   </object>
   <object id="304" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
     <property name="cond1" value="is variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:night_grass"/>
    </properties>
   </object>
   <object id="306" name="Sign: Leather Scoop" type="event" x="192" y="144" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_lion_mountain.tmx
+++ b/mods/tuxemon/maps/spyder_lion_mountain.tmx
@@ -202,12 +202,14 @@
    <properties>
     <property name="act1" value="set_variable environment:snow"/>
     <property name="cond1" value="not variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:snow"/>
    </properties>
   </object>
   <object id="6" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_snow"/>
     <property name="cond1" value="is variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:night_snow"/>
    </properties>
   </object>
   <object id="7" name="Player Spawn" type="event" x="64" y="1440" width="16" height="16"/>

--- a/mods/tuxemon/maps/spyder_omnichannel1.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel1.tmx
@@ -190,6 +190,7 @@
    <properties>
     <property name="act1" value="random_encounter omnichannel,0.6"/>
     <property name="cond1" value="is variable_set omnichannel1wall:yes"/>
+    <property name="cond2" value="is check_char_parameter player,moving,1"/>
    </properties>
   </object>
   <object id="49" name="Create Screen" type="event" x="112" y="288" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_omnichannel2.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel2.tmx
@@ -205,6 +205,7 @@
    <properties>
     <property name="act1" value="random_encounter omnichannel,0.6"/>
     <property name="cond1" value="is variable_set omnichannel1wall:yes"/>
+    <property name="cond2" value="is check_char_parameter player,moving,1"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_omnichannel3.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel3.tmx
@@ -168,6 +168,7 @@
    <properties>
     <property name="act1" value="random_encounter omnichannel,0.6"/>
     <property name="cond1" value="is variable_set omnichannel1wall:yes"/>
+    <property name="cond2" value="is check_char_parameter player,moving,1"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_omnichannel4.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel4.tmx
@@ -108,6 +108,7 @@
    <properties>
     <property name="act1" value="random_encounter omnichannel,0.6"/>
     <property name="cond1" value="is variable_set omnichannel1wall:yes"/>
+    <property name="cond2" value="is check_char_parameter player,moving,1"/>
    </properties>
   </object>
   <object id="41" name="No Pass 2" type="event" x="192" y="16" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_route1.tmx
+++ b/mods/tuxemon/maps/spyder_route1.tmx
@@ -185,12 +185,14 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:grass"/>
    </properties>
   </object>
   <object id="191" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
     <property name="cond1" value="is variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:night_grass"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_route2.tmx
+++ b/mods/tuxemon/maps/spyder_route2.tmx
@@ -572,12 +572,14 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:grass"/>
    </properties>
   </object>
   <object id="192" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
     <property name="cond1" value="is variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:night_grass"/>
    </properties>
   </object>
   <object id="188" name="Talk roddick" type="event" x="80" y="64" width="16" height="80">

--- a/mods/tuxemon/maps/spyder_route3.tmx
+++ b/mods/tuxemon/maps/spyder_route3.tmx
@@ -653,12 +653,14 @@
    <properties>
     <property name="act1" value="set_variable environment:sand"/>
     <property name="cond1" value="not variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:sand"/>
    </properties>
   </object>
   <object id="687" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_sand"/>
     <property name="cond1" value="is variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:night_sand"/>
    </properties>
   </object>
   <object id="679" name="Enforcer Talk" type="event" x="272" y="144" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_route4.tmx
+++ b/mods/tuxemon/maps/spyder_route4.tmx
@@ -369,12 +369,14 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:grass"/>
    </properties>
   </object>
   <object id="87" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
     <property name="cond1" value="is variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:night_grass"/>
    </properties>
   </object>
   <object id="82" name="Talk Marshall" type="event" x="48" y="464" width="48" height="16">

--- a/mods/tuxemon/maps/spyder_route5.tmx
+++ b/mods/tuxemon/maps/spyder_route5.tmx
@@ -355,12 +355,14 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:grass"/>
    </properties>
   </object>
   <object id="67" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
     <property name="cond1" value="is variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:night_grass"/>
    </properties>
   </object>
   <object id="62" name="Talk Sara" type="event" x="384" y="128" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_route6.tmx
+++ b/mods/tuxemon/maps/spyder_route6.tmx
@@ -434,12 +434,14 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:grass"/>
    </properties>
   </object>
   <object id="219" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
     <property name="cond1" value="is variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:night_grass"/>
    </properties>
   </object>
   <object id="213" name="Talk Maxwell" type="event" x="64" y="80" width="96" height="16">

--- a/mods/tuxemon/maps/spyder_route7.tmx
+++ b/mods/tuxemon/maps/spyder_route7.tmx
@@ -113,12 +113,14 @@
    <properties>
     <property name="act1" value="set_variable environment:cliff"/>
     <property name="cond1" value="not variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:cliff"/>
    </properties>
   </object>
   <object id="8" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_cliff"/>
     <property name="cond1" value="is variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:night_cliff"/>
    </properties>
   </object>
   <object id="9" name="Sign" type="event" x="80" y="560" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_routea.tmx
+++ b/mods/tuxemon/maps/spyder_routea.tmx
@@ -173,12 +173,14 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:grass"/>
    </properties>
   </object>
   <object id="68" name="Environment Night" type="event" x="80" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
     <property name="cond1" value="is variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:night_grass"/>
    </properties>
   </object>
   <object id="69" name="Billie" type="event" x="256" y="288" width="32" height="16">

--- a/mods/tuxemon/maps/spyder_routeb.tmx
+++ b/mods/tuxemon/maps/spyder_routeb.tmx
@@ -186,12 +186,14 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="is variable_set daytime:true"/>
+    <property name="cond2" value="not variable_set environment:grass"/>
    </properties>
   </object>
   <object id="82" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
     <property name="cond1" value="is variable_set daytime:false"/>
+    <property name="cond2" value="not variable_set environment:night_grass"/>
    </properties>
   </object>
   <object id="184" name="Billie" type="event" x="48" y="576" width="16" height="32">

--- a/mods/tuxemon/maps/spyder_routec.tmx
+++ b/mods/tuxemon/maps/spyder_routec.tmx
@@ -247,12 +247,14 @@
    <properties>
     <property name="act1" value="set_variable environment:ocean"/>
     <property name="cond1" value="not variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:ocean"/>
    </properties>
   </object>
   <object id="228" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_ocean"/>
     <property name="cond1" value="is variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:night_ocean"/>
    </properties>
   </object>
   <object id="222" name="Talk Rutherford" type="event" x="544" y="144" width="16" height="48">

--- a/mods/tuxemon/maps/spyder_routee.tmx
+++ b/mods/tuxemon/maps/spyder_routee.tmx
@@ -107,12 +107,14 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="is variable_set daytime:true"/>
+    <property name="cond2" value="not variable_set environment:grass"/>
    </properties>
   </object>
   <object id="79" name="Environment Night" type="event" x="32" y="208" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
     <property name="cond1" value="is variable_set daytime:false"/>
+    <property name="cond2" value="not variable_set environment:night_grass"/>
    </properties>
   </object>
   <object id="83" name="Create Calliope" type="event" x="96" y="224" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_timber_town.tmx
+++ b/mods/tuxemon/maps/spyder_timber_town.tmx
@@ -332,12 +332,14 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:grass"/>
    </properties>
   </object>
   <object id="358" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
     <property name="cond1" value="is variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:night_grass"/>
    </properties>
   </object>
   <object id="356" name="Destination - Timber" type="event" x="80" y="288" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_tunnel.tmx
+++ b/mods/tuxemon/maps/spyder_tunnel.tmx
@@ -307,12 +307,14 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="is variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:grass"/>
    </properties>
   </object>
   <object id="360" name="Environment Night" type="event" x="32" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
     <property name="cond1" value="not variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:night_grass"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_tunnel_below.tmx
+++ b/mods/tuxemon/maps/spyder_tunnel_below.tmx
@@ -182,6 +182,7 @@
   <object id="42" name="Encounters" type="event" x="0" y="64" width="16" height="16">
    <properties>
     <property name="act1" value="random_encounter routeb,0.6"/>
+    <property name="cond1" value="is check_char_parameter player,moving,1"/>
    </properties>
   </object>
   <object id="54" name="Create Shammer" type="event" x="32" y="608" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
+++ b/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
@@ -176,6 +176,18 @@
     <property name="cond1" value="is variable_set wayfarer1_botbot:yes"/>
     <property name="cond2" value="is variable_set quebotbot:yes"/>
     <property name="cond3" value="not variable_set gotbotbot:yes"/>
+    <property name="cond4" value="not check_char_parameter player,name,ApexPlayer"/>
+   </properties>
+  </object>
+  <object id="38" name="Talk Maniac - Got Botbot - Cheat" type="event" x="112" y="112" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_wayfarer1_maniac1"/>
+    <property name="act2" value="add_monster botbot,10"/>
+    <property name="act3" value="set_variable gotbotbot:yes"/>
+    <property name="cond1" value="is variable_set wayfarer1_botbot:yes"/>
+    <property name="cond2" value="is variable_set quebotbot:yes"/>
+    <property name="cond3" value="not variable_set gotbotbot:yes"/>
+    <property name="cond4" value="is check_char_parameter player,name,ApexPlayer"/>
    </properties>
   </object>
   <object id="80" name="Talk Maniac - Followup Yes" type="event" x="112" y="112" width="16" height="16">

--- a/mods/tuxemon/maps/taba_town.tmx
+++ b/mods/tuxemon/maps/taba_town.tmx
@@ -878,12 +878,14 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:grass"/>
    </properties>
   </object>
   <object id="180" name="Environment Night" type="event" x="16" y="16" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
     <property name="cond1" value="is variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:night_grass"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/tunnel.tmx
+++ b/mods/tuxemon/maps/tunnel.tmx
@@ -233,12 +233,14 @@
    <properties>
     <property name="act1" value="set_variable environment:grass"/>
     <property name="cond1" value="not variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:grass"/>
    </properties>
   </object>
   <object id="108" name="Environment Night" type="event" x="16" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="set_variable environment:night_grass"/>
     <property name="cond1" value="is variable_set stage_of_day:night"/>
+    <property name="cond2" value="not variable_set environment:night_grass"/>
    </properties>
   </object>
  </objectgroup>


### PR DESCRIPTION
PR:
- stops some loops by adding **not variable_set** condition, without this condition the event keeps to overwrite the same variable;
- fixes **environment** (battle) when swimming (**ocean** instead of sea, so it's the same like routec, Spyder);
- splits out the **set_variable environment** from the main one (Spyder.yaml) - related to swim;
- adds **is check_char_parameter player,moving,1** condition to **random_encounter**, there are some places where you can bump into a random encounter everywhere (eg caves), without this (new condition) it was checking for a random encounter every click and not only when moving (really annoying, because it was possible to trigger an encounter immediately after fighting against another one); the checking is doing nothing more than check if the player is moving (1) true, (0) false;
- adds **set_monster_plague ,inoculated** to the monsters  - cheat ApexPlayer (reminder from #2195);
- adds alternative event in **wayfarer inn** (Spyder), so the monster doesn't get sick  - cheat ApexPlayer (reminder from #2195)

@Sanglorian the last two points complete the cheat code, the others are quality of life

before:
```
    <property name="act1" value="set_variable environment:grass"/>
    <property name="cond1" value="not variable_set stage_of_day:night"/>
```
after
```
    <property name="act1" value="set_variable environment:grass"/>
    <property name="cond1" value="not variable_set stage_of_day:night"/>
    <property name="cond2" value="not variable_set environment:grass"/>
```