### PR TITLE
transition (various event actions)

### DIFF
--- a/tuxemon/event/actions/delayed_teleport.py
+++ b/tuxemon/event/actions/delayed_teleport.py
@@ -2,11 +2,14 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.states.world.worldstate import WorldState
+
+logger = logging.getLogger(__name__)
 
 
 @final
@@ -37,11 +40,10 @@ class DelayedTeleportAction(EventAction):
     position_y: int
 
     def start(self) -> None:
-        # Get the world object from the session
         world = self.session.client.get_state_by_name(WorldState)
 
-        # give up if there is a teleport in progress
         if world.delayed_teleport:
+            logger.error("Stop, there is a teleport in progress")
             return
 
         world.delayed_teleport = True

--- a/tuxemon/event/actions/screen_transition.py
+++ b/tuxemon/event/actions/screen_transition.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional, final
 
-from tuxemon import prepare
 from tuxemon.event.eventaction import EventAction
 from tuxemon.graphics import ColorLike, string_to_colorlike
+from tuxemon.prepare import BLACK_COLOR, TRANS_TIME
 from tuxemon.states.world.worldstate import WorldState
 
 
@@ -20,10 +20,10 @@ class ScreenTransitionAction(EventAction):
     Script usage:
         .. code-block::
 
-            screen_transition [transition_time][,rgb]
+            screen_transition [trans_time][,rgb]
 
     Script parameters:
-        transition_time: Transition time in seconds - default 2
+        trans_time: Transition time in seconds - default 0.3
         rgb: color (eg red > 255,0,0 > 255:0:0) - default rgb(0,0,0)
 
     eg: "screen_transition 3"
@@ -32,7 +32,7 @@ class ScreenTransitionAction(EventAction):
     """
 
     name = "screen_transition"
-    transition_time: Optional[float] = None
+    trans_time: Optional[float] = None
     rgb: Optional[str] = None
 
     def start(self) -> None:
@@ -40,15 +40,11 @@ class ScreenTransitionAction(EventAction):
 
     def update(self) -> None:
         world = self.session.client.get_state_by_name(WorldState)
-        if not self.transition_time:
-            self.transition_time = 2.0
-        rgb: ColorLike = prepare.BLACK_COLOR
+        _time = TRANS_TIME if self.trans_time is None else self.trans_time
+        rgb: ColorLike = BLACK_COLOR
         if self.rgb:
             rgb = string_to_colorlike(self.rgb)
 
         if not world.in_transition:
-            if self.rgb:
-                world.fade_and_teleport(self.transition_time, rgb)
-            else:
-                world.fade_and_teleport(self.transition_time, rgb)
+            world.fade_and_teleport(_time, rgb)
             self.stop()

--- a/tuxemon/event/actions/teleport.py
+++ b/tuxemon/event/actions/teleport.py
@@ -2,12 +2,15 @@
 # Copyright (c) 2014-2023 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
-from typing import Optional, final
+from typing import final
 
 from tuxemon import prepare
 from tuxemon.event.eventaction import EventAction
 from tuxemon.states.world.worldstate import WorldState
+
+logger = logging.getLogger(__name__)
 
 
 @final
@@ -32,27 +35,19 @@ class TeleportAction(EventAction):
     map_name: str
     x: int
     y: int
-    # This value is unused, but in too many places to remove right now
-    _: Optional[float] = None
 
     def start(self) -> None:
         player = self.session.player
         world = self.session.client.get_state_by_name(WorldState)
 
-        # If we're doing a screen transition with this teleport, set the map
-        # name that we'll load during the apex of the transition.
+        # Check to see if we're also performing a transition. If we are, wait
+        # to perform the teleport at the apex of the transition
         # TODO: This only needs to happen once.
         if world.in_transition:
             world.delayed_mapname = self.map_name
-
-        # Check to see if we're also performing a transition. If we are, wait
-        # to perform the teleport at the apex of the transition
-        if world.in_transition:
-            # the world state will handle the teleport/transition, hopefully
             world.delayed_teleport = True
             world.delayed_x = self.x
             world.delayed_y = self.y
-
         else:
             # If we're not doing a transition, then just do the teleport
             map_path = prepare.fetch("maps", self.map_name)
@@ -62,14 +57,14 @@ class TeleportAction(EventAction):
 
             elif map_path != world.current_map.filename:
                 world.change_map(map_path)
+                logger.debug(f"Load {map_path}")
 
-            # Stop the player's movement so they don't continue their move
-            # after they teleported.
+            logger.debug(f"Stop {player.slug}'s movements")
             player.cancel_path()
 
-            # must change position after the map is loaded
+            logger.debug(f"Set {player.slug}'s position")
+            logger.debug(f"Tile: ({self.x},{self.y})")
             player.set_position((self.x, self.y))
 
-            # unlock_controls will reset controls, but start moving if keys
-            # are pressed
+            logger.debug(f"Unlock {player.slug}'s controls")
             world.unlock_controls()

--- a/tuxemon/event/actions/teleport_faint.py
+++ b/tuxemon/event/actions/teleport_faint.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import final
+from typing import Optional, final
 
 from tuxemon.event.eventaction import EventAction
+from tuxemon.prepare import TRANS_TIME
 
 logger = logging.getLogger(__name__)
 
@@ -23,30 +24,30 @@ class TeleportFaintAction(EventAction):
     Script usage:
         .. code-block::
 
-            teleport_faint
+            teleport_faint [trans_time]
+
+    Script parameters:
+        trans_time: Transition time in seconds - default 0.3
 
     """
 
     name = "teleport_faint"
+    trans_time: Optional[float] = None
 
     def start(self) -> None:
         player = self.session.player
         client = self.session.client
-        # this function cleans up the previous state without crashing
-        assert client.current_state
-        if client.current_state.name == "DialogState":
+        current_state = client.current_state
+        if current_state and current_state.name == "DialogState":
             client.pop_state()
 
-        # If game variable exists, then teleport:
         if "teleport_faint" in player.game_variables:
             teleport = str(player.game_variables["teleport_faint"]).split(" ")
         else:
-            logger.error(
-                "Teleport_faint action failed, because the teleport_faint variable has not been set."
-            )
+            logger.error("The teleport_faint variable has not been set.")
             return
 
-        # Start the screen transition
-        client.event_engine.execute_action("screen_transition", [0.3], True)
-        # Call the teleport action
-        client.event_engine.execute_action("teleport", teleport, True)
+        _time = TRANS_TIME if self.trans_time is None else self.trans_time
+        action = client.event_engine
+        action.execute_action("screen_transition", [_time], True)
+        action.execute_action("teleport", teleport, True)

--- a/tuxemon/prepare.py
+++ b/tuxemon/prepare.py
@@ -194,6 +194,7 @@ PLAYER_NAME_LIMIT: int = 15  # The character limit for a player name.
 PARTY_LIMIT: int = 6  # The maximum number of tuxemon this npc can hold
 #  Moverate limits to avoid losing sprites
 MOVERATE_RANGE: tuple[float, float] = (0.0, 20.0)
+TRANS_TIME: float = 0.3  # transition time
 
 # PC
 KENNEL: str = "Kennel"

--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -196,6 +196,7 @@ class WorldState(state.State):
 
         Parameters:
             duration: Duration of the fade out. The fade in is slightly larger.
+            color: Fade's color.
 
         """
 
@@ -224,6 +225,7 @@ class WorldState(state.State):
 
         Parameters:
             duration: Duration of the fade in.
+            color: Fade's color.
 
         """
         self.set_transition_surface(color)
@@ -244,6 +246,7 @@ class WorldState(state.State):
 
         Parameters:
             duration: Duration of the fade out.
+            color: Fade's color.
 
         """
         self.set_transition_surface(color)


### PR DESCRIPTION
PR:
- updates **screen_transition**, moves the default value (**0.3**, since it's used 99% of the occasions) inside prepare.py as constant;
- updates **teleport_faint** by replacing the hardcoded value with the constant (related to screen transition);
- updates **transition_teleport** by replacing the hardcoded value with the constant + it simplifies the structure + fixes bug, since the value **trans_time** wasn't passed in the action, so all the float at the end of the action were completely pointless (default was 0.3); -> this means that we could mass remove all the 0.3 at the end of **transition_teleport**; 
- removes from **teleport** the **_: Optional[float] = None**, since it's not used anymore; teleport is used a handful of times and it doesn't show any float value;
- fix #2222 by adding the optional value "trans_time", in this way the modder can decide the length of the transition (by default as usual 0.3); 