### PR TITLE
check world (event condition) + set_monster_health (event action)

### DIFF
--- a/docs/handcrafted/condition_list.rst
+++ b/docs/handcrafted/condition_list.rst
@@ -11,6 +11,7 @@
 .. autoscriptinfoclass:: tuxemon.event.conditions.char_sprite.CharSpriteCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.check_evolution.CheckEvolutionCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.check_mission.CheckMissionCondition
+.. autoscriptinfoclass:: tuxemon.event.conditions.check_world.CheckWorldCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.current_state.CurrentStateCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.has_bag.HasBagCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.has_box.HasBoxCondition

--- a/mods/tuxemon/maps/spyder.yaml
+++ b/mods/tuxemon/maps/spyder.yaml
@@ -125,6 +125,7 @@ events:
     conditions:
     - is variable_set stage_of_day:night
     - not location_inside
+    - not check_world layer,0:0:128:128
     type: "event"
   Night Day Cycle Inside:
     actions:
@@ -132,6 +133,7 @@ events:
     conditions:
     - is variable_set stage_of_day:night
     - is location_inside
+    - not check_world layer,255:255:255:0
     type: "event"
   Phone GPS Leather:
     actions:

--- a/tuxemon/event/actions/set_monster_health.py
+++ b/tuxemon/event/actions/set_monster_health.py
@@ -46,8 +46,8 @@ class SetMonsterHealthAction(EventAction):
         else:
             monster.current_hp += int(value)
         # checks max and min
-        if monster.current_hp < 0:
-            monster.current_hp = 0
+        if monster.current_hp <= 0:
+            monster.faint()
         if monster.current_hp > monster.hp:
             monster.current_hp = monster.hp
         logger.info(f"{monster.name}'s {monster.current_hp} HP")

--- a/tuxemon/event/conditions/check_world.py
+++ b/tuxemon/event/conditions/check_world.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2024 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import final
+
+from tuxemon.event import MapCondition, get_npc
+from tuxemon.event.eventcondition import EventCondition
+from tuxemon.graphics import string_to_colorlike
+from tuxemon.session import Session
+from tuxemon.states.world.worldstate import WorldState
+
+logger = logging.getLogger(__name__)
+
+
+@final
+@dataclass
+class CheckWorldCondition(EventCondition):
+    """
+    Check some world's parameter against a given value.
+
+    Script usage:
+        .. code-block::
+
+            check_world <parameter>,<value>
+
+    Script parameters:
+        parameter: Name of the parameter to check (eg. "layer", etc.).
+        value: Given value to check.
+
+    layer: color value which is used to overlay the world
+    bubble: speech bubble of an npc
+
+    eg. "check_world layer,255:255:255:0"
+
+    """
+
+    name = "check_world"
+
+    def test(self, session: Session, condition: MapCondition) -> bool:
+        world = session.client.get_state_by_name(WorldState)
+        params = condition.parameters
+        if params[0] == "layer":
+            rgb = string_to_colorlike(params[1])
+            return world.layer_color == rgb
+        if params[0] == "bubble":
+            char = get_npc(session, params[1])
+            if char is None:
+                logger.error(f"{params[1]} not found")
+                return False
+            return char in world.bubble
+        return False


### PR DESCRIPTION
PR:
- fixes set_monster_health, if someone sets the hp at 0 (= faint) with `set_monster_health variable,-1.0`, then the monster doesn't faint; the fix changes `monster.current_hp < 0:` into `monster.current_hp <= 0:` since the monster is going to be fainted at 0 HP too; it replaces also the `current_hp = 0` with the `monster.faint()`;
- adds the event condition **check_world**, this will check for specific parameter of the world state.

at the moment there are two:
- **layer** (related to **set_layer** event action);
- **bubble** (related to **set_bubble** event action);

in this way the action stops and it doesn't keep running; it can be handy for modders too.
