### PR TITLE
updates play map animation (event action)

### DIFF
--- a/tuxemon/event/actions/play_map_animation.py
+++ b/tuxemon/event/actions/play_map_animation.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Union, final
+from typing import Optional, Union, final
 
 from tuxemon import prepare
+from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.graphics import load_animation_from_frames
 from tuxemon.states.world.worldstate import WorldState
@@ -23,7 +24,7 @@ class PlayMapAnimationAction(EventAction):
     Script usage:
         .. code-block::
 
-            play_map_animation <animation_name> <duration> <loop> "player"
+            play_map_animation <animation_name> <duration> <loop> "npc_slug"
             play_map_animation <animation_name> <duration> <loop> <tile_pos_x> <tile_pos_y>
 
     Script parameters:
@@ -32,8 +33,8 @@ class PlayMapAnimationAction(EventAction):
             "grass" will load frames called "grass.xxx.png".
         duration: The duration of each frame of the animation in seconds.
         loop: Can be either "loop" or "noloop" to loop the animation.
-        tile_pos: Can be either an x,y coordinate or "player" to draw the
-            animation at the player's location.
+        tile_pos: Can be either an x,y coordinate or "npc_slug" to draw the
+            animation at the character's location.
 
     """
 
@@ -42,7 +43,7 @@ class PlayMapAnimationAction(EventAction):
     duration: float
     loop: str
     tile_pos_x: Union[int, str]
-    tile_pos_y: Union[int, None] = None
+    tile_pos_y: Optional[int] = None
 
     def start(self) -> None:
         # ('play_animation', 'grass,1.5,noloop,player', '1', 6)
@@ -57,28 +58,29 @@ class PlayMapAnimationAction(EventAction):
         else:
             raise ValueError('animation loop value must be "loop" or "noloop"')
 
-        # Check to see if this animation has already been loaded.
-        # If it has, play the animation.
         world_state = self.session.client.get_state_by_name(WorldState)
 
         # Determine the tile position where to draw the animation.
         # TODO: unify npc/player sprites and map animations
-        if self.tile_pos_x == "player":
-            position = self.session.player.tile_pos
+        if isinstance(self.tile_pos_x, str):
+            character = get_npc(self.session, self.tile_pos_x)
+            if character is None:
+                logger.error(f"{self.tile_pos_x} not found")
+                return
+            position = character.tile_pos
         else:
-            assert self.tile_pos_y
-            position = (
-                int(self.tile_pos_x),
-                int(self.tile_pos_y),
-            )
+            if self.tile_pos_y is None:
+                logger.error("Y coordinate is missing.")
+                return
+            position = ((self.tile_pos_x), (self.tile_pos_y))
 
         animations = world_state.map_animations
         if animation_name in animations:
+            logger.debug(f"{animation_name} loaded")
             animations[animation_name]["position"] = position
             animations[animation_name]["animation"].play()
-
         else:
-            # Not loaded already, so load it...
+            logger.debug(f"{animation_name} not loaded, loading")
             animation = load_animation_from_frames(
                 directory,
                 animation_name,


### PR DESCRIPTION
PR:
- removes the hardcoded player from **play_map_animation** (event action), but it doesn't change the structure, in this way the modder can use other NPC slugs;

```
    <property name="act1" value="play_map_animation grass,0.1,noloop,npc_maple"/>
    <property name="cond1" value="is char_moved npc_maple"/>
    <property name="cond2" value="is char_at npc_maple"/>
```