### PR TITLE
event type inits

### DIFF
--- a/tuxemon/client.py
+++ b/tuxemon/client.py
@@ -64,7 +64,7 @@ class LocalPygameClient:
 
         # somehow this value is being patched somewhere
         self.events: Sequence[EventObject] = []
-        self.inits: Sequence[EventObject] = []
+        self.inits: list[EventObject] = []
 
         # setup controls
         keyboard = PygameKeyboardInput(config.keyboard_button_map)
@@ -144,7 +144,7 @@ class LocalPygameClient:
 
         """
         self.events = map_data.events
-        self.inits = map_data.inits
+        self.inits = list(map_data.inits)
         self.event_engine.reset()
         self.event_engine.current_map = map_data
         self.maps = map_data.maps

--- a/tuxemon/event/eventengine.py
+++ b/tuxemon/event/eventengine.py
@@ -296,6 +296,8 @@ class EventEngine:
             token = RunningEvent(map_event)
             assert map_event.id
             self.running_events[map_event.id] = token
+            if map_event in self.session.client.inits:
+                self.session.client.inits.remove(map_event)
 
     def process_map_event(self, map_event: EventObject) -> None:
         """
@@ -364,12 +366,10 @@ class EventEngine:
 
         """
         # do the "init" events.  this will be done just once
-        # TODO: find solution that doesn't nuke the init list
         # TODO: make event engine generic, so can be used in global scope,
         # not just maps
         if self.session.client.inits:
             self.process_map_events(self.session.client.inits)
-            self.session.client.inits = list()
 
         # process any other events
         self.process_map_events(self.session.client.events)


### PR DESCRIPTION
PR proposes:
- to change self.inits from **Sequence** to **list**;
- to remove only the **action** triggered instead of nuking entirely the list;

in this way someone can read a sign once and never read it anymore