### PR TITLE
learned techs (battle)

### DIFF
--- a/tuxemon/combat.py
+++ b/tuxemon/combat.py
@@ -166,9 +166,14 @@ def defeated(player: NPC) -> bool:
 
 
 def check_moves(monster: Monster, levels: int) -> Optional[str]:
-    tech = monster.update_moves(levels)
-    if tech:
-        params = {"name": monster.name.upper(), "tech": tech.name.upper()}
+    techs = monster.update_moves(levels)
+    if techs:
+        _techs = ""
+        _monster = monster.name.upper()
+        for tech in techs:
+            _tech = tech.name.upper()
+            _techs += _tech + ", "
+        params = {"name": _monster, "tech": _techs[:-2]}
         message = T.format("tuxemon_new_tech", params)
         return message
     return None

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -546,7 +546,7 @@ class Monster:
                 tech.load(ele)
                 self.learn(tech)
 
-    def update_moves(self, levels_earned: int) -> Optional[Technique]:
+    def update_moves(self, levels_earned: int) -> list[Technique]:
         """
         Set monster moves according to the levels increased.
         Excludes the moves already learned.
@@ -555,11 +555,10 @@ class Monster:
             levels_earned: Number of levels earned.
 
         Returns:
-            technique: if there is a technique, then it returns
-            a technique, otherwise none
+            techniques: list containing the learned techniques
 
         """
-        technique = None
+        _technique = []
         for move in self.moveset:
             if (
                 move.technique not in (m.slug for m in self.moves)
@@ -569,8 +568,9 @@ class Monster:
             ):
                 technique = Technique()
                 technique.load(move.technique)
+                _technique.append(technique)
                 self.learn(technique)
-        return technique
+        return _technique
 
     def experience_required(self, level_ofs: int = 0) -> int:
         """


### PR DESCRIPTION
PR:
- changes return **update_moves** in **monster.py** from `Optional[Technique]` to `list[Technique]`;
- updates **check_moves** in **combat.py**;

in this way when a monster bumps of more levels (and the learned techniques are more than 1), it'll appear:

eg Pairagrin from lv 3 to lv 10.
**PAIRAGRIN learned technique ASSAULT, NEGATION!**
instead of only the last one (before):
**PAIRAGRIN learned technique NEGATION!** 