### PR TITLE
minor fixes + estyle

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -33,7 +33,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/mods/tuxemon/maps/professor_lab.tmx
+++ b/mods/tuxemon/maps/professor_lab.tmx
@@ -67,7 +67,6 @@
     <property name="act1" value="pathfind professor,9,9"/>
     <property name="act2" value="char_face professor,up"/>
     <property name="act3" value="change_state JournalInfoState,rockitten"/>
-    <property name="act4" value="remove_state JournalInfoState"/>
     <property name="act5" value="translated_dialog chooseyerfateRockitten"/>
     <property name="act6" value="translated_dialog_choice yes:no,rockittenchoice"/>
     <property name="cond1" value="not variable_set havetuxemon:yes"/>
@@ -81,7 +80,6 @@
     <property name="act1" value="pathfind professor,10,9"/>
     <property name="act2" value="char_face professor,up"/>
     <property name="act3" value="change_state JournalInfoState,cardiling"/>
-    <property name="act4" value="remove_state JournalInfoState"/>
     <property name="act5" value="translated_dialog chooseyerfateCardiling"/>
     <property name="act6" value="translated_dialog_choice yes:no,cardilingchoice"/>
     <property name="cond1" value="not variable_set havetuxemon:yes"/>
@@ -95,7 +93,6 @@
     <property name="act1" value="pathfind professor,11,9"/>
     <property name="act2" value="char_face professor,up"/>
     <property name="act3" value="change_state JournalInfoState,tweesher"/>
-    <property name="act4" value="remove_state JournalInfoState"/>
     <property name="act5" value="translated_dialog chooseyerfateTweesher"/>
     <property name="act6" value="translated_dialog_choice yes:no,tweesherchoice"/>
     <property name="cond1" value="not variable_set havetuxemon:yes"/>

--- a/mods/tuxemon/maps/spyder_lion_mountain.tmx
+++ b/mods/tuxemon/maps/spyder_lion_mountain.tmx
@@ -319,7 +319,6 @@
     <property name="act5" value="set_variable lionmountainenforcer:yes"/>
     <property name="act6" value="add_monster chromeye,15"/>
     <property name="act7" value="change_state JournalInfoState,chromeye"/>
-    <property name="act8" value="remove_state"/>
     <property name="behav1" value="talk spyder_lionmountain_enforcer"/>
     <property name="cond1" value="not variable_set lionmountainenforcer:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_paper_mart.tmx
+++ b/mods/tuxemon/maps/spyder_paper_mart.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="23">
+<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="23">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -41,14 +41,11 @@
    eAHlzLENgCAARNFbA6HQdXASmVFxEMVBEBL+BlTY+JPXXU76V36WdhyIONFrY3PhRsKDEa38ZrwoqOgV2JhFmmDh8FUNeNsOrQ==
   </data>
  </layer>
- <objectgroup color="#ff0000" id="6" name="Collision" visible="0">
-  <object id="6" type="collision" x="0" y="176" width="208" height="32"/>
-  <object id="7" type="collision" x="0" y="16" width="208" height="32"/>
-  <object id="8" type="collision" x="-32" y="32" width="32" height="160"/>
-  <object id="9" type="collision" x="208" y="32" width="32" height="160"/>
+ <objectgroup color="#ff0000" id="6" name="Collision">
+  <object id="7" type="collision" x="0" y="32" width="208" height="16"/>
   <object id="10" type="collision" x="32" y="48" width="16" height="64"/>
   <object id="11" type="collision" x="0" y="112" width="48" height="16"/>
-  <object id="12" type="collision" x="128" y="80" width="48" height="16"/>
-  <object id="13" type="collision" x="128" y="128" width="48" height="16"/>
+  <object id="12" type="collision" x="128" y="80" width="80" height="16"/>
+  <object id="13" type="collision" x="128" y="128" width="80" height="16"/>
  </objectgroup>
 </map>

--- a/mods/tuxemon/maps/spyder_paper_town.tmx
+++ b/mods/tuxemon/maps/spyder_paper_town.tmx
@@ -550,7 +550,6 @@
    <properties>
     <property name="act05" value="translated_dialog spyder_papertown_thereis"/>
     <property name="act10" value="change_state JournalInfoState,rockitten"/>
-    <property name="act20" value="remove_state"/>
     <property name="act25" value="translated_dialog spyder_papertown_rockitten"/>
     <property name="act30" value="translated_dialog_choice yes:no,rockittenchosen"/>
     <property name="cond1" value="is char_facing_tile player"/>
@@ -562,7 +561,6 @@
    <properties>
     <property name="act05" value="translated_dialog spyder_papertown_thereis"/>
     <property name="act10" value="change_state JournalInfoState,lambert"/>
-    <property name="act20" value="remove_state"/>
     <property name="act25" value="translated_dialog spyder_papertown_lambert"/>
     <property name="act30" value="translated_dialog_choice yes:no,lambertchosen"/>
     <property name="cond1" value="is char_facing_tile player"/>
@@ -574,7 +572,6 @@
    <properties>
     <property name="act05" value="translated_dialog spyder_papertown_thereis"/>
     <property name="act10" value="change_state JournalInfoState,nut"/>
-    <property name="act20" value="remove_state"/>
     <property name="act25" value="translated_dialog spyder_papertown_nut"/>
     <property name="act30" value="translated_dialog_choice yes:no,nutchosen"/>
     <property name="cond1" value="is char_facing_tile player"/>
@@ -586,7 +583,6 @@
    <properties>
     <property name="act05" value="translated_dialog spyder_papertown_thereis"/>
     <property name="act10" value="change_state JournalInfoState,tweesher"/>
-    <property name="act20" value="remove_state"/>
     <property name="act25" value="translated_dialog spyder_papertown_tweesher"/>
     <property name="act30" value="translated_dialog_choice yes:no,tweesherchosen"/>
     <property name="cond1" value="is char_facing_tile player"/>
@@ -598,7 +594,6 @@
    <properties>
     <property name="act05" value="translated_dialog spyder_papertown_thereis"/>
     <property name="act10" value="change_state JournalInfoState,agnite"/>
-    <property name="act20" value="remove_state"/>
     <property name="act25" value="translated_dialog spyder_papertown_agnite"/>
     <property name="act30" value="translated_dialog_choice yes:no,agnitechosen"/>
     <property name="cond1" value="is char_facing_tile player"/>

--- a/tuxemon/animation.py
+++ b/tuxemon/animation.py
@@ -6,7 +6,7 @@ import logging
 from collections import defaultdict
 from collections.abc import Callable, Mapping, Sequence
 from math import cos, pi, sin, sqrt
-from typing import Any, DefaultDict, Optional, Union
+from typing import Any, Optional, Union
 
 import pygame
 
@@ -61,7 +61,7 @@ class TaskBase(pygame.sprite.Sprite):
 
     def __init__(self) -> None:
         super().__init__()
-        self._callbacks: DefaultDict[
+        self._callbacks: defaultdict[
             str,
             list[ScheduledFunction],
         ] = defaultdict(list)

--- a/tuxemon/event/actions/change_state.py
+++ b/tuxemon/event/actions/change_state.py
@@ -41,14 +41,18 @@ class ChangeStateAction(EventAction):
     def start(self) -> None:
         # Don't override previous state if we are still in the state.
         client = self.session.client
+        action = client.event_engine
         if client.current_state is None:
             # obligatory "should not happen"
             raise RuntimeError
         if client.current_state.name != self.state_name:
             if self.state_name == "JournalInfoState" and self.optional:
                 journal = db.lookup(self.optional, table="monster")
+                _set_tuxepedia = ["player", journal.slug, "caught"]
+                action.execute_action("set_tuxepedia", _set_tuxepedia, True)
                 params1 = {"monster": journal}
                 client.push_state(self.state_name, kwargs=params1)
+                action.execute_action("clear_tuxepedia", [journal.slug], True)
             elif self.state_name == "MonsterInfoState" and self.optional:
                 monster = self.retrieve_monster(self.optional)
                 if monster is None:

--- a/tuxemon/event/actions/random_encounter.py
+++ b/tuxemon/event/actions/random_encounter.py
@@ -57,11 +57,11 @@ class RandomEncounterAction(EventAction):
         encounters = db.lookup(slug, table="encounter").monsters
         filtered = list(encounters)
 
-        for meet in encounters:
-            if meet.variable:
-                part = meet.variable.split(":")
+        for _meet in encounters:
+            if _meet.variable:
+                part = _meet.variable.split(":")
                 if player.game_variables[part[0]] != part[1]:
-                    filtered.remove(meet)
+                    filtered.remove(_meet)
 
         if not filtered:
             logger.error(f"no wild monsters, check encounter/{slug}.json")

--- a/tuxemon/event/actions/teleport_faint.py
+++ b/tuxemon/event/actions/teleport_faint.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from typing import Optional, final
 
 from tuxemon.event.eventaction import EventAction
-from tuxemon.prepare import TRANS_TIME
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +46,7 @@ class TeleportFaintAction(EventAction):
             logger.error("The teleport_faint variable has not been set.")
             return
 
-        _time = TRANS_TIME if self.trans_time is None else self.trans_time
+        if self.trans_time is not None:
+            teleport.append(str(self.trans_time))
         action = client.event_engine
-        action.execute_action("screen_transition", [_time], True)
-        action.execute_action("teleport", teleport, True)
+        action.execute_action("transition_teleport", teleport)

--- a/tuxemon/map_loader.py
+++ b/tuxemon/map_loader.py
@@ -202,11 +202,10 @@ class TMXMapLoader:
                                 region_conditions = copy_dict_with_keys(
                                     obj.properties, region_properties
                                 )
-                                collision_map[
-                                    (x, y)
-                                ] = extract_region_properties(
+                                _extract = extract_region_properties(
                                     region_conditions
                                 )
+                                collision_map[(x, y)] = _extract
                         for line in self.collision_lines_from_object(
                             obj, tile_size
                         ):

--- a/tuxemon/networking.py
+++ b/tuxemon/networking.py
@@ -111,35 +111,31 @@ class TuxemonServer:
         :param event_data: Event information sent by client.
 
         """
+        registry = self.server.registry
         # Only respond to the latest message of a given type
-        if "event_list" not in self.server.registry[cuuid]:
-            self.server.registry[cuuid]["event_list"] = {}
-        elif (
-            event_data["type"] not in self.server.registry[cuuid]["event_list"]
-        ):
-            self.server.registry[cuuid]["event_list"][event_data["type"]] = -1
-
+        if "event_list" not in registry[cuuid]:
+            registry[cuuid]["event_list"] = {}
+        elif event_data["type"] not in registry[cuuid]["event_list"]:
+            registry[cuuid]["event_list"][event_data["type"]] = -1
         elif (
             event_data["event_number"]
-            <= self.server.registry[cuuid]["event_list"][event_data["type"]]
+            <= registry[cuuid]["event_list"][event_data["type"]]
         ):
             return
         else:
-            self.server.registry[cuuid]["event_list"][
-                event_data["type"]
-            ] = event_data["event_number"]
+            registry[cuuid]["event_list"][event_data["type"]] = event_data[
+                "event_number"
+            ]
 
         if event_data["type"] == "PUSH_SELF":
-            self.server.registry[cuuid]["sprite_name"] = event_data[
-                "sprite_name"
-            ]
-            self.server.registry[cuuid]["map_name"] = event_data["map_name"]
-            self.server.registry[cuuid]["char_dict"] = event_data["char_dict"]
-            self.server.registry[cuuid]["ping_timestamp"] = datetime.now()
+            registry[cuuid]["sprite_name"] = event_data["sprite_name"]
+            registry[cuuid]["map_name"] = event_data["map_name"]
+            registry[cuuid]["char_dict"] = event_data["char_dict"]
+            registry[cuuid]["ping_timestamp"] = datetime.now()
             self.notify_populate_client(cuuid, event_data)
 
         elif event_data["type"] == "PING":
-            self.server.registry[cuuid]["ping_timestamp"] = datetime.now()
+            registry[cuuid]["ping_timestamp"] = datetime.now()
 
         elif (
             event_data["type"] == "CLIENT_INTERACTION"
@@ -149,7 +145,7 @@ class TuxemonServer:
 
         elif event_data["type"] == "CLIENT_KEYDOWN":
             if event_data["kb_key"] == "SHIFT":
-                self.server.registry[cuuid]["char_dict"]["running"] = True
+                registry[cuuid]["char_dict"]["running"] = True
                 self.notify_client(cuuid, event_data)
             elif event_data["kb_key"] == "CTRL":
                 self.notify_client(cuuid, event_data)
@@ -158,7 +154,7 @@ class TuxemonServer:
 
         elif event_data["type"] == "CLIENT_KEYUP":
             if event_data["kb_key"] == "SHIFT":
-                self.server.registry[cuuid]["char_dict"]["running"] = False
+                registry[cuuid]["char_dict"]["running"] = False
                 self.notify_client(cuuid, event_data)
             elif event_data["kb_key"] == "CTRL":
                 self.notify_client(cuuid, event_data)
@@ -166,17 +162,15 @@ class TuxemonServer:
                 self.notify_client(cuuid, event_data)
 
         elif event_data["type"] == "CLIENT_START_BATTLE":
-            self.server.registry[cuuid]["char_dict"]["running"] = False
+            registry[cuuid]["char_dict"]["running"] = False
             self.update_char_dict(cuuid, event_data["char_dict"])
-            self.server.registry[cuuid]["map_name"] = event_data["map_name"]
+            registry[cuuid]["map_name"] = event_data["map_name"]
             self.notify_client(cuuid, event_data)
 
         else:
             self.update_char_dict(cuuid, event_data["char_dict"])
             if "map_name" in event_data:
-                self.server.registry[cuuid]["map_name"] = event_data[
-                    "map_name"
-                ]
+                registry[cuuid]["map_name"] = event_data["map_name"]
             self.notify_client(cuuid, event_data)
 
     def update_char_dict(self, cuuid: str, char_dict: CharDict) -> None:

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -109,9 +109,8 @@ class NPC(Entity[NPCState]):
         self.tuxepedia: dict[str, SeenStatus] = {}
         self.contacts: dict[str, str] = {}
         self.money: dict[str, int] = {}  # Tracks money
-        self.interactions: Sequence[
-            str
-        ] = []  # list of ways player can interact with the Npc
+        # list of ways player can interact with the Npc
+        self.interactions: Sequence[str] = []
         self.isplayer: bool = False  # used for various tests, idk
         # menu labels (world menu)
         self.menu_save: bool = True
@@ -156,12 +155,10 @@ class NPC(Entity[NPCState]):
         self.path_origin: Optional[tuple[int, int]] = None
 
         # movement related
-        self.move_direction: Optional[
-            Direction
-        ] = None  # Set this value to move the npc (see below)
-        self.facing = (
-            Direction.down
-        )  # Set this value to change the facing direction
+        # Set this value to move the npc (see below)
+        self.move_direction: Optional[Direction] = None
+        # Set this value to change the facing direction
+        self.facing = Direction.down
         self.moverate = CONFIG.player_walkrate  # walk by default
         self.ignore_collisions = False
 
@@ -173,12 +170,10 @@ class NPC(Entity[NPCState]):
         # TODO: move sprites into renderer so class can be used headless
         self.playerHeight = 0
         self.playerWidth = 0
-        self.standing: dict[
-            str, pygame.surface.Surface
-        ] = {}  # Standing animation frames
-        self.sprite: dict[
-            str, surfanim.SurfaceAnimation
-        ] = {}  # Moving animation frames
+        # Standing animation frames
+        self.standing: dict[str, pygame.surface.Surface] = {}
+        # Moving animation frames
+        self.sprite: dict[str, surfanim.SurfaceAnimation] = {}
         self.surface_animations = surfanim.SurfaceAnimationCollection()
         self.load_sprites()
         self.rect = Rect(

--- a/tuxemon/platform/__init__.py
+++ b/tuxemon/platform/__init__.py
@@ -1,6 +1,7 @@
 """
 Put platform specific fixes here
 """
+
 from __future__ import annotations
 
 import logging

--- a/tuxemon/platform/platform_pygame/events.py
+++ b/tuxemon/platform/platform_pygame/events.py
@@ -23,7 +23,9 @@ class PygameEventQueueHandler(EventQueueHandler):
     """Handle all events from the pygame event queue."""
 
     def __init__(self) -> None:
-        self._inputs: dict[int, list[InputHandler[Any]]] = defaultdict(list)
+        self._inputs: defaultdict[int, list[InputHandler[Any]]] = defaultdict(
+            list
+        )
 
     def add_input(self, player: int, handler: InputHandler[Any]) -> None:
         """

--- a/tuxemon/states/choice/choice_monster.py
+++ b/tuxemon/states/choice/choice_monster.py
@@ -42,9 +42,15 @@ class ChoiceMonster(PygameMenuState):
         rows = math.ceil(len(menu) / columns) * num_widgets
         super().__init__(columns=columns, rows=rows, **kwargs)
 
+        client = self.client
+        action = client.event_engine
+
         def open_journal(monster: MonsterModel) -> None:
+            _set_tuxepedia = ["player", monster.slug, "caught"]
+            action.execute_action("set_tuxepedia", _set_tuxepedia, True)
             param = {"monster": monster}
-            self.client.push_state("JournalInfoState", kwargs=param)
+            client.push_state("JournalInfoState", kwargs=param)
+            action.execute_action("clear_tuxepedia", [monster.slug], True)
 
         for name, slug, callback in menu:
             monster = db.lookup(slug, table="monster")

--- a/tuxemon/states/combat/combat_animations.py
+++ b/tuxemon/states/combat/combat_animations.py
@@ -69,9 +69,9 @@ class CombatAnimations(ABC, Menu[None]):
         self.players = list(players)
         self.graphics = graphics
 
-        self.monsters_in_play: MutableMapping[
-            NPC, list[Monster]
-        ] = defaultdict(list)
+        self.monsters_in_play: defaultdict[NPC, list[Monster]] = defaultdict(
+            list
+        )
         self._monster_sprite_map: MutableMapping[Monster, Sprite] = {}
         self.hud: MutableMapping[Monster, Sprite] = {}
         self.is_trainer_battle = False

--- a/tuxemon/states/combat/combat_menus.py
+++ b/tuxemon/states/combat/combat_menus.py
@@ -6,7 +6,7 @@ import logging
 from collections import defaultdict
 from collections.abc import Callable, Generator
 from functools import partial
-from typing import TYPE_CHECKING, DefaultDict
+from typing import TYPE_CHECKING
 
 import pygame
 from pygame.rect import Rect
@@ -399,7 +399,7 @@ class CombatTargetMenuState(Menu[Monster]):
         # this is used to determine who owns what monsters and what not
         # TODO: make less duplication of game data in memory, let combat
         # state have more registers, etc
-        self.targeting_map: DefaultDict[str, list[Monster]] = defaultdict(list)
+        self.targeting_map: defaultdict[str, list[Monster]] = defaultdict(list)
         # avoid choosing multiple targets (aether type tech)
         if (
             self.tech.has_type(ElementType.aether)

--- a/tuxemon/states/start/__init__.py
+++ b/tuxemon/states/start/__init__.py
@@ -57,9 +57,8 @@ class StartState(PygameMenuState):
         def new_game() -> None:
             map_path = prepare.fetch("maps", prepare.STARTING_MAP)
             self.client.push_state("WorldState", map_name=map_path)
-            local_session.player.game_variables[
-                "date_start_game"
-            ] = formula.today_ordinal()
+            game_var = local_session.player.game_variables
+            game_var["date_start_game"] = formula.today_ordinal()
             self.client.pop_state(self)
 
         def change_state(

--- a/tuxemon/states/world/world_menus.py
+++ b/tuxemon/states/world/world_menus.py
@@ -214,9 +214,8 @@ class WorldMenuState(PygameMenuState):
             else:
                 open_monster_submenu(menu_item)
 
-        context: dict[
-            str, Any
-        ] = dict()  # dict passed around to hold info between menus/callbacks
+        # dict passed around to hold info between menus/callbacks
+        context: dict[str, Any] = dict()
         monster_menu = self.client.push_state(MonsterMenuState())
         monster_menu.on_menu_selection = handle_selection  # type: ignore[assignment]
         monster_menu.on_menu_selection_change = monster_menu_hook  # type: ignore[method-assign]


### PR DESCRIPTION
PR fixes:
- updates **setup-python** for **tox_unite** too;
- adds **set_tuxepedia** and **clear_tuxepedia** for showing correctly the monsters menus, because if not it appears by default with missing info (as default for seen);
- removes **remove_state** since it closes automatically;
- removes some pointless collisions from **spyder_paper_mart** (Spyder), this map is used only for the Spyder intro;
- replaces **teleport** and **screen_transition** with **transition_teleport** in **teleport_faint** event action, simply because **transition_teleport** itself is the sum of teleport + screen_transition;
- removes the following **typehint**;
- simplifies and sorts piece of codes where black was failing;

`tuxemon/event/actions/random_encounter.py:70: error: Incompatible types in assignment (expression has type "EncounterItemModel | None", variable has type "EncounterItemModel")  [assignment]`