### PR TITLE
fix teleport

### DIFF
--- a/tuxemon/event/actions/delayed_teleport.py
+++ b/tuxemon/event/actions/delayed_teleport.py
@@ -45,7 +45,8 @@ class DelayedTeleportAction(EventAction):
         if world.delayed_teleport:
             logger.error("Stop, there is a teleport in progress")
             return
-
+        player = self.session.player
+        player.remove_collision(player.tile_pos)
         world.delayed_teleport = True
         world.delayed_mapname = self.map_name
         world.delayed_x = self.position_x


### PR DESCRIPTION
PR fixes teleport.

if someone uses **transition_teleport** in the same map:
```
player in map_cotton (1,1)
transition_teleport map_cotton,1,5,0.3)
player in map_cotton (1,5)
```
then the tile (1,1) isn't accessible, because it's in the **collision_map** (since occupied by the player); so it was necessary to add a **remove_collision**.