### PR TITLE
fix park attack

### DIFF
--- a/mods/tuxemon/db/item/tuxeball_park.json
+++ b/mods/tuxemon/db/item/tuxeball_park.json
@@ -3,6 +3,7 @@
     "is wild_monster"
   ],
   "effects": [
+    "park capture",
     "capture"
   ],
   "animation": "capture_1",

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -8489,6 +8489,15 @@ msgstr "I think the park has done a pretty good job of being everyone's friend."
 msgid "spyder_park_billie"
 msgstr "Hey ${{name}}! Maybe I'll see you deeper in the park. Bet I'll catch more than you!"
 
+msgid "spyder_park_afraid"
+msgstr "{target} gets afraid."
+
+msgid "spyder_park_stare"
+msgstr "{target} stares at you."
+
+msgid "spyder_park_wander"
+msgstr "{target} continues to wander around."
+
 msgid "0floor"
 msgstr "Ground Floor"
 msgid "1floor"

--- a/tuxemon/item/effects/capture.py
+++ b/tuxemon/item/effects/capture.py
@@ -10,10 +10,12 @@ from tuxemon import formula, prepare
 from tuxemon.db import CategoryCondition as Category
 from tuxemon.db import ElementType, GenderType, SeenStatus, TasteWarm
 from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
+from tuxemon.technique.technique import Technique
 
 if TYPE_CHECKING:
     from tuxemon.item.item import Item
     from tuxemon.monster import Monster
+
 logger = logging.getLogger(__name__)
 
 
@@ -131,6 +133,13 @@ class CaptureEffect(ItemEffect):
                 tuxeball = self.user.find_item(item.slug)
                 if tuxeball:
                     tuxeball.quantity += 1
+            if item.slug == "tuxeball_park":
+                empty = Technique()
+                empty.load("empty")
+                _wander = "spyder_park_wander"
+                label = self.user.game_variables.get(item.slug, _wander)
+                empty.use_tech = label
+                item.combat_state.rewrite_action_queue_method(target, empty)
 
             return {"success": False, "num_shakes": shakes, "extra": None}
 

--- a/tuxemon/item/effects/park.py
+++ b/tuxemon/item/effects/park.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2024 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Union
+
+from tuxemon.combat import set_var
+from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
+
+if TYPE_CHECKING:
+    from tuxemon.item.item import Item
+    from tuxemon.monster import Monster
+
+
+class ParkEffectResult(ItemEffectResult):
+    pass
+
+
+@dataclass
+class ParkEffect(ItemEffect):
+    """
+    Handles the items used in the park.
+
+    Parameters:
+        method: capture, doll or food
+
+    """
+
+    name = "park"
+    method: str
+
+    def apply(
+        self, item: Item, target: Union[Monster, None]
+    ) -> ParkEffectResult:
+        assert target
+
+        if self.method == "capture":
+            labels = [
+                "spyder_park_afraid",
+                "spyder_park_stare",
+                "spyder_park_wander",
+            ]
+            label = random.choice(labels)
+            set_var(self.session, item.slug, label)
+        elif self.method == "doll":
+            pass
+        elif self.method == "food":
+            pass
+        else:
+            raise ValueError(f"Must be capture, doll or food")
+
+        return {"success": True, "num_shakes": 0, "extra": None}

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -853,6 +853,25 @@ class CombatState(CombatAnimations):
                 new_action = EnqueuedAction(action.user, action.method, new)
                 self._action_queue[index] = new_action
 
+    def rewrite_action_queue_method(
+        self, attacker: Monster, method: Union[Technique, Item, Condition]
+    ) -> None:
+        """
+        Used to replace the method (eg technique, item or condition) used.
+
+        Parameters:
+            attacker: Monster.
+            technique: New technique used.
+
+        eg. "monster uses RAM" -> "monster uses SABER"
+
+        """
+        # rewrite actions in the queue to target the new monster
+        for index, action in enumerate(self._action_queue):
+            if action.user == attacker:
+                new_action = EnqueuedAction(action.user, method, action.target)
+                self._action_queue[index] = new_action
+
     def remove_monster_from_play(
         self,
         monster: Monster,


### PR DESCRIPTION
PR fixes the issue inside the park.

If the monster escapes the capture, then it attacks.
After this PR the wild monster doesn't attack anymore, but it shows one message (it gets chosen randomly at the moment).

```
msgid "spyder_park_afraid"
msgstr "{target} gets afraid."
msgid "spyder_park_stare"
msgstr "{target} stares at you."
msgid "spyder_park_wander"
msgstr "{target} continues to wander around."
```