### PR TITLE
regionproperties + collision zone

### DIFF
--- a/mods/tuxemon/maps/spyder.yaml
+++ b/mods/tuxemon/maps/spyder.yaml
@@ -102,6 +102,13 @@ events:
     - is variable_set swimming:yes
     - is current_state WorldState
     type: "event"
+  Forbid Swim:
+    actions:
+    - update_tile_properties surfable,0
+    conditions:
+    - is variable_set swimming:no
+    - is current_state WorldState
+    type: "event"
   Swim Encounters Day:
     actions:
     - random_encounter routec,0.25

--- a/tuxemon/entity.py
+++ b/tuxemon/entity.py
@@ -95,9 +95,19 @@ class Entity(Generic[SaveDict]):
 
         """
         coords = (int(pos[0]), int(pos[1]))
-        prop = RegionProperties(
-            enter_from=[], exit_from=[], endure=[], entity=self, key=None
-        )
+        region = self.world.collision_map.get(coords)
+        if region:
+            prop = RegionProperties(
+                region.enter_from,
+                region.exit_from,
+                region.endure,
+                self,
+                region.key,
+            )
+        else:
+            prop = RegionProperties(
+                enter_from=[], exit_from=[], endure=[], entity=self, key=None
+            )
         self.world.collision_map[coords] = prop
 
     def remove_collision(self, pos: tuple[int, int]) -> None:
@@ -108,10 +118,21 @@ class Entity(Generic[SaveDict]):
             pos: Position to be removed.
 
         """
-        try:
-            del self.world.collision_map[pos]
-        except:
-            pass
+        region = self.world.collision_map.get(pos)
+        if region and (region.enter_from or region.exit_from or region.endure):
+            prop = RegionProperties(
+                region.enter_from,
+                region.exit_from,
+                region.endure,
+                None,
+                region.key,
+            )
+            self.world.collision_map[pos] = prop
+        else:
+            try:
+                del self.world.collision_map[pos]
+            except:
+                pass
 
     # === PHYSICS END =========================================================
 


### PR DESCRIPTION
PR fixes wrong behavior of collision zone:
- acts on **add_collision**;
- acts on **remove_collision**;
- updates the **get_collision_map**;
- ameliorates swim (Spyder) by adding a new event (Spyder.yaml);

let's say there is a tree and the trunk is both **enter_from** and **exit_from** as **up**, **left** and **right**

right now, this doesn't work, because when walking "behind" the tree (as supposed), these limitations get lost, specifically these RegionProperties are overwritten and replaced with (up, down, left and right).
`enter_from = ["up", "right", "left"] -->  ["up", "right", "left", "down"]`

after the PR the system checks if there is an existing collision zone, it checks if there is a region property; if there is a regionproperties is going to updated only the specific field (eg NPC when the player or another NPC is walking), in this way there is no more overwriting.