### PR TITLE
fix player stuck bedroom (Xero)

### DIFF
--- a/mods/tuxemon/maps/player_house_bedroom.yaml
+++ b/mods/tuxemon/maps/player_house_bedroom.yaml
@@ -4,36 +4,31 @@ events:
     - play_music music_home
     conditions:
     - not music_playing music_home
-    height: 1
-    width: 1
     x: 7
     y: 0
+    type: "event"
   Go Downstairs:
     actions:
     - transition_teleport player_house_downstairs.tmx,0,2,0.3
     - char_face player,down
     conditions:
     - is char_at player
-    height: 1
-    width: 1
     x: 7
     y: 2
+    type: "event"
   Use Computer:
     actions:
     - change_state PCState
     conditions:
     - is char_facing_tile player
     - is button_pressed K_RETURN
-    height: 1
-    width: 1
     x: 3
     y: 1
     type: "event"
   Player Spawn:
-    height: 1
-    width: 1
     x: 3
     y: 4
+    type: "event"
   Resting in Bed:
     actions:
     - screen_transition 1
@@ -66,8 +61,6 @@ events:
     conditions:
     - not variable_set question_xero:yes
     - not variable_set question_xero:no
-    height: 1
-    width: 1
     x: 8
     y: 0
     type: "event"
@@ -85,8 +78,6 @@ events:
     conditions:
     - is variable_set question_xero:no
     - not variable_set xero_intro:done
-    height: 1
-    width: 1
     x: 8
     y: 1
     type: "event"
@@ -99,8 +90,6 @@ events:
     conditions:
     - is variable_set question_xero:yes
     - not variable_set xero_intro:done
-    height: 1
-    width: 1
     x: 9
     y: 0
     type: "event"

--- a/mods/tuxemon/maps/xero.yaml
+++ b/mods/tuxemon/maps/xero.yaml
@@ -1,4 +1,11 @@
 events:
+  Evolution all:
+    actions:
+    - evolution player
+    conditions:
+    - is check_evolution player
+    - is current_state WorldState
+    type: "event"
   Check Max Moves:
     actions:
     - translated_dialog new_tech_delete


### PR DESCRIPTION
PR split out from #2238 
- updates **player_bedroom** yaml, the y and x aren't necessary since both generated; in player_bedroom was missing **type:event** (so the action wasn't loaded and the player was stuck in the bedroom);