### PR TITLE
update def get_awake_monsters

### DIFF
--- a/tuxemon/ai.py
+++ b/tuxemon/ai.py
@@ -39,12 +39,11 @@ class AI:
         """
         Trainer battles.
         """
-        if self.check_strongest():
-            if len(self.character.items) > 0:
-                for itm in self.character.items:
-                    if itm.category == ItemCategory.potion:
-                        if self.need_potion():
-                            self.action_item(itm)
+        if len(self.character.items) > 0:
+            for itm in self.character.items:
+                if itm.category == ItemCategory.potion:
+                    if self.need_potion():
+                        self.action_item(itm)
         technique, target = self.track_next_use()
         # send data
         self.action_tech(technique, target)
@@ -75,36 +74,6 @@ class AI:
             return skip, random.choice(self.opponents)
         else:
             return random.choice(actions)
-
-    def check_weakest(self) -> bool:
-        """
-        Is it the weakest monster in the NPC's party?
-        """
-        weakest = [
-            m
-            for m in self.character.monsters
-            if m.level == min([m.level for m in self.character.monsters])
-        ]
-        weak = weakest[0]
-        if weak.level == self.monster.level:
-            return True
-        else:
-            return False
-
-    def check_strongest(self) -> bool:
-        """
-        Is it the strongest monster in the NPC's party?
-        """
-        strongest = [
-            m
-            for m in self.character.monsters
-            if m.level == max([m.level for m in self.character.monsters])
-        ]
-        strong = strongest[0]
-        if strong.level == self.monster.level:
-            return True
-        else:
-            return False
 
     def need_potion(self) -> bool:
         """

--- a/tuxemon/combat.py
+++ b/tuxemon/combat.py
@@ -15,7 +15,13 @@ import random
 from collections.abc import Generator, Sequence
 from typing import TYPE_CHECKING, Optional
 
-from tuxemon.db import GenderType, OutputBattle, PlagueType, SeenStatus
+from tuxemon.db import (
+    GenderType,
+    OutputBattle,
+    PlagueType,
+    SeenStatus,
+    StatType,
+)
 from tuxemon.locale import T
 from tuxemon.technique.technique import Technique
 
@@ -123,31 +129,39 @@ def recharging(technique: Technique) -> bool:
 
 
 def get_awake_monsters(
-    character: NPC, monsters: list[Monster], turn: int
+    character: NPC,
+    monsters: list[Monster],
+    turn: int,
+    method: Optional[str] = None,
 ) -> Generator[Monster, None, None]:
     """
     Iterate all non-fainted monsters in party.
 
     Parameters:
         character: The character.
+        monsters: List of monsters in the battlefield.
+        turn: Turn of the battle.
+        method: Parameter change the monster.
 
     Yields:
         Non-fainted monsters.
 
     """
     mons = [
-        ele
-        for ele in character.monsters
-        if not fainted(ele) and ele not in monsters
+        _mon
+        for _mon in character.monsters
+        if not fainted(_mon) and _mon not in monsters
     ]
     if mons:
         if len(mons) > 1:
-            mon = random.choice(mons)
-            # avoid random choice (1st turn)
             if turn == 1:
                 yield from mons
             else:
-                yield mon
+                if method is None:
+                    yield from mons
+                else:
+                    mon = retrieve_from_party(mons, method)
+                    yield mon
         else:
             yield mons[0]
 
@@ -535,3 +549,44 @@ def build_hud_text(
             return f"{monster.name}{icon} Lv.{monster.level}{symbol}"
         else:
             return f"{monster.name}{icon} Lv.{monster.level}"
+
+
+def retrieve_from_party(party: list[Monster], method: str) -> Monster:
+    """
+    Who is the "method" monster in the party?
+    Picks the respective monster from the party.
+
+    Parameters:
+        party: List of monster.
+        method: Parameter to pick the monster (random, strongest, etc.)
+
+    Returns:
+        Monster.
+    """
+    if method == "lv_highest":
+        highest = max([m.level for m in party])
+        return next(mon for mon in party if mon.level == highest)
+    elif method == "lv_lowest":
+        lowest = min([m.level for m in party])
+        return next(mon for mon in party if mon.level == lowest)
+    elif method == "healthiest":
+        current_hp = max([m.current_hp for m in party])
+        return next(mon for mon in party if mon.current_hp == current_hp)
+    elif method in list(StatType):
+        stat = max([getattr(m, method) for m in party])
+        return next(mon for mon in party if getattr(mon, method) == stat)
+    else:
+        return random_from_party(party)
+
+
+def random_from_party(party: list[Monster]) -> Monster:
+    """
+    Picks a monster randomly from the party.
+
+    Parameters:
+        party: List of monster.
+
+    Returns:
+        Monster.
+    """
+    return random.choice(party)


### PR DESCRIPTION
PR:
- updates **get_awake_monsters** in **combat.py**;
- moves both defs from **ai.py** to **combat.py**;
- generalizes and implements both inside a new def called **retrieve_from_party**;
- adds **healthiest** option, the monster in the party with max current HP;
- adds **stattype** option, by using "speed" would retrieve the fastest monster in the party (it works with hp, armour, dodge,  melee and ranged too);
- creates a def called **random_from_party** (pick a random monster from the party);

how it works **get_awake_monsters**, player "my_name_is_jeff":
```
    <property name="act1" value="add_monster rockitten,5,my_name_is_jeff,5,10"/>
    <property name="act2" value="add_monster nut,5,my_name_is_jeff,5,10"/>
    <property name="act3" value="add_monster apeoro,5,my_name_is_jeff,5,10"/>
    <property name="act4" value="start_battle player,my_name_is_jeff"/>
```
`get_awake_monsters` will pick the next monster when **Rockitten** faints, so the list contains **Nut** and **Apeoro**.

While checking I noticed this.
The battle is supposed to be: **Rockitten**, then **Nut** and ending with **Apeoro**
but it wasn't the case, because it was implemented a random choice after the first turn, so it was possible:
this: `Rockitten, then Apeoro or Nut` or `Rockitten, then Nut or Apeoro`

This gave me an idea, so instead of fixing it and getting the next monster, I thought it would have been interesting to add new methods. I still need to figure out how to handle the choice, but it's not the topic of this PR, it's simply a resort and first step. Included the use of items for NPC, that needs to be redone (it's an old version and there is a hardcoded parameter).