### PR TITLE
name (npc field)

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -83,8 +83,6 @@ is licensed under [CC-BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/
 
 * ["Beachgoer"](https://wiki.tuxemon.org/index.php?title=Beachgoer). Front sprites by tamashihoshi. Overland sprites by Catch Challenger. Face sprite by Superpowers Asset Packs.
 
-* ["Birb Robo"](https://wiki.tuxemon.org/index.php?title=Birb_Robo). Front sprite by FiveAsOne. Overland sprites by Catch Challenger.
-
 * ["Brute"](https://wiki.tuxemon.org/index.php?title=Brute). Overland sprites from the Superpowers Asset Packs.
 
 * ["Cat Girl"](https://wiki.tuxemon.org/index.php?title=Cat_Girl). Overland sprites by Pboop. Front sprites by Sanglorian and Tamashihoshi.

--- a/mods/tuxemon/db/npc/knight1.json
+++ b/mods/tuxemon/db/npc/knight1.json
@@ -1,5 +1,6 @@
 {
   "slug": "knight1",
+  "name": "knight",
   "template": [
     {
       "sprite_name": "knight",

--- a/mods/tuxemon/db/npc/knight2.json
+++ b/mods/tuxemon/db/npc/knight2.json
@@ -1,5 +1,6 @@
 {
   "slug": "knight2",
+  "name": "knight",
   "template": [
     {
       "sprite_name": "knight",

--- a/mods/tuxemon/db/npc/knight3.json
+++ b/mods/tuxemon/db/npc/knight3.json
@@ -1,5 +1,6 @@
 {
   "slug": "knight3",
+  "name": "knight",
   "template": [
     {
       "sprite_name": "knight",

--- a/mods/tuxemon/db/npc/knight4.json
+++ b/mods/tuxemon/db/npc/knight4.json
@@ -1,5 +1,6 @@
 {
   "slug": "knight4",
+  "name": "knight",
   "template": [
     {
       "sprite_name": "knight",

--- a/mods/tuxemon/db/npc/spyder_nimrod_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_nimrod_npcs.json
@@ -11,6 +11,7 @@
   },
   {
     "slug": "spyder_nimrod_xeon",
+    "name": "xeon",
     "template": [
       {
         "sprite_name": "robot",
@@ -91,6 +92,7 @@
   },
   {
     "slug": "spyder_nimrod_chromerobo",
+    "name": "chrome_robo",
     "template": [
       {
         "sprite_name": "robot",

--- a/mods/tuxemon/db/npc/xerogrund1.json
+++ b/mods/tuxemon/db/npc/xerogrund1.json
@@ -1,5 +1,6 @@
 {
   "slug": "xerogrund1",
+  "name": "xerogrunt",
   "template": [
     {
       "sprite_name": "xerogrunt",

--- a/mods/tuxemon/db/npc/xerogrund2.json
+++ b/mods/tuxemon/db/npc/xerogrund2.json
@@ -1,5 +1,6 @@
 {
   "slug": "xerogrund2",
+  "name": "xerogrunt",
   "template": [
     {
       "sprite_name": "xerogrunt",

--- a/mods/tuxemon/db/npc/xerogrunt1.json
+++ b/mods/tuxemon/db/npc/xerogrunt1.json
@@ -1,5 +1,6 @@
 {
   "slug": "xerogrunt1",
+  "name": "xerogrunt",
   "template": [
     {
       "sprite_name": "xerogrunt",

--- a/mods/tuxemon/db/npc/xerogrunt10.json
+++ b/mods/tuxemon/db/npc/xerogrunt10.json
@@ -1,5 +1,6 @@
 {
   "slug": "xerogrunt10",
+  "name": "xerogrunt",
   "template": [
     {
       "sprite_name": "xerogrunt",

--- a/mods/tuxemon/db/npc/xerogrunt2.json
+++ b/mods/tuxemon/db/npc/xerogrunt2.json
@@ -1,5 +1,6 @@
 {
   "slug": "xerogrunt2",
+  "name": "xerogrunt",
   "template": [
     {
       "sprite_name": "xerogrunt",

--- a/mods/tuxemon/db/npc/xerogrunt3.json
+++ b/mods/tuxemon/db/npc/xerogrunt3.json
@@ -1,5 +1,6 @@
 {
   "slug": "xerogrunt3",
+  "name": "xerogrunt",
   "template": [
     {
       "sprite_name": "xerogrunt",

--- a/mods/tuxemon/db/npc/xerogrunt4.json
+++ b/mods/tuxemon/db/npc/xerogrunt4.json
@@ -1,5 +1,6 @@
 {
   "slug": "xerogrunt4",
+  "name": "xerogrunt",
   "template": [
     {
       "sprite_name": "xerogrunt",

--- a/mods/tuxemon/db/npc/xerogrunt5.json
+++ b/mods/tuxemon/db/npc/xerogrunt5.json
@@ -1,5 +1,6 @@
 {
   "slug": "xerogrunt5",
+  "name": "xerogrunt",
   "template": [
     {
       "sprite_name": "xerogrunt",

--- a/mods/tuxemon/db/npc/xerogrunt6.json
+++ b/mods/tuxemon/db/npc/xerogrunt6.json
@@ -1,5 +1,6 @@
 {
   "slug": "xerogrunt6",
+  "name": "xerogrunt",
   "template": [
     {
       "sprite_name": "xerogrunt",

--- a/mods/tuxemon/db/npc/xerogrunt7.json
+++ b/mods/tuxemon/db/npc/xerogrunt7.json
@@ -1,5 +1,6 @@
 {
   "slug": "xerogrunt7",
+  "name": "xerogrunt",
   "template": [
     {
       "sprite_name": "xerogrunt",

--- a/mods/tuxemon/db/npc/xerogrunt8.json
+++ b/mods/tuxemon/db/npc/xerogrunt8.json
@@ -1,5 +1,6 @@
 {
   "slug": "xerogrunt8",
+  "name": "xerogrunt",
   "template": [
     {
       "sprite_name": "xerogrunt",

--- a/mods/tuxemon/db/npc/xerogrunt9.json
+++ b/mods/tuxemon/db/npc/xerogrunt9.json
@@ -1,5 +1,6 @@
 {
   "slug": "xerogrunt9",
+  "name": "xerogrunt",
   "template": [
     {
       "sprite_name": "xerogrunt",

--- a/mods/tuxemon/l18n/cs_CZ/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/cs_CZ/LC_MESSAGES/base.po
@@ -938,11 +938,8 @@ msgstr "Cotton Nurse"
 msgid "karrianna"
 msgstr "Karrianna"
 
-msgid "knight1"
-msgstr "Rytíř I"
-
-msgid "knight2"
-msgstr "Rytíř II"
+msgid "knight"
+msgstr "Rytíř"
 
 msgid "liela"
 msgstr "Liela"
@@ -971,38 +968,8 @@ msgstr "Tuxemart Obchodník"
 msgid "tuxemart_aide"
 msgstr "Tuxemart Zaměstnanec"
 
-msgid "xerogrund1"
-msgstr "Tým Xero Grunt I"
-
-msgid "xerogrund2"
-msgstr "Tým Xero Grunt II"
-
-msgid "xerogrunt2"
-msgstr "Tým Xero Grunt II"
-
-msgid "xerogrunt3"
-msgstr "Tým Xero Grunt III"
-
-msgid "xerogrunt4"
-msgstr "Tým Xero Grunt IV"
-
-msgid "xerogrunt5"
-msgstr "Tým Xero Grunt V"
-
-msgid "xerogrunt6"
-msgstr "Tým Xero Grunt VI"
-
-msgid "xerogrunt7"
-msgstr "Tým Xero Grunt VII"
-
-msgid "xerogrunt8"
-msgstr "Tým Xero Grunt VIII"
-
-msgid "xerogrunt9"
-msgstr "Tým Xero Grunt IX"
-
-msgid "xerogrunt10"
-msgstr "Tým Xero Grunt X"
+msgid "xerogrunt"
+msgstr "Tým Xero Grunt"
 
 ## DIALOG TRANSLATIONS ##
 # general dialogs
@@ -1276,9 +1243,6 @@ msgstr "Chrome Robo"
 
 msgid "dark_robo"
 msgstr "Dark Robo"
-
-msgid "birb_robo"
-msgstr "Birb Robo"
 
 msgid "xeon"
 msgstr "Xeon"

--- a/mods/tuxemon/l18n/de_DE/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/de_DE/LC_MESSAGES/base.po
@@ -1657,11 +1657,8 @@ msgstr "Cotton Krankenschwester"
 msgid "karrianna"
 msgstr "Karrianna"
 
-msgid "knight1"
-msgstr "Ritter I"
-
-msgid "knight2"
-msgstr "Ritter II"
+msgid "knight"
+msgstr "Ritter"
 
 msgid "liela"
 msgstr "Liela"
@@ -1690,38 +1687,8 @@ msgstr "Tuxemart Ladenbesitzer"
 msgid "tuxemart_aide"
 msgstr "Tuxemart Mitarbeiter"
 
-msgid "xerogrund1"
-msgstr "Team Xero Rüpel I"
-
-msgid "xerogrund2"
-msgstr "Team Xero Rüpel II"
-
-msgid "xerogrunt2"
-msgstr "Team Xero Rüpel II"
-
-msgid "xerogrunt3"
-msgstr "Team Xero Rüpel III"
-
-msgid "xerogrunt4"
-msgstr "Team Xero Rüpel IV"
-
-msgid "xerogrunt5"
-msgstr "Team Xero Rüpel V"
-
-msgid "xerogrunt6"
-msgstr "Team Xero Rüpel VI"
-
-msgid "xerogrunt7"
-msgstr "Team Xero Rüpel VII"
-
-msgid "xerogrunt8"
-msgstr "Team Xero Rüpel VIII"
-
-msgid "xerogrunt9"
-msgstr "Team Xero Rüpel IX"
-
-msgid "xerogrunt10"
-msgstr "Team Xero Rüpel X"
+msgid "xerogrunt"
+msgstr "Team Xero Rüpel"
 
 ## DIALOG TRANSLATIONS ##
 # general dialogs
@@ -2570,9 +2537,6 @@ msgstr "Yiinaang"
 
 msgid "dark_robo"
 msgstr "Dark Robo"
-
-msgid "birb_robo"
-msgstr "Birb Robo"
 
 msgid "xeon"
 msgstr "Xeon"

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -5443,11 +5443,8 @@ msgstr "Aeble"
 msgid "allie"
 msgstr "Allie"
 
-msgid "knight1"
-msgstr "Knight I"
-
-msgid "knight2"
-msgstr "Knight II"
+msgid "knight"
+msgstr "Knight"
 
 msgid "liela"
 msgstr "Liela"
@@ -5497,38 +5494,8 @@ msgstr "Tuxemart Shopkeeper"
 msgid "tuxemart_aide"
 msgstr "Tuxemart Employee"
 
-msgid "xerogrund1"
-msgstr "Team Xero Grunt I"
-
-msgid "xerogrund2"
-msgstr "Team Xero Grunt II"
-
-msgid "xerogrunt2"
-msgstr "Team Xero Grunt II"
-
-msgid "xerogrunt3"
-msgstr "Team Xero Grunt III"
-
-msgid "xerogrunt4"
-msgstr "Team Xero Grunt IV"
-
-msgid "xerogrunt5"
-msgstr "Team Xero Grunt V"
-
-msgid "xerogrunt6"
-msgstr "Team Xero Grunt VI"
-
-msgid "xerogrunt7"
-msgstr "Team Xero Grunt VII"
-
-msgid "xerogrunt8"
-msgstr "Team Xero Grunt VIII"
-
-msgid "xerogrunt9"
-msgstr "Team Xero Grunt IX"
-
-msgid "xerogrunt10"
-msgstr "Team Xero Grunt X"
+msgid "xerogrunt"
+msgstr "Team Xero Grunt"
 
 msgid "acolyte"
 msgstr "Acolyte Corren"
@@ -9184,10 +9151,6 @@ msgstr "Rosamund"
 msgid "spyder_route4_beck"
 msgstr "Beck"
 
-msgid "spyder_nimrod_chromerobo"
-msgstr "Chrome Robo"
-msgid "spyder_nimrod_xeon"
-msgstr "Xeon"
 msgid "spyder_nimrod_justice"
 msgstr "Justice"
 msgid "spyder_nimrod_thatcher"
@@ -9681,20 +9644,6 @@ msgid "spyder_dryadsgrove_ferris"
 msgstr "Ferris"
 msgid "spyder_dryadsgrove_sylvia"
 msgstr "Sylvia"
-msgid "spyder_dryadsgrove_volcoli"
-msgstr "Volcoli"
-msgid "_chromerobo"
-msgstr "Chrome Robo"
-msgid "_darkrobo"
-msgstr "Dark Robo"
-msgid "_xeon"
-msgstr "Xeon"
-msgid "_xeon-2"
-msgstr "Xeon-2"
-msgid "_mk01beta"
-msgstr "Mk01 Beta"
-msgid "_mk01alpha"
-msgstr "Mk01 Alpha"
 
 
 ## MESSAGE TRANSLATIONS ##

--- a/mods/tuxemon/l18n/eo/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/eo/LC_MESSAGES/base.po
@@ -897,11 +897,8 @@ msgstr "Cotton Nurse"
 msgid "karrianna"
 msgstr "Karrianna"
 
-msgid "knight1"
-msgstr ""
-
-msgid "knight2"
-msgstr ""
+msgid "knight"
+msgstr "Kavaliro"
 
 msgid "liela"
 msgstr "Liela"
@@ -930,38 +927,8 @@ msgstr ""
 msgid "tuxemart_aide"
 msgstr ""
 
-msgid "xerogrund1"
-msgstr "Team Xero Grunt I"
-
-msgid "xerogrund2"
-msgstr "Team Xero Grunt II"
-
-msgid "xerogrunt2"
-msgstr "Team Xero Grunt II"
-
-msgid "xerogrunt3"
-msgstr "Team Xero Grunt III"
-
-msgid "xerogrunt4"
-msgstr "Team Xero Grunt IV"
-
-msgid "xerogrunt5"
-msgstr "Team Xero Grunt V"
-
-msgid "xerogrunt6"
-msgstr "Team Xero Grunt VI"
-
-msgid "xerogrunt7"
-msgstr "Team Xero Grunt VII"
-
-msgid "xerogrunt8"
-msgstr "Team Xero Grunt VIII"
-
-msgid "xerogrunt9"
-msgstr "Team Xero Grunt IX"
-
-msgid "xerogrunt10"
-msgstr "Team Xero Grunt X"
+msgid "xerogrunt"
+msgstr "Team Xero Grunt"
 
 ## DIALOG TRANSLATIONS ##
 # general dialogs
@@ -1696,9 +1663,6 @@ msgstr "Windeye"
 
 msgid "yiinaang"
 msgstr "Yiinaang"
-
-msgid "birb_robo"
-msgstr "Birb Robo"
 
 msgid "mk01_beta"
 msgstr "Mk01 Beta"

--- a/mods/tuxemon/l18n/es_ES/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/es_ES/LC_MESSAGES/base.po
@@ -1260,11 +1260,8 @@ msgstr "Enfermera de Pueblo Algodón"
 msgid "karrianna"
 msgstr "Karrianna"
 
-msgid "knight1"
-msgstr "Caballero I"
-
-msgid "knight2"
-msgstr "Caballero II"
+msgid "knight"
+msgstr "Caballero"
 
 msgid "liela"
 msgstr "Liela"
@@ -1293,38 +1290,8 @@ msgstr "Dependiente de Tuxemart"
 msgid "tuxemart_aide"
 msgstr "Empleado de Tuxemart"
 
-msgid "xerogrund1"
-msgstr "Soldado del equipo Xero I"
-
-msgid "xerogrund2"
-msgstr "Soldado del equipo Xero II"
-
-msgid "xerogrunt2"
-msgstr "Soldado del equipo Xero II"
-
-msgid "xerogrunt3"
-msgstr "Soldado del equipo Xero III"
-
-msgid "xerogrunt4"
-msgstr "Soldado del equipo Xero IV"
-
-msgid "xerogrunt5"
-msgstr "Soldado del equipo Xero V"
-
-msgid "xerogrunt6"
-msgstr "Soldado del equipo Xero VI"
-
-msgid "xerogrunt7"
-msgstr "Soldado del equipo Xero VII"
-
-msgid "xerogrunt8"
-msgstr "Soldado del equipo Xero VIII"
-
-msgid "xerogrunt9"
-msgstr "Soldado del equipo Xero IX"
-
-msgid "xerogrunt10"
-msgstr "Soldado del equipo Xero X"
+msgid "xerogrunt"
+msgstr "Soldado del equipo Xero"
 
 ## DIALOG TRANSLATIONS ##
 # general dialogs
@@ -4227,9 +4194,6 @@ msgstr "Windeye"
 msgid "chrome_robo"
 msgstr "Chrome Robo"
 
-msgid "birb_robo"
-msgstr "Birb Robo"
-
 msgid "mk01_alpha"
 msgstr "MK01 Alpha"
 
@@ -4599,9 +4563,6 @@ msgstr "Técnicas"
 
 msgid "move_to_kennel"
 msgstr "mover a {box}"
-
-msgid "birb_robo_description"
-msgstr "Un robot hostil."
 
 msgid "mk01_proto_description"
 msgstr "Un robot asesino fusionado con un dragón. No nos preguntes cómo."

--- a/mods/tuxemon/l18n/es_MX/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/es_MX/LC_MESSAGES/base.po
@@ -958,11 +958,8 @@ msgstr "Enfermera de Pueblo Algodón"
 msgid "karrianna"
 msgstr "Karrianna"
 
-msgid "knight1"
-msgstr "Caballero I"
-
-msgid "knight2"
-msgstr "Caballero II"
+msgid "knight"
+msgstr "Caballero"
 
 msgid "liela"
 msgstr "Liela"
@@ -991,38 +988,8 @@ msgstr "Tendero de Tuxemart"
 msgid "tuxemart_aide"
 msgstr "Empleado de Tuxemart"
 
-msgid "xerogrund1"
-msgstr "Equipo Xero Grunt I"
-
-msgid "xerogrund2"
-msgstr "Equipo Xero Grunt II"
-
-msgid "xerogrunt2"
-msgstr "Equipo Xero Grunt II"
-
-msgid "xerogrunt3"
-msgstr "Equipo Xero Grunt III"
-
-msgid "xerogrunt4"
-msgstr "Equipo Xero Grunt IV"
-
-msgid "xerogrunt5"
-msgstr "Equipo Xero Grunt V"
-
-msgid "xerogrunt6"
-msgstr "Equipo Xero Grunt VI"
-
-msgid "xerogrunt7"
-msgstr "Equipo Xero Grunt VII"
-
-msgid "xerogrunt8"
-msgstr "Equipo Xero Grunt VIII"
-
-msgid "xerogrunt9"
-msgstr "Equipo Xero Grunt IX"
-
-msgid "xerogrunt10"
-msgstr "Equipo Xero Grunt X"
+msgid "xerogrunt"
+msgstr "Equipo Xero Grunt"
 
 ## DIALOG TRANSLATIONS ##
 # general dialogs
@@ -1957,9 +1924,6 @@ msgid "nudiflot_male_description"
 msgstr ""
 "Ingiere y almacena el veneno de las criaturas marinas que le sirven de "
 "alimento."
-
-msgid "birb_robo"
-msgstr "Robot Pajarito"
 
 msgid "firsts"
 msgstr ""
@@ -3518,9 +3482,6 @@ msgid "Kennel"
 msgstr "refugio"
 
 msgid "dark_robo_description"
-msgstr "Un robot hostil."
-
-msgid "birb_robo_description"
 msgstr "Un robot hostil."
 
 msgid "mk01_delta_description"

--- a/mods/tuxemon/l18n/fi/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/fi/LC_MESSAGES/base.po
@@ -1043,9 +1043,6 @@ msgstr "Chrome Robo"
 msgid "dark_robo"
 msgstr "Dark Robo"
 
-msgid "birb_robo"
-msgstr "Birb Robo"
-
 msgid "xeon"
 msgstr "Xeon"
 

--- a/mods/tuxemon/l18n/fr_FR/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/fr_FR/LC_MESSAGES/base.po
@@ -1011,11 +1011,8 @@ msgstr "Infirmière de Cottonville"
 msgid "karrianna"
 msgstr "Karrianna"
 
-msgid "knight1"
-msgstr "Chevalier I"
-
-msgid "knight2"
-msgstr "Chevalier II"
+msgid "knight"
+msgstr "Chevalier"
 
 msgid "liela"
 msgstr "Liela"
@@ -1044,38 +1041,8 @@ msgstr "Commerçant de Tuxemart"
 msgid "tuxemart_aide"
 msgstr "Employé de Tuxemart"
 
-msgid "xerogrund1"
-msgstr "Troufion I de l'Équipe Xero"
-
-msgid "xerogrund2"
-msgstr "Troufion II de l'Équipe Xero"
-
-msgid "xerogrunt2"
-msgstr "Troufion II de l'Équipe Xero"
-
-msgid "xerogrunt3"
-msgstr "Troufion III de l'Équipe Xero"
-
-msgid "xerogrunt4"
-msgstr "Troufion IV de l'Équipe Xero"
-
-msgid "xerogrunt5"
-msgstr "Troufion V de l'Équipe Xero"
-
-msgid "xerogrunt6"
-msgstr "Troufion VI de l'Équipe Xero"
-
-msgid "xerogrunt7"
-msgstr "Troufion VII de l'Équipe Xero"
-
-msgid "xerogrunt8"
-msgstr "Troufion VIII de l'Équipe Xero"
-
-msgid "xerogrunt9"
-msgstr "Troufion IX de l'Équipe Xero"
-
-msgid "xerogrunt10"
-msgstr "Troufion X de l'Équipe Xero"
+msgid "xerogrunt"
+msgstr "Troufion de l'Équipe Xero"
 
 ## DIALOG TRANSLATIONS ##
 # general dialogs
@@ -2381,32 +2348,11 @@ msgstr "Ignatia"
 msgid "spyder_dryadsgrove_ferris"
 msgstr "Ferris"
 
-msgid "_chromerobo"
-msgstr "Robot Chromé"
-
-msgid "_darkrobo"
-msgstr "Robot Sombre"
-
-msgid "_birbrobo"
-msgstr "Robot Neige"
-
 msgid "spyder_dryadsgrove_sylvia"
 msgstr "Sylvia"
 
-msgid "spyder_dryadsgrove_volcoli"
-msgstr "Volcoli"
-
 msgid "spyder_dryadsgrove_petra"
 msgstr "Pétra"
-
-msgid "_xeon"
-msgstr "Xénon"
-
-msgid "_xeon-2"
-msgstr "Xénon-2"
-
-msgid "_mk01beta"
-msgstr "Mk01 Béta"
 
 ## MESSAGE TRANSLATIONS ##
 # spyder messages
@@ -2426,9 +2372,6 @@ msgstr "Acheter des trucs ici"
 
 msgid "spyder_route1_routesign"
 msgstr "Route 1 : Prendre garde !"
-
-msgid "_mk01alpha"
-msgstr "Mk01 Alpha"
 
 msgid "spyder_citypark_achievement"
 msgstr "Manoir du Maniaque du Trophée : Fermé."
@@ -2579,9 +2522,6 @@ msgstr "Touche Retour"
 
 msgid "menu_secondary_select_key"
 msgstr "Touche Annuler"
-
-msgid "birb_robo"
-msgstr "Robot Neige"
 
 msgid "oopsie2"
 msgstr ""
@@ -3679,9 +3619,6 @@ msgstr "Bismuth"
 msgid "spyder_route4_marshall"
 msgstr "Marshall"
 
-msgid "spyder_nimrod_chromerobo"
-msgstr "Robot Chromé"
-
 #, fuzzy
 msgid "spyder_route4_rincewind"
 msgstr "Rincewind"
@@ -4337,9 +4274,6 @@ msgid "bothofyou"
 msgstr ""
 "Tous les deux, venez dehors. Un représentant de Omnichannel veut s'adresser "
 "à la foule."
-
-msgid "spyder_nimrod_xeon"
-msgstr "Xénon"
 
 msgid "spyder_leather_maniac"
 msgstr ""
@@ -5017,12 +4951,6 @@ msgstr ""
 "rivière de haut en bas.\n"
 " Mais je ne l'ai pas vu depuis quelques jours. "
 
-msgid "spyder_nimrod_birbrobo1"
-msgstr "Bip bop be di wap bop di wep"
-
-msgid "spyder_nimrod_birbrobo2"
-msgstr "Bip bip bop"
-
 msgid "spyder_nimrod_chromerobo1"
 msgstr "Bop bop bip bip"
 
@@ -5130,9 +5058,6 @@ msgstr "Nous, les nymphes, sentons notre puissance diminuer avec les saisons."
 #, fuzzy
 msgid "spyder_dryadsgrove_petra1"
 msgstr "Brisez les moules de la nature !"
-
-msgid "spyder_nimrod_birbrobo"
-msgstr "Robot Neige"
 
 msgid "spyder_dragonscave_mallory3"
 msgstr ""
@@ -7824,9 +7749,6 @@ msgid "chrome_robo_description"
 msgstr "Un robot hostile."
 
 msgid "dark_robo_description"
-msgstr "Un robot hostile."
-
-msgid "birb_robo_description"
 msgstr "Un robot hostile."
 
 msgid "mk01_alpha_description"

--- a/mods/tuxemon/l18n/it_IT/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/it_IT/LC_MESSAGES/base.po
@@ -1225,11 +1225,8 @@ msgstr "Infermiera di Cotonopoli"
 msgid "karrianna"
 msgstr "Karrianna"
 
-msgid "knight1"
-msgstr "Cavaliere I"
-
-msgid "knight2"
-msgstr "Cavaliere II"
+msgid "knight"
+msgstr "Cavaliere"
 
 msgid "liela"
 msgstr "Liela"
@@ -1258,38 +1255,8 @@ msgstr "Bottegaio del Tuxemercato"
 msgid "tuxemart_aide"
 msgstr "Impiegato del Tuxemercato"
 
-msgid "xerogrund1"
-msgstr "Scagnozzo del team Xero I"
-
-msgid "xerogrund2"
-msgstr "Scagnozzo del team Xero II"
-
-msgid "xerogrunt2"
-msgstr "Scagnozzo del team Xero II"
-
-msgid "xerogrunt3"
-msgstr "Scagnozzo del team Xero III"
-
-msgid "xerogrunt4"
-msgstr "Scagnozzo del team Xero IV"
-
-msgid "xerogrunt5"
-msgstr "Scagnozzo del team Xero V"
-
-msgid "xerogrunt6"
-msgstr "Scagnozzo del team Xero VI"
-
-msgid "xerogrunt7"
-msgstr "Scagnozzo del team Xero VII"
-
-msgid "xerogrunt8"
-msgstr "Scagnozzo del team Xero VIII"
-
-msgid "xerogrunt9"
-msgstr "Scagnozzo del team Xero IX"
-
-msgid "xerogrunt10"
-msgstr "Scagnozzo del team Xero X"
+msgid "xerogrunt"
+msgstr "Scagnozzo del team Xero"
 
 ## DIALOG TRANSLATIONS ##
 # general dialogs
@@ -1823,9 +1790,6 @@ msgstr "Roboscuro"
 
 msgid "xeon_2"
 msgstr "Xeon-2"
-
-msgid "birb_robo"
-msgstr "Roboccellino"
 
 msgid "xeon"
 msgstr "Xeon"
@@ -4111,15 +4075,6 @@ msgstr "Rincewind"
 
 msgid "spyder_route4_rosamund"
 msgstr "Rosamund"
-
-msgid "spyder_nimrod_birbrobo"
-msgstr "Birb Robo"
-
-msgid "spyder_nimrod_chromerobo"
-msgstr "Chrome Robo"
-
-msgid "spyder_nimrod_xeon"
-msgstr "Xeon"
 
 msgid "spyder_nimrod_justice"
 msgstr "Justice"

--- a/mods/tuxemon/l18n/ja/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/ja/LC_MESSAGES/base.po
@@ -783,9 +783,6 @@ msgstr "ゥロウゴン"
 msgid "dark_robo"
 msgstr "ダルク ロボ"
 
-msgid "birb_robo"
-msgstr "ビルブ ロボ"
-
 msgid "mk01_beta"
 msgstr "ンク01 ベタ"
 

--- a/mods/tuxemon/l18n/nb_NO/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/nb_NO/LC_MESSAGES/base.po
@@ -1325,9 +1325,6 @@ msgstr "Dark Robo"
 msgid "xeon_2"
 msgstr "Xeon-2"
 
-msgid "birb_robo"
-msgstr "Birb Robo"
-
 msgid "mk01_beta"
 msgstr "Mk01 Beta"
 

--- a/mods/tuxemon/l18n/pl/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/pl/LC_MESSAGES/base.po
@@ -124,21 +124,6 @@ msgstr "{name} nie może być teraz użyty na żadnym z twoich Tuxemonów."
 msgid "spyder_route4_wulf"
 msgstr "Wulf"
 
-msgid "_xeon"
-msgstr "Xeon"
-
-msgid "spyder_nimrod_xeon"
-msgstr "Xeon"
-
-msgid "xeon"
-msgstr "Xeon"
-
-msgid "_xeon-2"
-msgstr "Xeon–2"
-
-msgid "xeon_2"
-msgstr "Xeon-2"
-
 msgid "37707_tower_missing"
 msgstr "N1e m0ż3sz w3jść d0 budynku, który n1e 1stn13je."
 
@@ -1584,9 +1569,6 @@ msgstr "Conifrost"
 
 msgid "corvix"
 msgstr "Corvix"
-
-msgid "birb_robo"
-msgstr "Birb Robo"
 
 msgid "mk01_beta"
 msgstr "Mk01 Beta"

--- a/mods/tuxemon/l18n/pt_BR/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/pt_BR/LC_MESSAGES/base.po
@@ -1253,9 +1253,6 @@ msgstr ""
 msgid "nudiflot_male"
 msgstr "Nudiflot"
 
-msgid "birb_robo"
-msgstr "Birb Robo"
-
 msgid "horned_raptor"
 msgstr "Raptor Chifrudo"
 
@@ -1307,11 +1304,8 @@ msgstr "Visitante"
 msgid "earth"
 msgstr "Terra"
 
-msgid "knight1"
-msgstr "Cavaleiro I"
-
-msgid "knight2"
-msgstr "Cavaleiro II"
+msgid "knight"
+msgstr "Cavaleiro"
 
 msgid "professor"
 msgstr "Professor"
@@ -1363,9 +1357,6 @@ msgstr "Água"
 msgid "tree"
 msgstr "Essa árvore parece feliz e saudável!"
 
-msgid "xerogrunt2"
-msgstr "Equipe Xero Grunt II"
-
 msgid "itslockedboi"
 msgstr "Allie trancou a porta atrás de si..."
 
@@ -1404,15 +1395,6 @@ msgstr "Enfermeira do Toque"
 
 msgid "tuxemart_keeper"
 msgstr "Lojista da Tuxemart"
-
-msgid "xerogrunt4"
-msgstr "Equipe Xero Grunt IV"
-
-msgid "xerogrunt5"
-msgstr "Equipe Xero Grunt V"
-
-msgid "xerogrunt6"
-msgstr "Equipe Xero Grunt VI"
 
 msgid "famous_statue2"
 msgstr "Diz: Para nossos amados amigos e heróis de todos, o wywen"
@@ -1495,21 +1477,6 @@ msgstr ""
 msgid "cottonnurse"
 msgstr "Enfermeira Algodão"
 
-msgid "xerogrund2"
-msgstr "Equipe Xero Grunt II"
-
-msgid "xerogrunt7"
-msgstr "Equipe Xero Grunt VII"
-
-msgid "xerogrunt8"
-msgstr "Equipe Xero Grunt VIII"
-
-msgid "xerogrunt9"
-msgstr "Equipe Xero Grunt IX"
-
-msgid "xerogrunt10"
-msgstr "Equipe Xero Grunt X"
-
 msgid "karrianna_dialog2"
 msgstr "Bem... Você foi o primeiro treinador que enfrentei..."
 
@@ -1532,8 +1499,8 @@ msgstr "Professor"
 msgid "professor-rockitten"
 msgstr "Professor"
 
-msgid "xerogrund1"
-msgstr "Equipe Xero Grunt I"
+msgid "xerogrunt"
+msgstr "Equipe Xero Grunt"
 
 msgid "oops"
 msgstr ""
@@ -1567,9 +1534,6 @@ msgstr ""
 
 msgid "route2speech"
 msgstr "AEE!!!"
-
-msgid "xerogrunt3"
-msgstr "Equipe Xero Grunt III"
 
 msgid "backstory"
 msgstr ""
@@ -2414,9 +2378,6 @@ msgid "mk01_proto"
 msgstr "Mk01 Proto"
 
 msgid "dark_robo_description"
-msgstr "Um robô hostil."
-
-msgid "birb_robo_description"
 msgstr "Um robô hostil."
 
 msgid "mk01_beta_description"

--- a/mods/tuxemon/l18n/zh_CN/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/zh_CN/LC_MESSAGES/base.po
@@ -2591,9 +2591,6 @@ msgstr "雪人"
 msgid "restless"
 msgstr "不安"
 
-msgid "xerogrunt5"
-msgstr "Xero Grunt I团队"
-
 msgid "devil"
 msgstr "恶魔"
 
@@ -2612,38 +2609,17 @@ msgstr "凝块"
 msgid "slurpy"
 msgstr "泥泞的"
 
-msgid "xerogrunt4"
-msgstr "Xero Grunt I团队"
-
 msgid "purple_flowers"
 msgstr "有人种下了一些香甜的紫色花朵!"
 
-msgid "xerogrunt6"
-msgstr "Xero Grunt I团队"
-
 msgid "door_problems"
 msgstr "门被卡住了,打不开..."
-
-msgid "xerogrunt2"
-msgstr "Xero Grunt I团队"
-
-msgid "xerogrunt9"
-msgstr "Xero Grunt I团队"
-
-msgid "xerogrunt3"
-msgstr "Xero Grunt I团队"
 
 msgid "cotton_town_fountain"
 msgstr "这是个喷泉.很多硬币都在底部."
 
 msgid "sure_i_do"
 msgstr "我当然知道."
-
-msgid "xerogrunt8"
-msgstr "Xero Grunt I团队"
-
-msgid "xerogrunt10"
-msgstr "Xero Grunt I团队"
 
 msgid "orange_flowers"
 msgstr "有人种下了一些美丽的橙色花朵!"
@@ -4116,9 +4092,6 @@ msgstr "铬合金机器人"
 msgid "dark_robo"
 msgstr "黑暗机器人"
 
-msgid "birb_robo"
-msgstr "比尔布机器人"
-
 msgid "xeon"
 msgstr "至强"
 
@@ -4179,11 +4152,8 @@ msgstr "艾莉"
 msgid "karrianna"
 msgstr "卡里安纳"
 
-msgid "knight1"
-msgstr "骑士I"
-
-msgid "knight2"
-msgstr "骑士II"
+msgid "knight"
+msgstr "骑士"
 
 msgid "liela"
 msgstr "莉拉"
@@ -4221,14 +4191,8 @@ msgstr "Tuxemart 店主"
 msgid "tuxemart_aide"
 msgstr "Tuxemart员工"
 
-msgid "xerogrund1"
-msgstr "Xero Grunt I团队"
-
-msgid "xerogrund2"
-msgstr "Xero Grunt I团队"
-
-msgid "xerogrunt7"
-msgstr "Xero Grunt I团队"
+msgid "xerogrunt"
+msgstr "Xero Grunt 团队"
 
 msgid "yes"
 msgstr "是"
@@ -5437,12 +5401,6 @@ msgstr ""
 msgid "spyder_flowerhouse1_firefighter"
 msgstr "五大支柱公司是这个地区唯一的大公司.他们有很大的影响力."
 
-msgid "spyder_nimrod_birbrobo1"
-msgstr "哔哔哔哔哔哔哔哔哔哔哔哔哔哔哔哔哔哔哔哔哔哔哔哔"
-
-msgid "spyder_nimrod_birbrobo2"
-msgstr "噗噗"
-
 msgid "spyder_nimrod_chromerobo1"
 msgstr "哔哔"
 
@@ -6146,15 +6104,6 @@ msgstr "罗萨蒙德"
 msgid "spyder_route4_beck"
 msgstr "贝克"
 
-msgid "spyder_nimrod_birbrobo"
-msgstr "比尔布机器人"
-
-msgid "spyder_nimrod_chromerobo"
-msgstr "铬合金机器人"
-
-msgid "spyder_nimrod_xeon"
-msgstr "至强"
-
 msgid "spyder_nimrod_justice"
 msgstr "正义"
 
@@ -6419,34 +6368,10 @@ msgstr "费里斯"
 msgid "spyder_dryadsgrove_sylvia"
 msgstr "西尔维娅"
 
-msgid "spyder_dryadsgrove_volcoli"
-msgstr "沃尔科利"
-
 # # MESSAGE TRANSLATIONS ##
 # spyder messages
 msgid "spyder_multi_underrepairs"
 msgstr "牌子上写着：“正在维修”"
-
-msgid "_chromerobo"
-msgstr "铬合金机器人"
-
-msgid "_darkrobo"
-msgstr "黑暗机器人"
-
-msgid "_birbrobo"
-msgstr "比尔布机器人"
-
-msgid "_xeon"
-msgstr "至强"
-
-msgid "_xeon-2"
-msgstr "至强-2"
-
-msgid "_mk01beta"
-msgstr "Mk01 测试版"
-
-msgid "_mk01alpha"
-msgstr "Mk01 阿尔法"
 
 msgid "spyder_multi_martsign"
 msgstr "在这里买东西"
@@ -6774,9 +6699,6 @@ msgstr "一个充满敌意的机器人."
 
 msgid "taba_house4_client1a"
 msgstr "我奶奶以前也做过类似的菜!"
-
-msgid "birb_robo_description"
-msgstr "一个敌对的机器人."
 
 msgid "mk01_alpha_description"
 msgstr "一个与龙融合的杀手机器人.不要问我们怎么做."

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -970,6 +970,7 @@ class NpcTemplateModel(BaseModel):
 
 class NpcModel(BaseModel):
     slug: str = Field(..., description="Slug of the name of the NPC")
+    name: Optional[str] = Field(None, description="Name of the NPC (msgid)")
     forfeit: bool = Field(False, description="Whether you can forfeit or not")
     template: Sequence[NpcTemplateModel] = Field(
         [], description="List of templates"
@@ -980,6 +981,12 @@ class NpcModel(BaseModel):
     items: Sequence[BagItemModel] = Field(
         [], description="List of items in the NPCs bag"
     )
+
+    @field_validator("name")
+    def translation_exists(cls: NpcModel, v: str) -> str:
+        if v is not None and has.translation(v):
+            return v
+        raise ValueError(f"no translation exists with msgid: {v}")
 
 
 class BattleHudModel(BaseModel):

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -833,6 +833,8 @@ class NPC(Entity[NPCState]):
 
         # Look up the NPC's details from our NPC database
         npc_details = db.lookup(self.slug, "npc")
+        if npc_details.name:
+            self.name = T.translate(npc_details.name)
         self.forfeit = npc_details.forfeit
         npc_party = npc_details.monsters
         for npc_monster_details in npc_party:


### PR DESCRIPTION
waiting #2242

PR:
- adds a field called **name** (in the beginning **Optional[str]**, then later **str**);
- purges every trace of **birb_robo** from the PO files (deleted months ago because of copyright issue), the EN was purged back then, but no the others;

the field name allows to define a different name without being obliged to create duplicates inside the PO file. For instance the case of multiple PNGs like soldiers, nurses, which could share the same name (eg Nurse, Soldier, etc.).

for instance inside the PO file there was an entry for **spyder_nimrod_chromerobo** with the msgtr "Chrome Robo", since Chrome Robo is a monster, it exists the entry **chrome_robo**, so it was possible to set the field name inside the NPC with **chrome_robo** and avoid the duplicate. If you look at the changed file, then you can see the same example with knight as well as xerogrunt/d, here we can easily set a name, so no matter it fights or not, it's ready and we can use it

eventually we can create common entry like: 
```
msgid "beck"
msgstr "Beck"

for soldiers
msgid "private"
msgstr "Private"
msgid "sergeant"
msgstr "Sergeant"
msgid "corporal"
msgstr "Corporal"
etc
```
