### PR TITLE
maps fix (Spyder)

### DIFF
--- a/mods/tuxemon/gfx/tilesets/Superpowers_Tilesheet.tsx
+++ b/mods/tuxemon/gfx/tilesets/Superpowers_Tilesheet.tsx
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tileset version="1.10" tiledversion="git" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
+ <image source="Superpowers_Tilesheet.png" width="640" height="640"/>
+ <tile id="66">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="67">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="146">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="147">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="174">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="175">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+</tileset>

--- a/mods/tuxemon/gfx/tilesets/core_city_and_country.tsx
+++ b/mods/tuxemon/gfx/tilesets/core_city_and_country.tsx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<tileset version="1.8" tiledversion="1.8.0" name="core_city_and_country" tilewidth="16" tileheight="16" tilecount="1440" columns="40">
+<tileset version="1.10" tiledversion="git" name="core_city_and_country" tilewidth="16" tileheight="16" tilecount="1440" columns="40">
  <image source="core_city_and_country.png" width="640" height="576"/>
  <tile id="16">
   <animation>
@@ -21,6 +21,51 @@
    <frame tileid="101" duration="150"/>
   </animation>
  </tile>
+ <tile id="22">
+  <properties>
+   <property name="enter_from" value="right,down"/>
+   <property name="exit_from" value="right,down"/>
+  </properties>
+ </tile>
+ <tile id="23">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="24">
+  <properties>
+   <property name="enter_from" value="left,down"/>
+   <property name="exit_from" value="left,down"/>
+  </properties>
+ </tile>
+ <tile id="30">
+  <properties>
+   <property name="enter_from" value="up,left,right"/>
+   <property name="exit_from" value="up,left,right"/>
+  </properties>
+ </tile>
+ <tile id="31">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="32">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="33">
+  <properties>
+   <property name="enter_from" value="up,left,right"/>
+   <property name="exit_from" value="up,left,right"/>
+  </properties>
+ </tile>
+ <tile id="34">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
  <tile id="40">
   <animation>
    <frame tileid="40" duration="150"/>
@@ -32,6 +77,16 @@
    <frame tileid="82" duration="150"/>
    <frame tileid="83" duration="150"/>
   </animation>
+ </tile>
+ <tile id="44">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="45">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
  </tile>
  <tile id="56">
   <animation>
@@ -53,6 +108,70 @@
    <frame tileid="141" duration="150"/>
   </animation>
  </tile>
+ <tile id="62">
+  <properties>
+   <property name="enter_from" value="right,up,down"/>
+   <property name="exit_from" value="right,up,down"/>
+  </properties>
+ </tile>
+ <tile id="64">
+  <properties>
+   <property name="enter_from" value="left,up,down"/>
+   <property name="exit_from" value="left,up,down"/>
+  </properties>
+ </tile>
+ <tile id="70">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="71">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="73">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="74">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="84">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="85">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="102">
+  <properties>
+   <property name="enter_from" value="right,up"/>
+   <property name="exit_from" value="right,up"/>
+  </properties>
+ </tile>
+ <tile id="103">
+  <properties>
+   <property name="enter_from" value="up,left,right"/>
+   <property name="exit_from" value="up,left,right"/>
+  </properties>
+ </tile>
+ <tile id="104">
+  <properties>
+   <property name="enter_from" value="left,up"/>
+   <property name="exit_from" value="left,up"/>
+  </properties>
+ </tile>
  <tile id="123">
   <animation>
    <frame tileid="123" duration="150"/>
@@ -62,6 +181,145 @@
    <frame tileid="164" duration="150"/>
    <frame tileid="165" duration="150"/>
   </animation>
+ </tile>
+ <tile id="145">
+  <properties>
+   <property name="enter_from" value="up,down"/>
+   <property name="exit_from" value="up,down"/>
+  </properties>
+ </tile>
+ <tile id="151">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="152">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="181">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="191">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="192">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="203">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="204">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="205">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="206">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="207">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="208">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="209">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="210">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="221">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="222">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="223">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="224">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="228">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="229">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="230">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="235">
+  <properties>
+   <property name="enter_from" value="right,left,up"/>
+   <property name="exit_from" value="right,left,up"/>
+  </properties>
+ </tile>
+ <tile id="236">
+  <properties>
+   <property name="enter_from" value="right,left,up"/>
+   <property name="exit_from" value="right,left,up"/>
+  </properties>
+ </tile>
+ <tile id="237">
+  <properties>
+   <property name="enter_from" value="right,left,up"/>
+   <property name="exit_from" value="right,left,up"/>
+  </properties>
+ </tile>
+ <tile id="238">
+  <properties>
+   <property name="enter_from" value="right,left,up"/>
+   <property name="exit_from" value="right,left,up"/>
+  </properties>
+ </tile>
+ <tile id="239">
+  <properties>
+   <property name="enter_from" value="right,left,up"/>
+   <property name="exit_from" value="right,left,up"/>
+  </properties>
  </tile>
  <tile id="258">
   <animation>
@@ -80,6 +338,206 @@
    <frame tileid="260" duration="150"/>
    <frame tileid="300" duration="150"/>
   </animation>
+ </tile>
+ <tile id="261">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="275">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="276">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="277">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="278">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="279">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="286">
+  <properties>
+   <property name="enter_from" value="up,down"/>
+   <property name="exit_from" value="up,down"/>
+  </properties>
+ </tile>
+ <tile id="289">
+  <properties>
+   <property name="enter_from" value="right,left"/>
+   <property name="exit_from" value="right,left"/>
+  </properties>
+ </tile>
+ <tile id="291">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="292">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="306">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="307">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="308">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="309">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="310">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="315">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="316">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="317">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="318">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="319">
+  <properties>
+   <property name="enter_from" value="right,left,up"/>
+   <property name="exit_from" value="right,left,up"/>
+  </properties>
+ </tile>
+ <tile id="331">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="332">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="333">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="334">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="351">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="352">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="353">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="355">
+  <properties>
+   <property name="enter_from" value="up,left,right"/>
+   <property name="exit_from" value="up,left,right"/>
+  </properties>
+ </tile>
+ <tile id="356">
+  <properties>
+   <property name="enter_from" value="up,left,right"/>
+   <property name="exit_from" value="up,left,right"/>
+  </properties>
+ </tile>
+ <tile id="357">
+  <properties>
+   <property name="enter_from" value="up,left,right"/>
+   <property name="exit_from" value="up,left,right"/>
+  </properties>
+ </tile>
+ <tile id="358">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="359">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="371">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="372">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="373">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="374">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
  </tile>
  <tile id="377">
   <animation>
@@ -103,6 +561,10 @@
   </animation>
  </tile>
  <tile id="382">
+  <properties>
+   <property name="enter_from" value="right,left,up"/>
+   <property name="exit_from" value="right,left,up"/>
+  </properties>
   <animation>
    <frame tileid="382" duration="150"/>
    <frame tileid="385" duration="150"/>
@@ -110,6 +572,10 @@
   </animation>
  </tile>
  <tile id="383">
+  <properties>
+   <property name="enter_from" value="right,left,up"/>
+   <property name="exit_from" value="right,left,up"/>
+  </properties>
   <animation>
    <frame tileid="383" duration="150"/>
    <frame tileid="386" duration="150"/>
@@ -117,13 +583,104 @@
   </animation>
  </tile>
  <tile id="384">
+  <properties>
+   <property name="enter_from" value="right,left,up"/>
+   <property name="exit_from" value="right,left,up"/>
+  </properties>
   <animation>
    <frame tileid="384" duration="150"/>
    <frame tileid="387" duration="150"/>
    <frame tileid="390" duration="150"/>
   </animation>
  </tile>
+ <tile id="385">
+  <properties>
+   <property name="enter_from" value="right,left,up"/>
+   <property name="exit_from" value="right,left,up"/>
+  </properties>
+ </tile>
+ <tile id="386">
+  <properties>
+   <property name="enter_from" value="right,left,up"/>
+   <property name="exit_from" value="right,left,up"/>
+  </properties>
+ </tile>
+ <tile id="387">
+  <properties>
+   <property name="enter_from" value="right,left,up"/>
+   <property name="exit_from" value="right,left,up"/>
+  </properties>
+ </tile>
+ <tile id="388">
+  <properties>
+   <property name="enter_from" value="right,left,up"/>
+   <property name="exit_from" value="right,left,up"/>
+  </properties>
+ </tile>
+ <tile id="389">
+  <properties>
+   <property name="enter_from" value="right,left,up"/>
+   <property name="exit_from" value="right,left,up"/>
+  </properties>
+ </tile>
+ <tile id="390">
+  <properties>
+   <property name="enter_from" value="right,left,up"/>
+   <property name="exit_from" value="right,left,up"/>
+  </properties>
+ </tile>
+ <tile id="395">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="396">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="397">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="409">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="410">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="411">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="412">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="413">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="414">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
  <tile id="422">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
   <animation>
    <frame tileid="422" duration="150"/>
    <frame tileid="425" duration="150"/>
@@ -131,6 +688,9 @@
   </animation>
  </tile>
  <tile id="423">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
   <animation>
    <frame tileid="423" duration="150"/>
    <frame tileid="426" duration="150"/>
@@ -138,11 +698,452 @@
   </animation>
  </tile>
  <tile id="424">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
   <animation>
    <frame tileid="424" duration="150"/>
    <frame tileid="427" duration="150"/>
    <frame tileid="430" duration="150"/>
   </animation>
+ </tile>
+ <tile id="425">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="426">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="427">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="428">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="429">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="430">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="449">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="450">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="451">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="452">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="453">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="462">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="463">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="464">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="465">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="466">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="467">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="468">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="469">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="470">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="489">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="490">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="491">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="492">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="493">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="521">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="522">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="523">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="532">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="533">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="534">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="560">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="561">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="562">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="563">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="572">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="573">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="574">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="600">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="601">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="602">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="603">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="640">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="641">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="642">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="643">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="644">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="645">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="646">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="647">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="685">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="686">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="687">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="725">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="726">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="727">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="763">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="764">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="765">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="821">
+  <properties>
+   <property name="enter_from" value="up,left,right"/>
+   <property name="exit_from" value="up,left,right"/>
+  </properties>
+ </tile>
+ <tile id="822">
+  <properties>
+   <property name="enter_from" value="up,left,right"/>
+   <property name="exit_from" value="up,left,right"/>
+  </properties>
+ </tile>
+ <tile id="826">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="827">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="828">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="829">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="861">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="862">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="866">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="867">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="868">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="869">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="946">
+  <properties>
+   <property name="enter_from" value="down,left,right"/>
+   <property name="exit_from" value="down,left,right"/>
+  </properties>
+ </tile>
+ <tile id="947">
+  <properties>
+   <property name="enter_from" value="down,left,right"/>
+   <property name="exit_from" value="down,left,right"/>
+  </properties>
+ </tile>
+ <tile id="948">
+  <properties>
+   <property name="enter_from" value="down,left,right"/>
+   <property name="exit_from" value="down,left,right"/>
+  </properties>
+ </tile>
+ <tile id="1026">
+  <properties>
+   <property name="enter_from" value="up,left,right"/>
+   <property name="exit_from" value="up,left,right"/>
+  </properties>
+ </tile>
+ <tile id="1027">
+  <properties>
+   <property name="enter_from" value="up,left,right"/>
+   <property name="exit_from" value="up,left,right"/>
+  </properties>
+ </tile>
+ <tile id="1028">
+  <properties>
+   <property name="enter_from" value="up,left,right"/>
+   <property name="exit_from" value="up,left,right"/>
+  </properties>
+ </tile>
+ <tile id="1098">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="1099">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="1100">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="1101">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="1102">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
  </tile>
  <tile id="1163">
   <animation>
@@ -162,6 +1163,18 @@
    <frame tileid="1172" duration="150"/>
   </animation>
  </tile>
+ <tile id="1180">
+  <properties>
+   <property name="enter_from" value="up,down,right"/>
+   <property name="exit_from" value="up,down,right"/>
+  </properties>
+ </tile>
+ <tile id="1182">
+  <properties>
+   <property name="enter_from" value="up,down,left"/>
+   <property name="exit_from" value="up,down,left"/>
+  </properties>
+ </tile>
  <tile id="1203">
   <animation>
    <frame tileid="1203" duration="150"/>
@@ -179,5 +1192,99 @@
    <frame tileid="1210" duration="150"/>
    <frame tileid="1212" duration="150"/>
   </animation>
+ </tile>
+ <tile id="1220">
+  <properties>
+   <property name="enter_from" value="up,down,right"/>
+   <property name="exit_from" value="up,down,right"/>
+  </properties>
+ </tile>
+ <tile id="1222">
+  <properties>
+   <property name="enter_from" value="up,down,left"/>
+   <property name="exit_from" value="up,down,left"/>
+  </properties>
+ </tile>
+ <tile id="1248">
+  <properties>
+   <property name="enter_from" value="right,left,up"/>
+   <property name="exit_from" value="right,left,up"/>
+  </properties>
+ </tile>
+ <tile id="1249">
+  <properties>
+   <property name="enter_from" value="right,left,up"/>
+   <property name="exit_from" value="right,left,up"/>
+  </properties>
+ </tile>
+ <tile id="1260">
+  <properties>
+   <property name="enter_from" value="up,down,right"/>
+   <property name="exit_from" value="up,down,right"/>
+  </properties>
+ </tile>
+ <tile id="1262">
+  <properties>
+   <property name="enter_from" value="up,down,left"/>
+   <property name="exit_from" value="up,down,left"/>
+  </properties>
+ </tile>
+ <tile id="1288">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="1289">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="1300">
+  <properties>
+   <property name="enter_from" value="up,down,right"/>
+   <property name="exit_from" value="up,down,right"/>
+  </properties>
+ </tile>
+ <tile id="1302">
+  <properties>
+   <property name="enter_from" value="up,down,left"/>
+   <property name="exit_from" value="up,down,left"/>
+  </properties>
+ </tile>
+ <tile id="1313">
+  <properties>
+   <property name="enter_from" value="down,left,right"/>
+   <property name="exit_from" value="down,left,right"/>
+  </properties>
+ </tile>
+ <tile id="1328">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="1329">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="1349">
+  <properties>
+   <property name="enter_from" value="up,down,right"/>
+   <property name="exit_from" value="up,down,right"/>
+  </properties>
+ </tile>
+ <tile id="1350">
+  <properties>
+   <property name="enter_from" value="up,down,left"/>
+   <property name="exit_from" value="up,down,left"/>
+  </properties>
+ </tile>
+ <tile id="1353">
+  <properties>
+   <property name="enter_from" value="up,left,right"/>
+   <property name="exit_from" value="up,left,right"/>
+  </properties>
  </tile>
 </tileset>

--- a/mods/tuxemon/gfx/tilesets/core_outdoor.tsx
+++ b/mods/tuxemon/gfx/tilesets/core_outdoor.tsx
@@ -3866,38 +3866,32 @@
  </tile>
  <tile id="1362">
   <properties>
-   <property name="enter_from" value="up,left,right"/>
-   <property name="exit_from" value="up,left,right"/>
+   <property name="enter_from" value=""/>
   </properties>
  </tile>
  <tile id="1364">
   <properties>
-   <property name="enter_from" value="up,left,right"/>
-   <property name="exit_from" value="up,left,right"/>
+   <property name="enter_from" value=""/>
   </properties>
  </tile>
  <tile id="1365">
   <properties>
-   <property name="enter_from" value="up,left,right"/>
-   <property name="exit_from" value="up,left,right"/>
+   <property name="enter_from" value=""/>
   </properties>
  </tile>
  <tile id="1366">
   <properties>
-   <property name="enter_from" value="up,left,right"/>
-   <property name="exit_from" value="up,left,right"/>
+   <property name="enter_from" value=""/>
   </properties>
  </tile>
  <tile id="1367">
   <properties>
-   <property name="enter_from" value="up,left,right"/>
-   <property name="exit_from" value="up,left,right"/>
+   <property name="enter_from" value=""/>
   </properties>
  </tile>
  <tile id="1368">
   <properties>
-   <property name="enter_from" value="up,left,right"/>
-   <property name="exit_from" value="up,left,right"/>
+   <property name="enter_from" value=""/>
   </properties>
  </tile>
  <tile id="1371">
@@ -4055,6 +4049,31 @@
    <frame tileid="1560" duration="250"/>
   </animation>
  </tile>
+ <tile id="1562">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="1563">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="1564">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="1565">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="1566">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
  <tile id="1593">
   <animation>
    <frame tileid="1593" duration="250"/>
@@ -4063,6 +4082,31 @@
    <frame tileid="1596" duration="250"/>
    <frame tileid="1597" duration="250"/>
   </animation>
+ </tile>
+ <tile id="1599">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="1600">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="1601">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="1602">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="1603">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
  </tile>
  <tile id="1630">
   <animation>
@@ -4109,12 +4153,67 @@
    <frame tileid="1782" duration="250"/>
   </animation>
  </tile>
+ <tile id="1827">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="1828">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="1829">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="1830">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="1862">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="1863">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="1866">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="1867">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="1868">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
  <tile id="1892">
   <animation>
    <frame tileid="1859" duration="150"/>
    <frame tileid="1893" duration="150"/>
    <frame tileid="1894" duration="150"/>
   </animation>
+ </tile>
+ <tile id="1941">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="1942">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
  </tile>
  <tile id="2003">
   <animation>
@@ -4123,12 +4222,100 @@
    <frame tileid="2005" duration="150"/>
   </animation>
  </tile>
+ <tile id="2090">
+  <properties>
+   <property name="enter_from" value="right,left,up"/>
+   <property name="exit_from" value="right,left,up"/>
+  </properties>
+ </tile>
+ <tile id="2091">
+  <properties>
+   <property name="enter_from" value="right,left,up"/>
+   <property name="exit_from" value="right,left,up"/>
+  </properties>
+ </tile>
+ <tile id="2092">
+  <properties>
+   <property name="enter_from" value="right,left,up"/>
+   <property name="exit_from" value="right,left,up"/>
+  </properties>
+ </tile>
+ <tile id="2093">
+  <properties>
+   <property name="enter_from" value="right,left,up"/>
+   <property name="exit_from" value="right,left,up"/>
+  </properties>
+ </tile>
  <tile id="2114">
   <animation>
    <frame tileid="2081" duration="150"/>
    <frame tileid="2115" duration="150"/>
    <frame tileid="2116" duration="150"/>
   </animation>
+ </tile>
+ <tile id="2127">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="2128">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="2129">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="2130">
+  <properties>
+   <property name="enter_from" value="right,left,down"/>
+   <property name="exit_from" value="right,left,down"/>
+  </properties>
+ </tile>
+ <tile id="2163">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="2164">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="2200">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="2201">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="2202">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="2203">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="2204">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="2205">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
  </tile>
  <tile id="2225">
   <animation>
@@ -4137,10 +4324,59 @@
    <frame tileid="2227" duration="150"/>
   </animation>
  </tile>
+ <tile id="2237">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="2238">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="2239">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="2240">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="2241">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="2274">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="2275">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="2276">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="2277">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
+ <tile id="2278">
+  <properties>
+   <property name="enter_from" value=""/>
+  </properties>
+ </tile>
  <tile id="2432">
   <properties>
-   <property name="enter_from" value="up,left,right"/>
-   <property name="exit_from" value="up,left,right"/>
+   <property name="enter_from" value=""/>
   </properties>
  </tile>
 </tileset>

--- a/mods/tuxemon/maps/spyder_candy_port.tmx
+++ b/mods/tuxemon/maps/spyder_candy_port.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="23">
+<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="23">
  <properties>
   <property name="east" value="routec"/>
   <property name="edges" value="clamped"/>
@@ -14,12 +14,12 @@
  <tileset firstgid="5766" source="../gfx/tilesets/core_outdoor_water.tsx"/>
  <layer id="1" name="Tile Layer 1" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHtlMENwkAMBI8AH2iEIkCiACiCDnhRDNAL0BRvvFJWWNZeckghySMPy6e1z57YSaqUUpWxuenn2q7mb2Z3pzHWpfd9TgbWxLZxLP5elzyxlu+T48PcwDYGvsi/NK7jSPnIBuYh5od9xv0ejIWGuYGNnGq/q1lKF8v5l62tPr9D8Ob2yxkyzufC3T4M/4nIx7n5GZLvYfnPHu1V83G38HG/ZBvKq/l5zhKurb0ju9qQz3P0uZjSqe3tR6fmh3hbX1/jvUgJBo3n6HMxpXsNZ5pnAjt7+PxftaZ8xNpq+z14JtYtqcFc1astpu4ojXWUV/mlGuupfMSUrjTWUV7lK03dnbTvdzLNYppF1+/AB8HbE8c=
+   eAHtlMENwjAMRU2BCyzCECAxAAzBBj0xDLALsBRn/KV+YUU/TZFK6aEHy9G3Yz/ZaSszqzI2d71u7OL+6nYLGmN9+tjn5GBtbJvAEu/1yZPWin1yfJgb2MbAl/Ivnes4Uj6ygXks8zs4Cw1zAxs51X5XM7Oz5/zK1l6f3yHeX26/nCHjfLe4O4ThP5HycW5xhuS7e/5jQHs2fNwtfLpfsv3Lq/lFzi5cW38ju8aQz3PqczGlU9v7j07ND/FS31jjtTCDQeM59bmY0qOGMy0ygZ09Yv63Wls+YqXacQ+RiXW71GCu6lWKqTtKYx3lVX5XjfVUPmJKVxrrKK/ylabuTtrnO5lmMc2i7zfwBjzQE9Q=
   </data>
  </layer>
  <layer id="2" name="Tile Layer 2" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHtVUlKQ1EQfJhEXaqYQcVpp2jAtRgVxKVewY3TYZyWDifwLF4gGr2B01JcWc1PQdN0mx8TdGNDpd6v7lfd7/GTpNQ5FkopLQISW8WUiqMZhsASwsTzSEovwCvwBrwDzJG5n6z1bfhL6J6ZEn/uYLbd9nwfhZRKmEcw3J5LmBjHugxUgCpQA5gj16FpUBfPT/hL6J6ZEn/qs9j56E1eQ48GsA5sAJsAc2TeF5m6nk/3lMluB/357nBv+iwyH8++gt4W+9AOgEPgCDgGbE30LL693t803o+ZAHPQT9DjFDgDzoELYD6o93xmUSth7y9T/U99f35F/9VuenZzln5NanvuBe+f9IvOwt8HYRtRLtLt/qinrbPPZXUOfk+EGfyeeTmpiXTJrSpve3+S7yVamPEReFKz0i/KebrW+JtLH491PfOeVhjDfwpQAmxEOU/3NOunn736vBp9vHrJebrVGgN08dnW5/XVbp7HT3y0J9eed17tO4/fnm8J790yUHfevyjn6Z7Gc3rs1Xuat/df+/sbaFZSugfID1i3gEvgBrhus81TlzpZCwu4n8y8eDUB6cUcn7mf+pWqqVVTmgDIk1hPATY65VnP/WTqwtaDz6zRe7j+AvMYb+A=
+   eAHtVTlOA0EQbGEbCAHhAxCQgsASMcKAhAjhCyRcj+EKOV7AW/iAwfADrhARUS27pFarx2vYFSSMVK7Z6p7qnvGsLZI9Fioii4COrbJIebyLEbAOZeJ5TOQFeAXegHeAMTLXk62+DX8dtmZXSX/uoLfdXn8fJZEK+lGM9vpSJiYxrwI1oA40AMbITWgW1NXzE/46bM2ukv60e/H90Zu8hhotYB3YADYBxsg8LzJ125+tqZ3dDsf93eHc7F60P+59BbU99qEdAIfAEXAM+JzUs/rmPb9Z3I+5PjhBjVPgDDgHLoB++T42n/P+xadcvGq/syx3fxey8ouI+5p7ifuntb6zlyJ6y1OzavbB90SZg+9ZFNOclK6xVePtz0/jeUYHPT4CT6ZX+qVikW41/ubSJ2Kbz3iklSbwnwJUAD9SsUiPNO9nn6P8QTX6RPkai3SvtYboErPPH9TXukUeP/GxnpxH3oNq/Tx+u78l3LtloBncv1Qs0iON+4w4yo+0aO2/9vcn0K6J3APkB8w7wCVwA1z32Mepa57OlRVcT2ZcvdqA1mKMz1xP/crkNOoiUwB5GvMZwI+sOPO5nkxd2XvwmTl2DedfBnpvHg==
   </data>
  </layer>
  <layer id="5" name="Tile Layer 3" width="40" height="20">
@@ -27,16 +27,16 @@
    eAHt0KEBAAAIw7AZzuP/d/CoHZDqqiQiQIAAAQK9wE7/OgkQIECAwBc4D6kAUw==
   </data>
  </layer>
+ <layer id="6" name="Above Player" width="40" height="20">
+  <data encoding="base64" compression="zlib">
+   eAFjYBgFoyEwGgKjITD4QoBFkIEBhtFdBxMH0cgAlziymlH2aAiMhsBoCIyGwGgIjIbAwIYAAMjiAL4=
+  </data>
+ </layer>
  <objectgroup color="#ff0000" id="3" name="Collisions">
-  <object id="1" type="collision" x="192" y="64" width="160" height="16"/>
-  <object id="2" type="collision" x="368" y="64" width="224" height="16"/>
-  <object id="3" type="collision" x="192" y="0" width="16" height="64"/>
-  <object id="4" type="collision" x="576" y="0" width="16" height="64"/>
+  <object id="1" type="collision" x="320" y="64" width="32" height="16"/>
+  <object id="2" type="collision" x="368" y="64" width="32" height="16"/>
   <object id="6" type="collision" x="144" y="0" width="32" height="128"/>
   <object id="7" type="collision" x="352" y="48" width="16" height="16"/>
   <object id="10" type="collision" x="608" y="0" width="32" height="160"/>
-  <object id="19" type="collision" x="240" y="112" width="48" height="16"/>
-  <object id="20" type="collision" x="352" y="112" width="48" height="16"/>
-  <object id="21" type="collision" x="448" y="112" width="48" height="16"/>
  </objectgroup>
 </map>

--- a/mods/tuxemon/maps/spyder_candy_town.tmx
+++ b/mods/tuxemon/maps/spyder_candy_town.tmx
@@ -21,7 +21,7 @@
  </layer>
  <layer id="2" name="Tile Layer 4" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHNl8lPFEEUhwsUE/CiKBi9cHYX9C5xiye3k7K5+xcooIkynNzADb2xuaKJGmOiF1yBRAi7282bW0z0D2DTr+K8WKlUz9TM2A0v+fKqX/2632/edKdnevOU6gM7euP1oGzr5ThIb9e1XmpyblHpv5rs/cTHL4c/qQflsjlKlVtUcBykt+vak9TEn1mTPfFpavRa6kHZ1stxkN6ui97Otk582jqpB2VbL8dBersueju7dLvyVWwn7IDtsA3s86I6tuen+9bjJwZ1cApOQlR+7D6u+T3Cz4t8pR6SH8B9w19trlLHoRokauK1E0ZN9jLNrvklumZLAg9tCfYSXTPRnmt+ifRR+8tkfnk5KpYL8nmiml/zfKVaoBXaoB0kzPmV4K04ZH+u+fXjZwAGYQiGQcL0JzXJUc1vDD/jMAGTMAUSYfjLy1ZqrgPpqbPM0ay51l08o90B9KT5/JbgLVnIc5xMF8a+jz9zfkcLlDoG1VADtRBm+Pgz53cTP7fgNtyBDggzfPzp/n1Ff128xc87eA8f4COEHU1LlDJx9XsT95dVqFQ2zILZkANhx2P8mbj6yfzW4KcYSmAtrIN04+s8pb4l4Tv7pje9doXMz7WXbu0JvZ8modPTX2/8+03Xi+u8z/T+koQf7PuEzG8/v/f2wV6ogkrwOd+lWcC7Z6FBAetCWGTUFrP2Cbn/LuHnIlyARmgAn/Ndmg303miwifVm2GLUtrL2CZnfS/zo38/Pyc+gMwN/Pn3LPN5v+jph3H8+/nw1Mj9ffdQ6uf+i7uvbT+Z3gHvvIByCw3AEZlJcxs8VaIKrcA0kmnkXt0CrkdtYt8N1q651N+B/xyv8vIYu6IYekOin3wAMGnmI9TCMWHWtG4UoY4x+4zBh5EnWU/DbqmudyuDdnc7nWkq/ZbDcyCtYr4RVVl3rVkOUsZt+e6DMyOWsK6DSqmtdFaQadVlKxaAeUo3T9DsDZ418jvV5aLDqWtcIqUYHvu7CvTT8pdorHf0wvkZgdIb6c30m8/+ba3+6a+b/N5eXilLuf/i03rUbfi3Z/Jrx1gLTFTK/P41dUzM=
+   eAHNl8lPFEEUhwsUE/CiKBi9cHYX9C5xiye3k7K5+xcoookynNzADb0xgCuaqDEmesEVSISwu928ucVE/wA2/SrOi5VK9UzNQDe85MurfvXrfr95052e6c5Tqgfs6E7Ug7Ktl+MgvV3XeqnJuUWl/2uy9wsfvx3+pB6Uy+YoVW5RwXGQ3q5rT1ITf2ZN9sSnqdFrqQdlWy/HQXq7Lno72zrxaeukHpRtvRwH6e266O3s0u3KV7GdsAO2wzawz4vq2J6f7luHnxjUwmk4BVH5sfu45vcYPy/zlXpEfggPDH81uUqdSCDXkuOT1Kc6XPNL1iOexENLkr1k10y255pfMn3U/iYzv7wcFcsF+TxRza9pvlJxaIYWaAUJc34leCsO2Z9rfr346YN+GIBBkDD9SU1yVPMbwc8ojME4TIBEGP7yspWa60B66ixzNGuudQfPaGcAXRk+vyV4SxXyHKfShbHv48+c39ECpY5BNRyHGggzfPyZ87uFn9twB+5CG4QZPv50/56ify7e4ec9fICP8AnCjsYlSpm4+r1N+MsqVCobZsFsyIGw4wn+TFz9ZH5r8FMMJbAW1kGm8W2eUt9T8IN905teu0Lm59rLtPaU3s9S0O7przvx/WbqxXXeF3p/TcFP9n1C5ref33v7YC9UQSX4nO/SLODds9CggHUhLDJqi1n7hNx/l/FzCS5CA9SDz/kuzQZ6bzTYxHozbDFqW1n7hMzvFX707+cX5OfQPgl/Pn3LPN5v+jph3H8+/nw1Mj9ffdQ6uf+i7uvbT+Z3gHvvIByCw3AEZlJcwc9VaIRrcB0kmngXx6HZyC2sW+GGVde6mzDV8Ro/b6ADOqELJHrp1wf9Rh5gPQhDVl3rhiHKGKHfKIwZeZz1BPyx6lqnJvHuzuRzLaXfMlhu5BWsV8Iqq651qyHK2E2/PVBm5HLWFVBp1bWuCtKN2iylYlAH6cYZ+p2Fc0Y+z/oC1Ft1rWuAdKMNX/fgfgb+0u2ViX4QX0MwPEP9uT6T+f/NtT/dNfP/m8tLRSn3P3xe79oNv5Zqfk14i8N0hczvL/a9Uzg=
   </data>
  </layer>
  <layer id="3" name="Tile Layer 2" width="40" height="40">
@@ -41,53 +41,38 @@
   <object id="111" type="collision" x="576" y="0" width="64" height="192"/>
   <object id="113" type="collision" x="416" y="368" width="64" height="16"/>
   <object id="115" type="collision" x="320" y="304" width="160" height="64"/>
-  <object id="116" type="collision" x="464" y="384" width="128" height="16"/>
-  <object id="117" type="collision" x="576" y="320" width="16" height="64"/>
-  <object id="118" type="collision" x="464" y="192" width="128" height="16"/>
-  <object id="119" type="collision" x="576" y="208" width="16" height="80"/>
   <object id="120" type="collision" x="528" y="528" width="48" height="32"/>
   <object id="125" type="collision" x="16" y="448" width="48" height="48"/>
   <object id="126" type="collision" x="80" y="480" width="16" height="32"/>
   <object id="127" type="collision" x="16" y="352" width="80" height="32"/>
   <object id="129" type="collision" x="0" y="384" width="32" height="32"/>
   <object id="130" type="collision" x="0" y="416" width="16" height="16"/>
-  <object id="131" type="collision" x="0" y="480" width="32" height="64"/>
+  <object id="131" type="collision" x="0" y="496" width="32" height="48"/>
   <object id="134" type="collision" x="0" y="288" width="32" height="32"/>
-  <object id="135" type="collision" x="0" y="320" width="16" height="16"/>
+  <object id="135" type="collision" x="0" y="320" width="16" height="32"/>
   <object id="136" type="collision" x="16" y="240" width="80" height="48"/>
   <object id="138" type="collision" x="0" y="192" width="32" height="32"/>
-  <object id="139" type="collision" x="0" y="224" width="16" height="16"/>
+  <object id="139" type="collision" x="0" y="224" width="16" height="32"/>
   <object id="141" type="collision" x="16" y="160" width="32" height="48"/>
   <object id="142" type="collision" x="48" y="160" width="16" height="32"/>
   <object id="143" type="collision" x="64" y="160" width="32" height="48"/>
   <object id="144" type="collision" x="0" y="0" width="32" height="160"/>
   <object id="146" type="collision" x="32" y="64" width="16" height="32"/>
   <object id="147" type="collision" x="48" y="64" width="48" height="48"/>
-  <object id="148" type="collision" x="128" y="96" width="48" height="16"/>
-  <object id="149" type="collision" x="208" y="96" width="48" height="16"/>
-  <object id="150" type="collision" x="128" y="208" width="128" height="16"/>
-  <object id="152" type="collision" x="496" y="400" width="32" height="32"/>
-  <object id="153" type="collision" x="528" y="400" width="32" height="32"/>
+  <object id="152" type="collision" x="496" y="400" width="64" height="32"/>
   <object id="155" type="collision" x="64" y="576" width="32" height="64"/>
   <object id="156" type="collision" x="144" y="608" width="32" height="32"/>
   <object id="160" type="collision" x="192" y="608" width="384" height="32"/>
   <object id="161" type="collision" x="448" y="576" width="64" height="32"/>
   <object id="163" type="collision" x="608" y="576" width="32" height="64"/>
-  <object id="174" type="collision-line" x="128" y="112">
-   <polyline points="0,0 0,96"/>
-  </object>
-  <object id="175" type="collision-line" x="256" y="112">
-   <polyline points="0,0 0,93"/>
-  </object>
   <object id="176" type="collision" x="128" y="464" width="208" height="80"/>
   <object id="177" type="collision" x="128" y="544" width="96" height="16"/>
   <object id="178" type="collision" x="240" y="544" width="96" height="16"/>
-  <object id="205" type="collision" x="176" y="144" width="32" height="32"/>
   <object id="206" type="collision" x="32" y="544" width="32" height="32"/>
   <object id="207" type="collision" x="64" y="448" width="32" height="32"/>
   <object id="208" type="collision" x="608" y="192" width="32" height="64"/>
   <object id="215" type="collision" x="320" y="368" width="80" height="16"/>
-  <object id="218" type="collision" x="464" y="192" width="16" height="112"/>
+  <object id="218" type="collision" x="464" y="272" width="16" height="32"/>
   <object id="219" type="collision" x="480" y="288" width="64" height="48"/>
   <object id="220" type="collision" x="496" y="336" width="48" height="16"/>
   <object id="224" type="collision" x="128" y="224" width="16" height="16"/>

--- a/mods/tuxemon/maps/spyder_citypark.tmx
+++ b/mods/tuxemon/maps/spyder_citypark.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="290">
+<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="291">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="spyder"/>
@@ -8,12 +8,11 @@
   <property name="types" value="route"/>
   <property name="west" value="leather_town"/>
  </properties>
- <tileset firstgid="1" name="Tileset" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
-  <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>
- </tileset>
+ <tileset firstgid="1" source="../gfx/tilesets/Superpowers_Tilesheet.tsx"/>
  <tileset firstgid="1601" source="../gfx/tilesets/core_outdoor.tsx"/>
  <tileset firstgid="4376" source="../gfx/tilesets/core_buildings.tsx"/>
  <tileset firstgid="6726" source="../gfx/tilesets/core_set pieces.tsx"/>
+ <tileset firstgid="8276" source="../gfx/tilesets/core_outdoor_nature.tsx"/>
  <layer id="1" name="Tile Layer 1" width="40" height="40">
   <data encoding="base64" compression="zlib">
    eAHt1LEJgDAQheFXiaLDWDmMs6i7iAtkiuhYnkVK0UbuhL840gTyePmSVEmJoQMMYOAjA1MtzS9msT0ef9Fq5w7t82xB842NtFu2I2g+r96KpWy9XP3cjVdvJR+rz7und3rHAAYwgAEMYAADGMAABjAQz0DfxcuEk//fyQnxW2Up
@@ -21,12 +20,12 @@
  </layer>
  <layer id="2" name="Tile Layer 2" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHtlEsKwkAQRGulC3WjO0WjN/Ag/o4RD6NX8ncff0sRsQYpyMYs0z3QAy89ZAb6TQ1J2QG2pDSshz5wJCdyJhcinx299sSyXulzI3fyIE8iH3nCaFyHwHgATEhBpmRG5CVPIz30RsCCPkuyImuyIfKSp5Xfv77ykqf2vVrAp90Mb/aqDvVO7+Ulz+o+q3nB7zSNVOUlz9+Kn6dHL+XnJ6X8TTzec0rVq1f+Nx4nqEvA8z9Gbqp157Bay8EtB0er+6vrq9xU6/ZarTXllvo01csqy+gbCUQCkUAkEAlEAr4TmHd9+4Vdngl8AW1VYws=
+   eAHtlU1uwjAQhWdFJUo3ZdeKJNyAg7S0x4BLcAPYwFHY83cf2rJEqOobVU9YCJKwMOMQW/pwsEfM52cBg0eRIRgYzotnkSVYgTXYAPqM4TUBlvMWPl/gG/yAHaAPPcVobF9EOm2RBKQgA11AL3oa6cnTq8gbfN5BH3yAT0Avelr5XepLL3qybt8Q+X24DQf0cgd76zq96OnWWT2n+J7q0Jle9PzfCec1RC/mF05K1TcJ8Z411VC9qn/jxSeYN4tr7rUi5N8YunEO8Q6q4ObLMcH/eh5l7suXm/bWz86jyI9unIvqr93Py073ygxfbto7LzuffcucW2vc/KZ4PztZ0xrLcS6/UXbM1dJNe7v56bO6uWvWfqHnZ51P7B8TiAnEBOqYQK9Vx1PHM/tO4A9lXXAH
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHtls2OTFEQx8/KQpvZMIORsCERNhIbkYg1e8thwoZXsPS9YcNev4NX8BA8gkcQJOof/Uv/U6l7+8z0HZOIk9TUuXXq43dPd9V0a//2ejxr7UnI31ifT7RGvV79NtjehfT6Z7/9vhf1ejX5e/2zH/H/9cFu4OTx1k6FbIUcdH2L7+VhrRvBdS3y31yDD7b83V73WXnFp/eH70KaBdSAYUzn7/a6z/Btbiz5ZBMjXNQY43J/4tbV1NP9XTc+7g8u6uBfacXgP5Wmjvg0d/X5wub3gZ9sY4Kf9JifzvazdoPrfsiDEK0qfuPcn7Pev1PyeU3YpHs+V49lT9xUOs8/GPke5TrZHy7sxE2lfb7A5veX68h/ZvMIPuw8Z/3p2NLSs8ebvMw/7HBxf9jlX83zITtxX4yvZ0/cs4F6cMGJvzjuxf29CO0Le35PfH4ZX89ecXdmbX4xRPU8r/6fwAUndcTxNM4vzdre3ZBs9zw6e714jzOhz66QnYUvOSP/POrMVS/nhQtOYsT3Mfzjvfbi/fayPee5tagpfT7mwpjcTnzK/XxRL+eFC07n0Dx/mXKJmzmPr7Tzqe/GpOIbygsXnPofrSV/fk/o3lluxybtfGN3p7OKT/1BPc8LF5yciSP/ntDZkN35/O7I57bMR39U9eCCk3zi8N8Tq+zO5/f3PgI/hLgt89EfVT244HSOqp/EXdnhexXnflfsv24u7W/CJy/1R5UXLjiJE4f6t5p/suc+g0/xflfai81t1HBNvZwXLjiJkb/6tJp/Y/2reO7Mtd8fNVyrP6q8cMFJjPjUT9X8q/rsYfgPzeWdOBtb9EeVFy44ySM+9VM1/6o+I67SuR+yD/3heZlpcMFJrPjop+9brf0I+RnidnxX6VV8ild/UM/zwQUnZ7vhz+/ty9utXQm5GuL20+HzqJDtsPnq4fO8HgsXnH421X6Mz3vI99SGC07sU2r41J++nKfayxcuOD1+1V791rOqeay4islt6he44ERTl+ej1nCi4eP5qHW+H/iGdPY/7Od8P0Nc2LP/YT/3vj98vf5T+fW+P3y9/lP5/QaRyIQP
+   eAHtlj1uFEEQRjtywGIS2whMQGIkyySWSBASIoac0GZlJ3AFh/7BTvAV2DtwBQ7BFTgCAiTqg31yqVQ90+uZxRKipXb1Vn9V9aZ3qz2l/Nvj7aSUdzb/xvh8uxTqtdoPxnZps1UfdYs+F/VaLflb9VFH/H97vRNYu1XKus0Nm9cdX+13uazx1Lh2Lf+zAXywxd/20M/KKz49P3wPw11ADRi6bPxtD/0M353VKz75xAgXNbq4vJ64oZZ6Or8njo/zg4s66DOrGPRjWeqIT/euvl/Y/Hmgk69ropPt0mlvkbFnXPs239jUyOJXH/zZa/07Jp+vCZtsy/fqY+Oa+KE23n8w8juK+aMerugnfqj19wts/vxifukn7j6Cr+Zn/9MKq1Ja1qhreeHi/Lw+u8+VJ/MT98XxtayJO67khQtO9OJ4bed3atYP/Nzzfk/rn46vZa2Yl5My27Kpej6v/p/ABaf0GuI4sv1HkzJ9ZfO30/l9Hu2dz5/jntn7PXNzriWn5Z9ZnZnqxbxwwUmM+D6a3p5ras83jf6Y5/m8JhZ9Zl8EPmlO5vViXrjgJJ/4dJ+fhVz4Yx64sOTJbMZXywsXnPofrSE97xM6d4b345OFC+v34jrjU39Qz+vhgpM9ccT3Ce3V/HBhyZPZyEd/ZPXggpN84vDvE31+uLDoMxv56I+sHlxwkk98WT/V/HC9t7i+cZFo1B9ZPbjgJLc41L/Z/Sd/rT+IX9RSL+aFC07ySq/+ze4/3tPQynJ+3rfIWv2R5YULTnKKT/2U3X9Znx2YvnYvb9pe16A/srxwwUke8amfsvsv6zPiMhv7IWroD5+XOw0uOIkVH/30baOU7zZ/2PR+tH22j0/x6g/q+Xxwwcnenul5396+W8qOzcc2vV/f52Ey5fejhc/n9bFwwen3xlp38ekdNJvUhgtO/GNa+NSffmRc3ictXHD6+L61+q1lZPex4jxLtla/wAUnlrp8vmkLJxY+Pt+0jecDX81G/bI/x/OpceGP+mV/bn1++Fr1Y+lanx++Vv1Yul/I7HVG
   </data>
  </layer>
  <layer id="4" name="Above Player" width="40" height="40">
@@ -35,58 +34,32 @@
   </data>
  </layer>
  <objectgroup color="#ff0000" id="5" name="Collisions">
-  <object id="177" type="collision" x="0" y="224" width="32" height="416"/>
+  <object id="177" type="collision" x="0" y="224" width="32" height="320"/>
   <object id="178" type="collision" x="32" y="0" width="496" height="32"/>
   <object id="179" type="collision" x="64" y="32" width="192" height="32"/>
   <object id="180" type="collision" x="256" y="32" width="32" height="16"/>
   <object id="181" type="collision" x="288" y="32" width="224" height="32"/>
-  <object id="182" type="collision" x="64" y="224" width="48" height="272"/>
-  <object id="183" type="collision" x="160" y="224" width="48" height="272"/>
-  <object id="184" type="collision" x="608" y="224" width="32" height="320"/>
-  <object id="185" type="collision" x="512" y="208" width="48" height="288"/>
-  <object id="186" type="collision" x="208" y="208" width="304" height="32"/>
+  <object id="186" type="collision" x="224" y="208" width="288" height="32"/>
   <object id="187" type="collision" x="160" y="144" width="320" height="32"/>
-  <object id="188" type="collision" x="32" y="128" width="464" height="16"/>
-  <object id="189" type="collision" x="176" y="112" width="320" height="16"/>
-  <object id="190" type="collision" x="288" y="288" width="160" height="16"/>
-  <object id="191" type="collision" x="32" y="144" width="112" height="32"/>
-  <object id="192" type="collision" x="608" y="0" width="32" height="160"/>
-  <object id="193" type="collision" x="384" y="384" width="16" height="16"/>
+  <object id="189" type="collision" x="176" y="112" width="320" height="32"/>
+  <object id="192" type="collision" x="608" y="64" width="32" height="480"/>
   <object id="194" type="collision" x="112" y="288" width="16" height="32"/>
   <object id="195" type="collision" x="496" y="352" width="16" height="32"/>
   <object id="196" type="collision" x="496" y="272" width="16" height="32"/>
-  <object id="197" type="collision" x="608" y="160" width="32" height="64"/>
   <object id="198" type="collision" x="512" y="48" width="16" height="16"/>
   <object id="200" type="collision" x="32" y="224" width="32" height="32"/>
   <object id="201" type="collision" x="0" y="0" width="32" height="192"/>
-  <object id="202" type="collision" x="352" y="368" width="32" height="16"/>
-  <object id="203" type="collision-line" x="256" y="288">
-   <polyline points="0,0 0,144"/>
-  </object>
-  <object id="204" type="collision-line" x="288" y="304">
-   <polyline points="0,0 0,96"/>
-  </object>
-  <object id="205" type="collision-line" x="448" y="304">
-   <polyline points="0,0 0,96"/>
-  </object>
-  <object id="206" type="collision" x="96" y="544" width="544" height="32"/>
-  <object id="207" type="collision" x="192" y="576" width="448" height="32"/>
-  <object id="208" type="collision" x="192" y="608" width="448" height="32"/>
+  <object id="206" type="collision" x="96" y="544" width="512" height="32"/>
+  <object id="207" type="collision" x="192" y="576" width="16" height="64"/>
   <object id="209" type="collision" x="32" y="544" width="32" height="96"/>
   <object id="210" type="collision" x="64" y="608" width="96" height="32"/>
   <object id="212" type="collision" x="112" y="464" width="48" height="32"/>
-  <object id="213" type="collision" x="208" y="480" width="112" height="16"/>
-  <object id="214" type="collision" x="256" y="432" width="128" height="16"/>
-  <object id="215" type="collision-line" x="384" y="448">
-   <polyline points="0,0 0,96"/>
-  </object>
   <object id="260" type="collision" x="496" y="432" width="16" height="32"/>
   <object id="269" type="collision" x="528" y="48" width="48" height="16"/>
-  <object id="270" type="collision" x="512" y="80" width="48" height="112"/>
-  <object id="271" type="collision" x="192" y="208" width="16" height="16"/>
   <object id="272" type="collision" x="16" y="192" width="16" height="16"/>
   <object id="287" type="collision" x="592" y="48" width="16" height="16"/>
   <object id="288" type="collision" x="576" y="32" width="16" height="16"/>
+  <object id="290" type="collision" x="112" y="416" width="16" height="32"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="6" name="Events">
   <object id="30" name="random encounter 1" type="event" x="208" y="176" width="128" height="32">

--- a/mods/tuxemon/maps/spyder_cotton_town.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_town.tmx
@@ -21,25 +21,25 @@
  </layer>
  <layer id="2" name="Tile Layer 2" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHNmDdvFkEQhgcjA4KCLIEJDUkCbANCoqOAko6ODKJA4g+QGldQkGokcoYCelJnggTYgEg1FbnANiDA5hnrXn/LsRe+QFjp0ey3s7c7+97u3NpmldIzwawXpk40a4Gs32eazc7mcA6fl2mTzKZDrdbHUAxeV1xe95L1e9gIs6YchuPrY32fIVbyfOqvPukY5I9ZraUbfR7l8AyfNHuFfukiX7p99eRKi/pozoonu6a1DPj7Q6MsmjP0O5rML218piOR+L1dfTSntxUVraUa/WJjSpuYb1SyBvXRnLG+6TatpVb9NJ600e/QyierOcM+WXWtpRr99oy0jt2wC3bCDpA2h6kfgoNwAPaDfLJZscTatZZq9LvMnJfgIlyA86Cxb1G/CTfgOlwD90k79StrpV8b+789YRF2MSwJ2pZS1/pfMueLkWbPsc/gaRKDz/me+jt4C2/gNXi7nvW65vR6UZF+G5h/Y8Im7GbYErRtpb6tpWi0uF/ayWrOeO+/3yrtZMvq57mzbN96VyXtPF+G+nXx7e2GrBL2zerTiHZp52OFmqieZTW3/OQKI2f8BjklsxwbbXYcTsBJOAVhkXay0sR1Uz3LSl/58+Ijn5nwvKYY7hPPA3gIXdANYZF2su6THtXaVG6zTmIix5nnOPKZCeU1n+sb8XyHH9APA5Au0k7t0qNam8pt1kNM5DjzHEc+M6G85vPNH2O2ABZCK7RBukg7fYvT/j/5ew3xrIV1sB42QFiknazeadjnX9alnaze6b+MKT33gxmVlnr083HIJX4vsfB+ovHdcnYHzzF3FHO4s1jojz2v6D4FOUVtRXZfk3XsBfXjrA6e2+TsDt1PWpN7Jmd36Bz7edZZ1v7Ket7HnxL8jab5iuxVYrsSxMdZHTyzydn95X7iY3F2h86xn2edZe2vvOfL6hf7G6doHfJ/5B2dzvlmql/M1qJfbBxv6+JO1Q2P4DE8gbD4PtsN4T4t8pfVLxwnVl/FXa+feAY8Jt7hMGiCsKS+NUP7VH1i/jz99Legns+z24mvlXjaoB0WwWIIS+pb89s+Tfwd4T27UfqFcTSynqdfI+epZ6z/8fsRrqee70c4TqPrE8nN//P+u0vO9P33ZWyFr9TrKUU5zsfuJAfdhjtwF+5BrHh8rt9yYhIzx8V6lm+L5bD00z3E0wt98Bm+QKxIP8Xmtt74YjksPfcs8uJsmANzYR7EivRbgWbOsvFmK+vULzZPrW3Sb3zG/2BrHbdRz0m/t+xBv1/8CT4wbq3/h5F+ZdarHFnWlhkzr88O7rbSL6+ffPrGlLV6LmZ1Hyx6X+/R3vPfT1P7yY8=
+   eAHNmLdvFEEUhx9GBEFBlshCIkmAbUBIdBRQ0tGRQRRI8AeQGldQkGokcg4S9KSOJAE2IFJNRS4wSQTzPWt/vmGY3VvfnYEnfXqzM7Mzb36783buzCrWOdLsI4wbZTYe8q5PDDA7WcAp2twmjDabCLV6H0MxeFlxedkt77rfQLOmAvrT9on1fYaUFbWpv/rEMag95bWWDvR5UMAT2qTZC/SLTW1x/bIxlRr10ZyVlvyS1tLlzw+N8hiQo9/BbH5p4zMdSMTv9eqjOb2ummktvdEvNaa0SbUNztagPpoz1Teu01pq1U/jSRtdh15t8poz7JNX1lp6o9+OQda2HbbBVtgC0mY/5X2wF/bAblCbfF4sqXqtpTf6nWfOc3AWzsBp0NjXKV+Dq3AFLoO3STv1K+ulXwvvf2vGXPw8mB/ULaCs9T9nzmeDzJ7in8DjLAaf8y3lN/AaXsFL8Hrd62XN6eVqJv1WM/+ajLX4dbA+qNtAeeP4aqOl26WdvOZM9/77tdJOvqx+njvL9q13VdLO82WoXzvf3g7Is7BvXp9G1Es7HyvUROWynlxh5Iw/IKfk2qEhZofhCByFYxCatJOXJq6bymV9UXzkMxOe1xTDXeK5B/ehHTogNGkn721l9Yr7RbnNbhATOc48x5HPTCiv+VzfiOc7/ICf0AWxSTvVl9Ur7hflNuskJnKceY4jn5lQXvP5Zg01mw1zoBlaIDZpp29x3N6X18uJZwWshFWwGkKTdvJ6ZmGff1mWdvJ6Zv8ypnjue5MqNfXo5+OQS/xcYuH5ROO7Z+9272POKOZwZrGwPXW/ovsQ5BTVud80xWwzpGxXk7XtBLWxV7v3bbZ3e84nzdk5k73bs499P2sv6/3Ku9/HHxv8RtN87s9PMbsAKbtEbBeD+Nir3Xs227u/nU/8fvZuzz72/ay9rPer6P48/eK4Ur9x4j59cZ2nXy1ztXOm6oAH8BAeQWj+nm2H8D2t1l5Wv3CcVHkpZ72fxNPlMfEM+0EThBZ9a3reU/VJtRfpp9+Cur/IbyK+ZuJpgVaYC/MgtOhb88d7mrW3hefsRukXxtHIcpF+jZynnrH+x+9HuJ56vh/hOI0ujyI3/8/v322+bf7+fRlW4SvleqxajvOxb5CDbsItuA13IGUen+u3iJjE5OGpnuXrUjksvruTeD7CJ/gMXyBl0k+xua83vlQOi+eeSl6cBtNhBsyElEm/xWjmLBxhtqRO/VLz1Fon/Ubk/Adb67iNuk/6veYdPN5HvGPcWv+HkX5l1qscWdaXGbOozxbOttKvqJ/a9I0p63Vfyr8v+aze0s/z3y/HBcsn
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHtVztOxDAQHRrogZVgAYlLsCWHoKDjAnAASqDgFjSwBd8bICFoEBKgXc5ABQgo+LU8a21pZGXCZJO1LeSRRrbj+Ty/OGOHaCAzU7aTaPMxmSgwCyvzV+/9ZP7+N3/1Vlfde3lh4HM+ofMNWV9ugW3N4ntW4svfh+49SlaZP4kZ3fPU+dOtYnirb9yPfhK+I81NE81DU5U71Lt7W/NSxZhxxWdgH/f8A4V2I/0PXCPv+iLRBrRMbiLiOwG2U2iZxMTHcW2NEW1Dd6BcDL4O6q1TPqftO1/TasW8Xy6HwHUEPS7AZ+wuSmpuD7H60EfBZq9F9In5Ly8nz+/3fXw94OpDHwR8vj8fu9zSGjaBbxbctS1/q+Pcu7jv4yu2ItLsP55bisOf7wbGx3M31ef8PXnnJR9r+GsKE4/zgr1q6vObsGff7fyrMM9j5X5YBs4q1MGwyEafza1dU8NGj0bOoKlhsnfcmaV2mPyXOJeuoH/JisLGj6GJ7c71YVs/Z9Njd667tun4deO5c921VeO5b7mqX5H9L45JW3E=
+   eAFjYIAACWEoY5BSn4UGqcOgzhoNP8riZzT8hnf4UeY70nXbyUL07GYnTi89y5fTQLfFQt33ikj3jeYP4uIRl6rR8MMVMsSJD/bwI84X5Kv6BmwffR/EbSRpEQYGGSAerOAMsLw7Cy3zBqsbR91F3xC4J49p30JgO38REXjxAPUHjhFp7wki1WGGAGUiQ8199YwMDA1A3AjEyGCwhN9yoLtWAPFKHO7bR0SZ+xiHmjmiDAxfgOnkKwlpBT1+zwPddQGIL+JwH3KYorNhduPyQznQfZLAOk8KWu+FsaGbgMlHdx+mCogIMfGLbDcuc5DFW+nsPmS7qcVGDr+XaPUlMp+Y8KOWm5DNeQ1Mq7Dy+S1ausUnh2zGKHtgQmANjvbrfSz18MC4kHa2wvxOTBlGjiuwtWXIMYeYMowcc+mhx1SKHrYwMBwA1ksHgZgQCCJCDboZxJh9HljuXQBicml0O6nNh9XrMJra5lNqHqxeh9GkmgfLy6Tqw6YeAPQRWak=
   </data>
  </layer>
  <layer id="6" name="Above Player" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHtlk1uwjAQhWdFpS5hRSXu00KP0B9OQGkP078VUA4BHKGbdEd7j3bPY/EkY+G4ie3YbTzSJ2ec2PPmBZkUXZEPoEahzem5+myT19TxDX0/wJTH0LSvSV39nsgZMOVN6lNrURfn9Jx+8n4TY4yaofqq08v5icgFGIIRuASMK1xfgxtwC8bgP0cd/1z9iFHTVXNK66v4V+XZlHoMqeWYJ5zTR+rgvHp2mM4QruE4ORW5A1NwDx5AjPB5rtEP28g++RzzPKbrQH5Xbu/G1T/1jNG/T/bKbN8otvVu3YVf7epfeIVpV/Dl36wjMgcL8AaWQA3T74z1TffVPXxfs7bLvj72cKn/19eW+fc+OOxOzw/vtjMr86+djsTr+jdn2CPOxSfwDF7AK8hhd2DVF1mDDUgxttD1Cb4S1ZeiZ1lTeg7w/0QffSnV97XlOxN/eHo=
+   eAHtljkOwjAQRacCiRIqkLgP2xHYTsB2GLaK7RDAEWhCB9wDen6KkRwLY4JNbCAjPTkTx54/n8gkyBMdgRiBdE/OxWeTvGYdV+i7AVXuQlNYk3UVC0QloMqT1CfWYl18T87ZT55PYnRR81N9vdNLJUtUBTVQBw3A0cR1C7RBB3TBL8c7/pn64aKmqWaf1sfxL86zPvX4SS2PPOF7ulE8O1RniKy9lyPqgwEYghFwETbPNZ1PqnkXfac14znAv128VenT7ICpf+IZI3+fhDV03yi69azT19HUP1/7SkqXLf8WGaIlWIE12AAxVO8Z11fNi3vYvubaJvva2MOk/revfebfoRztTs6js/+ZPfPvPx1x1/UrZ9gY5+IETMEMzEEaege2RaId2AMf4wRdZ3DxVJ+PnqWa/HOA/0/k0ZZSeV9dfgfpxXwA
   </data>
  </layer>
  <objectgroup color="#ff0000" id="4" name="Collisions">
   <object id="439" type="collision" x="80" y="608" width="256" height="32"/>
-  <object id="441" type="collision" x="0" y="144" width="32" height="400"/>
+  <object id="441" type="collision" x="0" y="144" width="32" height="368"/>
   <object id="442" type="collision" x="0" y="592" width="400" height="16"/>
   <object id="444" type="collision" x="624" y="480" width="16" height="160"/>
-  <object id="445" type="collision" x="624" y="432" width="16" height="16"/>
+  <object id="445" type="collision" x="624" y="320" width="16" height="128"/>
   <object id="447" type="collision" x="608" y="0" width="32" height="80"/>
   <object id="448" type="collision" x="368" y="0" width="240" height="16"/>
   <object id="449" type="collision" x="352" y="96" width="48" height="48"/>
@@ -50,7 +50,7 @@
   <object id="454" type="collision" x="592" y="176" width="16" height="32"/>
   <object id="455" type="collision" x="576" y="208" width="32" height="32"/>
   <object id="456" type="collision" x="592" y="240" width="16" height="32"/>
-  <object id="457" type="collision" x="576" y="272" width="32" height="32"/>
+  <object id="457" type="collision" x="576" y="272" width="64" height="32"/>
   <object id="458" type="collision" x="592" y="304" width="16" height="16"/>
   <object id="459" type="collision" x="496" y="320" width="96" height="48"/>
   <object id="460" type="collision" x="480" y="336" width="16" height="32"/>
@@ -62,8 +62,6 @@
   <object id="466" type="collision" x="240" y="320" width="16" height="16"/>
   <object id="467" type="collision" x="288" y="384" width="32" height="48"/>
   <object id="468" type="collision" x="336" y="384" width="32" height="48"/>
-  <object id="469" type="collision" x="240" y="368" width="48" height="16"/>
-  <object id="470" type="collision" x="384" y="368" width="160" height="16"/>
   <object id="471" type="collision" x="368" y="400" width="32" height="32"/>
   <object id="473" type="collision" x="544" y="384" width="80" height="48"/>
   <object id="474" type="collision" x="304" y="512" width="80" height="48"/>
@@ -71,14 +69,8 @@
   <object id="476" type="collision" x="496" y="512" width="32" height="48"/>
   <object id="477" type="collision" x="480" y="512" width="16" height="16"/>
   <object id="478" type="collision" x="320" y="384" width="16" height="16"/>
-  <object id="479" type="collision" x="64" y="320" width="16" height="160"/>
-  <object id="480" type="collision" x="80" y="320" width="160" height="16"/>
-  <object id="481" type="collision" x="224" y="336" width="16" height="144"/>
-  <object id="482" type="collision" x="192" y="464" width="32" height="16"/>
   <object id="483" type="collision" x="112" y="448" width="16" height="16"/>
   <object id="484" type="collision" x="176" y="448" width="16" height="16"/>
-  <object id="485" type="collision" x="192" y="336" width="32" height="32"/>
-  <object id="486" type="collision" x="80" y="336" width="32" height="32"/>
   <object id="487" type="collision" x="128" y="368" width="48" height="32"/>
   <object id="488" type="collision" x="512" y="384" width="32" height="32"/>
   <object id="489" type="collision" x="32" y="208" width="208" height="64"/>
@@ -105,14 +97,10 @@
   <object id="564" type="collision" x="448" y="384" width="48" height="48"/>
   <object id="565" type="collision" x="416" y="384" width="16" height="48"/>
   <object id="566" type="collision" x="432" y="384" width="16" height="32"/>
-  <object id="569" type="collision" x="32" y="512" width="32" height="48"/>
-  <object id="570" type="collision" x="48" y="560" width="16" height="16"/>
-  <object id="571" type="collision" x="0" y="544" width="32" height="32"/>
   <object id="572" type="collision" x="0" y="576" width="16" height="16"/>
   <object id="575" type="collision" x="416" y="96" width="48" height="48"/>
   <object id="576" type="collision" x="400" y="96" width="16" height="32"/>
   <object id="579" type="collision" x="464" y="128" width="32" height="16"/>
-  <object id="581" type="collision" x="80" y="464" width="32" height="16"/>
   <object id="590" type="collision" x="448" y="208" width="80" height="16"/>
   <object id="592" type="collision" x="464" y="16" width="32" height="80"/>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_crystal_town.tmx
+++ b/mods/tuxemon/maps/spyder_crystal_town.tmx
@@ -47,9 +47,7 @@
   <object id="33" type="collision" x="608" y="128" width="32" height="32"/>
   <object id="34" type="collision" x="624" y="160" width="16" height="32"/>
   <object id="38" type="collision" x="592" y="384" width="32" height="16"/>
-  <object id="39" type="collision" x="128" y="256" width="32" height="32"/>
   <object id="41" type="collision" x="0" y="32" width="32" height="352"/>
-  <object id="45" type="collision" x="48" y="336" width="32" height="32"/>
   <object id="46" type="collision" x="176" y="32" width="144" height="32"/>
   <object id="48" type="collision" x="592" y="192" width="16" height="16"/>
   <object id="50" type="collision" x="320" y="80" width="48" height="16"/>
@@ -60,7 +58,7 @@
   <object id="57" type="collision" x="416" y="144" width="16" height="16"/>
   <object id="60" type="collision" x="192" y="144" width="16" height="176"/>
   <object id="61" type="collision" x="32" y="32" width="144" height="80"/>
-  <object id="63" type="collision" x="32" y="112" width="48" height="48"/>
+  <object id="63" type="collision" x="32" y="112" width="48" height="16"/>
   <object id="64" type="collision" x="80" y="112" width="16" height="16"/>
   <object id="65" type="collision" x="112" y="112" width="64" height="16"/>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_flower_city.tmx
+++ b/mods/tuxemon/maps/spyder_flower_city.tmx
@@ -40,8 +40,6 @@
   <object id="332" type="collision" x="368" y="336" width="32" height="48"/>
   <object id="333" type="collision" x="400" y="336" width="48" height="32"/>
   <object id="334" type="collision" x="416" y="368" width="32" height="16"/>
-  <object id="338" type="collision" x="32" y="320" width="160" height="16"/>
-  <object id="342" type="collision" x="192" y="384" width="16" height="64"/>
   <object id="343" type="collision" x="128" y="432" width="32" height="16"/>
   <object id="350" type="collision" x="32" y="240" width="16" height="16"/>
   <object id="351" type="collision" x="48" y="256" width="16" height="16"/>
@@ -59,7 +57,7 @@
   <object id="363" type="collision" x="176" y="160" width="16" height="16"/>
   <object id="364" type="collision" x="176" y="192" width="16" height="16"/>
   <object id="365" type="collision" x="176" y="224" width="16" height="16"/>
-  <object id="366" type="collision" x="320" y="0" width="64" height="160"/>
+  <object id="366" type="collision" x="320" y="0" width="32" height="160"/>
   <object id="367" type="collision" x="192" y="0" width="128" height="128"/>
   <object id="368" type="collision" x="192" y="128" width="112" height="32"/>
   <object id="369" type="collision" x="384" y="0" width="48" height="32"/>
@@ -117,10 +115,8 @@
   <object id="469" type="collision" x="352" y="368" width="16" height="16"/>
   <object id="480" type="collision" x="384" y="608" width="16" height="32"/>
   <object id="493" type="collision" x="0" y="576" width="400" height="32"/>
-  <object id="494" type="collision" x="176" y="336" width="16" height="112"/>
-  <object id="495" type="collision" x="32" y="336" width="16" height="80"/>
-  <object id="496" type="collision" x="32" y="416" width="144" height="16"/>
-  <object id="497" type="collision" x="128" y="384.25" width="48" height="16"/>
+  <object id="494" type="collision" x="176" y="384" width="32" height="64"/>
+  <object id="497" type="collision" x="128" y="384.25" width="48" height="48"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="7" name="Events">
   <object id="293" name="Teleport to Route 4" type="event" x="624" y="64" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_leather_museum.tmx
+++ b/mods/tuxemon/maps/spyder_leather_museum.tmx
@@ -7,9 +7,7 @@
   <property name="slug" value="leather_museum"/>
   <property name="types" value="notype"/>
  </properties>
- <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
-  <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>
- </tileset>
+ <tileset firstgid="1" source="../gfx/tilesets/Superpowers_Tilesheet.tsx"/>
  <tileset firstgid="1601" source="../gfx/tilesets/core_set pieces.tsx"/>
  <tileset firstgid="3151" source="../gfx/tilesets/core_outdoor.tsx"/>
  <tileset firstgid="5926" source="../gfx/tilesets/core_indoor_floors.tsx"/>

--- a/mods/tuxemon/maps/spyder_leather_town.tmx
+++ b/mods/tuxemon/maps/spyder_leather_town.tmx
@@ -9,35 +9,33 @@
   <property name="types" value="town"/>
  </properties>
  <tileset firstgid="1" source="../gfx/tilesets/core_city_and_country.tsx"/>
- <tileset firstgid="1441" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
-  <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>
- </tileset>
+ <tileset firstgid="1441" source="../gfx/tilesets/Superpowers_Tilesheet.tsx"/>
  <tileset firstgid="3041" source="../gfx/tilesets/core_outdoor.tsx"/>
  <tileset firstgid="5816" source="../gfx/tilesets/core_set pieces.tsx"/>
  <tileset firstgid="7366" source="../gfx/tilesets/core_buildings.tsx"/>
  <tileset firstgid="9716" source="../gfx/tilesets/core_outdoor_nature.tsx"/>
  <layer id="1" name="Layer 1" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHtWMtNxEAMnQIQvzO/ThCigb0ADSCgBqABqgDOSNsFnJGQKALOXOCCLeVJDzN2kk0mySIOljOTjfPi9+yZ2dlKSrM/Zqeby/1Nzxv94d9eTcnajsxNhfPX9ZSsHTr49gfi9YbeY7Hp2MM3Rk7PJVdqX2LAurv2m3PVQF+8fyygzwPCB5zWj5nXqeM7k/yBa/bM+5j583ou53VMfF5tLhO+qK6PZA0/FjsZeC3n/Nl6xlh5vxRcV2LX//h+rL1c11zLyJ16zt+b5E95tlaCd14HtX48rhmfcpyzprx32ftE+G4F153YU4XvsRrrnNq9mNcj+pqP8KF+3wVHiTpBfOgmpxeLD9+d47cpn4hR59EfoJ1cfIsPNaL4LL+55+swRPfb4vuk9fpCrhEbcbiOc1zg99bbmsR9xM3l76Har3H+NGd4Vj1+Y+P0pUUbN8dPhA9YEYfrt4/ahX6iftAGX+778A2l/BTwbYmu7HkT4z05l3DN5vIAfhfJn1cb/B7OEbCo19/w2NYHYnTBhxiR74JPz2XAx/0FPd/zbfoP4+Mex2cSveaex2cD4EOfauLbaIHxgUOsfU2+0/YB9IOcx14iwgftw+dqADmJ4kSa8e4hrqcFzQdr3l4jf4hTCp+nAX2fxcTjofDxWsM60HXH6p7HqIEof1h3PQ6j+Shu9Jy9hzieTry+UTffZS87p//ggM/TSdf5rrpu0zNYP02v+9jfWM5LjF+IsxLxS8T8BmKoujM=
+   eAHtWEtOxTAM7AEQvzW/myDEBd4GuAACzgBcgFMAayRuAWskJA4BazawwZY60mBi074kbR9iYblJ+9yJx+Okb7bUNLM/Zsfri72mp7Vy+DeXm8balsxNhfOX1aaxtu/g2x2I1yt6j8WmYw/fGDk9lVypfYoB6/bKT861Bkrx/j5Hfe4RPuC0fsy8Th3fieQPXLNn3sfMn9dzOa9j4vO0uUj4Il0fyB5+KHY08F7O+bN6xlh5PxdcF2KX//i+7b2sa9Yycqee8/cq+VOerdXgnfdB1Y/HNeNTjlPWlfecs0+E71pw3Yg9tvge2rHOqd2KeT2i1HyED/p9Exw1dIL4qJtUvVh8vG7oF9x25ZNjRNdd4lt80IjWn+V3bHwftF+fyTXWjnWyjlNc4HnrrSZxH3FT/Ny15zXOn+YMv1WPZ2ycUrVo46b4ifABK+KwfktoF/UT9YM++FLrwxpq+Sng25C6st+bOtY178h3CWs2lQfwO0/+PG3wezhHwKJen+Gx1Qdi5OBDjMjn4NPvMuDj/oKe7/k+/YfxcY/TNfF3Cfc8/jYAPvSpLr5PLTA+cIi9r8s6bR9AP0h5nCUifFYLKQ0gJ1GcqGa8e4jr1YLmg2veXiN/iFMLn1cD+j6LicdD4eO9hutA9x2ueXsNDUT5w77rcRjNR3Gj39l7iOPVidc3fpvPOcve039wwOfVSe58bl336RlcP12vS5xvLOc1xs/EWY34NWJ+Ae1RulY=
   </data>
  </layer>
  <layer id="2" name="Layer 2" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHtmEtOw0AMhr2EJSskJBArdrwk7sApWuAEXIGD0BbuQ5HYk5ajYKv9hWV5ZpykSSMUS9bMOI79xbWVtkS+TK6JpqwPrCLzC6IF61Bkxlxz1sWWb8Vs65Z8Z7dEdTRXC8uX841ey7EhhvaBzVvB98b1k8+5jUqPnNasnXDmBHzyGbdV9IiuDfaWAfYSX8Vcqxr6tH2OR+eeNdtEdE5wbK78XYNd+8KnzYp6o1ZeLJ1Tc6T2XoymtihfigV25JfzeaEH4RtZI3xeHHDZ1fON2O6PN14T7ik90+/b/rPzLrObE80lfvos+6aCepVmO9ePktvy6PPPTVM6oorrouc7Nb+Y3VQmzWP3qXua2MFb4rGxLZM+W99dng+OiA5ZS6J5sJd7ZN+lXDLb1YD5os+OmnlrNEaXfh4XbF3mjcYGi7dGY/TlN1Uzofd95Zc80bnumun5xM8QnWv/7tHaZwWG9pvTPvsufnPamON5eBX4JHpZsn6wlui+Aj6lGOP1+hUYynsnRT6+d1KV2a+9z75JfSe5S3xXkcqMfbPf/viP2V/5f/JZy//Ku6zLN7NVPfH9An8bm4U=
+   eAHtmF1KA0EMgPOojz4JglIQfPMPvIOCZ2jVE3gFD2J/vI8KvrutRzGhG0xDZiazfywygTAzmUzyNTth2wLYMr0EmKE+oJIszgCWqGOROXItUJc13xrZNi35Tq4BcjRWC80X8/Xuxdg4hvRhmzUy3wrrR8+5jdIdOc6sHXHGhPnoGbdVviOyNjzXDGxP8VXItc7Qp/pzPBpnNmgjkTmZY7vzt8d26cs+bUauN9fKiiVzSo7Q3IrR1OblC7GwnfPTepK4g+zrGT18Vhzm0qPl67HdHm69pninZE+/1fdP9zv1bkwkF/nJNc2bCtcr1dux+0i5NY9c/1w1pQOosC6yv0P9y70byiR59Dx0pomdeVM8OrZmkmvt2+V67wBgHzUlkofndIbmfco5sl2MmM/72blm1uiN0aefxcW2PvN6YzOLNXpjDOV3KhLNeu4PkWpnGuvre/Sc1N53O6e6Xzwf2TFTfU1cso52lGGtVDcpei33/tN8bL85dW27+M2pY5b1+CrwCfDygfqOmqL7cvikYpT9/ArE3jv50bo/kXrvdJ+xRPRUYMh7E/pOchP4rkL85d54nmLxyanAK/5PPm/5X3lOvlzfb2SrBuL7BVXVnM0=
   </data>
  </layer>
  <layer id="3" name="Layer 3" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHFl0lzVUUYhhsZQhjMwCRIEiUMC2UqWbBSYcGQMFQ57UAW+AuQBWKV9wfoHijGhUxOQIiCBboBNkwrEFHIyCiwkkFCgOcj9y07XafPzb0cQlc997unu0/3k+929zlxzrmhVc6Vg+KqcVRGyqEK5w7n2V/j3AFogoPQDGltl2c5Vwwt9LcyHbcZoPhVit8l3FRa8WmDduiATlBJausod7nWPtJCv7rZ/+dM4xaKvl9FrXOVUAXVMApUktqGD3O5NdXOfQ5rwcok53K1eAhdl9HX/JSznt6FP1+pdG4grCPH7+LzHrwP82A+pLWZ3wa8NsKmvF9D4Kdr+RU2yqZHDbkwv6N4/Qa/5/2UN8XPBrjcanhZfvKwqN/Sr/sGt689P+3ZbLIUH0X58130W1rdzoEu9y2oXfkrdv2ZwU326T9wC27DHfDLv1zfhXtwHx6A+b3D7xvuX9un5nQGt9Oen/qWkr/x7IMJ8DpMhBrwSz3Xk2EKTIVpsAKHlQFtnG+WJ+XsC9bkevgSVFdK/hYx32JogEZYAn75gOsP4SP4GD6BpGI5ffY75vfwNry2ww5QCfP3hBzPhW54BF2gvllH+S3M+x3D6zicAJ3lYf6mDXK5VThNIU6GeuiLl52HxRb5hWe2/bbaH2H+luOzDJbCEmiEYuf1+/9a63KH4RD8Aj9DM1gf80s6s32/MH/+2Fl8v4HLdbgGV+EKdIKNLb+kMzvM3xHWgN2TdXmtzuXGwVgYA6NhFNg88tNe9aP8lL/OF+SX9vfKT88087NniiE/rb8RPFOSxrpG36twBZLan6dOfnqmmZ89Uwz5KX9zIn7PM3+he81Pz4nwuTKTc7uU9z/N2cXf+DDPf0TV+/Eg+6AJDsB+2Ad++wr8VnrUM46u6/j+KW3KX5O9F/NeZ2UAsdl7T+6p7f1ZT74n5XkzkvsOfNqhDVqhBXqP0vvKflfzslo7sy1q/V0IfC4G19bXL404NeRZHPGrZp9WQSVUwKvgj6Hvth/03bzsWl7KX7F+Gi+LaHnzx7FrecnzZfr5bvouL3mm+aX9v6nxso7ykmd3sD+eeOsv7f/NrL00nrzkqfos43b26zbYCltgM9j4ae8Mml9e8lR9UnzAer0P94J1nNTXrzuLzxk4DafgJFh72juD7peXPFWfFN/g/KiD2sg5knSP1T3GpxseQRc8BKtPe2ewdivykmdPbfJnqX7Jo/WtVl7yTLtrEXlbCAuKzF/amLE2nRXykmesf3/X66yQlzz726PQfKV67WWN74HdsAt2gs0VO0vk8RP9foQf4Hv4DtSWZfyTcS/AH3AezoGNHztLNPdl+l2Cv+EvuAhqS4tDeJcqA8W0vtY2lHeQMhgCg2EQWH3sLLE2KyPpNwKGwzAoh2cNkQ+tv7dwexsUI937vVrrT3lT7HeRyISx/LV77wWRW19otbzC/NmkYQ4LXWusWCzlD5GX7tW6G+ytQXmpLbzWvRorFmPefa23eZ4Cs2eenA==
+   eAHNmMlzVUUUhxsZQhjMAIIDSZAwLACB0oUrpwVkQKzCYcfwP4ALhirfHwB7oJBhAc4DJBGwGDbqRsGVCAhkZFCGFTKFgN/R+yu6um7fN9RNpKs+zrvdfU9/Oenb7wbnnBtf51w1KK6dTmekHa5x7kjCgQbnDkIHdEIXZI1dXOxcOXQz39pC3F4CxY8y/C7gptaDTy/0QT8MgFraWH+1K/SUSDfzmpY8rpnyFou+X02jc7VQB/UwBdTSxiZOcIV19c6thw9BrREPYX32uYq55qeaaW6x+FStc6NhAzV+DZ/X4Q14E96CrDHz24bXdtiR+LUlPvLTtfyK+eQ13kAtzO8YXsfhROInL0Wt93/5ycPiLOcK/rV93jLKua0gPz2z8h6uqPr5PvpdWt/+0a6wDzQuv3L3n/n/xXN6Da7DDbgJfrvF9d9wG+7AXTC/l/n9hs+vPafmdAq3k56f5lZSv+d4Dp6HF2AGNIDfmrmeDXNgLsyDVTisDujlfLM6qWYb2ZObYDOor5L6tbBeK7RBOywHv63k+l14D96HDyCtWU3Nz8bMZzdee2AvqIX1e0SNX4UheACDoLl5R/ktI7H5/YDXj/AT6CwP6zdvjCusxWkOcTY0Qyledh6W2+QXntnmqucjrN87+KyAt2E5tEO56/rzv290hSNwGA7Bd9AFNsf80s5s3y+sn587j89/4nIVrsBluAQDYLnll3Zmh/U7yllp9+Tdnm1yhekwDZ6BqTAFbB35Wb1C5Kf6DQyTX9bPKz/NMUf7TjHkp/03aVR6/a4w9zJcAuXJK8pP32nmZ98phvxUv1cifnm5pOUxP31PhN8rizgXK3n/0zqD1PN+wr1IbTt5DjrgIByAb0H3W1yF32qPZvLouonPaxhT/Tp4L+5M3o0tdnnvyX5OfW6m3rMSXozUvh+fPuiFHugG3V9q1P47E/icC67DfO04tSW0RvzqeU7roBZq4GkI88Su5aX6lesXy5tXv7zk+aT5yUueWX5Zf2/mVa8wj7zkOcR+e5jsOYuPvP2X9fdmmDeva3nJM6+8fp49PK+7YRd8DDvBxrPeGXS/vOSp/rR4l7PoDtyGtPFY36/4nIKT8Av8DDY3651BueQlT/WnxZmcH03QGDlH0u6xvof4DMEDGIT7YP1Z7ww2bk1e8vyvN/3fSv3Ss5XWKy95Zt3VQt2WwdIy65eVMzams0Je8ozNH+l+nRXykudIexRbr1Kvz9njn8Gn8AnsB1srdpbI4xvmfQ1fwZfwBWgsz3iWvGfgdzgNv4Hlj50lWvsi8y7AefgDzoHGsuI4/q+sChSz5trYeN5BqmAcjIUxYP2xs8TGrE1m3iSYCBOgGv4diPyj/TcftwWgGJk+4t3af6qb4oiLRBaM1a/Pey+I3Dqs3fIK62eLhjUsdq1csVjJDyIv3at9N9bbg/LSWHite5UrFmPepfbbOv8AD2aRsg==
   </data>
  </layer>
  <layer id="4" name="Above Player" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHtlztOw0AQhkfKAegokKDgNEhpuAiPtNAE8uJxEiDAASBJRSCBjlcNHXAJPgtNtHJis7Y2MREz0ufdtWfHv/+VrbWIhTlgDvwnB66WRa6hA13ogRs3jPtwC3cwgFDRKkm1CQ2oQw209nBR5B4eoKi4RM8FnEMbzkC1fKDrE74K1PeKnhd4hid4BNVn7ewdaK6ItOAADuEIjsHCHPBxoCdS7UIHfPItJ5wDe7yn+1CDOjQgLVZtjUb2rC+Nut6dsuPfmtP3LjClRHddI13ueEq3zFTW9S2aGB9nKmbJM3Ngg+/JJmzBNlQgCtsz/Pjgc9wN+O/hc7+sOad/XF/W57H8Yh1I2pMkfUtUbdI8vT6v7duCyDtom/YcuifZyflO5p2XpmnStZOc+vLMU9+0naTHzvk5EPfwt7Ff1fBZ86orrju8M+MVvwEAYVvz
+   eAHtlztOAzEQhgflAHQUSAkSJ+IQUAKhhSaQNzkJ7wNAkoo3Ha+adIRL8K3QSJHJbhyzq/Uij/TFcjzj/P6jtb0iIYrswKoh3uwbw6E7w4H1BZEN8CGy+i8vyyJX0IcBDGEyrunfwC3cwT2kFe2S1FrQhAbUQed+WBJ5hCfIKy7Qcw5ncAonoFo+0TWGrxz1vaPnDV7hBZ5B9WXVrmQ18T+Yt1URaUMHunAIPQgRHLBxYChSG0AfbPJdcibPtOhMyepccdGWZ80+z+kB1KEBTUiKIvime7W2Sev5y9jasnu1bz76psfd2VDpkwOb7CdbsA1V2IEowp3hxwebz70U3z1sfm/enGPP9c27npCfrwNxd5K4vUTVxtXpeFHbj0WREWibtA69k+w6PpOudUmapo0dOepzqVPftJ2mJ3xn54Dp4ay+3azpZxVVl6k7fWd+z/gNDLtZHw==
   </data>
  </layer>
  <objectgroup color="#ff0000" id="5" name="Collisions">
-  <object id="188" type="collision" x="192" y="32" width="80" height="32"/>
+  <object id="188" type="collision" x="224" y="48" width="48" height="16"/>
   <object id="189" type="collision" x="288" y="48" width="96" height="16"/>
   <object id="190" type="collision" x="400" y="48" width="32" height="16"/>
   <object id="191" type="collision" x="432" y="64" width="80" height="64"/>
@@ -51,8 +49,6 @@
   <object id="202" type="collision" x="192" y="512" width="80" height="48"/>
   <object id="203" type="collision" x="176" y="544" width="16" height="16"/>
   <object id="204" type="collision" x="368" y="400" width="80" height="48"/>
-  <object id="206" type="collision" x="448" y="432" width="16" height="16"/>
-  <object id="207" type="collision" x="272" y="432" width="48" height="16"/>
   <object id="209" type="collision" x="368" y="288" width="80" height="32"/>
   <object id="210" type="collision" x="352" y="320" width="32" height="16"/>
   <object id="211" type="collision" x="448" y="304" width="32" height="32"/>
@@ -77,22 +73,11 @@
   <object id="232" type="collision" x="368" y="624" width="208" height="16"/>
   <object id="233" type="collision" x="576" y="592" width="32" height="32"/>
   <object id="234" type="collision" x="608" y="544" width="32" height="48"/>
-  <object id="235" type="collision" x="608" y="352" width="32" height="160"/>
+  <object id="235" type="collision" x="608" y="320" width="32" height="192"/>
   <object id="236" type="collision" x="576" y="480" width="16" height="16"/>
-  <object id="237" type="collision" x="592" y="336" width="16" height="16"/>
-  <object id="238" type="collision" x="528" y="336" width="16" height="16"/>
-  <object id="240" type="collision" x="560" y="288" width="16" height="32"/>
-  <object id="241" type="collision" x="576" y="320" width="16" height="16"/>
-  <object id="243" type="collision" x="32" y="304" width="32" height="16"/>
-  <object id="244" type="collision" x="80" y="304" width="32" height="16"/>
-  <object id="246" type="collision" x="80" y="384" width="32" height="16"/>
-  <object id="247" type="collision" x="32" y="384" width="32" height="16"/>
   <object id="261" type="collision" x="0" y="32" width="32" height="32"/>
   <object id="262" type="collision" x="16" y="0" width="64" height="32"/>
   <object id="264" type="collision" x="80" y="16" width="16" height="16"/>
-  <object id="265" type="collision-line" x="112" y="320">
-   <polyline points="0,0 0,64"/>
-  </object>
   <object id="266" type="collision" x="144" y="384" width="16" height="16"/>
   <object id="267" type="collision" x="288" y="176" width="16" height="16"/>
   <object id="280" type="collision" x="80" y="16" width="16" height="16"/>
@@ -102,7 +87,6 @@
   <object id="297" type="collision" x="384" y="32" width="16" height="16"/>
   <object id="299" type="collision" x="0" y="480" width="64" height="32"/>
   <object id="300" type="collision" x="0" y="544" width="64" height="64"/>
-  <object id="302" type="collision" x="128" y="256" width="48" height="16"/>
   <object id="305" type="collision" x="192" y="144" width="16" height="16"/>
   <object id="310" type="collision" x="400" y="320" width="48" height="16"/>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_paper_town.tmx
+++ b/mods/tuxemon/maps/spyder_paper_town.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="284">
+<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="285">
  <properties>
   <property name="east" value="brideswood"/>
   <property name="edges" value="clamped"/>
@@ -22,37 +22,30 @@
  </layer>
  <layer id="2" name="Tile Layer 2" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHNVjtOA0EMdZUPpKDgU2YLThEhQcXnFEBNjyAHoEaiRpyCEwC7cIhAR5McgmdlnzSxxmF2NYuw9PTWHo/91plMUg5FKqA0LI5dI+832+mJ7K7BHtas2f705+i3ACzb/ervj1ajD/Bnh6sx9SaR/mHWQWTd9qdPnZbDek2f2+iz/elTp+WmmsJ81XcXmRFz/sP81s0wpo/zsmznRv9+k2/bnPX8nwMXBuOjZewyMlv2tWz1NleTZ8f2RryO1RvP6j7q6eP8ciq4wX31koApctjfY86vrb4rc06f4T9qX3NXav1XxN4A8hPy2N9j6rZ92urlvnlEH9fIqo/9PaZu7snFsfmFtSvoT5nfFr7rir+e36LW582N8Vkfv6HAJ5DbeM68uinz496vwVJnDr2pn0XK+aM+y6o3Znp33AaI5Xgxe+doHs+/x14tL653B03/b/GcdMXslcrfgT7d4713rvj7WKRXiPSB0DSu9lGzPg8KkSEQWldzY13tdVyInACqpQSqWhNZ46r3FDlnQGi55uTV+QEYIxiD
+   eAHNVjlOA0EQ7MgHEBBwhN6AVyAkiDheAcTkCPwAYiRixCv4AezCIwwZQrIfQbW8JY1bPcvsahbRUqncvT3T5fJ47HIsUgGlYYnENfp+i+2ByE4DdvHMhp3PfI55C8CyXa/53sZq9QH57HC1ptm+Mz/sOnCe2/nMqdNyuF/b11302fnMqdNyW01hv+q7czxiz3/wr8lDTx/9smx9Y36/znfbnvX8nwMXBpOjZe3S8ZZzLVu97dXkWbG15u9j9fpd/Vdj+uhfTgU3uK9uEzBFD+fHmP511Xdlzukz8keda+5K3f8FtVeA/IQ+zo8xdds5XfVy3dzRx2dk1cf5MaZursnFnn/h3hX0p/i3ie+64q/9W9T6Yr6xPhviNxT4AHIHz1ls3xT/uPZztNSZQ2/qZ/GdcP6oz7Lq9SL17ki5X7SH5z/Gnoammt4dDP2/xXPSF3NWKn8F+nRN7H3nqr9NRAaFyBAIQ+sa7zXr61EhMgbC6Ms37quzjguRE0C1lEBVayJrXfWeoucMCCOXT7F9fgBvDxsi
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHN1skuBEEcx/FysSe2A3HAc4jYDngLnO2JmTEO4uIZMMxYYt8egUjEvhzs2xNwtS/x7VDR6dR/0s2kqeSjZmr+VfXr6tEoZW6hNKXCBiU53/VSTZB5q+g0CDCWVahUNnKQizxIbYz6cTh7qb7Clk+qiTceYa9y8lSgElWohnN//T7eWm4/aytQva1oQTOaIM218rWQpxVtaEcHpKZzOnup3jQeKVBqCMOIIgapWfmGyRNFDCMYhXN//V5axxrvZ94ABhHBEJzNut9b5NnGDnaxh1VyLBusMLbDOrvYwz4OIDWdU/e6ri5DqXXmbWATW9iG29aTLlc+s84LXvGGd/yk3THvHg94xBN++/vhNYfz3LzO97O+NNnP3dztZT8/na/Px5x6f6m3X4XOV0a+bp5hYXQhhCACsNfr10v5qncRC5jHHPRniezt+SZ4RkxiCtOYwSxM7Zo8V7jEBc5hqjONSeemx9d5Hm3AavZ8h2Q5wjFOcIozlDv+vqXwPpNzzYD17EujTxXO+XMXbz9vyHb7la+e+9qAxn/6/bvn0h7w6O0SfasuSlKqGCVw00z/f8Ubc665xn3T3zOpt8/xms8+14/XNZxbLepcnp+VSbruRI37cd1/uUeizkla5wO0rL/G
+   eAHV1ckuQ1Ecx/FjY04oC2JBn0OkxQJvgTVtCVW1EBvPoGoW8/QY6MTCPD0BW605vjecuG7uH5Wm6p98nN5zz/DraXspZV+BIqWCNpyOj/HSmD7m9Qv89JfVKFUOBypQCanmGD8PayuNd5vySWNCrCdVmHsu8rjRiCY0w7q/vpbWSaffV61GvPCgG12Q5hv5POTxwoce9EIqndPaSuPt+sPVSk1gElOYhlRGvknyTGEaM5iFdX99La1j9I8xL4RxhDEBaxmfd4Q8UcQQRwJfVYx14khgD/uQSufUrR7XVqLUNvN2sIsIovhpDRfLIx9Y5xFPeMYLflO3zEsihTvc4ye/j9/sJc2xnps0Lhf66/NzIcXnDObz0/lGs5hT7y+15rQ6XwP5hniGBTGIAAbgh3m8fr1VpUY2sYF1rEHfy2RrzrfAM2IRS1jGClZhV1fkucQFznEGu3F2fdK56f5tnpc7MMqc74AshzjCMU5wCpfl/1sB16WcawmMZ18RbaFwzm+7pPf3mmw37/na+Vw70Jmj378kby2Fu/TeYtZG1+YpVQcnslX6eya15hx/kc+8/3evWzi3VrSlcX7S+85U/3eZ//v9TJ2TtM4rgtOzvQ==
   </data>
  </layer>
  <layer id="4" name="Above Player" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAFjYBg+QFgKu1/MJRgYLIDYEoitgNgaiEfByAwBBcHB7W/7Qe6+wR16o64bDQHUEFjIycCwCIhHwWgIDIYQcBUizRWw9EsuTZpto6pHQ4C+IQAA9w4OmA==
+   eAFjYBg+QFhq+Phl1Ce0CQEFQdqYSy1T7Qe5+6jlz1FzRkOAHiGwkJOBYREQj4LREBgMIeAqRJorYOmXXJo020ZVj4YAfUMAAKV8DQM=
   </data>
  </layer>
  <layer id="5" name="Above Player" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHt1DsOglAUhOFpfUYrDQ1uwwetz42AugMRenUT2Kmb9C8NURoNOSZnki+EewsmUyD9b5qB1EIbHXRhKWP6TDDFDBEsJaZPgi122KOcUb984u9VC/heVevUf1c0pCs+Petv9JsvzofSAkussMYG73IYSCmOyJDDQk496YwLrCR8+d/d6HXHw1A/Kzt5D1/AF/AFvl3gCTo4FAg=
+   eAHt1DkOgkAAheHXukYrjY3eQgFtcbuICzdw69VLaKfeAa/mXxoyVgSZSeYlXwhTwMsjQXI31Z5UQx0NNGHKsCuNECBEhH8koE+ICGNMYFNW9Fljgy0SZDNoZ0/cuE8rksmb8yLj6l5FblLms2987zt+XcvslufdMf+wKWaYY4ElTNl1pD0OOOIEG3JuSRdcYUv6X/+7B72eeFnUz5adfA+/gF/AL5B3gQ/iAxsP
   </data>
  </layer>
  <objectgroup color="#ff0000" id="6" name="Collisions">
   <properties>
    <property name="Collision" value=""/>
   </properties>
-  <object id="133" type="collision" x="192" y="240" width="320" height="48"/>
   <object id="164" type="collision" x="512" y="128" width="128" height="112"/>
   <object id="165" type="collision" x="448" y="80" width="64" height="16"/>
-  <object id="166" type="collision" x="336" y="0" width="16" height="48"/>
-  <object id="168" type="collision" x="336" y="128" width="176" height="16"/>
-  <object id="169" type="collision" x="432" y="144" width="64" height="16"/>
-  <object id="170" type="collision" x="480" y="176" width="16" height="32"/>
-  <object id="171" type="collision" x="352" y="144" width="16" height="64"/>
-  <object id="173" type="collision" x="368" y="208" width="32" height="16"/>
   <object id="174" type="collision" x="272" y="160" width="80" height="32"/>
   <object id="175" type="collision" x="320" y="192" width="32" height="16"/>
   <object id="178" type="collision" x="256" y="192" width="48" height="16"/>
@@ -70,12 +63,11 @@
   <object id="195" type="collision" x="96" y="160" width="96" height="32"/>
   <object id="197" type="collision" x="64" y="240" width="16" height="16"/>
   <object id="202" type="collision" x="176" y="192" width="32" height="16"/>
-  <object id="231" type="collision" x="336" y="144" width="16" height="16"/>
-  <object id="247" type="collision" x="336" y="64" width="128" height="16"/>
-  <object id="248" type="collision" x="352" y="0" width="112" height="16"/>
+  <object id="247" type="collision" x="336" y="64" width="16" height="16"/>
   <object id="249" type="collision" x="464" y="0" width="64" height="80"/>
   <object id="253" type="collision" x="96" y="192" width="64" height="16"/>
   <object id="275" type="collision" x="528" y="80" width="112" height="16"/>
+  <object id="284" type="collision" x="336" y="32" width="16" height="16"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="7" name="Events">
   <object id="135" name="Mart Sign" type="event" x="256" y="192" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_park.tmx
+++ b/mods/tuxemon/maps/spyder_park.tmx
@@ -39,40 +39,22 @@
   <object id="158" type="collision" x="336" y="256" width="32" height="176"/>
   <object id="159" type="collision" x="464" y="560" width="48" height="16"/>
   <object id="160" type="collision" x="272" y="384" width="64" height="48"/>
-  <object id="161" type="collision" x="208" y="224" width="160" height="32"/>
-  <object id="162" type="collision" x="32" y="256" width="96" height="16"/>
-  <object id="164" type="collision" x="32" y="304" width="16" height="16"/>
-  <object id="165" type="collision" x="64" y="304" width="96" height="192"/>
+  <object id="161" type="collision" x="256" y="224" width="112" height="32"/>
+  <object id="165" type="collision" x="64" y="304" width="96" height="240"/>
   <object id="166" type="collision" x="0" y="80" width="32" height="272"/>
-  <object id="169" type="collision" x="160" y="192" width="48" height="192"/>
-  <object id="170" type="collision" x="32" y="80" width="80" height="16"/>
-  <object id="172" type="collision" x="192" y="112" width="96" height="32"/>
   <object id="174" type="collision" x="368" y="208" width="80" height="32"/>
-  <object id="179" type="collision" x="288" y="32" width="16" height="160"/>
-  <object id="187" type="collision" x="576" y="192" width="32" height="80"/>
-  <object id="190" type="collision" x="32" y="192" width="48" height="16"/>
-  <object id="191" type="collision" x="96" y="176" width="64" height="16"/>
+  <object id="187" type="collision" x="576" y="208" width="32" height="64"/>
   <object id="195" type="collision" x="448" y="192" width="128" height="16"/>
-  <object id="197" type="collision" x="127.667" y="80" width="64" height="16"/>
-  <object id="213" type="collision" x="80" y="496" width="16" height="80"/>
+  <object id="213" type="collision" x="80" y="544" width="80" height="32"/>
   <object id="220" type="collision" x="0" y="32" width="288" height="16"/>
-  <object id="222" type="collision" x="144" y="256" width="16" height="48"/>
+  <object id="222" type="collision" x="144" y="272" width="16" height="32"/>
   <object id="223" type="collision" x="160" y="384" width="48" height="96"/>
   <object id="224" type="collision" x="208" y="432" width="16" height="48"/>
   <object id="226" type="collision" x="240" y="448" width="96" height="16"/>
   <object id="227" type="collision" x="240" y="464" width="160" height="48"/>
-  <object id="228" type="collision" x="96" y="496" width="64" height="80"/>
-  <object id="263" type="collision" x="64" y="176" width="16" height="16"/>
-  <object id="264" type="collision" x="64" y="576" width="16" height="16"/>
-  <object id="265" type="collision" x="32" y="528" width="48" height="16"/>
-  <object id="268" type="collision" x="624" y="192" width="16" height="192"/>
-  <object id="278" type="collision" x="208" y="144" width="80" height="64"/>
+  <object id="268" type="collision" x="624" y="208" width="16" height="176"/>
   <object id="279" type="collision" x="144" y="96" width="16" height="80"/>
   <object id="281" type="collision" x="160" y="96" width="32" height="32"/>
-  <object id="282" type="collision" x="160" y="128" width="16" height="16"/>
-  <object id="286" type="collision" x="240" y="208" width="16" height="16"/>
-  <object id="287" type="collision" x="304" y="192" width="64" height="16"/>
-  <object id="288" type="collision" x="608" y="176" width="16" height="16"/>
   <object id="295" type="collision" x="624" y="448" width="16" height="192"/>
  </objectgroup>
 </map>

--- a/mods/tuxemon/maps/spyder_park_south.tmx
+++ b/mods/tuxemon/maps/spyder_park_south.tmx
@@ -20,7 +20,7 @@
  </layer>
  <layer id="2" name="Tile Layer 2" width="60" height="40">
   <data encoding="base64" compression="zlib">
-   eAHlmGtuVTEMhA/rQILCH1gAZxk8ugdYAouABQFLYDe8VJWfzXD4xFwrTpwrVFQRyXcSe2yPk9sierVt29V/YG3EX3O+vbdt+8RWOBWu+olXMXH/hmle+t1/tm0jE2+24IAVPv1HSJ2RvlGMfCF9RnzFmGH0vYcDep/ent4zJHemMYuTL6RXxsXPDMJ9YNSkR+9+iNF7hvDRsorkC+nlNT42/6dm7hNPS+h+7ePaf3Pl1z4afNWqGPzR3cGJ+Pni1EM/n+G6UX42c594WkL39+Y9mPNPes+QSj3ehxbE4I2QGnGGeBZPS0isd9/uOzLyf+v2Vqti1FHvaMwqrCz1Uw1myFA8LedqP7IjI58p65X5e72Yl14V9BmyXtRxbq+/+8jJMOuV+b02++q7ugbl+veQvTjaa+ETFz30zPDIzD+pU8Ven7x6HlGdvWPKkB+Egz7ljQweyJ1V8Oh6+kl/x1NG7STNKwv9o1kVgwc6f2/xaB5f0bPC1V2rD5pmKD4c19fbwwOd09M4i/dyVn30QNMMxYdDbobwQOdJJ36hVowf3vonv6tHSI/Kz1T8LpCboc+jvfM0hcd1jnH5tKraKjzvUd2jc8aHBzpfc+AXasX44T31O+e29uic9YMHOl+z4BdqxfjhPfU757b26Jz1gwc6n1kcie/td4Qv/P8K0S9dIw3wQOdqnvjzRtxn1V59MDgZwsswyxv50S/M6srvPO29pubws+8Vy5bzevvYkzP1ejkzHzVAas3Q64rrZ9+P6uz21nGvGmiKSE3vU93HWvF7Se2Irk+xrF/Mq56jDj9TI+s58sd5I1d9WJHr55jHmdxVJL+H1OrFZj7XrH2Pz91Grp/35LspbfxNCZ0V7OnARz7nFXTN2bzUi9zKWdr4mxI6K7gn9yc/C10r6Jr1jqNc3pl+jl7H987R/nX7Dr1plmHkj84jrVnMtWWc6PefafR4Hd8TB9+1Wd83yxBeBaOuyhlts7eNteJbUydi1J29K/7IH52jpsoZfRVuj8NbUydi1Ju9K/7I5+x18fX0zHzUmfFGcc1MnYi82yoyE+h18aFpH/xuizHqkHsuUof/n3Pm3VaRmUDqCVlo5fzlybZ9bfat2fdmP5rFRR3dA/nnIHXivKvvCj/TOZr3wdNte9jsotmjZo+bxYVO4bkzK486cd7Vd4U/0kmMd+H8vM33otnLZq+aXTZjcY/oBFdmFlemRX5E+qziUfXPp9fFG+fF30Pu0etor8Uc1OMc8WAfn7EOZ/qsotfO9ujL4u7nvtEFOof53JftyY9In1XM+rhf80pjZXHfUV8lt8eJdTjTZxV7PaJPs67e413nr97jXeffAE0tbN0=
+   eAHlmUmOVFkMRT/rQCqaCQim/GXQ7QEGwJhFwE5oxsAS2ApUSUVVCRVDfPl5xA3r+TUIgRCWHNfPvu7ej8jIVH7ctu3jb6Cx4pc9H5/btn2gK5wZrvqJN6Pifg/VvvQ7f2PbeireSOCAM3z695A6vfl6MfKF9Lkedi+HHXrvezig92nZ9B4huXm+a4OZ4ZMvpBexCtlBuHeUmvRo3Q8xeo8QfjXbyE++kF6e8yL8L0PdJ55E6H7ZWfYzrvyys8JXrRmF37s7OBnfXjz10M93+DMof4XK9+AMxZMIndva92COX+k9Qiq1eK8iiMLrITXyDvksnkRIrHXf7jsy6u+6PWrNKHXUOyu7CmdE/VSDHSoUT+Jc2T09Muqdql6Vv9WLfek1g75D1Ys6zm31dx85FVa9qu8Kr409+1x9BuX6+xBbHNkSfOIyJz0rPDLrV+rMYqtPXb2OqM7eUGXID8JhPuX1FB7Inc3g0fX0lf6Op4y5k2ZeEebv7apY/n3A+XvEs3p8ZZ4Vru5afdhhhOLD8flaNjzQOa0ZR/FWzqqPHsw0QvHhkFshPNB5mhO/UJLjh3f+lZ/VPaTHzGcqvxfIrdD3ke08beFxnXNcPsnsbDM87zFrM+eIDw90vvbAL5Tk+OE99TvnR9nMOeoHD3S+dsEvlOT44T31O+dH2cw56gcPdD67OBLf42eEC/6fhcyvuXozwBM+igWcq33y54247ypbfVA4FcKrsMrr+X2Pqq78zpPtNbWHn91WrBLntWx6PowC2EKklTPyeR2vRc0Kva44fna7ypd/t2edbdXIs3GmpveZtVXjWRR4Hio7vy+pndHnU6zql/Nmz3kOP1Oj6tnza8d3UeB9qOzMVR9E8UpzHmdyV5H8FlKrFRv58vwtPnebuX7ei/emZnsd+oYhJ7E1Bz5KcF5Bn1l2LzdzZ86a7f/QTww5iXtxf/IjvVmrmM+s51jx5Oc508/R67jtHNn34k7vh1aY+b1zb9Yq5rNVnOz3zzTzeB23iYNPYtenoRXCm8E818yZ2UbPNtfKz5o6GfPc1XPFn/m9c55p5sx8M9wWh2dNnYx53uq54s98nf37UvWR1jwjH/ONeL24dqZORp7bKrKT0L8vW/vunZ9tOcZ8vX1mYtTh73POPLdV9H1lU0+IMBfnv69s24fQf0L/Df0vNAt1dA/kfwtSJ///ZvW5wq/m7O37x9VtuxB6MfRS6OXQLMwp/NadlUcd//+NfKvPFX5rTv5uIMZz4Xwz9rsVejv0TujdUIR7ZE5wZWdxpRLyM9JnFY+qX1+9Lt68L/4Wco9eR7aEPajHOePBPl5zHc70WUWvXdnMV8Xlf3AW5L6ZC/Rc9nNfZZOfkT6rWPVxv/bVjDPCfef5ZnJbnFyHM31WsdUj+7Tr6j3+6vzVe/zV+Z8BV2xxuA==
   </data>
  </layer>
  <layer id="6" name="Tile Layer 3" width="60" height="40">
@@ -39,12 +39,10 @@
   <object id="159" type="collision" x="272" y="560" width="48" height="16"/>
   <object id="160" type="collision" x="256" y="352" width="64" height="208"/>
   <object id="161" type="collision" x="800" y="352" width="112" height="64"/>
-  <object id="162" type="collision" x="592" y="384" width="32" height="32"/>
   <object id="164" type="collision" x="176" y="208" width="16" height="32"/>
   <object id="165" type="collision" x="16" y="240" width="176" height="272"/>
   <object id="166" type="collision" x="176" y="48" width="16" height="144"/>
   <object id="169" type="collision" x="416" y="176" width="48" height="192"/>
-  <object id="170" type="collision" x="800" y="224" width="144" height="16"/>
   <object id="172" type="collision" x="192" y="48" width="96" height="32"/>
   <object id="174" type="collision" x="464" y="176" width="80" height="32"/>
   <object id="179" type="collision" x="288" y="32" width="16" height="48"/>
@@ -79,11 +77,6 @@
   <object id="299" type="collision" x="304" y="576" width="32" height="16"/>
   <object id="300" type="collision" x="112" y="544" width="16" height="16"/>
   <object id="301" type="collision" x="48" y="544" width="48" height="16"/>
-  <object id="302" type="collision" x="512" y="496" width="32" height="48"/>
-  <object id="303" type="collision" x="752" y="96" width="32" height="48"/>
-  <object id="304" type="collision" x="784" y="96" width="16" height="32"/>
-  <object id="305" type="collision" x="752" y="144" width="16" height="16"/>
-  <object id="306" type="collision" x="64" y="80" width="32" height="32"/>
   <object id="307" type="collision" x="944" y="0" width="16" height="128"/>
  </objectgroup>
 </map>

--- a/mods/tuxemon/maps/spyder_route1.tmx
+++ b/mods/tuxemon/maps/spyder_route1.tmx
@@ -39,13 +39,12 @@
   </data>
  </layer>
  <objectgroup color="#ff0000" id="7" name="Collisions">
-  <object id="162" type="collision" x="0" y="32" width="160" height="32"/>
+  <object id="162" type="collision" x="0" y="16" width="160" height="48"/>
   <object id="163" type="collision" x="448" y="0" width="64" height="320"/>
   <object id="164" type="collision" x="160" y="256" width="224" height="32"/>
   <object id="165" type="collision" x="320" y="32" width="32" height="144"/>
   <object id="166" type="collision" x="384" y="272" width="16" height="16"/>
   <object id="167" type="collision" x="160" y="288" width="32" height="32"/>
-  <object id="168" type="collision" x="192" y="304" width="16" height="16"/>
   <object id="169" type="collision" x="240" y="304" width="208" height="16"/>
   <object id="171" type="collision" x="160" y="0" width="176" height="16"/>
   <object id="195" type="collision" x="512" y="0" width="128" height="64"/>

--- a/mods/tuxemon/maps/spyder_route2.tmx
+++ b/mods/tuxemon/maps/spyder_route2.tmx
@@ -38,129 +38,22 @@
   </data>
  </layer>
  <objectgroup color="#ff0000" id="5" name="Collisions">
-  <object id="18" type="collision-line" x="448" y="112">
-   <polyline points="0,0 0,80 0,-16"/>
-  </object>
-  <object id="20" type="collision-line" x="560" y="80">
-   <polyline points="0,0 0,32"/>
-  </object>
-  <object id="32" type="collision" x="192" y="272" width="16" height="48"/>
-  <object id="33" type="collision" x="240" y="224" width="96" height="16"/>
-  <object id="38" type="collision" x="208" y="256" width="16" height="16"/>
-  <object id="39" type="collision" x="224" y="240" width="16" height="16"/>
   <object id="40" type="collision" x="160" y="240" width="32" height="32"/>
-  <object id="41" type="collision" x="64" y="224" width="96" height="48"/>
+  <object id="41" type="collision" x="64" y="224" width="96" height="16"/>
   <object id="42" type="collision" x="96" y="208" width="32" height="16"/>
   <object id="43" type="collision" x="144" y="32" width="16" height="16"/>
   <object id="45" type="collision" x="0" y="0" width="160" height="32"/>
-  <object id="49" type="collision-line" x="64" y="112">
-   <polyline points="0,0 0,128"/>
-  </object>
-  <object id="51" type="collision" x="448" y="288" width="160" height="16"/>
-  <object id="52" type="collision" x="368" y="272" width="80" height="16"/>
-  <object id="53" type="collision" x="512" y="80" width="16" height="16"/>
-  <object id="54" type="collision" x="528" y="64" width="32" height="16"/>
   <object id="55" type="collision" x="192" y="0" width="448" height="32"/>
-  <object id="56" type="collision" x="336" y="240" width="16" height="16"/>
-  <object id="57" type="collision" x="352" y="256" width="16" height="16"/>
   <object id="58" type="collision" x="624" y="128" width="16" height="192"/>
   <object id="59" type="collision" x="608" y="32" width="32" height="96"/>
-  <object id="64" type="collision" x="560" y="112" width="48" height="16"/>
-  <object id="68" type="collision" x="448" y="192" width="96" height="16"/>
-  <object id="69" type="collision-line" x="304" y="80">
-   <polyline points="0,0 0,48"/>
-  </object>
-  <object id="70" type="collision-line" x="240" y="128">
-   <polyline points="0,0 64,0"/>
-  </object>
-  <object id="71" type="collision-line" x="240" y="128">
-   <polyline points="0,0 0,48"/>
-  </object>
-  <object id="72" type="collision-line" x="240" y="176">
-   <polyline points="0,0 -64,0"/>
-  </object>
-  <object id="73" type="collision-line" x="176" y="176">
-   <polyline points="0,0 0,-16"/>
-  </object>
   <object id="76" type="collision" x="176" y="112" width="16" height="16"/>
   <object id="77" type="collision" x="240" y="80" width="16" height="16"/>
-  <object id="78" type="collision-line" x="32" y="48">
-   <polyline points="0,0 96,0"/>
-  </object>
-  <object id="79" type="collision-line" x="128" y="48">
-   <polyline points="0,0 0,16"/>
-  </object>
-  <object id="80" type="collision-line" x="128" y="64">
-   <polyline points="0,0 16,0"/>
-  </object>
-  <object id="81" type="collision-line" x="144" y="64">
-   <polyline points="0,0 0,32"/>
-  </object>
-  <object id="136" type="collision-line" x="512" y="96">
-   <polyline points="0,0 0,64"/>
-  </object>
-  <object id="137" type="collision-line" x="512" y="160">
-   <polyline points="0,0 96,0"/>
-  </object>
-  <object id="137" type="collision" x="16" y="96" width="16" height="16"/>
   <object id="138" type="collision" x="0" y="64" width="16" height="64"/>
-  <object id="139" type="collision" x="48" y="96" width="16" height="16"/>
-  <object id="140" type="collision-line" x="144" y="96">
-   <polyline points="0,0 0,64"/>
-  </object>
-  <object id="142" type="collision-line" x="144" y="160">
-   <polyline points="0,0 32,0"/>
-  </object>
   <object id="143" type="collision" x="0" y="160" width="16" height="160"/>
   <object id="144" type="collision" x="16" y="192" width="32" height="128"/>
   <object id="145" type="collision" x="48" y="256" width="16" height="64"/>
-  <object id="146" type="collision-line" x="144" y="96">
-   <polyline points="0,0 0,48"/>
-  </object>
-  <object id="147" type="collision-line" x="288" y="96">
-   <polyline points="0,0 0,-48"/>
-  </object>
-  <object id="148" type="collision-line" x="384" y="32">
-   <polyline points="0,0 0,16"/>
-  </object>
-  <object id="151" type="collision-line" x="288" y="48">
-   <polyline points="0,0 96,0"/>
-  </object>
-  <object id="165" type="collision-line" x="368" y="112">
-   <polyline points="0,0 0,48"/>
-  </object>
-  <object id="166" type="collision-line" x="416" y="160">
-   <polyline points="0,0 0,16"/>
-  </object>
-  <object id="167" type="collision-line" x="432" y="176">
-   <polyline points="0,0 0,48"/>
-  </object>
-  <object id="168" type="collision-line" x="480" y="224">
-   <polyline points="0,0 0,16"/>
-  </object>
-  <object id="169" type="collision-line" x="496" y="240">
-   <polyline points="0,0 0,16"/>
-  </object>
-  <object id="170" type="collision-line" x="368" y="160">
-   <polyline points="0,0 48,0"/>
-  </object>
-  <object id="171" type="collision-line" x="416" y="176">
-   <polyline points="0,0 16,0"/>
-  </object>
-  <object id="172" type="collision-line" x="432" y="224">
-   <polyline points="0,0 48,0"/>
-  </object>
-  <object id="173" type="collision-line" x="480" y="240">
-   <polyline points="0,0 16,0"/>
-  </object>
-  <object id="174" type="collision-line" x="496" y="256">
-   <polyline points="0,0 48,0"/>
-  </object>
   <object id="177" type="collision" x="16" y="112" width="16" height="16"/>
   <object id="201" type="collision" x="208" y="288" width="128" height="16"/>
-  <object id="206" type="collision" x="192" y="112" width="16" height="16"/>
-  <object id="207" type="collision" x="256" y="80" width="16" height="16"/>
-  <object id="210" type="collision" x="368" y="80" width="80" height="16"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="6" name="Events">
   <object id="30" name="Teleport to City Park" type="event" x="160" y="0" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_route3.tmx
+++ b/mods/tuxemon/maps/spyder_route3.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="698">
+<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="701">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="spyder"/>
@@ -9,9 +9,7 @@
   <property name="west" value="route4"/>
  </properties>
  <tileset firstgid="1" source="../gfx/tilesets/core_city_and_country.tsx"/>
- <tileset firstgid="1441" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
-  <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>
- </tileset>
+ <tileset firstgid="1441" source="../gfx/tilesets/Superpowers_Tilesheet.tsx"/>
  <tileset firstgid="3041" source="../gfx/tilesets/core_outdoor.tsx"/>
  <tileset firstgid="5816" source="../gfx/tilesets/core_buildings.tsx"/>
  <tileset firstgid="8166" source="../gfx/tilesets/core_outdoor_nature.tsx"/>
@@ -23,12 +21,12 @@
  </layer>
  <layer id="2" name="Layer 2" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHdmE1uFDEQhb1MMiACQkiIkGSyJ3AEFqyAREgkt8g+mQBSDgKR2PF7COAQ/GQ1ipI9N+A9ZUp5U7Ld3e7uYcDSG7vtcvlztdvtnoXrISxCC3Oa3wPXJsR87XY4WoXuQivQHUjbzW6WeZC0DZ4t6Cn0BHoMSXNvxdS98wO+As9L6AV0CI0g2nx+yN/+UuoecURjZ/kTeD5CH6D30DuI9UxngxB2rl7oHGW9tvqqnP1iyRh8TltjZ/kEPL+gn9AP6DvEeqYHYLO0ibJeW31Vzn6xZAw+p60xx/ppnfKU8j2fxF/jfD9Sp3E2ZrLk7tnuZO6LyAdXQliCBpM6nUcXZZ2H+tMYab2WGbtnYKPq2Gvf0rLFzWKU80O+JvY5X3XbmsSBsa8zj7pj17Frwqf+uBaXJmq7FsdD9TxdruJTDuNhzuek7VpM+bZxSMpn0a5juXIYj+Zcj6X3XJ839Tkdwcs4qI2W7ZnQvcvKTdj2wuWeTwbdS8yf5rTJjW22TRjos8vk19/+jRAOoBH0N5KuSY7P9Xcq7+7X4HoDHQvf28zz1eUcyMb17pPG8Au4vkLfhM/b93XN5yWWlC/W3lfd4c1pz/PGN02Hb405i19ffCN3X/w4pdf/c/z83l8ao1y/fyF+sbPMLPeX39fSEWwTv+FG2m9JyyN3VqCPNnwlDNpnvK5X8TL5hpF3qd5ffT9Hz4OJPTQ+YrNanrf0+9J6K18qxmbb57clx/CM/vxbxUcffTMqg8aOY2sbr1PJ90vZldTbuZp9OY6+r9rw3VoOgeoyWRzsDOr5Yud//m8yqzO/8dmcPZ9vN7tcftzh+cGPX8Jnsc8xl7b5719//vf8VeNU7Z+6p7b934Esnl/9x8p+frn5VPnO9W3bNu7gff0HmoeLHg==
+   eAHVWMluFDEQ9THJAEk4ICGW9HAn8AkcOLEGkfxF7hAWiQ8BJG6sHwF8BNtpFIU7f8B7YkrzumK7x70ME0tvqmyXq57Lbrd7VjZDWAVWllReBa9tgHLrfHhxGbgEXAQuANpvdouUQco98LkL3AFuA7cA6R5MTa2dD/gcfJ4BT4EnwAFAm083+DtcSa0RIxp36h/B5wPwHngHvAXYznI0CmH39D/8hq51a2+SHBcrxsFL2hp36r/A5yfwA/gOfAPYznId3KxsQ9e6tTdJjosV4+AlbY1zbJy2KZ+2/B5O8695vhZp0zwbZ3LJrdnedO6rkKNTIawBo2mbzqMPXeeh/jRH2q46c7cDbsQ89jq2rW55sxzl/JBfiX3Ol/bdr7RW10vywNzPM496hOO1B9XxtlRLCT/1wb24NkXXvTgZq+e63sRPeRgfSj4nXfdiyrfFIVM+i1aPSeVhfFRyP7Zdc33e1Gc9g7M8qI3q9kzo2WV6Cbf9MDvzyUHPEvOnkja52GZbwoE++yx+/z06G8Jj4AD4H0X3JONz/x3Ku/sleL0CXgu/N5nnq885kBv3uy+aw8/g9QX4Kvy8/VB1Pi+xovxi/UO1bVR1z8vGr84O3xpLlr+h+K27dfFx2tZPcv5ydxzmw5/9bXOUG3cS8he7yyzyfPmzns5gl/yNr6T9tum56e4K9NGFXxsOOmZSaS2uk9848i7V9dX3c/Q+mDhD4xHLWnnf0u9LG638Ujk22yG/LRnDc/T33yZ+9DE0R+WguWNs7WM9Vfy4lF2bdrtXcyzjbFYzL134ndsIgeizWB7sDur5xe7//N9kUXd+42dz9vx8v9nl5E6V6y3r8/Hb8LPcl0Wez9p///r7v+ff5LXp/NQztfR/h9gdxvNX/zHdzy83nybffqz/HrD+M5Vp88tJD+/rv+Xpi+A=
   </data>
  </layer>
  <layer id="3" name="Layer 3" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHtmE1uFDEQhb1CIKQwCRmxnQuQFWTFHVixQGzgGoifnACOkAQhOAWwIAkC8XMQxM8RqKfuR54qVW476UWQsOSutl1d9fVz290zpfwv51mBd4uB7u1oa6wX12ujfWPMS4ur9bwv2r/vDW0vzahvTRHo3Kv1dWPbOiPf3mYpu67uW3uO0qpfdu9ge2H1wNUP1j4LI7l69IsYHxvHI6u+HFofGKlrL2uN69qy3L9l9YFVn9e3wXEU8MEPY9Q183mfXEv9EMfzfFqit5TPox1apz/euFLKTavbVh8mPD661+9LJ4ven4/t23eNC+XeaIdW/dgan3589tjW+9P1Gz1nPXzMw/jMR8txtunHfrb17vU5i9ZtLx9i+/zMW+NQpuw8Ws89fIxLHrbnsnPxUb9Wru8Xyo73fXP5ZN8U3w9bIy/H+jNZL5hDr1+Uy/NkbV0feJf4vU7n95UwbRpHxtirn2ezvftv0fXh2eCU8WHstfCizeL1Q7/mpB8std3dKGXP6r7V1oK9eXtt8Mb+t2Ga/RamiA/ftDX98KxFrAfGdWj1qJFP2UDI/VnnOOKDb6Qf+qPC9xPeUT2VujFmD5/Xr8bg8zBfj13YHO+M85rph3XL4vXjM8zxOa2yIW7GpzlVvzu2J/TyIedT06OlUjfkx/63FJ1an79ePj5Les88r+3Bqh38Mz7VD35PGrWgXqoJrteiDNiD+b6Aj2qHdsQXvT/gO1dRvqmYER+u8fppHI7R6lh2rnPqNcqu+WVzdlWeRfXz6zcao4+ue/XT80gz5P9YqRkb4k5pw3GwTfH5NUnubO44TovvC//dTW3oA6scHMe7UPvVn+eZdjV9eC1/P0ffFfShrWlFPemrVvk4pxGbfofxd3H0PYbYkSY1PuoZXYdvEpaIC2PUib+HaWu6+VzUyPcz92kt2WosLbGpUYtvj0/tP4Ysjtfo2aqU51bPa/lqbN+sooDd8w8jfcc5YvD/4dur49wadz3pP/aePmOOac/Bg/lp0btYDWP+uJb0q5/G0f7sPPPX/j+e3dlm
+   eAHtmFtOFkEQhfvJaEjk+sdXNgBPwBMbMbzoPrywAlkClxBdhfICGIyXhRgvS7BO/jlyUlT3dME8YGInRU1311R9c3p6Zn5K+d/uswJnS3O6D4NvsT5cbs3m5liXHmfrcS7bvx8NbR9NqG9LEeic1XrD2DbvyHe0Vsqhs2PrT9F69atdO9hOzM6dfbT+XRjJldEvYnxpHC/MfLuwMTBS1yxri+vJrDzbNXtu5uv6PjguAz7EYY661mJ8PvapH/qe59NsHvV58Dzntn5rsZRtsx2z3ub1+5Jk0esbq/l04NpL8PXmZxzvPfb1+nT/RvdZho91mJ/16DnPPuM4zr5qpvdZtG+zfMjt67Nui0OZasfRfs7wMS952J/KT8VH/Xq5vj8o+z72/cLNsTG+H7ZHTgf7WdkvWEOvX1TL89T6uj/wLvHPOl3ft8K0Zhw1xqx+ns2e3X+b7g/PhqAaH+beCS/6bF4/jGtNxsFT28OVUo7Mjs16G57NO4/n0Xj+rZhmv4Up4sM3bUs/3GsR67lxXZhddvIpGwj5fNY1jvgQG+mH8ajx/YR3VMaoG3Nm+Lx+LQZfh/UyfsnWeH9Y15p+2LdsXj/ew5yf0isb8tb4tKbXL8uHmq9Njx6jbqiP599MdOq9/7J8vJf0mnncegardoiv8Xn9XnVqQb1UE3LRKwOewXxfYF61Qz/ii94fiJ2qKd9YzogP53j9NA/n6HWudqxr6jWqnfPL1mxV7kWN8/s3mmOM7nuN0+NIM9S/aliNDXnHtOE82Mb4/J4kd23tOE+P7wv/3U1tGAOvHJzHu1DHNZ7HNe1a+vBc/n6OvisYQ9/SinoyVr3ycU0jNv0O4+/i6HsMuSNNWnzUMzoP3yRsERfmqBN/D9O3dPO1qJEfZ+3berK1WHpyU6Oe2ExM638MtTxeozfrpRyY3df21di+maGB3fPPZ3J/p8gR/X9Y8y6uXzPp+PXo+FFUo3UW69C3Ynvmsnlq8Tr+B9qs1sk=
   </data>
  </layer>
  <layer id="4" name="Above Player" width="40" height="40">
@@ -42,126 +40,26 @@
   </data>
  </layer>
  <objectgroup color="#ff0000" id="6" name="Collisions">
-  <object id="459" type="collision" x="64" y="592" width="16" height="48"/>
-  <object id="461" type="collision" x="80" y="576" width="16" height="32"/>
-  <object id="462" type="collision" x="160" y="608" width="16" height="32"/>
   <object id="464" type="collision" x="112" y="464" width="64" height="16"/>
   <object id="465" type="collision" x="128" y="480" width="32" height="32"/>
   <object id="466" type="collision" x="192" y="512" width="32" height="32"/>
-  <object id="467" type="collision" x="432" y="544" width="32" height="32"/>
-  <object id="468" type="collision" x="448" y="528" width="32" height="32"/>
-  <object id="469" type="collision" x="464" y="512" width="96" height="32"/>
-  <object id="470" type="collision" x="544" y="496" width="32" height="32"/>
-  <object id="471" type="collision" x="560" y="480" width="32" height="32"/>
-  <object id="472" type="collision" x="576" y="464" width="16" height="16"/>
-  <object id="473" type="collision" x="592" y="480" width="16" height="16"/>
-  <object id="474" type="collision" x="512" y="224" width="96" height="16"/>
-  <object id="475" type="collision" x="528" y="96" width="64" height="16"/>
-  <object id="476" type="collision" x="592" y="112" width="16" height="16"/>
-  <object id="479" type="collision" x="544" y="144" width="16" height="16"/>
   <object id="480" type="collision" x="528" y="0" width="16" height="96"/>
   <object id="484" type="collision" x="0" y="0" width="528" height="32"/>
-  <object id="485" type="collision" x="32" y="240" width="144" height="16"/>
-  <object id="486" type="collision" x="176" y="224" width="112" height="16"/>
-  <object id="487" type="collision" x="288" y="208" width="16" height="16"/>
-  <object id="488" type="collision" x="192" y="160" width="32" height="16"/>
-  <object id="489" type="collision" x="224" y="144" width="32" height="16"/>
   <object id="490" type="collision" x="48" y="160" width="48" height="16"/>
   <object id="491" type="collision" x="112" y="144" width="48" height="16"/>
-  <object id="492" type="collision" x="128" y="320" width="16" height="16"/>
-  <object id="493" type="collision" x="80" y="304" width="16" height="16"/>
   <object id="494" type="collision" x="80" y="272" width="48" height="16"/>
   <object id="495" type="collision" x="64" y="272" width="16" height="16"/>
   <object id="496" type="collision" x="176" y="304" width="16" height="16"/>
   <object id="497" type="collision" x="192" y="256" width="16" height="16"/>
   <object id="498" type="collision" x="112" y="320" width="16" height="16"/>
   <object id="499" type="collision" x="208" y="304" width="48" height="16"/>
-  <object id="500" type="collision" x="256" y="288" width="16" height="16"/>
-  <object id="503" type="collision" x="304" y="192" width="64" height="32"/>
-  <object id="504" type="collision" x="304" y="272" width="64" height="32"/>
   <object id="505" type="collision" x="272" y="256" width="16" height="16"/>
-  <object id="506" type="collision" x="352" y="208" width="32" height="80"/>
-  <object id="507" type="collision" x="288" y="112" width="32" height="48"/>
-  <object id="508" type="collision" x="304" y="96" width="96" height="32"/>
-  <object id="509" type="collision" x="384" y="112" width="32" height="32"/>
-  <object id="510" type="collision" x="400" y="128" width="64" height="32"/>
-  <object id="511" type="collision" x="432" y="160" width="48" height="208"/>
-  <object id="512" type="collision" x="416" y="304" width="32" height="96"/>
-  <object id="513" type="collision" x="448" y="368" width="16" height="16"/>
-  <object id="514" type="collision" x="400" y="320" width="16" height="80"/>
-  <object id="515" type="collision" x="176" y="336" width="224" height="64"/>
-  <object id="516" type="collision" x="64" y="352" width="208" height="80"/>
-  <object id="517" type="collision" x="32" y="496" width="16" height="16"/>
-  <object id="518" type="collision" x="32" y="528" width="16" height="16"/>
-  <object id="519" type="collision" x="32" y="144" width="32" height="16"/>
-  <object id="520" type="collision" x="64" y="112" width="112" height="16"/>
-  <object id="521" type="collision" x="176" y="64" width="32" height="16"/>
-  <object id="522" type="collision" x="240" y="64" width="192" height="16"/>
-  <object id="523" type="collision" x="432" y="96" width="80" height="16"/>
-  <object id="524" type="collision" x="48" y="32" width="16" height="64"/>
+  <object id="524" type="collision" x="48" y="32" width="16" height="48"/>
   <object id="525" type="collision" x="64" y="32" width="64" height="32"/>
   <object id="526" type="collision" x="80" y="64" width="48" height="16"/>
-  <object id="527" type="collision" x="160" y="544" width="64" height="16"/>
-  <object id="528" type="collision" x="240" y="544" width="16" height="16"/>
-  <object id="529" type="collision" x="0" y="64" width="32" height="576"/>
-  <object id="530" type="collision" x="32" y="272" width="16" height="224"/>
-  <object id="531" type="collision" x="32" y="80" width="32" height="64"/>
-  <object id="532" type="collision" x="176" y="608" width="464" height="32"/>
-  <object id="533" type="collision" x="336" y="592" width="192" height="16"/>
-  <object id="534" type="collision" x="608" y="0" width="32" height="608"/>
-  <object id="535" type="collision" x="592" y="256" width="16" height="224"/>
-  <object id="536" type="collision" x="576" y="272" width="16" height="192"/>
-  <object id="537" type="collision" x="512" y="192" width="96" height="32"/>
-  <object id="546" type="collision" x="32" y="208" width="144" height="32"/>
-  <object id="547" type="collision" x="144" y="192" width="144" height="32"/>
+  <object id="531" type="collision" x="32" y="80" width="32" height="32"/>
+  <object id="534" type="collision" x="624" y="128" width="16" height="64"/>
   <object id="561" type="collision" x="80" y="544" width="32" height="32"/>
-  <object id="562" type="collision-line" x="80" y="544">
-   <polyline points="0,0 0,-80"/>
-  </object>
-  <object id="563" type="collision-line" x="224" y="464">
-   <polyline points="0,0 -144,0"/>
-  </object>
-  <object id="564" type="collision-line" x="240" y="480">
-   <polyline points="0,0 0,16"/>
-  </object>
-  <object id="565" type="collision-line" x="256" y="496">
-   <polyline points="0,0 0,48"/>
-  </object>
-  <object id="566" type="collision-line" x="224" y="480">
-   <polyline points="0,0 16,0"/>
-  </object>
-  <object id="567" type="collision-line" x="160" y="560">
-   <polyline points="0,0 0,48"/>
-  </object>
-  <object id="568" type="collision-line" x="224" y="464">
-   <polyline points="0,0 0,16"/>
-  </object>
-  <object id="569" type="collision-line" x="32" y="592">
-   <polyline points="0,0 32,0"/>
-  </object>
-  <object id="570" type="collision-line" x="208" y="80">
-   <polyline points="0,0 0,32"/>
-  </object>
-  <object id="571" type="collision-line" x="240" y="80">
-   <polyline points="0,0 0,32"/>
-  </object>
-  <object id="572" type="collision-line" x="208" y="112">
-   <polyline points="0,0 -16,0"/>
-  </object>
-  <object id="573" type="collision-line" x="240" y="112">
-   <polyline points="0,0 16,0"/>
-  </object>
-  <object id="574" type="collision-line" x="192" y="112">
-   <polyline points="0,0 0,48"/>
-  </object>
-  <object id="575" type="collision-line" x="256" y="112">
-   <polyline points="0,0 0,32"/>
-  </object>
-  <object id="576" type="collision" x="480" y="160" width="16" height="16"/>
-  <object id="577" type="collision" x="512" y="304" width="16" height="16"/>
-  <object id="578" type="collision" x="352" y="560" width="16" height="16"/>
-  <object id="591" type="collision" x="48" y="384" width="16" height="16"/>
-  <object id="630" type="collision" x="240" y="176" width="64" height="32"/>
   <object id="634" type="collision" x="480" y="416" width="16" height="16"/>
   <object id="635" type="collision" x="400" y="464" width="16" height="16"/>
   <object id="636" type="collision" x="528" y="464" width="16" height="16"/>
@@ -183,17 +81,11 @@
   <object id="672" type="collision" x="112" y="160" width="16" height="16"/>
   <object id="673" type="collision" x="144" y="160" width="16" height="16"/>
   <object id="677" type="collision" x="96" y="80" width="32" height="16"/>
-  <object id="678" type="collision-line" x="240" y="496">
-   <polyline points="0,0 16,0"/>
-  </object>
-  <object id="685" type="collision-line" x="432" y="80">
-   <polyline points="0,0 0,16"/>
-  </object>
+  <object id="698" type="collision" x="0" y="64" width="32" height="16"/>
+  <object id="699" type="collision" x="624" y="240" width="16" height="16"/>
+  <object id="700" type="collision" x="624" y="528" width="16" height="80"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="7" name="Events">
-  <object id="559" type="collision-line" x="176" y="80">
-   <polyline points="0,0 0,32"/>
-  </object>
   <object id="579" name="Teleport to Leather Town" type="event" x="144" y="624" width="16" height="16">
    <properties>
     <property name="act1" value="transition_teleport spyder_leather_town.tmx,9,0,0.3"/>

--- a/mods/tuxemon/maps/spyder_route4.tmx
+++ b/mods/tuxemon/maps/spyder_route4.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="93">
+<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="93">
  <properties>
   <property name="east" value="route3"/>
   <property name="edges" value="clamped"/>
@@ -20,7 +20,7 @@
    eAGt1uFNw0AMhuGIn5Qx2I4dQLACs7BDWaE7wAzECo9wrXMuSD0p8d3nz+85TQg53y/L53qcbxS/Vs73etwq6mtJg/ay7hNHjKfTFmdnfWUfDQ8ze/47H/W4x+DvPLXHzkfn77h016xOfHww2yI/7nX2734/p3tSPXmNg5tzMad3/XV+3JqnH+Xx66Py6Hivd8tyao63VefHxas6nnwXcdTzVf0oD0c9nkg/yuPHxRHpwdsb8vy4tYZ+2XkP5N75cSuv07Mv8/hxsy/mnZ59mcePm30xp3fPXTxzmcePW3l0vpqPdebN/Dh8M171W6vLnOhjNPb6y/VRiz97X9mLv3L0Qc89yI0iP2710PG6+xzvnL33C6798Oji++/73vXy6yN8H+vflrXY8cKfc/y4kY9hLdp/y16fM48f99p5bJV5OLgdobsPcQ9i6B8Hd8v2Z72I8VzmgYObc2po1p5t64gGDq4YnlwX/u6a/b8bPX/4ee+8/+x7Tf3o2xRTz0djXMvo2zT0YNrzaIy62d56rbGrm+2t1+DleVc3+v26vWd67Df6/bq9Z3rwfgBfJGbu
   </data>
  </layer>
- <layer id="3" name="Tile Layer 1" width="20" height="40">
+ <layer id="3" name="Tile Layer 3" width="20" height="40">
   <data encoding="base64" compression="zlib">
    eAFjYBgFoyEwGgKjITAaAqMhMBoCoyEwMCFwgouB4SQQUwu8BZr1jormUctdo+aMhsBoCCBCAACenwOV
   </data>
@@ -34,11 +34,6 @@
   <object id="8" type="collision" x="112" y="544" width="208" height="32"/>
   <object id="10" type="collision" x="224" y="576" width="96" height="32"/>
   <object id="11" type="collision" x="240" y="608" width="80" height="32"/>
-  <object id="12" type="collision" x="160" y="160" width="128" height="16"/>
-  <object id="13" type="collision" x="128" y="288" width="112" height="16"/>
-  <object id="14" type="collision" x="160" y="384" width="128" height="16"/>
-  <object id="15" type="collision" x="128" y="464" width="112" height="16"/>
-  <object id="16" type="collision" x="144" y="512" width="144" height="16"/>
   <object id="17" type="collision" x="96" y="64" width="32" height="400"/>
   <object id="19" type="collision" x="64" y="416" width="32" height="32"/>
   <object id="20" type="collision" x="64" y="176" width="32" height="32"/>

--- a/mods/tuxemon/maps/spyder_route5.tmx
+++ b/mods/tuxemon/maps/spyder_route5.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="68">
+<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="68">
  <properties>
   <property name="east" value="flower_city"/>
   <property name="edges" value="clamped"/>
@@ -8,56 +8,42 @@
   <property name="south" value="timber_town"/>
   <property name="types" value="route"/>
  </properties>
- <tileset firstgid="1" name="Tileset" tilewidth="16" tileheight="16" tilecount="1120" columns="28">
-  <image source="../gfx/tilesets/Tileset.png" width="448" height="640"/>
- </tileset>
- <tileset firstgid="1121" source="../gfx/tilesets/core_city_and_country.tsx"/>
- <tileset firstgid="2561" source="../gfx/tilesets/core_outdoor.tsx"/>
+ <tileset firstgid="1" source="../gfx/tilesets/core_city_and_country.tsx"/>
+ <tileset firstgid="1441" source="../gfx/tilesets/core_outdoor.tsx"/>
+ <tileset firstgid="4216" source="../gfx/tilesets/Superpowers_Tilesheet.tsx"/>
  <layer id="1" name="Tile Layer 1" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHt0iERAAAMA7Hiqa1/VBdDAW/gL72k8oABBhhggAEGGGCAAQYeDAxDjn1Q
+   eAHt0iERAAAMA7Gi4fpXWxdDAW/gL72k8oABBhhggAEGGGCAAQYeDAxMckTB
   </data>
  </layer>
  <layer id="2" name="Long Grass" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHtklEKAkEMQ/cEfnh7PZxeRYI+CCXtKKvohwVJJ0kzncVt+9e7vsD1sG3f/k1vYbfJgybvpbxHGhkg/g7xkdX5xOP1Hs6x0xOfOLKSJq6raQ5NqPIzfeITt/JrJlWd45vDg2l24pirqJnEdVl40xzaqzhl1T2UPRV3y0M/Yfd9fWbKco1e2BW50un3YsriXa6pXxW7yEe/F6espInril06vfL4Qb4LZ+Gq3LvyJ69zuouz93AJJ1/SxHVV8+Vzzs/eu6f2ky9p4rpaZWsOj/dwCSdf0sR1pfxafmfV3nEmn//ulIn3m/jsfrzn07vWe6b9fl07He8bnh/4C/veACeFfPA=
+   eAHtklEOwjAMQ/vNoeGKcCNkjSdZUZKObWL7oBI4tR03LYzxX0e9wOM2xtmf7i7M1nnQ5L2H+0gjA8RfIT6w8ol3D3WG7nU94zOOnqjpvt2q+uB5r5iLnvEZN/NXM3Z9aMJvl/dS81bswS7bPdR7UedVGXEW+bpFjjzUe7HLco1aWC1mkU7Nf469Y6fh8yw40DXVs5X1wW1FnVn1Zlo3IzmdxzX8Hbo/q2Nv5oHLvJFjrx7qiP67d75ME1eteI58kWMfNZ8JjzD6ZtrSkX9775bs2L8lI59sYclzj5/p/FE1+bx/l4v3TFwzH3f5xZzxrG6+q2vPz4CvCw36BnXj3pw=
   </data>
  </layer>
  <layer id="3" name="Path" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHtldFNgzEMhPMEIwDTAEMwA7ADrFCmYAXYALaBFfAJfdLJcpy/1f+CRKS0jp2cz86lHeN/7NmBi/MxLjfMq9jjg3Pux9fh+X7H6+yvszE+Y+r7O+ZHWit2m/hdxzr78XVYGafjpRiYh8j3UMyX8IlvxtW57MdXYQkn17PiBr+cx88pp3r6Ft9+b++FH1+uZUsez+k2+StMx63uTHVlPcxqJY/XuUWLOifdzfjdR7y698rX3aHyiLvXOcuZ+3eKLhwDGw5VXsWUR9pUHU9hey+lnbvw5dFh5r2rtbB03zN+3D05vZeKPU/4Vfr3t4C90gt5c1903t/OTDOvE35ZF7N11RfvqfipJ7kvrOmfn1nZ1CJN6J3w24XW0csWbPoHhr8h8FY1zvhSO+fJpbXsma4cr9vneH6ms/3/UvrwHpFLWiJW6QptojFhVPtcfx0nj1ET+vAeVTHl9r2nrLkf5zGzxeEmpuvlMdYa6NI1tIcN/m+W/hN+x9TUI+4bpUfH1LQvg7+H9gMNbLRm
-  </data>
- </layer>
- <layer id="4" name="Gravestones" width="40" height="20">
-  <data encoding="base64" compression="zlib">
-   eAHNlsFuwjAMhiOmieOOQ+wF2HmwHXkCupeBp4dp86/2kyyLtOpom1hyUjtp8sU2oc1LSifTpqI+mcC0M6530+sqpVsF+msMMHnO1ydZ/5PmOaVvU4l/bj3DLbHSzDfj8LZiJ4HvuG7tMe3Z2C4dn38eswZzxSchhqo7CXytVa6FjxjCWRMfTIoSnEvx+b3vZWmo/u69M6WPeOTWJL+co7b6+7Dfx4/dMZwDzqXym4tbzg9nLXz6n1D8iFu8/3LnyPlZJ47n/HFetKk/4vZo/bFO3Cfnj/Nk+7OIz9s8l8yvP0u8XxgryedjSn6JG2N9fHEu78zRw0fc2LuPj7lz8MQ1Y/2xt/g23bfDtuvju0vYsf64X3Rv700Ppp+mpb5Vv2xvCXnlfmm907bsMbYXBXn9AwOndcg=
+   eAHNlstNQ0EMRQeQgLAOEgtoAbqBDqAb6IZfBdAEvz3UgI+SIyzLQUEEEUvDvPGbub6275vwsTfGe4yPNZpHmJwegtdjjOvpGDdrMO6Dg5wyz6fwYzebY9wuMe5iz3RjjIMY+zE8pz/7vsNjv7Ui/lvwyGtqh8nvOfZfxriYz1cxn5c1715jZONc9ev7Dgsc8iQfDH6YNUR3WOYH3vHWGLvNOAkffMW1fnDJfuLp67DAqfnAQ37WUJ6ZX42T8yMmNT0N/Ny3s1hXvz5zgbNYcs/v5Ccn1vLM/IjDuc7E7XpGXlUP5iqWsbs80eKy+st5mTMxdqJOXd87X+6hGNajy5OY9tc8Fumvq58xlp3l0GHxTp2Tx2Gs0cz2fugmfcPyzP21J5WHPVp2toddLzJ3n6tmjoKz9c78qs7zd5Cf0QtW83Bt3PotgZG/nawZfieon3Xr7j/qV3Pp1tRFnBnTr7/6Oded5Y6tfeK0+rNuVX/mgibAWHR3iS0O2NaNZ/3sW4QB75oj/MwNHJ/pL/j5vvW8cZ07XYGVzb3eVa6d7T38zIXz9X7xHfz8DVUf1ohz3btOV1mfaAyMbl/WH/ia/bVu+uFnTlkvuf7Eyu9WsQbfmsJFftZNnvJ7if1ZL5OogXu7O/i3PvCzVf0ZG34Y/DBz+us5x+K56s/7hXt7JwY2ifm//lfdm3Owr94vM2ar/WuMn86wsK+fh6R/wA==
   </data>
  </layer>
  <layer id="5" name="Tile Layer 8" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAFjYBgFhEJAg5+BQROIR8FoCIyGwGgIjIbAaAiMhsBoCIyGAP1DQJKZ/naO2ki7EAAAK24AjA==
+   eAHtVUkOgCAM7Nmz/3+PvkK9uz3BcpiENJUlgAFik2Zsi9MOkEDUr+0s7WY/hMST40vkXOE0EM3stVqsnlAdufYvtJ9cB11AWY+JwQG0/9Vydr3Vb+gCpujIweHrjx6h6ONLrcs5UvhycsXOIXsjjuWpdf1Xekr3Mfyu90rrr+XMOck8YmCtZ9niXD3uKTSVRu2uvt2BZSRa2Tf23/rYgQdckGRy
   </data>
  </layer>
  <objectgroup color="#ff0000" id="6" name="Collisions">
-  <object id="3" type="collision" x="0" y="0" width="32" height="240"/>
-  <object id="4" type="collision" x="32" y="0" width="608" height="32"/>
-  <object id="5" type="collision" x="576" y="32" width="16" height="112"/>
-  <object id="6" type="collision" x="576" y="160" width="64" height="160"/>
-  <object id="7" type="collision" x="80" y="288" width="496" height="32"/>
-  <object id="10" type="collision" x="320" y="32" width="32" height="32"/>
-  <object id="11" type="collision" x="272" y="32" width="32" height="32"/>
+  <object id="3" type="collision" x="0" y="32" width="32" height="256"/>
+  <object id="4" type="collision" x="32" y="16" width="560" height="16"/>
+  <object id="5" type="collision" x="592" y="32" width="48" height="112"/>
+  <object id="6" type="collision" x="592" y="160" width="48" height="128"/>
+  <object id="7" type="collision" x="80" y="288" width="512" height="16"/>
   <object id="12" type="collision" x="448" y="96" width="32" height="32"/>
   <object id="13" type="collision" x="352" y="176" width="32" height="32"/>
   <object id="14" type="collision" x="256" y="176" width="32" height="32"/>
-  <object id="15" type="collision" x="528" y="16" width="32" height="32"/>
+  <object id="15" type="collision" x="528" y="32" width="32" height="16"/>
   <object id="16" type="collision" x="528" y="192" width="32" height="32"/>
   <object id="17" type="collision" x="144" y="240" width="32" height="32"/>
-  <object id="21" type="collision" x="0" y="240" width="32" height="16"/>
   <object id="22" type="collision" x="32" y="288" width="32" height="16"/>
-  <object id="23" type="collision" x="0" y="256" width="32" height="32"/>
-  <object id="41" type="collision" x="48" y="304" width="16" height="16"/>
-  <object id="42" type="collision" x="80" y="304" width="16" height="16"/>
-  <object id="52" type="collision" x="592" y="128" width="48" height="16"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="7" name="Events">
   <object id="1" name="Teleport to Timber Town" type="event" x="64" y="304" width="16" height="16">
@@ -170,7 +156,7 @@
     <property name="cond2" value="is char_moved player"/>
    </properties>
   </object>
-  <object id="34" name="encounter 3" type="event" x="192" y="192" width="32" height="48">
+  <object id="34" name="encounter 3" type="event" x="176" y="192" width="48" height="48">
    <properties>
     <property name="act1" value="random_encounter route5,11"/>
     <property name="act2" value="play_map_animation grass,0.1,noloop,player"/>

--- a/mods/tuxemon/maps/spyder_route7.tmx
+++ b/mods/tuxemon/maps/spyder_route7.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="260">
+<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="260">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="north" value="crystal_town"/>
@@ -12,62 +12,43 @@
  <tileset firstgid="8193" source="../gfx/tilesets/core_set pieces.tsx"/>
  <layer id="1" name="Tile Layer 1" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHt0rENACAIBMC3cwb3H9QwALGk8AoqCj7PrSRraM5OXjOVre6+stVevr4D/fXdTLpx218YYIABBhhggAEGGGCAAQYYYIABBhhg4AcDF+koDA4=
+   eAHt0rENADAIA7Cw9Yb+f2jFA6xIlQcmBqLgSlKLc08yzWa2vj1l6518cwf6m/vZ9uO+/zDAAAMMMMAAAwwwwAADDDDAAAMMMMDArwYe6ZsLaQ==
   </data>
  </layer>
  <layer id="2" name="Tile Layer 2" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHVmLtuFEEQRdcrE5NByk8sLznlkzpBRBtABl8zCSJEggi+ZhIi6mCf3aLc07NrxKul6+ruulV1u6ZnVnK7t9m0M3ER/DzOjZf/eLvZPAk8DTwLvHtwDfbdm6MWmArc12b/6xD35gaXJS7zjF2yb2/0qKva56HT2NwP5u5rq7+FLkAv9+Hswdglu6bv5S/os+ZI31R6a4x2Td/70GeO2h9zaJf8I33EXF0eI82lRd+rcOfnmtffQp/36FPwmHOfGFM5+/Xu8a811vQdI27n/BL6vt7g/sPj3D1sC43Ake++2rNueerLfM9oHGfdR8AI5tO2iMmYQxsY5UA/fcpDfe7VeGqMeivfeK15DzZqr+nDX/VNUR84rKcl/yn6WvAyiPsJJ+rjOdbnN3qO1Khn8izZTsHrQY1T6AOeu2fxM67Ctg56fSJ/vpuepVrfx+sKx7/q6+Wofbq8OMZ5nmx7+ujJaHzgnIMeEw/sB3wGPdLq69XfB0l4xnqu2ivWuV9z1DcWXy9+Dj2gN/St6fMc5nDds+Ry0J+l0ehdQA32Ilt9a/qmOB9wuO5Z+9XrVe4vvf2ByDsH9pG8wvzmJB4s5c77p3ybaz36ZX+nmAO0LemzH9gWPJH3e3N4az2v2ljTL3qRz4k20OPn2vKWuDkezl31WbNFDkAusA9HhVysvCVujoVzF308T8cUOQC5wNqQh90HeQQ4p95Z7nNF7/m2yCnQ6lw7h1+MtOGDR9zSwFdRufqn4FbArXtz8MQ+/COs8fRnW/Ppq71lnfvLmm+FfGzNVddy675r/dnq0x58UX8uiOVh7yq0cdcP/O2f1dfit78Cfe719OHPo4XmDM9iL6rVn+0SRx3ZUtu1+qbQILI25rlOntearjPHuT6t++rIlpqu0Ve/FfmOcjenbR/Wqtba2S5x1JFt1lfvpms4S9p9p+D0Rtbl/K76su48p65aq/VO9LSxN21v34lz9e3ivRmBOllvnqM334m17xU9rMO+5rzOK5d1PR9r+T2be0p8XvO9oocZcPLAh8a13OZFT8Vupcf6qZvr5N5yV/P75tr3LseN5lUb63NGzu2ZsyVXXtNjRo4bzeHm+HPmp9SpnBeh72P8b6mnabfym9KLGe3V2plLLVA5nh+uHO3nR7f3iNd/rh3F4nO0Tl/YWxq9O/c79/53fT7zv2V7/dul58v8X8N30Aoevw==
+   eAHVlb2OFDEQhIcVxGSQ8hLLny5DIuRtnCCiAUEGTzMJIocInmYSIrq4/Xbr+vyzc4g/S3Vtu6u7y23vXLkzTWUjnk1Xx9Z4+C/uTdOj3TQ9DjwJfIi18ND21tAmLAnsY93/NuS9O2B363osXGJb9v1BD7qyfRo6ib3akdN+y18OPVcv5waIbdmRvpe/oI+aPX3L4E5G+j6GPnJs7d85+pTz4vYpMzFY6XsVbr9XX38Pfbyjz8HTXO9JA93Yy93TX2r0+ndiX87Ihf0a+r4dcPf+ac6ebAmNAsPfPtpdNzz0OZ8zEqezzhHQA/mw5fCusWtoE3o5pD9/U9BH3hyv/L3ewiceS96jjdojffJnfcvh7ZOXeljlP0dfyf2K9VGb5mfq0z3m++vdI/rQ37JLaKgBjUvoEzh3zcqvcRG2VFDrk/L72+Qs2fJ7vKxw+ou+Wo7cJ8/BedzW9KknvfFJ5wzO8wZJ8QL9EF9DPcLiq9WfgwQ4Yz5X7pXWftY16hMrXy1+DT1CbeAb6eMc5GBds8rFUH9ao6h3ATTQC7f4RvqWOJ/AYF2z9KvWK++vevsTkXcNzJE8g/zkVLzQyu3753ybcz31i/4uMRekraWPfsiW4AHfr83FG/U8a9Na/VIv/JzSJtT4Xhtei+vx4txUHzVL5BCUS5jDkQFXFl6L67Hi3ESf7pOxRA5BuYTRgCc7B7kHcc59s3rPGbX7LZETSCtz7Bp+0NMmn3iKaw35MjIX/xLcDHHz3ho8MIe/hxEPv9ucD1/urdbeX631rYAvm3PlNdy8zxq/W3zYoy/qrwmxPO5dxJvVWz/yd39WX4neZEgfezV98vsoodnBWehFtvjdtjjocKvarNG3hAbg2jT3Oj7PNVk7hzk+LPvocKuarKUvfyv8jeptLrs6qJUttd22OOhw6/ry22QtTks7vylxasN1Mb+pPtftc9VFa7a8iZo27S27629iq7593FsPquN6fS69/iZG3yv1MA/66nmZZ67W+Xxaw69Z76nifa3vlXroEMeHfNI4yk1e6cnYD3qMX3W9jvdWb9V/b6z53Xlcb561ab1leG7O7Fa5fK0ea3hcby6ux2+Zn1Mnc17HxptATdN+8D+lFtPby7Wdq1pC5nB+ceFgvzy4vqd4/FttL1Y+Rqn0RXutUXtzv3Pvf9fHnf8tW+vf3u5X838NPwCXAiT8
   </data>
  </layer>
  <layer id="6" name="Tile Layer 3" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHt0DENADAMA8FAKf0yKawy8JpIOa9eXlfVv3v6G1LBG96X2n0ECBAgQIAAAQIECBAgQIAAAQIECBAgQGCjwAfz1AGy
+   eAHt0LENACAIBEDiJE7hzm7iWBYsQIeJR03y/xfRd2tk9p59HSrJ5/F+lQ1+CBAgQIAAAQIECBAgQIAAAQIECBAgQIDATwIXUQwB6g==
   </data>
  </layer>
  <objectgroup color="#ff0000" id="3" name="Collisions">
   <object id="3" type="collision" x="48" y="608" width="592" height="32"/>
-  <object id="151" type="collision" x="0" y="384" width="80" height="80"/>
-  <object id="152" type="collision" x="432" y="304" width="160" height="16"/>
   <object id="153" type="collision" x="464" y="496" width="80" height="64"/>
-  <object id="154" type="collision" x="0" y="464" width="80" height="112"/>
-  <object id="155" type="collision" x="560" y="496" width="80" height="112"/>
-  <object id="156" type="collision" x="416" y="464" width="48" height="112"/>
+  <object id="155" type="collision" x="560" y="512" width="80" height="96"/>
+  <object id="156" type="collision" x="416" y="480" width="48" height="96"/>
   <object id="157" type="collision" x="176" y="528" width="224" height="48"/>
   <object id="158" type="collision" x="336" y="320" width="32" height="112"/>
   <object id="159" type="collision" x="464" y="560" width="48" height="16"/>
   <object id="160" type="collision" x="272" y="384" width="64" height="48"/>
-  <object id="161" type="collision" x="224" y="240" width="80" height="16"/>
-  <object id="162" type="collision" x="144" y="240" width="64" height="16"/>
-  <object id="163" type="collision" x="112" y="176" width="32" height="80"/>
-  <object id="164" type="collision" x="0" y="320" width="80" height="64"/>
+  <object id="163" type="collision" x="112" y="192" width="32" height="64"/>
+  <object id="164" type="collision" x="0" y="320" width="80" height="256"/>
   <object id="165" type="collision" x="96" y="320" width="112" height="160"/>
   <object id="166" type="collision" x="0" y="0" width="32" height="320"/>
   <object id="167" type="collision" x="32" y="0" width="336" height="32"/>
   <object id="168" type="collision" x="96" y="32" width="64" height="64"/>
   <object id="169" type="collision" x="144" y="112" width="16" height="64"/>
-  <object id="170" type="collision" x="64" y="96" width="96" height="16"/>
-  <object id="171" type="collision" x="160" y="144" width="16" height="16"/>
-  <object id="172" type="collision" x="192" y="144" width="80" height="48"/>
-  <object id="173" type="collision" x="272" y="192" width="32" height="48"/>
-  <object id="174" type="collision" x="336" y="192" width="112" height="48"/>
+  <object id="172" type="collision" x="192" y="160" width="80" height="32"/>
+  <object id="173" type="collision" x="272" y="208" width="32" height="32"/>
+  <object id="174" type="collision" x="336" y="208" width="112" height="32"/>
   <object id="175" type="collision" x="608" y="80" width="32" height="416"/>
-  <object id="176" type="collision" x="336" y="240" width="16" height="80"/>
+  <object id="176" type="collision" x="336" y="256" width="16" height="64"/>
   <object id="177" type="collision" x="576" y="80" width="32" height="80"/>
-  <object id="178" type="collision" x="368" y="160" width="144" height="16"/>
-  <object id="179" type="collision" x="256" y="96" width="48" height="16"/>
   <object id="180" type="collision" x="432" y="0" width="64" height="96"/>
   <object id="181" type="collision" x="368" y="0" width="64" height="64"/>
-  <object id="182" type="collision" x="560" y="80" width="16" height="16"/>
-  <object id="183" type="collision" x="496" y="80" width="48" height="16"/>
-  <object id="184" type="collision" x="448" y="224" width="32" height="16"/>
-  <object id="185" type="collision" x="496" y="224" width="80" height="16"/>
-  <object id="186" type="collision" x="512" y="192" width="48" height="16"/>
-  <object id="187" type="collision" x="576" y="256" width="16" height="16"/>
-  <object id="188" type="collision" x="576" y="192" width="32" height="16"/>
-  <object id="190" type="collision" x="32" y="176" width="48" height="16"/>
-  <object id="191" type="collision" x="96" y="176" width="16" height="16"/>
-  <object id="192" type="collision" x="320" y="96" width="48" height="16"/>
   <object id="193" type="collision" x="464" y="320" width="80" height="176"/>
   <object id="194" type="collision" x="496" y="176" width="16" height="48"/>
   <object id="195" type="collision" x="560" y="240" width="16" height="64"/>
@@ -79,14 +60,8 @@
   <object id="213" type="collision" x="80" y="496" width="16" height="80"/>
   <object id="215" type="collision" x="512" y="128" width="64" height="32"/>
   <object id="216" type="collision" x="528" y="16" width="16" height="16"/>
-  <object id="218" type="collision" x="320" y="192" width="16" height="16"/>
-  <object id="219" type="collision" x="320" y="240" width="16" height="16"/>
-  <object id="220" type="collision" x="48" y="80" width="16" height="16"/>
-  <object id="221" type="collision" x="352" y="304" width="64" height="16"/>
   <object id="222" type="collision" x="160" y="256" width="48" height="64"/>
-  <object id="223" type="collision" x="208" y="416" width="16" height="64"/>
-  <object id="224" type="collision" x="240" y="416" width="16" height="16"/>
-  <object id="225" type="collision" x="256" y="432" width="96" height="16"/>
+  <object id="223" type="collision" x="208" y="432" width="16" height="48"/>
   <object id="226" type="collision" x="240" y="448" width="112" height="16"/>
   <object id="227" type="collision" x="240" y="464" width="160" height="48"/>
   <object id="228" type="collision" x="96" y="496" width="64" height="80"/>

--- a/mods/tuxemon/maps/spyder_routea.tmx
+++ b/mods/tuxemon/maps/spyder_routea.tmx
@@ -17,68 +17,22 @@
  </layer>
  <layer id="2" name="Layer 2" width="20" height="40">
   <data encoding="base64" compression="zlib">
-   eAHdlr1uU0EQhTcoisB2H+h5gaD0cco8Qmz32OIhkCIgZYxokpdIKkTSOX1AICSgAx6EiHPkPTdHk70/Rq5Y6Xj37sx8+zfre3cepKrsWLvqXLHxzBjeLmHewPcY6kH9oAGeWUaoj3L7MNdLy/3fc9gvoNK4uxa7jdAh9LiDnsCnjbcHn2FH7Wfey15KLp/f/8rD0qs1r2O9dbznMEw7aga/tvM9gc+8o9524H2Az2XQcDOlfSj2X3Xg/YTPr6ApWDMo9v+GX+ke+XnApSoPN1Iq6RH6e5DucBWQG+K970dL+Vl39zvu6Q+7q/Im74Wx6saVv+xNPPmy1vje523Zu/I8tqktbvTR/sX+f31ehfd00D7KKrx2Wkrr4uk/1Xml+12a0+fQqRwis473FTGn0BlE/29ZfK8xTgz6ee6UePJdwPcaYm7cZvG9Rp7nSxtPdu1Jqf6CcVTEPsD5l+YXeTcI/Gj6JFCutS98LPE0XgirfVzAwn1hiTytbWm9+/Uz8bOhh/ab7cjztfm6uAd/7Fx4PjwbFu0P25HHPhXPM8Vw/irv8v2Tjf11PK1B61eM88SVrYmnM3Hea6yPe8ec1ply3FeQ/qtL85OvWKzJ95xeYDKe68rzEk++5DBvxUWztsinxGOQ7L6PtTDzr+MpVvvoeaS7wnwabaU0zpqgbuOJG+u5vRPd5jx+Q4+D9H3NGH5/R3t8nsCnqfg3hbebYmj7C3z/x28=
+   eAHdVrtOW0EQvSCEkE0f0vMDIHrskk+IcR8QHxEFJVACogHyD6FCQOckbRIFRUrSBVr4BhDnyHvsw2QvXitUjHTuzt2ZObszO/exMFkNZMH0weSYyqJxuJ6j2YLvNtAAmgGzuKd0MG4m/VUa+5Z/rx9hPwZy6y5Z7AuEtoC5AryEzyi+Zfi0CtFOfG8aVeXw/T1XPvaXcn6KfMmR43uNGq8VYj2dB4bK9+T6Dmy7hdiDn/rFOVw/hc9ZQGuqqtpAnD8v4PsLn8uANXCtA3H+Cn56jnxPrvOc9GzOTFRVDrJrBG22fifNfj30bNIvJ7L/xtp/AIrvifoGuCisr6/bn314lf0xPkWQT+trLo6yl/J9Rt2+AKNEvPSL+SqW+zsC14cCPsX8D9/8rLMM9ZL9vcVeVwvRhZ/EuZnvNXK9GTNfcuXeB+QrkR/BST1Ezrg/uf6EcgAcAvT/lcDvGuPEQb+63tH+5NuD7yeAvXGXwO8a+bxfRvHJrprkxgusIxH3Cs4/l2/k+4rAb4bvIkqj6sLbHJ/WC2G1tz1YWBdK5FNufevw6mfiZ0MP1Zt65PPcPC/W4NbOhefDs6GoPtQjH+ck3meK4f4l++n5k43zdXzKQfkrxvnEK9tjfDoT53uP/Fg79rTOlOu+A3LvavWzfMXFkfze0z1sxntdfZ7LV77kYd+KF2qtyCfHxyDZvY61ZOZfx6dY1dH7SM8K+6kzjfdkQhfjKD7xxnE3fRPjvPPxHzq+k/V/zTj+f0d7vPd3dVyL9/qniHrO1+fuAU8S2vE=
   </data>
  </layer>
  <layer id="3" name="Layer 3" width="20" height="40">
   <data encoding="base64" compression="zlib">
-   eAFjYKAtEAcaL4GGJSmw0h6o1wENO5Jh3kFWiKZ0IJWBhjPJMA+mpR/ImICGJ8IkyaC3A/XsQMM7gfxdZJgF0nIfiB+g4YdA/iMgJgewMzIwcKBhTiCfC4hHAfEh4MDCwOAIxNQCGUCzMik0DxS3IBAKzCthQBwOxBHQfAORGSVHQ2A0BEZDYDQERkNgNARGQ4D0EAAA/ZMW7A==
+   eAFjYKAtEAcaL4GGJSmw0h6o1wENO5Jh3kFWiKZ0IJWBhjPJMA+mpR/ImICGJ8IkyaC3A/XsQMM7gfxdZJgF0nIfiB+g4YdA/iMgJgewMzIwcAAxJzA8uYAYzAbyuYCYEmAINMsIGkeUmDNU9DqwMDA4AjG1QAbQrEwKzQPFLQiEAuMhDIjDgThiBMUJxPej5GgIjIbAaAiMhsBoCIyGALVDAAClCBdk
   </data>
  </layer>
  <layer id="4" name="Above Player" width="20" height="40">
   <data encoding="base64" compression="zlib">
-   eAFjYBgFgz0EspAciMxGEiaJOQmo+iELA8MjIAaxqQE4WRkYuIAYHzBkwieLKmcINMuIgHkmJJiHajp2HrHm3QWG2z0gvg/ED4AYFyDGPHugflYkf3IA2SAxbIAY89KBenWRzDMAskFi2AAu80Dx1AbE7XjCF5s8LvOMgOasA+L1eMwjxX0g88gB+NxHbfMOMTIwHAZiUgA+980CmjV7CJjXCIybaCJxDI54BMXvK6BfX5PoX1LCelTtaAiMhsBoCIyGwMCGAADOxx1J
+   eAFjYBgFgz0EspAciMxGEiaJOQmo+iELA8MjIAaxRwFpIXAXGG73gPg+ED8AYkqAPVA/KyvCBA4gGyRGLkgH6tVFMs8AyAaJjYLREBgNgdEQGA2B0RAYDYHREBgsIQAA76wJKA==
   </data>
  </layer>
  <objectgroup color="#ff0000" id="6" name="Collisions">
-  <object id="2" type="collision" x="128" y="208" width="32" height="80"/>
-  <object id="3" type="collision" x="64" y="208" width="32" height="80"/>
-  <object id="5" type="collision" x="128" y="448" width="32" height="96"/>
-  <object id="6" type="collision" x="160" y="448" width="64" height="32"/>
-  <object id="7" type="collision" x="160" y="512" width="112" height="32"/>
-  <object id="8" type="collision" x="240" y="352" width="32" height="160"/>
-  <object id="9" type="collision" x="48" y="384" width="32" height="64"/>
-  <object id="10" type="collision" x="112" y="368" width="64" height="32"/>
-  <object id="11" type="collision" x="64" y="320" width="192" height="16"/>
-  <object id="12" type="collision" x="240" y="112" width="16" height="208"/>
-  <object id="13" type="collision" x="192" y="272" width="32" height="16"/>
-  <object id="14" type="collision" x="208" y="16" width="96" height="16"/>
-  <object id="16" type="collision" x="288" y="32" width="16" height="592"/>
-  <object id="17" type="collision" x="16" y="160" width="16" height="464"/>
-  <object id="18" type="collision" x="32" y="608" width="80" height="16"/>
-  <object id="19" type="collision" x="224" y="608" width="64" height="16"/>
-  <object id="21" type="collision" x="224" y="624" width="16" height="16"/>
   <object id="24" type="collision" x="64" y="16" width="96" height="80"/>
-  <object id="25" type="collision" x="32" y="272" width="32" height="80"/>
-  <object id="26" type="collision" x="112" y="416" width="80" height="16"/>
-  <object id="27" type="collision" x="32" y="464" width="64" height="16"/>
-  <object id="28" type="collision" x="128" y="576" width="96" height="16"/>
-  <object id="30" type="collision" x="64" y="496" width="32" height="32"/>
-  <object id="31" type="collision" x="80" y="368" width="32" height="32"/>
-  <object id="32" type="collision" x="160" y="160" width="64" height="112"/>
-  <object id="34" type="collision" x="192" y="368" width="32" height="32"/>
-  <object id="35" type="collision" x="96" y="560" width="32" height="32"/>
-  <object id="36" type="collision" x="48" y="528" width="32" height="32"/>
-  <object id="37" type="collision" x="80" y="480" width="16" height="16"/>
-  <object id="38" type="collision" x="96" y="544" width="16" height="16"/>
-  <object id="39" type="collision" x="192" y="400" width="16" height="16"/>
-  <object id="40" type="collision" x="176" y="352" width="16" height="16"/>
-  <object id="41" type="collision" x="224" y="368" width="16" height="16"/>
-  <object id="42" type="collision" x="64" y="368" width="16" height="16"/>
-  <object id="49" type="collision" x="32" y="208" width="32" height="64"/>
-  <object id="50" type="collision" x="32" y="160" width="64" height="48"/>
-  <object id="51" type="collision" x="128" y="160" width="32" height="48"/>
-  <object id="57" type="collision" x="144" y="608" width="80" height="32"/>
-  <object id="58" type="collision" x="96" y="624" width="16" height="16"/>
   <object id="99" type="collision" x="96" y="160" width="32" height="32"/>
-  <object id="100" type="collision" x="96" y="96" width="32" height="48"/>
-  <object id="101" type="collision" x="144" y="96" width="16" height="16"/>
-  <object id="102" type="collision" x="64" y="96" width="16" height="16"/>
-  <object id="103" type="collision" x="160" y="32" width="64" height="16"/>
-  <object id="105" type="collision" x="48" y="0" width="16" height="48"/>
-  <object id="106" type="collision" x="0" y="0" width="16" height="160"/>
-  <object id="107" type="collision" x="16" y="32" width="16" height="16"/>
-  <object id="108" type="collision" x="208" y="48" width="16" height="112"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="5" name="Events">
   <object id="44" name="Teleport to Flower City" type="event" x="112" y="624" width="16" height="16">
@@ -489,9 +443,9 @@
     <property name="cond2" value="is char_facing player,up"/>
    </properties>
   </object>
-  <object id="111" name="Create Guard" type="event" x="32" y="48" width="16" height="16">
+  <object id="111" name="Create Guard" type="event" x="32" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc spyder_routea_little,2,3"/>
+    <property name="act1" value="create_npc spyder_routea_little,2,2"/>
     <property name="cond1" value="not char_exists spyder_routea_little"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_routec.tmx
+++ b/mods/tuxemon/maps/spyder_routec.tmx
@@ -31,12 +31,7 @@
   </data>
  </layer>
  <objectgroup color="#ff0000" id="3" name="Collisions">
-  <object id="177" type="collision" x="112" y="272" width="64" height="64"/>
   <object id="198" type="collision" x="608" y="320" width="32" height="224"/>
-  <object id="238" type="collision" x="144" y="336" width="112" height="32"/>
-  <object id="239" type="collision" x="144" y="368" width="48" height="16"/>
-  <object id="240" type="collision" x="208" y="368" width="48" height="16"/>
-  <object id="241" type="collision" x="112" y="336" width="32" height="16"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="4" name="Events">
   <object id="155" name="Teleport to Candy Town" type="event" x="0" y="128" width="16" height="128">

--- a/mods/tuxemon/maps/spyder_routef.tmx
+++ b/mods/tuxemon/maps/spyder_routef.tmx
@@ -38,8 +38,6 @@
   <object id="283" type="collision" x="608" y="0" width="32" height="288"/>
   <object id="284" type="collision" x="386" y="128" width="160" height="96"/>
   <object id="285" type="collision" x="448" y="0" width="160" height="64"/>
-  <object id="298" type="collision" x="0" y="96" width="16" height="32"/>
-  <object id="299" type="collision" x="0" y="160" width="16" height="32"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="7" name="Events">
   <object id="290" name="Teleport to Route" type="event" x="384" y="0" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_routeg.tmx
+++ b/mods/tuxemon/maps/spyder_routeg.tmx
@@ -37,26 +37,11 @@
   <object id="281" type="collision" x="304" y="384" width="80" height="256"/>
   <object id="282" type="collision" x="512" y="288" width="96" height="32"/>
   <object id="283" type="collision" x="608" y="0" width="32" height="640"/>
-  <object id="284" type="collision" x="512" y="0" width="64" height="64"/>
+  <object id="284" type="collision" x="544" y="0" width="32" height="64"/>
   <object id="285" type="collision" x="336" y="320" width="48" height="16"/>
   <object id="286" type="collision" x="336" y="352" width="48" height="16"/>
   <object id="287" type="collision" x="448" y="576" width="160" height="64"/>
   <object id="288" type="collision" x="384" y="448" width="160" height="64"/>
-  <object id="309" type="collision" x="144" y="160" width="32" height="32"/>
-  <object id="310" type="collision" x="160" y="144" width="32" height="32"/>
-  <object id="311" type="collision" x="176" y="128" width="96" height="32"/>
-  <object id="312" type="collision" x="256" y="112" width="32" height="32"/>
-  <object id="313" type="collision" x="272" y="96" width="32" height="32"/>
-  <object id="319" type="collision" x="352" y="96" width="32" height="48"/>
-  <object id="320" type="collision" x="368" y="80" width="96" height="32"/>
-  <object id="321" type="collision" x="448" y="96" width="32" height="32"/>
-  <object id="322" type="collision" x="464" y="112" width="64" height="32"/>
-  <object id="323" type="collision" x="192" y="208" width="64" height="32"/>
-  <object id="324" type="collision" x="192" y="288" width="64" height="32"/>
-  <object id="325" type="collision" x="240" y="224" width="32" height="80"/>
-  <object id="326" type="collision" x="176" y="432" width="64" height="32"/>
-  <object id="327" type="collision" x="176" y="512" width="64" height="32"/>
-  <object id="328" type="collision" x="224" y="448" width="32" height="80"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="7" name="Events">
   <object id="289" name="Teleport to Route3" type="event" x="0" y="592" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_routeh.tmx
+++ b/mods/tuxemon/maps/spyder_routeh.tmx
@@ -44,11 +44,6 @@
   <object id="288" type="collision" x="512" y="448" width="96" height="96"/>
   <object id="289" type="collision" x="480" y="576" width="96" height="64"/>
   <object id="290" type="collision" x="480" y="0" width="32" height="32"/>
-  <object id="313" type="collision" x="352" y="0" width="16" height="16"/>
-  <object id="314" type="collision" x="432" y="0" width="16" height="16"/>
-  <object id="315" type="collision" x="0" y="112" width="16" height="16"/>
-  <object id="316" type="collision" x="0" y="192" width="16" height="16"/>
-  <object id="317" type="collision" x="16" y="128" width="16" height="64"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="7" name="Events">
   <object id="295" name="Teleport to Route" type="event" x="368" y="624" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_routei.tmx
+++ b/mods/tuxemon/maps/spyder_routei.tmx
@@ -54,14 +54,8 @@
   <object id="295" type="collision" x="0" y="352" width="256" height="16"/>
   <object id="296" type="collision" x="240" y="288" width="16" height="64"/>
   <object id="297" type="collision" x="608" y="368" width="32" height="272"/>
-  <object id="298" type="collision" x="320" y="416" width="160" height="32"/>
   <object id="299" type="collision" x="448" y="560" width="128" height="80"/>
   <object id="300" type="collision" x="272" y="288" width="80" height="80"/>
-  <object id="315" type="collision" x="0" y="368" width="16" height="16"/>
-  <object id="316" type="collision" x="0" y="448" width="16" height="16"/>
-  <object id="317" type="collision" x="352" y="624" width="16" height="16"/>
-  <object id="318" type="collision" x="432" y="624" width="16" height="16"/>
-  <object id="319" type="collision" x="16" y="384" width="16" height="64"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="7" name="Events">
   <object id="302" name="Teleport to Route" type="event" x="368" y="624" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_scoop1.tmx
+++ b/mods/tuxemon/maps/spyder_scoop1.tmx
@@ -7,9 +7,7 @@
   <property name="slug" value="scoop1"/>
   <property name="types" value="dungeon"/>
  </properties>
- <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
-  <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>
- </tileset>
+ <tileset firstgid="1" source="../gfx/tilesets/Superpowers_Tilesheet.tsx"/>
  <tileset firstgid="1601" source="../gfx/tilesets/core_indoor_floors.tsx"/>
  <tileset firstgid="5465" source="../gfx/tilesets/core_set pieces.tsx"/>
  <layer id="1" name="Tile Layer 1" width="21" height="15">
@@ -42,9 +40,6 @@
   <object id="7" type="collision" x="128" y="64" width="64" height="112"/>
   <object id="8" type="collision" x="224" y="64" width="48" height="48"/>
   <object id="9" type="collision" x="224" y="128" width="96" height="96"/>
-  <object id="15" type="collision-line" x="336" y="48">
-   <polyline points="0,0 0,192"/>
-  </object>
   <object id="58" type="collision" x="48" y="176" width="16" height="16"/>
   <object id="59" type="collision" x="112" y="176" width="16" height="16"/>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_scoop3.tmx
+++ b/mods/tuxemon/maps/spyder_scoop3.tmx
@@ -7,37 +7,33 @@
   <property name="slug" value="scoop3"/>
   <property name="types" value="dungeon"/>
  </properties>
- <tileset firstgid="1" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
-  <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>
- </tileset>
- <tileset firstgid="1601" source="../gfx/tilesets/core_city_and_country.tsx"/>
- <tileset firstgid="3041" source="../gfx/tilesets/core_indoor_floors.tsx"/>
- <tileset firstgid="6905" source="../gfx/tilesets/core_set pieces.tsx"/>
+ <tileset firstgid="1" source="../gfx/tilesets/core_city_and_country.tsx"/>
+ <tileset firstgid="1441" source="../gfx/tilesets/core_indoor_floors.tsx"/>
+ <tileset firstgid="5305" source="../gfx/tilesets/core_set pieces.tsx"/>
  <layer id="1" name="Tile Layer 1" width="12" height="12">
   <data encoding="base64" compression="zlib">
-   eAG7KsvAcJUE/AWolhQsLMfAQAqW4mFgGAlYTYA0f9JaPblhDgCz4Sqp
+   eAGbKs7AMJUEvAWolhR8GaieFHyLlYFhJOBnnKT5k9bqyQ1zAB+UetE=
   </data>
  </layer>
  <layer id="2" name="Tile Layer 4" width="12" height="12">
   <data encoding="base64" compression="zlib">
-   eAFjYGBgaGYDEkg0hAchscldhqqH0ddlGRhuAPF5IIaJwWhks0BskJpvQPwdiGEAJEYKqOFkYKgF4jogBoGb0gwMt4AYF1gCVLcUiJdB1f8Aqv2Jph6XGRrM2E3FZgZ2lfhFWWUYGIjBIFNA6ogCxKqDGYamfiYaH6YMGw0An2QanA==
+   eAGVjjsOgzAQREfKGSCXCTScIn3gOiko+BwEko6GezErPBQrkM1IzyOvn1YGgIpY1PttPzVT27QNgrp7Aj35Es3UQT3KnInMRLHZnbweQEFKYhkyYCRX+dCrSRP8H92/82M7/O6zHd5Jua/8Rwq2y7yULImednn/nesl3hsCHRui
   </data>
  </layer>
  <layer id="3" name="Tile Layer 2" width="12" height="12">
   <data encoding="base64" compression="zlib">
-   eAFjYBgFgz0EHkqT5kJS1ZNmOqpqAAX5Afk=
+   eAFjYBgFgz0EFoqS5kJS1ZNmOqpqAL3GAW0=
   </data>
  </layer>
  <layer id="4" name="Tile Layer 4" width="12" height="12">
   <data encoding="base64" compression="zlib">
-   eAFjYBgF1AyBZ9IMDMRgkJ0gdUMdAAB7DgsM
+   eAFjYBgF1AyBZaIMDMRgkJ0gdUMdAADmgwgK
   </data>
  </layer>
  <objectgroup color="#ff0000" id="6" name="Collisions">
   <object id="4" type="collision" x="0" y="0" width="80" height="48"/>
   <object id="5" type="collision" x="80" y="0" width="112" height="32"/>
   <object id="6" type="collision" x="112" y="32" width="80" height="16"/>
-  <object id="7" type="collision" x="144" y="48" width="48" height="16"/>
   <object id="8" type="collision" x="16" y="64" width="32" height="32"/>
   <object id="9" type="collision" x="96" y="80" width="32" height="32"/>
   <object id="10" type="collision" x="0" y="128" width="160" height="16"/>

--- a/mods/tuxemon/maps/spyder_timber_town.tmx
+++ b/mods/tuxemon/maps/spyder_timber_town.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="386">
+<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="388">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="north" value="route5"/>
@@ -9,40 +9,36 @@
   <property name="types" value="town"/>
  </properties>
  <tileset firstgid="1" source="../gfx/tilesets/core_city_and_country.tsx"/>
- <tileset firstgid="1441" name="Superpowers_Tilesheet" tilewidth="16" tileheight="16" tilecount="1600" columns="40">
-  <image source="../gfx/tilesets/Superpowers_Tilesheet.png" width="640" height="640"/>
- </tileset>
- <tileset firstgid="3041" source="../gfx/tilesets/core_outdoor.tsx"/>
- <tileset firstgid="5816" source="../gfx/tilesets/core_set pieces.tsx"/>
- <tileset firstgid="7366" source="../gfx/tilesets/core_buildings.tsx"/>
- <tileset firstgid="9716" source="../gfx/tilesets/core_outdoor_nature.tsx"/>
+ <tileset firstgid="1441" source="../gfx/tilesets/core_outdoor.tsx"/>
+ <tileset firstgid="4216" source="../gfx/tilesets/core_set pieces.tsx"/>
+ <tileset firstgid="5766" source="../gfx/tilesets/core_buildings.tsx"/>
+ <tileset firstgid="8116" source="../gfx/tilesets/core_outdoor_nature.tsx"/>
  <layer id="1" name="Tile Layer 1" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHtV8tNw0AQdQGI3xHx6wQhGsiF0AACagAaoArgTB3QABJFwDmX5MKM5EdeRvu1N7BGPozW3rXHb+a9t5tMNppm0sa5jFOJC5rDWg3jreC6k7gf8f1wlsPLf+rfw+5Stzk96PrspXxvKP37FH+ojxG1+Bn9Uw9z1OLnR8H1RPHW4qwFn9Uu+jni67YX+Pq3rnNwf7NpDkwwp/gufPvV6s/6GfOleT8VbB/bq8H40C/2bui6L76XnVVeY/jgX/j2lbzMvsb1s6xzfX2vY/iQH32M9Wdm6sf7OSNr7nhrye1cuL6WcOVKxed6N3fO1TPV4JkHm577NePT+oHP+nYd5zD3D5wqrzee/jE+692YHnO51ecZn49Tmxc+hk8xlvZrF3zsJ7uXu+4PAzzYul33uf3j59VHmtPu6XxvObFnEM4iO0LL/D2bK1ZPF3zwltWuvYeW++LjXrmubc0+7ULDGKHl38bn4iQ0l4vvSvSu+08oFrKOXh7JmeTyTeocn2mWi1BdoTWuGThTR85r3xk6vvfE/9wpGgjpg9dYK6X6pxydRGrZi6yDZ9ZKSXzI33cc8bl/46b2tUT/SvyO9+Etgc+Xu8T8iO/v9VeCR1+OofP7DXrip9o=
+   eAHtV0suRUEQbZEgGLwJNiBYAzZgFRhbBxuQWARjE3YifjuhKrmH8yr9v32f++QOKtW/W326Tp3u92Zrzs062xG/K7ZHY5gbgz8WXCdipxO+H85KePlP+Tvb/q3bkhzUrt2X/ZYlf/eiD9UxbCx6Rv5Uw2xj0fO54Logu+lwjgWfrV3kc8JXdxeE8jfUO/i67tybMeYU+0K3D139WT1jvDXvKxvO3W3OG+NDvli7sXZffFdb87ym8EG/0O01aZl1jfalzPP5+rZT+BAfeUzl59GcH9+XeK65T+L3SdqHYr5Yufh835aO+XKmNbgawKbv/pjx6fmBz+p2iHeY8wdOldejQP4Yn9Vuqh5LudX1jC/EqY0LHUOn8K31WoOP9WTvcl//Xe57e76Sfmn+eL3qSPeydzr3LSf2DcJbZD1qmfezsXzn5PU1+KAtW7u2j1rm/Wrwca58bRszVLuoYXjU8qLx+TiJjZXiO5B7R++fmD3LPHL5IW2fbnLH+E2zXMTOFZvjMwNnrue49ptlx3eb+Z87pwZi9cFzXCut8qccfSV+W70k5sEz10pLfIjf10/4Fvv++vhq8TveF1fHJn7/nt8QNy3GJ36H5fcbVJsbIg==
   </data>
  </layer>
  <layer id="2" name="Tile Layer 2" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHtl19OwkAQxicYAd/kHRIB45twBW/AH0m8gXoKKRxAjyO+gnAN5AgovvNN0k0mUGppm3WMM8kvQ2e33a9fl2SWaD9qV/u1NJXrClELuJzmGb9xzw1RsLtuVG13jq/rxwh9UTVfev7SOpMYsXFjMbflOuQ0cJbwIm4s1wVTPoy1FE+JSkCTLvc6rKkFbW2l+lYFCj5ClshOt5asXd/ZCQXlkBKyFt9MhzlwjAPTOtEMvIM5WABNsYaeT/AFNuAbaIqLBlEdNEATXAIfUUZfmyQ60NMFPdAHt8BHcM+dJJ6gZwgCMAJjYGEOmAPmwH9w4A2990TwqqwX5z68KtB2VmB9vE9YI2eN+h6g7T70UKM++X3vcJaR+zHr76z72e0/6eELvHwO/TxUl3P4/eQ8vnbjWb+HPAe682Ce2c6W/K+2SOLA4DzJLJvzkwM+fdwCYoaAcA==
+   eAHtmEtuwjAQhketWtpuoI9dkVAvUG7Ao8tegBsUjhH1wRLO0gcCbsAlENB2W87AP1IsjSCJQmKZgXqkT0PGjv3njyPZEG3GtLJZy1L5uyBaApOzjLGLexpEwfq8UbX1Pq6uOxH6omqu9OzTPKMEsUltCbdZbTIaOEt4EtNmdcKMg7GW0xOiAtCkyzwOa7qHtqpSfYsjCuYhM2SjW0vWru/8mIKzkAKyFt+8Du/ANg483xK9gFfwBrpAU7xDzwf4BF9gADTFHHoW4Bv8gF/gIibY16aJYpmoBC7BFbgGLoL33GmiBj110ABN8AB8eAe8A96B/+DAGHvvkWCobC/O+/CyQNtZgfXxOmGNnDXqa0PbU+ihRn3y/bZwlpHrMe/vvOvZrD/pYR9e9kI/4+qyDz+f7MfXpj3v+5DnQHMetJldnC0fI/7P428pLu627B83jq/bdeAm5Z7b7qyHN5pLH1fkGISD
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHVl0mMVFUUhi/SDd2QKBiQqbtaw7SCAAJhBwgy6UoBXZEAkoYVARk0LCg3sGQM0UQUhDC4wDFRd5CgsEMX0M0CqpEdowumJd9J1R9ubu4bu5rEk3x13jvn3Hv/Ou/We6/aRjrXDm0N7zxT7Cvnql+CzkO/coQ3KOVwHHOMzWAMeX+KaeiaDvLK7aRQsQuMOQ86D73pq7U715fCbXILmWMB7Bpc93YsFJtPTN/fYUm9s1wRGz7MVW/McO5mhBox8m4Ta2+EE+gz76NYN3F9f1s/1rsiulRr+jpnOleJ0EXM9B1g7f0Z7CNvc6qH8lpH/lGnc4/hCTyFZ5BmefT9wdrzW1z1d3wMy/3W0KceyodrT6w4NwkmwxSYCmmWV193Q18fvgY34UYjZjnT5/csaf99gJ4PYSWsgtWQZnn1qW9trS9+p60cK276/J69zP13i7X7Gszw9E3jWPEaeeuDeihvsf5Ynv7Z/HtfcdU98DGaPoLVsAoUlwb1UF7xLH+H38lduAf34QGY5dXXi7YesDEdeMOO/bjfM9t/Zu+wziJYDO/CEojZOPbheJgAHdAJZmX01UfWP319fs9s/5ltQc9W+BS2wXYIbSnPlGXoWQ4r4D14H8yaqa8+Y/1TvTyGnuPwHZyAk1DEBkqf38siesLavPp+YL+da+w5f46keNL9zx+b5zivvqS5dB3DfLPuf9c6nOspQS9jzMLrKL16t6tXlf9sZb8OKcHQhH0uvXq3K6+sPrLZ+tS/Zu2/2fRhTgnmZvSvWftvMOu0lKA9QZ/6Jx+7vs94Vj+FJ41ndqxGsVms83YJ5iXo0/6T1zq+f3OQq3ZBBfx47Hgt66yD9fAJbMh53k1daOpZ6MO6Ivr2s84BOAiH4HDO8yPUhaaehT6sK6IvHJt1/jnP8jTL6p2NXcZ1XQpLclzftLXK5LJ6V2bOrDGf8f9iJ+yA7bANYmPC3uk8VtvM2DH0fAvfwFH4GmLzh73Teay2mbHL6LkEf8GfcBGS5lfP5JPqLL57EDdA+AL6Y/+h5yE8gPtwD2Lz2W9HPZOP1Sl2Gl1n4Gw/9Y3lf9AYeANGwyjQGkk+z/vLFXT9Df/0U1+Shlhc1/UCl+58judXbI6BjOm6SudArlV0bmkyL51F5xjIemkyX/T979eKq/4CP8NP8COsYH98jz8LZ+A0nILN452L1b+VYz+ph0Xf/26z7r9wC/qgBtbL6/he6IFrcBUsnlRvuTRTD6UzrdbPvd7lqiNhBLwGr4Ll2/BDYQi0QgtYPKneckkmTf+3/efr9vdlGPe/d5hLOtd9Nsz7c9lxmPf3n655lvfnzKpVXvdZncuvmfJitgrHiss/B5PWjOg=
+   eAHVmEtsVVUUhg+UykMmSl8mhodoSEwIIhjiqDJBh75AhviIBUYIrZow4DLBITCA3hKgKAPfOBFbZxD6uJ3YwkRA20IUnAgSRWTIt3LPn+7s7HPPo/eSuJLvrnPW2nuv/66z7zmnrSyKojGoxD5yTLG+KCqVQee+b2FuFnuCNTpSaCfvrnWLtW+DvHIbHpuJnWfOOdAY35u+PQujqLsGPeQ2ssZLsLep6u1YKNZJTN8/wpJ6Z7k8Vqb+iWej6GSAfmLHyO+g9nY4jT7zLop1Edf3t/qh3uXRpbGmbxIdUwGmY32HqX0ohYPkbU31UF515L9nI5yFH2AABqGWZdH3I7U750WlQXwIyw3E+tRDeb/2b+j5HW7ATfgDallWfV2xvmv4aZiCyThmuQH0uT1L2n+P80NbAi3QCm1Qy7LqG4x7t6B55nfazLHips/t2cPcf9epfS3mOUffao4VnyZvfVAP5S02G8vSP1v/k7lR6QBsRdNbsAU2g+LSoB7KK57mv2Iffg3fwLdwBsyy6ruMtp/B5jyJN+zYjbs9s/1nNpc6TTAPmuERCNkV4lfhF/gVJsGsiL7qzOqnq8/tme0/s7XUeR7WwXp4AXybzzNlAb+ThbAIHoXFYFZPfdUVq5/q5Tb0vA3vwLvwHuSxRulze5lHjz82q77v2G9n4j3nrpEUT7r/uXOzHGfVl7SWrqOfr9f972hbFPUWoMwcM/86Sq/e7aqjin8OU2ekAKOxPr+y9Ordzs/nPa+3PvWvXvvvLn34twD3UvpXr/13gTpDBRhL0Kf+yYeu532e1f/BvfiZHRqj2N/U+acA9xP0af/Jq47rl8+JSstgKbjx0PEK7udPwUp4Gp7JeL6Kcb6pZ773x+XR9yp1XoPX4Q14M+P5Fsb5pp753h+XR58/N+38RZ7ltSytdzb3Fa7ry7Apw/WtVatILq13RdZMm/Mxf198BB9CD3RDaI7fO52HxtYzdgo9/XASTsBxCK3v907nobH1jFXQMwojMAxDkLS+eiafNM7i++ZwA4T9MBu7g56/4Dbcgj8htJ79dtQz+dA4xT5H1xfw5Sz1dfB3UDu0QSu0gGok+SzvL+PomoCLs9SXpCEU13U9z6U7l+H5FVqjkTFdV+lsZK28a0uTeenMu0Yjx0uT+bzvf90dUWkP7IYPYBeY1p34HbAduuB9WNPC/yzxofFp3089zPv+d5p6n8GncAr6wWr14cvQC0fhCFg8abzlapl6KJ21xrq5S9S9CBMwDj+B5Sv4URiBYRgCiyeNt1ySSdP/bf+5ut196cfd7+3nks51n/Xz7lp27Ofd/adrnubdNdPGKq/7rM7lly6fWW1q2cz9RPkHYyCfEQ==
   </data>
  </layer>
  <layer id="7" name="Tile Layer 5" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHt1TEKwCAMBVAv0nN2KfQ2XQqesXuWECgY5LkFg/m+QcewCBAgQIDA/gL30fuOs3m+3nrSESBAoLfAGd74WK9O/4R8sV6dz3wCBAgQIEDgf4Er/P/ZhGp/dl62/xbzVfuz+fb3EfgAq6EG2A==
+   eAHt1TEKwCAMBVBv0aN0KfQ2XQref+yeJQQKBnluwWC+b9AxLAIECBAgsL/AffS+42yer7eedAQIEOgtcIY3Ptar0z8hX6xX5zOfAAECBAgQ+F/gCv9/NqHan52X7b/FfNX+bL79fQQ+9CYEHA==
   </data>
  </layer>
  <layer id="4" name="Tile Layer 4" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHt0zsKwkAARdG3B3UEQUFX5G7ip3EP8bMYjVYm8bMRdRPe0iLEIiBDfA9OM00mF0by/rHAeSjlKFDiAs8FXKC+wJ53ckCGI074xTp8p4seAvr43DVIN9wR4x7c64lXpPeLsZnv1LxAOpbW2GCLHTwXcAEXcAEXcAEXcAEXcIF2FEhG0gxzLLDERFpVnU8HUtV5O0r4L1zABb4VeANzoxzH
+   eAHt0zkOglAYReG7BAojJnZsQtBlOLAYcWic2Yi6HES34yktiBYm5gXvTb7mVT8nQfL+scAmlrbYYY8DPBdwgfcF5vwnBRZYYoVfrOpKN9S444HXHSPphBIh7sxdF1wDvS/EZr7p+wLjvjTBFDPk8FzABVzABVzABVzABVzABdpRYNCTUmQYYoREWje9Rx2p6b0dJfwVLuACnwo8AfooFkY=
   </data>
  </layer>
  <objectgroup color="#ff0000" id="6" name="Collisions">
-  <object id="245" type="collision" x="288" y="16" width="144" height="224"/>
   <object id="246" type="collision" x="96" y="0" width="176" height="32"/>
   <object id="248" type="collision" x="0" y="0" width="64" height="32"/>
   <object id="249" type="collision" x="0" y="32" width="48" height="32"/>
@@ -70,11 +66,9 @@
   <object id="277" type="collision" x="0" y="544" width="48" height="32"/>
   <object id="278" type="collision" x="0" y="576" width="32" height="32"/>
   <object id="280" type="collision" x="256" y="608" width="256" height="32"/>
-  <object id="282" type="collision" x="272" y="544" width="16" height="16"/>
   <object id="283" type="collision" x="192" y="544" width="80" height="48"/>
   <object id="284" type="collision" x="288" y="544" width="80" height="32"/>
   <object id="285" type="collision" x="384" y="544" width="80" height="48"/>
-  <object id="286" type="collision" x="464" y="544" width="16" height="16"/>
   <object id="287" type="collision" x="368" y="544" width="16" height="16"/>
   <object id="288" type="collision" x="144" y="448" width="48" height="32"/>
   <object id="293" type="collision" x="576" y="608" width="64" height="32"/>
@@ -89,14 +83,10 @@
   <object id="303" type="collision" x="608" y="368" width="32" height="32"/>
   <object id="304" type="collision" x="592" y="336" width="48" height="32"/>
   <object id="305" type="collision" x="608" y="240" width="32" height="96"/>
-  <object id="310" type="collision" x="448" y="128" width="32" height="96"/>
-  <object id="311" type="collision" x="544" y="128" width="32" height="128"/>
+  <object id="311" type="collision" x="544" y="224" width="32" height="32"/>
   <object id="312" type="collision" x="592" y="144" width="32" height="32"/>
   <object id="313" type="collision" x="608" y="112" width="32" height="32"/>
   <object id="315" type="collision" x="592" y="80" width="32" height="32"/>
-  <object id="316" type="collision" x="608" y="48" width="32" height="32"/>
-  <object id="317" type="collision" x="592" y="16" width="32" height="32"/>
-  <object id="318" type="collision" x="368" y="0" width="64" height="16"/>
   <object id="319" type="collision" x="432" y="48" width="64" height="80"/>
   <object id="320" type="collision" x="496" y="48" width="96" height="48"/>
   <object id="321" type="collision" x="528" y="96" width="64" height="32"/>

--- a/mods/tuxemon/maps/spyder_tunnel.tmx
+++ b/mods/tuxemon/maps/spyder_tunnel.tmx
@@ -23,32 +23,10 @@
  </layer>
  <layer id="3" name="Obstacles 2" width="20" height="40">
   <data encoding="base64" compression="zlib">
-   eAHtlmsOwiAQhNFE/3gS20uoBzDeRb20XkIm6abDCikLmMYEkoallK+zUx517v/KdRNqvql22PvduhzCezGelcnEGI/7c+Kjz2mYrpEG7Hz8NOaL4VqTIEvzXOJtlcfyvlR99zntI52l+oAC8zFx4RviEu+0LHBbcDQ3p/0acp6anzllfIe3kTnTe5RywDr/U5x+37lgL/Rrr7bw3lWzv4iOGO+cse5kvK5532qhT/jQiaWOc2Vs7CO4JUz2SZ8BpUzJFzV/G7Stfup1XMuDBi6/4tWcd/x/JPqsvnGOHMvcXuv8ZC09Xt+BDzrLFog=
+   eAHtlWEOwiAMhdFE/3gSt0voDmC8i3ppvYTU7IVHZZEChj9bslAG/WjfCjjX99ke7OtfNrHPVfXj0e/epNZM8axMXiXF4/Ec++hzGuZ3JIedtx/GfMVdxwRkaZ6/eNb/evM57REUtaXxCUKY95kruoldoh2F8zGF24KjuTn955AzK8w5qVoPI8F6GZnBc7WWFLDW/xJn/e5cdBb6vVf78NlVc74gjhTvnLHv4K9bPrdaxIdalDhlq8u9MjbWUbglTNZJ3wGlTNaT/418t+oJ7cCs5YGD9l+8mvtuotpFfFbdkJ9uUdu97k8dz9rvq8AbErAWog==
   </data>
  </layer>
  <objectgroup color="#ff0000" id="5" name="Collisions">
-  <object id="263" type="collision" x="208" y="32" width="16" height="16"/>
-  <object id="264" type="collision" x="176" y="32" width="16" height="16"/>
-  <object id="265" type="collision" x="160" y="32" width="16" height="112"/>
-  <object id="266" type="collision" x="144" y="144" width="16" height="48"/>
-  <object id="267" type="collision" x="128" y="192" width="16" height="32"/>
-  <object id="268" type="collision" x="112" y="224" width="16" height="32"/>
-  <object id="269" type="collision" x="96" y="224" width="16" height="16"/>
-  <object id="270" type="collision" x="80" y="224" width="16" height="64"/>
-  <object id="271" type="collision" x="80" y="288" width="80" height="16"/>
-  <object id="272" type="collision" x="144" y="304" width="16" height="80"/>
-  <object id="273" type="collision" x="160" y="368" width="16" height="16"/>
-  <object id="274" type="collision" x="160" y="304" width="16" height="16"/>
-  <object id="275" type="collision" x="176" y="384" width="16" height="16"/>
-  <object id="280" type="collision" x="192" y="400" width="16" height="80"/>
-  <object id="281" type="collision" x="208" y="480" width="32" height="64"/>
-  <object id="282" type="collision" x="112" y="544" width="96" height="32"/>
-  <object id="283" type="collision" x="112" y="464" width="16" height="80"/>
-  <object id="284" type="collision" x="96" y="416" width="16" height="64"/>
-  <object id="285" type="collision" x="64" y="400" width="48" height="16"/>
-  <object id="286" type="collision" x="64" y="416" width="16" height="80"/>
-  <object id="287" type="collision" x="80" y="496" width="16" height="80"/>
-  <object id="288" type="collision" x="64" y="576" width="16" height="16"/>
   <object id="291" type="collision" x="64" y="608" width="256" height="32"/>
   <object id="292" type="collision" x="288" y="496" width="32" height="32"/>
   <object id="321" type="collision" x="256" y="0" width="64" height="32"/>
@@ -56,7 +34,6 @@
   <object id="323" type="collision" x="288" y="80" width="32" height="368"/>
   <object id="324" type="collision" x="176" y="112" width="64" height="64"/>
   <object id="325" type="collision" x="256" y="224" width="32" height="32"/>
-  <object id="328" type="collision" x="160" y="0" width="64" height="32"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="4" name="Events">
   <object id="197" name="Teleport to Below" type="event" x="192" y="32" width="16" height="16">


### PR DESCRIPTION
follows #2238

PR purges pointless collision zones, fixes some small issues and adds some enter_from / exit_from to the core cities and country (mostly rocks, hedges, the castle, status, etc. the results are really good, considering the quantity of collision zones removed in the spyder routea map.

some examples, in this case the player can move right/left/up but not down; if the player is in front of the bench, then it's possible to move right/left/down, but not up (the same principle is applied to the boxes, etc.)
![Screenshot_2024-02-23_11-19-09](https://github.com/Tuxemon/Tuxemon/assets/64643719/9e60bdff-fdd5-401b-80e2-bfa209ddbce8)
