### PR TITLE
fix crash max moves (Xero)

### DIFF
--- a/mods/tuxemon/maps/xero.yaml
+++ b/mods/tuxemon/maps/xero.yaml
@@ -9,7 +9,7 @@ events:
   Check Max Moves:
     actions:
     - translated_dialog new_tech_delete
-    - get_monster_tech chosen_tech,check_moves
+    - get_monster_tech chosen_tech
     - remove_tech chosen_tech
     conditions:
     - is check_max_tech

--- a/tuxemon/event/actions/remove_tech.py
+++ b/tuxemon/event/actions/remove_tech.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 from typing import final
 
 from tuxemon.event.eventaction import EventAction
-from tuxemon.states.world.worldstate import WorldState
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +16,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class RemoveTechAction(EventAction):
     """
-    Remove a specific technique from a specific monster.
+    Remove a specific technique from a specific monster in the party.
 
     Script usage:
         .. code-block::
@@ -35,18 +34,14 @@ class RemoveTechAction(EventAction):
     tech_id: str
 
     def start(self) -> None:
-        world = self.session.client.get_state_by_name(WorldState)
-        monsters = world.get_all_monsters()
         player = self.session.player
         if self.tech_id not in player.game_variables:
             logger.error(f"Game variable {self.tech_id} not found")
             return
         tech_id = uuid.UUID(player.game_variables[self.tech_id])
 
-        for monster in monsters:
+        for monster in player.monsters:
             technique = monster.find_tech_by_id(tech_id)
-            if technique is None:
-                logger.error(f"Technique isn't among {monster.name}'s moves")
-                return
-            monster.moves.remove(technique)
-            logger.info(f"{technique.name} removed from {monster.name}")
+            if technique:
+                monster.moves.remove(technique)
+                logger.info(f"{technique.name} removed from {monster.name}")


### PR DESCRIPTION
fix #2284 

changed the source of the monsters (now **player.monsters**) because the monster is inside the party;
removes the logger.error because it gets wild if the player has more than 1 monster in the party, eg the player has 6 monsters and the move is one of the monster nr6, in this case in the terminal it would appear:
```
(f"Technique isn't among {monster1.name}'s moves")
(f"Technique isn't among {monster2.name}'s moves")
(f"Technique isn't among {monster3.name}'s moves")
(f"Technique isn't among {monster4.name}'s moves")
(f"Technique isn't among {monster5.name}'s moves")
```