### PR TITLE
skinsprite (class enum)

### DIFF
--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -69,6 +69,14 @@ class GenderType(str, Enum):
     female = "female"
 
 
+class SkinSprite(str, Enum):
+    light = "light"
+    tanned = "tanned"
+    dark = "dark"
+    albino = "albino"
+    orc = "orc"
+
+
 class TasteWarm(str, Enum):
     tasteless = "tasteless"
     peppy = "peppy"


### PR DESCRIPTION
PR adds **skinsprite** inside the **db.py**. It'll be used to define each sprite, because the goal is to split the gender choice and the "race" (aka sprite skin color) in two separate choices. This will not be handled anymore by game variables.

Terms from, but I don't care about the names.
![skin](https://github.com/Tuxemon/Tuxemon/assets/64643719/267b7cee-b0eb-4d6b-8d53-603b1336a276)
