### PR TITLE
update unlock_controls (event action)

### DIFF
--- a/tuxemon/event/actions/lock_controls.py
+++ b/tuxemon/event/actions/lock_controls.py
@@ -11,9 +11,7 @@ from tuxemon.states.sink import SinkState
 
 @final
 @dataclass
-class LockControlsAction(
-    EventAction,
-):
+class LockControlsAction(EventAction):
     """
     Lock player controls
 

--- a/tuxemon/event/actions/unlock_controls.py
+++ b/tuxemon/event/actions/unlock_controls.py
@@ -6,14 +6,11 @@ from dataclasses import dataclass
 from typing import final
 
 from tuxemon.event.eventaction import EventAction
-from tuxemon.states.sink import SinkState
 
 
 @final
 @dataclass
-class UnlockControlsAction(
-    EventAction,
-):
+class UnlockControlsAction(EventAction):
     """
     Unlock player controls
 
@@ -27,7 +24,11 @@ class UnlockControlsAction(
     name = "unlock_controls"
 
     def start(self) -> None:
-        sink_state = self.session.client.get_state_by_name(SinkState)
-
-        if sink_state:
-            self.session.client.remove_state(sink_state)
+        current_state = self.session.client.current_state
+        if current_state is None:
+            # obligatory "should not happen"
+            raise RuntimeError
+        if current_state.name == "SinkState":
+            self.session.client.pop_state()
+        else:
+            raise ValueError("It has never been locked or already unlocked!")


### PR DESCRIPTION
PR makes clear that you cannot remove a state that doesn't exist (or that it has been already removed).

how it works lock/unlock, here we go:

```
(states: backgroundstate, worldstate) <--- by default

event: lock_controls -> (states: backgroundstate, worldstate, sinkstate)
event: translated_dialog -> (states: backgroundstate, worldstate, sinkstate, dialogstate)
event: start_battle -> (states: backgroundstate, worldstate, sinkstate, combatstate)
-> as soon as the combat is ended, the state combatstate is removed
event: translated_dialog -> (states: backgroundstate, worldstate, sinkstate, dialogstate)
-> as soon as the dialogue gets closed, the state dialogstate is removed
event: unlock_controls -> (states: backgroundstate, worldstate)

if you use again unlock_controls --> crash
```
I need to admit that **sinkstate** isn't the best name for a locking state