### PR TITLE
Add upstairs to Xeno Taba House

### DIFF
--- a/mods/tuxemon/db/encounter/default_encounter.json
+++ b/mods/tuxemon/db/encounter/default_encounter.json
@@ -6,8 +6,8 @@
        "variable": "daytime:true",
        "exp_req_mod": 1,
        "level_range": [
-         2,
-         4
+         5,
+         10
        ],
        "monster": "eyenemy"
      },
@@ -16,8 +16,8 @@
        "variable": "daytime:true",
        "exp_req_mod": 1,
        "level_range": [
-         2,
-         4
+         5,
+         9
        ],
        "monster": "dandicub"
      },
@@ -26,8 +26,8 @@
        "variable": "daytime:true",
        "exp_req_mod": 1,
        "level_range": [
-         2,
-         4
+         5,
+         9
        ],
        "monster": "cardiling"
      },
@@ -36,8 +36,8 @@
        "variable": "daytime:true",
        "exp_req_mod": 1,
        "level_range": [
-         2,
-         4
+         5,
+         9
        ],
        "monster": "budaye"
      },
@@ -46,8 +46,8 @@
        "variable": "daytime:true",
        "exp_req_mod": 1,
        "level_range": [
-         2,
-         4
+         4,
+         9
        ],
        "monster": "cataspike"
      },
@@ -57,7 +57,7 @@
        "exp_req_mod": 1,
        "level_range": [
          3,
-         6
+         8
        ],
        "monster": "elofly"
      },
@@ -66,8 +66,8 @@
        "variable": "daytime:false",
        "exp_req_mod": 1,
        "level_range": [
-         3,
-         6
+         5,
+         9
        ],
        "monster": "aardorn"
      },
@@ -76,8 +76,8 @@
        "variable": "daytime:false",
        "exp_req_mod": 1,
        "level_range": [
-         3,
-         6
+         5,
+         8
        ],
        "monster": "nut"
      },
@@ -86,8 +86,8 @@
        "variable": "daytime:false",
        "exp_req_mod": 1,
        "level_range": [
-         3,
-         6
+         4,
+         8
        ],
        "monster": "grimachin"
      },
@@ -96,8 +96,8 @@
        "variable": "daytime:false",
        "exp_req_mod": 1,
        "level_range": [
-         3,
-         6
+         5,
+         9
        ],
        "monster": "spighter"
      }

--- a/mods/tuxemon/db/encounter/xenoroute2.json
+++ b/mods/tuxemon/db/encounter/xenoroute2.json
@@ -1,0 +1,105 @@
+{
+  "slug": "xenoroute2",
+  "monsters": [
+    {
+      "monster": "cardiling",
+      "encounter_rate": 2.5,
+      "variable": "daytime:true",
+      "exp_req_mod": 1,
+      "level_range": [
+        5,
+        8
+      ]
+    },
+    {
+      "monster": "chloragon",
+      "encounter_rate": 2.5,
+      "variable": "daytime:true",
+      "exp_req_mod": 1,
+      "level_range": [
+        3,
+        8
+      ]
+    },
+    {
+      "monster": "eyenemy",
+      "encounter_rate": 2.5,
+      "variable": "daytime:true",
+      "exp_req_mod": 1,
+      "level_range": [
+        3,
+        8
+      ]
+    },
+    {
+      "monster": "axylightl",
+      "encounter_rate": 1,
+      "variable": "daytime:true",
+      "exp_req_mod": 1,
+      "level_range": [
+        6,
+        9
+      ]
+    },
+    {
+      "monster": "cataspike",
+      "encounter_rate": 2.5,
+      "variable": "daytime:true",
+      "exp_req_mod": 1,
+      "level_range": [
+        5,
+        7
+      ]
+    },
+    {
+      "monster": "cardiling",
+      "encounter_rate": 2.5,
+      "variable": "daytime:false",
+      "exp_req_mod": 1,
+      "level_range": [
+        3,
+        9
+      ]
+    },
+    {
+      "monster": "aardorn",
+      "encounter_rate": 2.5,
+      "variable": "daytime:false",
+      "exp_req_mod": 1,
+      "level_range": [
+        4,
+        9
+      ]
+    },
+    {
+      "monster": "eyenemy",
+      "encounter_rate": 2.5,
+      "variable": "daytime:false",
+      "exp_req_mod": 1,
+      "level_range": [
+        4,
+        9
+      ]
+    },
+    {
+      "monster": "axylightl",
+      "encounter_rate": 1,
+      "variable": "daytime:false",
+      "exp_req_mod": 1,
+      "level_range": [
+        5,
+        9
+      ]
+    },
+    {
+      "monster": "cataspike",
+      "encounter_rate": 2.5,
+      "variable": "daytime:false",
+      "exp_req_mod": 1,
+      "level_range": [
+        4,
+        9
+      ]
+    }
+  ]
+}

--- a/mods/tuxemon/db/npc/taba_master.json
+++ b/mods/tuxemon/db/npc/taba_master.json
@@ -1,0 +1,11 @@
+{
+    "slug": "master1",
+    "template": [
+      {
+        "sprite_name": "disciple",
+        "combat_front": "disciple",
+        "slug": "disciple"
+      }
+    ]
+  }
+  

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -5584,6 +5584,9 @@ msgstr "Team Xero Grunt X"
 msgid "acolyte"
 msgstr "Acolyte Corren"
 
+msgid "master1"
+msgstr "Jim Master"
+
 ## DIALOG TRANSLATIONS ##
 # general dialogs
 
@@ -7168,6 +7171,22 @@ msgstr "Received the papers back from Kyle"
 msgid "headupstairstababa7"
 msgstr "The Battle Area Master is up those stairs on the far side.\n"
 "I'd wish you luck, but, y'know? I don't actually want you to win!"
+
+msgid "masterrumble"
+msgstr "Are you ready for the master?"
+
+msgid "masterrumbleyes"
+msgstr "Very well, we will heal you."
+
+msgid "masterrumbleconfirmed"
+msgstr "Step forward to earn your badge!"
+
+msgid "master1loss"
+msgstr "Everyone was rooting against you."
+
+msgid "tabamasterwonagainst"
+msgstr "Impressive. Here's your badge. You may now leave back the way you came. \n"
+"There should be Tuxemon in the wild now."
 
 msgid "ripjimmy"
 msgstr "The grave says:\n"

--- a/mods/tuxemon/maps/route1.tmx
+++ b/mods/tuxemon/maps/route1.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="59" height="42" tilewidth="16" tileheight="16" infinite="0" nextlayerid="12" nextobjectid="156">
+<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="59" height="42" tilewidth="16" tileheight="16" infinite="0" nextlayerid="12" nextobjectid="156">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="xero"/>
@@ -11,22 +11,22 @@
  <tileset firstgid="5126" source="../gfx/tilesets/core_set pieces.tsx"/>
  <layer id="1" name="Tile Layer 1" width="59" height="42">
   <data encoding="base64" compression="zlib">
-   eAHt0iERAAAMA7HS+efVWhdDAW/gL72k8oABBhhggAEGGGCAAQYYYIABBhhggAEGGGCAAQYYYIABBhhggAEGGGCAAQYYYODJwAAwJFDd
+   eJztw6ENAAAMAjDs/vfcyhdTbdJeUlVVVVVVVVVVVX06MCRQ3Q==
   </data>
  </layer>
  <layer id="2" name="Tile Layer 2" width="59" height="42">
   <data encoding="base64" compression="zlib">
-   eAHlmUtuFEEMhht2IMIteO2QYMMlYEG4CyDgJJBAQu4C4SUOAtnxWmGL/iTrV7tdUz3DhNCSZbvK9du/Pd2T6ezuDMMDk90t6eEvXo+M42OTbWmlusk6/od50s9N9nHu80J+1V7Ppq5tzvW+8HpovsvO5VpW6ceTi3+itzXXmyOvWHPF9VLoQTxX2XCt5lrhTO1XmOzr2YprnLeenfPhWs11DiPbqzDZ1/Nw1fWlPlzpcaaX5vHzip1hvrL76mBCDsf7jbkSx3qGxzpc6XGmiV9FKzfFZl8xWff5Tl1wZf5ZnJ6FK/iZ5tw3M76b/DD5OdrR/2VrXBk3crBPPJr1o3GOrKPhylynPgNza+BnmjxXzg3DVZNrE/q6rd0wyS7FzuLgcpxwzc61rtPrTIPz3Iw9k32TlyYvRA7Mz64Km3Ob5qo9V5863pnxweSjySeT9yKfzc8uxcTX+Ixr1qt1r2s9Pb7WdM+ePedN7oZnUFzTzzC92bTu4aZntEa4a9xpmuvhhWF4HeTI7JYLbmi469mMK/Gb1rGeN8btbZDjRq5aY8SMdsaVHvVqclTniXPdyzXLEbHdzrhqr1b1yVOdI851L9csR8R2O+Oa9ap1nTxVPHGue7lqjog5ZZ/I3xJZr1rXyVHFE+e6l6vmgHvEnrKJW6rBrnCIc93LVXPAPWJP2cQt1WBXOMS57uWqOSLmlK29WeqTo8IhznUv1yxHxI629mapD3aFQ5zrXq5ZjojtdtaTpevkqXCIc93LVXNEzGhnPVm6To4KhzjXvVw1B9wj9lKbdw8ZzjP7HiNvpuPZXq6KDfeIvdRu4UreTMcaerkqNpjVbwn+jqq047Vw1Z6rT12ue7lGjGhXeBVH9h2zhav2XP1VaouxLXbFtQWDmBauOkf1wXK9ztrWjedc92Z+Y/qzSeeo/r/C1d+j3h653ho1vnNY9Tn8xTC+BjkZMemHPmviO4wp+47V1/Pbn3yqeW/s/w94aoLv74x9TeeovuLN+foZjzxa7Nb3HHM1zO3p/an+3FndO+1cdY7qK585f91c+U6p9FxNcU/nqH6MrWy9n+O93WLr/V9xZL+qi32do/rEnQWtczyrvs9K53hWfef6G16BwkE=
+   eJzlmUtOwzAQhlN2jQi34LVDohsuAQvKXQAVTgKFNvQuUF7iINAdrxUTNZbMqMYzju1xyi/9chspjv988cR1+0WWHYH7Qm1MncD1Tgu5NuZ4/gPPGPeRw1MfTyhJcj1EuY6LuYs1uzka5PNWiutOnYuTdbVh1hDzynXOSnN1keucVVl9KyRXLGqfIxjTeIHLeqyK6QgdtykkV5wN92nKrI6b2Kqsij/1GeByfQd/gD/BX/Vn/fu31rcpG86OpY5PDLwwV66pXNc7WbYB3lzQboG3O+b7Sn1WVJYp8dnkisr1AjwEX4GvwZfIY4drYIXOSuV6D34EP4GfwQ/ILw7XwDJlbdO6Ffd5AF4B72v968dwVul1K0fUOpwS17KbZTeaJ11aVmodNmWV4HoL2e40T4lZm9ZhX7w4XF2zNq3DvnhJcI1dh6n9+MjKre2zJeJKzey7vkpwpb7PfNfXlOqw6d60mavtGQ713kypDodeD6VUh0Ovh1KuwxwNLL8Dz/O06zBHlKySddj2W4Kyd6r2T1PhapKtP99ZY3B1zcpR27lyVGUd/nH+MnGt9lF79fm7ddvT+uNyfYVz3zTP0NhwrbF5L/d77/T/A87y3/vIJZOrTZgT102z2uRzHzH1rClz5bxzKPLJFc9nrvH89501xv5wKoq1zyzdVoq1zyzdVvoBXoHCQQ==
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="59" height="42">
   <data encoding="base64" compression="zlib">
-   eAHt2MsyHUEYwPGOI8SCWAhhZ2OLIHkBEWzDFpHEC+SGd0CI5AEQEkubJBz3ZJdN7skLJBG5uGwt/LtOdelqI3oMZ0ZXf1W/0zOjp7u/r4c6Q4j4or1QiMriaPO3MYYcx6aNNtPR765mfTUwQ123bfsYox82rTlXts7VPpjzqesn0ZpzZetc7YM+33X2R7Ldp7D99LniPla52qyjiproMXB+72xHO1ZXC4vU0fG2Nr9rQTOGzVXPL2g8/dpJ5arPEeY4bK5hxk5armHWbj7Dh92btFzVsy/393+h9v+wfvoYSctVX1uU45ks/m2Kss4471XPlc0aVF+ztbk3CX3U9xebtai+ZmtzbxL6BH2/OWhdqq/ZHtTfX/cV8BXwFQiqQNT/CQSNmcRrT/geJvnwFTAr8KbEvBLf+YscIV7iFWYxhzRkBL27Z35yOj+/k9cP/MQafmEdMtYKMjJnp//zQkqIUpThIspRARnyfc6ld7pG8rqKJlxDM1rQCtdyvUNOd3EP9/EAvehDP1za1zHyGccEnmISU3iG55iGK/GOXN7jAz7iEz7jC77iG5yJXCHOIAcp5OIs8pCPc3AlqsmlBrW4hDrUowGXcQWuRAe5dKILN9CNm7iF2+iBKzFALoMYwkMMYwSPMIrHcCXS5DKPBSxiCctYwSpew5VYJ5ff+IO/+IcNbGIL23A53ibo3cTlOvvcfAV8BXwFfAX2V2AXBYd3pw==
+   eJzt2LlS20AAxvHFMgEK4RQBAh0NLUcCvABn2pAWCNcLcCTmHQzhSB6AG0oacjjhTEfDDS9AOHPRUuTPCA0ZRbblK7KW/WZ+sx5JI+0nyR7JQriXF7oQpQ+T20eLbuzHyehWyjl2hc3xzeVOxyAGHY5uxTzfkZanY3Qr5vn+O891g9PrFO+YSTG7OkmZZbtQ4O7zdUD8Ez0/8XlFi5Pvml3i7Rqy6RQp6eqaaJK5rrGSaV3jide7mvd4rGtrXn+n98BNMq1rqrL4H3+bvJpIzzfRtrWOXkmk55to21pHr8Tu+SbWttZRRUVFJZ4k+5+AV/JON6ioWPP1kdszuMuST4j3+ICP+ISwz1hn9+7u5RzT6xtOcIoznN92Pc0zyJICTYhCFOExilGiGetu3nFkes+po1c9GtCIJjTjmSZf11469aEfA3iF1whiUJOr6wR9JjGFacxgFnOYx4Lm9gxTly26bGMHu9jDPg5wiCOJugq/EFnwQYMf2XiAHOT63Z5g6lJOlwpUogpP8BTVqEGtRF1b6dKGdrxEBzrRhW70SNQ1RJchDOMNRjCKMYzjrURdw3T5jC9YxgpWsYZ1bEjU9ZwuF7jEd/zAT/zCb1xJ1NUumxn0bqKioqKicr/yBwWHd6c=
   </data>
  </layer>
  <layer id="4" name="Above Player" width="59" height="42">
   <data encoding="base64" compression="zlib">
-   eAHtktFtwzAMRL1AZ0mHaYdpp6/6cT8PoUWRVAQWNWAQJ/Eej04eb9f1Pt7HoXrh+Rg5PsfrrbDfylM7ai7D6XxH3cH0/E/0u3FXnXsr/Xf61K5f43/6PV7r0f2sWv5n56d2fZZl99ls18j8GfP3/sQzy1WRiTMqmBEGc1BHmPTsYHKGRzMHtYfBHjIsTd9ubeXQecV8sVQrmBGG5ls1wqSHbN6/SjMHdUUOMqUr2CsMzbXqCsvqJdvqs87p36Wt+SvnzLbirexlDuqKWWRKe9nq3129ee76mPGud+cdc1BXzM4y6V/V2mHmU1+mWjMyzIjXyqHzCJMesVR5P9PyRav4M7/6MpUzMqyMlzmoM2x5yZTWvVXVl63izzjqy1TOyLAyXuagzrDlXWWyf1VrLuuMw/6ItmZEWBmPlUPnGba8YqnqnFX32Uqu9IyrvkzljAwr42UO6gxbXjKldf+qqrlWrchBdgUzwmAO6giTnh1MzvBo5qD2MLr0cDfqLnt4cnI3ag+jSw93o+6yhycnd6P2MLr0cDfqLnt4cnI3ag+jSw93o+6yhycnd6P2MLr0cDfqLnt4cnK3v6o93+K/p+cX+AF5h8CC
+   eJztl0sKgEAMQ72AZ9HD6GH09M7GjTh+MJ2kkgdDQcHpM8XP0HfdWNZAqkemcmzun9c3sBxrrpH7sRxrufwx16Ws9aLX/fxdzeDKIKKnJ74MWtx/hUzP+rAr9posZ+dqV/QercmQa6Z3PjvPWh+KM+xcv/eh6IrKK8MMo3CuWq4olGcY/Xx1rlzXqPek8gyjUco1+vtHyTUaz7BzRe3BooWrCna1a3bsatfs2NWu2UH9R6lX8182eYfAgg==
   </data>
  </layer>
  <objectgroup color="#ff0000" id="5" name="Collisions">
@@ -165,6 +165,7 @@
     <property name="act21" value="char_face postboy,right"/>
     <property name="cond1" value="not char_exists rock"/>
     <property name="cond2" value="not char_exists postboy"/>
+    <property name="cond3" value="not variable_set badge:yes"/>
    </properties>
   </object>
   <object id="110" name="move please" type="event" x="512" y="240" width="16" height="16">
@@ -173,6 +174,7 @@
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,up"/>
     <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond4" value="is char_exists postboy"/>
    </properties>
   </object>
   <object id="111" name="angry populace" type="event" x="432" y="320" width="16" height="16">
@@ -651,6 +653,7 @@
     <property name="act13" value="char_move player,right 1"/>
     <property name="act20" value="unlock_controls"/>
     <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="not variable_set badge:yes"/>
    </properties>
   </object>
   <object id="144" name="gym time" type="event" x="720" y="432" width="16" height="208">

--- a/mods/tuxemon/maps/route2.tmx
+++ b/mods/tuxemon/maps/route2.tmx
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="1" nextobjectid="145">
+<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="1" nextobjectid="145">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="xero"/>
-  <property name="slug" value="route2"/>
+  <property name="slug" value="xenoroute2"/>
   <property name="types" value="route"/>
  </properties>
  <tileset firstgid="1" source="../gfx/tilesets/core_outdoor.tsx"/>
@@ -11,22 +11,22 @@
  <tileset firstgid="4326" source="../gfx/tilesets/core_outdoor_nature.tsx"/>
  <layer id="1" name="Layer 1" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHt0iERAAAMxLBKfv9oLoYCaqCXVZMHDDDAAAMMMMAAAwww8GDgAMjSXhA=
+   eJztwzENAAAMBKGT/P6nuugECaumqqr68ADI0l4Q
   </data>
  </layer>
  <layer id="2" name="Layer 2" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHtVVEOgjAMrYn6q57CCHdR7oLcQ2+mN7L9aFKawV7ZCD82aQZsbV/f0gfR30oYeF2I3uxbWbMjUk9h+DC2L/vNnNPzLX9DTePR85Fzw55I3FvDH1CM90Avvk7uPYVNYzqw7pUDjhpUefW9Hzj/k3FJzQHEVxnSKJ3Hh3I2SjLx8gjOnnDibSm+NWfCYlyKz8fZnDWffR2ZW9UYXVNz7OPOwF36GKQPJCaJ2SRfU+d7ntFSbVCd7wAOTVvwI8LhVLJTBUy5+rl9j001UnSyxLQ3Wz+lb5E7Fmwlup36b+bwCQcIRostqr2WZz9vrdlM8afbgnHOorzJ/VtH5nAOXwkn2tecDub6lxxRDrTuFusPQ8Aewg==
+   eJztlVEOgjAMhrdEfVVOQcC7KHcB7qE30xu5hjTWWbdupdEH/6QvwNJv3f4f5/7S6NI4d22+17/3z+J0C2z3UJ1//Rbq+GENpy7RQ6t5s1Ss3skZT0ZsII4NNQj7tqF2q9C8K977NtTkl56z4VykivmkM5PoXOi9lnlWy2fpCapaPktPpPqAbyVZE687CM6yZk+SNSwzeW+Z86PXZwPm/GDEqLlL+xWYcv1L+TAjJ6VHcG+0P+fPkjMGNk1uc//NHB9IwkjZSrOXKvYb9Voq38bMXErnhncAS3JGKT7NTFCpHMztH/QL/3ypHkPAHsI=
   </data>
  </layer>
  <layer id="3" name="Layer 3" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHFlQtOxDAMRIMEnGU/Z2HFUZBgrwtXwcP2iZHXbVLUikjZie2JPXXS7uGptWPMQwfbNHq8reMvoesSs4fo6/G2jlN3Lzw+tHZK8xy2hmJfj78TnuKcw4253S81wHOR+hQ+xYlJo4/XiHEO7v+PdVyt9hF6NJ8nAdK3V/9U4i2malDXEQ3iSds1eJzxJdYaa/v3mfp/y3L/S3703TPiXZw0KCYd0qb8QmJV/3gGcmKD+JeQ/Gv1UeN90q6e+v0jznOgAT/2HFbvgnpQDZ5BMfpHnYy+fynmvGrNXmJ/7R95cp/IK4QjHBkVX/r4hvx8R6yXzncOZwB/9P0lX9aKPz+r/HlIB99knS97M7JP5+73D3/Guf3Og5N9bmvNfdQ74N8b1vrukEvcXv+IswfMdbGJg/hB9GFn9H1L/UMX/cXW/rlBD0B64Xy/a5y1x9EHUtc5Wmdd2c78ytYZ+v9Exck+6eIua03dzMPO8WzDm8M1GukZqJxz/VOMc6pQ8dHB/8EI37WJv7YfIzVGOdVzu095lvo3WmdPHv37BlDcnQA=
+   eJzFVgEKgzAMbMH5Ft3eMvEpA/W77iszzMMsa9pU2u0gFE2ol0sa212c6zfrEiuQiiu93jcbDCtgjS+11kbvnbsKu/nD92wO435Zt1L44hKKcZ8+4sYx+t/plwJRmP3b2v3dWFE/wmP/xhywlsXR5xdW48Ef/HL0W5t0DAH7g18sBjyI1xrgJ/VDDvJZvq/BDzbtvkXoB/+qcEwhdBbO8ItpckYvLY+z+mk6aTxzuEl+mCF83sl4HiPno/X8alxjPSFBPMBxiNQUsJ5fS821XpFAvafI3MFelvkHv7UvU3FaP4byjOkn7w2cpwZNCw6tH7X8NP0kL/lswST+ExbwXiZL9Z92r7Iih2OoN2J6hPoXloMpI1727T/vL7H8oUHN+0sJQL8XUNydAA==
   </data>
  </layer>
  <layer id="4" name="Above Player" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAFjYBj6oIF7cPthPpXcVzIA3jTnJN7SmcQrpYrKemC4xpDgvn1UsRW/IcjhNQ/ovkYS3IffZMplCYXXLqAVu6F4D+XWkWwCvcJrpJQXJEfAqIbREBgNgdEQGA2B0RCgUwgAAL5vC+Y=
+   eJxjYBj6oIF7oF2AH8ynkvtKqGMMScCck3i1M2nnDKygHhiuMSS4bx/tnAIHyOE1D+i+RhLcR2tAKLx2AfFuKN5DJzchA3qF10gpL0bBKBgFo2AUjILBCgC+bwvm
   </data>
  </layer>
  <objectgroup color="#ff0000" id="5" name="Collisions">
@@ -87,8 +87,8 @@
   </object>
   <object id="82" name="Sign: Route 2" type="event" x="592" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog route2"/>
-    <property name="act2" value="translated_dialog route2_description"/>
+    <property name="act1" value="translated_dialog xenoroute2"/>
+    <property name="act2" value="translated_dialog xenoroute2_description"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
@@ -127,13 +127,13 @@
    <properties>
     <property name="act10" value="set_variable sadsong:yes"/>
     <property name="act20" value="play_music music_the_princess"/>
-    <property name="act30" value="translated_dialog route2speech"/>
+    <property name="act30" value="translated_dialog xenoroute2speech"/>
     <property name="act40" value="char_face misa,right"/>
-    <property name="act50" value="translated_dialog route2speech2"/>
+    <property name="act50" value="translated_dialog xenoroute2speech2"/>
     <property name="act60" value="char_face misa,up"/>
-    <property name="act70" value="translated_dialog route2speech3"/>
+    <property name="act70" value="translated_dialog xenoroute2speech3"/>
     <property name="act80" value="set_variable skadoosh:no"/>
-    <property name="act90" value="translated_dialog_choice sure_i_do:not_really,route2choice"/>
+    <property name="act90" value="translated_dialog_choice sure_i_do:not_really,xenoroute2choice"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,left"/>
     <property name="cond30" value="is button_pressed K_RETURN"/>
@@ -145,20 +145,20 @@
   <object id="89" name="yes to talk" type="event" x="48" y="48" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog yestalk"/>
-    <property name="act20" value="set_variable route2choice:again"/>
+    <property name="act20" value="set_variable xenoroute2choice:again"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,left"/>
-    <property name="cond30" value="is variable_set route2choice:sure_i_do"/>
+    <property name="cond30" value="is variable_set xenoroute2choice:sure_i_do"/>
    </properties>
   </object>
   <object id="90" name="no to talk" type="event" x="48" y="48" width="16" height="16">
    <properties>
     <property name="act10" value="char_face misa,right"/>
     <property name="act20" value="translated_dialog notalk"/>
-    <property name="act30" value="set_variable route2choice:again"/>
+    <property name="act30" value="set_variable xenoroute2choice:again"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,left"/>
-    <property name="cond30" value="is variable_set route2choice:not_really"/>
+    <property name="cond30" value="is variable_set xenoroute2choice:not_really"/>
    </properties>
   </object>
   <object id="93" name="spill the beans" type="event" x="48" y="48" width="16" height="16">
@@ -187,237 +187,237 @@
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,left"/>
     <property name="cond30" value="not variable_set yahoo:maybe"/>
-    <property name="cond40" value="is variable_set route2choice:again"/>
+    <property name="cond40" value="is variable_set xenoroute2choice:again"/>
     <property name="cond50" value="not variable_set leavemealone:yes"/>
    </properties>
   </object>
   <object id="97" name="random battle" type="event" x="160" y="192" width="16" height="48">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="101" name="random battle2" type="event" x="128" y="176" width="32" height="48">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="102" name="random battle3" type="event" x="176" y="208" width="16" height="16">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="103" name="random battle4" type="event" x="112" y="192" width="16" height="16">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="104" name="random battle5" type="event" x="512" y="96" width="48" height="64">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="105" name="random battle6" type="event" x="528" y="80" width="32" height="16">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="106" name="random battle7" type="event" x="560" y="128" width="32" height="32">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="107" name="random battle8" type="event" x="512" y="32" width="48" height="16">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="108" name="random battle9" type="event" x="544" y="208" width="32" height="80">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="109" name="random battle10" type="event" x="560" y="192" width="32" height="16">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="111" name="random battle11" type="event" x="576" y="224" width="32" height="32">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="112" name="random battle12" type="event" x="256" y="160" width="32" height="48">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="113" name="random battle13" type="event" x="288" y="144" width="16" height="32">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="114" name="random battle14" type="event" x="336" y="192" width="16" height="32">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="115" name="random battle15" type="event" x="288" y="208" width="48" height="16">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="116" name="random battle16" type="event" x="352" y="224" width="16" height="16">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="117" name="random battle17" type="event" x="272" y="144" width="16" height="16">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="118" name="random battle18" type="event" x="224" y="176" width="32" height="16">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="119" name="random battle19" type="event" x="528" y="48" width="16" height="16">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="120" name="random battle20" type="event" x="608" y="128" width="16" height="16">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="121" name="random battle21" type="event" x="592" y="144" width="32" height="16">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="122" name="random battle22" type="event" x="464" y="176" width="96" height="16">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="123" name="random battle23" type="event" x="448" y="160" width="48" height="16">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="124" name="random battle24" type="event" x="32" y="112" width="32" height="48">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="125" name="random battle25" type="event" x="64" y="128" width="16" height="48">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="126" name="random battle26" type="event" x="80" y="144" width="16" height="32">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="127" name="random battle27" type="event" x="96" y="160" width="16" height="16">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="128" name="random battle28" type="event" x="16" y="128" width="16" height="16">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="129" name="random battle29" type="event" x="96" y="112" width="64" height="16">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="130" name="random battle30" type="event" x="128" y="128" width="16" height="16">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="131" name="random battle31" type="event" x="144" y="96" width="16" height="16">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="132" name="random battle32" type="event" x="528" y="256" width="16" height="16">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>
   </object>
   <object id="133" name="random battle33" type="event" x="576" y="256" width="16" height="16">
    <properties>
-    <property name="act10" value="random_encounter route2"/>
+    <property name="act10" value="random_encounter xenoroute2"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_moved player"/>
    </properties>

--- a/mods/tuxemon/maps/taba_ba_main.tmx
+++ b/mods/tuxemon/maps/taba_ba_main.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.10.2" orientation="orthogonal" renderorder="right-down" width="19" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="50">
+<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="19" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="51">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="xero"/>
@@ -446,7 +446,7 @@
     <property name="cond4" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
-  <object id="37" name="locked" type="event" x="272" y="48" width="16" height="16">
+  <object id="37" name="locked" type="event" x="256" y="48" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog itslocked"/>
     <property name="act2" value="char_move player,left 1"/>
@@ -573,6 +573,13 @@
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is variable_set fourthacolyte:finished"/>
     <property name="cond3" value="not variable_set kyletalkafter4th:done"/>
+   </properties>
+  </object>
+  <object id="50" name="to upstairs" type="event" x="272" y="48" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport taba_ba_upstairs.tmx,1,7,0.5"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,right"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/taba_ba_upstairs.tmx
+++ b/mods/tuxemon/maps/taba_ba_upstairs.tmx
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="26" height="16" tilewidth="16" tileheight="16" infinite="0" nextlayerid="11" nextobjectid="39">
+ <properties>
+  <property name="edges" value="clamped"/>
+  <property name="scenario" value="xero"/>
+  <property name="slug" value="taba_ba_br_1"/>
+ </properties>
+ <tileset firstgid="1" name="core_indoor_floors" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
+  <image source="../gfx/tilesets/core_indoor_floors.png" width="736" height="1344"/>
+ </tileset>
+ <tileset firstgid="3865" name="core_indoor_walls" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
+  <image source="../gfx/tilesets/core_indoor_walls.png" width="736" height="1344"/>
+ </tileset>
+ <tileset firstgid="7729" source="../gfx/tilesets/core_outdoor.tsx"/>
+ <layer id="7" name="Tile Layer 1" width="26" height="16">
+  <data encoding="base64" compression="zlib">
+   eJy9lGEKwjAMhYPQG2juoLIdQj2EJ/C31Ut4i7KLeATFXUdFOzT0WTqbTjDwSFaWfmuylIjITohOGe29SPlunCPW+OcZf1fzznHe35RyCc7SvLSKvMTIyX2TKOY44KRYMec40mkzDoyujmcva4J2CS81bwdyrj7vDufp40nNifWcNXCmPm/On/vH6jhS87qAU3HgpHoh3kKM61rOwgROqhfoJcZ1LWcLHM28HTio5DwW/mvtzOHsaTk4P9qZw9kbwim1f3EuBfdo+wPnUdBL4ux2vVYV9LIGzhPw69HE
+  </data>
+ </layer>
+ <layer id="8" name="Tile Layer 2" width="26" height="16">
+  <data encoding="base64" compression="zlib">
+   eJxjYBiegF8ZDSsxMEQBcaQS9e0xAZppqgRhC0DtoMSehaLY7UH3D03sUYL4wQxKgwCl4YbNHlqAUXsGtz2jYBSgAwBiAwz3
+  </data>
+ </layer>
+ <layer id="9" name="Tile Layer 3" width="26" height="16">
+  <data encoding="base64" compression="zlib">
+   eJxjYBgFo2AUjIJRMAroDwAGgAAB
+  </data>
+ </layer>
+ <layer id="10" name="Above Player" width="26" height="16">
+  <data encoding="base64" compression="zlib">
+   eJxjYBgFo2AUDBdwThSCi0UH2iWjYBQQBgAwbwJP
+  </data>
+ </layer>
+ <objectgroup color="#ff0000" id="5" name="Collisions">
+  <object id="1" type="collision" x="192" y="0" width="192" height="48"/>
+  <object id="2" type="collision" x="368" y="48" width="16" height="64"/>
+  <object id="3" type="collision" x="368" y="96" width="32" height="48"/>
+  <object id="4" type="collision" x="192" y="144" width="16" height="112"/>
+  <object id="5" type="collision" x="208" y="208" width="176" height="48"/>
+  <object id="6" type="collision" x="368" y="144" width="48" height="48"/>
+  <object id="7" type="collision" x="368" y="192" width="16" height="16"/>
+  <object id="18" type="collision" x="192" y="48" width="16" height="64"/>
+  <object id="26" type="collision" x="160" y="16" width="32" height="96"/>
+  <object id="27" type="collision" x="0" y="144" width="192" height="48"/>
+  <object id="28" type="collision" x="0" y="64" width="32" height="48"/>
+  <object id="29" type="collision" x="0" y="16" width="32" height="48"/>
+  <object id="30" type="collision" x="32" y="0" width="128" height="32"/>
+ </objectgroup>
+ <objectgroup color="#ffff00" id="6" name="Events">
+  <object id="13" name="start battle?" type="event" x="208" y="112" width="16" height="32">
+   <properties>
+    <property name="act1" value="translated_dialog masterrumble"/>
+    <property name="act2" value="translated_dialog_choice yes:no,choicechosen2"/>
+    <property name="act3" value="set_variable choose:chose2"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,right"/>
+    <property name="cond4" value="not variable_set choose:chose2"/>
+    <property name="cond5" value="not variable_set movealong:now2"/>
+   </properties>
+  </object>
+  <object id="14" name="choice-no" type="event" x="384" y="48" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog areyoureadytorumbleno"/>
+    <property name="act2" value="set_variable choose:no"/>
+    <property name="act3" value="char_face player,left"/>
+    <property name="cond1" value="is variable_set choicechosen2:no"/>
+    <property name="cond2" value="not variable_set choose:no"/>
+   </properties>
+  </object>
+  <object id="15" name="choice-yes" type="event" x="384" y="80" width="16" height="16">
+   <properties>
+    <property name="act10" value="translated_dialog masterrumbleyes"/>
+    <property name="act11" value="set_monster_health"/>
+    <property name="act12" value="set_monster_status"/>
+    <property name="act13" value="play_sound sound_confirm"/>
+    <property name="act14" value="wait 0.5"/>
+    <property name="act15" value="translated_dialog masterrumbleconfirmed"/>
+    <property name="act20" value="set_variable choose:yes"/>
+    <property name="act21" value="set_variable battledone:no"/>
+    <property name="act30" value="set_variable movealong:now2"/>
+    <property name="cond1" value="is variable_set choicechosen2:yes"/>
+    <property name="cond2" value="not variable_set movealong:now2"/>
+   </properties>
+  </object>
+  <object id="19" name="move to middle" type="event" x="224" y="48" width="16" height="160">
+   <properties>
+    <property name="act10" value="lock_controls"/>
+    <property name="act20" value="pathfind player,17,7"/>
+    <property name="act21" value="char_face player,right"/>
+    <property name="act30" value="set_variable battledone:start"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is variable_set battledone:no"/>
+    <property name="cond3" value="not variable_set battledone:redo"/>
+   </properties>
+  </object>
+  <object id="20" name="start fight" type="event" x="304" y="16" width="16" height="16">
+   <properties>
+    <property name="act12" value="wait 0.1"/>
+    <property name="act20" value="pathfind master1,19,7"/>
+    <property name="act23" value="char_face master1,left"/>
+    <property name="act25" value="translated_dialog challenger2"/>
+    <property name="act26" value="wait 0.5"/>
+    <property name="act50" value="translated_dialog challenger7"/>
+    <property name="act54" value="add_monster spighter,6,master1,5,100"/>
+    <property name="act55" value="add_monster katapill,9,master1,10,100"/>
+    <property name="act60" value="start_battle player,master1"/>
+    <property name="act99" value="set_variable battledone:yes"/>
+    <property name="cond1" value="is variable_set battledone:start"/>
+   </properties>
+  </object>
+  <object id="21" name="won battle" type="event" x="336" y="0" width="16" height="16">
+   <properties>
+    <property name="act10" value="wait 0.2"/>
+    <property name="act11" value="char_face master1,left"/>
+    <property name="act12" value="wait 0.6"/>
+    <property name="act13" value="translated_dialog tabamasterwonagainst"/>
+    <property name="act14" value="wait 1"/>
+    <property name="act20" value="char_face master1,right"/>
+    <property name="act21" value="wait 0.2"/>
+    <property name="act24" value="unlock_controls"/>
+    <property name="act97" value="set_variable badge:yes"/>
+    <property name="act99" value="set_variable master:done"/>
+    <property name="cond1" value="not variable_set master:done"/>
+    <property name="cond2" value="is variable_set battle_last_trainer:master1"/>
+    <property name="cond3" value="is variable_set battle_last_result:won"/>
+    <property name="cond4" value="not variable_set redo:please"/>
+    <property name="cond5" value="is variable_set battledone:yes"/>
+   </properties>
+  </object>
+  <object id="22" name="lost battle" type="event" x="272" y="112" width="48" height="16">
+   <properties>
+    <property name="act13" value="translated_dialog master1loss"/>
+    <property name="act20" value="wait 0.5"/>
+    <property name="act28" value="unlock_controls"/>
+    <property name="act30" value="transition_teleport healing_center.tmx,6,10,0.3"/>
+    <property name="act31" value="variable_set redo:please"/>
+    <property name="cond1" value="is variable_set battle_last_result:lost"/>
+    <property name="cond2" value="is variable_set battle_last_trainer:master1"/>
+    <property name="cond4" value="not variable_set redo:please"/>
+    <property name="cond5" value="is variable_set battledone:yes"/>
+    <property name="cond6" value="is char_at player"/>
+   </properties>
+  </object>
+  <object id="23" name="redo" type="event" x="160" y="112" width="16" height="32">
+   <properties>
+    <property name="act12" value="set_variable battledone:redo"/>
+    <property name="act13" value="set variable redo:please"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is variable_set battledone:yes"/>
+    <property name="cond3" value="not variable_set master:done"/>
+   </properties>
+  </object>
+  <object id="24" name="move to middle redo" type="event" x="240" y="48" width="16" height="160">
+   <properties>
+    <property name="act10" value="lock_controls"/>
+    <property name="act11" value="wait 0.3"/>
+    <property name="act12" value="pathfind master1,19,7"/>
+    <property name="act13" value="char_face master1,left"/>
+    <property name="act14" value="pathfind player,17,7"/>
+    <property name="act20" value="translated_dialog acolyte1redo"/>
+    <property name="act25" value="set_variable redo:finished"/>
+    <property name="act54" value="add_monster spighter,7,master1,5,100"/>
+    <property name="act55" value="add_monster katapill,9,master1,10,100"/>
+    <property name="act60" value="start_battle player,master1"/>
+    <property name="act99" value="set_variable battledone:yes"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is variable_set battledone:redo"/>
+   </properties>
+  </object>
+  <object id="25" name="teleport to main" type="event" x="0" y="112" width="16" height="32">
+   <properties>
+    <property name="act1" value="transition_teleport taba_ba_main.tmx,15,3,1"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,left"/>
+   </properties>
+  </object>
+  <object id="33" name="wild tuxemon 1" type="event" x="32" y="32" width="64" height="48">
+   <properties>
+    <property name="act1" value="random_encounter taba_ba_passageway_1"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_moved player"/>
+   </properties>
+  </object>
+  <object id="34" name="wild tuxemon 2" type="event" x="112" y="32" width="32" height="64">
+   <properties>
+    <property name="act1" value="random_encounter taba_ba_passageway_2"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_moved player"/>
+   </properties>
+  </object>
+  <object id="35" name="wild tuxemon 3" type="event" x="80" y="80" width="16" height="16">
+   <properties>
+    <property name="act1" value="random_encounter taba_ba_passageway_3"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_moved player"/>
+   </properties>
+  </object>
+  <object id="36" name="wild tuxemon 3" type="event" x="32" y="80" width="32" height="16">
+   <properties>
+    <property name="act1" value="random_encounter taba_ba_passageway_3"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_moved player"/>
+   </properties>
+  </object>
+  <object id="37" name="wild tuxemon 3" type="event" x="96" y="32" width="16" height="48">
+   <properties>
+    <property name="act1" value="random_encounter taba_ba_passageway_3"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_moved player"/>
+   </properties>
+  </object>
+  <object id="38" name="spawnmaster" type="event" x="336" y="64" width="16" height="16">
+   <properties>
+    <property name="act10" value="create_npc master1,22,3,stand"/>
+    <property name="cond2" value="not char_exists master1"/>
+   </properties>
+  </object>
+ </objectgroup>
+</map>


### PR DESCRIPTION
For some reason the map didn't seem to exist even though many Xeno maps further ahead seem to? Also gives a working script, if rather plain, but someone could always improve upon it with better dialogue later. Unlocks first badge after a battle and lets you wander past the pet rock. Plus boost the wild rate of some nearby mons because by the time you reach them you are well past level 2-5 and should be in the 6-15s.
The reason the map has wild grass on it is to prevent an accidental no-win game scenario where you can't grind anywhere to get stronger. (Didn't do this, but might be a good idea to unlock route 1 mons when the trial begins instead of after first badge considering how low level they are?)
The master mons should probably be adjusted at some point after the starter mons are better balanced. Right now Cardaling is absurdly powerful due to Give All, but also early mons all tend to be able to heal and a lot can one-shot mons of near the same level. The extreme randomness makes it hard to strategize much too.
Both winning and losing, and losing twice, work. The latter took three hours straight to get working... 