### PR TITLE
Add some movement to cafe, trainer

### DIFF
--- a/mods/tuxemon/db/npc/confusedperson.json
+++ b/mods/tuxemon/db/npc/confusedperson.json
@@ -1,0 +1,10 @@
+{
+  "slug": "confusedperson",
+  "template": [
+    {
+      "sprite_name": "childactor_fiery",
+      "combat_front": "tennisplayer_fiery",
+      "slug": "noclass"
+    }
+  ]
+}

--- a/mods/tuxemon/db/npc/spyder_cotton_town_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_cotton_town_npcs.json
@@ -64,7 +64,7 @@
     "template": [
       {
         "sprite_name": "goth",
-        "combat_front": "adventurer",
+        "combat_front": "goth",
         "slug": "goth"
       }
     ]

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -5584,6 +5584,9 @@ msgstr "Team Xero Grunt X"
 msgid "acolyte"
 msgstr "Acolyte Corren"
 
+msgid "confusedperson"
+msgstr "Confused Guy"
+
 ## DIALOG TRANSLATIONS ##
 # general dialogs
 
@@ -7737,6 +7740,15 @@ msgstr "Great work on Tuxepedia, my friend.\n You're our top contributor."
 
 msgid "spyder_cottontown_mom2"
 msgstr "!!!"
+
+msgid "spyder_lostfight"
+msgstr "I guess I shouldn't have picked that fight. But it's the spirit, the spirit of too much coffee, that matters!"
+
+msgid "confused1"
+msgstr "This guy won't let me through! I can't figure out how to get out of town! If I win, you have to tell me how! \n If I lose... the same!"
+
+msgid "confused2"
+msgstr "Oh, you say there is another way out on the opposite side of town? Just take a right and go straight past the heal center? Thanks!"
 
 msgid "spyder_cottontown_hacker2"
 msgstr "Right, right!\n There's a data center along the river to the north-east of Timber Town.\n If Omnichannel's done anything to the computer network, they would have done it there."

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -7748,7 +7748,7 @@ msgid "confused1"
 msgstr "This guy won't let me through! I can't figure out how to get out of town! If I win, you have to tell me how! \n If I lose... the same!"
 
 msgid "confused2"
-msgstr "Oh, you say there is another way out on the opposite side of town? Just take a right and go straight past the heal center? Thanks!"
+msgstr "Oh, you say there is another way out on the opposite side of town? Just go right and go straight past the heal center? Thanks!"
 
 msgid "spyder_cottontown_hacker2"
 msgstr "Right, right!\n There's a data center along the river to the north-east of Timber Town.\n If Omnichannel's done anything to the computer network, they would have done it there."
@@ -7849,8 +7849,11 @@ msgstr "You are so engrossed reading the new entries, that you don't notice peop
 msgid "spyder_cotton_tuxepediaintro4"
 msgstr "It's so cool that you came. There's still so many tuxemon to be added - over a hundred, I think. \n You could really get into it, and make a difference to the world. "
 
+msgid "request_fight"
+msgstr "Do you want a quick battle?"
+
 msgid "spyder_cotton_cafegoth"
-msgstr "Don't look at me. I'm just here for the free canapes."
+msgstr "Don't look at me. I'm just here for the free canapes and heals."
 
 msgid "spyder_cotton_cafeflorist1"
 msgstr "Shhh, it's about to begin."

--- a/mods/tuxemon/maps/spyder_cotton_cafe.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_cafe.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="12" height="12" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="43">
+<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="12" height="12" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="44">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -171,7 +171,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_cotton_cafegoth"/>
     <property name="behav1" value="talk spyder_cottoncafe_cayden"/>
-    <property name="cond1" value="is variable_set foughtcafe:yes"/>
+    <property name="cond1" value="is variable_set foughtincafe:yes"/>
    </properties>
   </object>
   <object id="30" name="Hillary Talk" type="event" x="176" y="112" width="16" height="16">
@@ -220,16 +220,15 @@
     <property name="cond1" value="not music_playing music_cathedral_theme"/>
    </properties>
   </object>
-  <object id="40" name="battle cayden" type="event" x="32" y="112" width="16" height="16">
+  <object id="40" name="battle cayden" type="event" x="16" y="176" width="16" height="16">
    <properties>
-    <property name="act10" value="translated_dialog spyder_cotton_cafegoth"/>
     <property name="act11" value="add_monster capiti,4,spyder_cottoncafe_cayden,17,10"/>
     <property name="act12" value="add_monster tweesher,4,spyder_cottoncafe_cayden,17,10"/>
     <property name="act20" value="start_battle player,spyder_cottoncafe_cayden"/>
-    <property name="act22" value="set_variable foughtcafe:yes"/>
+    <property name="act22" value="set_variable foughtincafe:yes"/>
     <property name="act23" value="translated_dialog spyder_lostfight"/>
-    <property name="behav1" value="talk spyder_cottoncafe_cayden"/>
-    <property name="cond1" value="not variable_set foughtcafe:yes"/>
+    <property name="cond1" value="not variable_set foughtincafe:yes"/>
+    <property name="cond2" value="is variable_set cafebattle:yes"/>
    </properties>
   </object>
   <object id="42" name="Rand facing" type="event" x="0" y="0" width="16" height="16">
@@ -244,6 +243,14 @@
     <property name="act65" value="wait 1.5"/>
     <property name="act66" value="char_face spyder_cottoncafe_wilford,up"/>
     <property name="act80" value="wait 2"/>
+   </properties>
+  </object>
+  <object id="43" name="ask battle cayden" type="event" x="16" y="144" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog request_fight"/>
+    <property name="act2" value="translated_dialog_choice yes:no,cafebattle"/>
+    <property name="behav1" value="talk spyder_cottoncafe_cayden"/>
+    <property name="cond1" value="not variable_set foughtincafe:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_cotton_cafe.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_cafe.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="12" height="12" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="37">
+<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="12" height="12" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="43">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -13,22 +13,22 @@
  <tileset firstgid="8190" source="../gfx/tilesets/core_indoor_walls.tsx"/>
  <layer id="1" name="Tile Layer 1" width="12" height="12">
   <data encoding="base64" compression="zlib">
-   eAHbr8zAsJ8E/BaolhQsrcLAQAoWEWRgGMVDJwwArcop6Q==
+   eJzbr8zAsJ8E/JZELK1CGhYRHMVDCQMArcop6Q==
   </data>
  </layer>
  <layer id="2" name="Tile Layer 5" width="12" height="12">
   <data encoding="base64" compression="zlib">
-   eAFjYCAduLMg9BBifwYq/QLEt4H4DhDnMQMJHMCQl4FBiJGBQRiIfwHV/AbiXjzqw4Dq0cEaPOpBak8A5UH4JBCfAuLTQIwMLjAxMIAwDPhDGTAaJg6iLwHVbQDSG4H4IpIekBwMIJsHUn8eKHEBiLGpJ8Y8mLkgmpB5yGqpwS4Fur8MiMuhft0BDDsAxhUf2g==
+   eJxjYCAduLMQz/4MxF+A+DYQ3wHiPGbc5hryMjAIMTIwCAPxLyD/NxD34lEfxosptgaPehA4wQzBJ4H4FBCfRlN/gQmCYcAfjUYGl4DqNgDpjUB8kQmLAjTzQOrPg8RwqCfGPHT1+MyjNigF2lEGxOVQu3YAww4AxhUf2g==
   </data>
  </layer>
  <layer id="3" name="Tile Layer 4" width="12" height="12">
   <data encoding="base64" compression="zlib">
-   eAFjYKAvkGIizT5LItQjm3mOCOOJMZMIY+ii5DzQ/yBMLUBt8wC0iQTB
+   eJxjYKAvkGIiTb0lEeqRzTxHJTMHCzjPBMGD1TwAtIkEwQ==
   </data>
  </layer>
  <layer id="4" name="Above Player" width="12" height="12">
   <data encoding="base64" compression="zlib">
-   eAFjYBjeYCMTAwMIEwM2I6nbhMRG1otsHiH12OQ3AM0FYWwAm3ps6pDF8JmHrI4Y9kxmYlShqgEAkasL1Q==
+   eJxjYBjeYCMTBBMDNiOp24RDD7J5hNRjk9/ABMHk2o8O8JlHKpjJTLoeAJGrC9U=
   </data>
  </layer>
  <objectgroup color="#ff0000" id="5" name="Collisions">
@@ -49,7 +49,7 @@
     <property name="cond2" value="is char_facing player,down"/>
    </properties>
   </object>
-  <object id="14" name="Player Spawn" type="event" x="112" y="144" width="16" height="16"/>
+  <object id="14" name="Player Spawn" type="event" x="112" y="160" width="16" height="16"/>
   <object id="15" name="Create Hacker" type="event" x="160" y="64" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_cottontown_hacker,10,4"/>
@@ -62,7 +62,7 @@
     <property name="cond1" value="not char_exists spyder_cottontown_barmaid"/>
    </properties>
   </object>
-  <object id="18" name="Talk Hacker" type="event" x="144" y="64" width="16" height="16">
+  <object id="18" name="Talk Hacker" type="event" x="128" y="80" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_cottoncafe_hackerchat"/>
     <property name="behav1" value="talk spyder_cottontown_hacker"/>
@@ -120,9 +120,10 @@
     <property name="cond1" value="not char_exists spyder_cottoncafe_lotus"/>
    </properties>
   </object>
-  <object id="23" name="Create Goth (1st)" type="event" x="32" y="96" width="16" height="16">
+  <object id="23" name="Create Goth (1st)" type="event" x="80" y="96" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_cottoncafe_cayden,2,6"/>
+    <property name="act2" value="char_wander spyder_cottoncafe_cayden"/>
     <property name="cond1" value="not char_exists spyder_cottoncafe_cayden"/>
    </properties>
   </object>
@@ -166,10 +167,11 @@
     <property name="cond6" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
-  <object id="29" name="Cayden Talk" type="event" x="48" y="96" width="16" height="16">
+  <object id="29" name="Cayden Talk" type="event" x="32" y="96" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_cotton_cafegoth"/>
     <property name="behav1" value="talk spyder_cottoncafe_cayden"/>
+    <property name="cond1" value="is variable_set foughtcafe:yes"/>
    </properties>
   </object>
   <object id="30" name="Hillary Talk" type="event" x="176" y="112" width="16" height="16">
@@ -186,7 +188,7 @@
     <property name="cond2" value="is variable_set visitedcottoncafe:yes"/>
    </properties>
   </object>
-  <object id="32" name="Lotus Talk" type="event" x="32" y="112" width="16" height="16">
+  <object id="32" name="Lotus Talk" type="event" x="48" y="128" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_cotton_cafegranny"/>
     <property name="behav1" value="talk spyder_cottoncafe_lotus"/>
@@ -216,6 +218,32 @@
    <properties>
     <property name="act1" value="play_music music_cathedral_theme"/>
     <property name="cond1" value="not music_playing music_cathedral_theme"/>
+   </properties>
+  </object>
+  <object id="40" name="battle cayden" type="event" x="32" y="112" width="16" height="16">
+   <properties>
+    <property name="act10" value="translated_dialog spyder_cotton_cafegoth"/>
+    <property name="act11" value="add_monster capiti,4,spyder_cottoncafe_cayden,17,10"/>
+    <property name="act12" value="add_monster tweesher,4,spyder_cottoncafe_cayden,17,10"/>
+    <property name="act20" value="start_battle player,spyder_cottoncafe_cayden"/>
+    <property name="act22" value="set_variable foughtcafe:yes"/>
+    <property name="act23" value="translated_dialog spyder_lostfight"/>
+    <property name="behav1" value="talk spyder_cottoncafe_cayden"/>
+    <property name="cond1" value="not variable_set foughtcafe:yes"/>
+   </properties>
+  </object>
+  <object id="42" name="Rand facing" type="event" x="0" y="0" width="16" height="16">
+   <properties>
+    <property name="act1" value="char_face spyder_cottoncafe_wilford,left"/>
+    <property name="act2" value="wait 1.5"/>
+    <property name="act20" value="char_face spyder_cottoncafe_juliana,down"/>
+    <property name="act30" value="char_face spyder_cottontown_barmaid,up"/>
+    <property name="act40" value="wait 1.5"/>
+    <property name="act50" value="char_face spyder_cottontown_barmaid,down"/>
+    <property name="act60" value="char_face spyder_cottoncafe_juliana,right"/>
+    <property name="act65" value="wait 1.5"/>
+    <property name="act66" value="char_face spyder_cottoncafe_wilford,up"/>
+    <property name="act80" value="wait 2"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_cotton_town.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_town.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="599">
+<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="600">
  <properties>
   <property name="east" value="route2"/>
   <property name="edges" value="clamped"/>
@@ -492,17 +492,12 @@
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
-  <object id="596" name="Talk to confused" type="event" x="112" y="512" width="16" height="80">
+  <object id="596" name="Talk to confused" type="event" x="112" y="544" width="16" height="16">
    <properties>
-    <property name="act0" value="pathfind_to_player confusedperson"/>
-    <property name="act1" value="translated_dialog confused1"/>
-    <property name="act2" value="add_monster aardorn,3,confusedperson,5,10"/>
-    <property name="act3" value="add_monster cataspike,3,confusedperson,5,10"/>
-    <property name="act4" value="start_battle player,confusedperson"/>
-    <property name="act5" value="translated_dialog confused2"/>
-    <property name="act6" value="set_variable confusedcotton:yes"/>
-    <property name="cond1" value="not variable_set confusedcotton:yes"/>
-    <property name="cond2" value="is char_at player"/>
+    <property name="act0" value="translated_dialog confused1"/>
+    <property name="act3" value="translated_dialog_choice yes:no,confusedchoice"/>
+    <property name="behav1" value="talk confusedperson"/>
+    <property name="cond1" value="not variable_set confusedbattle"/>
    </properties>
   </object>
   <object id="597" name="Create confused" type="event" x="96" y="528" width="16" height="16">
@@ -513,11 +508,22 @@
     <property name="cond2" value="not variable_set dragonscavedrokoro:yes"/>
    </properties>
   </object>
-  <object id="598" name="Talk less confused" type="event" x="80" y="512" width="16" height="16">
+  <object id="598" name="Talk less confused later" type="event" x="80" y="512" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog confused2"/>
     <property name="behav1" value="talk confusedperson"/>
-    <property name="cond1" value="is variable_set confusedcotton:yes"/>
+    <property name="cond1" value="is variable_set confusedbattle:yes"/>
+   </properties>
+  </object>
+  <object id="599" name="Battle confused" type="event" x="128" y="576" width="16" height="16">
+   <properties>
+    <property name="act2" value="add_monster pairagrin,2,confusedperson,5,10"/>
+    <property name="act3" value="add_monster capiti,2,confusedperson,5,10"/>
+    <property name="act4" value="start_battle player,confusedperson"/>
+    <property name="act5" value="translated_dialog confused2"/>
+    <property name="act6" value="set_variable confusedbattle:yes"/>
+    <property name="cond1" value="not variable_set confusedbattle:yes"/>
+    <property name="cond2" value="is variable_set confusedchoice:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_cotton_town.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_town.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="596">
+<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="599">
  <properties>
   <property name="east" value="route2"/>
   <property name="edges" value="clamped"/>
@@ -16,22 +16,22 @@
  <tileset firstgid="8116" source="../gfx/tilesets/core_outdoor_nature.tsx"/>
  <layer id="1" name="Tile Layer 1" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHtmN0NwjAMhNmAjfoC7ALsAgwDw8A2JA+WPlW51C1Jf0QerFipm1zvHDvQ7Xe7rtlfcHAIOh9hpxXpHrF9gl1g7+CvBeMZuNaE0fTsc0eM14B9qTNOHMpfEt89cBPtJfSNmJfEZ7qp/HsGfI9gFsexf94tV34Z1XlU+HLcqXdUnnjm1X63wJFpzVFxF3mcEx918/rqm/h9Hp+5r/jzYqoRRx0avvRZz/G+df5q1LExNZC9NZV/5NdTo2rGbB1f7GeemlUrJtUPqG+K39zZm+NZwze+JlKXxl/jj/lgfs2+w3v01Pzje6V7Cusc9+G88aRGvjcXvvifgbe3s6+rvsO7sYpJ9SL2kRI8KN65topR+tg815iqk9qba6sYw6HGEr9zqAf3KYGP65X2t4RPnT3WutL8DK1H/lRuT83Lob09zz25rXLXs36Lyd9tvtkeRfk=
+   eJztmMENwjAMRbsBG/UC7ALdBRiGDtNuQ5BA+or60yR1sENzeLdGebUdu2l/6Lq+sQuOjhNwNuCEbrPjCkyGHC+emxXHby792CGDoh9zsuJ3/zAa9Vurv6fjQdb4510CVuvMLxQ7tmYLbL8b5Bphsfu1Xw7snVLB2rdQ66E8NL/9+ZXoYyngbF3yK9EnJPtLTX7veSbR03JZmge1nx9tml/zq9Gv5NzB7+hcv5J9fSD7WPebEnKAc53NnTHimbU5IhEHFneJs2fdT+Kew+55/9q7NPzY2dP8PxZT25pxjant0D+KxjZe2R5F+Q==
   </data>
  </layer>
  <layer id="2" name="Tile Layer 2" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHNmLdvFEEUhx9GBEFBlshCIkmAbUBIdBRQ0tGRQRRI8AeQGldQkGokcg4S9KSOJAE2IFJNRS4wSQTzPWt/vmGY3VvfnYEnfXqzM7Mzb36783buzCrWOdLsI4wbZTYe8q5PDDA7WcAp2twmjDabCLV6H0MxeFlxedkt77rfQLOmAvrT9on1fYaUFbWpv/rEMag95bWWDvR5UMAT2qTZC/SLTW1x/bIxlRr10ZyVlvyS1tLlzw+N8hiQo9/BbH5p4zMdSMTv9eqjOb2ummktvdEvNaa0SbUNztagPpoz1Teu01pq1U/jSRtdh15t8poz7JNX1lp6o9+OQda2HbbBVtgC0mY/5X2wF/bAblCbfF4sqXqtpTf6nWfOc3AWzsBp0NjXKV+Dq3AFLoO3STv1K+ulXwvvf2vGXPw8mB/ULaCs9T9nzmeDzJ7in8DjLAaf8y3lN/AaXsFL8Hrd62XN6eVqJv1WM/+ajLX4dbA+qNtAeeP4aqOl26WdvOZM9/77tdJOvqx+njvL9q13VdLO82WoXzvf3g7Is7BvXp9G1Es7HyvUROWynlxh5Iw/IKfk2qEhZofhCByFYxCatJOXJq6bymV9UXzkMxOe1xTDXeK5B/ehHTogNGkn721l9Yr7RbnNbhATOc48x5HPTCiv+VzfiOc7/ICf0AWxSTvVl9Ur7hflNuskJnKceY4jn5lQXvP5Zg01mw1zoBlaIDZpp29x3N6X18uJZwWshFWwGkKTdvJ6ZmGff1mWdvJ6Zv8ypnjue5MqNfXo5+OQS/xcYuH5ROO7Z+9272POKOZwZrGwPXW/ovsQ5BTVud80xWwzpGxXk7XtBLWxV7v3bbZ3e84nzdk5k73bs499P2sv6/3Ku9/HHxv8RtN87s9PMbsAKbtEbBeD+Nir3Xs227u/nU/8fvZuzz72/ay9rPer6P48/eK4Ur9x4j59cZ2nXy1ztXOm6oAH8BAeQWj+nm2H8D2t1l5Wv3CcVHkpZ72fxNPlMfEM+0EThBZ9a3reU/VJtRfpp9+Cur/IbyK+ZuJpgVaYC/MgtOhb88d7mrW3hefsRukXxtHIcpF+jZynnrH+x+9HuJ56vh/hOI0ujyI3/8/v322+bf7+fRlW4SvleqxajvOxb5CDbsItuA13IGUen+u3iJjE5OGpnuXrUjksvruTeD7CJ/gMXyBl0k+xua83vlQOi+eeSl6cBtNhBsyElEm/xWjmLBxhtqRO/VLz1Fon/Ubk/Adb67iNuk/6veYdPN5HvGPcWv+HkX5l1qscWdaXGbOozxbOttKvqJ/a9I0p63Vfyr8v+aze0s/z3y/HBcsn
+   eJzNmMtPE0Ecx3/UtBA4AC1NFB8h8ZWo5WFMvHnQozdvPvARDyb4B4By6UkPBT2b4FurYqJ3fNxQTMQWTVHPnhDRgyAYFfxOOuP+OuxMd7tt7Tf5ZLad3dnvfpn5MVsiR/NRogWwLkbUHjN/vh0mumPhbjg/3vo2og1tpbfck5DyoWT6XBchCllYA37gvEV2LZetTz9H92CTepYs8pmyMB12MvjUtnocng/Xofjqc3h+xaSeZUX8/SJmwob8RuT9ed8VF5/8nErn5yZbX0O88Jxq5qfkpa9a+Q3WU/I8OAcGQD9QfZdxfAkMgyGQYn22jMuZ3yju+QDcB/dAGqjxnuP4GXgKnoAx2edlfdvy68T9uyTdoAfsZt/tiTjP/xH3/FBP9B7tNMgxf3M4/gJmwWcwI/tM9c9rfr24/3HJCXASnGLfnQZn2v0/v1CQ+VcN6fPPa36idvrJOohUdqJe8vwyYm1a7l+trE3zTx17bVEraMAF1BSjrjYSXQPXwQ1ws7Gw3zT/smyf4rW1+RtipNiafQ0/k+ANyICs5s+2h/HbarWNxoFo0/l6Roox5u8X/PwGf8AyWNH88QyV/OamWq220TwQbS5fz0gxw/ztaCLaCXaBBOhsMs+/hvjqvkrrMPwcAUfBMdCr+dPnX7Vqhlfp86/W6rPQ5EbnOEh+YpzB/L6E+P5EjS/alFzDwxLsWYj3u12vxv8edc+vr4PobIe7p4shSl4IOWOk5bqVa/ff/iQh5/YYW8d8Lav5ZbpeaK1h/o3C20ODv8fw9oj5y8k1K9duwf5EaIatY76W1fyyXW/KT5fbO041ZMqvFGWwp8qCKfAWvIsU9rvto4v1e82vmA5ir7cMPyvCE/5OdSCk/Q+27aNN/bb8RnzU7j74S8BPJ+gC3aBH82fbR7P+JO8vV36VUjnnX6VUy/kJ1Wp+sZj3+vc/NBHNz7+lZoefzcHGLFbjhMZRg16Al2ACvIq4DCT9ifz2NTtsagnmr1iNE5qHnwXx+wJYBEsWfyK/cvpzq2H6OZtRA7eArWAb2G54l1L57W/Js7eV6EBAf+WUyq+1BteGkMpvFtyqEF+jpf8Oo/LzIr/vnUHVH3fy8yK/7502ffOY/ZzM7y/HBcsn
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAFjYIAACWEoY5BSn4UGqcOgzhoNP8riZzT8hnf4UeY70nXbyUL07GYnTi89y5fTQLfFQt33ikj3jeYP4uIRl6rR8MMVMsSJD/bwI84X5Kv6BmwffR/EbSRpEQYGGSAerOAMsLw7Cy3zBqsbR91F3xC4J49p30JgO38REXjxAPUHjhFp7wki1WGGAGUiQ8199YwMDA1A3AjEyGCwhN9yoLtWAPFKHO7bR0SZ+xiHmjmiDAxfgOnkKwlpBT1+zwPddQGIL+JwH3KYorNhduPyQznQfZLAOk8KWu+FsaGbgMlHdx+mCogIMfGLbDcuc5DFW+nsPmS7qcVGDr+XaPUlMp+Y8KOWm5DNeQ1Mq7Dy+S1ausUnh2zGKHtgQmANjvbrfSz18MC4kHa2wvxOTBlGjiuwtWXIMYeYMowcc+mhx1SKHrYwMBwA1ksHgZgQCCJCDboZxJh9HljuXQBicml0O6nNh9XrMJra5lNqHqxeh9GkmgfLy6Tqw6YeAPQRWak=
+   eJxjYIAACWGGQQ0+Cw20C/CD0fCjDIyGH2VgsIcfvYGdLITezU6cenrG72mg22Kh7ntFpPsGe/yO5g/KwGj4DW7wDej/74M4DKRFGBhkRAbaFbjBGWB5d1Z2oF0xCgYTuCePKbYQWA4uIgIvHqDy8hiR9p4YdR9WgO6+ekYGhgYgbmREFR8s7lsOdNcKIF6Jw337iChzH+NQM0eUgeEL0JyvJPgV3X3nge66AMQXyQg/mN24/FAOdJ8ksM6TgtZ7YWykuw8XIMZ9yHYTA1rp7D5aAGT3vUSrL5H5A+W+10hl8Fsh4uVGwcCDNTjy0n0s9fBwA2tIKMPIAdjaMuQAYsqwwQpMpehjzwFgvXRQlLC6ICLUkGP2eWDZdkGIfJrWAFavk9q2oBeA1euk1u8wgKscIwcAAPQRWak=
   </data>
  </layer>
  <layer id="6" name="Above Player" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHtljkOwjAQRacCiRIqkLgP2xHYTsB2GLaK7RDAEWhCB9wDen6KkRwLY4JNbCAjPTkTx54/n8gkyBMdgRiBdE/OxWeTvGYdV+i7AVXuQlNYk3UVC0QloMqT1CfWYl18T87ZT55PYnRR81N9vdNLJUtUBTVQBw3A0cR1C7RBB3TBL8c7/pn64aKmqWaf1sfxL86zPvX4SS2PPOF7ulE8O1RniKy9lyPqgwEYghFwETbPNZ1PqnkXfac14znAv128VenT7ICpf+IZI3+fhDV03yi69azT19HUP1/7SkqXLf8WGaIlWIE12AAxVO8Z11fNi3vYvubaJvva2MOk/revfebfoRztTs6js/+ZPfPvPx1x1/UrZ9gY5+IETMEMzEEaege2RaId2AMf4wRdZ3DxVJ+PnqWa/HOA/0/k0ZZSeV9dfgfpxXwA
+   eJztmDkOglAQhqeChBIqTLyP2xHcTuB2GLfK7RDqEWywU++hvT8FEYEHKOB7mPmSLzCAZt44GRDHJDpDP07gWDCWhZfHHT5McSwjJxcvD9siqljiWBZeHqJYdv3KzjdrqelEddiATdjSX+fa2O/ALuzBvi7+nn+A+698fFI/rnWYqJp4x5K2/tkhmiFBBgbREI7gGE6MYtcnIs+5lrZewS2jPvxbZSNr/eKeT1ySnlGSPq863H/ZyKt+K41oDTdwC3fa+3lRn0XdK3/Vh3msnfsvG3H1O1XjY4b7TyXSzLAp5uIMzuECLrXwNUyYvU10gEdbdibRXJDXFd4UzY9h0lD0f/FP3wE8AenFfAA=
   </data>
  </layer>
  <objectgroup color="#ff0000" id="4" name="Collisions">
@@ -490,6 +490,34 @@
     <property name="act1" value="translated_dialog spyder_door_locked"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
+   </properties>
+  </object>
+  <object id="596" name="Talk to confused" type="event" x="112" y="512" width="16" height="80">
+   <properties>
+    <property name="act0" value="pathfind_to_player confusedperson"/>
+    <property name="act1" value="translated_dialog confused1"/>
+    <property name="act2" value="add_monster aardorn,3,confusedperson,5,10"/>
+    <property name="act3" value="add_monster cataspike,3,confusedperson,5,10"/>
+    <property name="act4" value="start_battle player,confusedperson"/>
+    <property name="act5" value="translated_dialog confused2"/>
+    <property name="act6" value="set_variable confusedcotton:yes"/>
+    <property name="cond1" value="not variable_set confusedcotton:yes"/>
+    <property name="cond2" value="is char_at player"/>
+   </properties>
+  </object>
+  <object id="597" name="Create confused" type="event" x="96" y="528" width="16" height="16">
+   <properties>
+    <property name="act1" value="create_npc confusedperson,6,33"/>
+    <property name="act2" value="char_face confusedperson,player"/>
+    <property name="cond1" value="not char_exists confusedperson"/>
+    <property name="cond2" value="not variable_set dragonscavedrokoro:yes"/>
+   </properties>
+  </object>
+  <object id="598" name="Talk less confused" type="event" x="80" y="512" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog confused2"/>
+    <property name="behav1" value="talk confusedperson"/>
+    <property name="cond1" value="is variable_set confusedcotton:yes"/>
    </properties>
   </object>
  </objectgroup>


### PR DESCRIPTION
Confused Guy helps lost players figure things out, and get some exp.

(Like this confused player:
https://github.com/Tuxemon/Tuxemon/issues/2291)

Some of the npcs will now occasionally change their direction they are facing. One wanders around inside and is a trainer (so grinding isn't as painful - I always found it weird that you fought your rival and then immediately again with no action in-between.)
Cafe issue;  I didn't touch the cutscene part as I think that's only supposed to trigger when you actually talk to the hacker guy:
https://github.com/Tuxemon/Tuxemon/issues/1946