### PR TITLE
tech update + various

### DIFF
--- a/mods/tuxemon/db/monster/angesnow.json
+++ b/mods/tuxemon/db/monster/angesnow.json
@@ -1,6 +1,6 @@
 {
     "slug": "angesnow",
-    "category": "driven_snow",	
+    "category": "driven_snow",
     "moveset": [
         {
             "level_learned": 2,

--- a/mods/tuxemon/db/monster/anu.json
+++ b/mods/tuxemon/db/monster/anu.json
@@ -32,7 +32,7 @@
         },
         {
             "level_learned": 24,
-            "technique": "sword"
+            "technique": "slice"
         },
         {
             "level_learned": 28,

--- a/mods/tuxemon/db/monster/bearloch.json
+++ b/mods/tuxemon/db/monster/bearloch.json
@@ -4,7 +4,7 @@
     "moveset": [
         {
             "level_learned": 2,
-            "technique": "maori"
+            "technique": "greenstone"
         },
         {
             "level_learned": 2,

--- a/mods/tuxemon/db/monster/boltnu.json
+++ b/mods/tuxemon/db/monster/boltnu.json
@@ -16,7 +16,7 @@
         },
         {
             "level_learned": 8,
-            "technique": "sword"
+            "technique": "slice"
         },
         {
             "level_learned": 12,

--- a/mods/tuxemon/db/monster/bricgard.json
+++ b/mods/tuxemon/db/monster/bricgard.json
@@ -1,6 +1,6 @@
 {
     "slug": "bricgard",
-    "category": "brick_wall",	
+    "category": "brick_wall",
     "moveset": [
         {
             "level_learned": 2,

--- a/mods/tuxemon/db/monster/cairfrey.json
+++ b/mods/tuxemon/db/monster/cairfrey.json
@@ -20,7 +20,7 @@
         },
         {
             "level_learned": 12,
-            "technique": "maori"
+            "technique": "greenstone"
         },
         {
             "level_learned": 16,

--- a/mods/tuxemon/db/monster/cateye.json
+++ b/mods/tuxemon/db/monster/cateye.json
@@ -32,7 +32,7 @@
         },
         {
             "level_learned": 24,
-            "technique": "sword"
+            "technique": "slice"
         },
         {
             "level_learned": 28,

--- a/mods/tuxemon/db/monster/chenipode.json
+++ b/mods/tuxemon/db/monster/chenipode.json
@@ -32,7 +32,7 @@
         },
         {
             "level_learned": 32,
-            "technique": "headbutt"
+            "technique": "hammerhead"
         }
     ],
     "evolutions": [

--- a/mods/tuxemon/db/monster/cherubat.json
+++ b/mods/tuxemon/db/monster/cherubat.json
@@ -32,7 +32,7 @@
         },
         {
             "level_learned": 24,
-            "technique": "sword"
+            "technique": "slice"
         },
         {
             "level_learned": 28,

--- a/mods/tuxemon/db/monster/chloragon.json
+++ b/mods/tuxemon/db/monster/chloragon.json
@@ -12,7 +12,7 @@
         },
         {
             "level_learned": 6,
-            "technique": "maori"
+            "technique": "greenstone"
         },
         {
             "level_learned": 8,

--- a/mods/tuxemon/db/monster/cochini.json
+++ b/mods/tuxemon/db/monster/cochini.json
@@ -12,7 +12,7 @@
         },
         {
             "level_learned": 6,
-            "technique": "headbutt"
+            "technique": "hammerhead"
         },
         {
             "level_learned": 8,

--- a/mods/tuxemon/db/monster/conglolem.json
+++ b/mods/tuxemon/db/monster/conglolem.json
@@ -28,7 +28,7 @@
         },
         {
             "level_learned": 20,
-            "technique": "maori"
+            "technique": "greenstone"
         },
         {
             "level_learned": 28,

--- a/mods/tuxemon/db/monster/coproblight.json
+++ b/mods/tuxemon/db/monster/coproblight.json
@@ -40,7 +40,7 @@
         },
         {
             "level_learned": 32,
-            "technique": "maori"
+            "technique": "greenstone"
         },
         {
             "level_learned": 36,

--- a/mods/tuxemon/db/monster/corvix.json
+++ b/mods/tuxemon/db/monster/corvix.json
@@ -16,7 +16,7 @@
         },
         {
             "level_learned": 8,
-            "technique": "sword"
+            "technique": "slice"
         },
         {
             "level_learned": 12,

--- a/mods/tuxemon/db/monster/cowpignon.json
+++ b/mods/tuxemon/db/monster/cowpignon.json
@@ -4,7 +4,7 @@
     "moveset": [
         {
             "level_learned": 2,
-            "technique": "headbutt"
+            "technique": "hammerhead"
         },
         {
             "level_learned": 2,

--- a/mods/tuxemon/db/monster/dark_robo.json
+++ b/mods/tuxemon/db/monster/dark_robo.json
@@ -28,7 +28,7 @@
         },
         {
             "level_learned": 20,
-            "technique": "sword"
+            "technique": "slice"
         },
         {
             "level_learned": 24,

--- a/mods/tuxemon/db/monster/demosnow.json
+++ b/mods/tuxemon/db/monster/demosnow.json
@@ -1,6 +1,6 @@
 {
     "slug": "demosnow",
-    "category": "tempted",	
+    "category": "tempted",
     "moveset": [
         {
             "level_learned": 2,

--- a/mods/tuxemon/db/monster/dollfin.json
+++ b/mods/tuxemon/db/monster/dollfin.json
@@ -61,7 +61,7 @@
         "water"
     ],
     "possible_genders": ["male", "female"],
-    "txmn_id": 24,	
+    "txmn_id": 24,
     "height": 250,
     "weight": 190,
     "catch_rate": 100.0,

--- a/mods/tuxemon/db/monster/dragarbor.json
+++ b/mods/tuxemon/db/monster/dragarbor.json
@@ -12,7 +12,7 @@
         },
         {
             "level_learned": 6,
-            "technique": "maori"
+            "technique": "greenstone"
         },
         {
             "level_learned": 8,

--- a/mods/tuxemon/db/monster/exapode.json
+++ b/mods/tuxemon/db/monster/exapode.json
@@ -32,7 +32,7 @@
         },
         {
             "level_learned": 32,
-            "technique": "headbutt"
+            "technique": "hammerhead"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/exclawvate.json
+++ b/mods/tuxemon/db/monster/exclawvate.json
@@ -16,7 +16,7 @@
         },
         {
             "level_learned": 8,
-            "technique": "sword"
+            "technique": "slice"
         },
         {
             "level_learned": 12,

--- a/mods/tuxemon/db/monster/flacono.json
+++ b/mods/tuxemon/db/monster/flacono.json
@@ -16,7 +16,7 @@
         },
         {
             "level_learned": 8,
-            "technique": "sword"
+            "technique": "slice"
         },
         {
             "level_learned": 12,

--- a/mods/tuxemon/db/monster/foofle.json
+++ b/mods/tuxemon/db/monster/foofle.json
@@ -8,7 +8,7 @@
         },
         {
             "level_learned": 2,
-            "technique": "headbutt"
+            "technique": "hammerhead"
         },
         {
             "level_learned": 6,

--- a/mods/tuxemon/db/monster/fordin.json
+++ b/mods/tuxemon/db/monster/fordin.json
@@ -44,7 +44,7 @@
         },
         {
             "level_learned": 36,
-            "technique": "maori"
+            "technique": "greenstone"
         },
         {
             "level_learned": 40,

--- a/mods/tuxemon/db/monster/fruitera.json
+++ b/mods/tuxemon/db/monster/fruitera.json
@@ -36,7 +36,7 @@
         },
         {
             "level_learned": 28,
-            "technique": "maori"
+            "technique": "greenstone"
         },
         {
             "level_learned": 32,

--- a/mods/tuxemon/db/monster/fuzzina.json
+++ b/mods/tuxemon/db/monster/fuzzina.json
@@ -44,7 +44,7 @@
         },
         {
             "level_learned": 36,
-            "technique": "maori"
+            "technique": "greenstone"
         },
         {
             "level_learned": 40,

--- a/mods/tuxemon/db/monster/fuzzlet.json
+++ b/mods/tuxemon/db/monster/fuzzlet.json
@@ -44,7 +44,7 @@
         },
         {
             "level_learned": 36,
-            "technique": "maori"
+            "technique": "greenstone"
         },
         {
             "level_learned": 40,

--- a/mods/tuxemon/db/monster/glombroc.json
+++ b/mods/tuxemon/db/monster/glombroc.json
@@ -28,7 +28,7 @@
         },
         {
             "level_learned": 20,
-            "technique": "maori"
+            "technique": "greenstone"
         },
         {
             "level_learned": 28,

--- a/mods/tuxemon/db/monster/grintrock.json
+++ b/mods/tuxemon/db/monster/grintrock.json
@@ -32,7 +32,7 @@
         },
         {
             "level_learned": 24,
-            "technique": "headbutt"
+            "technique": "hammerhead"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/grumpi.json
+++ b/mods/tuxemon/db/monster/grumpi.json
@@ -48,7 +48,7 @@
         },
         {
             "level_learned": 40,
-            "technique": "maori"
+            "technique": "greenstone"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/gryfix.json
+++ b/mods/tuxemon/db/monster/gryfix.json
@@ -16,7 +16,7 @@
         },
         {
             "level_learned": 8,
-            "technique": "sword"
+            "technique": "slice"
         },
         {
             "level_learned": 12,

--- a/mods/tuxemon/db/monster/howl.json
+++ b/mods/tuxemon/db/monster/howl.json
@@ -20,7 +20,7 @@
         },
         {
             "level_learned": 12,
-            "technique": "maori"
+            "technique": "greenstone"
         },
         {
             "level_learned": 16,

--- a/mods/tuxemon/db/monster/hydrone.json
+++ b/mods/tuxemon/db/monster/hydrone.json
@@ -44,7 +44,7 @@
         },
         {
             "level_learned": 36,
-            "technique": "sword"
+            "technique": "slice"
         },
         {
             "level_learned": 40,

--- a/mods/tuxemon/db/monster/kernel.json
+++ b/mods/tuxemon/db/monster/kernel.json
@@ -28,7 +28,7 @@
         },
         {
             "level_learned": 20,
-            "technique": "sword"
+            "technique": "slice"
         },
         {
             "level_learned": 24,

--- a/mods/tuxemon/db/monster/mauai.json
+++ b/mods/tuxemon/db/monster/mauai.json
@@ -16,7 +16,7 @@
         },
         {
             "level_learned": 8,
-            "technique": "sword"
+            "technique": "slice"
         },
         {
             "level_learned": 12,

--- a/mods/tuxemon/db/monster/memnomnom.json
+++ b/mods/tuxemon/db/monster/memnomnom.json
@@ -16,7 +16,7 @@
         },
         {
             "level_learned": 8,
-            "technique": "sword"
+            "technique": "slice"
         },
         {
             "level_learned": 12,

--- a/mods/tuxemon/db/monster/miaownolith.json
+++ b/mods/tuxemon/db/monster/miaownolith.json
@@ -16,7 +16,7 @@
         },
         {
             "level_learned": 8,
-            "technique": "sword"
+            "technique": "slice"
         },
         {
             "level_learned": 12,

--- a/mods/tuxemon/db/monster/mk01_omega.json
+++ b/mods/tuxemon/db/monster/mk01_omega.json
@@ -40,7 +40,7 @@
         },
         {
             "level_learned": 32,
-            "technique": "sword"
+            "technique": "slice"
         },
         {
             "level_learned": 36,

--- a/mods/tuxemon/db/monster/polyrock.json
+++ b/mods/tuxemon/db/monster/polyrock.json
@@ -44,7 +44,7 @@
         },
         {
             "level_learned": 36,
-            "technique": "headbutt"
+            "technique": "hammerhead"
         },
         {
             "level_learned": 40,

--- a/mods/tuxemon/db/monster/possessun.json
+++ b/mods/tuxemon/db/monster/possessun.json
@@ -20,7 +20,7 @@
         },
         {
             "level_learned": 12,
-            "technique": "maori"
+            "technique": "greenstone"
         },
         {
             "level_learned": 16,

--- a/mods/tuxemon/db/monster/pyraminx.json
+++ b/mods/tuxemon/db/monster/pyraminx.json
@@ -16,7 +16,7 @@
         },
         {
             "level_learned": 8,
-            "technique": "sword"
+            "technique": "slice"
         },
         {
             "level_learned": 12,

--- a/mods/tuxemon/db/monster/rhincus.json
+++ b/mods/tuxemon/db/monster/rhincus.json
@@ -4,7 +4,7 @@
     "moveset": [
         {
             "level_learned": 2,
-            "technique": "headbutt"
+            "technique": "hammerhead"
         },
         {
             "level_learned": 2,

--- a/mods/tuxemon/db/monster/rhincus.json
+++ b/mods/tuxemon/db/monster/rhincus.json
@@ -36,7 +36,7 @@
         },
         {
             "level_learned": 28,
-            "technique": "maori"
+            "technique": "greenstone"
         },
         {
             "level_learned": 32,

--- a/mods/tuxemon/db/monster/rinocereed.json
+++ b/mods/tuxemon/db/monster/rinocereed.json
@@ -12,7 +12,7 @@
         },
         {
             "level_learned": 6,
-            "technique": "maori"
+            "technique": "greenstone"
         },
         {
             "level_learned": 8,

--- a/mods/tuxemon/db/monster/rocktot.json
+++ b/mods/tuxemon/db/monster/rocktot.json
@@ -40,7 +40,7 @@
         },
         {
             "level_learned": 32,
-            "technique": "maori"
+            "technique": "greenstone"
         },
         {
             "level_learned": 36,

--- a/mods/tuxemon/db/monster/rocktot.json
+++ b/mods/tuxemon/db/monster/rocktot.json
@@ -12,7 +12,7 @@
         },
         {
             "level_learned": 6,
-            "technique": "headbutt"
+            "technique": "hammerhead"
         },
         {
             "level_learned": 8,

--- a/mods/tuxemon/db/monster/sampsage.json
+++ b/mods/tuxemon/db/monster/sampsage.json
@@ -48,7 +48,7 @@
         },
         {
             "level_learned": 40,
-            "technique": "sword"
+            "technique": "slice"
         }
     ],
     "evolutions": [],

--- a/mods/tuxemon/db/monster/sapragon.json
+++ b/mods/tuxemon/db/monster/sapragon.json
@@ -12,7 +12,7 @@
         },
         {
             "level_learned": 6,
-            "technique": "maori"
+            "technique": "greenstone"
         },
         {
             "level_learned": 8,

--- a/mods/tuxemon/db/monster/sapsnap.json
+++ b/mods/tuxemon/db/monster/sapsnap.json
@@ -8,7 +8,7 @@
         },
         {
             "level_learned": 2,
-            "technique": "headbutt"
+            "technique": "hammerhead"
         },
         {
             "level_learned": 6,

--- a/mods/tuxemon/db/monster/sapsnap.json
+++ b/mods/tuxemon/db/monster/sapsnap.json
@@ -12,7 +12,7 @@
         },
         {
             "level_learned": 6,
-            "technique": "maori"
+            "technique": "greenstone"
         },
         {
             "level_learned": 8,

--- a/mods/tuxemon/db/monster/shammer.json
+++ b/mods/tuxemon/db/monster/shammer.json
@@ -4,7 +4,7 @@
     "moveset": [
         {
             "level_learned": 2,
-            "technique": "headbutt"
+            "technique": "hammerhead"
         },
         {
             "level_learned": 2,

--- a/mods/tuxemon/db/monster/slichen.json
+++ b/mods/tuxemon/db/monster/slichen.json
@@ -28,7 +28,7 @@
         },
         {
             "level_learned": 20,
-            "technique": "maori"
+            "technique": "greenstone"
         },
         {
             "level_learned": 28,

--- a/mods/tuxemon/db/monster/spycozeus.json
+++ b/mods/tuxemon/db/monster/spycozeus.json
@@ -20,7 +20,7 @@
         },
         {
             "level_learned": 12,
-            "technique": "sword"
+            "technique": "slice"
         },
         {
             "level_learned": 16,

--- a/mods/tuxemon/db/monster/tarpeur.json
+++ b/mods/tuxemon/db/monster/tarpeur.json
@@ -24,7 +24,7 @@
         },
         {
             "level_learned": 24,
-            "technique": "headbutt"
+            "technique": "hammerhead"
         },
         {
             "level_learned": 28,

--- a/mods/tuxemon/db/monster/teddisun.json
+++ b/mods/tuxemon/db/monster/teddisun.json
@@ -8,7 +8,7 @@
         },
         {
             "level_learned": 2,
-            "technique": "headbutt"
+            "technique": "hammerhead"
         },
         {
             "level_learned": 6,

--- a/mods/tuxemon/db/monster/toufigel.json
+++ b/mods/tuxemon/db/monster/toufigel.json
@@ -44,7 +44,7 @@
         },
         {
             "level_learned": 36,
-            "technique": "maori"
+            "technique": "greenstone"
         },
         {
             "level_learned": 40,

--- a/mods/tuxemon/db/monster/trapsnap.json
+++ b/mods/tuxemon/db/monster/trapsnap.json
@@ -8,7 +8,7 @@
         },
         {
             "level_learned": 2,
-            "technique": "headbutt"
+            "technique": "hammerhead"
         },
         {
             "level_learned": 6,

--- a/mods/tuxemon/db/monster/trapsnap.json
+++ b/mods/tuxemon/db/monster/trapsnap.json
@@ -12,7 +12,7 @@
         },
         {
             "level_learned": 6,
-            "technique": "maori"
+            "technique": "greenstone"
         },
         {
             "level_learned": 8,

--- a/mods/tuxemon/db/monster/vigueur.json
+++ b/mods/tuxemon/db/monster/vigueur.json
@@ -24,7 +24,7 @@
         },
         {
             "level_learned": 24,
-            "technique": "headbutt"
+            "technique": "hammerhead"
         },
         {
             "level_learned": 28,

--- a/mods/tuxemon/db/monster/vivicinder.json
+++ b/mods/tuxemon/db/monster/vivicinder.json
@@ -8,7 +8,7 @@
         },
         {
             "level_learned": 2,
-            "technique": "headbutt"
+            "technique": "hammerhead"
         },
         {
             "level_learned": 6,

--- a/mods/tuxemon/db/monster/vividactil.json
+++ b/mods/tuxemon/db/monster/vividactil.json
@@ -8,7 +8,7 @@
         },
         {
             "level_learned": 2,
-            "technique": "headbutt"
+            "technique": "hammerhead"
         },
         {
             "level_learned": 6,

--- a/mods/tuxemon/db/monster/vivipere.json
+++ b/mods/tuxemon/db/monster/vivipere.json
@@ -8,7 +8,7 @@
         },
         {
             "level_learned": 2,
-            "technique": "headbutt"
+            "technique": "hammerhead"
         },
         {
             "level_learned": 6,

--- a/mods/tuxemon/db/monster/viviphyta.json
+++ b/mods/tuxemon/db/monster/viviphyta.json
@@ -8,7 +8,7 @@
         },
         {
             "level_learned": 2,
-            "technique": "headbutt"
+            "technique": "hammerhead"
         },
         {
             "level_learned": 6,

--- a/mods/tuxemon/db/monster/vivisource.json
+++ b/mods/tuxemon/db/monster/vivisource.json
@@ -8,7 +8,7 @@
         },
         {
             "level_learned": 2,
-            "technique": "headbutt"
+            "technique": "hammerhead"
         },
         {
             "level_learned": 6,

--- a/mods/tuxemon/db/monster/viviteel.json
+++ b/mods/tuxemon/db/monster/viviteel.json
@@ -8,7 +8,7 @@
         },
         {
             "level_learned": 2,
-            "technique": "headbutt"
+            "technique": "hammerhead"
         },
         {
             "level_learned": 6,

--- a/mods/tuxemon/db/monster/vivitrans.json
+++ b/mods/tuxemon/db/monster/vivitrans.json
@@ -8,7 +8,7 @@
         },
         {
             "level_learned": 2,
-            "technique": "headbutt"
+            "technique": "hammerhead"
         },
         {
             "level_learned": 6,

--- a/mods/tuxemon/db/monster/vivitron.json
+++ b/mods/tuxemon/db/monster/vivitron.json
@@ -8,7 +8,7 @@
         },
         {
             "level_learned": 2,
-            "technique": "headbutt"
+            "technique": "hammerhead"
         },
         {
             "level_learned": 6,

--- a/mods/tuxemon/db/monster/wolffsky.json
+++ b/mods/tuxemon/db/monster/wolffsky.json
@@ -36,7 +36,7 @@
         },
         {
             "level_learned": 28,
-            "technique": "maori"
+            "technique": "greenstone"
         },
         {
             "level_learned": 32,

--- a/mods/tuxemon/db/monster/ziggurat.json
+++ b/mods/tuxemon/db/monster/ziggurat.json
@@ -16,7 +16,7 @@
         },
         {
             "level_learned": 8,
-            "technique": "headbutt"
+            "technique": "hammerhead"
         },
         {
             "level_learned": 12,

--- a/mods/tuxemon/db/technique/greenstone.json
+++ b/mods/tuxemon/db/technique/greenstone.json
@@ -12,7 +12,7 @@
   "range": "touch",
   "recharge": 2,
   "sfx": "sfx_blaster",
-  "slug": "maori",
+  "slug": "greenstone",
   "sort": "damage",
   "target": {
     "enemy monster": 2,

--- a/mods/tuxemon/db/technique/hammerhead.json
+++ b/mods/tuxemon/db/technique/hammerhead.json
@@ -1,18 +1,18 @@
 {
-  "tech_id": 101,
-  "accuracy": 0.9,
-  "animation": "pound",
+  "tech_id": 72,
+  "accuracy": 1,
+  "animation": "slash_power",
   "effects": [
     "damage"
   ],
-  "flip_axes": "",
+  "flip_axes": "x",
   "is_fast": false,
   "potency": 0.0,
-  "power": 1.2,
+  "power": 1,
   "range": "melee",
   "recharge": 1,
   "sfx": "sfx_blaster",
-  "slug": "sword",
+  "slug": "hammerhead",
   "sort": "damage",
   "target": {
     "enemy monster": 2,
@@ -23,7 +23,7 @@
     "own trainer": 0
   },
   "types": [
-    "metal"
+    "earth"
   ],
   "use_failure": "combat_miss",
   "use_success": null,

--- a/mods/tuxemon/db/technique/slice.json
+++ b/mods/tuxemon/db/technique/slice.json
@@ -1,18 +1,18 @@
 {
-  "tech_id": 72,
-  "accuracy": 1,
-  "animation": "slash_power",
+  "tech_id": 101,
+  "accuracy": 0.9,
+  "animation": "pound",
   "effects": [
     "damage"
   ],
-  "flip_axes": "x",
+  "flip_axes": "",
   "is_fast": false,
   "potency": 0.0,
-  "power": 1,
+  "power": 1.2,
   "range": "melee",
   "recharge": 1,
   "sfx": "sfx_blaster",
-  "slug": "headbutt",
+  "slug": "slice",
   "sort": "damage",
   "target": {
     "enemy monster": 2,
@@ -23,7 +23,7 @@
     "own trainer": 0
   },
   "types": [
-    "earth"
+    "metal"
   ],
   "use_failure": "combat_miss",
   "use_success": null,

--- a/mods/tuxemon/l18n/de_DE/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/de_DE/LC_MESSAGES/base.po
@@ -3792,9 +3792,6 @@ msgstr "Lust"
 msgid "magma"
 msgstr "Magma"
 
-msgid "maori"
-msgstr "Maori"
-
 msgid "mobbing"
 msgstr "Mobbing"
 

--- a/mods/tuxemon/l18n/de_DE/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/de_DE/LC_MESSAGES/base.po
@@ -448,9 +448,6 @@ msgstr "Finsterblick"
 msgid "goad"
 msgstr "Anspornen"
 
-msgid "headbutt"
-msgstr "Kopfnuss"
-
 msgid "hibernate"
 msgstr "Winterschlaf"
 
@@ -2984,9 +2981,6 @@ msgstr "Sei vorsichtig!"
 
 msgid "spyder_citypark_maniac"
 msgstr "Puh, wir sind fix und fertig!"
-
-msgid "sword"
-msgstr "Schwert"
 
 msgid "ubuntu"
 msgstr "Ubuntu"

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -1667,17 +1667,17 @@ msgstr "The user creates a powerful wind that blows the opponent back."
 msgid "gust"
 msgstr "Gust"
 
+msgid "hammerhead_description"
+msgstr "The user charges forward, striking the opponent with its head."
+
+msgid "hammerhead"
+msgstr "Hammerhead"
+
 msgid "hawk_description"
 msgstr "The user soars high into the air before diving down with a powerful attack."
 
 msgid "hawk"
 msgstr "Hawk"
-
-msgid "headbutt_description"
-msgstr "The user charges forward, striking the opponent with its head."
-
-msgid "headbutt"
-msgstr "Headbutt"
 
 msgid "hibernate_description"
 msgstr "The user falls into a restorative sleep."
@@ -2087,6 +2087,12 @@ msgstr "A cloud of sleep-inducing pollen is released, causing the opponent to fa
 msgid "sleeping_powder"
 msgstr "Sleeping Powder"
 
+msgid "slice_description"
+msgstr "The user wields a sharp blade, delivery a powerful, cutting attack."
+
+msgid "slice"
+msgstr "Slice"
+
 msgid "slime_description"
 msgstr "A sticky, viscous substance is emitted, engulfing the opponent and dealing damage."
 
@@ -2206,12 +2212,6 @@ msgstr "A powerful electric discharge that shocks the opponent."
 
 msgid "surge"
 msgstr "Surge"
-
-msgid "sword_description"
-msgstr "The user wields a sharp blade, delivery a powerful, cutting attack."
-
-msgid "sword"
-msgstr "Sword"
 
 msgid "sylvan_description"
 msgstr "The user summons the power of nature, transforming the opponent into a wooden puppet."

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -1248,19 +1248,19 @@ msgstr "Wild"
 
 ## TECHNIQUE TRANSLATIONS ##
 msgid "acid_description"
-msgstr ""
+msgstr "A corrosive liquid is ejected from the user's mouth, burning the opponent."
 
 msgid "acid"
 msgstr "Acid"
 
 msgid "adamantine_description"
-msgstr ""
+msgstr "The user's body glows intensely before it delivers a crushing blow."
 
 msgid "adamantine"
 msgstr "Adamantine"
 
 msgid "air_chain_description"
-msgstr ""
+msgstr "The user rapidly strikes the air, creating a series of powerful gusts that hit the opponent."
 
 msgid "air_chain"
 msgstr "Air Chain"
@@ -1284,7 +1284,7 @@ msgid "amnesia"
 msgstr "Amnesia"
 
 msgid "ants_description"
-msgstr ""
+msgstr "The user summons a swarm of ants that crawl over the opponent, changing their type to Earth."
 
 msgid "ants"
 msgstr "Ants"
@@ -1296,43 +1296,43 @@ msgid "arcane_eye"
 msgstr "Arcane Eye"
 
 msgid "assault_description"
-msgstr ""
+msgstr "The user unleashes a flurry of rapid, powerful attacks."
 
 msgid "assault"
 msgstr "Assault"
 
 msgid "avalanche_description"
-msgstr ""
+msgstr "The user gathers momentum before unleashing a devastating avalanche of ice and rock."
 
 msgid "avalanche"
 msgstr "Avalanche"
 
 msgid "barking_description"
-msgstr ""
+msgstr "The user lets out a powerful, intimidating roar that makes the opponent flinch."
 
 msgid "barking"
 msgstr "Barking"
 
 msgid "battery_acid_description"
-msgstr ""
+msgstr "A corrosive liquid is ejected from the user's body, poisoning the opponent."
 
 msgid "battery_acid"
 msgstr "Battery Acid"
 
 msgid "battery_discharge_description"
-msgstr ""
+msgstr "The user's body emits a bright light as it restores its own health."
 
 msgid "battery_discharge"
 msgstr "Battery Discharge"
 
 msgid "beam_description"
-msgstr ""
+msgstr "A concentrated beam of energy is fired from the user's eyes, blinding the opponent."
 
 msgid "beam"
 msgstr "Beam"
 
 msgid "berserk_description"
-msgstr ""
+msgstr "The user enters a frenzied state, attacking with reckless abandon."
 
 msgid "berserk"
 msgstr "Berserk"
@@ -1356,7 +1356,7 @@ msgid "blood_bond"
 msgstr "Blood Bond"
 
 msgid "blood_nets_description"
-msgstr ""
+msgstr "A web of sticky, blood-red substance is shot from the user's body, draining the opponent's life force."
 
 msgid "blood_nets"
 msgstr "Blood Nets"
@@ -1374,7 +1374,7 @@ msgid "boulder"
 msgstr "Boulder"
 
 msgid "breath_description"
-msgstr ""
+msgstr "The user exhales a cloud of sleep-inducing gas."
 
 msgid "breath"
 msgstr "Breath"
@@ -1386,7 +1386,7 @@ msgid "breathe_fire"
 msgstr "Breathe Fire"
 
 msgid "bubble_trap_description"
-msgstr ""
+msgstr "The user creates a large bubble that traps both itself and the opponent."
 
 msgid "bubble_trap"
 msgstr "Bubble Trap"
@@ -1398,109 +1398,109 @@ msgid "bullet"
 msgstr "Bullet"
 
 msgid "canine_description"
-msgstr ""
+msgstr "The user unleashes a primal, ferocious attack that sends the opponent into a frenzy."
 
 msgid "canine"
 msgstr "Canine"
 
 msgid "cat_calling_description"
-msgstr ""
+msgstr "The user emits a high-pitched cry that distracts the opponent."
 
 msgid "cat_calling"
 msgstr "Cat Calling"
 
 msgid "cavity_description"
-msgstr ""
+msgstr "The user strikes with pinpoint accuracy, targeting the opponent's weak points."
 
 msgid "cavity"
 msgstr "Cavity"
 
 msgid "chameleon_description"
-msgstr ""
+msgstr "The user changes its type to Wood, while also creating a protective shell around itself."
 
 msgid "chameleon"
 msgstr "Chameleon"
 
 msgid "changeling_description"
-msgstr ""
+msgstr "The user undergoes a transformation, healing its wounds in the process."
 
 msgid "changeling"
 msgstr "Changeling"
 
 msgid "chill_mist_description"
-msgstr ""
+msgstr "The user releases a freezing mist that lowers the opponent's stats."
 
 msgid "chill_mist"
 msgstr "Chill Mist"
 
 msgid "clairaudience_description"
-msgstr ""
+msgstr "The user attunes its senses, anticipating the opponent's next move and preparing a counterattack."
 
 msgid "clairaudience"
 msgstr "Clairaudience"
 
 msgid "clamp_on_description"
-msgstr ""
+msgstr "The user latches onto the opponent with its powerful jaws."
 
 msgid "clamp_on"
 msgstr "Clamp On"
 
 msgid "clock_description"
-msgstr ""
+msgstr "The user creates a swirling vortex that confuses the opponent."
 
 msgid "clock"
 msgstr "Clock"
 
 msgid "cloud_aether_description"
-msgstr ""
+msgstr "The user is enveloped in a swirling cloud, causing both it and the opponent to change types randomly."
 
 msgid "cloud_aether"
 msgstr "Cloud Aether"
 
 msgid "conjurer_description"
-msgstr ""
+msgstr "The user conjures a force field that traps the opponent."
 
 msgid "conjurer"
 msgstr "Conjurer"
 
 msgid "constrict_description"
-msgstr ""
+msgstr "The user wraps its body around the opponent, squeezing tightly."
 
 msgid "constrict"
 msgstr "Constrict"
 
 msgid "crystal_description"
-msgstr ""
+msgstr "The user fires a sharp, crystalline projectile at the opponent."
 
 msgid "crystal"
 msgstr "Crystal"
 
 msgid "demiurge_description"
-msgstr ""
+msgstr "The user undergoes a transformation, healing itself and confusing the opponent."
 
 msgid "demiurge"
 msgstr "Demiurge"
 
 msgid "earthquake_description"
-msgstr ""
+msgstr "The ground shakes violently as the user unleashes a powerful ground attack."
 
 msgid "earthquake"
 msgstr "Earthquake"
 
 msgid "electrical_storm_description"
-msgstr ""
+msgstr "The user summons a raging thunderstorm, striking the opponent with lightning bolts."
 
 msgid "electrical_storm"
 msgstr "Electrical Storm"
 
 msgid "electroplate_description"
-msgstr ""
+msgstr "Electricity causes the target to be coated in metal, changing its type."
 
 msgid "electroplate"
 msgstr "Electroplate"
 
 msgid "energy_claws_description"
-msgstr ""
+msgstr "The user's claws glow with energy as it delivers a powerful, focused attack."
 
 msgid "energy_claws"
 msgstr "Energy Claws"
@@ -1512,7 +1512,7 @@ msgid "energy_field"
 msgstr "Energy Field"
 
 msgid "evasion_description"
-msgstr ""
+msgstr "The user becomes a blur of motion, making it difficult in the next round to miss."
 
 msgid "evasion"
 msgstr "Evasion"
@@ -1524,13 +1524,13 @@ msgid "eyebite"
 msgstr "Eyebite"
 
 msgid "feint_description"
-msgstr ""
+msgstr "The user feigns an attack, then strikes with a swift, surprise blow."
 
 msgid "feint"
 msgstr "Feint"
 
 msgid "feline_description"
-msgstr ""
+msgstr "The user focuses its predatory instincts."
 
 msgid "feline"
 msgstr "Feline"
@@ -1542,7 +1542,7 @@ msgid "fester"
 msgstr "Fester"
 
 msgid "fiery_description"
-msgstr ""
+msgstr "The user emits a powerful blast of fire that changes the opponent's type to Fire."
 
 msgid "fiery"
 msgstr "Fiery"
@@ -1554,79 +1554,79 @@ msgid "fire_ball"
 msgstr "Fire Ball"
 
 msgid "fire_claw_description"
-msgstr ""
+msgstr "The user's claws ignite with fire as it delivers a burning attack."
 
 msgid "fire_claw"
 msgstr "Fire Claw"
 
 msgid "fire_shield_description"
-msgstr ""
+msgstr "The user surrounds itself with a protective wall of fire, while also burning the opponent."
 
 msgid "fire_shield"
 msgstr "Fire Shield"
 
 msgid "firestorm_description"
-msgstr ""
+msgstr "The user creates a raging inferno that engulfs the opponent."
 
 msgid "firestorm"
 msgstr "Firestorm"
 
 msgid "flamethrower_description"
-msgstr ""
+msgstr "The user spews a stream of intense flames at the opponent."
 
 msgid "flamethrower"
 msgstr "Flamethrower"
 
 msgid "fledgling_description"
-msgstr ""
+msgstr "The user hurls a clump of hardened earth at the opponent."
 
 msgid "fledgling"
 msgstr "Fledgling"
 
 msgid "flood_description"
-msgstr ""
+msgstr "The user summons a powerful flood that washes over the opponent."
 
 msgid "flood"
 msgstr "Flood"
 
 msgid "flow_description"
-msgstr ""
+msgstr "The user channels a powerful water stream."
 
 msgid "flow"
 msgstr "Flow"
 
 msgid "fluff_up_description"
-msgstr ""
+msgstr "The user's body puffs up, healing its wounds."
 
 msgid "fluff_up"
 msgstr "Fluff Up"
 
 msgid "font_description"
-msgstr ""
+msgstr "The user draws energy from a mystical font to heal itself."
 
 msgid "font"
 msgstr "Font"
 
 msgid "frostbite_description"
-msgstr ""
+msgstr "The user shoots a freezing blast that inflicts poison on the opponent."
 
 msgid "frostbite"
 msgstr "Frostbite"
 
 msgid "fume_description"
-msgstr ""
+msgstr "The user becomes enraged."
 
 msgid "fume"
 msgstr "Fume"
 
 msgid "geyser_description"
-msgstr ""
+msgstr "The user erupts with a powerful water spout, changing the opponent's type to Water."
 
 msgid "geyser"
 msgstr "Geyser"
 
 msgid "give_all_description"
-msgstr ""
+msgstr "The user sacrifices itself."
 
 msgid "give_all"
 msgstr "Give All"
@@ -1638,37 +1638,43 @@ msgid "glower"
 msgstr "Glower"
 
 msgid "goad_description"
-msgstr ""
+msgstr "The user taunts the opponent, causing them to become enraged."
 
 msgid "goad"
 msgstr "Goad"
 
 msgid "gold_digger_description"
-msgstr ""
+msgstr "The user digs into the ground, finding treasure or attacking itself."
 
 msgid "gold_digger"
 msgstr "Gold Digger"
 
+msgid "greenstone_description"
+msgstr "The user strikes with the force of a falling stone."
+
+msgid "greenstone"
+msgstr "Greenstone"
+
 msgid "grinding_description"
-msgstr ""
+msgstr "The user grinds its opponent down with a relentless attack."
 
 msgid "grinding"
 msgstr "Grinding"
 
 msgid "gust_description"
-msgstr ""
+msgstr "The user creates a powerful wind that blows the opponent back."
 
 msgid "gust"
 msgstr "Gust"
 
 msgid "hawk_description"
-msgstr ""
+msgstr "The user soars high into the air before diving down with a powerful attack."
 
 msgid "hawk"
 msgstr "Hawk"
 
 msgid "headbutt_description"
-msgstr ""
+msgstr "The user charges forward, striking the opponent with its head."
 
 msgid "headbutt"
 msgstr "Headbutt"
@@ -1680,61 +1686,61 @@ msgid "hibernate"
 msgstr "Hibernate"
 
 msgid "ice_claw_description"
-msgstr ""
+msgstr "The user's claws become covered in ice as it delivers a freezing attack."
 
 msgid "ice_claw"
 msgstr "Ice Claw"
 
 msgid "ice_shield_description"
-msgstr ""
+msgstr "The user surrounds itself with a protective wall of ice, while also slowing down the opponent."
 
 msgid "ice_shield"
 msgstr "Ice Shield"
 
 msgid "ice_storm_description"
-msgstr ""
+msgstr "The opponent is engulfed in a freezing aura, creating a treacherous environment."
 
 msgid "ice_storm"
 msgstr "Ice Storm"
 
 msgid "icicle_spear_description"
-msgstr ""
+msgstr "The user launches a volley of sharp ice shards at the opponent."
 
 msgid "icicle_spear"
 msgstr "Icicle Spear"
 
 msgid "insanity_description"
-msgstr ""
+msgstr "The user becomes consumed by rage, increasing its power."
 
 msgid "insanity"
 msgstr "Insanity"
 
 msgid "invictus_description"
-msgstr ""
+msgstr "The user enters a berserker state, attacking with relentless fury and trapping the opponent."
 
 msgid "invictus"
 msgstr "Invictus"
 
 msgid "kindling_flame_description"
-msgstr ""
+msgstr "The user ignites with inner fire, increasing its attack power."
 
 msgid "kindling_flame"
 msgstr "Kindling Flame"
 
 msgid "kraken_description"
-msgstr ""
+msgstr "The user summons the power of a legendary sea creature, unleashing a devastating attack."
 
 msgid "kraken"
 msgstr "Kraken"
 
 msgid "lantern_description"
-msgstr ""
+msgstr "The user creates a bright light that illuminates the battlefield, boosts its accuracy and damages the opponent."
 
 msgid "lantern"
 msgstr "Lantern"
 
 msgid "lava_description"
-msgstr ""
+msgstr "The user erupts with molten lava, burning both itself and the opponent."
 
 msgid "lava"
 msgstr "Lava"
@@ -1752,67 +1758,61 @@ msgid "life_surge"
 msgstr "Life Surge"
 
 msgid "lightning_spheres_description"
-msgstr ""
+msgstr "The user launches multiple balls of electricity at the opponent."
 
 msgid "lightning_spheres"
 msgstr "Lightning Spheres"
 
 msgid "lineage_description"
-msgstr ""
+msgstr "The user draws power from its ancestors to unleash an attack."
 
 msgid "lineage"
 msgstr "Lineage"
 
 msgid "lust_description"
-msgstr ""
+msgstr "The user uses its charm to weaken the opponent's defenses."
 
 msgid "lust"
 msgstr "Lust"
 
 msgid "magma_description"
-msgstr ""
+msgstr "The user erupts with a torrent of molten rock."
 
 msgid "magma"
 msgstr "Magma"
 
-msgid "maori_description"
-msgstr ""
-
-msgid "maori"
-msgstr "Maori"
-
 msgid "meltdown_description"
-msgstr ""
+msgstr "The user unleashes a corrosive attack that damages the opponent."
 
 msgid "meltdown"
 msgstr "Meltdown"
 
 msgid "mending_description"
-msgstr ""
+msgstr "The user draws energy from its surroundings to heal itself."
 
 msgid "mending"
 msgstr "Mending"
 
 msgid "midnight_mantle_description"
-msgstr ""
+msgstr "The user shrouds itself in a cloak of darkness, striking out with shadowy tendrils that inflict damage and disorient the opponent."
 
 msgid "midnight_mantle"
 msgstr "Midnight Mantle"
 
 msgid "mind_vise_description"
-msgstr ""
+msgstr "The user traps the opponent's mind, preventing them from acting."
 
 msgid "mind_vise"
 msgstr "Mind Vise"
 
 msgid "mobbing_description"
-msgstr ""
+msgstr "A swarm of small creatures emerges from the user, overwhelming the opponent with a flurry of attacks."
 
 msgid "mobbing"
 msgstr "Mobbing"
 
 msgid "muck_description"
-msgstr ""
+msgstr "The user covers the opponent in a sticky, poisonous substance."
 
 msgid "muck"
 msgstr "Muck"
@@ -1824,25 +1824,25 @@ msgid "muddle"
 msgstr "Muddle"
 
 msgid "mudslide_description"
-msgstr ""
+msgstr "The user creates a massive mudslide that engulfs the opponent."
 
 msgid "mudslide"
 msgstr "Mudslide"
 
 msgid "mystic_blending_description"
-msgstr ""
+msgstr "The user becomes one with its surroundings, healing itself."
 
 msgid "mystic_blending"
 msgstr "Mystic Blending"
 
 msgid "negation_description"
-msgstr ""
+msgstr "The user cancels out the effects of the opponent's healing."
 
 msgid "negation"
 msgstr "Negation"
 
 msgid "nest_description"
-msgstr ""
+msgstr "The user constructs a protective nest around itself, using it as a defensive and offensive weapon."
 
 msgid "nest"
 msgstr "Nest"
@@ -1854,13 +1854,13 @@ msgid "neutralize"
 msgstr "Neutralize"
 
 msgid "oedipus_description"
-msgstr ""
+msgstr "The user attacks with a vengeance, confusing the opponent and seeking revenge."
 
 msgid "oedipus"
 msgstr "Oedipus"
 
 msgid "one_million_talons_description"
-msgstr ""
+msgstr "The user unleashes a flurry of rapid, razor-sharp attacks."
 
 msgid "one_million_talons"
 msgstr "One Million Talons"
@@ -1872,13 +1872,13 @@ msgid "one_two"
 msgstr "One-Two"
 
 msgid "orbs_description"
-msgstr "The user undergoes a magical transformation, firing off an energy ball of a random element."
+msgstr "The user fires off an energy ball that causes a mystical transformation in the target."
 
 msgid "orbs"
 msgstr "Orbs"
 
 msgid "overfeed_description"
-msgstr ""
+msgstr "The user overloads the opponent with energy, slowing them down."
 
 msgid "overfeed"
 msgstr "Overfeed"
@@ -1896,109 +1896,109 @@ msgid "panjandrum"
 msgstr "Panjandrum"
 
 msgid "peck_description"
-msgstr ""
+msgstr "The user attacks with a sharp peck from its beak."
 
 msgid "peck"
 msgstr "Peck"
 
 msgid "peregrine_description"
-msgstr ""
+msgstr "The user dives from the sky with incredible speed, delivering a powerful, piercing attack."
 
 msgid "peregrine"
 msgstr "Peregrine"
 
 msgid "perfect_cut_description"
-msgstr ""
+msgstr "The user strikes with surgical precision, leaving no room for error."
 
 msgid "perfect_cut"
 msgstr "Perfect Cut"
 
 msgid "petrify_description"
-msgstr ""
+msgstr "The user emits a powerful aura that renders the opponent stuck."
 
 msgid "petrify"
 msgstr "Petrify"
 
 msgid "phantasmal_force_description"
-msgstr ""
+msgstr "The user creates an illusionary copy of itself that attacks the opponent."
 
 msgid "phantasmal_force"
 msgstr "Phantasmal Force"
 
 msgid "pit_description"
-msgstr ""
+msgstr "The user creates a pit beneath the opponent, causing them to fall and take damage."
 
 msgid "pit"
 msgstr "Pit"
 
 msgid "platinum_description"
-msgstr ""
+msgstr "The user's body becomes infused with a lustrous metal, granting it increased defense and the ability to inflict damage."
 
 msgid "platinum"
 msgstr "Platinum"
 
 msgid "poison_courtship_description"
-msgstr ""
+msgstr "The user emits a seductive aura laces with toxins, charming the opponent while slowly poisoning them."
 
 msgid "poison_courtship"
 msgstr "Poison Courtship"
 
 msgid "proboscis_description"
-msgstr ""
+msgstr "The user extends a long, proboscis-like appendage, draining the opponent's life force while inflicting damage."
 
 msgid "proboscis"
 msgstr "Proboscis"
 
 msgid "pseudopod_description"
-msgstr ""
+msgstr "The user extends a pseudopod to deliver a forceful, sticky blow."
 
 msgid "pseudopod"
 msgstr "Pseudopod"
 
 msgid "punch_description"
-msgstr ""
+msgstr "A classic, powerful strike with the user's fist."
 
 msgid "punch"
 msgstr "Punch"
 
 msgid "quicksand_description"
-msgstr ""
+msgstr "The user creates a treacherous patch of quicksand, trapping and damaging the opponent."
 
 msgid "quicksand"
 msgstr "Quicksand"
 
 msgid "radiance_description"
-msgstr ""
+msgstr "The user emits blinding flash of light, followed by a powerful energy blast."
 
 msgid "radiance"
 msgstr "Radiance"
 
 msgid "ram_description"
-msgstr ""
+msgstr "The user charges forward with incredible force, delivering a devastating physical blow."
 
 msgid "ram"
 msgstr "Ram"
 
 msgid "refresh_description"
-msgstr ""
+msgstr "The user rejuvenates itself, restoring health and entering a state of rapid recovery."
 
 msgid "refresh"
 msgstr "Refresh"
 
 msgid "revenge_stance_description"
-msgstr ""
+msgstr "The user adopts a defensive posture, provoking the opponent into attacking first, while preparing for revenge."
 
 msgid "revenge_stance"
 msgstr "Revenge Stance"
 
 msgid "ring_description"
-msgstr ""
+msgstr "The user conjures a ring that expands, engulfing the opponent."
 
 msgid "ring"
 msgstr "Ring"
 
 msgid "riposte_description"
-msgstr ""
+msgstr "The user assumes a defensive stance, preparing to counter any attack with a swift and powerful retaliation."
 
 msgid "riposte"
 msgstr "Riposte"
@@ -2016,19 +2016,19 @@ msgid "rot"
 msgstr "Rot"
 
 msgid "ruby_description"
-msgstr ""
+msgstr "The user fires a concentrated beam of ruby-like energy, inflicting damage."
 
 msgid "ruby"
 msgstr "Ruby"
 
 msgid "rust_bomb_description"
-msgstr ""
+msgstr "A corrosive projectile that explodes on impact, dealing damage and poisoning the opponent."
 
 msgid "rust_bomb"
 msgstr "Rust Bomb"
 
 msgid "saber_description"
-msgstr ""
+msgstr "The user strikes with a swift and powerful sword-like attack."
 
 msgid "saber"
 msgstr "Saber"
@@ -2040,7 +2040,7 @@ msgid "salamander"
 msgstr "Salamander"
 
 msgid "sand_spray_description"
-msgstr ""
+msgstr "A cloud of abrasive sand is hurled at the opponent, damaging their vision and inflicting damage."
 
 msgid "sand_spray"
 msgstr "Sand Spray"
@@ -2058,19 +2058,19 @@ msgid "shadow_boxing"
 msgstr "Shadow Boxing"
 
 msgid "shapechange_description"
-msgstr ""
+msgstr "The user undergoes a rapid transformation, striking the opponent with a surprising and powerful attack."
 
 msgid "shapechange"
 msgstr "Shapechange"
 
 msgid "shrapnel_description"
-msgstr ""
+msgstr "The user unleashes a barrage of sharp fragments, causing widespread damage."
 
 msgid "shrapnel"
 msgstr "Shrapnel"
 
 msgid "shuriken_description"
-msgstr ""
+msgstr "The user hurls a deadly array of throwing stars, reinforcing its own resolve with each hit."
 
 msgid "shuriken"
 msgstr "Shuriken"
@@ -2082,19 +2082,19 @@ msgid "sleep_bomb"
 msgstr "Sleep Bomb"
 
 msgid "sleeping_powder_description"
-msgstr ""
+msgstr "A cloud of sleep-inducing pollen is released, causing the opponent to fall asleep."
 
 msgid "sleeping_powder"
 msgstr "Sleeping Powder"
 
 msgid "slime_description"
-msgstr ""
+msgstr "A sticky, viscous substance is emitted, engulfing the opponent and dealing damage."
 
 msgid "slime"
 msgstr "Slime"
 
 msgid "snowstorm_description"
-msgstr ""
+msgstr "A blizzard engulfs the opponent, inflicting cold damage and leaving them exhausted."
 
 msgid "snowstorm"
 msgstr "Snowstorm"
@@ -2106,37 +2106,37 @@ msgid "spit_poison"
 msgstr "Spit Poison"
 
 msgid "splinter_description"
-msgstr ""
+msgstr "The user launches a barrage of wooden splinters, blinding and damaging the opponent."
 
 msgid "splinter"
 msgstr "Splinter"
 
 msgid "stabilo_description"
-msgstr ""
+msgstr "The user summons a barrage of sharp wooden splinters that pierce the opponent."
 
 msgid "stabilo"
 msgstr "Stabilo"
 
 msgid "stampede_description"
-msgstr ""
+msgstr "A powerful, overwhelming charge that inflicts heavy physical damage."
 
 msgid "stampede"
 msgstr "Stampede"
 
 msgid "starfall_description"
-msgstr ""
+msgstr "A shower of celestial bodies descends upon the opponent, inflicting damage and granting the user heightened focus while exhausting the opponent."
 
 msgid "starfall"
 msgstr "Starfall"
 
 msgid "static_field_description"
-msgstr ""
+msgstr "The user generates a static electric field around itself, granting it increased defense."
 
 msgid "static_field"
 msgstr "Static Field"
 
 msgid "sting_description"
-msgstr ""
+msgstr "The user inflicts a painful sting, injecting poison into the opponent's body."
 
 msgid "sting"
 msgstr "Sting"
@@ -2148,109 +2148,109 @@ msgid "stone_rot"
 msgstr "Stone Rot"
 
 msgid "stonehenge_description"
-msgstr ""
+msgstr "The user manipulates the earth, creating a ring of stones that crush the opponent."
 
 msgid "stonehenge"
 msgstr "Stonehenge"
 
 msgid "strangulation_description"
-msgstr ""
+msgstr "The user constricts the opponent's throat, cutting off their air supply."
 
 msgid "strangulation"
 msgstr "Strangulation"
 
 msgid "strike_description"
-msgstr ""
+msgstr "The user delivers a powerful, focused blow."
 
 msgid "strike"
 msgstr "Strike"
 
 msgid "suck_poison_description"
-msgstr ""
+msgstr "The user drains the opponent's vitality, inflicting damage and poisoning them."
 
 msgid "suck_poison"
 msgstr "Suck Poison"
 
 msgid "sudden_glow_description"
-msgstr ""
+msgstr "The user emits a radiant light, healing itself and restoring its stamina."
 
 msgid "sudden_glow"
 msgstr "Sudden Glow"
 
 msgid "sunburst_description"
-msgstr ""
+msgstr "The user channels the energy of the sun, unleashing a blindingly bright attack."
 
 msgid "sunburst"
 msgstr "Sunburst"
 
 msgid "supernova_description"
-msgstr ""
+msgstr "A cataclysmic explosion of energy, dealing immense damage to all opponents."
 
 msgid "supernova"
 msgstr "Supernova"
 
 msgid "suplex_description"
-msgstr ""
+msgstr "A powerful grappling move that throws the opponent to the ground, inflicting damage and granting the user increased resilience."
 
 msgid "suplex"
 msgstr "Suplex"
 
 msgid "surf_description"
-msgstr ""
+msgstr "AA massive wave crashes down upon the opponent."
 
 msgid "surf"
 msgstr "Surf"
 
 msgid "surge_description"
-msgstr ""
+msgstr "A powerful electric discharge that shocks the opponent."
 
 msgid "surge"
 msgstr "Surge"
 
 msgid "sword_description"
-msgstr ""
+msgstr "The user wields a sharp blade, delivery a powerful, cutting attack."
 
 msgid "sword"
 msgstr "Sword"
 
 msgid "sylvan_description"
-msgstr ""
+msgstr "The user summons the power of nature, transforming the opponent into a wooden puppet."
 
 msgid "sylvan"
 msgstr "Sylvan"
 
 msgid "take_cover_description"
-msgstr ""
+msgstr "The user assumes a defensive stance, increasing its accuracy."
 
 msgid "take_cover"
 msgstr "Take Cover"
 
 msgid "ten_thousand_feathers_description"
-msgstr ""
+msgstr "A flurry of feathers descends upon the opponent, inflicting multiple hits."
 
 msgid "ten_thousand_feathers"
 msgstr "Ten Thousand Feathers"
 
 msgid "terror_description"
-msgstr ""
+msgstr "The target is shaking with fear, unable to pick up or use items."
 
 msgid "terror"
 msgstr "Terror"
 
 msgid "thunderball_description"
-msgstr ""
+msgstr "With a rumbling like thunder, a hard ball of rock strikes the target."
 
 msgid "thunderball"
 msgstr "Thunderball"
 
 msgid "thunderclap_description"
-msgstr ""
+msgstr "A sudden, deafening clap of thunder that stuns and damages the opponent."
 
 msgid "thunderclap"
 msgstr "Thunderclap"
 
 msgid "time_crisis_description"
-msgstr ""
+msgstr "The user distorts the flow of time, causing the opponent damage."
 
 msgid "time_crisis"
 msgstr "Time Crisis"
@@ -2262,7 +2262,7 @@ msgid "tinder"
 msgstr "Tinder"
 
 msgid "tip_description"
-msgstr ""
+msgstr "The user delivery a swift, precise strike to a vital point."
 
 msgid "tip"
 msgstr "Tip"
@@ -2274,61 +2274,61 @@ msgid "tonguespear"
 msgstr "Tonguespear"
 
 msgid "torch_description"
-msgstr ""
+msgstr "A projectile that strikes the opponent."
 
 msgid "torch"
 msgstr "Torch"
 
 msgid "tsunami_description"
-msgstr ""
+msgstr "The user summons a colossal wave that crashes down upon the opponent."
 
 msgid "tsunami"
 msgstr "Tsunami"
 
 msgid "tux_attack_description"
-msgstr ""
+msgstr "The user transforms into a whirlwind of data, dealing heavy damage."
 
 msgid "tux_attack"
 msgstr "Tux Attack"
 
 msgid "ubuntu_description"
-msgstr ""
+msgstr "The user emits a chaotic energy that randomly alters the opponent's type."
 
 msgid "ubuntu"
 msgstr "Ubuntu"
 
 msgid "undertaker_description"
-msgstr ""
+msgstr "A desperate, self-sacrificing attack that deals a massive damage at the cost of the user's health."
 
 msgid "undertaker"
 msgstr "Undertaker"
 
 msgid "venom_description"
-msgstr ""
+msgstr "The user secretes a corrosive acid that burns the opponent upon contact."
 
 msgid "venom"
 msgstr "Venom"
 
 msgid "venomous_tentacle_description"
-msgstr ""
+msgstr "A poisonous tentacle strikes the opponent, inflicting damage and poisoning them."
 
 msgid "venomous_tentacle"
 msgstr "Venomous Tentacle"
 
 msgid "viper_description"
-msgstr ""
+msgstr "The user launches a volley of sharp, wooden darts with incredible speed and accuracy."
 
 msgid "viper"
 msgstr "Viper"
 
 msgid "vorpal_description"
-msgstr ""
+msgstr "The user unleashes a devastating, precision strike that inflicts severe damage and fills the opponent with a burning desire for revenge."
 
 msgid "vorpal"
 msgstr "Vorpal"
 
 msgid "wall_fire_description"
-msgstr ""
+msgstr "The user conjures a fiery wall that both protects it and scorches the opponent."
 
 msgid "wall_fire"
 msgstr "Wall Fire"
@@ -2340,37 +2340,37 @@ msgid "wall_of_steel"
 msgstr "Wall of Steel"
 
 msgid "wallow_description"
-msgstr ""
+msgstr "The user relaxes in a pool of mud, healing its wounds."
 
 msgid "wallow"
 msgstr "Wallow"
 
 msgid "walls_description"
-msgstr ""
+msgstr "The user constructs sturdy walls of earth or rock to create a defensive barrier."
 
 msgid "walls"
 msgstr "Walls"
 
 msgid "web_description"
-msgstr ""
+msgstr "A sticky web is shot at the opponent, trapping them and inflicting damage."
 
 msgid "web"
 msgstr "Web"
 
 msgid "webs_wind_description"
-msgstr ""
+msgstr "The user creates a swirling vortex of sticky webs that ensnare the opponent, dealing multiple hits and slowing their movement."
 
 msgid "webs_wind"
 msgstr "Webs Wind"
 
 msgid "whirlwind_description"
-msgstr ""
+msgstr "The user creates a powerful vortex of wind that sweeps the opponent away."
 
 msgid "whirlwind"
 msgstr "Whirlwind"
 
 msgid "wing_tip_description"
-msgstr ""
+msgstr "The user delivers a sharp, cutting attack with the tip of its wing."
 
 msgid "wing_tip"
 msgstr "Wing Tip"

--- a/mods/tuxemon/l18n/es_ES/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/es_ES/LC_MESSAGES/base.po
@@ -408,9 +408,6 @@ msgstr "Mirada Fulminante"
 msgid "goad"
 msgstr "Aguijón"
 
-msgid "headbutt"
-msgstr "Cabezazo"
-
 msgid "hibernate"
 msgstr "Hibernar"
 
@@ -4533,9 +4530,6 @@ msgstr "Estrangulación"
 
 msgid "sunburst"
 msgstr "Rayos de Sol"
-
-msgid "sword"
-msgstr "Espada"
 
 msgid "sylvan"
 msgstr "Silvestre"

--- a/mods/tuxemon/l18n/es_ES/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/es_ES/LC_MESSAGES/base.po
@@ -4480,9 +4480,6 @@ msgstr "Lujuria"
 msgid "magma"
 msgstr "Magma"
 
-msgid "maori"
-msgstr "Maorí"
-
 msgid "meltdown"
 msgstr "Fusión"
 

--- a/mods/tuxemon/l18n/es_MX/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/es_MX/LC_MESSAGES/base.po
@@ -3383,9 +3383,6 @@ msgstr "Lujuria"
 msgid "magma"
 msgstr "Magma"
 
-msgid "maori"
-msgstr "Maorí"
-
 msgid "meltdown"
 msgstr "Fusión"
 

--- a/mods/tuxemon/l18n/es_MX/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/es_MX/LC_MESSAGES/base.po
@@ -1415,9 +1415,6 @@ msgstr "Respira Fuego"
 msgid "energy_field"
 msgstr "Campo de Energía"
 
-msgid "headbutt"
-msgstr "Golpe de cabeza"
-
 msgid "ice_claw"
 msgstr "Garra de Hielo"
 
@@ -3436,9 +3433,6 @@ msgstr "Estrangulación"
 
 msgid "sunburst"
 msgstr "Rayos de Sol"
-
-msgid "sword"
-msgstr "Espada"
 
 msgid "sylvan"
 msgstr "Silvestre"

--- a/mods/tuxemon/l18n/fi/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/fi/LC_MESSAGES/base.po
@@ -472,9 +472,6 @@ msgstr "Kimaltaja"
 msgid "goad"
 msgstr "Yllytä"
 
-msgid "headbutt"
-msgstr "Pääpusku"
-
 msgid "hibernate"
 msgstr "Vaivuta"
 

--- a/mods/tuxemon/l18n/fr_FR/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/fr_FR/LC_MESSAGES/base.po
@@ -1557,9 +1557,6 @@ msgstr "Sable mouvant"
 msgid "levitate"
 msgstr "Lévitation"
 
-msgid "headbutt"
-msgstr "Coup de Boule"
-
 msgid "flood"
 msgstr "Inondation"
 
@@ -7549,9 +7546,6 @@ msgstr "Strangulation"
 
 msgid "sunburst"
 msgstr "Éclat Solaire"
-
-msgid "sword"
-msgstr "Épée"
 
 msgid "sylvan"
 msgstr "Sylvestre"

--- a/mods/tuxemon/l18n/fr_FR/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/fr_FR/LC_MESSAGES/base.po
@@ -7640,9 +7640,6 @@ msgstr "Magma"
 msgid "lust"
 msgstr "Luxure"
 
-msgid "maori"
-msgstr "Maori"
-
 msgid "monster_menu_tech"
 msgstr "Techniques"
 

--- a/mods/tuxemon/l18n/it_IT/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/it_IT/LC_MESSAGES/base.po
@@ -358,9 +358,6 @@ msgstr "Occhiata"
 msgid "goad"
 msgstr "Pungolo"
 
-msgid "headbutt"
-msgstr "Testata"
-
 msgid "hibernate"
 msgstr "Ibernazione"
 

--- a/mods/tuxemon/l18n/it_IT/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/it_IT/LC_MESSAGES/base.po
@@ -4770,9 +4770,6 @@ msgstr "Lava"
 msgid "lineage"
 msgstr "Lignaggio"
 
-msgid "maori"
-msgstr "Maori"
-
 msgid "meltdown"
 msgstr "Fusione"
 

--- a/mods/tuxemon/l18n/pl/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/pl/LC_MESSAGES/base.po
@@ -480,9 +480,6 @@ msgstr "Lodowy Pazur"
 msgid "hibernate"
 msgstr "Hibernacja"
 
-msgid "headbutt"
-msgstr "Headbutt"
-
 msgid "spyder_cotton_tuxepediaintro"
 msgstr ""
 "Obecnie, jedyne wiarygodne informacje o tuxemonach pochodzą z drogiej i "

--- a/mods/tuxemon/l18n/pt_BR/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/pt_BR/LC_MESSAGES/base.po
@@ -279,9 +279,6 @@ msgstr "Olhar Ameaçador"
 msgid "goad"
 msgstr "Incitar"
 
-msgid "headbutt"
-msgstr "Cabeçada"
-
 msgid "perfect_cut"
 msgstr "Corte Perfeito"
 
@@ -3384,9 +3381,6 @@ msgstr "Anel"
 
 msgid "ruby"
 msgstr "Rubi"
-
-msgid "sword"
-msgstr "Espada"
 
 msgid "poison_courtship"
 msgstr "Namoro Venenoso"

--- a/mods/tuxemon/l18n/pt_BR/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/pt_BR/LC_MESSAGES/base.po
@@ -3376,9 +3376,6 @@ msgstr "{target} começa a sniffle."
 msgid "lust"
 msgstr "Luxúria"
 
-msgid "maori"
-msgstr "Maori"
-
 msgid "phantasmal_force"
 msgstr "Força Fantasmagórica"
 

--- a/mods/tuxemon/l18n/zh_CN/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/zh_CN/LC_MESSAGES/base.po
@@ -427,9 +427,6 @@ msgstr "热切注视"
 msgid "goad"
 msgstr "刺棒"
 
-msgid "headbutt"
-msgstr "头锤"
-
 msgid "hibernate"
 msgstr "冬眠"
 
@@ -1359,9 +1356,6 @@ msgstr "缠绕"
 
 msgid "sunburst"
 msgstr "旭日子"
-
-msgid "sword"
-msgstr "剑击"
 
 msgid "sylvan"
 msgstr "塞尔万"

--- a/mods/tuxemon/l18n/zh_CN/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/zh_CN/LC_MESSAGES/base.po
@@ -1294,9 +1294,6 @@ msgstr "欲望"
 msgid "magma"
 msgstr "岩浆攻击"
 
-msgid "maori"
-msgstr "毛利语"
-
 msgid "meltdown"
 msgstr "崩溃"
 


### PR DESCRIPTION
PR:
- adds the missing descriptions (techniques);
- removes some empty spaces;
- replaces "maori" with "greenstone" as per Tuxepedia change;

updated as per https://github.com/Tuxemon/Tuxemon/discussions/2268#discussioncomment-10241164
11 descriptions fixed: Earthquake‎, Electroplate‎, Feline‎, Flow‎, Fume, Orbs, Surf‎, Sylvan, Terror, Thunderball‎ and Tsunami