### PR TITLE
fix CATCH_RATE_RANGE constant

### DIFF
--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -154,11 +154,12 @@ class Monster:
         self.height = 0.0
         self.weight = 0.0
 
-        # The multiplier for checks when a monster ball is thrown this should be a value between 0-255 meaning that
-        # 0 is 0% capture rate and 255 has a very good chance of capture. This numbers are based on the capture system
-        # calculations. This is inspired by the calculations which can be found at:
-        # https://bulbapedia.bulbagarden.net/wiki/List_of_Pok%C3%A9mon_by_catch_rate
-        self.catch_rate = 125.0
+        # The multiplier for checks when a monster ball is thrown this should be a value between 0-100 meaning that
+        # 0 is 0% capture rate and 100 has a very good chance of capture. This numbers are based on the capture system
+        # calculations. This was originally inspired by the calculations which can be found at:
+        # https://bulbapedia.bulbagarden.net/wiki/List_of_Pok%C3%A9mon_by_catch_rate, but has been modified to fit with
+        # most people's intuitions.
+        self.catch_rate = 100.0
 
         # The catch_resistance value is calculated during the capture. The upper and lower catch_resistance
         # set the span on which the catch_resistance will be. For more information check capture.py

--- a/tuxemon/prepare.py
+++ b/tuxemon/prepare.py
@@ -218,7 +218,7 @@ MAX_TYPES_BAG: int = 99  # eg 5 capture devices, 1 type and 5 items
 MAX_LEVEL: int = 999
 MAX_MOVES: int = 4
 MISSING_IMAGE: str = "gfx/sprites/battle/missing.png"
-CATCH_RATE_RANGE: tuple[int, int] = (0, 255)
+CATCH_RATE_RANGE: tuple[int, int] = (0, 100)
 CATCH_RESISTANCE_RANGE: tuple[float, float] = (0.0, 2.0)
 # set bond and define range
 BOND: int = 25


### PR DESCRIPTION
After multiple complaints about the difficulty in catching monsters, I decided to dig deeper to find the root of the issue. It wasn't until I wasted some time investigating that I realized the problem wasn't with the monster's stats, but rather with the catch rate calculation itself.

I'd like to propose a modification to adjust the **CATCH_RATE_RANGE** constant from (0,255) to (0,100).

The reason for this adjustment is that the majority of monsters have catch rates equal to or less than 100. By scaling down the range, we can make the catch rate values more representative of the actual capture chances. 

To illustrate the improvement, let's take a look at the graphic (results after 10k simulations):

![Figure_1](https://github.com/user-attachments/assets/d0b74495-63bd-45c6-9bb7-2b33bbb59efe)

Before the catch rate calculation, the probability to capture a wild monster, no matter the level, without modifiers, using a standard Tuxeball, at 5% of its lifespan (e.g., 5/100) was around 0.38 (38%). This is a relatively low capture rate.

Alternatively, we could keep the actual value of 255 and focus on making targeted adjustments to address specific complaints. For example, we could focus on adjusting the catch rates for the infamous monsters found on Route 1 and Route 2, which are notoriously difficult to catch.

Let me know