### PR TITLE
fix combat skip & fix 2340

### DIFF
--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -464,10 +464,10 @@ class CombatState(CombatAnimations):
                 # tracks ai players who need to choose an action
                 for trainer in self.ai_players:
                     for monster in self.monsters_in_play[trainer]:
-                        AI(self, monster, trainer)
                         # recharge opponent moves
                         for tech in monster.moves:
                             tech.recharge()
+                        AI(self, monster, trainer)
 
         elif phase == "action phase":
             self.sort_action_queue()

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -227,7 +227,7 @@ class CombatState(CombatAnimations):
         self._run: bool = False
         self._post_animation_task: Optional[Task] = None
         self._xp_message: Optional[str] = None
-        self._random_tech_hit: float = 0.0
+        self._random_tech_hit: dict[Monster, float] = {}
 
         super().__init__(players, graphics)
         self.is_trainer_battle = combat_type == "trainer"
@@ -453,21 +453,17 @@ class CombatState(CombatAnimations):
 
         elif phase == "decision phase":
             self.reset_status_icons()
-            # saves random value, so we are able to reproduce
-            # inside the condition files if a tech hit or missed
-            value = random.random()
-            self._random_tech_hit = value
             if not self._decision_queue:
-                # tracks human players who need to choose an action
-                for player in self.human_players:
-                    self._decision_queue.extend(self.monsters_in_play[player])
-                # tracks ai players who need to choose an action
-                for trainer in self.ai_players:
-                    for monster in self.monsters_in_play[trainer]:
-                        # recharge opponent moves
-                        for tech in monster.moves:
-                            tech.recharge()
-                        AI(self, monster, trainer)
+                for player in list(self.human_players) + list(self.ai_players):
+                    for monster in self.monsters_in_play[player]:
+                        value = random.random()
+                        self._random_tech_hit[monster] = value
+                        if player in self.human_players:
+                            self._decision_queue.append(monster)
+                        else:
+                            for tech in monster.moves:
+                                tech.recharge()
+                            AI(self, monster, player)
 
         elif phase == "action phase":
             self.sort_action_queue()

--- a/tuxemon/technique/effects/area.py
+++ b/tuxemon/technique/effects/area.py
@@ -33,7 +33,7 @@ class AreaEffect(TechEffect):
         combat = tech.combat_state
         player = user.owner
         assert combat and player
-        value = combat._random_tech_hit
+        value = combat._random_tech_hit.get(user, 0.0)
         hit = tech.accuracy >= value
         if hit:
             tech.advance_counter_success()

--- a/tuxemon/technique/effects/damage.py
+++ b/tuxemon/technique/effects/damage.py
@@ -41,15 +41,14 @@ class DamageEffect(TechEffect):
         self, tech: Technique, user: Monster, target: Monster
     ) -> DamageEffectResult:
         combat = tech.combat_state
-        value = combat._random_tech_hit if combat else 0.0
+        value = combat._random_tech_hit.get(user, 0.0) if combat else 0.0
         hit = tech.accuracy >= value
+        tech.hit = hit
         if hit and not target.out_of_range:
-            tech.hit = True
             tech.advance_counter_success()
             damage, mult = formula.simple_damage_calculate(tech, user, target)
             target.current_hp -= damage
         else:
-            tech.hit = False
             damage = 0
             mult = 1.0
 

--- a/tuxemon/technique/effects/enhance.py
+++ b/tuxemon/technique/effects/enhance.py
@@ -36,18 +36,14 @@ class EnhanceEffect(TechEffect):
     def apply(
         self, tech: Technique, user: Monster, target: Monster
     ) -> EnhanceEffectResult:
-        enhance: bool = False
         combat = tech.combat_state
-        value = combat._random_tech_hit if combat else 0.0
+        value = combat._random_tech_hit.get(user, 0.0) if combat else 0.0
         hit = tech.accuracy >= value
+        tech.hit = hit
         if hit:
-            tech.hit = True
             tech.advance_counter_success()
-            enhance = True
-        else:
-            tech.hit = False
         return {
-            "success": enhance,
+            "success": hit,
             "damage": 0,
             "element_multiplier": 0.0,
             "should_tackle": False,

--- a/tuxemon/technique/effects/give.py
+++ b/tuxemon/technique/effects/give.py
@@ -37,7 +37,7 @@ class GiveEffect(TechEffect):
         player = user.owner
         assert combat and player
         potency = random.random()
-        value = combat._random_tech_hit
+        value = combat._random_tech_hit.get(user, 0.0)
         success = tech.potency >= potency and tech.accuracy >= value
         if success:
             status = Condition()

--- a/tuxemon/technique/effects/healing.py
+++ b/tuxemon/technique/effects/healing.py
@@ -39,8 +39,9 @@ class HealingEffect(TechEffect):
         mon: Monster
         heal: int = 0
         combat = tech.combat_state
-        value = combat._random_tech_hit if combat else 0.0
+        value = combat._random_tech_hit.get(user, 0.0) if combat else 0.0
         hit = tech.accuracy >= value
+        tech.hit = hit
         # define user or target
         if self.objective == "user":
             mon = user
@@ -53,7 +54,6 @@ class HealingEffect(TechEffect):
             heal = (COEFF_DAMAGE + mon.level) * tech.healing_power
         diff = mon.hp - mon.current_hp
         if hit:
-            tech.hit = True
             tech.advance_counter_success()
             if diff > 0:
                 if heal >= diff:
@@ -63,8 +63,6 @@ class HealingEffect(TechEffect):
                 done = True
             else:
                 extra = "combat_full_health"
-        else:
-            tech.hit = False
         return {
             "success": done,
             "damage": 0,

--- a/tuxemon/technique/effects/money.py
+++ b/tuxemon/technique/effects/money.py
@@ -33,18 +33,15 @@ class MoneyEffect(TechEffect):
         self, tech: Technique, user: Monster, target: Monster
     ) -> MoneyEffectResult:
         extra: Optional[str] = None
-        done: bool = False
         player = user.owner
         combat = tech.combat_state
         assert combat and player
-        value = combat._random_tech_hit
+        value = combat._random_tech_hit.get(user, 0.0)
         damage, mult = formula.simple_damage_calculate(tech, user, target)
         hit = tech.accuracy >= value
         if hit:
-            done = True
             user.current_hp -= damage
         else:
-            done = False
             tech.advance_counter_success()
             amount = int(damage * mult)
             recipient = "player" if player.isplayer else player.slug
@@ -54,7 +51,7 @@ class MoneyEffect(TechEffect):
             params = {"name": user.name.upper(), "symbol": "$", "gold": amount}
             extra = T.format("combat_state_gold", params)
         return {
-            "success": done,
+            "success": hit,
             "damage": 0,
             "element_multiplier": 0.0,
             "should_tackle": False,

--- a/tuxemon/technique/effects/multiattack.py
+++ b/tuxemon/technique/effects/multiattack.py
@@ -35,38 +35,33 @@ class MultiAttackEffect(TechEffect):
     def apply(
         self, tech: Technique, user: Monster, target: Monster
     ) -> MultiAttackEffectResult:
-        done: bool = True
-        _track: int = 0
         assert tech.combat_state
         combat = tech.combat_state
         value = random.random()
-        combat._random_tech_hit = value
+        combat._random_tech_hit[user] = value
         log = combat._log_action
         turn = combat._turn
+        # Track previous actions with the same technique, user, and target
         track = [
             action
             for action in log
-            if turn == action[0]
+            if action[0] == turn
             and action[1].method == tech
             and action[1].user == user
             and action[1].target == target
         ]
-        if track:
-            _track = len(track)
-
-        if _track == self.times:
-            done = False
-
-        # check if technique hits
+        # Check if the technique has been used the maximum number of times
+        done = len(track) < self.times
+        # Check if the technique hits
         hit = tech.accuracy >= value
-
+        # If the technique is done and hits, enqueue the action
         if done and hit:
             combat.enqueue_action(user, tech, target)
 
         return {
             "damage": 0,
             "element_multiplier": 0.0,
-            "should_tackle": bool(done),
-            "success": bool(done),
+            "should_tackle": done,
+            "success": done,
             "extra": None,
         }

--- a/tuxemon/technique/effects/prop_damage.py
+++ b/tuxemon/technique/effects/prop_damage.py
@@ -39,15 +39,14 @@ class PropDamageEffect(TechEffect):
         self, tech: Technique, user: Monster, target: Monster
     ) -> PropDamageEffectResult:
         combat = tech.combat_state
-        value = combat._random_tech_hit if combat else 0.0
+        value = combat._random_tech_hit.get(user, 0.0) if combat else 0.0
         hit = tech.accuracy >= value
+        tech.hit = hit
         if hit:
-            tech.hit = True
             tech.advance_counter_success()
             reference_hp = target.hp if self.objective == "target" else user.hp
             target.current_hp -= reference_hp // self.proportional
         else:
-            tech.hit = False
             damage = 0
 
         return {

--- a/tuxemon/technique/effects/remove.py
+++ b/tuxemon/technique/effects/remove.py
@@ -35,7 +35,7 @@ class RemoveEffect(TechEffect):
     ) -> RemoveEffectResult:
         done: bool = False
         combat = tech.combat_state
-        value = combat._random_tech_hit if combat else 0.0
+        value = combat._random_tech_hit.get(user, 0.0) if combat else 0.0
         potency = random.random()
         success = tech.potency >= potency and tech.accuracy >= value
         if success:

--- a/tuxemon/technique/effects/sacrifice.py
+++ b/tuxemon/technique/effects/sacrifice.py
@@ -40,16 +40,15 @@ class SacrificeEffect(TechEffect):
         self, tech: Technique, user: Monster, target: Monster
     ) -> SacrificeEffectResult:
         combat = tech.combat_state
-        value = combat._random_tech_hit if combat else 0.0
+        value = combat._random_tech_hit.get(user, 0.0) if combat else 0.0
         hit = tech.accuracy >= value
+        tech.hit = hit
         if hit:
-            tech.hit = True
             tech.advance_counter_success()
             damage = int(user.current_hp * self.multiplier)
             user.current_hp -= user.current_hp
             target.current_hp -= damage
         else:
-            tech.hit = False
             damage = 0
 
         return {

--- a/tuxemon/technique/effects/splash.py
+++ b/tuxemon/technique/effects/splash.py
@@ -31,15 +31,14 @@ class SplashEffect(TechEffect):
         self, tech: Technique, user: Monster, target: Monster
     ) -> SplashEffectResult:
         combat = tech.combat_state
-        value = combat._random_tech_hit if combat else 0.0
+        value = combat._random_tech_hit.get(user, 0.0) if combat else 0.0
         hit = tech.accuracy >= value
+        tech.hit = hit
         damage, mult = formula.simple_damage_calculate(tech, user, target)
         tech.advance_counter_success()
         if hit:
-            tech.hit = True
             target.current_hp -= damage
         else:
-            tech.hit = True
             damage //= self.divisor
             target.current_hp -= damage
         return {


### PR DESCRIPTION
PR:
- simplifies the **loop** in **combat.py**;
- moves below the **AI()** after the **recharge**;
- turns **_random_tech_hit** into a **dict** and moved inside the **loop**;
- updates all the effects that use **_random_tech_hit** and simplifies some;

I stumbled upon a minor issue while testing a different scenario (Tuxemon battles with only one technique).

During a fight against a wild Pairagrin, I noticed that it couldn't repeat the same technique (Peck) consecutively, instead following a pattern of "Peck" -> "Skip" -> "Peck", and so on.

Curious, I investigated further and discovered that the recharge mechanism was occurring after the AI module, preventing the technique from recharging as expected.

To resolve this issue, I'm going to implement a micro fix that moves the recharge mechanism to occur before the AI module, ensuring that techniques recharge properly and can be used consecutively as intended.

fix #2340 as reported by @ultidonki it confirms the issue that the random was similar for both monsters, so I have implemented a fix, even if I'm thinking about something else, but for now this fix the issue (after #2331 because I don't want to trigger conflicts).

before, same turn:
```
0.15208814455599795 Peck Pairagrin Cataspike
0.15208814455599795 Bullet Cataspike Pairagrin
```

after
```
0.454057320050562 Peck Pairagrin Cataspike
0.11096621957467656 Bullet Cataspike Pairagrin
```