### PR TITLE
improvement combat defs

### DIFF
--- a/tuxemon/combat.py
+++ b/tuxemon/combat.py
@@ -195,12 +195,8 @@ def check_moves(monster: Monster, levels: int) -> Optional[str]:
     """
     techs = monster.update_moves(levels)
     if techs:
-        _techs = ""
-        _monster = monster.name.upper()
-        for tech in techs:
-            _tech = tech.name.upper()
-            _techs += _tech + ", "
-        params = {"name": _monster, "tech": _techs[:-2]}
+        tech_list = ", ".join(tech.name.upper() for tech in techs)
+        params = {"name": monster.name.upper(), "tech": tech_list}
         message = T.format("tuxemon_new_tech", params)
         return message
     return None
@@ -221,19 +217,21 @@ def award_money(loser: Monster, winner: Monster) -> int:
     Returns:
         Amount of money.
     """
-    method: str = "default"
-    # update method
-    if winner.owner and winner.owner.isplayer:
-        trainer = winner.owner
-        method = trainer.game_variables.get("method_money", "default")
+    method = (
+        winner.owner.game_variables.get("method_money", "default")
+        if winner.owner and winner.owner.isplayer
+        else "default"
+    )
 
-    # methods
-    if method == "default":
-        result = loser.level * loser.money_modifier
-        money = int(result)
-    else:
-        raise ValueError(f"A formula for '{method}' doesn't exist.")
-    return money
+    def default_method() -> int:
+        return int(loser.level * loser.money_modifier)
+
+    methods = {"default": default_method}
+
+    if method not in methods:
+        raise ValueError(f"A formula for {method} doesn't exist.")
+
+    return methods[method]()
 
 
 def award_experience(
@@ -254,58 +252,75 @@ def award_experience(
     Returns:
         Amount of experience.
     """
-    # how many loser has been hit
-    hits = len([ele for ele in damages if ele.defense == loser])
-    # how many loser has been hit by the winner
-    hits_mon = len(
-        [
-            ele
-            for ele in damages
-            if ele.defense == loser and ele.attack == winner
-        ]
+    hits = sum(1 for damage in damages if damage.defense == loser)
+    hits_mon = sum(
+        1
+        for damage in damages
+        if damage.defense == loser and damage.attack == winner
     )
-    # all the monsters who hit the loser
-    winners = [ele.attack for ele in damages if ele.defense == loser]
+    winners = [damage.attack for damage in damages if damage.defense == loser]
 
-    method: str = "default"
+    method = (
+        winner.owner.game_variables.get("method_experience", "default")
+        if winner.owner and winner.owner.isplayer
+        else "default"
+    )
+
     exp_tot = float(loser.total_experience)
     exp_mod = float(loser.experience_modifier)
 
-    # update method
-    if winner.owner and winner.owner.isplayer:
-        trainer = winner.owner
-        method = trainer.game_variables.get("method_experience", "default")
+    def default_method() -> int:
+        return int((exp_tot // (loser.level * hits)) * exp_mod)
 
-    # methods
-    if method == "default":
-        result = (exp_tot // (loser.level * hits)) * exp_mod
-        exp = int(result)
-    elif method == "proportional":
-        prop = hits_mon / hits
-        result = (exp_tot // (loser.level * hits)) * exp_mod * prop
-        exp = int(result)
-    elif method == "test":
-        traded = 1.5 if winner.traded else 1.0
-        wild = 1 if loser.money_modifier == 0 else 1.5
-        result = (
+    def proportional_method() -> int:
+        return int(
+            (exp_tot // (loser.level * hits)) * exp_mod * (hits_mon / hits)
+        )
+
+    def test_method() -> int:
+        return int(
             ((exp_tot * loser.level) / 7)
             * 1
             / len(winners)
             * exp_mod
-            * traded
-            * wild
+            * (1.5 if winner.traded else 1.0)
+            * (1 if loser.money_modifier == 0 else 1.5)
         )
-        exp = int(result)
-    elif method == "xp_transmitter" and trainer:
-        alive = alive_party(trainer)
+
+    def xp_transmitter_method() -> int:
+        return distribute_experience(
+            exp_tot, loser.level, hits, exp_mod, winners, winner.owner
+        )
+
+    methods = {
+        "default": default_method,
+        "proportional": proportional_method,
+        "test": test_method,
+        "xp_transmitter": xp_transmitter_method,
+    }
+
+    if method not in methods:
+        raise ValueError(f"A formula for {method} doesn't exist.")
+
+    return methods[method]()
+
+
+def distribute_experience(
+    exp_tot: float,
+    level: int,
+    hits: int,
+    exp_mod: float,
+    winners: list[Monster],
+    owner: Optional[NPC],
+) -> int:
+    if owner:
+        alive = alive_party(owner)
         idle_monsters = list(set(alive).symmetric_difference(winners))
-        result = (exp_tot // (loser.level * hits)) * exp_mod * 1 / len(alive)
-        exp = int(result)
+        exp = int((exp_tot // (level * hits)) * exp_mod * 1 / len(alive))
         for monster in idle_monsters:
             monster.give_experience(exp)
-    else:
-        raise ValueError(f"A formula for '{method}' doesn't exist.")
-    return exp
+        return exp
+    return 0
 
 
 def get_winners(loser: Monster, damages: list[DamageMap]) -> set[Monster]:
@@ -319,20 +334,14 @@ def get_winners(loser: Monster, damages: list[DamageMap]) -> set[Monster]:
     Returns:
         Set of winners.
     """
-    method: str = "default"
-    winners = [ele.attack for ele in damages if ele.defense == loser]
-
-    # update method
-    if winners and winners[0].owner and winners[0].owner.isplayer:
-        trainer = winners[0].owner
-        method = trainer.game_variables.get("method_experience", "default")
-
-    # methods
-    if method == "xp_transmitter":
-        alive = alive_party(trainer)
-        return set(alive)
-    else:
-        return set(winners)
+    winners = {damage.attack for damage in damages if damage.defense == loser}
+    if winners and next(iter(winners)).owner:
+        trainer = next(iter(winners)).owner
+        if trainer and trainer.isplayer:
+            method = trainer.game_variables.get("method_experience", "default")
+            if method == "xp_transmitter":
+                return set(alive_party(trainer))
+    return winners
 
 
 def battlefield(


### PR DESCRIPTION
PR improve some defs:
- check_moves(): this version is more concise and readable, and it uses more efficient and Pythonic ways to manipulate strings;
- award_money(): this version introduces a methods dictionary to map method names, uses lambda to define and it makes it more concise and minor things;
- award_experience(): this version simplifies calculation of hits and hits_mon, introduces a methods dictionary to map method names, uses lambda to define the calculation (more concise) and minor things;
- get_winners(): this version use next() to get a single element from the winners set without modifying it, more efficient and safe ;

waiting a reply on https://github.com/Tuxemon/Tuxemon/discussions/2313#discussioncomment-10265110 so we can update once for all the standard formula for exp

