### PR TITLE
fix pending_queue (combat)

### DIFF
--- a/tuxemon/technique/effects/fly_off.py
+++ b/tuxemon/technique/effects/fly_off.py
@@ -34,28 +34,31 @@ class FlyOffEffect(TechEffect):
     def apply(
         self, tech: Technique, user: Monster, target: Monster
     ) -> FlyOffEffectResult:
-        done = True
+        user_is_flying = False
         combat = tech.combat_state
         assert combat
 
-        # make fly the user
+        # Get the user's sprite
         user_sprite = combat._monster_sprite_map.get(user, None)
         if user_sprite and user_sprite.visible:
+            # Make the user fly
             user_sprite.visible = False
             user.out_of_range = True
-            technique = Technique()
-            technique.load(self.attack)
-            land = EnqueuedAction(user, technique, target)
-            combat._pending_queue.append(land)
+            # Create a new technique to land the user
+            land_technique = Technique()
+            land_technique.load(self.attack)
+            # Add the land action to the pending queue
+            land_action = EnqueuedAction(user, land_technique, target)
+            combat._pending_queue.append(land_action)
         else:
-            # if it's already flying
-            done = False
+            # If the user is already flying, don't do anything
+            user_is_flying = True
 
         params = {"name": user.name.upper()}
         extra = T.format("combat_fly", params)
 
         return {
-            "success": done,
+            "success": not user_is_flying,
             "damage": 0,
             "element_multiplier": 0.0,
             "should_tackle": False,

--- a/tuxemon/technique/effects/land.py
+++ b/tuxemon/technique/effects/land.py
@@ -28,25 +28,28 @@ class LandEffect(TechEffect):
     def apply(
         self, tech: Technique, user: Monster, target: Monster
     ) -> LandEffectResult:
-        done = True
         combat = tech.combat_state
         assert combat
-
-        # make land the user
+        # Check if the user is flying
         user_sprite = combat._monster_sprite_map.get(user, None)
         if user_sprite and not user_sprite.visible:
+            # Make the user land
             user_sprite.visible = True
             user.out_of_range = False
 
-        # check if the enemy isn't flying
+        # Check if the target is flying
         target_sprite = combat._monster_sprite_map.get(target, None)
         if target_sprite and not target_sprite.visible:
-            done = False
+            # If the target is flying, don't tackle
+            target_is_flying = True
+        else:
+            target_is_flying = False
 
+        # Return the result
         return {
-            "success": done,
+            "success": not target_is_flying,
             "damage": 0,
             "element_multiplier": 0.0,
-            "should_tackle": done,
+            "should_tackle": not target_is_flying,
             "extra": None,
         }


### PR DESCRIPTION
after mass testing for #2333 
the issue: monster flies off -> it faints (eg poison) -> it lands -> damage
the issue: monster flies off -> it faints (eg poison) -> nothing else

PR:
- fix **pending_queue** by improving the **loop**;
- removes the **fainted** user or target from the **pending_queue**;
- simplifies both effects related to the pending_queue (fly_off and land);

