### PR TITLE
fix double combat + music in start_battle

### DIFF
--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -1003,7 +1003,6 @@ class NpcTemplateModel(BaseModel):
 class NpcModel(BaseModel):
     slug: str = Field(..., description="Slug of the name of the NPC")
     forfeit: bool = Field(False, description="Whether you can forfeit or not")
-    double: bool = Field(False, description="Whether triggers 2vs2 or not")
     template: NpcTemplateModel
     monsters: Sequence[PartyMemberModel] = Field(
         [], description="List of monsters in the NPCs party"
@@ -1243,6 +1242,7 @@ class TemplateModel(BaseModel):
     slug: str = Field(
         ..., description="Slug uniquely identifying the template"
     )
+    double: bool = Field(False, description="Whether triggers 2vs2 or not")
 
 
 class MissionModel(BaseModel):

--- a/tuxemon/event/actions/start_battle.py
+++ b/tuxemon/event/actions/start_battle.py
@@ -6,7 +6,7 @@ import logging
 from dataclasses import dataclass
 from typing import Optional, final
 
-from tuxemon.combat import alive_party, check_battle_legal
+from tuxemon.combat import check_battle_legal
 from tuxemon.db import db
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
@@ -24,7 +24,7 @@ class StartBattleAction(EventAction):
     Script usage:
         .. code-block::
 
-            start_battle <character1>,<character2>
+            start_battle <character1>,<character2>[,]
 
     Script parameters:
         character1: Either "player" or character slug name (e.g. "npc_maple").
@@ -35,49 +35,52 @@ class StartBattleAction(EventAction):
     name = "start_battle"
     character1: str
     character2: Optional[str] = None
+    music: Optional[str] = None
 
     def start(self) -> None:
-        self.character2 = (
-            "player" if self.character2 is None else self.character2
-        )
+        self.character2 = self.character2 or "player"
+
         character1 = get_npc(self.session, self.character1)
         character2 = get_npc(self.session, self.character2)
-        if not character1:
-            logger.error(f"{self.character1} not found in map")
-            return
-        if not character2:
-            logger.error(f"{self.character2} not found in map")
+
+        if not character1 or not character2:
+            _char = self.character1 if not character1 else self.character2
+            logger.error(f"Character not found in map: {_char}")
             return
 
-        # check the battle is legal
-        if not check_battle_legal(character1) or not check_battle_legal(
-            character2
+        if not (
+            check_battle_legal(character1) and check_battle_legal(character2)
         ):
-            logger.warning("battle is not legal, won't start")
+            logger.warning("Battle is not legal, won't start")
             return
 
-        # default environment
-        env_slug = "grass"
+        # double (2 vs 2)
+        template1 = db.lookup(character1.template.slug, table="template")
+        template2 = db.lookup(character2.template.slug, table="template")
 
-        fighters = [character1, character2]
-        for fighter in fighters:
-            # check and trigger 2 vs 2
-            if fighter.double and len(alive_party(fighter)) > 1:
-                fighter.max_position = 2
-            # check the human
+        if (template1 and template1.double) or (
+            template2 and template2.double
+        ):
+            character1.max_position = 2
+            character2.max_position = 2
+
+        # environment
+        env_slug = "grass"
+        for fighter in [character1, character2]:
             if fighter.isplayer:
                 env_slug = fighter.game_variables.get("environment", "grass")
             else:
-                player = self.session.player
-                env_slug = player.game_variables.get("environment", "grass")
+                env_slug = self.session.player.game_variables.get(
+                    "environment", "grass"
+                )
 
-        # set the environment
         env = db.lookup(env_slug, table="environment")
 
-        # sort the fighters, player first
-        fighters = sorted(fighters, key=lambda x: not x.isplayer)
-
-        # Add our players and setup combat
+        # sort fighters
+        fighters = sorted(
+            [character1, character2], key=lambda x: not x.isplayer
+        )
+        # start the battle
         logger.info(
             f"Starting battle between {fighters[0].name} and {fighters[1].name}!"
         )
@@ -88,9 +91,8 @@ class StartBattleAction(EventAction):
                 graphics=env.battle_graphics,
             )
         )
-
-        # Start some music!
-        filename = env.battle_music
+        # music
+        filename = env.battle_music if not self.music else self.music
         self.session.client.event_engine.execute_action(
             "play_music",
             [filename],

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -135,8 +135,6 @@ class NPC(Entity[NPCState]):
         self.pending_evolutions: list[tuple[Monster, Monster]] = []
         # nr tuxemon fight
         self.max_position: int = 1
-        # triggers fights 2 vs 2
-        self.double: bool = False
         self.speed = 10  # To determine combat order (not related to movement!)
         self.moves: Sequence[Technique] = []  # list of techniques
         self.steps: float = 0.0
@@ -827,7 +825,6 @@ class NPC(Entity[NPCState]):
         # Look up the NPC's details from our NPC database
         npc_details = db.lookup(self.slug, "npc")
         self.forfeit = npc_details.forfeit
-        self.double = npc_details.double
         npc_party = npc_details.monsters
         for npc_monster_details in npc_party:
             # This seems slightly wrong. The only usable element in

--- a/tuxemon/states/combat/combat_animations.py
+++ b/tuxemon/states/combat/combat_animations.py
@@ -789,17 +789,17 @@ class CombatAnimations(ABC, Menu[None]):
         Updates hud (where it appears name, level, etc.).
 
         Parameters:
-            character: Character who needs to update the hud.
-            animate: Whether the hud is animated (slide in) or not.
+            character: The character whose HUD needs to be updated.
+            animate: Whether to animate the HUD update. Defaults to True.
 
         """
-        total = self.monsters_in_play[character]
-        alive = alive_party(character)
-        if total:
-            monster = self.monsters_in_play[character][0]
-            if len(total) > 1 and len(total) == len(alive):
-                monster2 = self.monsters_in_play[character][1]
-                self.build_hud(monster, "hud0", animate)
-                self.build_hud(monster2, "hud1", animate)
-            else:
-                self.build_hud(monster, "hud", animate)
+        monsters = self.monsters_in_play.get(character)
+        if not monsters:
+            return
+
+        alive_members = alive_party(character)
+        if len(monsters) > 1 and len(monsters) <= len(alive_members):
+            self.build_hud(monsters[0], "hud0", animate)
+            self.build_hud(monsters[1], "hud1", animate)
+        else:
+            self.build_hud(monsters[0], "hud", animate)


### PR DESCRIPTION
while working on #2346 I noticed some issues related to the double combat, nothing crash level, but annoying

PR:
- adds the possibility to set a **specific music** for the battle without acting on the JSON, fix #2303 as requested by @Qiangong2 
- moves the **double** component from the NPC to the **template**, in this way it can be immediately loaded (follows #2288)
- updates **start_battle** event action;
- updates **update_hud** in **combat_animation** where it was the issue;
