### PR TITLE
add constants (sound, unit measure, etc.)

### DIFF
--- a/mods/tuxemon/maps/debug.yaml
+++ b/mods/tuxemon/maps/debug.yaml
@@ -1,16 +1,9 @@
 events:
   Scenario:
     actions:
-    - set_money player,0
-    - set_variable unit_measure:Metric
-    - set_variable hemisphere:Northern
-    - set_variable music_volume:0.5
-    - set_variable sound_volume:0.3
-    - set_variable cathedral_ads:0
     - translated_dialog_choice spyder_campaign:xero_campaign,scenario_choice
     conditions:
-    - not variable_set scenario_choice:spyder_campaign
-    - not variable_set scenario_choice:xero_campaign
+    - not variable_set scenario_choice
     type: "event"
   Spyder:
     actions:
@@ -22,11 +15,8 @@ events:
     - set_variable spyder_starting_money:yes
     conditions:
     - is variable_set scenario_choice:spyder_campaign
-    - not variable_set spyder_starting_money:yes
-    - not variable_set gender_choice:gender_male
-    - not variable_set gender_choice:gender_female
-    - not variable_set gender_choice:gender_enby
-    - not variable_set gender_choice:gender_whatever
+    - not variable_set spyder_starting_money
+    - not variable_set gender_choice
     type: "event"
   Xero:
     actions:
@@ -38,11 +28,8 @@ events:
     - set_variable xero_starting_money:yes
     conditions:
     - is variable_set scenario_choice:xero_campaign
-    - not variable_set xero_starting_money:yes
-    - not variable_set gender_choice:gender_male
-    - not variable_set gender_choice:gender_female
-    - not variable_set gender_choice:gender_enby
-    - not variable_set gender_choice:gender_whatever
+    - not variable_set xero_starting_money
+    - not variable_set gender_choice
     type: "event"
   White Male:
     actions:

--- a/tuxemon/audio.py
+++ b/tuxemon/audio.py
@@ -9,6 +9,7 @@ from typing import Optional, Protocol
 import pygame
 from pygame import mixer
 
+from tuxemon import prepare
 from tuxemon.db import db
 from tuxemon.session import local_session
 from tuxemon.tools import transform_resource_filename
@@ -69,11 +70,11 @@ def load_sound(slug: Optional[str], value: Optional[float]) -> SoundProtocol:
     filename = get_sound_filename(slug)
     if filename is None:
         return DummySound()
-    volume: float = 0.3
+    volume = prepare.SOUND_VOLUME
     if value is None:
         if local_session.player:
             player = local_session.player
-            volume = float(player.game_variables["sound_volume"])
+            volume = float(player.game_variables.get("sound_volume", volume))
     else:
         volume = value
     try:

--- a/tuxemon/event/actions/play_music.py
+++ b/tuxemon/event/actions/play_music.py
@@ -48,16 +48,17 @@ class PlayMusicAction(EventAction):
         player = self.session.player
         client = self.session.client
         loop = -1 if self.loop is None else self.loop
-        music_volume = float(player.game_variables["music_volume"])
-        volume: float = 0.0
+        _music = prepare.MUSIC_VOLUME
+        music_volume = float(player.game_variables.get("music_volume", _music))
         if not self.volume:
             volume = music_volume
         else:
-            if 0.0 <= self.volume <= 1.0:
+            lower, upper = prepare.MUSIC_RANGE
+            if lower <= self.volume <= upper:
                 volume = self.volume * music_volume
             else:
                 raise ValueError(
-                    f"{self.volume} must be between 0.0 and 1.0",
+                    f"{self.volume} must be between {lower} and {upper}",
                 )
         try:
             path = prepare.fetch(

--- a/tuxemon/event/actions/play_sound.py
+++ b/tuxemon/event/actions/play_sound.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional, final
 
-from tuxemon import audio
+from tuxemon import audio, prepare
 from tuxemon.event.eventaction import EventAction
 
 
@@ -39,16 +39,17 @@ class PlaySoundAction(EventAction):
 
     def start(self) -> None:
         player = self.session.player
-        sound_volume = float(player.game_variables["sound_volume"])
-        volume: float = 0.0
+        _sound = prepare.SOUND_VOLUME
+        sound_volume = float(player.game_variables.get("sound_volume", _sound))
         if not self.volume:
             volume = sound_volume
         else:
-            if 0.0 <= self.volume <= 1.0:
+            lower, upper = prepare.SOUND_RANGE
+            if lower <= self.volume <= upper:
                 volume = self.volume * sound_volume
             else:
                 raise ValueError(
-                    f"{self.volume} must be between 0.0 and 1.0",
+                    f"{self.volume} must be between {lower} and {upper}",
                 )
         sound = audio.load_sound(self.filename, volume)
         sound.play()

--- a/tuxemon/locale.py
+++ b/tuxemon/locale.py
@@ -216,27 +216,22 @@ def replace_text(session: Session, text: str) -> str:
     text = text.replace("${{name}}", player.name)
     text = text.replace("${{currency}}", "$")
     text = text.replace(r"\n", "\n")
-    text = text.replace("${{money}}", str(player.money["player"]))
+    text = text.replace("${{money}}", str(player.money.get("player", 0)))
     # replace variables
     for key, value in player.game_variables.items():
         text = text.replace("${{var:" + str(key) + "}}", str(value))
     # distance (metric / imperial)
-    if player.game_variables["unit_measure"] == "Metric":
-        text = text.replace("${{length}}", "km")
-        text = text.replace("${{weight}}", "kg")
-        text = text.replace("${{height}}", "cm")
-        text = text.replace(
-            "${{steps}}",
-            str(convert_km(player.steps)),
-        )
+    _unit_measure = player.game_variables.get("unit_measure", prepare.METRIC)
+    if str(_unit_measure) == prepare.METRIC:
+        text = text.replace("${{length}}", prepare.U_KM)
+        text = text.replace("${{weight}}", prepare.U_KG)
+        text = text.replace("${{height}}", prepare.U_CM)
+        text = text.replace("${{steps}}", str(convert_km(player.steps)))
     else:
-        text = text.replace("${{length}}", "mi")
-        text = text.replace("${{weight}}", "lb")
-        text = text.replace("${{height}}", "ft")
-        text = text.replace(
-            "${{steps}}",
-            str(convert_mi(player.steps)),
-        )
+        text = text.replace("${{length}}", prepare.U_MI)
+        text = text.replace("${{weight}}", prepare.U_LB)
+        text = text.replace("${{height}}", prepare.U_FT)
+        text = text.replace("${{steps}}", str(convert_mi(player.steps)))
     # maps
     text = text.replace("${{map_name}}", client.map_name)
     text = text.replace("${{map_desc}}", client.map_desc)

--- a/tuxemon/player.py
+++ b/tuxemon/player.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import datetime as dt
 import logging
 
+from tuxemon import prepare
 from tuxemon.map import proj
 from tuxemon.npc import NPC
 from tuxemon.states.world.worldstate import WorldState
@@ -102,7 +103,8 @@ class Player(NPC):
             var["stage_of_day"] = "night"
 
         # Seasons
-        if var["hemisphere"] == "Northern":
+        hemi = var.get("hemisphere", prepare.NORTHERN)
+        if hemi == prepare.NORTHERN:
             if int(var["day_of_year"]) < 81:
                 var["season"] = "winter"
             elif 81 <= int(var["day_of_year"]) < 173:

--- a/tuxemon/prepare.py
+++ b/tuxemon/prepare.py
@@ -205,6 +205,20 @@ MOVERATE_RANGE: tuple[float, float] = (0.0, 20.0)
 TRANS_TIME: float = 0.3  # transition time
 
 # PC
+METRIC: str = "Metric"
+IMPERIAL: str = "Imperial"
+NORTHERN: str = "Northern"
+SOUTHERN: str = "Southern"
+U_KM: str = "km"
+U_MI: str = "mi"
+U_KG: str = "kg"
+U_LB: str = "lb"
+U_CM: str = "cm"
+U_FT: str = "ft"
+MUSIC_VOLUME: float = 0.5
+MUSIC_RANGE: tuple[float, float] = (0.0, 1.0)
+SOUND_VOLUME: float = 0.2
+SOUND_RANGE: tuple[float, float] = (0.0, 1.0)
 KENNEL: str = "Kennel"
 LOCKER: str = "Locker"
 MAX_KENNEL: int = 30  # nr max of pc monsters

--- a/tuxemon/save_upgrader.py
+++ b/tuxemon/save_upgrader.py
@@ -70,16 +70,6 @@ def upgrade_save(save_data: dict[str, Any]) -> SaveData:
             save_data["game_variables"]["billie_choice"] = random.choice(
                 starter
             )
-    if "cathedral_ads" not in save_data["game_variables"]:
-        save_data["game_variables"]["cathedral_ads"] = 0
-    if "music_volume" not in save_data["game_variables"]:
-        save_data["game_variables"]["music_volume"] = 0.5
-    if "sound_volume" not in save_data["game_variables"]:
-        save_data["game_variables"]["sound_volume"] = 0.2
-    if "unit_measure" not in save_data["game_variables"]:
-        save_data["game_variables"]["unit_measure"] = "Metric"
-    if "hemisphere" not in save_data["game_variables"]:
-        save_data["game_variables"]["hemisphere"] = "Northern"
     if "gender_choice" not in save_data["game_variables"]:
         save_data["game_variables"]["gender_choice"] = "gender_male"
     if "date_start_game" not in save_data["game_variables"]:

--- a/tuxemon/states/character/__init__.py
+++ b/tuxemon/states/character/__init__.py
@@ -105,13 +105,13 @@ class CharacterState(PygameMenuState):
         msg_battles = T.format("player_battles", _msg_battles)
         # steps
         steps = self.char.steps
-        unit = self.char.game_variables.get("unit_measure", "Metric")
-        if unit == "Metric":
+        unit = self.char.game_variables.get("unit_measure", pre.METRIC)
+        if unit == pre.METRIC:
             walked = formula.convert_km(steps)
-            unit_walked = "km"
+            unit_walked = pre.U_KM
         else:
             walked = formula.convert_mi(steps)
-            unit_walked = "mi"
+            unit_walked = pre.U_MI
         _msg_walked = {"distance": str(walked), "unit": unit_walked}
         msg_walked = T.format("player_walked", _msg_walked)
         # name

--- a/tuxemon/states/control/__init__.py
+++ b/tuxemon/states/control/__init__.py
@@ -28,11 +28,6 @@ from tuxemon.state import State
 tuxe_config = config.TuxemonConfig(paths.USER_CONFIG_PATH)
 pre_config = prepare.CONFIG
 
-METRIC = "Metric"
-IMPERIAL = "Imperial"
-NORTHERN = "Northern"
-SOUTHERN = "Southern"
-
 
 class SetKeyState(PygameMenuState):
     """
@@ -215,25 +210,24 @@ class ControlState(PygameMenuState):
             font_size=self.font_size_small,
         )
 
-        default_music: int = 50
-        default_sound: int = 20
-        default_unit: int = 0
-        default_hemi: int = 0
+        default_music = prepare.MUSIC_VOLUME
+        default_sound = prepare.SOUND_VOLUME
+        _unit: int = 0
+        _hemi: int = 0
         if player:
-            default_music = int(
-                float(player.game_variables["music_volume"]) * 100
-            )
-            default_sound = int(
-                float(player.game_variables["sound_volume"]) * 100
-            )
-            if player.game_variables["unit_measure"] == METRIC:
-                default_unit = 0
-            elif player.game_variables["unit_measure"] == IMPERIAL:
-                default_unit = 1
-            if player.game_variables["hemisphere"] == NORTHERN:
-                default_hemi = 0
-            elif player.game_variables["hemisphere"] == SOUTHERN:
-                default_hemi = 1
+            _music = player.game_variables.get("music_volume", default_music)
+            default_music = int(float(_music) * 100)
+            _sound = player.game_variables.get("sound_volume", default_sound)
+            default_sound = int(float(_sound) * 100)
+
+            unit = player.game_variables.get("unit_measure", prepare.METRIC)
+            _unit = 0 if str(unit) == prepare.METRIC else 1
+
+            hemi = player.game_variables.get("hemisphere", prepare.NORTHERN)
+            _hemi = 0 if str(hemi) == prepare.NORTHERN else 1
+        else:
+            default_music *= 100
+            default_sound *= 100
 
         music = menu.add.range_slider(
             title=T.translate("menu_music_volume").upper(),
@@ -286,7 +280,7 @@ class ControlState(PygameMenuState):
             title=T.translate("menu_units").upper(),
             items=units,
             selector_id="unit",
-            default=default_unit,
+            default=_unit,
             style="fancy",
             onchange=on_change_units,
             font_size=self.font_size_small,
@@ -307,7 +301,7 @@ class ControlState(PygameMenuState):
             title=T.translate("menu_hemisphere").upper(),
             items=hemispheres,
             selector_id="hemisphere",
-            default=default_hemi,
+            default=_hemi,
             style="fancy",
             onchange=on_change_hemisphere,
             font_size=self.font_size_small,

--- a/tuxemon/states/journal/journal_info.py
+++ b/tuxemon/states/journal/journal_info.py
@@ -47,17 +47,18 @@ class JournalInfoState(PygameMenuState):
         # types
         types = " ".join(map(lambda s: T.translate(s.name), monster.types))
         # weight and height
-        unit = local_session.player.game_variables["unit_measure"]
-        if unit == "Metric":
+        player = local_session.player
+        unit = player.game_variables.get("unit_measure", prepare.METRIC)
+        if unit == prepare.METRIC:
             mon_weight = monster.weight
             mon_height = monster.height
-            unit_weight = "kg"
-            unit_height = "cm"
+            unit_weight = prepare.U_KG
+            unit_height = prepare.U_CM
         else:
             mon_weight = formula.convert_lbs(monster.weight)
             mon_height = formula.convert_ft(monster.height)
-            unit_weight = "lb"
-            unit_height = "ft"
+            unit_weight = prepare.U_LB
+            unit_height = prepare.U_FT
         # name
         menu._auto_centering = False
         name = T.translate(monster.slug).upper()

--- a/tuxemon/states/monster_info/__init__.py
+++ b/tuxemon/states/monster_info/__init__.py
@@ -74,17 +74,18 @@ class MonsterInfoState(PygameMenuState):
         results = db.lookup(monster.slug, table="monster")
         diff_weight = formula.diff_percentage(monster.weight, results.weight)
         diff_height = formula.diff_percentage(monster.height, results.height)
-        unit = local_session.player.game_variables["unit_measure"]
-        if unit == "Metric":
+        player = local_session.player
+        unit = player.game_variables.get("unit_measure", prepare.METRIC)
+        if unit == prepare.METRIC:
             mon_weight = monster.weight
             mon_height = monster.height
-            unit_weight = "kg"
-            unit_height = "cm"
+            unit_weight = prepare.U_KG
+            unit_height = prepare.U_CM
         else:
             mon_weight = formula.convert_lbs(monster.weight)
             mon_height = formula.convert_ft(monster.height)
-            unit_weight = "lb"
-            unit_height = "ft"
+            unit_weight = prepare.U_LB
+            unit_height = prepare.U_FT
         # name
         menu._auto_centering = False
         lab1: Any = menu.add.label(

--- a/tuxemon/states/party/__init__.py
+++ b/tuxemon/states/party/__init__.py
@@ -149,13 +149,13 @@ class PartyState(PygameMenuState):
             _sorted = sorted(monsters, key=lambda x: x.steps, reverse=True)
             for monster in _sorted:
                 steps = monster.steps
-                unit = game_variables["unit_measure"]
-                if unit == "Metric":
+                unit = game_variables.get("unit_measure", prepare.METRIC)
+                if unit == prepare.METRIC:
                     walked = formula.convert_km(steps)
-                    unit_walked = "km"
+                    unit_walked = prepare.U_KM
                 else:
                     walked = formula.convert_mi(steps)
-                    unit_walked = "mi"
+                    unit_walked = prepare.U_MI
                 # labels
                 params = {
                     "name": monster.name.upper(),


### PR DESCRIPTION
split from #2242 (too messy)

PR:
- uses get to get the amount of player's money (in this case if it's None, then it doesn't crash);
- new values are added in **prepare.py** (**music**, **sound**, **unit_measure** and **hemisphere**);
- removes a series of variable from the **debug.yaml**, because (1) now these have a default value, (2) these can be overwritten in game (control menu and/or set_variable) ;- some **game_variables** will **get** the **value** with the **default value** as backup;
- **cathedral_ads** is removed from **save_upgrade**, this has already been purged in separated PRs: #2253 (Spyder) and #2266 (Xero);
- sound operations will continue in #2280