### PR TITLE
fix run attempts

### DIFF
--- a/tuxemon/technique/effects/run.py
+++ b/tuxemon/technique/effects/run.py
@@ -63,7 +63,7 @@ class RunEffect(TechEffect):
             target,
             attempts,
         ):
-            game_variables["run_attempts"] = attempts + 1
+            game_variables["run_attempts"] = 0
             ran = True
 
         # Trigger the run effect
@@ -75,6 +75,8 @@ class RunEffect(TechEffect):
                 combat.clean_combat()
                 del combat.monsters_in_play[remove]
                 combat.players.remove(remove)
+        else:
+            game_variables["run_attempts"] = attempts + 1
 
         return {
             "success": ran,


### PR DESCRIPTION
PR fixes #2355 
hoping this time I understood correctly, if the PC escape a  battle with a wild monster, then the counter resets, otherwise the counter keep increasing each failed attempt

waiting reply from @Sanglorian if renaming it


```
    def default_method() -> bool:
        if target.level > user.level:
            return False
        elif target.level < user.level:
            return True
        else:
            return random.random() >= 0.5
```