### PR TITLE
fix day cycle (Sypder)

### DIFF
--- a/mods/tuxemon/maps/spyder.yaml
+++ b/mods/tuxemon/maps/spyder.yaml
@@ -236,6 +236,14 @@ events:
     - is location_inside
     - not check_world layer,255:255:255:0
     type: "event"
+  Day Cycle Outside:
+    actions:
+    - set_layer
+    conditions:
+    - not variable_set stage_of_day:night
+    - not location_inside
+    - is check_world layer,0:0:128:128
+    type: "event"
   Phone GPS Leather:
     actions:
     - set_variable nu_map_1:leather_town*0.20*0.42


### PR DESCRIPTION
PR fixes a bug related to the Spyder scenario
the bug: if the player saved the game in the night and loaded it the next morning, then it was still dark (night)