### PR TITLE
post talk (Spyder)

### DIFF
--- a/mods/tuxemon/maps/cotton_underground.tmx
+++ b/mods/tuxemon/maps/cotton_underground.tmx
@@ -69,7 +69,7 @@
   <object id="291" type="collision" x="352" y="208" width="32" height="48"/>
   <object id="292" type="collision" x="160" y="224" width="16" height="16"/>
   <object id="293" type="collision" x="144" y="240" width="16" height="16"/>
-  <object id="294" type="collision" x="400" y="16.3333" width="48" height="16"/>
+  <object id="294" type="collision" x="400" y="16" width="48" height="16"/>
   <object id="295" type="collision" x="384" y="0" width="16" height="16"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="5" name="Events">

--- a/mods/tuxemon/maps/omnichannel0.tmx
+++ b/mods/tuxemon/maps/omnichannel0.tmx
@@ -24,8 +24,8 @@
   <object id="1" type="collision" x="0" y="0" width="16" height="336"/>
   <object id="2" type="collision" x="16" y="0" width="208" height="16"/>
   <object id="4" type="collision" x="208" y="16" width="16" height="320"/>
-  <object id="5" type="collision" x="80.3333" y="47.6667" width="16" height="112"/>
-  <object id="6" type="collision" x="95.6667" y="127.667" width="112" height="32"/>
+  <object id="5" type="collision" x="80" y="48" width="16" height="112"/>
+  <object id="6" type="collision" x="96" y="128" width="112" height="32"/>
   <object id="7" type="collision" x="96" y="48" width="80" height="32"/>
   <object id="8" type="collision" x="16" y="96" width="48" height="48"/>
   <object id="9" type="collision" x="48" y="144" width="16" height="16"/>

--- a/mods/tuxemon/maps/spyder_candy_hospital1.tmx
+++ b/mods/tuxemon/maps/spyder_candy_hospital1.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="11" nextobjectid="99">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="11" nextobjectid="105">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -288,6 +288,48 @@
     <property name="act4" value="quarantine out,1"/>
     <property name="behav1" value="talk spyder_hospital1_smith"/>
     <property name="cond1" value="not variable_set quarantine_garvan:yes"/>
+   </properties>
+  </object>
+  <object id="99" name="Talk Felu" type="event" x="48" y="256" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_hospital1_felu2"/>
+    <property name="behav1" value="talk spyder_hospital1_felu"/>
+    <property name="cond1" value="is variable_set hospital1felu:yes"/>
+   </properties>
+  </object>
+  <object id="100" name="Post Talk Fring" type="event" x="32" y="96" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_hospital1_fring2"/>
+    <property name="behav1" value="talk spyder_hospital1_fring"/>
+    <property name="cond1" value="is variable_set hospital1fring:yes"/>
+   </properties>
+  </object>
+  <object id="101" name="Post Talk Aurora" type="event" x="48" y="160" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_hospital1_aurora2"/>
+    <property name="behav1" value="talk spyder_hospital1_aurora"/>
+    <property name="cond1" value="is variable_set hospital1aurora:yes"/>
+   </properties>
+  </object>
+  <object id="102" name="Post Talk Eleni" type="event" x="256" y="160" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_hospital1_eleni2"/>
+    <property name="behav1" value="talk spyder_hospital1_eleni"/>
+    <property name="cond1" value="is variable_set hospital1eleni:yes"/>
+   </properties>
+  </object>
+  <object id="103" name="Post Talk Liane" type="event" x="256" y="224" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_hospital1_liane2"/>
+    <property name="behav1" value="talk spyder_hospital1_liane"/>
+    <property name="cond1" value="is variable_set hospital1liane:yes"/>
+   </properties>
+  </object>
+  <object id="104" name="Post Talk Walt" type="event" x="272" y="96" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_hospital1_walt2"/>
+    <property name="behav1" value="talk spyder_hospital1_walt"/>
+    <property name="cond1" value="is variable_set hospital1walt:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_candy_hospital2.tmx
+++ b/mods/tuxemon/maps/spyder_candy_hospital2.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="11" nextobjectid="111">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="11" nextobjectid="115">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -249,6 +249,34 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_hospital2_nurse1"/>
     <property name="behav1" value="talk spyder_hospital1_melanie"/>
+   </properties>
+  </object>
+  <object id="111" name="Post Talk Zekar" type="event" x="48" y="224" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_hospital1_zekar2"/>
+    <property name="behav1" value="talk spyder_hospital1_zekar"/>
+    <property name="cond1" value="is variable_set hospital1zekar:yes"/>
+   </properties>
+  </object>
+  <object id="112" name="Post Talk Rakez" type="event" x="32" y="96" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_hospital1_rakez2"/>
+    <property name="behav1" value="talk spyder_hospital1_rakez"/>
+    <property name="cond1" value="is variable_set hospital1rakez:yes"/>
+   </properties>
+  </object>
+  <object id="113" name="Post Talk Luzia" type="event" x="176" y="96" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_hospital1_luzia2"/>
+    <property name="behav1" value="talk spyder_hospital1_luzia"/>
+    <property name="cond1" value="is variable_set hospital1luzia:yes"/>
+   </properties>
+  </object>
+  <object id="114" name="Post Talk Rhizome" type="event" x="256" y="96" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_hospital1_rhizome2"/>
+    <property name="behav1" value="talk spyder_hospital1_rhizome"/>
+    <property name="cond1" value="is variable_set hospital1rhizome:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_candy_town.tmx
+++ b/mods/tuxemon/maps/spyder_candy_town.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="445">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="445">
  <properties>
   <property name="east" value="routec"/>
   <property name="edges" value="clamped"/>

--- a/mods/tuxemon/maps/spyder_citypark.tmx
+++ b/mods/tuxemon/maps/spyder_citypark.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="293">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="296">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="spyder"/>
@@ -585,6 +585,27 @@
     <property name="act2" value="set_monster_health"/>
     <property name="act3" value="set_monster_status"/>
     <property name="behav1" value="talk spyder_citypark_nurse"/>
+   </properties>
+  </object>
+  <object id="293" name="Post Talk Bobette" type="event" x="256" y="224" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_citypark_bobette2"/>
+    <property name="behav1" value="talk spyder_citypark_bobette"/>
+    <property name="cond1" value="is variable_set citypark_bobette:yes"/>
+   </properties>
+  </object>
+  <object id="294" name="Post Talk Frances" type="event" x="448" y="352" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_citypark_frances2"/>
+    <property name="behav1" value="talk spyder_citypark_frances"/>
+    <property name="cond1" value="is variable_set citypark_frances:yes"/>
+   </properties>
+  </object>
+  <object id="295" name="Post Talk Edith" type="event" x="624" y="272" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_citypark_edith2"/>
+    <property name="behav1" value="talk spyder_citypark_edith"/>
+    <property name="cond1" value="is variable_set citypark_edith:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_cotton_tunnel.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_tunnel.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="104">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="105">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -281,6 +281,14 @@
     <property name="act2" value="char_face player,down"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,up"/>
+   </properties>
+  </object>
+  <object id="104" name="Post Talk Carlos" type="event" x="608" y="208" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_cottontunnel_carlos2"/>
+    <property name="behav1" value="talk spyder_cottontunnel_carlos"/>
+    <property name="cond1" value="is variable_set cottontunnelcarlos:yes"/>
+    <property name="cond2" value="is variable_set dragonscavedrokoro:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_datacenter.tmx
+++ b/mods/tuxemon/maps/spyder_datacenter.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="11" nextobjectid="118">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="11" nextobjectid="123">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -487,6 +487,41 @@
     <property name="act99" value="unlock_controls"/>
     <property name="cond1" value="not variable_set datacenterbillie:yes"/>
     <property name="cond2" value="is variable_set kernelquest:done"/>
+   </properties>
+  </object>
+  <object id="118" name="Talk Lagrange" type="event" x="48" y="80" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_datacenter_lagrange2"/>
+    <property name="behav1" value="talk spyder_datacenter_lagrange"/>
+    <property name="cond1" value="is variable_set datacenterlagrange:yes"/>
+   </properties>
+  </object>
+  <object id="119" name="Talk Chomsky" type="event" x="144" y="80" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_datacenter_chomsky2"/>
+    <property name="behav1" value="talk spyder_datacenter_chomsky"/>
+    <property name="cond1" value="is variable_set datacenterchomsky:yes"/>
+   </properties>
+  </object>
+  <object id="120" name="Talk Bayliss" type="event" x="208" y="80" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_datacenter_bayliss2"/>
+    <property name="behav1" value="talk spyder_datacenter_bayliss"/>
+    <property name="cond1" value="is variable_set datacenterbayliss:yes"/>
+   </properties>
+  </object>
+  <object id="121" name="Talk Fermi" type="event" x="144" y="240" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_datacenter_fermi2"/>
+    <property name="behav1" value="talk spyder_datacenter_fermi"/>
+    <property name="cond1" value="is variable_set datacenterfermi:yes"/>
+   </properties>
+  </object>
+  <object id="122" name="Talk Onnes" type="event" x="208" y="240" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_datacenter_onnes2"/>
+    <property name="behav1" value="talk spyder_datacenter_onnes"/>
+    <property name="cond1" value="is variable_set datacenteronnes:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_dojo2.tmx
+++ b/mods/tuxemon/maps/spyder_dojo2.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="24" height="12" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="32">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="24" height="12" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="39">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -257,6 +257,41 @@
     <property name="cond5" value="is variable_set dojosokka:yes"/>
     <property name="cond6" value="is variable_set dojotoph:yes"/>
     <property name="cond7" value="not variable_set dojowan:yes"/>
+   </properties>
+  </object>
+  <object id="33" name="Post Talk Iroh" type="event" x="128" y="16" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_dojo_iroh2"/>
+    <property name="behav1" value="talk spyder_dojo_iroh"/>
+    <property name="cond1" value="is variable_set dojoiroh:yes"/>
+   </properties>
+  </object>
+  <object id="34" name="Post Talk Yangchen" type="event" x="144" y="16" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_dojo_yangchen2"/>
+    <property name="behav1" value="talk spyder_dojo_yangchen"/>
+    <property name="cond1" value="is variable_set dojoyangchen:yes"/>
+   </properties>
+  </object>
+  <object id="35" name="Post Talk Kataro" type="event" x="160" y="16" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_dojo_kataro2"/>
+    <property name="behav1" value="talk spyder_dojo_kataro"/>
+    <property name="cond1" value="is variable_set dojokataro:yes"/>
+   </properties>
+  </object>
+  <object id="36" name="Post Talk Sokka" type="event" x="176" y="16" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_dojo_sokka2"/>
+    <property name="behav1" value="talk spyder_dojo_sokka"/>
+    <property name="cond1" value="is variable_set dojosokka:yes"/>
+   </properties>
+  </object>
+  <object id="37" name="Post Talk Toph" type="event" x="192" y="16" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_dojo_toph2"/>
+    <property name="behav1" value="talk spyder_dojo_toph"/>
+    <property name="cond1" value="is variable_set dojotoph:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_dojo3.tmx
+++ b/mods/tuxemon/maps/spyder_dojo3.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="24" height="12" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="32">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="24" height="12" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="37">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -249,6 +249,41 @@
     <property name="cond5" value="is variable_set dojoorion:yes"/>
     <property name="cond6" value="is variable_set dojoares:yes"/>
     <property name="cond7" value="not variable_set dojotu:yes"/>
+   </properties>
+  </object>
+  <object id="32" name="Post Talk Saturn" type="event" x="128" y="16" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_dojo_saturn2"/>
+    <property name="behav1" value="talk spyder_dojo_saturn"/>
+    <property name="cond1" value="is variable_set dojosaturn:yes"/>
+   </properties>
+  </object>
+  <object id="33" name="Post Talk Hephastus" type="event" x="144" y="16" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_dojo_hephastus2"/>
+    <property name="behav1" value="talk spyder_dojo_hephastus"/>
+    <property name="cond1" value="is variable_set dojohephastus:yes"/>
+   </properties>
+  </object>
+  <object id="34" name="Post Talk Hermes" type="event" x="160" y="16" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_dojo_hermes2"/>
+    <property name="behav1" value="talk spyder_dojo_hermes"/>
+    <property name="cond1" value="is variable_set dojohermes:yes"/>
+   </properties>
+  </object>
+  <object id="35" name="Post Talk Orion" type="event" x="176" y="16" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_dojo_orion2"/>
+    <property name="behav1" value="talk spyder_dojo_orion"/>
+    <property name="cond1" value="is variable_set dojoorion:yes"/>
+   </properties>
+  </object>
+  <object id="36" name="Post Talk Ares" type="event" x="192" y="16" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_dojo_ares2"/>
+    <property name="behav1" value="talk spyder_dojo_ares"/>
+    <property name="cond1" value="is variable_set dojoares:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_dragonscave.tmx
+++ b/mods/tuxemon/maps/spyder_dragonscave.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="106">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="111">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -483,6 +483,41 @@
     <property name="act1" value="random_encounter dragonscave,0.6"/>
     <property name="cond1" value="not variable_set dragonscavebenden:yes"/>
     <property name="cond2" value="is check_char_parameter player,moving,1"/>
+   </properties>
+  </object>
+  <object id="106" name="Post Talk Cailin" type="event" x="176" y="528" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_dragonscave_cailin2"/>
+    <property name="behav1" value="talk spyder_dragonscave_cailin"/>
+    <property name="cond1" value="is variable_set dragonscavecailin:yes"/>
+   </properties>
+  </object>
+  <object id="107" name="Post Talk Daenny" type="event" x="192" y="528" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_dragonscave_daenny2"/>
+    <property name="behav1" value="talk spyder_dragonscave_daenny"/>
+    <property name="cond1" value="is variable_set dragonscavedaenny:yes"/>
+   </properties>
+  </object>
+  <object id="108" name="Post Talk Tomas" type="event" x="176" y="544" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_dragonscave_tomas2"/>
+    <property name="behav1" value="talk spyder_dragonscave_tomas"/>
+    <property name="cond1" value="is variable_set dragonscavetomas:yes"/>
+   </properties>
+  </object>
+  <object id="109" name="Post Talk Griffin" type="event" x="192" y="544" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_dragonscave_griffin2"/>
+    <property name="behav1" value="talk spyder_dragonscave_griffin"/>
+    <property name="cond1" value="is variable_set dragonscavegriffin:yes"/>
+   </properties>
+  </object>
+  <object id="110" name="Post Talk Lessa" type="event" x="208" y="528" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_dragonscave_lessa2"/>
+    <property name="behav1" value="talk spyder_dragonscave_lessa"/>
+    <property name="cond1" value="is variable_set dragonscavelessa:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_greenwash.tmx
+++ b/mods/tuxemon/maps/spyder_greenwash.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="16" height="32" tilewidth="16" tileheight="16" infinite="0" nextlayerid="11" nextobjectid="89">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="16" height="32" tilewidth="16" tileheight="16" infinite="0" nextlayerid="11" nextobjectid="95">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -54,10 +54,7 @@
   <object id="61" type="collision" x="16" y="176" width="80" height="16"/>
   <object id="62" type="collision" x="224" y="336" width="16" height="16"/>
   <object id="63" type="collision" x="224" y="288" width="16" height="16"/>
-  <object id="64" type="collision" x="32" y="272" width="32" height="16"/>
-  <object id="65" type="collision-line" x="16" y="288">
-   <polyline points="0,0 16,0"/>
-  </object>
+  <object id="64" type="collision" x="16" y="272" width="48" height="16"/>
   <object id="66" type="collision-line" x="16" y="96">
    <polyline points="0,0 16,0"/>
   </object>
@@ -226,6 +223,48 @@
     <property name="act6" value="set_variable greenwashmorehouse:yes"/>
     <property name="cond1" value="not variable_set greenwashmorehouse:yes"/>
     <property name="cond2" value="is char_at player"/>
+   </properties>
+  </object>
+  <object id="89" name="Post Talk Broer" type="event" x="160" y="96" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_greenwash_broer2"/>
+    <property name="behav1" value="talk spyder_greenwash_broer"/>
+    <property name="cond1" value="is variable_set greenwashbroer:yes"/>
+   </properties>
+  </object>
+  <object id="90" name="Post Talk Clarence" type="event" x="176" y="112" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_greenwash_clarence2"/>
+    <property name="behav1" value="talk spyder_greenwash_clarence"/>
+    <property name="cond1" value="is variable_set greenwashclarence:yes"/>
+   </properties>
+  </object>
+  <object id="91" name="Post Talk Lewie" type="event" x="144" y="176" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_greenwash_lewie2"/>
+    <property name="behav1" value="talk spyder_greenwash_lewie"/>
+    <property name="cond1" value="is variable_set greenwashlewie:yes"/>
+   </properties>
+  </object>
+  <object id="92" name="Post Talk Chip" type="event" x="96" y="272" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_greenwash_chip2"/>
+    <property name="behav1" value="talk spyder_greenwash_chip"/>
+    <property name="cond1" value="is variable_set greenwashchip:yes"/>
+   </properties>
+  </object>
+  <object id="93" name="Post Talk Morehouse" type="event" x="144" y="304" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_greenwash_morehouse2"/>
+    <property name="behav1" value="talk spyder_greenwash_morehouse"/>
+    <property name="cond1" value="is variable_set greenwashmorehouse:yes"/>
+   </properties>
+  </object>
+  <object id="94" name="Post Talk Looten" type="event" x="144" y="480" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_greenwash_looten4"/>
+    <property name="behav1" value="talk spyder_greenwash_looten"/>
+    <property name="cond1" value="is variable_set gotaardant:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_greenwash_greenhouse.tmx
+++ b/mods/tuxemon/maps/spyder_greenwash_greenhouse.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="32" height="16" tilewidth="16" tileheight="16" infinite="0" nextlayerid="12" nextobjectid="109">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="32" height="16" tilewidth="16" tileheight="16" infinite="0" nextlayerid="12" nextobjectid="115">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -371,6 +371,48 @@
     <property name="act6" value="set_variable greenwashgluck:yes"/>
     <property name="cond1" value="not variable_set greenwashgluck:yes"/>
     <property name="cond2" value="is char_at player"/>
+   </properties>
+  </object>
+  <object id="109" name="Post Talk Alex" type="event" x="144" y="208" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_greenwash_alex2"/>
+    <property name="behav1" value="talk spyder_greenwash_alex"/>
+    <property name="cond1" value="is variable_set greenwashalex:yes"/>
+   </properties>
+  </object>
+  <object id="110" name="Post Talk Louis" type="event" x="144" y="32" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_greenwash_louis2"/>
+    <property name="behav1" value="talk spyder_greenwash_louis"/>
+    <property name="cond1" value="is variable_set greenwashlouis:yes"/>
+   </properties>
+  </object>
+  <object id="111" name="Post Talk Lewis" type="event" x="256" y="128" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_greenwash_lewis2"/>
+    <property name="behav1" value="talk spyder_greenwash_lewis"/>
+    <property name="cond1" value="is variable_set greenwashlewis:yes"/>
+   </properties>
+  </object>
+  <object id="112" name="Post Talk Hunt" type="event" x="304" y="176" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_greenwash_hunt2"/>
+    <property name="behav1" value="talk spyder_greenwash_hunt"/>
+    <property name="cond1" value="is variable_set greenwashhunt:yes"/>
+   </properties>
+  </object>
+  <object id="113" name="Post Talk Gluck" type="event" x="448" y="176" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_greenwash_gluck2"/>
+    <property name="behav1" value="talk spyder_greenwash_gluck"/>
+    <property name="cond1" value="is variable_set greenwashgluck:yes"/>
+   </properties>
+  </object>
+  <object id="114" name="Post Talk Gregor" type="event" x="352" y="16" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_greenwash_gregor2"/>
+    <property name="behav1" value="talk spyder_greenwash_gregor"/>
+    <property name="cond1" value="is variable_set greenwashgregor:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_greenwash_level2.tmx
+++ b/mods/tuxemon/maps/spyder_greenwash_level2.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="16" height="32" tilewidth="16" tileheight="16" infinite="0" nextlayerid="13" nextobjectid="122">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="16" height="32" tilewidth="16" tileheight="16" infinite="0" nextlayerid="13" nextobjectid="127">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -290,6 +290,41 @@
     <property name="act6" value="set_variable got_both_fossils:yes"/>
     <property name="cond1" value="is variable_set both_fossils:yes"/>
     <property name="cond2" value="not variable_set got_both_fossils:yes"/>
+   </properties>
+  </object>
+  <object id="122" name="Post Talk Moreau" type="event" x="192" y="400" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_greenwash_moreau2"/>
+    <property name="behav1" value="talk spyder_greenwash_moreau"/>
+    <property name="cond1" value="is variable_set greenwashmoreau:yes"/>
+   </properties>
+  </object>
+  <object id="123" name="Post Talk Heidenstam" type="event" x="80" y="336" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_greenwash_heidenstam2"/>
+    <property name="behav1" value="talk spyder_greenwash_heidenstam"/>
+    <property name="cond1" value="is variable_set greenwashheidenstam:yes"/>
+   </properties>
+  </object>
+  <object id="124" name="Post Talk Dempsey" type="event" x="48" y="224" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_greenwash_dempsey1"/>
+    <property name="behav1" value="talk spyder_greenwash_dempsey"/>
+    <property name="cond1" value="is variable_set greenwashdempsey:yes"/>
+   </properties>
+  </object>
+  <object id="125" name="Post Talk Dippel" type="event" x="96" y="96" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_greenwash_dippel2"/>
+    <property name="behav1" value="talk spyder_greenwash_dippel"/>
+    <property name="cond1" value="is variable_set greenwashdippel:yes"/>
+   </properties>
+  </object>
+  <object id="126" name="Post Talk Aissa" type="event" x="144" y="80" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_greenwash_aissa2"/>
+    <property name="behav1" value="talk spyder_greenwash_aissa"/>
+    <property name="cond1" value="is variable_set greenwashaissa:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_lion_mountain.tmx
+++ b/mods/tuxemon/maps/spyder_lion_mountain.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="100" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="452">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="100" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="462">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="spyder"/>
@@ -565,6 +565,76 @@
     <property name="act20" value="char_face player,down"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,down"/>
+   </properties>
+  </object>
+  <object id="452" name="Post Talk Emilio" type="event" x="416" y="1536" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_lionmountain_emilio2"/>
+    <property name="behav1" value="talk spyder_lionmountain_emilio"/>
+    <property name="cond1" value="is variable_set lionmountainemilio:yes"/>
+   </properties>
+  </object>
+  <object id="453" name="Post Talk Tom" type="event" x="496" y="1184" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_lionmountain_tom2"/>
+    <property name="behav1" value="talk spyder_lionmountain_tom"/>
+    <property name="cond1" value="is variable_set lionmountaintom:yes"/>
+   </properties>
+  </object>
+  <object id="454" name="Post Talk Chhurim" type="event" x="512" y="896" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_lionmountain_chhurim2"/>
+    <property name="behav1" value="talk spyder_lionmountain_chhurim"/>
+    <property name="cond1" value="is variable_set lionmountainchhurim:yes"/>
+   </properties>
+  </object>
+  <object id="455" name="Post Talk Kurt" type="event" x="496" y="656" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_lionmountain_kurt2"/>
+    <property name="behav1" value="talk spyder_lionmountain_kurt"/>
+    <property name="cond1" value="is variable_set lionmountainkurt:yes"/>
+   </properties>
+  </object>
+  <object id="456" name="Post Talk Conrad" type="event" x="432" y="512" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_lionmountain_conrad2"/>
+    <property name="behav1" value="talk spyder_lionmountain_conrad"/>
+    <property name="cond1" value="is variable_set lionmountainconrad:yes"/>
+   </properties>
+  </object>
+  <object id="457" name="Post Talk David" type="event" x="16" y="176" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_lionmountain_david2"/>
+    <property name="behav1" value="talk spyder_lionmountain_david"/>
+    <property name="cond1" value="is variable_set lionmountaindavid:yes"/>
+   </properties>
+  </object>
+  <object id="458" name="Post Talk Arlene" type="event" x="64" y="240" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_lionmountain_arlene2"/>
+    <property name="behav1" value="talk spyder_lionmountain_arlene"/>
+    <property name="cond1" value="is variable_set lionmountainarlene:yes"/>
+   </properties>
+  </object>
+  <object id="459" name="Post Talk Alexander" type="event" x="64" y="480" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_lionmountain_alexander2"/>
+    <property name="behav1" value="talk spyder_lionmountain_alexander"/>
+    <property name="cond1" value="is variable_set lionmountainalex:yes"/>
+   </properties>
+  </object>
+  <object id="460" name="Post Talk Adam" type="event" x="48" y="992" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_lionmountain_adam2"/>
+    <property name="behav1" value="talk spyder_lionmountain_adam"/>
+    <property name="cond1" value="is variable_set lionmountainadam:yes"/>
+   </properties>
+  </object>
+  <object id="461" name="Post Talk Jacques" type="event" x="32" y="1152" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_lionmountain_jacques2"/>
+    <property name="behav1" value="talk spyder_lionmountain_jacques"/>
+    <property name="cond1" value="is variable_set lionmountainjacques:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_mansion.tmx
+++ b/mods/tuxemon/maps/spyder_mansion.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="18" height="18" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="71">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="18" height="18" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="74">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -305,9 +305,31 @@
     <property name="act1" value="translated_dialog spyder_mansion_lucy3"/>
     <property name="act2" value="add_item mystery_tea"/>
     <property name="act3" value="set_variable tealucy:yes"/>
-    <property name="behav1" value="talk spyder_mansion_lainey"/>
+    <property name="behav1" value="talk spyder_mansion_lucy"/>
     <property name="cond1" value="is variable_set mansionlucy:yes"/>
     <property name="cond2" value="not variable_set tealucy:yes"/>
+   </properties>
+  </object>
+  <object id="71" name="Post Talk Gillette" type="event" x="128" y="112" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_mansion_gillette2"/>
+    <property name="behav1" value="talk spyder_mansion_gillette"/>
+    <property name="cond1" value="is variable_set mansiongillette:yes"/>
+   </properties>
+  </object>
+  <object id="72" name="Post Talk Lucy" type="event" x="224" y="96" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_mansion_lucy2"/>
+    <property name="behav1" value="talk spyder_mansion_lucy"/>
+    <property name="cond1" value="is variable_set mansionlucy:yes"/>
+    <property name="cond2" value="is variable_set tealucy:yes"/>
+   </properties>
+  </object>
+  <object id="73" name="Post Talk Lyle" type="event" x="8.88178e-15" y="112" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_mansion_pirate2"/>
+    <property name="behav1" value="talk spyder_mansion_lyle"/>
+    <property name="cond1" value="is variable_set mansionlyle:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_mansion.tmx
+++ b/mods/tuxemon/maps/spyder_mansion.tmx
@@ -325,7 +325,7 @@
     <property name="cond2" value="is variable_set tealucy:yes"/>
    </properties>
   </object>
-  <object id="73" name="Post Talk Lyle" type="event" x="8.88178e-15" y="112" width="16" height="16">
+  <object id="73" name="Post Talk Lyle" type="event" x="0" y="112" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_mansion_pirate2"/>
     <property name="behav1" value="talk spyder_mansion_lyle"/>

--- a/mods/tuxemon/maps/spyder_mansion_basement.tmx
+++ b/mods/tuxemon/maps/spyder_mansion_basement.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="24" height="22" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="65">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="24" height="22" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="70">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -68,9 +68,6 @@
   <object id="33" type="collision" x="352" y="176" width="16" height="16"/>
   <object id="34" type="collision-line" x="96" y="288">
    <polyline points="0,0 0,32"/>
-  </object>
-  <object id="38" type="collision-line" x="80" y="352">
-   <polyline points="0,0 288,0"/>
   </object>
  </objectgroup>
  <objectgroup color="#ffff00" id="6" name="Events">
@@ -245,6 +242,34 @@
     <property name="act1" value="translated_dialog spyder_basement_josephine2"/>
     <property name="behav1" value="talk spyder_basement_josephine"/>
     <property name="cond1" value="is variable_set healed_josephine:yes"/>
+   </properties>
+  </object>
+  <object id="65" name="Post Talk Bobby" type="event" x="128" y="128" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_basement_bobby2"/>
+    <property name="behav1" value="talk spyder_basement_bobby"/>
+    <property name="cond1" value="is variable_set basementbobby:yes"/>
+   </properties>
+  </object>
+  <object id="67" name="Post Talk Coralli" type="event" x="320" y="112" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_basement_coralli2"/>
+    <property name="behav1" value="talk spyder_basement_coralli"/>
+    <property name="cond1" value="is variable_set basementcoralli:yes"/>
+   </properties>
+  </object>
+  <object id="68" name="Post Talk Catholi" type="event" x="176" y="240" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_basement_catholi2"/>
+    <property name="behav1" value="talk spyder_basement_catholi"/>
+    <property name="cond1" value="is variable_set basementcatholi:yes"/>
+   </properties>
+  </object>
+  <object id="69" name="Post Talk Roger" type="event" x="240" y="240" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_basement_roger2"/>
+    <property name="behav1" value="talk spyder_basement_roger"/>
+    <property name="cond1" value="is variable_set basementroger:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_mansion_top.tmx
+++ b/mods/tuxemon/maps/spyder_mansion_top.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" width="23" height="19" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="60">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" width="23" height="19" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="64">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -227,6 +227,34 @@
     <property name="act2" value="char_face player,down"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,down"/>
+   </properties>
+  </object>
+  <object id="60" name="Post Talk Jackson" type="event" x="96" y="240" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_top_jackson2"/>
+    <property name="behav1" value="talk spyder_top_jackson"/>
+    <property name="cond1" value="is variable_set mansiontop_jackson:yes"/>
+   </properties>
+  </object>
+  <object id="61" name="Post Talk Russell" type="event" x="112" y="240" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_top_russell2"/>
+    <property name="behav1" value="talk spyder_top_russell"/>
+    <property name="cond1" value="is variable_set mansiontop_russell:yes"/>
+   </properties>
+  </object>
+  <object id="62" name="Post Talk Mickey" type="event" x="128" y="240" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_top_mickey2"/>
+    <property name="behav1" value="talk spyder_top_mickey"/>
+    <property name="cond1" value="is variable_set mansiontop_mickey:yes"/>
+   </properties>
+  </object>
+  <object id="63" name="Post Talk Ricardo" type="event" x="144" y="240" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_top_ricardo2"/>
+    <property name="behav1" value="talk spyder_top_ricardo"/>
+    <property name="cond1" value="is variable_set mansiontop_ricardo:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_nimrod_bottom.tmx
+++ b/mods/tuxemon/maps/spyder_nimrod_bottom.tmx
@@ -207,7 +207,7 @@
     <property name="cond1" value="is variable_set nimrodbowie:yes"/>
    </properties>
   </object>
-  <object id="60" name="Post Talk Tru" type="event" x="96.3333" y="221.667" width="16" height="16">
+  <object id="60" name="Post Talk Tru" type="event" x="96" y="224" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_nimrod_tru3"/>
     <property name="behav1" value="talk spyder_nimrod_tru"/>

--- a/mods/tuxemon/maps/spyder_nimrod_bottom.tmx
+++ b/mods/tuxemon/maps/spyder_nimrod_bottom.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" width="18" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="58">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" width="18" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="61">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -53,7 +53,7 @@
     <property name="cond1" value="not char_exists spyder_nimrod_dirk"/>
    </properties>
   </object>
-  <object id="35" name="Talk Dirk" type="event" x="48" y="304" width="16" height="16">
+  <object id="35" name="Talk Dirk" type="event" x="96" y="256" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_nimrod_dirk1"/>
     <property name="behav1" value="talk spyder_nimrod_dirk"/>
@@ -97,7 +97,7 @@
     <property name="cond1" value="not char_exists spyder_nimrod_bowie"/>
    </properties>
   </object>
-  <object id="43" name="Talk Bowie" type="event" x="48" y="240" width="16" height="16">
+  <object id="43" name="Talk Bowie" type="event" x="16" y="224" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_nimrod_bowie1"/>
     <property name="act2" value="add_monster tigrock,35,spyder_nimrod_bowie,5,10"/>
@@ -116,7 +116,7 @@
     <property name="cond1" value="not char_exists spyder_nimrod_tru"/>
    </properties>
   </object>
-  <object id="45" name="Talk Tru" type="event" x="16" y="304" width="16" height="16">
+  <object id="45" name="Talk Tru" type="event" x="96" y="240" width="16" height="16">
    <properties>
     <property name="act01" value="translated_dialog spyder_nimrod_tru1"/>
     <property name="act02" value="add_monster grimachin,20,spyder_nimrod_tru,5,10"/>
@@ -193,6 +193,27 @@
     <property name="cond2" value="is char_at player"/>
    </properties>
   </object>
+  <object id="58" name="Post Talk Rebel" type="event" x="176" y="240" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_nimrod_rebel2"/>
+    <property name="behav1" value="talk spyder_nimrod_rebel"/>
+    <property name="cond1" value="is variable_set nimrodrebel:yes"/>
+   </properties>
+  </object>
+  <object id="59" name="Post Talk Bowie" type="event" x="32" y="224" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_nimrod_bowie2"/>
+    <property name="behav1" value="talk spyder_nimrod_bowie"/>
+    <property name="cond1" value="is variable_set nimrodbowie:yes"/>
+   </properties>
+  </object>
+  <object id="60" name="Post Talk Tru" type="event" x="96.3333" y="221.667" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_nimrod_tru3"/>
+    <property name="behav1" value="talk spyder_nimrod_tru"/>
+    <property name="cond1" value="is variable_set nimrodtru:yes"/>
+   </properties>
+  </object>
  </objectgroup>
  <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="3" type="collision" x="0" y="0" width="288" height="32"/>
@@ -205,7 +226,7 @@
   <object id="13" type="collision" x="224" y="112" width="32" height="16"/>
   <object id="14" type="collision" x="16" y="80" width="112" height="32"/>
   <object id="17" type="collision" x="192" y="64" width="16" height="16"/>
-  <object id="18" type="collision" x="256" y="48" width="16" height="176"/>
+  <object id="18" type="collision" x="256" y="48" width="16" height="160"/>
   <object id="20" type="collision" x="80" y="48" width="16" height="32"/>
   <object id="21" type="collision" x="32" y="32" width="16" height="32"/>
   <object id="22" type="collision" x="224" y="32" width="16" height="32"/>

--- a/mods/tuxemon/maps/spyder_nimrod_middle.tmx
+++ b/mods/tuxemon/maps/spyder_nimrod_middle.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" width="18" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="45">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" width="18" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="50">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -287,6 +287,41 @@
     <property name="act6" value="set_variable nimrodantimony:yes"/>
     <property name="cond1" value="not variable_set nimrodantimony:yes"/>
     <property name="cond2" value="is char_at player"/>
+   </properties>
+  </object>
+  <object id="45" name="Post Talk Archer" type="event" x="64" y="256" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_nimrod_archer2"/>
+    <property name="behav1" value="talk spyder_nimrod_archer"/>
+    <property name="cond1" value="is variable_set nimrodarcher:yes"/>
+   </properties>
+  </object>
+  <object id="46" name="Post Talk Antimony" type="event" x="80" y="256" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_nimrod_antimony2"/>
+    <property name="behav1" value="talk spyder_nimrod_antimony"/>
+    <property name="cond1" value="is variable_set nimrodantimony:yes"/>
+   </properties>
+  </object>
+  <object id="47" name="Post Talk Argon" type="event" x="96" y="256" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_nimrod_argon2"/>
+    <property name="behav1" value="talk spyder_nimrod_argon"/>
+    <property name="cond1" value="is variable_set nimrodargon:yes"/>
+   </properties>
+  </object>
+  <object id="48" name="Post Talk Thatcher" type="event" x="112" y="256" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_nimrod_thatcher2"/>
+    <property name="behav1" value="talk spyder_nimrod_thatcher"/>
+    <property name="cond1" value="is variable_set nimrodthatcher:yes"/>
+   </properties>
+  </object>
+  <object id="49" name="Post Talk Honour" type="event" x="128" y="256" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_nimrod_honour2"/>
+    <property name="behav1" value="talk spyder_nimrod_honour"/>
+    <property name="cond1" value="is variable_set nimrodhonour:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_nimrod_top.tmx
+++ b/mods/tuxemon/maps/spyder_nimrod_top.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" width="18" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="47">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" width="18" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="51">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -193,6 +193,34 @@
     <property name="act7" value="set_variable nimrodmace:yes"/>
     <property name="behav1" value="talk spyder_nimrod_mace"/>
     <property name="cond1" value="not variable_set nimrodmace:yes"/>
+   </properties>
+  </object>
+  <object id="47" name="Post Talk Justice" type="event" x="208" y="256" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_nimrod_justice2"/>
+    <property name="behav1" value="talk spyder_nimrod_justice"/>
+    <property name="cond1" value="is variable_set nimrodjustice:yes"/>
+   </properties>
+  </object>
+  <object id="48" name="Post Talk Mace" type="event" x="224" y="176" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_nimrod_mace2"/>
+    <property name="behav1" value="talk spyder_nimrod_mace"/>
+    <property name="cond1" value="is variable_set nimrodmace:yes"/>
+   </properties>
+  </object>
+  <object id="49" name="Post Talk Maverick" type="event" x="112" y="160" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_nimrod_maverick2"/>
+    <property name="behav1" value="talk spyder_nimrod_maverick"/>
+    <property name="cond1" value="is variable_set nimrodmaverick:yes"/>
+   </properties>
+  </object>
+  <object id="50" name="Post Talk Zircon" type="event" x="176" y="128" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_nimrod_zircon2"/>
+    <property name="behav1" value="talk spyder_nimrod_zircon"/>
+    <property name="cond1" value="is variable_set nimrodzircon:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_omnichannel1.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel1.tmx
@@ -198,7 +198,7 @@
     <property name="cond2" value="not variable_set omnichannel1wall:yes"/>
    </properties>
   </object>
-  <object id="51" name="Remove Screen" type="event" x="144" y="271.333" width="16" height="16">
+  <object id="51" name="Remove Screen" type="event" x="144" y="272" width="16" height="16">
    <properties>
     <property name="act1" value="remove_collision screen"/>
     <property name="cond1" value="is variable_set omnichannel1wall:yes"/>

--- a/mods/tuxemon/maps/spyder_radiotower.tmx
+++ b/mods/tuxemon/maps/spyder_radiotower.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="14" height="21" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="40">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="14" height="21" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="40">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -41,18 +41,6 @@
   <object id="1" type="collision" x="0" y="0" width="16" height="336"/>
   <object id="2" type="collision" x="208" y="0" width="16" height="336"/>
   <object id="3" type="collision" x="16" y="0" width="192" height="32"/>
-  <object id="13" type="collision-line" x="16" y="336">
-   <polyline points="0,0 192,0"/>
-  </object>
-  <object id="32" type="collision-line" x="32" y="288">
-   <polyline points="0,0 0,32"/>
-  </object>
-  <object id="33" type="collision-line" x="32" y="320">
-   <polyline points="0,0 32,0"/>
-  </object>
-  <object id="34" type="collision-line" x="64" y="288">
-   <polyline points="0,0 0,32"/>
-  </object>
   <object id="35" type="collision" x="64" y="48" width="112" height="16"/>
   <object id="36" type="collision" x="64" y="32" width="32" height="16"/>
   <object id="37" type="collision" x="128" y="32" width="32" height="16"/>

--- a/mods/tuxemon/maps/spyder_route2.tmx
+++ b/mods/tuxemon/maps/spyder_route2.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="2" nextobjectid="211">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="2" nextobjectid="214">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="north" value="citypark"/>
@@ -532,6 +532,27 @@
     <property name="act2" value="play_map_animation grass,0.1,noloop,player"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_moved player"/>
+   </properties>
+  </object>
+  <object id="211" name="Post Talk roddick" type="event" x="192" y="16" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route2_roddick2"/>
+    <property name="behav1" value="talk spyder_route2_roddick"/>
+    <property name="cond1" value="is variable_set route2roddick:yes"/>
+   </properties>
+  </object>
+  <object id="212" name="Post Talk marion" type="event" x="208" y="16" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route2_marion2"/>
+    <property name="behav1" value="talk spyder_route2_marion"/>
+    <property name="cond1" value="is variable_set route2marion:yes"/>
+   </properties>
+  </object>
+  <object id="213" name="Post Talk graf" type="event" x="224" y="16" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route2_graf2"/>
+    <property name="behav1" value="talk spyder_route2_graf"/>
+    <property name="cond1" value="is variable_set route2graf:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_route3.tmx
+++ b/mods/tuxemon/maps/spyder_route3.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="708">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="713">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="spyder"/>
@@ -358,13 +358,13 @@
     <property name="cond2" value="is char_moved player"/>
    </properties>
   </object>
-  <object id="611" name="Novak Enforcer" type="event" x="160" y="432" width="16" height="16">
+  <object id="611" name="Novak Enforcer" type="event" x="192" y="464" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_route3_novak,12,29"/>
-    <property name="cond1" value="not char_exists spyder_route3_weaver"/>
+    <property name="cond1" value="not char_exists spyder_route3_novak"/>
    </properties>
   </object>
-  <object id="612" name="Novak Talk" type="event" x="160" y="416" width="16" height="16">
+  <object id="612" name="Novak Talk" type="event" x="144" y="464" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_route3_novak1"/>
     <property name="act2" value="add_monster elofly,13,spyder_route3_novak,5,10"/>
@@ -739,6 +739,41 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_route3_boulder"/>
     <property name="behav1" value="talk spyder_boulder"/>
+   </properties>
+  </object>
+  <object id="708" name="Post Curie Talk" type="event" x="512" y="496" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route3_curie2"/>
+    <property name="behav1" value="talk spyder_route3_curie"/>
+    <property name="cond1" value="is variable_set route3curie:yes"/>
+   </properties>
+  </object>
+  <object id="709" name="Post Novak Talk" type="event" x="144" y="480" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route3_novak2"/>
+    <property name="behav1" value="talk spyder_route3_novak"/>
+    <property name="cond1" value="is variable_set route3novak:yes"/>
+   </properties>
+  </object>
+  <object id="710" name="Post Talk Wanda" type="event" x="480" y="272" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route3_wanda2"/>
+    <property name="behav1" value="talk spyder_route3_wanda"/>
+    <property name="cond1" value="is variable_set route3wanda:yes"/>
+   </properties>
+  </object>
+  <object id="711" name="Post Connor Talk" type="event" x="320" y="16" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route3_connor2"/>
+    <property name="behav1" value="talk spyder_route3_connor"/>
+    <property name="cond1" value="is variable_set route3connor:yes"/>
+   </properties>
+  </object>
+  <object id="712" name="Post Enforcer Talk" type="event" x="240" y="144" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route3_weaver2"/>
+    <property name="behav1" value="talk spyder_route3_weaver"/>
+    <property name="cond1" value="is variable_set route3weaver:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_route4.tmx
+++ b/mods/tuxemon/maps/spyder_route4.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="93">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="99">
  <properties>
   <property name="east" value="route3"/>
   <property name="edges" value="clamped"/>
@@ -482,6 +482,48 @@
     <property name="act3" value="remove_npc spyder_route4_boost"/>
     <property name="act4" value="set_variable route4_boost:yes"/>
     <property name="behav1" value="talk spyder_route4_boost"/>
+   </properties>
+  </object>
+  <object id="93" name="Post Talk Rincewind" type="event" x="288" y="80" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route4_rincewind2"/>
+    <property name="behav1" value="talk spyder_route4_rincewind"/>
+    <property name="cond1" value="is variable_set route4rincewind:yes"/>
+   </properties>
+  </object>
+  <object id="94" name="Post Talk Roger" type="event" x="144" y="320" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route4_roger2"/>
+    <property name="behav1" value="talk spyder_route4_roger"/>
+    <property name="cond1" value="is variable_set route4roger:yes"/>
+   </properties>
+  </object>
+  <object id="95" name="Post Talk Rosamund" type="event" x="192" y="464" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route4_rosamund2"/>
+    <property name="behav1" value="talk spyder_route4_rosamund"/>
+    <property name="cond1" value="is variable_set route4rosamund:yes"/>
+   </properties>
+  </object>
+  <object id="96" name="Post Talk Marshall" type="event" x="16" y="464" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route4_marshall2"/>
+    <property name="behav1" value="talk spyder_route4_marshall"/>
+    <property name="cond1" value="is variable_set route4marshall:yes"/>
+   </properties>
+  </object>
+  <object id="97" name="Post Talk Beck" type="event" x="16" y="320" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route4_beck2"/>
+    <property name="behav1" value="talk spyder_route4_beck"/>
+    <property name="cond1" value="is variable_set route4beck:yes"/>
+   </properties>
+  </object>
+  <object id="98" name="Post Talk Wulf" type="event" x="16" y="176" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route4_wulf2"/>
+    <property name="behav1" value="talk spyder_route4_wulf"/>
+    <property name="cond1" value="is variable_set route4wulf:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_route5.tmx
+++ b/mods/tuxemon/maps/spyder_route5.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="68">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="73">
  <properties>
   <property name="east" value="flower_city"/>
   <property name="edges" value="clamped"/>
@@ -399,6 +399,41 @@
     <property name="act6" value="set_variable route5edith:yes"/>
     <property name="cond1" value="not variable_set route5edith:yes"/>
     <property name="cond2" value="is char_at player"/>
+   </properties>
+  </object>
+  <object id="68" name="Post Talk Sara" type="event" x="272" y="176" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route5_sara2"/>
+    <property name="behav1" value="talk spyder_route5_sara"/>
+    <property name="cond1" value="is variable_set route5sara:yes"/>
+   </properties>
+  </object>
+  <object id="69" name="Post Talk Edith" type="event" x="272" y="192" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route5_edith2"/>
+    <property name="behav1" value="talk spyder_route5_edith"/>
+    <property name="cond1" value="is variable_set route5edith:yes"/>
+   </properties>
+  </object>
+  <object id="70" name="Post Talk Tryphaena" type="event" x="256" y="176" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route5_tryphaena2"/>
+    <property name="behav1" value="talk spyder_route5_tryphaena"/>
+    <property name="cond1" value="is variable_set route5tryphaena:yes"/>
+   </properties>
+  </object>
+  <object id="71" name="Post Talk Cleo" type="event" x="256" y="192" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route5_cleo2"/>
+    <property name="behav1" value="talk spyder_route5_cleo"/>
+    <property name="cond1" value="is variable_set route5cleo:yes"/>
+   </properties>
+  </object>
+  <object id="72" name="Post Talk Hunter" type="event" x="32" y="128" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route5_hunter2"/>
+    <property name="behav1" value="talk spyder_route5_hunter"/>
+    <property name="cond1" value="is variable_set route5hunter:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_route6.tmx
+++ b/mods/tuxemon/maps/spyder_route6.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="5" nextobjectid="236">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="5" nextobjectid="244">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="spyder"/>
@@ -365,6 +365,7 @@
     <property name="act1" value="create_npc spyder_route6_gunner,30,17"/>
     <property name="act2" value="char_face spyder_route6_gunner,up"/>
     <property name="cond1" value="not char_exists spyder_route6_gunner"/>
+    <property name="cond2" value="not variable_set route6gunner:yes"/>
    </properties>
   </object>
   <object id="208" name="Talk Gunner" type="event" x="464" y="272" width="16" height="16">
@@ -570,6 +571,55 @@
    <properties>
     <property name="act1" value="set_variable billie_choice:miaownolith"/>
     <property name="cond1" value="is variable_set billie_choice:memnomnom"/>
+   </properties>
+  </object>
+  <object id="236" name="Post Talk Maxwell" type="event" x="176" y="80" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route6_maxwell2"/>
+    <property name="behav1" value="talk spyder_route6_maxwell"/>
+    <property name="cond1" value="is variable_set route6maxwell:yes"/>
+   </properties>
+  </object>
+  <object id="237" name="Post Talk Ping" type="event" x="384" y="144" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route6_ping2"/>
+    <property name="behav1" value="talk spyder_route6_ping"/>
+    <property name="cond1" value="is variable_set route6ping:yes"/>
+   </properties>
+  </object>
+  <object id="238" name="Post Talk Orion" type="event" x="368" y="144" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route6_orion2"/>
+    <property name="behav1" value="talk spyder_route6_orion"/>
+    <property name="cond1" value="is variable_set route6orion:yes"/>
+   </properties>
+  </object>
+  <object id="239" name="Post Talk Frances" type="event" x="368" y="160" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route6_frances2"/>
+    <property name="behav1" value="talk spyder_route6_frances"/>
+    <property name="cond1" value="is variable_set route6frances:yes"/>
+   </properties>
+  </object>
+  <object id="240" name="Post Talk Mungo" type="event" x="384" y="160" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route6_mungo2"/>
+    <property name="behav1" value="talk spyder_route6_mungo"/>
+    <property name="cond1" value="is variable_set route6mungo:yes"/>
+   </properties>
+  </object>
+  <object id="241" name="Post Talk Richard" type="event" x="352" y="160" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route6_richard2"/>
+    <property name="behav1" value="talk spyder_route6_richard"/>
+    <property name="cond1" value="is variable_set route6richard:yes"/>
+   </properties>
+  </object>
+  <object id="242" name="Post Talk Blair" type="event" x="352" y="144" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route6_blair2"/>
+    <property name="behav1" value="talk spyder_route6_blair"/>
+    <property name="cond1" value="is variable_set route6blair:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_route7.tmx
+++ b/mods/tuxemon/maps/spyder_route7.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="260">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="270">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="north" value="crystal_town"/>
@@ -238,7 +238,7 @@
     <property name="cond1" value="not char_exists spyder_route7_arnaut"/>
    </properties>
   </object>
-  <object id="235" name="Talk Arnaut" type="event" x="79.9997" y="304" width="16" height="16">
+  <object id="235" name="Talk Arnaut" type="event" x="80" y="304" width="16" height="16">
    <properties>
     <property name="act10" value="pathfind_to_player spyder_route7_arnaut"/>
     <property name="act11" value="translated_dialog spyder_route7_arnaut1"/>
@@ -475,6 +475,76 @@
     <property name="act17" value="set_variable route7conrad:yes"/>
     <property name="cond1" value="not variable_set route7conrad:yes"/>
     <property name="cond2" value="is char_at player"/>
+   </properties>
+  </object>
+  <object id="260" name="Post Talk Arnaut" type="event" x="32" y="320" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route7_arnaut2"/>
+    <property name="behav1" value="talk spyder_route7_arnaut"/>
+    <property name="cond1" value="is variable_set route7arnaut:yes"/>
+   </properties>
+  </object>
+  <object id="261" name="Post Talk Hugh" type="event" x="96" y="80" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route7_hugh2"/>
+    <property name="behav1" value="talk spyder_route7_hugh"/>
+    <property name="cond1" value="is variable_set route7hugh:yes"/>
+   </properties>
+  </object>
+  <object id="262" name="Post Talk Penitent" type="event" x="112" y="80" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route7_penitent2"/>
+    <property name="behav1" value="talk spyder_route7_penitent"/>
+    <property name="cond1" value="is variable_set route7penitent:yes"/>
+   </properties>
+  </object>
+  <object id="263" name="Post Talk Nino" type="event" x="256" y="416" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route7_nino2"/>
+    <property name="behav1" value="talk spyder_route7_nino"/>
+    <property name="cond1" value="is variable_set route7nino:yes"/>
+   </properties>
+  </object>
+  <object id="264" name="Post Talk Pia" type="event" x="288" y="224" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route7_pia2"/>
+    <property name="behav1" value="talk spyder_route7_pia"/>
+    <property name="cond1" value="is variable_set route7pia:yes"/>
+   </properties>
+  </object>
+  <object id="265" name="Post Talk Conrad" type="event" x="416" y="48.3333" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route7_conrad2"/>
+    <property name="behav1" value="talk spyder_route7_conrad"/>
+    <property name="cond1" value="is variable_set route7conrad:yes"/>
+   </properties>
+  </object>
+  <object id="266" name="Post Talk Jacopo" type="event" x="432" y="208" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route7_jacopo2"/>
+    <property name="behav1" value="talk spyder_route7_jacopo"/>
+    <property name="cond1" value="is variable_set route7jacopo:yes"/>
+   </properties>
+  </object>
+  <object id="267" name="Post Talk Sordello" type="event" x="384" y="464" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route7_sordello2"/>
+    <property name="behav1" value="talk spyder_route7_sordello"/>
+    <property name="cond1" value="is variable_set route7sordello:yes"/>
+   </properties>
+  </object>
+  <object id="268" name="Post Talk Statius" type="event" x="560" y="496" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route7_statius2"/>
+    <property name="behav1" value="talk spyder_route7_statius"/>
+    <property name="cond1" value="is variable_set route7statius:yes"/>
+   </properties>
+  </object>
+  <object id="269" name="Post Talk Manfred" type="event" x="576" y="80" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_route7_manfred2"/>
+    <property name="behav1" value="talk spyder_route7_manfred"/>
+    <property name="cond1" value="is variable_set route7manfred:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_route7.tmx
+++ b/mods/tuxemon/maps/spyder_route7.tmx
@@ -512,7 +512,7 @@
     <property name="cond1" value="is variable_set route7pia:yes"/>
    </properties>
   </object>
-  <object id="265" name="Post Talk Conrad" type="event" x="416" y="48.3333" width="16" height="16">
+  <object id="265" name="Post Talk Conrad" type="event" x="416" y="48" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_route7_conrad2"/>
     <property name="behav1" value="talk spyder_route7_conrad"/>

--- a/mods/tuxemon/maps/spyder_routea.tmx
+++ b/mods/tuxemon/maps/spyder_routea.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="119">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="128">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="north" value="route7"/>
@@ -505,6 +505,71 @@
     <property name="act3" value="remove_npc spyder_routea_cureall"/>
     <property name="act4" value="set_variable routea_cureall:yes"/>
     <property name="behav1" value="talk spyder_routea_cureall"/>
+   </properties>
+  </object>
+  <object id="119" name="Post Talk Koan" type="event" x="16" y="592" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_routea_koan2"/>
+    <property name="behav1" value="talk spyder_routea_koan"/>
+    <property name="cond1" value="is variable_set routeakoan:yes"/>
+   </properties>
+  </object>
+  <object id="120" name="Post Talk Lexi" type="event" x="16" y="480" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_routea_lexi2"/>
+    <property name="behav1" value="talk spyder_routea_lexi"/>
+    <property name="cond1" value="is variable_set routealexi:yes"/>
+   </properties>
+  </object>
+  <object id="121" name="Post Talk Dagger" type="event" x="16" y="352" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_routea_dagger2"/>
+    <property name="behav1" value="talk spyder_routea_dagger"/>
+    <property name="cond1" value="is variable_set routeadagger:yes"/>
+   </properties>
+  </object>
+  <object id="122" name="Talk Vince4" type="event" x="32" y="304" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_routea_vince4"/>
+    <property name="behav1" value="talk spyder_routea_vince"/>
+    <property name="cond1" value="is variable_set vincefirst:yes"/>
+    <property name="cond2" value="is variable_set vincesecond:yes"/>
+    <property name="cond3" value="is variable_set routeavince:yes"/>
+   </properties>
+  </object>
+  <object id="123" name="Post Talk Rosy" type="event" x="176" y="256" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_routea_rosy2"/>
+    <property name="behav1" value="talk spyder_routea_rosy"/>
+    <property name="cond1" value="is variable_set routearosy:yes"/>
+   </properties>
+  </object>
+  <object id="124" name="Post Talk Doris" type="event" x="160" y="320" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_routea_doris2"/>
+    <property name="behav1" value="talk spyder_routea_doris"/>
+    <property name="cond1" value="is variable_set routeadoris:yes"/>
+   </properties>
+  </object>
+  <object id="125" name="Post Talk Connie" type="event" x="192" y="400" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_routea_connie2"/>
+    <property name="behav1" value="talk spyder_routea_connie"/>
+    <property name="cond1" value="is variable_set routeaconnie:yes"/>
+   </properties>
+  </object>
+  <object id="126" name="Post Talk Joe" type="event" x="192" y="528" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_routea_joe2"/>
+    <property name="behav1" value="talk spyder_routea_joe"/>
+    <property name="cond1" value="is variable_set routeajoe:yes"/>
+   </properties>
+  </object>
+  <object id="127" name="Talk Lotu" type="event" x="240" y="480" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_routea_lotu2"/>
+    <property name="behav1" value="talk spyder_routea_lotu"/>
+    <property name="cond1" value="is variable_set routealotu:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_routeb.tmx
+++ b/mods/tuxemon/maps/spyder_routeb.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="185">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="190">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="spyder"/>
@@ -205,6 +205,41 @@
     <property name="act99" value="unlock_controls"/>
     <property name="cond1" value="not variable_set routebbillie:yes"/>
     <property name="cond2" value="is char_at player"/>
+   </properties>
+  </object>
+  <object id="185" name="Post Talk Electra" type="event" x="240" y="560" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_routeb_electra2"/>
+    <property name="behav1" value="talk spyder_routeb_electra"/>
+    <property name="cond1" value="is variable_set routebelectra:yes"/>
+   </properties>
+  </object>
+  <object id="186" name="Post Talk Cytherea" type="event" x="240" y="416" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_routeb_cytherea2"/>
+    <property name="behav1" value="talk spyder_routeb_cytherea"/>
+    <property name="cond1" value="is variable_set routebcytherea:yes"/>
+   </properties>
+  </object>
+  <object id="187" name="Post Talk Nephthys" type="event" x="96" y="368" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_routeb_nephthys2"/>
+    <property name="behav1" value="talk spyder_routeb_nephthys"/>
+    <property name="cond1" value="is variable_set routebnephthys:yes"/>
+   </properties>
+  </object>
+  <object id="188" name="Post Talk Sedna" type="event" x="240" y="272" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_routeb_sedna2"/>
+    <property name="behav1" value="talk spyder_routeb_sedna"/>
+    <property name="cond1" value="is variable_set routebsedna:yes"/>
+   </properties>
+  </object>
+  <object id="189" name="Post Talk Calypso" type="event" x="48" y="128" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_routeb_calypso2"/>
+    <property name="behav1" value="talk spyder_routeb_calypso"/>
+    <property name="cond1" value="is variable_set routebcalypso:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_routec.tmx
+++ b/mods/tuxemon/maps/spyder_routec.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="282">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="294">
  <properties>
   <property name="east" value="paper_town"/>
   <property name="edges" value="clamped"/>
@@ -240,35 +240,6 @@
     <property name="cond2" value="is char_at player"/>
    </properties>
   </object>
-  <object id="224" name="Talk Carstair" type="event" x="384" y="96" width="16" height="16">
-   <properties>
-    <property name="act0" value="pathfind_to_player spyder_searoutec_carstair"/>
-    <property name="act1" value="translated_dialog spyder_searoutec_carstair1"/>
-    <property name="act2" value="add_monster axylightl,24,spyder_searoutec_carstair,5,10"/>
-    <property name="act3" value="start_battle player,spyder_searoutec_carstair"/>
-    <property name="act4" value="translated_dialog spyder_searoutec_carstair2"/>
-    <property name="act6" value="set_variable searouteccarstair:yes"/>
-    <property name="cond1" value="not variable_set searouteccarstair:yes"/>
-    <property name="cond2" value="is char_at player"/>
-   </properties>
-  </object>
-  <object id="225" name="Talk Wade" type="event" x="224" y="192" width="16" height="16">
-   <properties>
-    <property name="act00" value="pathfind_to_player spyder_searoutec_wade"/>
-    <property name="act01" value="translated_dialog spyder_searoutec_wade1"/>
-    <property name="act02" value="add_monster picc,20,spyder_searoutec_wade,5,10"/>
-    <property name="act03" value="add_monster picc,20,spyder_searoutec_wade,5,10"/>
-    <property name="act04" value="add_monster picc,20,spyder_searoutec_wade,5,10"/>
-    <property name="act05" value="add_monster picc,20,spyder_searoutec_wade,5,10"/>
-    <property name="act06" value="add_monster picc,20,spyder_searoutec_wade,5,10"/>
-    <property name="act07" value="add_monster picc,20,spyder_searoutec_wade,5,10"/>
-    <property name="act08" value="start_battle player,spyder_searoutec_wade"/>
-    <property name="act09" value="translated_dialog spyder_searoutec_wade2"/>
-    <property name="act10" value="set_variable searoutecwade:yes"/>
-    <property name="cond1" value="not variable_set searoutecwade:yes"/>
-    <property name="cond2" value="is char_at player"/>
-   </properties>
-  </object>
   <object id="226" name="Talk Sandy" type="event" x="80" y="240" width="16" height="48">
    <properties>
     <property name="act0" value="pathfind_to_player spyder_searoutec_sandy"/>
@@ -480,6 +451,91 @@
     <property name="act2" value="char_face player,up"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,up"/>
+   </properties>
+  </object>
+  <object id="282" name="Post Talk Maurice" type="event" x="112" y="480" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_searoutec_maurice2"/>
+    <property name="behav1" value="talk spyder_searoutec_maurice"/>
+    <property name="cond1" value="is variable_set searoutecmaurice:yes"/>
+   </properties>
+  </object>
+  <object id="283" name="Post Talk Nigel" type="event" x="176" y="384" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_searoutec_nigel2"/>
+    <property name="behav1" value="talk spyder_searoutec_nigel"/>
+    <property name="cond1" value="is variable_set searoutecnigel:yes"/>
+    <property name="cond2" value="is variable_set hospitalcure:yes"/>
+   </properties>
+  </object>
+  <object id="284" name="Post Talk Sandy" type="event" x="112" y="272" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_searoutec_sandy2"/>
+    <property name="behav1" value="talk spyder_searoutec_sandy"/>
+    <property name="cond1" value="is variable_set searoutecsandy:yes"/>
+   </properties>
+  </object>
+  <object id="285" name="Post Talk Beech" type="event" x="128" y="272" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_searoutec_beech2"/>
+    <property name="behav1" value="talk spyder_searoutec_beech"/>
+    <property name="cond1" value="is variable_set searoutecbeech:yes"/>
+   </properties>
+  </object>
+  <object id="286" name="Post Talk River" type="event" x="144" y="272" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_searoutec_river2"/>
+    <property name="behav1" value="talk spyder_searoutec_river"/>
+    <property name="cond1" value="is variable_set searoutecriver:yes"/>
+   </properties>
+  </object>
+  <object id="287" name="Post Talk Wade" type="event" x="160" y="272" width="16" height="16">
+   <properties>
+    <property name="act01" value="translated_dialog spyder_searoutec_wade2"/>
+    <property name="behav1" value="talk spyder_searoutec_wade"/>
+    <property name="cond1" value="is variable_set searoutecwade:yes"/>
+   </properties>
+  </object>
+  <object id="288" name="Post Talk Stafford" type="event" x="416" y="544.333" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_searoutec_stafford2"/>
+    <property name="behav1" value="talk spyder_searoutec_stafford"/>
+    <property name="cond1" value="is variable_set searoutecstafford:yes"/>
+   </properties>
+  </object>
+  <object id="289" name="Post Talk Gil" type="event" x="128" y="288" width="16" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_searoutec_gil2"/>
+    <property name="behav1" value="talk spyder_searoutec_gil"/>
+    <property name="cond1" value="is variable_set searoutecgil:yes"/>
+   </properties>
+  </object>
+  <object id="290" name="Post Talk Carstair" type="event" x="144" y="288" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_searoutec_carstair2"/>
+    <property name="behav1" value="talk spyder_searoutec_carstair"/>
+    <property name="cond1" value="is variable_set searouteccarstair:yes"/>
+   </properties>
+  </object>
+  <object id="291" name="Post Talk Rutherford" type="event" x="432" y="304" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_searoutec_rutherford2"/>
+    <property name="behav1" value="talk spyder_searoutec_rutherford"/>
+    <property name="cond1" value="is variable_set searoutecrutherford:yes"/>
+   </properties>
+  </object>
+  <object id="292" name="Post Talk Leek" type="event" x="416" y="304" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_searoutec_leek2"/>
+    <property name="behav1" value="talk spyder_searoutec_leek"/>
+    <property name="cond1" value="is variable_set searoutecleek:yes"/>
+   </properties>
+  </object>
+  <object id="293" name="Post Talk More" type="event" x="512" y="480" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_searoutec_more2"/>
+    <property name="behav1" value="talk spyder_searoutec_more"/>
+    <property name="cond1" value="is variable_set searoutecmore:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_routec.tmx
+++ b/mods/tuxemon/maps/spyder_routec.tmx
@@ -496,7 +496,7 @@
     <property name="cond1" value="is variable_set searoutecwade:yes"/>
    </properties>
   </object>
-  <object id="288" name="Post Talk Stafford" type="event" x="416" y="544.333" width="16" height="16">
+  <object id="288" name="Post Talk Stafford" type="event" x="416" y="544" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_searoutec_stafford2"/>
     <property name="behav1" value="talk spyder_searoutec_stafford"/>

--- a/mods/tuxemon/maps/spyder_routee.tmx
+++ b/mods/tuxemon/maps/spyder_routee.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="87">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="89">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="scenario" value="spyder"/>
@@ -102,7 +102,7 @@
     <property name="cond1" value="not char_exists spyder_routee_calliope"/>
    </properties>
   </object>
-  <object id="84" name="Battle Calliope" type="event" x="96" y="192" width="32" height="16">
+  <object id="84" name="Battle Calliope" type="event" x="96" y="208" width="32" height="16">
    <properties>
     <property name="act0" value="pathfind_to_player spyder_routee_calliope,down"/>
     <property name="act1" value="translated_dialog spyder_routee_calliope1"/>
@@ -111,8 +111,9 @@
     <property name="act6" value="start_battle player,spyder_routee_calliope"/>
     <property name="act7" value="translated_dialog spyder_routee_calliope2"/>
     <property name="act8" value="set_variable routeecalliope:yes"/>
-    <property name="cond1" value="is variable_set routeecalliope:yes"/>
-    <property name="cond2" value="is char_at player"/>
+    <property name="cond1" value="not variable_set routeecalliope:yes"/>
+    <property name="cond2" value="is variable_set kernelquestbegin:yes"/>
+    <property name="cond3" value="is char_at player"/>
    </properties>
   </object>
   <object id="87" name="Talk Calliope" type="event" x="96" y="192" width="32" height="16">
@@ -148,6 +149,20 @@
     <property name="act8" value="set_variable routeeaiolos:yes"/>
     <property name="cond1" value="not variable_set routeeaiolos:yes"/>
     <property name="cond2" value="is char_at player"/>
+   </properties>
+  </object>
+  <object id="87" name="Post Talk Calliope" type="event" x="128" y="224" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_routee_calliope2"/>
+    <property name="behav1" value="talk spyder_routee_calliope"/>
+    <property name="cond1" value="is variable_set routeecalliope:yes"/>
+   </properties>
+  </object>
+  <object id="88" name="Post Talk Aiolos" type="event" x="128" y="240" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_routee_aiolos2"/>
+    <property name="behav1" value="talk spyder_routee_aiolos"/>
+    <property name="cond1" value="is variable_set routeeaiolos:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_scoop1.tmx
+++ b/mods/tuxemon/maps/spyder_scoop1.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="21" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="71">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="21" height="15" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="76">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -102,14 +102,14 @@
     <property name="cond1" value="not variable_set scooppaine:yes"/>
    </properties>
   </object>
-  <object id="51" name="Create Rubid" type="event" x="224" y="160" width="16" height="16">
+  <object id="51" name="Create Rubid" type="event" x="208" y="160" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_scoop_rubid,13,10"/>
     <property name="act2" value="char_face spyder_scoop_rubid,left"/>
     <property name="cond1" value="not char_exists spyder_scoop_rubid"/>
    </properties>
   </object>
-  <object id="52" name="Talk Rubid" type="event" x="208" y="160" width="16" height="16">
+  <object id="52" name="Talk Rubid" type="event" x="224" y="160" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_scoop_rubid1"/>
     <property name="act2" value="add_monster birdling,35,spyder_scoop_rubid,5,10"/>
@@ -250,6 +250,41 @@
     <property name="act6" value="set_variable scooprubid:yes"/>
     <property name="cond1" value="not variable_set scooprubid:yes"/>
     <property name="cond2" value="is char_at player"/>
+   </properties>
+  </object>
+  <object id="71" name="Post Talk Turner" type="event" x="32" y="128" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_scoop_turner2"/>
+    <property name="behav1" value="talk spyder_scoop_turner"/>
+    <property name="cond1" value="is variable_set scoopturner:yes"/>
+   </properties>
+  </object>
+  <object id="72" name="Post Talk Lanth" type="event" x="32" y="64" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_scoop_lanth2"/>
+    <property name="behav1" value="talk spyder_scoop_lanth"/>
+    <property name="cond1" value="is variable_set scooplanth:yes"/>
+   </properties>
+  </object>
+  <object id="73" name="Post Talk Paine" type="event" x="96" y="32" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_scoop_paine2"/>
+    <property name="behav1" value="talk spyder_scoop_paine"/>
+    <property name="cond1" value="is variable_set scooppaine:yes"/>
+   </properties>
+  </object>
+  <object id="74" name="Post Talk Rubid" type="event" x="224" y="176" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_scoop_rubid2"/>
+    <property name="behav1" value="talk spyder_scoop_rubid"/>
+    <property name="cond1" value="is variable_set scooprubid:yes"/>
+   </properties>
+  </object>
+  <object id="75" name="Post Talk Berys" type="event" x="320" y="96" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_scoop_berys2"/>
+    <property name="behav1" value="talk spyder_scoop_berys"/>
+    <property name="cond1" value="is variable_set scoopberys:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_scoop2.tmx
+++ b/mods/tuxemon/maps/spyder_scoop2.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="8" height="5" tilewidth="16" tileheight="16" infinite="0" nextlayerid="5" nextobjectid="19">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="8" height="5" tilewidth="16" tileheight="16" infinite="0" nextlayerid="5" nextobjectid="19">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -25,15 +25,6 @@
   <object id="5" type="collision" x="32" y="0" width="48" height="48"/>
   <object id="6" type="collision" x="80" y="16" width="32" height="48"/>
   <object id="7" type="collision" x="112" y="16" width="16" height="32"/>
-  <object id="8" type="collision-line" x="0" y="80">
-   <polyline points="0,0 128,0"/>
-  </object>
-  <object id="9" type="collision-line" x="0" y="64">
-   <polyline points="0,0 0,16"/>
-  </object>
-  <object id="10" type="collision-line" x="128" y="48">
-   <polyline points="0,0 0,32"/>
-  </object>
   <object id="13" type="collision-line" x="64" y="64">
    <polyline points="0,0 16,0"/>
   </object>

--- a/mods/tuxemon/maps/spyder_scoop3.tmx
+++ b/mods/tuxemon/maps/spyder_scoop3.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="12" height="12" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="30">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="12" height="12" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="30">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -69,58 +69,42 @@
   </object>
   <object id="18" name="Create Alyssa" type="event" x="80" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc spyder_scoop_alyssa,4,9"/>
+    <property name="act1" value="create_npc spyder_scoop_alyssa,5,9"/>
     <property name="cond1" value="not char_exists spyder_scoop_alyssa"/>
    </properties>
   </object>
-  <object id="19" name="Talk Alyssa" type="event" x="64" y="144" width="16" height="16">
+  <object id="19" name="Post Talk Alyssa" type="event" x="80.1818" y="127.818" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_scoop_alyssa1"/>
-    <property name="act2" value="add_monster possessun,40,spyder_scoop_alyssa,5,10"/>
-    <property name="act3" value="start_battle player,spyder_scoop_alyssa"/>
-    <property name="act4" value="translated_dialog spyder_scoop_alyssa2"/>
-    <property name="act6" value="set_variable scoopalyssa:yes"/>
+    <property name="act1" value="translated_dialog spyder_scoop_alyssa2"/>
     <property name="behav1" value="talk spyder_scoop_alyssa"/>
-    <property name="cond1" value="not variable_set scoopalyssa:yes"/>
+    <property name="cond1" value="is variable_set scoopalyssa:yes"/>
    </properties>
   </object>
   <object id="20" name="Create Taggart" type="event" x="112" y="176" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc spyder_scoop_taggart,6,11"/>
+    <property name="act1" value="create_npc spyder_scoop_taggart,7,11"/>
     <property name="act2" value="char_face spyder_scoop_taggart,up"/>
     <property name="cond1" value="not char_exists spyder_scoop_taggart"/>
    </properties>
   </object>
-  <object id="21" name="Talk Taggart" type="event" x="96" y="176" width="16" height="16">
+  <object id="21" name="Post Talk Taggart" type="event" x="112" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_scoop_taggart1"/>
-    <property name="act2" value="add_monster elofly,30,spyder_scoop_taggart,5,10"/>
-    <property name="act3" value="add_monster elowind,35,spyder_scoop_taggart,5,10"/>
-    <property name="act4" value="add_monster lapinou,30,spyder_scoop_taggart,5,10"/>
-    <property name="act5" value="start_battle player,spyder_scoop_taggart"/>
-    <property name="act6" value="translated_dialog spyder_scoop_taggart2"/>
-    <property name="act7" value="set_variable scooptaggart:yes"/>
+    <property name="act1" value="translated_dialog spyder_scoop_taggart2"/>
     <property name="behav1" value="talk spyder_scoop_taggart"/>
-    <property name="cond1" value="not variable_set scooptaggart:yes"/>
+    <property name="cond1" value="is variable_set scooptaggart:yes"/>
    </properties>
   </object>
-  <object id="22" name="Create Donald" type="event" x="176" y="128" width="16" height="16">
+  <object id="22" name="Create Donald" type="event" x="176" y="144" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_scoop_donald,11,9"/>
     <property name="cond1" value="not char_exists spyder_scoop_donald"/>
    </properties>
   </object>
-  <object id="23" name="Talk Donald" type="event" x="176" y="144" width="16" height="16">
+  <object id="23" name="Post Talk Donald" type="event" x="176" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_scoop_donald1"/>
-    <property name="act2" value="add_monster birdling,35,spyder_scoop_donald,5,10"/>
-    <property name="act3" value="add_monster pigabyte,35,spyder_scoop_donald,5,10"/>
-    <property name="act4" value="add_monster zunna,35,spyder_scoop_donald,5,10"/>
-    <property name="act5" value="start_battle player,spyder_scoop_donald"/>
-    <property name="act6" value="translated_dialog spyder_scoop_donald2"/>
-    <property name="act7" value="set_variable scoopdonald:yes"/>
+    <property name="act1" value="translated_dialog spyder_scoop_donald2"/>
     <property name="behav1" value="talk spyder_scoop_donald"/>
-    <property name="cond1" value="not variable_set scoopdonald:yes"/>
+    <property name="cond1" value="is variable_set scoopdonald:yes"/>
    </properties>
   </object>
   <object id="25" name="Environment" type="event" x="16" y="0" width="16" height="16">
@@ -129,7 +113,7 @@
     <property name="cond1" value="not variable_set environment:interior"/>
    </properties>
   </object>
-  <object id="26" name="Talk Alyssa" type="event" x="64" y="160" width="16" height="32">
+  <object id="26" name="Talk Alyssa" type="event" x="64" y="144" width="16" height="48">
    <properties>
     <property name="act0" value="pathfind_to_player spyder_scoop_alyssa"/>
     <property name="act1" value="translated_dialog spyder_scoop_alyssa1"/>
@@ -141,7 +125,7 @@
     <property name="cond2" value="is char_at player"/>
    </properties>
   </object>
-  <object id="27" name="Talk Taggart" type="event" x="96" y="144" width="16" height="32">
+  <object id="27" name="Talk Taggart" type="event" x="96" y="144" width="16" height="48">
    <properties>
     <property name="act0" value="pathfind_to_player spyder_scoop_taggart"/>
     <property name="act1" value="translated_dialog spyder_scoop_taggart1"/>
@@ -155,7 +139,7 @@
     <property name="cond2" value="is char_at player"/>
    </properties>
   </object>
-  <object id="28" name="Talk Donald" type="event" x="176" y="160" width="16" height="32">
+  <object id="28" name="Talk Donald" type="event" x="160" y="160" width="32" height="16">
    <properties>
     <property name="act0" value="pathfind_to_player spyder_scoop_donald"/>
     <property name="act1" value="translated_dialog spyder_scoop_donald1"/>

--- a/mods/tuxemon/maps/spyder_scoop3.tmx
+++ b/mods/tuxemon/maps/spyder_scoop3.tmx
@@ -73,7 +73,7 @@
     <property name="cond1" value="not char_exists spyder_scoop_alyssa"/>
    </properties>
   </object>
-  <object id="19" name="Post Talk Alyssa" type="event" x="80.1818" y="127.818" width="16" height="16">
+  <object id="19" name="Post Talk Alyssa" type="event" x="80" y="128" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_scoop_alyssa2"/>
     <property name="behav1" value="talk spyder_scoop_alyssa"/>

--- a/mods/tuxemon/maps/spyder_scoop4.tmx
+++ b/mods/tuxemon/maps/spyder_scoop4.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="12" height="22" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="59">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="12" height="22" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="62">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -39,15 +39,6 @@
  <objectgroup color="#ff0000" id="7" name="Collisions">
   <object id="4" type="collision" x="0" y="0" width="192" height="48"/>
   <object id="5" type="collision" x="112" y="160" width="80" height="16"/>
-  <object id="7" type="collision-line" x="0" y="352">
-   <polyline points="0,0 192,0"/>
-  </object>
-  <object id="8" type="collision-line" x="0" y="48">
-   <polyline points="0,0 0,304"/>
-  </object>
-  <object id="9" type="collision-line" x="192" y="48">
-   <polyline points="0,0 0,304"/>
-  </object>
   <object id="10" type="collision-line" x="176" y="64">
    <polyline points="0,0 16,0"/>
   </object>
@@ -127,18 +118,6 @@
     <property name="cond2" value="not variable_set scooplandrace:yes"/>
    </properties>
   </object>
-  <object id="35" name="Talk Weaver" type="event" x="112" y="96" width="16" height="16">
-   <properties>
-    <property name="act1" value="translated_dialog spyder_scoop_weaver1"/>
-    <property name="act2" value="add_monster cardiling,30,spyder_scoop_weaver,5,10"/>
-    <property name="act3" value="add_monster spighter,30,spyder_scoop_weaver,5,10"/>
-    <property name="act4" value="start_battle player,spyder_scoop_weaver"/>
-    <property name="act5" value="translated_dialog spyder_scoop_weaver2"/>
-    <property name="act6" value="set_variable scoopweaver:yes"/>
-    <property name="behav1" value="talk spyder_scoop_weaver"/>
-    <property name="cond1" value="not variable_set scoopweaver:yes"/>
-   </properties>
-  </object>
   <object id="36" name="Create Arachne" type="event" x="160" y="128" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_scoop_arachne,10,8"/>
@@ -147,17 +126,12 @@
     <property name="cond2" value="not variable_set scooplandrace:yes"/>
    </properties>
   </object>
-  <object id="37" name="Talk Arachne" type="event" x="160" y="144" width="16" height="16">
+  <object id="37" name="Post Talk Arachne" type="event" x="176" y="160" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_scoop_arachne1"/>
-    <property name="act2" value="add_monster cardiwing,35,spyder_scoop_arachne,5,10"/>
-    <property name="act3" value="add_monster spighter,35,spyder_scoop_arachne,5,10"/>
-    <property name="act4" value="add_monster abesnaki,35,spyder_scoop_arachne,5,10"/>
-    <property name="act5" value="start_battle player,spyder_scoop_arachne"/>
-    <property name="act6" value="translated_dialog spyder_scoop_arachne2"/>
-    <property name="act7" value="set_variable scooparachne:yes"/>
+    <property name="act1" value="translated_dialog spyder_scoop_arachne2"/>
     <property name="behav1" value="talk spyder_scoop_arachne"/>
-    <property name="cond1" value="not variable_set scooparachne:yes"/>
+    <property name="cond1" value="is variable_set scooparachne:yes"/>
+    <property name="cond2" value="not variable_set scooplandrace:yes"/>
    </properties>
   </object>
   <object id="38" name="Create Landrace" type="event" x="160" y="64" width="16" height="16">
@@ -306,19 +280,6 @@
     <property name="cond1" value="not variable_set environment:interior"/>
    </properties>
   </object>
-  <object id="55" name="Talk Orba" type="event" x="0" y="192" width="32" height="16">
-   <properties>
-    <property name="act0" value="pathfind_to_player spyder_scoop_orba"/>
-    <property name="act1" value="translated_dialog spyder_scoop_orba1"/>
-    <property name="act2" value="add_monster abesnaki,30,spyder_scoop_orba,5,10"/>
-    <property name="act3" value="add_monster spighter,30,spyder_scoop_orba,5,10"/>
-    <property name="act4" value="start_battle player,spyder_scoop_orba"/>
-    <property name="act5" value="translated_dialog spyder_scoop_orba2"/>
-    <property name="act6" value="set_variable scooporba:yes"/>
-    <property name="cond1" value="not variable_set scooporba:yes"/>
-    <property name="cond2" value="is char_at player"/>
-   </properties>
-  </object>
   <object id="56" name="Talk Arachne" type="event" x="128" y="128" width="32" height="16">
    <properties>
     <property name="act0" value="pathfind_to_player spyder_scoop_arachne"/>
@@ -344,6 +305,34 @@
     <property name="act6" value="set_variable scoopweaver:yes"/>
     <property name="cond1" value="not variable_set scoopweaver:yes"/>
     <property name="cond2" value="is char_at player"/>
+   </properties>
+  </object>
+  <object id="59" name="Post Talk Orba" type="event" x="32" y="224" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_scoop_orba2"/>
+    <property name="behav1" value="talk spyder_scoop_orba"/>
+    <property name="cond1" value="is variable_set scooporba:yes"/>
+   </properties>
+  </object>
+  <object id="60" name="Post Talk Weaver" type="event" x="96" y="96" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_scoop_weaver2"/>
+    <property name="behav1" value="talk spyder_scoop_weaver"/>
+    <property name="cond1" value="is variable_set scoopweaver:yes"/>
+    <property name="cond2" value="not variable_set scooplandrace:yes"/>
+   </properties>
+  </object>
+  <object id="61" name="Talk Arachne" type="event" x="160" y="160" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_scoop_arachne1"/>
+    <property name="act2" value="add_monster cardiwing,35,spyder_scoop_arachne,5,10"/>
+    <property name="act3" value="add_monster spighter,35,spyder_scoop_arachne,5,10"/>
+    <property name="act4" value="add_monster abesnaki,35,spyder_scoop_arachne,5,10"/>
+    <property name="act5" value="start_battle player,spyder_scoop_arachne"/>
+    <property name="act6" value="translated_dialog spyder_scoop_arachne2"/>
+    <property name="act7" value="set_variable scooparachne:yes"/>
+    <property name="behav1" value="talk spyder_scoop_arachne"/>
+    <property name="cond1" value="not variable_set scooparachne:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_timber_walledgarden1.tmx
+++ b/mods/tuxemon/maps/spyder_timber_walledgarden1.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="16" height="12" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="72">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="16" height="12" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="78">
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
@@ -202,7 +202,7 @@
     <property name="act3" value="add_monster cowpignon,50,spyder_walled_vanderbilt,5,10"/>
     <property name="act4" value="add_monster narcileaf,50,spyder_walled_vanderbilt,5,10"/>
     <property name="act5" value="start_battle player,spyder_walled_vanderbilt"/>
-    <property name="act6" value="translated_dialog spyder_walled_vanderbilt"/>
+    <property name="act6" value="translated_dialog spyder_walled_vanderbilt2"/>
     <property name="act7" value="set_variable walledvanderbilt:yes"/>
     <property name="cond1" value="not variable_set walledvanderbilt:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -230,7 +230,7 @@
     <property name="act3" value="add_monster cowpignon,50,spyder_walled_vanderbilt,5,10"/>
     <property name="act4" value="add_monster narcileaf,50,spyder_walled_vanderbilt,5,10"/>
     <property name="act5" value="start_battle player,spyder_walled_vanderbilt"/>
-    <property name="act6" value="translated_dialog spyder_walled_vanderbilt"/>
+    <property name="act6" value="translated_dialog spyder_walled_vanderbilt2"/>
     <property name="act7" value="set_variable walledvanderbilt:yes"/>
     <property name="cond1" value="not variable_set walledvanderbilt:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -255,6 +255,48 @@
     <property name="act7" value="set_variable walledastor:yes"/>
     <property name="cond1" value="not variable_set walledastor:yes"/>
     <property name="cond2" value="is char_at player"/>
+   </properties>
+  </object>
+  <object id="72" name="Post Talk astor" type="event" x="176" y="128" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_walled_astor2"/>
+    <property name="behav1" value="talk spyder_walled_astor"/>
+    <property name="cond1" value="is variable_set walledastor:yes"/>
+   </properties>
+  </object>
+  <object id="73" name="Post Talk girard" type="event" x="64" y="128" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_walled_girard2"/>
+    <property name="behav1" value="talk spyder_walled_girard"/>
+    <property name="cond1" value="is variable_set walledgirard:yes"/>
+   </properties>
+  </object>
+  <object id="74" name="Post Talk ford" type="event" x="64" y="96" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_walled_ford2"/>
+    <property name="behav1" value="talk spyder_walled_ford"/>
+    <property name="cond1" value="is variable_set walledford:yes"/>
+   </properties>
+  </object>
+  <object id="75" name="Post Talk vanderbilt" type="event" x="176" y="96" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_walled_vanderbilt2"/>
+    <property name="behav1" value="talk spyder_walled_vanderbilt"/>
+    <property name="cond1" value="is variable_set walledvanderbilt:yes"/>
+   </properties>
+  </object>
+  <object id="76" name="Post Talk fugger" type="event" x="176" y="32" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_walled_fugger2"/>
+    <property name="behav1" value="talk spyder_walled_fugger"/>
+    <property name="cond1" value="is variable_set walledfugger:yes"/>
+   </properties>
+  </object>
+  <object id="77" name="Post Talk carnegie" type="event" x="48" y="32" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_walled_carnegie2"/>
+    <property name="behav1" value="talk spyder_walled_carnegie"/>
+    <property name="cond1" value="is variable_set walledcarnegie:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_timber_walledgarden2.tmx
+++ b/mods/tuxemon/maps/spyder_timber_walledgarden2.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="16" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="79">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="16" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="85">
  <properties>
   <property name="inside" type="bool" value="true"/>
   <property name="scenario" value="spyder"/>
@@ -117,7 +117,7 @@
     <property name="cond1" value="not char_exists spyder_walled_alexander"/>
    </properties>
   </object>
-  <object id="63" name="Talk NPC4" type="event" x="96" y="176" width="16" height="32">
+  <object id="63" name="Talk Alexander" type="event" x="96" y="176" width="16" height="32">
    <properties>
     <property name="act0" value="pathfind_to_player spyder_walled_alexander"/>
     <property name="act1" value="translated_dialog spyder_walled_alexander1"/>
@@ -244,6 +244,48 @@
     <property name="act99" value="unlock_controls"/>
     <property name="cond1" value="is variable_set walledmidas:yes"/>
     <property name="cond2" value="not variable_set walledbillie:yes"/>
+   </properties>
+  </object>
+  <object id="79" name="Post Talk rufus" type="event" x="144" y="240" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_walled_rufus2"/>
+    <property name="behav1" value="talk spyder_walled_rufus"/>
+    <property name="cond1" value="is variable_set walledrufus:yes"/>
+   </properties>
+  </object>
+  <object id="80" name="Post Talk crassus" type="event" x="144" y="208" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_walled_crassus2"/>
+    <property name="behav1" value="talk spyder_walled_crassus"/>
+    <property name="cond1" value="is variable_set walledcrassus:yes"/>
+   </properties>
+  </object>
+  <object id="81" name="Post Talk osman" type="event" x="144" y="160" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_walled_osman2"/>
+    <property name="behav1" value="talk spyder_walled_osman"/>
+    <property name="cond1" value="is variable_set walledosman:yes"/>
+   </properties>
+  </object>
+  <object id="82" name="Post Talk Alexander" type="event" x="96" y="160" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_walled_alexander2"/>
+    <property name="behav1" value="talk spyder_walled_alexander"/>
+    <property name="cond1" value="is variable_set walledalexander:yes"/>
+   </properties>
+  </object>
+  <object id="83" name="Post Talk augustus" type="event" x="80" y="112" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_walled_augustus2"/>
+    <property name="behav1" value="talk spyder_walled_augustus"/>
+    <property name="cond1" value="is variable_set walledaugustus:yes"/>
+   </properties>
+  </object>
+  <object id="84" name="Post Talk musa" type="event" x="160" y="112" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_walled_musa2"/>
+    <property name="behav1" value="talk spyder_walled_musa"/>
+    <property name="cond1" value="is variable_set walledmusa:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_tunnel.tmx
+++ b/mods/tuxemon/maps/spyder_tunnel.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="361">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="364">
  <properties>
   <property name="east" value="route6"/>
   <property name="edges" value="clamped"/>
@@ -221,6 +221,27 @@
     <property name="act1" value="set_variable environment:night_grass"/>
     <property name="cond1" value="not variable_set stage_of_day:night"/>
     <property name="cond2" value="not variable_set environment:night_grass"/>
+   </properties>
+  </object>
+  <object id="361" name="Post Talk Tommy" type="event" x="208" y="96" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_tunnelb_tommy2"/>
+    <property name="behav1" value="talk spyder_tunnelb_tommy"/>
+    <property name="cond1" value="is variable_set tunnelbtommy:yes"/>
+   </properties>
+  </object>
+  <object id="362" name="Post Talk Iris" type="event" x="176" y="240" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_tunnelb_iris2"/>
+    <property name="behav1" value="talk spyder_tunnelb_iris"/>
+    <property name="cond1" value="is variable_set tunnelbiris:yes"/>
+   </properties>
+  </object>
+  <object id="363" name="Post Talk Greta" type="event" x="192" y="560" width="16" height="16">
+   <properties>
+    <property name="act01" value="translated_dialog spyder_tunnelb_greta2"/>
+    <property name="behav1" value="talk spyder_tunnelb_greta"/>
+    <property name="cond1" value="is variable_set tunnelbgreta:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_tunnel_below.tmx
+++ b/mods/tuxemon/maps/spyder_tunnel_below.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="75">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="78">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -215,6 +215,27 @@
     <property name="act3" value="remove_npc spyder_tunnelb_rhincus"/>
     <property name="act4" value="set_variable tunnelb_rhincus:yes"/>
     <property name="behav1" value="talk spyder_tunnelb_rhincus"/>
+   </properties>
+  </object>
+  <object id="75" name="Talk Beryll" type="event" x="160" y="496" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_tunnelb_beryll2"/>
+    <property name="behav1" value="talk spyder_tunnelb_beryll"/>
+    <property name="cond1" value="is variable_set tunnelbberyll:yes"/>
+   </properties>
+  </object>
+  <object id="76" name="Talk Lute" type="event" x="48" y="576" width="16" height="16">
+   <properties>
+    <property name="act01" value="translated_dialog spyder_tunnelb_lute2"/>
+    <property name="behav1" value="talk spyder_tunnelb_lute"/>
+    <property name="cond1" value="is variable_set tunnelblute:yes"/>
+   </properties>
+  </object>
+  <object id="77" name="Talk Meitner" type="event" x="256" y="304" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_tunnelb_meitner2"/>
+    <property name="behav1" value="talk spyder_tunnelb_meitner"/>
+    <property name="cond1" value="is variable_set tunnelbmeitner:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
+++ b/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="16" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="82">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="16" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="89">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -34,10 +34,9 @@
  <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="1" type="collision" x="0" y="0" width="16" height="256"/>
   <object id="5" type="collision" x="16" y="0" width="160" height="32"/>
-  <object id="8" type="collision" x="32" y="176" width="96" height="16"/>
+  <object id="8" type="collision" x="32" y="176" width="192" height="16"/>
   <object id="9" type="collision" x="32" y="192" width="32" height="16"/>
   <object id="10" type="collision" x="112" y="192" width="16" height="64"/>
-  <object id="12" type="collision" x="128" y="176" width="112" height="16"/>
   <object id="13" type="collision" x="224" y="0" width="16" height="176"/>
   <object id="14" type="collision" x="176" y="0" width="32" height="16"/>
   <object id="15" type="collision" x="208" y="0" width="16" height="32"/>
@@ -159,7 +158,7 @@
     <property name="cond1" value="not variable_set quebotbot:yes"/>
    </properties>
   </object>
-  <object id="54" name="Talk Maniac - Got Botbot" type="event" x="112" y="112" width="16" height="16">
+  <object id="54" name="Talk Maniac - Got Botbot" type="event" x="112" y="128" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_wayfarer1_maniac1"/>
     <property name="act2" value="add_monster botbot,10"/>
@@ -171,7 +170,7 @@
     <property name="cond4" value="not check_char_parameter player,name,ApexPlayer"/>
    </properties>
   </object>
-  <object id="38" name="Talk Maniac - Got Botbot - Cheat" type="event" x="112" y="112" width="16" height="16">
+  <object id="38" name="Talk Maniac - Got Botbot - Cheat" type="event" x="112" y="64" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_wayfarer1_maniac1"/>
     <property name="act2" value="add_monster botbot,10"/>
@@ -182,14 +181,14 @@
     <property name="cond4" value="is check_char_parameter player,name,ApexPlayer"/>
    </properties>
   </object>
-  <object id="80" name="Talk Maniac - Followup Yes" type="event" x="112" y="112" width="16" height="16">
+  <object id="80" name="Talk Maniac - Followup Yes" type="event" x="112" y="80" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_wayfarer1_maniac2"/>
     <property name="behav1" value="talk spyder_wayfarer1_wes"/>
     <property name="cond1" value="is variable_set wayfarer1_botbot:yes"/>
    </properties>
   </object>
-  <object id="81" name="Talk Maniac - Followup no" type="event" x="112" y="112" width="16" height="16">
+  <object id="81" name="Talk Maniac - Followup no" type="event" x="112" y="96" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_wayfarer1_maniac2"/>
     <property name="behav1" value="talk spyder_wayfarer1_wes"/>
@@ -358,6 +357,55 @@
     <property name="act15" value="set_variable wayfarer1bismuth:yes"/>
     <property name="behav1" value="talk spyder_wayfarer1_bismuth"/>
     <property name="cond1" value="not variable_set wayfarer1bismuth:yes"/>
+   </properties>
+  </object>
+  <object id="82" name="Post Talk Jessie" type="event" x="112" y="224" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_wayfarer1_jessie2"/>
+    <property name="behav1" value="talk spyder_wayfarer1_jessie"/>
+    <property name="cond1" value="is variable_set wayfarer1jessie:yes"/>
+   </properties>
+  </object>
+  <object id="83" name="Post Talk Nightshade" type="event" x="112" y="208" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_wayfarer1_nightshade2"/>
+    <property name="behav1" value="talk spyder_wayfarer1_nightshade"/>
+    <property name="cond1" value="is variable_set wayfarer1nightshade:yes"/>
+   </properties>
+  </object>
+  <object id="84" name="Post Talk Bismuth" type="event" x="112" y="192" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_wayfarer1_bismuth2"/>
+    <property name="behav1" value="talk spyder_wayfarer1_bismuth"/>
+    <property name="cond1" value="is variable_set wayfarer1bismuth:yes"/>
+   </properties>
+  </object>
+  <object id="85" name="Post Talk Morton" type="event" x="32" y="64" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_wayfarer1_morton2"/>
+    <property name="behav1" value="talk spyder_wayfarer1_morton"/>
+    <property name="cond1" value="is variable_set wayfarer1morton:yes"/>
+   </properties>
+  </object>
+  <object id="86" name="Post Talk Ratcher" type="event" x="48" y="64" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_wayfarer1_ratcher2"/>
+    <property name="behav1" value="talk spyder_wayfarer1_ratcher"/>
+    <property name="cond1" value="is variable_set wayfarer1ratcher:yes"/>
+   </properties>
+  </object>
+  <object id="87" name="Post Talk Morningstar" type="event" x="64" y="64" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_wayfarer1_morningstar2"/>
+    <property name="behav1" value="talk spyder_wayfarer1_morningstar"/>
+    <property name="cond1" value="is variable_set wayfarer1morningstar:yes"/>
+   </properties>
+  </object>
+  <object id="88" name="Post Talk Victor" type="event" x="208" y="16" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_wayfarer1_victor2"/>
+    <property name="behav1" value="talk spyder_wayfarer1_victor"/>
+    <property name="cond1" value="is variable_set wayfarer1victor:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_wayfarer_inn2.tmx
+++ b/mods/tuxemon/maps/spyder_wayfarer_inn2.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="16" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="51">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="15" height="16" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="53">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -52,12 +52,10 @@
   <object id="18" type="collision" x="48" y="32" width="16" height="32"/>
   <object id="19" type="collision" x="64" y="48" width="16" height="16"/>
   <object id="20" type="collision" x="224" y="32" width="16" height="144"/>
-  <object id="21" type="collision" x="128" y="176" width="96" height="16"/>
   <object id="22" type="collision" x="96" y="240" width="16" height="16"/>
   <object id="25" type="collision" x="176" y="48" width="16" height="16"/>
   <object id="26" type="collision" x="80" y="96" width="16" height="16"/>
-  <object id="28" type="collision" x="80" y="176" width="48" height="32"/>
-  <object id="29" type="collision" x="112" y="208" width="16" height="16"/>
+  <object id="28" type="collision" x="80" y="176" width="144" height="16"/>
   <object id="30" type="collision-line" x="160" y="48">
    <polyline points="0,0 16,0"/>
   </object>
@@ -178,6 +176,20 @@
     <property name="act17" value="set_variable wayfarer1bravo:yes"/>
     <property name="cond1" value="not variable_set wayfarer1bravo:yes"/>
     <property name="cond2" value="is char_at player"/>
+   </properties>
+  </object>
+  <object id="51" name="Post Talk James" type="event" x="128" y="128" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_wayfarer1_james2"/>
+    <property name="behav1" value="talk spyder_wayfarer1_james"/>
+    <property name="cond1" value="is variable_set wayfarer1james:yes"/>
+   </properties>
+  </object>
+  <object id="52" name="Post Talk Bravo" type="event" x="192" y="16" width="16" height="16">
+   <properties>
+    <property name="act10" value="translated_dialog spyder_wayfarer1_bravo2"/>
+    <property name="behav1" value="talk spyder_wayfarer1_bravo"/>
+    <property name="cond1" value="is variable_set wayfarer1bravo:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/tests/tuxemon/test_folder_maps_tmx.py
+++ b/tests/tuxemon/test_folder_maps_tmx.py
@@ -51,7 +51,7 @@ def _is_object_type(obj_name: str) -> bool:
 def _is_valid_integer(value: str) -> bool:
     try:
         int(value)
-        return True
+        return value == str(int(value))
     except ValueError:
         return False
 


### PR DESCRIPTION
PR:
- introduces events that enable the player to engage in conversation with the NPC after a fight and fixes #2341
- adds `return value == str(int(value))`, because this will now return False for values like 1.0 or any other values that contain decimal characters, ensuring that only integer are accepted;

@Sanglorian , here #2341  @ultidonki says that he can't talk with some NPCs after fighting them, this could be solved by adding an extra event and allow the NPC to repeat the sentence that says after the combat.

right now:
NPC says XYZ -> fight > says QWE > interact again > no reply
after:
NPC says XYZ -> fight > says QWE > interact again > repeats QWE

is it ok for you or do you want to keep NPC that cannot "talk"? Let me know, because this PR solves the cases in different maps. Of course it the NPC doesn't disappear (eg. Omnichannel, etc.)

as usual I bumped into weird things, like events over collision zone, some duplicates, wrong position, etc.