### PR TITLE
fix bug walking

### DIFF
--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -111,7 +111,6 @@ class NPC(Entity[NPCState]):
         self.money: dict[str, int] = {}  # Tracks money
         # list of ways player can interact with the Npc
         self.interactions: Sequence[str] = []
-        self.isplayer: bool = False  # used for various tests, idk
         # menu labels (world menu)
         self.menu_save: bool = True
         self.menu_load: bool = True


### PR DESCRIPTION
while testing with the savegame of @ultidonki I bumped into this

![Screenshot_2024-08-21_11-22-32](https://github.com/user-attachments/assets/f7301c1a-9d0e-46f5-aac4-4d43384484f4)

this happened because the NPC wasn't using its collision zone, but it was keeping the collision zone of the tile (the one below the NPC), the tile allows to **enter_from** **right**, **left** and **down** as well as **exit_from** in the same directions, of course **up** is absent because of the "cliff".

so I needed to updated the code in **entity.py** and introduced the _handle player vs non-player entities_, this obliged me to move the boolean **self.isplayer** from **npc.py** to **entity.py**.

at the same time I noticed the def remove_collision and I took the opportunity to improve readibility, add an early return and simplify a bit.