### PR TITLE
fix 2366 (collision zone in Flower City)

### DIFF
--- a/mods/tuxemon/maps/spyder_flower_city.tmx
+++ b/mods/tuxemon/maps/spyder_flower_city.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="500">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="501">
  <properties>
   <property name="east" value="route4"/>
   <property name="edges" value="clamped"/>
@@ -40,7 +40,7 @@
   <object id="332" type="collision" x="368" y="336" width="32" height="48"/>
   <object id="333" type="collision" x="400" y="336" width="48" height="32"/>
   <object id="334" type="collision" x="416" y="368" width="32" height="16"/>
-  <object id="343" type="collision" x="128" y="432" width="32" height="16"/>
+  <object id="343" type="collision" x="128" y="416" width="32" height="32"/>
   <object id="350" type="collision" x="32" y="240" width="16" height="16"/>
   <object id="351" type="collision" x="48" y="256" width="16" height="16"/>
   <object id="352" type="collision" x="64" y="240" width="16" height="16"/>
@@ -116,7 +116,8 @@
   <object id="480" type="collision" x="384" y="608" width="16" height="32"/>
   <object id="493" type="collision" x="0" y="576" width="400" height="32"/>
   <object id="494" type="collision" x="176" y="384" width="32" height="64"/>
-  <object id="497" type="collision" x="128" y="384" width="48" height="48"/>
+  <object id="497" type="collision" x="128" y="384" width="48" height="16"/>
+  <object id="500" type="collision" x="144" y="400" width="16" height="16"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="7" name="Events">
   <object id="293" name="Teleport to Route 4" type="event" x="624" y="64" width="16" height="16">


### PR DESCRIPTION
related to #2366 by @ultidonki 

> If you go into this house in Flower city (spyder_flower_city.tmx), and then leave through the exit on the left, into this garden: There's no door back into the house again, and you can't walk over the fence, so you're softlocked and need to load a save file from before going through the door. Expected behaviour: You should be able to go inside the house again somehow.

fix issue with collision zone, there was the event teleport, but it was over a collision zone, so no way to reenter inside

the other one needs more investigation