### PR TITLE
combat animation

### DIFF
--- a/tuxemon/sprite.py
+++ b/tuxemon/sprite.py
@@ -236,17 +236,20 @@ class CaptureDeviceSprite(Sprite):
         """
         if self.state == "empty":
             self.sprite.image = self.empty_img
+            return "empty"
+
+        assert self.monster
+
+        if any(t.slug == "faint" for t in self.monster.status):
+            self.state = "faint"
+            self.sprite.image = self.faint_img
+        elif self.monster.status:
+            self.state = "effected"
+            self.sprite.image = self.effected_img
         else:
-            assert self.monster
-            if any(t for t in self.monster.status if t.slug == "faint"):
-                self.state = "faint"
-                self.sprite.image = self.faint_img
-            elif len(self.monster.status) > 0:
-                self.state = "effected"
-                self.sprite.image = self.effected_img
-            else:
-                self.state = "alive"
-                self.sprite.image = self.alive_img
+            self.state = "alive"
+            self.sprite.image = self.alive_img
+
         return self.state
 
     def animate_capture(

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -43,7 +43,7 @@ from typing import Literal, Optional, Union
 import pygame
 from pygame.rect import Rect
 
-from tuxemon import audio, graphics, prepare, state, tools
+from tuxemon import graphics, prepare, state, tools
 from tuxemon.ai import AI
 from tuxemon.animation import Animation, Task
 from tuxemon.combat import (
@@ -586,7 +586,7 @@ class CombatState(CombatAnimations):
         self,
         player: NPC,
         monster: Monster,
-        removed: Union[Monster, None] = None,
+        removed: Optional[Monster] = None,
     ) -> None:
         """
         Add a monster to the battleground.
@@ -594,32 +594,36 @@ class CombatState(CombatAnimations):
         Parameters:
             player: Player who adds the monster, if any.
             monster: Added monster.
+            removed: Monster that was previously in play, if any.
 
         """
-        item = Item()
-        item.load(monster.capture_device)
-        sprite = self._method_cache.get(item, False)
-        assert sprite
+        capture_device = Item()
+        capture_device.load(monster.capture_device)
+        sprite = self._method_cache.get(capture_device, False)
+        if not sprite:
+            raise ValueError(f"Sprite not found for item {capture_device}")
+
         self.animate_monster_release(player, monster, sprite)
         self.monsters_in_play[player].append(monster)
         self.update_hud(player)
 
-        # remove "bond" status (eg. lifeleech, etc.)
+        # Remove "bond" status from all active monsters
         for mon in self.active_monsters:
-            if any(sta.bond for sta in monster.status):
-                mon.status.clear()
+            mon.status = [sta for sta in mon.status if not sta.bond]
 
-        # TODO: not hardcode
-        message = None
-        if removed and removed.status:
+        # Handle removed monster's status effects
+        if removed is not None and removed.status:
             removed.status[0].combat_state = self
             removed.status[0].phase = "add_monster_into_play"
             removed.status[0].use(removed)
 
-        params = {"target": monster.name.upper(), "user": player.name.upper()}
+        # Create message for combat swap
+        format_params = {
+            "target": monster.name.upper(),
+            "user": player.name.upper(),
+        }
         if self._turn > 1:
-            message = T.format("combat_swap", params)
-        if message:
+            message = T.format("combat_swap", format_params)
             self.text_animations_queue.append(
                 (partial(self.alert, message), 0)
             )
@@ -847,8 +851,7 @@ class CombatState(CombatAnimations):
                     m = T.translate(result_tech["extra"])
                 message += "\n" + m
                 action_time += compute_text_animation_time(message)
-            # TODO: caching sounds
-            audio.load_sound(method.sfx, None).play()
+            self.play_sound_effect(method.sfx)
             # animation own monster, technique doesn't tackle
             hit_delay += 0.5
             if "own monster" in method.target:


### PR DESCRIPTION
PR:
- updates **update_state** in **sprite.py** (do we need an Enum or Str Enum for empty, effected, etc?);
- updates **add_monster_into_play** in **combat/combat.py**, missing parameter, typehints, name of variables (eg capture_device);
- updates **animate_monster_release** in **combat_animations.py**, the famous issue related to #1301, for the sliding in, it was necessary to change from `transition="out_back",` to `transition="out_quad",`;
- updates **transition_none_normal**, **animate_trainer_leave**, **animate_monster_faint**, **get_side**, **split_label**  in **combat_animations.py**;
- splits **animate_parties_in** in **combat_animations.py**, this method was particularly long, so it has been split into: **flip_sprites**,  **animate_sprites**, **play_sound_effect** and **display_alert_message**;
- **play_sound_effect** method will serve as a centralized gateway for playing all sound effects related to combat and combat animations;
- and related to **play_sound_effect**, the sounds will be cached in **_sound_cache**, a simple **dict** (as per TODO);
- updates description of **animate_capture_monster**, I forgot in #2354 ;