### PR TITLE
ActionQueue history

### DIFF
--- a/tuxemon/condition/effects/elemental_shield.py
+++ b/tuxemon/condition/effects/elemental_shield.py
@@ -39,7 +39,7 @@ class ElementalShieldBackEffect(CondEffect):
         done: bool = False
         assert condition.combat_state
         combat = condition.combat_state
-        log = combat._log_action
+        log = combat._action_queue.history
         turn = combat._turn
         ranges = self.ranges.split(":")
         # check log actions

--- a/tuxemon/condition/effects/feedback.py
+++ b/tuxemon/condition/effects/feedback.py
@@ -39,7 +39,7 @@ class FeedBackEffect(CondEffect):
         done: bool = False
         assert condition.combat_state
         combat = condition.combat_state
-        log = combat._log_action
+        log = combat._action_queue.history
         turn = combat._turn
         ranges = self.ranges.split(":")
         # check log actions

--- a/tuxemon/condition/effects/prickly.py
+++ b/tuxemon/condition/effects/prickly.py
@@ -39,7 +39,7 @@ class PricklyBackEffect(CondEffect):
         done: bool = False
         assert condition.combat_state
         combat = condition.combat_state
-        log = combat._log_action
+        log = combat._action_queue.history
         turn = combat._turn
         ranges = self.ranges.split(":")
         # check log actions

--- a/tuxemon/condition/effects/retaliate.py
+++ b/tuxemon/condition/effects/retaliate.py
@@ -40,7 +40,7 @@ class RetaliateEffect(CondEffect):
         done: bool = False
         assert condition.combat_state
         combat = condition.combat_state
-        log = combat._log_action
+        log = combat._action_queue.history
         turn = combat._turn
         # check log actions
         attacker: Union[Monster, None] = None

--- a/tuxemon/condition/effects/revenge.py
+++ b/tuxemon/condition/effects/revenge.py
@@ -39,7 +39,7 @@ class RevengeEffect(CondEffect):
         done: bool = False
         assert condition.combat_state
         combat = condition.combat_state
-        log = combat._log_action
+        log = combat._action_queue.history
         turn = combat._turn
         # check log actions
         attacker: Union[Monster, None] = None

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -159,7 +159,6 @@ class CombatState(CombatAnimations):
         self._action_queue = ActionQueue()
         self._decision_queue: list[Monster] = []
         self._pending_queue: list[EnqueuedAction] = []
-        self._log_action: list[tuple[int, EnqueuedAction]] = []
         self._monster_sprite_map: MutableMapping[Monster, Sprite] = {}
         self._layout = dict()  # player => home areas on screen
         self._turn: int = 0
@@ -747,8 +746,7 @@ class CombatState(CombatAnimations):
 
         """
         action = EnqueuedAction(user, technique, target)
-        self._action_queue.enqueue(action)
-        self._log_action.append((self._turn, action))
+        self._action_queue.enqueue(action, self._turn)
 
     def remove_monster_from_play(
         self,
@@ -1243,8 +1241,8 @@ class CombatState(CombatAnimations):
 
         # clear action queue
         self._action_queue.clear_queue()
+        self._action_queue.clear_history()
         self._pending_queue = list()
-        self._log_action = list()
         self._damage_map = list()
 
     def end_combat(self) -> None:

--- a/tuxemon/states/combat/combat_classes.py
+++ b/tuxemon/states/combat/combat_classes.py
@@ -99,15 +99,22 @@ class ActionQueue:
 
     def __init__(self) -> None:
         self._action_queue: list[EnqueuedAction] = []
+        self._action_history: list[tuple[int, EnqueuedAction]] = []
 
     @property
     def queue(self) -> list[EnqueuedAction]:
         """Returns the current action queue."""
         return self._action_queue
 
-    def enqueue(self, action: EnqueuedAction) -> None:
-        """Adds an action to the end of the queue."""
+    @property
+    def history(self) -> list[tuple[int, EnqueuedAction]]:
+        """Returns the current action history."""
+        return self._action_history
+
+    def enqueue(self, action: EnqueuedAction, turn: int) -> None:
+        """Adds an action to the end of the queue and history."""
         self._action_queue.append(action)
+        self._action_history.append((turn, action))
 
     def dequeue(self, action: EnqueuedAction) -> None:
         """Removes an action from the queue if it exists."""
@@ -127,6 +134,10 @@ class ActionQueue:
     def clear_queue(self) -> None:
         """Clears the entire queue."""
         self._action_queue.clear()
+
+    def clear_history(self) -> None:
+        """Clears the entire history."""
+        self._action_history.clear()
 
     def sort(self) -> None:
         """

--- a/tuxemon/technique/effects/multiattack.py
+++ b/tuxemon/technique/effects/multiattack.py
@@ -39,7 +39,7 @@ class MultiAttackEffect(TechEffect):
         combat = tech.combat_state
         value = random.random()
         combat._random_tech_hit[user] = value
-        log = combat._log_action
+        log = combat._action_queue.history
         turn = combat._turn
         # Track previous actions with the same technique, user, and target
         track = [


### PR DESCRIPTION
PR integrates the old **_log_action** as history of **ActionQueue**, because _log_action is an **EnqueuedAction** list that gets cleared only at the end of the fight.