### PR TITLE
fix 2366

### DIFF
--- a/tuxemon/event/actions/transition_teleport.py
+++ b/tuxemon/event/actions/transition_teleport.py
@@ -45,7 +45,8 @@ class TransitionTeleportAction(EventAction):
 
         if world.npcs:
             for _npc in world.npcs:
-                world.npcs.remove(_npc)
+                if _npc.moving or _npc.path:
+                    world.npcs.remove(_npc)
 
         if world.delayed_teleport:
             self.stop()

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -672,6 +672,7 @@ class CombatState(CombatAnimations):
                             )
                         )
                     icon = self._status_icon_cache[status.icon]
+                    self.sprites.add(icon, layer=200)
                     self._status_icons[monster].append(icon)
 
         # update tuxemon balls to reflect status


### PR DESCRIPTION
PR fixes #2366 first issue reported by @ultidonki :
```
Traceback (most recent call last):
File "run_tuxemon.py", line 49, in
main.main(load_slot=args.slot)
File "tuxemon/main.py", line 90, in main
client.main()
File "tuxemon/client.py", line 301, in main
update(clock_tick)
File "tuxemon/client.py", line 346, in update
self.event_engine.update(time_delta)
File "tuxemon/event/eventengine.py", line 359, in update
self.update_running_events(dt)
File "tuxemon/event/eventengine.py", line 450, in update_running_events
action.start()
File "tuxemon/event/actions/pathfind.py", line 37, in start
assert self.npc
AssertionError
```
this happens because self.npc (spyder_billie) wasn't in the map (among self.npcs - world); the cause for this was **transition_teleport.py**, this piece:
```
        if world.npcs:
            for _npc in world.npcs:
                world.npcs.remove(_npc)
```
So, I dug into the issue and found that when the player faints, it triggers a teleportation bug that removes some NPCs, including Spyder Billie. This, in turn, causes the pathfinding to crash. I actually tried to fix a similar issue with wandering NPCs in #2317, but I ended up implementing a more generic solution instead of targeting the specific problem. I should've been more precise and only filtered out NPCs that are actually moving (i.e., those with a True boolean) or have a path (i.e., a list of tuples).

```
        if world.npcs:
            for _npc in world.npcs:
                if _npc.moving or _npc.path:
                    world.npcs.remove(_npc)
```
Bug fixed.

I also added **self.sprites.add(icon, layer=200)** in combat/combat.py, because I noticed that without it, the icons would only appear once and then disappear. Turns out, they need to be explicitly added to the sprites group in order to stick around - I stumbled upon this while testing for this bug.