### PR TITLE
spawn_monster (event action) and formula

### DIFF
--- a/tuxemon/event/actions/spawn_monster.py
+++ b/tuxemon/event/actions/spawn_monster.py
@@ -4,14 +4,16 @@ from __future__ import annotations
 
 import logging
 import random
+import re
 import uuid
 from dataclasses import dataclass
 from typing import final
 
-from tuxemon import formula, monster
+from tuxemon import formula
 from tuxemon.event import get_monster_by_iid, get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.locale import T
+from tuxemon.monster import Monster
 from tuxemon.states.dialog import DialogState
 from tuxemon.tools import open_dialog
 
@@ -51,63 +53,65 @@ class SpawnMonsterAction(EventAction):
         mother_id = uuid.UUID(player.game_variables["breeding_mother"])
         father_id = uuid.UUID(player.game_variables["breeding_father"])
 
-        mother = get_monster_by_iid(self.session, mother_id)
+        mother = get_monster_by_iid(
+            self.session, mother_id
+        ) or player.find_monster_in_storage(mother_id)
         if mother is None:
-            logger.debug("Mother not found in party, searching boxes.")
-            mother = player.find_monster_in_storage(mother_id)
-            if mother is None:
-                logger.debug(f"Mother {mother_id} not found in boxes.")
-                return
+            logger.debug(f"Mother {mother_id} not found.")
+            return
 
-        father = get_monster_by_iid(self.session, father_id)
+        father = get_monster_by_iid(
+            self.session, father_id
+        ) or player.find_monster_in_storage(father_id)
         if father is None:
-            logger.debug("Father not found in party, searching boxes.")
-            father = player.find_monster_in_storage(father_id)
-            if father is None:
-                logger.debug(f"Father {father_id} not found in boxes.")
-                return
+            logger.debug(f"Father {father_id} not found.")
+            return
 
-        # matrix, it respects the types[0], strong against weak.
-        # Mother (Water), Father (Earth)
-        # Earth > Water => Child (Earth)
-        if mother.types[0].slug.water and father.types[0].slug.earth:
-            seed = father
-        elif mother.types[0].slug.fire and father.types[0].slug.water:
-            seed = father
-        elif mother.types[0].slug.wood and father.types[0].slug.metal:
-            seed = father
-        elif mother.types[0].slug.metal and father.types[0].slug.fire:
-            seed = father
-        elif mother.types[0].slug.earth and father.types[0].slug.wood:
-            seed = father
+        # Determine the seed monster based on the types of the mother and father
+        seed = _determine_seed(mother, father)
+        if seed == father:
+            name = _determine_name(father.name, mother.name)
         else:
-            seed = mother
+            name = _determine_name(mother.name, father.name)
 
-        # retrieve the basic form
-        for element in seed.history:
-            if element.evo_stage.basic:
-                seed_slug = element.mon_slug
+        # Get the basic form of the seed monster
+        seed_slug = seed.slug
+        if seed.history:
+            seed_slug = next(
+                (
+                    element.mon_slug
+                    for element in seed.history
+                    if element.evo_stage.basic
+                ),
+                seed_slug,
+            )
 
-        # continues the creation of the child.
-        child = monster.Monster()
+        level = (father.level + mother.level) // 2
+
+        # Create a new child monster
+        child = Monster()
         child.load_from_db(seed_slug)
-        child.set_level(5)
-        child.set_moves(5)
+        child.set_level(level)
+        child.set_moves(level)
         child.set_capture(formula.today_ordinal())
+        child.name = name
         child.current_hp = child.hp
-        # child gets random father's moves
+
+        # Give the child a random move from the father
         father_moves = len(father.moves)
         replace_tech = random.randrange(0, 2)
         child.moves[replace_tech] = father.moves[
             random.randrange(0, father_moves - 1)
         ]
 
+        # Add the child to the character's monsters
         character = get_npc(self.session, self.character)
         if character is None:
             logger.error(f"{self.character} not found")
             return
         character.add_monster(child, len(character.monsters))
 
+        # Display a message to the player
         msg = T.format("got_new_tuxemon", {"monster_name": child.name})
         open_dialog(self.session, [msg])
 
@@ -116,3 +120,61 @@ class SpawnMonsterAction(EventAction):
             self.session.client.get_state_by_name(DialogState)
         except ValueError:
             self.stop()
+
+
+def _determine_seed(mother: Monster, father: Monster) -> Monster:
+    """Determine the seed monster based on the multiplier."""
+
+    mother_multiplier = formula.calculate_multiplier(
+        mother.types, father.types
+    )
+    father_multiplier = formula.calculate_multiplier(
+        father.types, mother.types
+    )
+
+    if mother_multiplier > father_multiplier:
+        return mother
+    elif father_multiplier > mother_multiplier:
+        return father
+    else:
+        return random.choice([father, mother])
+
+
+def _determine_name(first: str, second: str) -> str:
+    """Combine two names by cutting each at the closest vocal."""
+
+    if not re.search(r"[aeiouy]", first) or not re.search(r"[aeiouy]", second):
+        # If either word doesn't have a vowel, split at the midpoint
+        midpoint1 = len(first) // 2
+        midpoint2 = len(second) // 2
+        _first = first[:midpoint1]
+        _second = second[midpoint2:]
+        result = _first + _second
+    else:
+        # If both words have vowels, use the original algorithm
+        def find_closest_vocal(word: str) -> int:
+            midpoint = len(word) // 2
+            min_distance = float("inf")
+            closest_index = 0
+            for i, char in enumerate(word):
+                if char in "aeiouy":
+                    distance = abs(i - midpoint)
+                    if distance < min_distance:
+                        min_distance = distance
+                        closest_index = i
+            return closest_index
+
+        vocal_index1 = find_closest_vocal(first)
+        vocal_index2 = find_closest_vocal(second)
+
+        _first = first[: vocal_index1 + 1]
+        _second = second[vocal_index2:]
+
+        result = _first + _second
+
+    # Remove duplicate characters
+    result = "".join(
+        [j for i, j in enumerate(result) if i == 0 or j != result[i - 1]]
+    )
+
+    return result.capitalize()


### PR DESCRIPTION
PR acts on spawn_monster (event action) and formula.py

regarding **spawn_monster**:
- introduces `_determine_seed` is introduced to determine the seed monster based on the types of the mother and father. This function uses a multiplier calculation to determine the seed monster (before it was hardcoded on the standard types, but now it can work event with 13, etc.);
- introduces `_determine_name` is introduced to combine the names of the mother and father monsters to create the name of the child monster. There are two system, one with vowels and the other without. Old struggle from #1580, so if **Pairagrim** and **Pharfan** have a child, it'll be named **Pairarfan**;
- calculates child's level, before the level of the child monster was hardcoded at 5, now is calculated as the average of the levels of the mother and father monsters;

regarding **formula.py**:
- introduces `additional_factors` which is an optional dictionary of additional factors that affect the damage multiplier (this will allow to ship multiplier modification from effect - eg terrains, etc.);
- introduces `multiplier_cache` to store the results of previous `lookup_multiplier` calls, which can improve performance by avoiding repeated calculations;