### PR TITLE
fix 2383

### DIFF
--- a/mods/tuxemon/db/item/cureall.json
+++ b/mods/tuxemon/db/item/cureall.json
@@ -4,7 +4,7 @@
     "is current_hp >,0"
   ],
   "effects": [
-    "heal 1.0",
+    "heal 1.0,percentage",
     "restore"
   ],
   "slug": "cureall",

--- a/mods/tuxemon/db/item/imperial_potion.json
+++ b/mods/tuxemon/db/item/imperial_potion.json
@@ -4,7 +4,7 @@
     "is current_hp >,0"
   ],
   "effects": [
-    "heal 500"
+    "heal 500,fixed"
   ],
   "slug": "imperial_potion",
   "sort": "potion",

--- a/mods/tuxemon/db/item/mega_potion.json
+++ b/mods/tuxemon/db/item/mega_potion.json
@@ -4,7 +4,7 @@
     "is current_hp >,0"
   ],
   "effects": [
-    "heal 200"
+    "heal 200,fixed"
   ],
   "slug": "mega_potion",
   "sort": "potion",

--- a/mods/tuxemon/db/item/potion.json
+++ b/mods/tuxemon/db/item/potion.json
@@ -4,7 +4,7 @@
     "is current_hp >,0"
   ],
   "effects": [
-    "heal 20"
+    "heal 20,fixed"
   ],
   "slug": "potion",
   "sort": "potion",

--- a/mods/tuxemon/db/item/revive.json
+++ b/mods/tuxemon/db/item/revive.json
@@ -5,7 +5,7 @@
   ],
   "effects": [
     "restore",
-    "heal 20"
+    "heal 20,fixed"
   ],
   "slug": "revive",
   "sort": "food",

--- a/mods/tuxemon/db/item/super_potion.json
+++ b/mods/tuxemon/db/item/super_potion.json
@@ -4,7 +4,7 @@
     "is current_hp >,0"
   ],
   "effects": [
-    "heal 50"
+    "heal 50,fixed"
   ],
   "slug": "super_potion",
   "sort": "potion",

--- a/tuxemon/item/effects/heal.py
+++ b/tuxemon/item/effects/heal.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Union
 
 from tuxemon.combat import has_status, set_var
 from tuxemon.db import ItemCategory
@@ -25,30 +25,45 @@ class HealEffect(ItemEffect):
     Heals the target by 'amount' hp.
 
     Parameters:
-        amount: this is a constant if amount is an integer,
-        a percentage of total hp if a float
+        amount: int or float, where:
+            - int: constant amount of hp to heal
+            - float: percentage of total hp to heal (e.g., 0.5 for 50%)
+        heal_type: indicating whether the amount is a fixed value or a percentage
 
     Examples:
-        heal 0.5 > is healed by 50% of it's total hp
-
+        heal 0.5 > heals 50% of target's total hp
     """
 
     name = "heal"
     amount: Union[int, float]
+    heal_type: str
 
     def apply(
         self, item: Item, target: Union[Monster, None]
     ) -> HealEffectResult:
-        extra: Optional[str] = None
-        assert target
-        category = ItemCategory.potion
-        # condition festering = no healing
-        if has_status(target, "festering") and item.category == category:
-            extra = T.translate("combat_state_festering_item")
-        else:
-            set_var(self.session, self.name, str(target.instance_id.hex))
-            client = self.session.client.event_engine
-            params = [self.name, self.amount]
-            client.execute_action("modify_monster_health", params, True)
+        if not target:
+            raise ValueError("Target cannot be None")
 
-        return {"success": True, "num_shakes": 0, "extra": extra}
+        category = ItemCategory.potion
+        if has_status(target, "festering") and item.category == category:
+            return {
+                "success": False,
+                "num_shakes": 0,
+                "extra": T.translate("combat_state_festering_item"),
+            }
+
+        if self.heal_type == "fixed":
+            healing_amount = int(self.amount)
+        elif self.heal_type == "percentage":
+            healing_amount = int(target.hp * self.amount)
+        else:
+            raise ValueError(
+                f"Invalid heal type '{self.heal_type}'. Must be either 'fixed' or 'percentage'."
+            )
+
+        set_var(self.session, self.name, str(target.instance_id.hex))
+        client = self.session.client.event_engine
+        params = [self.name, healing_amount]
+        client.execute_action("modify_monster_health", params, True)
+
+        return {"success": True, "num_shakes": 0, "extra": None}


### PR DESCRIPTION
PR fixes #2383 reported by @ultidonki 

> My tuxemon had a Max HP of 84, and it only had a tiny amount of health left (I'm not sure of the number, but maybe 10-20HP remaining?) When I used Potion, I expected a small healing effect. Instead, it restored 100% of the health.

We had a bit of a mix-up because the value 20 was being passed as a float (20.0) instead of an integer. To avoid any more confusion (already happened), I have added a new parameter that lets explicitly define whether the value is a fixed amount or a percentage. That way, everyone's on the same page and we can avoid wasting time.