### PR TITLE
world menu

### DIFF
--- a/mods/tuxemon/db/item/app_tuxepedia.json
+++ b/mods/tuxemon/db/item/app_tuxepedia.json
@@ -8,7 +8,7 @@
   "usable_in": [
     "WorldState"
   ],
-  "menu": ["0","menu_tuxepedia","JournalChoice"],
+  "world_menu": ["0","menu_tuxepedia","JournalChoice"],
   "visible": false,
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/booster_tech.json
+++ b/mods/tuxemon/db/item/booster_tech.json
@@ -9,7 +9,7 @@
   "slug": "booster_tech",
   "sort": "utility",
   "sprite": "gfx/items/booster_tech.png",
-  "category": "booster",
+  "category": "morph",
   "type": "Consumable",
   "usable_in": [
     "WorldState"

--- a/mods/tuxemon/db/item/earth_booster.json
+++ b/mods/tuxemon/db/item/earth_booster.json
@@ -9,7 +9,7 @@
   "slug": "earth_booster",
   "sort": "utility",
   "sprite": "gfx/items/earth_booster.png",
-  "category": "booster",
+  "category": "morph",
   "type": "Consumable",
   "usable_in": [
     "WorldState"

--- a/mods/tuxemon/db/item/fire_booster.json
+++ b/mods/tuxemon/db/item/fire_booster.json
@@ -9,7 +9,7 @@
   "slug": "fire_booster",
   "sort": "utility",
   "sprite": "gfx/items/fire_booster.png",
-  "category": "booster",
+  "category": "morph",
   "type": "Consumable",
   "usable_in": [
     "WorldState"

--- a/mods/tuxemon/db/item/metal_booster.json
+++ b/mods/tuxemon/db/item/metal_booster.json
@@ -9,7 +9,7 @@
   "slug": "metal_booster",
   "sort": "utility",
   "sprite": "gfx/items/metal_booster.png",
-  "category": "booster",
+  "category": "morph",
   "type": "Consumable",
   "usable_in": [
     "WorldState"

--- a/mods/tuxemon/db/item/nu_phone.json
+++ b/mods/tuxemon/db/item/nu_phone.json
@@ -8,7 +8,7 @@
   "usable_in": [
     "WorldState"
   ],
-  "menu": ["3","nu_phone","NuPhone"],
+  "world_menu": ["3","nu_phone","NuPhone"],
   "visible": false,
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/water_booster.json
+++ b/mods/tuxemon/db/item/water_booster.json
@@ -9,7 +9,7 @@
   "slug": "water_booster",
   "sort": "utility",
   "sprite": "gfx/items/water_booster.png",
-  "category": "booster",
+  "category": "morph",
   "type": "Consumable",
   "usable_in": [
     "WorldState"

--- a/mods/tuxemon/db/item/wood_booster.json
+++ b/mods/tuxemon/db/item/wood_booster.json
@@ -9,7 +9,7 @@
   "slug": "wood_booster",
   "sort": "utility",
   "sprite": "gfx/items/wood_booster.png",
-  "category": "booster",
+  "category": "morph",
   "type": "Consumable",
   "usable_in": [
     "WorldState"

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -113,7 +113,6 @@ class ItemType(str, Enum):
 class ItemCategory(str, Enum):
     none = "none"
     badge = "badge"
-    booster = "booster"
     elements = "elements"
     fossil = "fossil"
     morph = "morph"
@@ -255,9 +254,9 @@ class ItemModel(BaseModel):
     animation: Optional[str] = Field(
         None, description="Animation to play for this technique"
     )
-    menu: tuple[int, str, str] = Field(
+    world_menu: tuple[int, str, str] = Field(
         None,
-        description="Item has a menu (position, label -inside the PO -,state, eg. 3:nu_phone:PhoneState)",
+        description="Item adds to World Menu a button (position, label -inside the PO -,state, eg. 3:nu_phone:PhoneState)",
     )
     visible: bool = Field(
         True, description="Whether or not this item is visible."

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -103,7 +103,7 @@ class Item:
 
         # misc attributes (not translated!)
         self.visible = results.visible
-        self.menu = results.menu
+        self.world_menu = results.world_menu
         self.sort = results.sort
         self.category = results.category or ItemCategory.none
         self.type = results.type or ItemType.consumable

--- a/tuxemon/states/world/world_menus.py
+++ b/tuxemon/states/world/world_menus.py
@@ -84,10 +84,10 @@ class WorldMenuState(PygameMenuState):
         menu.append(("menu_options", change("ControlState")))
         menu.append(("exit", exit_game))
         for itm in player.items:
-            if itm.menu:
+            if itm.world_menu:
                 menu.insert(
-                    itm.menu[0],
-                    (itm.menu[1], change(itm.menu[2])),
+                    itm.world_menu[0],
+                    (itm.world_menu[1], change(itm.world_menu[2])),
                 )
         add_menu_items(self.menu, menu)
 


### PR DESCRIPTION
PR:
- updates the attribute **menu** to **world_menu**, simply because it adds a button to the **World Menu**;
- deletes the **booster** category, because all the items below have an **evolve** effect, it means these are in the **morph** category (I noticed it while trying to implement the evolution transition after using an item);