### PR TITLE
menuitem and ItemBehaviors

### DIFF
--- a/mods/tuxemon/db/item/aardant.json
+++ b/mods/tuxemon/db/item/aardant.json
@@ -8,6 +8,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/allies_address.json
+++ b/mods/tuxemon/db/item/allies_address.json
@@ -7,6 +7,7 @@
   "usable_in": [
     ""
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/ancient_egg.json
+++ b/mods/tuxemon/db/item/ancient_egg.json
@@ -8,6 +8,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/ancient_tea.json
+++ b/mods/tuxemon/db/item/ancient_tea.json
@@ -11,6 +11,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/app_banking.json
+++ b/mods/tuxemon/db/item/app_banking.json
@@ -8,7 +8,9 @@
   "usable_in": [
     "WorldState"
   ],
-  "visible": false,
+  "behaviors": {
+    "visible": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/app_contacts.json
+++ b/mods/tuxemon/db/item/app_contacts.json
@@ -8,7 +8,9 @@
   "usable_in": [
     "WorldState"
   ],
-  "visible": false,
+  "behaviors": {
+    "visible": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/app_map.json
+++ b/mods/tuxemon/db/item/app_map.json
@@ -8,7 +8,9 @@
   "usable_in": [
     "WorldState"
   ],
-  "visible": false,
+  "behaviors": {
+    "visible": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/app_tuxepedia.json
+++ b/mods/tuxemon/db/item/app_tuxepedia.json
@@ -8,8 +8,10 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {
+    "visible": false
+  },
   "world_menu": ["0","menu_tuxepedia","JournalChoice"],
-  "visible": false,
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/book_wishes.json
+++ b/mods/tuxemon/db/item/book_wishes.json
@@ -8,6 +8,7 @@
   "usable_in": [
     ""
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/boost_armour.json
+++ b/mods/tuxemon/db/item/boost_armour.json
@@ -11,6 +11,7 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/boost_dodge.json
+++ b/mods/tuxemon/db/item/boost_dodge.json
@@ -11,6 +11,7 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/boost_melee.json
+++ b/mods/tuxemon/db/item/boost_melee.json
@@ -11,6 +11,7 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/boost_ranged.json
+++ b/mods/tuxemon/db/item/boost_ranged.json
@@ -11,6 +11,7 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/boost_speed.json
+++ b/mods/tuxemon/db/item/boost_speed.json
@@ -11,6 +11,7 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/booster_tech.json
+++ b/mods/tuxemon/db/item/booster_tech.json
@@ -14,6 +14,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/cureall.json
+++ b/mods/tuxemon/db/item/cureall.json
@@ -16,6 +16,7 @@
     "MainCombatMenuState",
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/dojo_pass.json
+++ b/mods/tuxemon/db/item/dojo_pass.json
@@ -8,6 +8,7 @@
   "usable_in": [
     ""
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/earth_booster.json
+++ b/mods/tuxemon/db/item/earth_booster.json
@@ -14,6 +14,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/earthmover_key.json
+++ b/mods/tuxemon/db/item/earthmover_key.json
@@ -8,6 +8,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/fire_berry.json
+++ b/mods/tuxemon/db/item/fire_berry.json
@@ -13,6 +13,7 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/fire_booster.json
+++ b/mods/tuxemon/db/item/fire_booster.json
@@ -14,6 +14,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/fishing_rod.json
+++ b/mods/tuxemon/db/item/fishing_rod.json
@@ -13,6 +13,10 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {
+    "requires_monster_menu": false,
+    "show_dialog_on_success": false
+  },
   "use_failure": "fishing_rod_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/flintstone.json
+++ b/mods/tuxemon/db/item/flintstone.json
@@ -14,6 +14,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/friendship_scroll.json
+++ b/mods/tuxemon/db/item/friendship_scroll.json
@@ -8,7 +8,9 @@
   "usable_in": [
     "WorldState"
   ],
-  "visible": false,
+  "behaviors": {
+    "visible": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/gold_pass.json
+++ b/mods/tuxemon/db/item/gold_pass.json
@@ -8,6 +8,7 @@
   "usable_in": [
     ""
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/greenwash_badge.json
+++ b/mods/tuxemon/db/item/greenwash_badge.json
@@ -12,6 +12,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/hatchet.json
+++ b/mods/tuxemon/db/item/hatchet.json
@@ -13,6 +13,9 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {
+    "requires_monster_menu": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "spyder_successful_log"

--- a/mods/tuxemon/db/item/imperial_potion.json
+++ b/mods/tuxemon/db/item/imperial_potion.json
@@ -15,6 +15,7 @@
     "MainCombatMenuState",
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/imperial_tea.json
+++ b/mods/tuxemon/db/item/imperial_tea.json
@@ -11,6 +11,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/lima_pie.json
+++ b/mods/tuxemon/db/item/lima_pie.json
@@ -14,6 +14,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/lucky_bamboo.json
+++ b/mods/tuxemon/db/item/lucky_bamboo.json
@@ -14,6 +14,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/mega_potion.json
+++ b/mods/tuxemon/db/item/mega_potion.json
@@ -15,6 +15,7 @@
     "MainCombatMenuState",
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/metal_booster.json
+++ b/mods/tuxemon/db/item/metal_booster.json
@@ -14,6 +14,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/metal_cherry.json
+++ b/mods/tuxemon/db/item/metal_cherry.json
@@ -13,6 +13,7 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/miaow_milk.json
+++ b/mods/tuxemon/db/item/miaow_milk.json
@@ -14,6 +14,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/mm_earth.json
+++ b/mods/tuxemon/db/item/mm_earth.json
@@ -14,6 +14,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/mm_fire.json
+++ b/mods/tuxemon/db/item/mm_fire.json
@@ -14,6 +14,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/mm_metal.json
+++ b/mods/tuxemon/db/item/mm_metal.json
@@ -14,6 +14,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/mm_water.json
+++ b/mods/tuxemon/db/item/mm_water.json
@@ -14,6 +14,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/mm_wood.json
+++ b/mods/tuxemon/db/item/mm_wood.json
@@ -14,6 +14,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/mystery_tea.json
+++ b/mods/tuxemon/db/item/mystery_tea.json
@@ -11,6 +11,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/neptune.json
+++ b/mods/tuxemon/db/item/neptune.json
@@ -13,6 +13,10 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {
+    "requires_monster_menu": false,
+    "show_dialog_on_success": false
+  },
   "use_failure": "fishing_rod_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/nimrod_badge.json
+++ b/mods/tuxemon/db/item/nimrod_badge.json
@@ -12,6 +12,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/nu_phone.json
+++ b/mods/tuxemon/db/item/nu_phone.json
@@ -8,8 +8,10 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {
+    "visible": false
+  },
   "world_menu": ["3","nu_phone","NuPhone"],
-  "visible": false,
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/omnichannel_badge.json
+++ b/mods/tuxemon/db/item/omnichannel_badge.json
@@ -12,6 +12,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/ox_stick.json
+++ b/mods/tuxemon/db/item/ox_stick.json
@@ -14,6 +14,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/p_monsters_eyes_meet.json
+++ b/mods/tuxemon/db/item/p_monsters_eyes_meet.json
@@ -8,6 +8,7 @@
   "usable_in": [
     ""
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/p_starry_night.json
+++ b/mods/tuxemon/db/item/p_starry_night.json
@@ -8,6 +8,7 @@
   "usable_in": [
     ""
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/p_trepidation.json
+++ b/mods/tuxemon/db/item/p_trepidation.json
@@ -8,6 +8,7 @@
   "usable_in": [
     ""
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/peace_lily.json
+++ b/mods/tuxemon/db/item/peace_lily.json
@@ -14,6 +14,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/petrified_dung.json
+++ b/mods/tuxemon/db/item/petrified_dung.json
@@ -14,6 +14,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/poseidon.json
+++ b/mods/tuxemon/db/item/poseidon.json
@@ -13,6 +13,10 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {
+    "requires_monster_menu": false,
+    "show_dialog_on_success": false
+  },
   "use_failure": "fishing_rod_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/potion.json
+++ b/mods/tuxemon/db/item/potion.json
@@ -15,6 +15,7 @@
     "MainCombatMenuState",
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/pyramidion.json
+++ b/mods/tuxemon/db/item/pyramidion.json
@@ -14,6 +14,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/raise_armour.json
+++ b/mods/tuxemon/db/item/raise_armour.json
@@ -11,6 +11,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/raise_dodge.json
+++ b/mods/tuxemon/db/item/raise_dodge.json
@@ -11,6 +11,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/raise_hp.json
+++ b/mods/tuxemon/db/item/raise_hp.json
@@ -11,6 +11,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/raise_melee.json
+++ b/mods/tuxemon/db/item/raise_melee.json
@@ -11,6 +11,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/raise_ranged.json
+++ b/mods/tuxemon/db/item/raise_ranged.json
@@ -11,6 +11,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/raise_speed.json
+++ b/mods/tuxemon/db/item/raise_speed.json
@@ -11,6 +11,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/reg_papers.json
+++ b/mods/tuxemon/db/item/reg_papers.json
@@ -7,6 +7,7 @@
   "usable_in": [
     ""
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/restoration.json
+++ b/mods/tuxemon/db/item/restoration.json
@@ -16,6 +16,7 @@
     "MainCombatMenuState",
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/revive.json
+++ b/mods/tuxemon/db/item/revive.json
@@ -16,6 +16,7 @@
     "MainCombatMenuState",
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/rhincus_fossil.json
+++ b/mods/tuxemon/db/item/rhincus_fossil.json
@@ -14,6 +14,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/scoop_badge.json
+++ b/mods/tuxemon/db/item/scoop_badge.json
@@ -12,6 +12,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/sea_girdle.json
+++ b/mods/tuxemon/db/item/sea_girdle.json
@@ -14,6 +14,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/shaft_badge.json
+++ b/mods/tuxemon/db/item/shaft_badge.json
@@ -12,6 +12,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/shammer_fossil.json
+++ b/mods/tuxemon/db/item/shammer_fossil.json
@@ -14,6 +14,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/sledgehammer.json
+++ b/mods/tuxemon/db/item/sledgehammer.json
@@ -13,6 +13,9 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {
+    "requires_monster_menu": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "spyder_successful_boulder"

--- a/mods/tuxemon/db/item/spyder_pass.json
+++ b/mods/tuxemon/db/item/spyder_pass.json
@@ -8,6 +8,7 @@
   "usable_in": [
     ""
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/stovepipe.json
+++ b/mods/tuxemon/db/item/stovepipe.json
@@ -14,6 +14,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/super_potion.json
+++ b/mods/tuxemon/db/item/super_potion.json
@@ -15,6 +15,7 @@
     "MainCombatMenuState",
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/surfboard.json
+++ b/mods/tuxemon/db/item/surfboard.json
@@ -8,6 +8,7 @@
   "usable_in": [
     ""
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/sweet_sand.json
+++ b/mods/tuxemon/db/item/sweet_sand.json
@@ -14,6 +14,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tea.json
+++ b/mods/tuxemon/db/item/tea.json
@@ -11,6 +11,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tectonic_drill.json
+++ b/mods/tuxemon/db/item/tectonic_drill.json
@@ -14,6 +14,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/thunderstone.json
+++ b/mods/tuxemon/db/item/thunderstone.json
@@ -14,6 +14,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tm_avalanche.json
+++ b/mods/tuxemon/db/item/tm_avalanche.json
@@ -15,6 +15,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tm_blossom.json
+++ b/mods/tuxemon/db/item/tm_blossom.json
@@ -15,6 +15,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tm_earth.json
+++ b/mods/tuxemon/db/item/tm_earth.json
@@ -11,6 +11,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tm_fire.json
+++ b/mods/tuxemon/db/item/tm_fire.json
@@ -11,6 +11,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tm_metal.json
+++ b/mods/tuxemon/db/item/tm_metal.json
@@ -11,6 +11,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tm_surf.json
+++ b/mods/tuxemon/db/item/tm_surf.json
@@ -16,6 +16,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tm_water.json
+++ b/mods/tuxemon/db/item/tm_water.json
@@ -11,6 +11,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tm_wood.json
+++ b/mods/tuxemon/db/item/tm_wood.json
@@ -11,6 +11,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball.json
+++ b/mods/tuxemon/db/item/tuxeball.json
@@ -15,6 +15,7 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_ancient.json
+++ b/mods/tuxemon/db/item/tuxeball_ancient.json
@@ -15,6 +15,7 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_candy.json
+++ b/mods/tuxemon/db/item/tuxeball_candy.json
@@ -15,6 +15,7 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_crusher.json
+++ b/mods/tuxemon/db/item/tuxeball_crusher.json
@@ -15,6 +15,7 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_earth.json
+++ b/mods/tuxemon/db/item/tuxeball_earth.json
@@ -15,6 +15,7 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_female.json
+++ b/mods/tuxemon/db/item/tuxeball_female.json
@@ -15,6 +15,7 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_fire.json
+++ b/mods/tuxemon/db/item/tuxeball_fire.json
@@ -15,6 +15,7 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_hardened.json
+++ b/mods/tuxemon/db/item/tuxeball_hardened.json
@@ -15,6 +15,7 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_hearty.json
+++ b/mods/tuxemon/db/item/tuxeball_hearty.json
@@ -15,6 +15,7 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_lavish.json
+++ b/mods/tuxemon/db/item/tuxeball_lavish.json
@@ -15,6 +15,7 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_male.json
+++ b/mods/tuxemon/db/item/tuxeball_male.json
@@ -15,6 +15,7 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_metal.json
+++ b/mods/tuxemon/db/item/tuxeball_metal.json
@@ -15,6 +15,7 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_neuter.json
+++ b/mods/tuxemon/db/item/tuxeball_neuter.json
@@ -15,6 +15,7 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_omni.json
+++ b/mods/tuxemon/db/item/tuxeball_omni.json
@@ -15,6 +15,7 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_park.json
+++ b/mods/tuxemon/db/item/tuxeball_park.json
@@ -15,6 +15,7 @@
   "usable_in": [
     "MainParkMenuState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_peppy.json
+++ b/mods/tuxemon/db/item/tuxeball_peppy.json
@@ -15,6 +15,7 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_refined.json
+++ b/mods/tuxemon/db/item/tuxeball_refined.json
@@ -15,6 +15,7 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_salty.json
+++ b/mods/tuxemon/db/item/tuxeball_salty.json
@@ -15,6 +15,7 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_water.json
+++ b/mods/tuxemon/db/item/tuxeball_water.json
@@ -15,6 +15,7 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_wood.json
+++ b/mods/tuxemon/db/item/tuxeball_wood.json
@@ -15,6 +15,7 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_xero.json
+++ b/mods/tuxemon/db/item/tuxeball_xero.json
@@ -15,6 +15,7 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_zesty.json
+++ b/mods/tuxemon/db/item/tuxeball_zesty.json
@@ -15,6 +15,7 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/water_booster.json
+++ b/mods/tuxemon/db/item/water_booster.json
@@ -14,6 +14,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/wood_booster.json
+++ b/mods/tuxemon/db/item/wood_booster.json
@@ -14,6 +14,7 @@
   "usable_in": [
     "WorldState"
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/xp_transmitter.json
+++ b/mods/tuxemon/db/item/xp_transmitter.json
@@ -8,6 +8,7 @@
   "usable_in": [
     ""
   ],
+  "behaviors": {},
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -215,6 +215,21 @@ State = Enum(
 )
 
 
+class ItemBehaviors(BaseModel):
+    visible: bool = Field(
+        True, description="Whether or not this item is visible."
+    )
+    requires_monster_menu: bool = Field(
+        True, description="Whether the monster menu is required to be open."
+    )
+    show_dialog_on_failure: bool = Field(
+        True, description="Whether to show a dialogue after a failed use."
+    )
+    show_dialog_on_success: bool = Field(
+        True, description="Whether to show a dialogue after a successful use."
+    )
+
+
 class ItemModel(BaseModel):
     model_config = ConfigDict(title="Item")
     slug: str = Field(..., description="Slug to use")
@@ -239,6 +254,7 @@ class ItemModel(BaseModel):
     usable_in: Sequence[State] = Field(
         ..., description="State(s) where this item can be used."
     )
+    behaviors: ItemBehaviors
     # TODO: We'll need some more advanced validation logic here to parse item
     # conditions and effects to ensure they are formatted properly.
     conditions: Sequence[str] = Field(
@@ -257,9 +273,6 @@ class ItemModel(BaseModel):
     world_menu: tuple[int, str, str] = Field(
         None,
         description="Item adds to World Menu a button (position, label -inside the PO -,state, eg. 3:nu_phone:PhoneState)",
-    )
-    visible: bool = Field(
-        True, description="Whether or not this item is visible."
     )
 
     # Validate fields that refer to translated text

--- a/tuxemon/event/conditions/has_bag.py
+++ b/tuxemon/event/conditions/has_bag.py
@@ -33,15 +33,14 @@ class HasBagCondition(EventCondition):
     name = "has_bag"
 
     def test(self, session: Session, condition: MapCondition) -> bool:
-        _character, check, _number = condition.parameters[:3]
-        number = int(_number)
-        character = get_npc(session, _character)
+        character_name, check, number = condition.parameters[:3]
+        character = get_npc(session, character_name)
         if character is None:
-            logger.error(f"{_character} not found")
+            logger.error(f"Character '{character_name}' not found")
             return False
-        sum_total = []
-        for itm in character.items:
-            if itm.visible:
-                sum_total.append(itm.quantity)
-        bag_size = sum(sum_total)
-        return compare(check, bag_size, number)
+
+        visible_items = [
+            item for item in character.items if item.behaviors.visible
+        ]
+        bag_size = sum(item.quantity for item in visible_items)
+        return compare(check, bag_size, int(number))

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -102,8 +102,8 @@ class Item:
         self.use_failure = T.translate(results.use_failure)
 
         # misc attributes (not translated!)
-        self.visible = results.visible
         self.world_menu = results.world_menu
+        self.behaviors = results.behaviors
         self.sort = results.sort
         self.category = results.category or ItemCategory.none
         self.type = results.type or ItemType.consumable

--- a/tuxemon/states/items/item_menu.py
+++ b/tuxemon/states/items/item_menu.py
@@ -103,37 +103,56 @@ class ItemMenuState(Menu[Item]):
 
         Parameters:
             menu_item: Selected menu item.
-
         """
         item = menu_item.game_object
         active_state_names = [a.name for a in self.client.active_states]
 
+        # Check if the item can be used on any monster
         if not any(item.validate(m) for m in local_session.player.monsters):
             self.on_menu_selection_change()
-            msg = T.format("item_no_available_target", {"name": item.name})
-            for i in item.conditions:
-                if i.name == "location_inside":
-                    loc_inside = getattr(i, "location_inside")
-                    params = {
-                        "name": item.name.upper(),
-                        "here": T.translate(loc_inside),
-                    }
-                    msg = T.format("item_used_wrong_location_inside", params)
-                elif i.name == "location_type":
-                    loc_type = getattr(i, "location_type")
-                    params = {
-                        "name": item.name.upper(),
-                        "here": T.translate(loc_type),
-                    }
-                    msg = T.format("item_used_wrong_location_type", params)
-                elif i.name == "facing_tile" or i.name == "facing_sprite":
-                    msg = T.format("item_cannot_use_here", {"name": item.name})
-            tools.open_dialog(local_session, [msg])
+            error_message = self.get_error_message(item)
+            tools.open_dialog(local_session, [error_message])
+        # Check if the item can be used in the current state
         elif not any(s.name in active_state_names for s in item.usable_in):
-            msg = T.format("item_cannot_use_here", {"name": item.name})
-            tools.open_dialog(local_session, [msg])
+            error_message = T.format(
+                "item_cannot_use_here", {"name": item.name}
+            )
+            tools.open_dialog(local_session, [error_message])
         else:
             self.open_confirm_use_menu(item)
+
+    def get_error_message(self, item: Item) -> str:
+        """
+        Returns an error message based on the item's conditions.
+
+        Parameters:
+            item: The item to check.
+
+        Returns:
+            An error message.
+        """
+        for condition in item.conditions:
+            if condition.name == "location_inside":
+                loc_inside = getattr(condition, "location_inside")
+                return T.format(
+                    "item_used_wrong_location_inside",
+                    {
+                        "name": item.name.upper(),
+                        "here": T.translate(loc_inside),
+                    },
+                )
+            elif condition.name == "location_type":
+                loc_type = getattr(condition, "location_type")
+                return T.format(
+                    "item_used_wrong_location_type",
+                    {
+                        "name": item.name.upper(),
+                        "here": T.translate(loc_type),
+                    },
+                )
+            elif condition.name in ["facing_tile", "facing_sprite"]:
+                return T.format("item_cannot_use_here", {"name": item.name})
+        return T.format("item_no_available_target", {"name": item.name})
 
     def open_confirm_use_menu(self, item: Item) -> None:
         """
@@ -141,96 +160,99 @@ class ItemMenuState(Menu[Item]):
 
         Parameters:
             item: Selected item.
-
         """
 
-        def use_item(menu_item: MenuItem[Monster]) -> None:
+        def use_item_with_monster(menu_item: MenuItem[Monster]) -> None:
+            """Use the item with a monster."""
             player = local_session.player
             monster = menu_item.game_object
-
-            # item must be used before state is popped.
             result = item.use(player, monster)
             self.client.pop_state()  # pop the monster screen
             self.client.pop_state()  # pop the item screen
             tools.show_item_result_as_dialog(local_session, item, result)
 
-        def use_item_no_monster(itm: Item) -> None:
+        def use_item_without_monster() -> None:
+            """Use the item without a monster."""
             player = local_session.player
             self.client.pop_state()
-            result = itm.use(player, None)
-            if item.category == "fish" and not result["success"]:
+            result = item.use(player, None)
+            if item.behaviors.show_dialog_on_failure and not result["success"]:
                 tools.show_item_result_as_dialog(local_session, item, result)
-            elif item.category == "fish" and result["success"]:
-                pass
-            else:
+            elif item.behaviors.show_dialog_on_success and result["success"]:
                 tools.show_item_result_as_dialog(local_session, item, result)
 
         def confirm() -> None:
+            """Confirm the use of the item."""
             self.client.pop_state()  # close the confirm dialog
-            categories = ["fish", "destroy"]  # not opening monster menu
-
-            if item.category in categories:
-                use_item_no_monster(item)
-            else:
+            if item.behaviors.requires_monster_menu:
                 menu = self.client.push_state(MonsterMenuState())
                 menu.is_valid_entry = item.validate  # type: ignore[assignment]
-                menu.on_menu_selection = use_item  # type: ignore[assignment]
+                menu.on_menu_selection = use_item_with_monster  # type: ignore[assignment]
+            else:
+                use_item_without_monster()
 
         def cancel() -> None:
+            """Cancel the use of the item."""
             self.client.pop_state()  # close the use/cancel menu
 
         def open_choice_menu() -> None:
-            # open the menu for use/cancel
-            var_menu = []
-            _use = T.translate("item_confirm_use").upper()
-            var_menu.append(("use", _use, confirm))
-            _cancel = T.translate("item_confirm_cancel").upper()
-            var_menu.append(("cancel", _cancel, cancel))
-            tools.open_choice_dialog(local_session, var_menu, True)
+            """Open the use/cancel menu."""
+            menu_options = [
+                ("use", T.translate("item_confirm_use").upper(), confirm),
+                ("cancel", T.translate("item_confirm_cancel").upper(), cancel),
+            ]
+            tools.open_choice_dialog(local_session, menu_options, True)
 
         open_choice_menu()
 
     def initialize_items(self) -> Generator[MenuItem[Item], None, None]:
         """Get all player inventory items and add them to menu."""
         state = self.determine_state_called_from()
-        inventory = []
-        # in battle shows only items with MainCombatMenuState (usable_in)
-        if state == "MainCombatMenuState":
-            inventory = [
-                item
-                for item in local_session.player.items
-                if State[state] in item.usable_in
-            ]
-        # shows all items (only visible)
-        else:
-            inventory = [
-                item for item in local_session.player.items if item.visible
-            ]
+        inventory = self.get_inventory(state)
 
-        # required because the max() below will fail if inv empty
         if not inventory:
             return
 
         for obj in sort_inventory(inventory):
-            label = obj.name + " x " + str(obj.quantity)
-            image = self.shadow_text(label, bg=(128, 128, 128))
+            label = f"{obj.name} x {obj.quantity}"
+            image = self.shadow_text(label, bg=prepare.DIMGRAY_COLOR)
             yield MenuItem(image, obj.name, obj.description, obj)
+
+    def get_inventory(self, state: str) -> list[Item]:
+        """Get player inventory items based on the current state."""
+        if state == "MainCombatMenuState":
+            return [
+                item
+                for item in local_session.player.items
+                if State[state] in item.usable_in
+            ]
+        else:
+            return [
+                item
+                for item in local_session.player.items
+                if item.behaviors.visible
+            ]
 
     def on_menu_selection_change(self) -> None:
         """Called when menu selection changes."""
-        item = self.get_selected_item()
-        if item:
-            # animate item being pulled from the bag
-            image = item.game_object.surface
-            assert image
-            self.item_sprite.image = image
-            self.item_sprite.rect = image.get_rect(center=self.backpack_center)
-            self.animate(
-                self.item_sprite.rect,
-                centery=self.item_center[1],
-                duration=0.2,
-            )
+        selected_item = self.get_selected_item()
+        if selected_item:
+            self.animate_item_selection(selected_item.game_object)
+            self.show_item_description(selected_item.game_object)
 
-            # show item description
-            if item.description:
-                self.alert(item.description)
+    def animate_item_selection(self, item: Item) -> None:
+        """Animate the selected item being pulled from the bag."""
+        image = item.surface
+        assert image
+        self.item_sprite.image = image
+        self.item_sprite.rect = image.get_rect(center=self.backpack_center)
+        self.animate(
+            self.item_sprite.rect,
+            centery=self.item_center[1],
+            duration=0.2,
+        )
+
+    def show_item_description(self, item: Item) -> None:
+        """Show the description of the selected item."""
+        if item.description:
+            self.alert(item.description)

--- a/tuxemon/states/techniques/__init__.py
+++ b/tuxemon/states/techniques/__init__.py
@@ -133,7 +133,7 @@ class TechniqueMenuState(Menu[Technique]):
         for tech in output:
             name = tech.name
             types = " ".join(map(lambda s: T.translate(s.slug), tech.types))
-            image = self.shadow_text(name, bg=(128, 128, 128))
+            image = self.shadow_text(name, bg=prepare.DIMGRAY_COLOR)
             if tech.counter == 0:
                 sus = 100
             else:


### PR DESCRIPTION
PR:
* added a new attribute called `behavior` to our base model, which is a dictionary that maps strings to booleans (`dict[str, bool]`). This will help us store various item behaviors in a flexible way.
* removed the `visible` attribute and integrated it into the new `behavior` attribute. This simplifies our code and makes it more efficient.
* improved some methods inside `menu_item` to make them more readable and comprehensible. This should make it easier for us to work with menu items in the future.

But here's the thing: this change has got me thinking... Since the `type` attribute only has two options (keyitem and consumable), we could integrate it into the `behavior` attribute as a simple flag called `is_consumable`. This would default to `True` or `False`, depending on the item type.

This approach could be really useful for replacing other attributes with simple flags, making our code even more efficient and easier to maintain. What do you think?