### PR TITLE
test tmx

### DIFF
--- a/tests/tuxemon/test_folder_maps_tmx.py
+++ b/tests/tuxemon/test_folder_maps_tmx.py
@@ -156,6 +156,19 @@ class TestTMXFiles(unittest.TestCase):
                                 f"Invalid property value '{value}' for name '{name}' in object {obj} at {to_basename(path)}"
                             )
 
+    def test_object_property_name_duplicate(self):
+        for path, root in self.loaded_data.items():
+            for obj in root.findall(".//object"):
+                property_names = {}
+                for prop in obj.findall("properties/property"):
+                    if _is_valid_property_name(prop.attrib["name"]):
+                        if prop.attrib["name"] in property_names:
+                            self.fail(
+                                f"Duplicate property name '{prop.attrib['name']}' in object {obj} at {to_basename(path)}"
+                            )
+                        else:
+                            property_names[prop.attrib["name"]] = True
+
     def test_object_width(self):
         for path, root in self.loaded_data.items():
             for obj in root.findall(".//object"):


### PR DESCRIPTION
PR introduces a new test in `test_folder_maps_tmx.py` called `test_object_property_name_duplicate`. Its mission is to sniff out duplicates of `act`, `cond`, or `behav` properties in your TMX files. For example, if you've accidentally created a duplicate `act6` property (like in the example below), this test will catch it and save you from a world of frustration.

```
   <properties>
    <property name="act0" value="pathfind_to_player spyder_nimrod_antimony"/>
    <property name="act1" value="translated_dialog spyder_nimrod_antimony1"/>
    <property name="act2" value="add_monster komodraw,30,spyder_nimrod_antimony,5,10"/>
    <property name="act3" value="start_battle player,spyder_nimrod_antimony"/>
    <property name="act6" value="translated_dialog spyder_nimrod_antimony2"/>    <---------
    <property name="act6" value="set_variable nimrodantimony:yes"/>    <---------
    <property name="cond1" value="not variable_set nimrodantimony:yes"/>
    <property name="cond2" value="is char_at player"/>
   </properties>
```