### PR TITLE
consumable (item)

### DIFF
--- a/mods/tuxemon/db/item/aardant.json
+++ b/mods/tuxemon/db/item/aardant.json
@@ -4,11 +4,12 @@
   "sort": "utility",
   "sprite": "gfx/items/aardant.png",
   "category": "none",
-  "type": "KeyItem",
   "usable_in": [
     "WorldState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "consumable": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/allies_address.json
+++ b/mods/tuxemon/db/item/allies_address.json
@@ -3,11 +3,12 @@
   "sort": "utility",
   "sprite": "gfx/items/key-card.png",
   "category": "none",
-  "type": "KeyItem",
   "usable_in": [
     ""
   ],
-  "behaviors": {},
+  "behaviors": {
+    "consumable": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/ancient_egg.json
+++ b/mods/tuxemon/db/item/ancient_egg.json
@@ -4,11 +4,12 @@
   "sort": "utility",
   "sprite": "gfx/items/ancient_egg.png",
   "category": "none",
-  "type": "KeyItem",
   "usable_in": [
     "WorldState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "consumable": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/ancient_tea.json
+++ b/mods/tuxemon/db/item/ancient_tea.json
@@ -7,7 +7,6 @@
   "sort": "potion",
   "sprite": "gfx/items/ancient_tea.png",
   "category": "none",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/app_banking.json
+++ b/mods/tuxemon/db/item/app_banking.json
@@ -4,11 +4,11 @@
   "sort": "utility",
   "sprite": "gfx/items/app_banking.png",
   "category": "phone",
-  "type": "KeyItem",
   "usable_in": [
     "WorldState"
   ],
   "behaviors": {
+    "consumable": false,
     "visible": false
   },
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/item/app_contacts.json
+++ b/mods/tuxemon/db/item/app_contacts.json
@@ -4,11 +4,11 @@
   "sort": "utility",
   "sprite": "gfx/items/app_contacts.png",
   "category": "phone",
-  "type": "KeyItem",
   "usable_in": [
     "WorldState"
   ],
   "behaviors": {
+    "consumable": false,
     "visible": false
   },
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/item/app_map.json
+++ b/mods/tuxemon/db/item/app_map.json
@@ -4,11 +4,11 @@
   "sort": "utility",
   "sprite": "gfx/items/app_map.png",
   "category": "phone",
-  "type": "KeyItem",
   "usable_in": [
     "WorldState"
   ],
   "behaviors": {
+    "consumable": false,
     "visible": false
   },
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/item/app_tuxepedia.json
+++ b/mods/tuxemon/db/item/app_tuxepedia.json
@@ -4,11 +4,11 @@
   "sort": "utility",
   "sprite": "gfx/items/app_tuxepedia.png",
   "category": "phone",
-  "type": "KeyItem",
   "usable_in": [
     "WorldState"
   ],
   "behaviors": {
+    "consumable": false,
     "visible": false
   },
   "world_menu": ["0","menu_tuxepedia","JournalChoice"],

--- a/mods/tuxemon/db/item/book_wishes.json
+++ b/mods/tuxemon/db/item/book_wishes.json
@@ -4,11 +4,12 @@
   "sort": "utility",
   "sprite": "gfx/items/book_wishes.png",
   "category": "none",
-  "type": "KeyItem",
   "usable_in": [
     ""
   ],
-  "behaviors": {},
+  "behaviors": {
+    "consumable": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/boost_armour.json
+++ b/mods/tuxemon/db/item/boost_armour.json
@@ -7,7 +7,6 @@
   "sort": "utility",
   "sprite": "gfx/items/boost_armour.png",
   "category": "stats",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/boost_dodge.json
+++ b/mods/tuxemon/db/item/boost_dodge.json
@@ -7,7 +7,6 @@
   "sort": "utility",
   "sprite": "gfx/items/boost_dodge.png",
   "category": "stats",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/boost_melee.json
+++ b/mods/tuxemon/db/item/boost_melee.json
@@ -7,7 +7,6 @@
   "sort": "utility",
   "sprite": "gfx/items/boost_melee.png",
   "category": "stats",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/boost_ranged.json
+++ b/mods/tuxemon/db/item/boost_ranged.json
@@ -7,7 +7,6 @@
   "sort": "utility",
   "sprite": "gfx/items/boost_ranged.png",
   "category": "stats",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/boost_speed.json
+++ b/mods/tuxemon/db/item/boost_speed.json
@@ -7,7 +7,6 @@
   "sort": "utility",
   "sprite": "gfx/items/boost_speed.png",
   "category": "stats",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/booster_tech.json
+++ b/mods/tuxemon/db/item/booster_tech.json
@@ -10,7 +10,6 @@
   "sort": "utility",
   "sprite": "gfx/items/booster_tech.png",
   "category": "morph",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/cureall.json
+++ b/mods/tuxemon/db/item/cureall.json
@@ -11,7 +11,6 @@
   "sort": "potion",
   "sprite": "gfx/items/orange.png",
   "category": "potion",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState",
     "WorldState"

--- a/mods/tuxemon/db/item/dojo_pass.json
+++ b/mods/tuxemon/db/item/dojo_pass.json
@@ -4,11 +4,12 @@
   "sort": "utility",
   "sprite": "gfx/items/dojo_pass.png",
   "category": "none",
-  "type": "KeyItem",
   "usable_in": [
     ""
   ],
-  "behaviors": {},
+  "behaviors": {
+    "consumable": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/earth_booster.json
+++ b/mods/tuxemon/db/item/earth_booster.json
@@ -10,7 +10,6 @@
   "sort": "utility",
   "sprite": "gfx/items/earth_booster.png",
   "category": "morph",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/earthmover_key.json
+++ b/mods/tuxemon/db/item/earthmover_key.json
@@ -4,11 +4,12 @@
   "sort": "utility",
   "sprite": "gfx/items/earthmover_key.png",
   "category": "none",
-  "type": "KeyItem",
   "usable_in": [
     "WorldState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "consumable": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/fire_berry.json
+++ b/mods/tuxemon/db/item/fire_berry.json
@@ -9,7 +9,6 @@
   "sort": "utility",
   "sprite": "gfx/items/berry.png",
   "category": "elements",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/fire_booster.json
+++ b/mods/tuxemon/db/item/fire_booster.json
@@ -10,7 +10,6 @@
   "sort": "utility",
   "sprite": "gfx/items/fire_booster.png",
   "category": "morph",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/fishing_rod.json
+++ b/mods/tuxemon/db/item/fishing_rod.json
@@ -9,11 +9,11 @@
   "sort": "utility",
   "sprite": "gfx/items/fishing_rod.png",
   "category": "fish",
-  "type": "KeyItem",
   "usable_in": [
     "WorldState"
   ],
   "behaviors": {
+    "consumable": false,
     "requires_monster_menu": false,
     "show_dialog_on_success": false
   },

--- a/mods/tuxemon/db/item/flintstone.json
+++ b/mods/tuxemon/db/item/flintstone.json
@@ -10,7 +10,6 @@
   "sort": "utility",
   "sprite": "gfx/items/flintstone.png",
   "category": "morph",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/friendship_scroll.json
+++ b/mods/tuxemon/db/item/friendship_scroll.json
@@ -4,11 +4,11 @@
   "sort": "utility",
   "sprite": "gfx/items/friendship_scroll.png",
   "category": "none",
-  "type": "KeyItem",
   "usable_in": [
     "WorldState"
   ],
   "behaviors": {
+    "consumable": false,
     "visible": false
   },
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/item/gold_pass.json
+++ b/mods/tuxemon/db/item/gold_pass.json
@@ -4,11 +4,12 @@
   "sort": "utility",
   "sprite": "gfx/items/gold_pass.png",
   "category": "none",
-  "type": "KeyItem",
   "usable_in": [
     ""
   ],
-  "behaviors": {},
+  "behaviors": {
+    "consumable": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/greenwash_badge.json
+++ b/mods/tuxemon/db/item/greenwash_badge.json
@@ -8,7 +8,6 @@
   "sort": "utility",
   "sprite": "gfx/items/greenwash_badge.png",
   "category": "badge",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/hatchet.json
+++ b/mods/tuxemon/db/item/hatchet.json
@@ -9,11 +9,11 @@
   "sort": "utility",
   "sprite": "gfx/items/hatchet.png",
   "category": "destroy",
-  "type": "KeyItem",
   "usable_in": [
     "WorldState"
   ],
   "behaviors": {
+    "consumable": false,
     "requires_monster_menu": false
   },
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/item/imperial_potion.json
+++ b/mods/tuxemon/db/item/imperial_potion.json
@@ -10,7 +10,6 @@
   "sort": "potion",
   "sprite": "gfx/items/imperial_potion.png",
   "category": "potion",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState",
     "WorldState"

--- a/mods/tuxemon/db/item/imperial_tea.json
+++ b/mods/tuxemon/db/item/imperial_tea.json
@@ -7,7 +7,6 @@
   "sort": "potion",
   "sprite": "gfx/items/imperial_tea.png",
   "category": "none",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/lima_pie.json
+++ b/mods/tuxemon/db/item/lima_pie.json
@@ -10,7 +10,6 @@
   "sort": "utility",
   "sprite": "gfx/items/lima_pie.png",
   "category": "morph",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/lucky_bamboo.json
+++ b/mods/tuxemon/db/item/lucky_bamboo.json
@@ -10,7 +10,6 @@
   "sort": "utility",
   "sprite": "gfx/items/lucky_bamboo.png",
   "category": "morph",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/mega_potion.json
+++ b/mods/tuxemon/db/item/mega_potion.json
@@ -10,7 +10,6 @@
   "sort": "potion",
   "sprite": "gfx/items/mega_potion.png",
   "category": "potion",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState",
     "WorldState"

--- a/mods/tuxemon/db/item/metal_booster.json
+++ b/mods/tuxemon/db/item/metal_booster.json
@@ -10,7 +10,6 @@
   "sort": "utility",
   "sprite": "gfx/items/metal_booster.png",
   "category": "morph",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/metal_cherry.json
+++ b/mods/tuxemon/db/item/metal_cherry.json
@@ -9,7 +9,6 @@
   "sort": "utility",
   "sprite": "gfx/items/cherry.png",
   "category": "elements",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/miaow_milk.json
+++ b/mods/tuxemon/db/item/miaow_milk.json
@@ -10,7 +10,6 @@
   "sort": "utility",
   "sprite": "gfx/items/miaow_milk.png",
   "category": "morph",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/mm_earth.json
+++ b/mods/tuxemon/db/item/mm_earth.json
@@ -10,7 +10,6 @@
   "sort": "utility",
   "sprite": "gfx/items/mm_earth.png",
   "category": "technique",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/mm_fire.json
+++ b/mods/tuxemon/db/item/mm_fire.json
@@ -10,7 +10,6 @@
   "sort": "utility",
   "sprite": "gfx/items/mm_fire.png",
   "category": "technique",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/mm_metal.json
+++ b/mods/tuxemon/db/item/mm_metal.json
@@ -10,7 +10,6 @@
   "sort": "utility",
   "sprite": "gfx/items/mm_metal.png",
   "category": "technique",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/mm_water.json
+++ b/mods/tuxemon/db/item/mm_water.json
@@ -10,7 +10,6 @@
   "sort": "utility",
   "sprite": "gfx/items/mm_water.png",
   "category": "technique",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/mm_wood.json
+++ b/mods/tuxemon/db/item/mm_wood.json
@@ -10,7 +10,6 @@
   "sort": "utility",
   "sprite": "gfx/items/mm_wood.png",
   "category": "technique",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/mystery_tea.json
+++ b/mods/tuxemon/db/item/mystery_tea.json
@@ -7,7 +7,6 @@
   "sort": "potion",
   "sprite": "gfx/items/mystery_tea.png",
   "category": "none",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/neptune.json
+++ b/mods/tuxemon/db/item/neptune.json
@@ -9,11 +9,11 @@
   "sort": "utility",
   "sprite": "gfx/items/neptune.png",
   "category": "fish",
-  "type": "KeyItem",
   "usable_in": [
     "WorldState"
   ],
   "behaviors": {
+    "consumable": false,
     "requires_monster_menu": false,
     "show_dialog_on_success": false
   },

--- a/mods/tuxemon/db/item/nimrod_badge.json
+++ b/mods/tuxemon/db/item/nimrod_badge.json
@@ -8,7 +8,6 @@
   "sort": "utility",
   "sprite": "gfx/items/nimrod_badge.png",
   "category": "badge",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/nu_phone.json
+++ b/mods/tuxemon/db/item/nu_phone.json
@@ -4,11 +4,11 @@
   "sort": "utility",
   "sprite": "gfx/items/nu_phone.png",
   "category": "phone",
-  "type": "KeyItem",
   "usable_in": [
     "WorldState"
   ],
   "behaviors": {
+    "consumable": false,
     "visible": false
   },
   "world_menu": ["3","nu_phone","NuPhone"],

--- a/mods/tuxemon/db/item/omnichannel_badge.json
+++ b/mods/tuxemon/db/item/omnichannel_badge.json
@@ -8,7 +8,6 @@
   "sort": "utility",
   "sprite": "gfx/items/omnichannel_badge.png",
   "category": "badge",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/ox_stick.json
+++ b/mods/tuxemon/db/item/ox_stick.json
@@ -10,7 +10,6 @@
   "sort": "utility",
   "sprite": "gfx/items/ox_stick.png",
   "category": "morph",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/p_monsters_eyes_meet.json
+++ b/mods/tuxemon/db/item/p_monsters_eyes_meet.json
@@ -4,11 +4,12 @@
   "sort": "utility",
   "sprite": "gfx/items/monsters_eyes.png",
   "category": "none",
-  "type": "KeyItem",
   "usable_in": [
     ""
   ],
-  "behaviors": {},
+  "behaviors": {
+    "consumable": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/p_starry_night.json
+++ b/mods/tuxemon/db/item/p_starry_night.json
@@ -4,11 +4,12 @@
   "sort": "utility",
   "sprite": "gfx/items/starry_night.png",
   "category": "none",
-  "type": "KeyItem",
   "usable_in": [
     ""
   ],
-  "behaviors": {},
+  "behaviors": {
+    "consumable": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/p_trepidation.json
+++ b/mods/tuxemon/db/item/p_trepidation.json
@@ -4,11 +4,12 @@
   "sort": "utility",
   "sprite": "gfx/items/trepidation.png",
   "category": "none",
-  "type": "KeyItem",
   "usable_in": [
     ""
   ],
-  "behaviors": {},
+  "behaviors": {
+    "consumable": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/peace_lily.json
+++ b/mods/tuxemon/db/item/peace_lily.json
@@ -10,7 +10,6 @@
   "sort": "utility",
   "sprite": "gfx/items/peace_lily.png",
   "category": "morph",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/petrified_dung.json
+++ b/mods/tuxemon/db/item/petrified_dung.json
@@ -10,7 +10,6 @@
   "sort": "utility",
   "sprite": "gfx/items/petrified_dung.png",
   "category": "morph",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/poseidon.json
+++ b/mods/tuxemon/db/item/poseidon.json
@@ -9,11 +9,11 @@
   "sort": "utility",
   "sprite": "gfx/items/poseidon.png",
   "category": "fish",
-  "type": "KeyItem",
   "usable_in": [
     "WorldState"
   ],
   "behaviors": {
+    "consumable": false,
     "requires_monster_menu": false,
     "show_dialog_on_success": false
   },

--- a/mods/tuxemon/db/item/potion.json
+++ b/mods/tuxemon/db/item/potion.json
@@ -10,7 +10,6 @@
   "sort": "potion",
   "sprite": "gfx/items/potion.png",
   "category": "potion",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState",
     "WorldState"

--- a/mods/tuxemon/db/item/pyramidion.json
+++ b/mods/tuxemon/db/item/pyramidion.json
@@ -10,7 +10,6 @@
   "sort": "utility",
   "sprite": "gfx/items/pyramidion.png",
   "category": "morph",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/raise_armour.json
+++ b/mods/tuxemon/db/item/raise_armour.json
@@ -7,7 +7,6 @@
   "sort": "utility",
   "sprite": "gfx/items/raise_armour.png",
   "category": "stats",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/raise_dodge.json
+++ b/mods/tuxemon/db/item/raise_dodge.json
@@ -7,7 +7,6 @@
   "sort": "utility",
   "sprite": "gfx/items/raise_dodge.png",
   "category": "stats",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/raise_hp.json
+++ b/mods/tuxemon/db/item/raise_hp.json
@@ -7,7 +7,6 @@
   "sort": "utility",
   "sprite": "gfx/items/raise_hp.png",
   "category": "stats",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/raise_melee.json
+++ b/mods/tuxemon/db/item/raise_melee.json
@@ -7,7 +7,6 @@
   "sort": "utility",
   "sprite": "gfx/items/raise_melee.png",
   "category": "stats",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/raise_ranged.json
+++ b/mods/tuxemon/db/item/raise_ranged.json
@@ -7,7 +7,6 @@
   "sort": "utility",
   "sprite": "gfx/items/raise_ranged.png",
   "category": "stats",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/raise_speed.json
+++ b/mods/tuxemon/db/item/raise_speed.json
@@ -7,7 +7,6 @@
   "sort": "utility",
   "sprite": "gfx/items/raise_speed.png",
   "category": "stats",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/reg_papers.json
+++ b/mods/tuxemon/db/item/reg_papers.json
@@ -3,11 +3,12 @@
   "sort": "utility",
   "sprite": "gfx/items/key-card.png",
   "category": "none",
-  "type": "KeyItem",
   "usable_in": [
     ""
   ],
-  "behaviors": {},
+  "behaviors": {
+    "consumable": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/restoration.json
+++ b/mods/tuxemon/db/item/restoration.json
@@ -11,7 +11,6 @@
   "sort": "potion",
   "sprite": "gfx/items/apple.png",
   "category": "potion",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState",
     "WorldState"

--- a/mods/tuxemon/db/item/revive.json
+++ b/mods/tuxemon/db/item/revive.json
@@ -11,7 +11,6 @@
   "sort": "food",
   "sprite": "gfx/items/revive.png",
   "category": "revive",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState",
     "WorldState"

--- a/mods/tuxemon/db/item/rhincus_fossil.json
+++ b/mods/tuxemon/db/item/rhincus_fossil.json
@@ -10,11 +10,12 @@
   "sort": "utility",
   "sprite": "gfx/items/rhincus_fossil.png",
   "category": "fossil",
-  "type": "KeyItem",
   "usable_in": [
     "WorldState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "consumable": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/scoop_badge.json
+++ b/mods/tuxemon/db/item/scoop_badge.json
@@ -8,7 +8,6 @@
   "sort": "utility",
   "sprite": "gfx/items/scoop_badge.png",
   "category": "badge",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/sea_girdle.json
+++ b/mods/tuxemon/db/item/sea_girdle.json
@@ -10,7 +10,6 @@
   "sort": "utility",
   "sprite": "gfx/items/sea_girdle.png",
   "category": "morph",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/shaft_badge.json
+++ b/mods/tuxemon/db/item/shaft_badge.json
@@ -8,7 +8,6 @@
   "sort": "utility",
   "sprite": "gfx/items/shaft_badge.png",
   "category": "badge",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/shammer_fossil.json
+++ b/mods/tuxemon/db/item/shammer_fossil.json
@@ -10,11 +10,12 @@
   "sort": "utility",
   "sprite": "gfx/items/shammer_fossil.png",
   "category": "fossil",
-  "type": "KeyItem",
   "usable_in": [
     "WorldState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "consumable": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/sledgehammer.json
+++ b/mods/tuxemon/db/item/sledgehammer.json
@@ -9,11 +9,11 @@
   "sort": "utility",
   "sprite": "gfx/items/sledgehammer.png",
   "category": "destroy",
-  "type": "KeyItem",
   "usable_in": [
     "WorldState"
   ],
   "behaviors": {
+    "consumable": false,
     "requires_monster_menu": false
   },
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/item/spyder_pass.json
+++ b/mods/tuxemon/db/item/spyder_pass.json
@@ -4,11 +4,12 @@
   "sort": "utility",
   "sprite": "gfx/items/spyder_pass.png",
   "category": "none",
-  "type": "KeyItem",
   "usable_in": [
     ""
   ],
-  "behaviors": {},
+  "behaviors": {
+    "consumable": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/stovepipe.json
+++ b/mods/tuxemon/db/item/stovepipe.json
@@ -10,7 +10,6 @@
   "sort": "utility",
   "sprite": "gfx/items/stovepipe.png",
   "category": "morph",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/super_potion.json
+++ b/mods/tuxemon/db/item/super_potion.json
@@ -10,7 +10,6 @@
   "sort": "potion",
   "sprite": "gfx/items/super_potion.png",
   "category": "potion",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState",
     "WorldState"

--- a/mods/tuxemon/db/item/surfboard.json
+++ b/mods/tuxemon/db/item/surfboard.json
@@ -4,11 +4,12 @@
   "sort": "utility",
   "sprite": "gfx/items/surfboard.png",
   "category": "none",
-  "type": "KeyItem",
   "usable_in": [
     ""
   ],
-  "behaviors": {},
+  "behaviors": {
+    "consumable": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/sweet_sand.json
+++ b/mods/tuxemon/db/item/sweet_sand.json
@@ -10,7 +10,6 @@
   "sort": "utility",
   "sprite": "gfx/items/sweet_sand.png",
   "category": "morph",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tea.json
+++ b/mods/tuxemon/db/item/tea.json
@@ -7,7 +7,6 @@
   "sort": "potion",
   "sprite": "gfx/items/tea.png",
   "category": "none",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tectonic_drill.json
+++ b/mods/tuxemon/db/item/tectonic_drill.json
@@ -10,7 +10,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tectonic_drill.png",
   "category": "morph",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/thunderstone.json
+++ b/mods/tuxemon/db/item/thunderstone.json
@@ -10,7 +10,6 @@
   "sort": "utility",
   "sprite": "gfx/items/thunderstone.png",
   "category": "morph",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tm_avalanche.json
+++ b/mods/tuxemon/db/item/tm_avalanche.json
@@ -11,7 +11,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tm_earth.png",
   "category": "technique",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tm_blossom.json
+++ b/mods/tuxemon/db/item/tm_blossom.json
@@ -11,7 +11,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tm_wood.png",
   "category": "technique",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tm_earth.json
+++ b/mods/tuxemon/db/item/tm_earth.json
@@ -7,7 +7,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tm_earth.png",
   "category": "technique",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tm_fire.json
+++ b/mods/tuxemon/db/item/tm_fire.json
@@ -7,7 +7,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tm_fire.png",
   "category": "technique",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tm_metal.json
+++ b/mods/tuxemon/db/item/tm_metal.json
@@ -7,7 +7,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tm_metal.png",
   "category": "technique",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tm_surf.json
+++ b/mods/tuxemon/db/item/tm_surf.json
@@ -12,7 +12,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tm_water.png",
   "category": "technique",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tm_water.json
+++ b/mods/tuxemon/db/item/tm_water.json
@@ -7,7 +7,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tm_water.png",
   "category": "technique",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tm_wood.json
+++ b/mods/tuxemon/db/item/tm_wood.json
@@ -7,7 +7,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tm_wood.png",
   "category": "technique",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tuxeball.json
+++ b/mods/tuxemon/db/item/tuxeball.json
@@ -11,7 +11,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball.png",
   "category": "capture",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_ancient.json
+++ b/mods/tuxemon/db/item/tuxeball_ancient.json
@@ -11,7 +11,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_ancient.png",
   "category": "capture",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_candy.json
+++ b/mods/tuxemon/db/item/tuxeball_candy.json
@@ -11,7 +11,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_candy.png",
   "category": "capture",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_crusher.json
+++ b/mods/tuxemon/db/item/tuxeball_crusher.json
@@ -11,7 +11,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_crusher.png",
   "category": "capture",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_earth.json
+++ b/mods/tuxemon/db/item/tuxeball_earth.json
@@ -11,7 +11,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_earth.png",
   "category": "capture",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_female.json
+++ b/mods/tuxemon/db/item/tuxeball_female.json
@@ -11,7 +11,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_female.png",
   "category": "capture",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_fire.json
+++ b/mods/tuxemon/db/item/tuxeball_fire.json
@@ -11,7 +11,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_fire.png",
   "category": "capture",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_hardened.json
+++ b/mods/tuxemon/db/item/tuxeball_hardened.json
@@ -11,11 +11,12 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_hardened.png",
   "category": "capture",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "consumable": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_hearty.json
+++ b/mods/tuxemon/db/item/tuxeball_hearty.json
@@ -11,7 +11,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_hearty.png",
   "category": "capture",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_lavish.json
+++ b/mods/tuxemon/db/item/tuxeball_lavish.json
@@ -11,7 +11,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_lavish.png",
   "category": "capture",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_male.json
+++ b/mods/tuxemon/db/item/tuxeball_male.json
@@ -11,7 +11,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_male.png",
   "category": "capture",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_metal.json
+++ b/mods/tuxemon/db/item/tuxeball_metal.json
@@ -11,7 +11,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_metal.png",
   "category": "capture",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_neuter.json
+++ b/mods/tuxemon/db/item/tuxeball_neuter.json
@@ -11,7 +11,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_neuter.png",
   "category": "capture",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_omni.json
+++ b/mods/tuxemon/db/item/tuxeball_omni.json
@@ -11,7 +11,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_omni.png",
   "category": "capture",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_park.json
+++ b/mods/tuxemon/db/item/tuxeball_park.json
@@ -11,7 +11,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_park.png",
   "category": "capture",
-  "type": "Consumable",
   "usable_in": [
     "MainParkMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_peppy.json
+++ b/mods/tuxemon/db/item/tuxeball_peppy.json
@@ -11,7 +11,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_peppy.png",
   "category": "capture",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_refined.json
+++ b/mods/tuxemon/db/item/tuxeball_refined.json
@@ -11,7 +11,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_refined.png",
   "category": "capture",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_salty.json
+++ b/mods/tuxemon/db/item/tuxeball_salty.json
@@ -11,7 +11,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_salty.png",
   "category": "capture",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_water.json
+++ b/mods/tuxemon/db/item/tuxeball_water.json
@@ -11,7 +11,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_water.png",
   "category": "capture",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_wood.json
+++ b/mods/tuxemon/db/item/tuxeball_wood.json
@@ -11,7 +11,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_wood.png",
   "category": "capture",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_xero.json
+++ b/mods/tuxemon/db/item/tuxeball_xero.json
@@ -11,7 +11,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_xero.png",
   "category": "capture",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_zesty.json
+++ b/mods/tuxemon/db/item/tuxeball_zesty.json
@@ -11,7 +11,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_zesty.png",
   "category": "capture",
-  "type": "Consumable",
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/water_booster.json
+++ b/mods/tuxemon/db/item/water_booster.json
@@ -10,7 +10,6 @@
   "sort": "utility",
   "sprite": "gfx/items/water_booster.png",
   "category": "morph",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/wood_booster.json
+++ b/mods/tuxemon/db/item/wood_booster.json
@@ -10,7 +10,6 @@
   "sort": "utility",
   "sprite": "gfx/items/wood_booster.png",
   "category": "morph",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/xp_transmitter.json
+++ b/mods/tuxemon/db/item/xp_transmitter.json
@@ -4,11 +4,12 @@
   "sort": "utility",
   "sprite": "gfx/items/xp_transmitter.png",
   "category": "none",
-  "type": "KeyItem",
   "usable_in": [
     ""
   ],
-  "behaviors": {},
+  "behaviors": {
+    "consumable": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -105,11 +105,6 @@ class ElementType(str, Enum):
     water = "water"
 
 
-class ItemType(str, Enum):
-    consumable = "Consumable"
-    key_item = "KeyItem"
-
-
 class ItemCategory(str, Enum):
     none = "none"
     badge = "badge"
@@ -216,6 +211,9 @@ State = Enum(
 
 
 class ItemBehaviors(BaseModel):
+    consumable: bool = Field(
+        True, description="Whether or not this item is consumable."
+    )
     visible: bool = Field(
         True, description="Whether or not this item is visible."
     )
@@ -247,7 +245,6 @@ class ItemModel(BaseModel):
     )
     sort: ItemSort = Field(..., description="The kind of item this is.")
     sprite: str = Field(..., description="The sprite to use")
-    type: ItemType = Field(..., description="The type of item this is")
     category: ItemCategory = Field(
         ..., description="The category of item this is"
     )

--- a/tuxemon/item/effects/capture.py
+++ b/tuxemon/item/effects/capture.py
@@ -146,11 +146,7 @@ class CaptureEffect(ItemEffect):
 
     def _handle_capture_failure(self, item: Item, target: Monster) -> None:
         assert item.combat_state
-        if item.slug == "tuxeball_hardened":
-            tuxeball = self.user.find_item(item.slug)
-            if tuxeball:
-                tuxeball.quantity += 1
-        elif item.slug == "tuxeball_park":
+        if item.slug == "tuxeball_park":
             empty = Technique()
             empty.load("empty")
             _wander = "spyder_park_wander"
@@ -162,6 +158,10 @@ class CaptureEffect(ItemEffect):
         assert item.combat_state
         if item.slug == "tuxeball_candy":
             target.level += 1
+        elif item.slug == "tuxeball_hardened":
+            tuxeball = self.user.find_item(item.slug)
+            if tuxeball:
+                tuxeball.quantity -= 1
 
         if (
             target.slug in self.user.tuxepedia

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -11,7 +11,7 @@ import pygame
 
 from tuxemon import graphics, plugin, prepare
 from tuxemon.constants import paths
-from tuxemon.db import ItemCategory, ItemType, State, db
+from tuxemon.db import ItemCategory, State, db
 from tuxemon.item.itemcondition import ItemCondition
 from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
 from tuxemon.locale import T
@@ -43,7 +43,6 @@ class Item:
         self.description = ""
         self.instance_id = uuid.uuid4()
         self.quantity = 1
-        self.type = ItemType.consumable
         self.animation: Optional[str] = None
         self.flip_axes = ""
         # The path to the sprite to load.
@@ -106,7 +105,6 @@ class Item:
         self.behaviors = results.behaviors
         self.sort = results.sort
         self.category = results.category or ItemCategory.none
-        self.type = results.type or ItemType.consumable
         self.sprite = results.sprite
         self.usable_in = results.usable_in
         self.effects = self.parse_effects(results.effects)
@@ -245,7 +243,7 @@ class Item:
         # If this is a consumable item, remove it from the player's inventory.
         if (
             prepare.CONFIG.items_consumed_on_failure or meta_result["success"]
-        ) and self.type == "Consumable":
+        ) and self.behaviors.consumable:
             if self.quantity <= 1:
                 user.remove_item(self)
             else:


### PR DESCRIPTION
PR picks up where #2396 left off. The main changes are that we're dropping the **type** attribute and the ItemType class, which was an Enum that inherited from str. Instead, we're introducing a new behavior - a consumable property that's a boolean, defaulting to True. To make sure everything still works as expected, I've updated all the items that were previously marked as KeyItem to have consumable set to False.