### PR TITLE
fix 2349

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -2906,6 +2906,9 @@ msgstr "Cancel Key"
 msgid "menu_back_key"
 msgstr "Back Key"
 
+msgid "menu_reset_default"
+msgstr "Reset Keys to Default"
+
 msgid "enable"
 msgstr "Enable"
 

--- a/tuxemon/states/control/__init__.py
+++ b/tuxemon/states/control/__init__.py
@@ -4,15 +4,15 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from configparser import ConfigParser
 from functools import partial
 from typing import Any, Optional, Union
 
 import pygame
 import pygame_menu
 from pygame_menu import locals
-from pygame_menu.locals import POSITION_CENTER
 
-from tuxemon import config, prepare, tools
+from tuxemon import config, prepare
 from tuxemon.animation import Animation
 from tuxemon.constants import paths
 from tuxemon.event.eventengine import EventEngine
@@ -27,6 +27,43 @@ from tuxemon.state import State
 
 tuxe_config = config.TuxemonConfig(paths.USER_CONFIG_PATH)
 pre_config = prepare.CONFIG
+
+
+def update_custom_pygame_keyboard_controls(
+    config: ConfigParser, button: str, key: int
+) -> None:
+    config.set("controls", button, pygame.key.name(key))
+    with open(paths.USER_CONFIG_PATH, "w") as fp:
+        config.write(fp)
+    # Get the current control state and reload controls
+    control_state = local_session.client.get_state_by_name(ControlState)
+    if isinstance(control_state, ControlState):
+        control_state.reload_controls()
+
+
+def reset_config_to_default() -> None:
+    default_controls = {
+        "up": "up",
+        "down": "down",
+        "left": "left",
+        "right": "right",
+        "a": "return",
+        "b": "rshift, lshift",
+        "back": "escape",
+        "backspace": "backspace",
+    }
+
+    config = tuxe_config.cfg
+
+    for button, key in default_controls.items():
+        config.set("controls", button, key)
+
+    with open(paths.USER_CONFIG_PATH, "w") as fp:
+        config.write(fp)
+
+    control_state = local_session.client.get_state_by_name(ControlState)
+    if isinstance(control_state, ControlState):
+        control_state.reload_controls()
 
 
 class SetKeyState(PygameMenuState):
@@ -54,15 +91,6 @@ class SetKeyState(PygameMenuState):
         theme.widget_alignment = locals.ALIGN_LEFT
 
     def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
-        # must use get_pressed because the events do not contain references to pygame events
-        pressed_key: Optional[int] = None
-        for k in range(len(pygame.key.get_pressed())):
-            if pygame.key.get_pressed()[k]:
-                pressed_key = k
-
-        # to prevent a KeyError from happening, the game won't let you
-        # input a key if that key has already been set a value
-        invalid_keys: list[int] = []
         invalid_keys = [
             pygame.K_UP,
             pygame.K_DOWN,
@@ -75,27 +103,31 @@ class SetKeyState(PygameMenuState):
             pygame.K_BACKSPACE,
         ]
 
-        is_pressed = (
-            event.pressed or event.value == ""
-        ) and pressed_key is not None
+        pressed_key = next(
+            (
+                k
+                for k in range(len(pygame.key.get_pressed()))
+                if pygame.key.get_pressed()[k]
+            ),
+            None,
+        )
+
         if (
             isinstance(pressed_key, int)
-            and is_pressed
+            and (event.pressed or event.value == "")
             and pressed_key not in invalid_keys
         ):
-            # TODO: fix or rewrite PlayerInput
-            # event.value is being compared here since sometimes the
-            # value just returns an empty string and event.pressed doesn't
-            # return True when a key is being pressed
             assert self.button and pressed_key
             local_session.client.pop_state()
             pressed_key_str = pygame.key.name(pressed_key)
             if event.value == pressed_key_str:
+                # Update the configuration file with the new key
+                update_custom_pygame_keyboard_controls(
+                    tuxe_config.cfg, self.button, pressed_key
+                )
                 return event
-            else:
-                return None
-        else:
-            return None
+
+        return None
 
     def update_animation_size(self) -> None:
         widgets_size = self.menu.get_size(widget=True)
@@ -160,6 +192,8 @@ class ControlState(PygameMenuState):
         for k, v in key_names.items():
             display_buttons[v] = k
 
+        menu.select_widget(None)
+
         menu.add.button(
             title=T.translate("menu_up_key").upper(),
             action=change_state(
@@ -207,6 +241,11 @@ class ControlState(PygameMenuState):
             action=change_state(
                 "SetKeyState", button=display_buttons[buttons.BACK]
             ),
+            font_size=self.font_size_small,
+        )
+        menu.add.button(
+            title=T.translate("menu_reset_default").upper(),
+            action=reset_config_to_default,
             font_size=self.font_size_small,
         )
 
@@ -334,8 +373,7 @@ class ControlState(PygameMenuState):
         return ani
 
     def reload_controls(self) -> None:
-        with open(paths.USER_CONFIG_PATH, "w") as fp:
-            tuxe_config.cfg.write(fp)
+        tuxe_config.cfg.read(paths.USER_CONFIG_PATH)
 
         # reload inputs
         tuxe_config.keyboard_button_map = (
@@ -350,5 +388,6 @@ class ControlState(PygameMenuState):
     def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
         if event.button == buttons.BACK:
             self.reload_controls()
+            self.client.pop_state()
 
         return super().process_event(event)


### PR DESCRIPTION
PR fixes #2349 (ultra urgent), and you can now switch functions using different keyboard letters. Just a heads up, if you decide to get creative and swap 'down' with 'j', then later want to revert back to 'down' (among the locked ones), you'll need to manually edit the tuxemon.cfg file to make the change stick.

I've also added a 'Reset Keys' button, just in case. Now you can experiment with all the custom key combos you want, without worrying about getting stuck in a mess of your own making.

![Screenshot_2024-09-08_09-54-17](https://github.com/user-attachments/assets/4961aa1a-55f6-436f-97ff-e8fb824dd1b1)
