### PR TITLE
removes counter_success from techniques

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -704,7 +704,7 @@ msgid "item_no_available_target"
 msgstr "{name} cannot be used on any of your Tuxemon right now."
 
 msgid "technique_description"
-msgstr "ID.{id} ({types}) - Accuracy {acc}%, Potency {pot}%, Power {pow}/3, Recharge {rec} turns - Successful: {sus}%"
+msgstr "ID.{id} ({types}) - Accuracy {acc}%, Potency {pot}%, Power {pow}/3, Recharge {rec} turns"
 
 msgid "reg_papers"
 msgstr "Registration Papers"

--- a/tuxemon/states/techniques/__init__.py
+++ b/tuxemon/states/techniques/__init__.py
@@ -134,10 +134,6 @@ class TechniqueMenuState(Menu[Technique]):
             name = tech.name
             types = " ".join(map(lambda s: T.translate(s.slug), tech.types))
             image = self.shadow_text(name, bg=prepare.DIMGRAY_COLOR)
-            if tech.counter == 0:
-                sus = 100
-            else:
-                sus = int((tech.counter_success / tech.counter) * 100)
             label = T.format(
                 "technique_description",
                 {
@@ -147,7 +143,6 @@ class TechniqueMenuState(Menu[Technique]):
                     "pot": int(tech.potency * 100),
                     "pow": tech.power,
                     "rec": str(tech.recharge_length),
-                    "sus": sus,
                 },
             )
             desc: str = ""

--- a/tuxemon/technique/effects/damage.py
+++ b/tuxemon/technique/effects/damage.py
@@ -45,7 +45,6 @@ class DamageEffect(TechEffect):
         hit = tech.accuracy >= value
         tech.hit = hit
         if hit and not target.out_of_range:
-            tech.advance_counter_success()
             damage, mult = formula.simple_damage_calculate(tech, user, target)
             target.current_hp -= damage
         else:

--- a/tuxemon/technique/effects/enhance.py
+++ b/tuxemon/technique/effects/enhance.py
@@ -40,8 +40,6 @@ class EnhanceEffect(TechEffect):
         value = combat._random_tech_hit.get(user, 0.0) if combat else 0.0
         hit = tech.accuracy >= value
         tech.hit = hit
-        if hit:
-            tech.advance_counter_success()
         return {
             "success": hit,
             "damage": 0,

--- a/tuxemon/technique/effects/healing.py
+++ b/tuxemon/technique/effects/healing.py
@@ -54,7 +54,6 @@ class HealingEffect(TechEffect):
             heal = (COEFF_DAMAGE + mon.level) * tech.healing_power
         diff = mon.hp - mon.current_hp
         if hit:
-            tech.advance_counter_success()
             if diff > 0:
                 if heal >= diff:
                     mon.current_hp = mon.hp

--- a/tuxemon/technique/effects/money.py
+++ b/tuxemon/technique/effects/money.py
@@ -42,7 +42,6 @@ class MoneyEffect(TechEffect):
         if hit:
             user.current_hp -= damage
         else:
-            tech.advance_counter_success()
             amount = int(damage * mult)
             recipient = "player" if player.isplayer else player.slug
             client = self.session.client.event_engine

--- a/tuxemon/technique/effects/prop_damage.py
+++ b/tuxemon/technique/effects/prop_damage.py
@@ -43,7 +43,6 @@ class PropDamageEffect(TechEffect):
         hit = tech.accuracy >= value
         tech.hit = hit
         if hit:
-            tech.advance_counter_success()
             reference_hp = target.hp if self.objective == "target" else user.hp
             target.current_hp -= reference_hp // self.proportional
         else:

--- a/tuxemon/technique/effects/sacrifice.py
+++ b/tuxemon/technique/effects/sacrifice.py
@@ -44,7 +44,6 @@ class SacrificeEffect(TechEffect):
         hit = tech.accuracy >= value
         tech.hit = hit
         if hit:
-            tech.advance_counter_success()
             damage = int(user.current_hp * self.multiplier)
             user.current_hp -= user.current_hp
             target.current_hp -= damage

--- a/tuxemon/technique/effects/splash.py
+++ b/tuxemon/technique/effects/splash.py
@@ -35,7 +35,6 @@ class SplashEffect(TechEffect):
         hit = tech.accuracy >= value
         tech.hit = hit
         damage, mult = formula.simple_damage_calculate(tech, user, target)
-        tech.advance_counter_success()
         if hit:
             target.current_hp -= damage
         else:

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -24,7 +24,6 @@ logger = logging.getLogger(__name__)
 SIMPLE_PERSISTANCE_ATTRIBUTES = (
     "slug",
     "counter",
-    "counter_success",
 )
 
 
@@ -42,7 +41,6 @@ class Technique:
 
         self.instance_id = uuid.uuid4()
         self.counter = 0
-        self.counter_success = 0
         self.tech_id = 0
         self.accuracy = 0.0
         self.animation: Optional[str] = None
@@ -114,7 +112,6 @@ class Technique:
 
         self.icon = results.icon
         self.counter = self.counter
-        self.counter_success = self.counter_success
         # types
         for _ele in results.types:
             _element = Element(_ele)
@@ -226,13 +223,6 @@ class Technique:
 
         """
         self.counter += 1
-
-    def advance_counter_success(self) -> None:
-        """
-        Advance the counter for this technique if used successfully.
-
-        """
-        self.counter_success += 1
 
     def validate(self, target: Optional[Monster]) -> bool:
         """


### PR DESCRIPTION
PR removes the counter_success metric because it was causing more harm than good. Unfortunately, it was often being misinterpreted as accuracy, leading to unnecessary debates and confusion. By taking it out, we can avoid these misunderstandings and keep the focus on more meaningful metrics. Improves "area" effect since this PR was already acting on it.