### PR TITLE
icon cache (fix #2412)

### DIFF
--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -168,7 +168,9 @@ class CombatState(CombatAnimations):
         self._run: bool = False
         self._post_animation_task: Optional[Task] = None
         self._xp_message: Optional[str] = None
-        self._status_icon_cache: dict[str, Sprite] = {}
+        self._status_icon_cache: dict[
+            tuple[str, tuple[float, float]], Sprite
+        ] = {}
         self._random_tech_hit: dict[Monster, float] = {}
 
         super().__init__(players, graphics)
@@ -657,6 +659,7 @@ class CombatState(CombatAnimations):
 
         # add status icons
         for monster in self.active_monsters:
+            self._status_icons[monster] = []
             for status in monster.status:
                 if status.icon:
                     icon_position = (
@@ -668,13 +671,13 @@ class CombatState(CombatAnimations):
                             monster, self.monsters_in_play_right
                         )
                     )
-                    if status.icon not in self._status_icon_cache:
-                        self._status_icon_cache[status.icon] = (
-                            self.load_sprite(
-                                status.icon, layer=200, center=icon_position
-                            )
+                    cache_key = (status.icon, icon_position)
+                    if cache_key not in self._status_icon_cache:
+                        self._status_icon_cache[cache_key] = self.load_sprite(
+                            status.icon, layer=200, center=icon_position
                         )
-                    icon = self._status_icon_cache[status.icon]
+
+                    icon = self._status_icon_cache[cache_key]
                     self.sprites.add(icon, layer=200)
                     self._status_icons[monster].append(icon)
 


### PR DESCRIPTION
PR fixes #2412

@ultidonki I'm going to write the cause of it, even if probably I'll never get a reply (excluding maybe an emoticon or a thumbs up).

The main issue with the first version of the code what that it was using a cache to store the icon instances, but it was using the icon name as the key. This meant that if two monsters had the same status icon, they would both be using the same icon instance from the cache.

The problem with this is that the icon instance is being added to the self.sprites list multiple times, but it's the same instance each time. This means that when the icon is updated or removed, it'll affect all the monsters that are using that icon instance.

Now, I have changed the cache to use a tuple of the icon name and its position as the key. This means that each monster gets its own unique icon instance from the cache, even if they have the same status icon.

![Screenshot_2024-09-08_21-30-18](https://github.com/user-attachments/assets/05090d96-56b0-49c0-9b20-f58798f9a7e9)
