### PR TITLE
fix scoop2

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -8536,6 +8536,8 @@ msgstr "Remember, we had nothing to do with the disease getting out!"
 
 msgid "spyder_scoop_asta1"
 msgstr "Why yes, I am the inventor of the Extreme Restraints. \n What are they, I hear you ask? \n Only a set of manacles so powerful that even a dragon could not escape them. \n They are being used in the containment unit to make sure none of the infected tuxemon escape."
+msgid "spyder_scoop_asta2"
+msgstr "Are you sure you want to leave Scoop HQ?"
 
 msgid "spyder_scoop_alyssa1"
 msgstr "As soon as disease was detected, we moved the infected tuxemon to this containment unit."

--- a/mods/tuxemon/maps/scoop2.tmx
+++ b/mods/tuxemon/maps/scoop2.tmx
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="8" height="5" tilewidth="16" tileheight="16" infinite="0" nextlayerid="5" nextobjectid="15">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="8" height="5" tilewidth="16" tileheight="16" infinite="0" nextlayerid="5" nextobjectid="15">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
+  <property name="map_type" value="dungeon"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="scoop2"/>
-  <property name="map_type" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="core_indoor_floors" tilewidth="16" tileheight="16" tilecount="3864" columns="46">
   <image source="../gfx/tilesets/core_indoor_floors.png" width="736" height="1344"/>
@@ -16,6 +16,7 @@
  <tileset firstgid="5415" name="core_indoor_stairs" tilewidth="16" tileheight="16" tilecount="2970" columns="45">
   <image source="../gfx/tilesets/core_indoor_stairs.png" width="720" height="1056"/>
  </tileset>
+ <tileset firstgid="8385" source="../gfx/tilesets/core_set pieces.tsx"/>
  <layer id="1" name="Tile Layer 1" width="8" height="5">
   <data encoding="base64" compression="zlib">
    eAFjYICAL4IMDF+B+BsQIwOYmLAQA4MIEIsCMUwtSA4mZgQUNwZiEyCGqQXJwcQOszAwwDBMLUgOJoaLBgDlUxQW
@@ -23,7 +24,7 @@
  </layer>
  <layer id="4" name="Tile Layer 2" width="8" height="5">
   <data encoding="base64" compression="zlib">
-   eAFjYCAebBfAr/YaUJ5PAqIGl1prqDxILQjsJGAmADZLBJ0=
+   eAFjYCAebBfAr/YaUJ5PAqIGl1prqDxIrYIyA8NOAmYCAD+UBOA=
   </data>
  </layer>
  <objectgroup color="#ffff00" id="2" name="Events">
@@ -64,15 +65,6 @@
   <object id="5" type="collision" x="32" y="0" width="48" height="48"/>
   <object id="6" type="collision" x="80" y="16" width="32" height="48"/>
   <object id="7" type="collision" x="112" y="16" width="16" height="32"/>
-  <object id="8" type="collision-line" x="0" y="80">
-   <polyline points="0,0 128,0"/>
-  </object>
-  <object id="9" type="collision-line" x="0" y="64">
-   <polyline points="0,0 0,16"/>
-  </object>
-  <object id="10" type="collision-line" x="128" y="48">
-   <polyline points="0,0 0,32"/>
-  </object>
   <object id="13" type="collision-line" x="64" y="64">
    <polyline points="0,0 16,0"/>
   </object>

--- a/mods/tuxemon/maps/spyder_scoop2.tmx
+++ b/mods/tuxemon/maps/spyder_scoop2.tmx
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="8" height="5" tilewidth="16" tileheight="16" infinite="0" nextlayerid="5" nextobjectid="19">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="8" height="5" tilewidth="16" tileheight="16" infinite="0" nextlayerid="5" nextobjectid="22">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
+  <property name="map_type" value="dungeon"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="scoop2"/>
-  <property name="map_type" value="dungeon"/>
  </properties>
  <tileset firstgid="1" source="../gfx/tilesets/core_indoor_floors.tsx"/>
  <tileset firstgid="3865" source="../gfx/tilesets/core_set pieces.tsx"/>
@@ -17,7 +17,7 @@
  </layer>
  <layer id="4" name="Tile Layer 2" width="8" height="5">
   <data encoding="base64" compression="zlib">
-   eAFjYCAebBfAr/YaUJ5PAqIGl1prqDxILQjsJGAmADZLBJ0=
+   eAFjYCAebBfAr/YaUJ5PAqIGl1prqDxIbYUgA8NOAmYCAEl+BSY=
   </data>
  </layer>
  <objectgroup color="#ff0000" id="3" name="Collisions">
@@ -60,13 +60,13 @@
     <property name="cond2" value="is char_facing player,right"/>
    </properties>
   </object>
-  <object id="15" name="Create Asta" type="event" x="32" y="64" width="16" height="16">
+  <object id="15" name="Create Asta" type="event" x="32" y="48" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_scoop_reese,2,3"/>
     <property name="cond1" value="not char_exists spyder_scoop_reese"/>
    </properties>
   </object>
-  <object id="16" name="Talk Asta" type="event" x="32" y="48" width="16" height="16">
+  <object id="16" name="Talk Asta" type="event" x="32" y="32" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_scoop_asta1"/>
     <property name="behav1" value="talk spyder_scoop_reese"/>
@@ -76,6 +76,32 @@
    <properties>
     <property name="act1" value="set_variable environment:interior"/>
     <property name="cond1" value="not variable_set environment:interior"/>
+   </properties>
+  </object>
+  <object id="19" name="Leaving Scoop HQ" type="event" x="48" y="48" width="16" height="16">
+   <properties>
+    <property name="act1" value="lock_controls"/>
+    <property name="act2" value="char_face spyder_scoop_reese,right"/>
+    <property name="act3" value="translated_dialog spyder_scoop_asta2"/>
+    <property name="act4" value="char_face spyder_scoop_reese,down"/>
+    <property name="act5" value="unlock_controls"/>
+    <property name="act6" value="translated_dialog_choice yes:no,leavescoophq"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="not variable_set leavescoophq"/>
+   </properties>
+  </object>
+  <object id="20" name="Leaving Yes" type="event" x="48" y="16" width="16" height="16">
+   <properties>
+    <property name="act1" value="pathfind player,4,3"/>
+    <property name="act2" value="clear_variable leavescoophq"/>
+    <property name="cond1" value="is variable_set leavescoophq:yes"/>
+   </properties>
+  </object>
+  <object id="21" name="Leaving no" type="event" x="48" y="32" width="16" height="16">
+   <properties>
+    <property name="act1" value="pathfind player,4,4"/>
+    <property name="act2" value="clear_variable leavescoophq"/>
+    <property name="cond1" value="is variable_set leavescoophq:no"/>
    </properties>
   </object>
  </objectgroup>


### PR DESCRIPTION
PR fixes from #2410 

> Scoop HQ spyder_scoop2.tmx - See Save file/screenshot. The only way to access the rest of Scoop HQ is to go 'up' on the very right of the map, as if there should be a door there. (I only knew there was something missing because I'd played the dungeon before)

adds the door (missing both in spyder and xero version)

![spyder_scoop2](https://github.com/user-attachments/assets/4f6afce9-33dc-4fca-8851-c96da780fb63)

and

> Same map: Maybe have a warning before you go up the stairs - "Are you sure you want to leave Scoop HQ?" As I was surprised the stairs took me outside, I thought I'd completed the dungeon already.

if the player moves in the tile close to the NPC, the NPC turns right and says:
"Are you sure you want to leave Scoop HQ?"
then 
Yes / No
if NO -> it goes in the tile below the stair
if YES -> it goes out

@Sanglorian 
