### PR TITLE
crash sleeping_powder (technique)

### DIFF
--- a/mods/tuxemon/db/technique/sleeping_powder.json
+++ b/mods/tuxemon/db/technique/sleeping_powder.json
@@ -4,7 +4,7 @@
   "animation": "explosion_dusty_96",
   "effects": [
     "give noddingoff,target",
-    "area"
+    "enhance"
   ],
   "flip_axes": "",
   "is_fast": false,

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -759,11 +759,20 @@ class TechniqueModel(BaseModel):
         cls: TechniqueModel, v: Range, info: ValidationInfo
     ) -> Range:
         # Special indicates that we are not doing damage
-        if v == Range.special and "damage" in info.data["effects"]:
+        if v == Range.special and any(
+            effect in info.data["effects"]
+            for effect in [
+                "damage",
+                "area",
+                "retaliate",
+                "revenge",
+                "money",
+                "splash",
+            ]
+        ):
             raise ValueError(
-                '"special" range cannot be used with effect "damage"'
+                '"special" range cannot be used with effects "damage", "area", "retaliate", "revenge", "money", or "splash"'
             )
-
         return v
 
     @field_validator("animation")

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -140,7 +140,9 @@ def simple_damage_calculate(
     else:
         target_resist = getattr(target, target_stat)
 
-    mult = simple_damage_multiplier((technique.types), (target.types))
+    mult = simple_damage_multiplier(
+        (technique.types), (target.types), additional_factors
+    )
     move_strength = technique.power * mult
     damage = int(user_strength * move_strength / target_resist)
     return damage, mult


### PR DESCRIPTION
**sleeping_powder** technique that managed to slip through the cracks. Despite the growth and additions to the codebase, only one technique was able to evade the checks.

With this update, we should be able to catch any future techniques that try to sneak in with the "area" effect. And as for the **sleeping_powder** technique, we can either update it to remove the "area" effect or change its range to something other than "special".

I'm not a fan of this, so consider it temporary.

All of these effects have: `damage, mult = formula.simple_damage_calculate(tech, user, target)` and if a technique with a special range pass through it, crash

refresh of the area effect: #2415 (PR was already acting on the file)

log:
```
  File "/home/giorgio/Tuxemon/tuxemon/states/combat/combat.py", line 814, in perform_action
    result_tech = method.use(user, target)
                  ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/giorgio/Tuxemon/tuxemon/technique/technique.py", line 313, in use
    result = effect.apply(self, user, target)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/giorgio/Tuxemon/tuxemon/technique/effects/area.py", line 40, in apply
    damage, mult = formula.simple_damage_calculate(tech, user, target)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/giorgio/Tuxemon/tuxemon/formula.py", line 127, in simple_damage_calculate
    raise RuntimeError(f"Unhandled damage category: {technique.range}")
RuntimeError: Unhandled damage category: Range.special
```