### PR TITLE
build hud text (combat.py)

### DIFF
--- a/tuxemon/combat.py
+++ b/tuxemon/combat.py
@@ -542,7 +542,6 @@ def build_hud_text(
 ) -> str:
     """
     Returns the text image for use on the callout of the monster.
-    eg. Rockitten Lv3
 
     Parameters:
         menu: Combat menu (eg. MainCombatMenuState).
@@ -551,28 +550,29 @@ def build_hud_text(
             right side (player), left side (opponent)
         is_trainer: Boolean battle (trainer: true, wild: false).
 
+    Returns:
+        A string representing the HUD text for the monster.
+
     """
-    trainer = monster.owner
-    icon: str = ""
-    if menu == "MainParkMenuState" and trainer and is_right:
+    if menu == "MainParkMenuState" and monster.owner and is_right:
+        # Special case for MainParkMenuState
         ball = T.translate("tuxeball_park")
-        item = trainer.find_item("tuxeball_park")
+        item = monster.owner.find_item("tuxeball_park")
         if item is None:
             return f"{ball.upper()}: 0"
         return f"{ball.upper()}: {item.quantity}"
-    else:
-        if monster.gender == GenderType.male:
-            icon += "♂"
-        if monster.gender == GenderType.female:
-            icon += "♀"
-        if not is_trainer:
-            # shows captured symbol (wild encounter)
-            symbol: str = ""
-            if is_status and is_status == SeenStatus.caught and not is_right:
-                symbol += "◉"
-            return f"{monster.name}{icon} Lv.{monster.level}{symbol}"
-        else:
-            return f"{monster.name}{icon} Lv.{monster.level}"
+
+    icon = ""
+    if monster.gender == GenderType.male:
+        icon = "♂"
+    elif monster.gender == GenderType.female:
+        icon = "♀"
+
+    symbol = ""
+    if not is_trainer and is_status == SeenStatus.caught and not is_right:
+        symbol = "◉"
+
+    return f"{monster.name}{icon} Lv.{monster.level}{symbol}"
 
 
 def retrieve_from_party(party: list[Monster], method: str) -> Monster:


### PR DESCRIPTION
PR for improving the build HUD text. However, I think we can take it a step further. I'd love to see the hardcoded part related to the park removed, but I know that's a bigger task. Let's consider this PR as the first step in that direction.

Reminder: I was thinking about a JSON addition (battle menu):

```
{
    "menu_states": {
        "MainParkMenuState": {
            "format": "{ball}: {quantity}",
            "ball": "tuxeball_park",
            "item": "tuxeball_park"
        },
        "MainCombatMenuState": {
            "format": "{name}{icon} Lv.{level}{symbol}"
        }
    }
}
```





