### PR TITLE
pause / unpause

### DIFF
--- a/tuxemon/audio.py
+++ b/tuxemon/audio.py
@@ -58,12 +58,12 @@ class MusicPlayerState:
             self.cache[filename] = path
             return path
 
-    def pause(self, fadeout_time: int = prepare.MUSIC_FADEOUT) -> None:
+    def pause(self) -> None:
         if self.status == MusicStatus.playing:
-            if fadeout_time > 0:
-                self.fadeout(fadeout_time)
             self.status = MusicStatus.paused
             mixer2.music.pause()
+        elif self.status == MusicStatus.paused:
+            logger.warning("Music is already paused.")
         else:
             logger.warning("Music cannot be paused, none is playing.")
 
@@ -71,6 +71,8 @@ class MusicPlayerState:
         if self.status == MusicStatus.paused:
             self.status = MusicStatus.playing
             mixer2.music.unpause()
+        elif self.status == MusicStatus.stopped:
+            logger.warning("Music is stopped, cannot unpause.")
         else:
             logger.warning(
                 "Music cannot be unpaused, none is paused or not playing."
@@ -90,7 +92,7 @@ class MusicPlayerState:
         mixer2.music.fadeout(time)
 
     def is_playing(self) -> bool:
-        return mixer2.music.get_busy()
+        return bool(mixer2.music.get_busy())
 
     def is_playing_same_song(self, song: str) -> bool:
         return self.status == MusicStatus.playing and self.current_song == song

--- a/tuxemon/event/actions/pause_music.py
+++ b/tuxemon/event/actions/pause_music.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Optional, final
+from typing import final
 
-from tuxemon import prepare
 from tuxemon.event.eventaction import EventAction
 
 logger = logging.getLogger(__name__)
@@ -21,18 +20,11 @@ class PauseMusicAction(EventAction):
     Script usage:
         .. code-block::
 
-            pause_music [duration]
-
-    Script parameters:
-        duration: Number of milliseconds to fade out the music over.
+            pause_music
 
     """
 
     name = "pause_music"
-    duration: Optional[int] = None
 
     def start(self) -> None:
-        duration = (
-            prepare.MUSIC_FADEOUT if self.duration is None else self.duration
-        )
-        self.session.client.current_music.pause(duration)
+        self.session.client.current_music.pause()

--- a/tuxemon/event/conditions/music_playing.py
+++ b/tuxemon/event/conditions/music_playing.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2014-2024 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+from tuxemon.db import MusicStatus
 from tuxemon.event import MapCondition
 from tuxemon.event.eventcondition import EventCondition
 from tuxemon.session import Session
@@ -47,7 +48,10 @@ class MusicPlayingCondition(EventCondition):
         if not names.isdisjoint(combat_states):
             return True
 
-        return (
-            session.client.current_music.current_song == song
-            and session.client.current_music.is_playing()
-        )
+        if session.client.current_music.status == MusicStatus.paused:
+            return True
+        else:
+            return (
+                session.client.current_music.current_song == song
+                and session.client.current_music.is_playing()
+            )


### PR DESCRIPTION
PR fixes an issue with pausing and unpausing music, where the fadeout during pausing was causing some problems. To address this, I've updated the **pause_music** event action and the **music_playing** event condition. The latter was particularly tricky, as pausing the music would immediately trigger it to start playing again. To prevent this, I've added an extra check to make sure the music isn't already paused before triggering playback