### PR TITLE
various

### DIFF
--- a/tests/tuxemon/test_monster_actions.py
+++ b/tests/tuxemon/test_monster_actions.py
@@ -40,7 +40,7 @@ class TestMonsterActions(unittest.TestCase):
     _agnite = MonsterModel(
         slug="agnite",
         category="false_dragon",
-        moveset=[],
+        moveset=[{"level_learned": 1, "technique": "ram"}],
         evolutions=[],
         history=[],
         tags=["dragon", "coastal", "desert", "mountains"],
@@ -58,7 +58,7 @@ class TestMonsterActions(unittest.TestCase):
     _nut = MonsterModel(
         slug="nut",
         category="hardware",
-        moveset=[],
+        moveset=[{"level_learned": 1, "technique": "ram"}],
         evolutions=[],
         history=[],
         tags=["blob"],

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -337,10 +337,9 @@ class MonsterMovesetItemModel(BaseModel):
         ..., description="Monster level in which this moveset is learned", gt=0
     )
     technique: str = Field(
-        ..., description="Name of the technique for this moveset item"
-    )
-    element: Optional[ElementType] = Field(
-        None, description="Element random technique"
+        ...,
+        description="Name of the technique for this moveset item",
+        json_schema_extra={"unique": True},
     )
 
     @field_validator("technique")
@@ -563,7 +562,7 @@ class MonsterModel(BaseModel, validate_assignment=True):
         le=prepare.CATCH_RESISTANCE_RANGE[1],
     )
     moveset: Sequence[MonsterMovesetItemModel] = Field(
-        [], description="The moveset of this monster"
+        [], description="The moveset of this monster", min_length=1
     )
     history: Sequence[MonsterHistoryItemModel] = Field(
         [], description="The evolution history of this monster"

--- a/tuxemon/event/conditions/has_party_breeder.py
+++ b/tuxemon/event/conditions/has_party_breeder.py
@@ -31,18 +31,19 @@ class HasPartyBreederCondition(EventCondition):
 
     def test(self, session: Session, condition: MapCondition) -> bool:
         _character = condition.parameters[0]
-        basic = EvolutionStage.basic
-        male = GenderType.male
-        female = GenderType.female
         character = get_npc(session, _character)
         if character is None:
             logger.error(f"{_character} not found")
             return False
-        party = character.monsters
-        var1 = [
-            mon for mon in party if mon.stage != basic and mon.gender == male
-        ]
-        var2 = [
-            mon for mon in party if mon.stage != basic and mon.gender == female
-        ]
-        return any(var1) and any(var2)
+
+        has_male_evolved_monsters = any(
+            mon.stage != EvolutionStage.basic and mon.gender == GenderType.male
+            for mon in character.monsters
+        )
+        has_female_evolved_monsters = any(
+            mon.stage != EvolutionStage.basic
+            and mon.gender == GenderType.female
+            for mon in character.monsters
+        )
+
+        return has_male_evolved_monsters and has_female_evolved_monsters


### PR DESCRIPTION
This PR simplifies our database model by removing the redundant `moveset` element from `db.py`. Additionally, it introduces a minimum requirement of 1 tech per monster, which should prevent issues like #2328 from arising in the future.

The PR also refactors the condition for checking if monsters are available for breeding, making the logic more clear and concise.