### PR TITLE
add remove_state_by_name (state.py)

### DIFF
--- a/mods/tuxemon/db/item/booster_tech.json
+++ b/mods/tuxemon/db/item/booster_tech.json
@@ -13,7 +13,9 @@
   "usable_in": [
     "WorldState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "show_dialog_on_success": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/earth_booster.json
+++ b/mods/tuxemon/db/item/earth_booster.json
@@ -13,7 +13,9 @@
   "usable_in": [
     "WorldState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "show_dialog_on_success": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/fire_booster.json
+++ b/mods/tuxemon/db/item/fire_booster.json
@@ -13,7 +13,9 @@
   "usable_in": [
     "WorldState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "show_dialog_on_success": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/flintstone.json
+++ b/mods/tuxemon/db/item/flintstone.json
@@ -13,7 +13,9 @@
   "usable_in": [
     "WorldState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "show_dialog_on_success": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/lima_pie.json
+++ b/mods/tuxemon/db/item/lima_pie.json
@@ -13,7 +13,9 @@
   "usable_in": [
     "WorldState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "show_dialog_on_success": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/lucky_bamboo.json
+++ b/mods/tuxemon/db/item/lucky_bamboo.json
@@ -13,7 +13,9 @@
   "usable_in": [
     "WorldState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "show_dialog_on_success": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/metal_booster.json
+++ b/mods/tuxemon/db/item/metal_booster.json
@@ -13,7 +13,9 @@
   "usable_in": [
     "WorldState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "show_dialog_on_success": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/miaow_milk.json
+++ b/mods/tuxemon/db/item/miaow_milk.json
@@ -13,7 +13,9 @@
   "usable_in": [
     "WorldState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "show_dialog_on_success": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/ox_stick.json
+++ b/mods/tuxemon/db/item/ox_stick.json
@@ -13,7 +13,9 @@
   "usable_in": [
     "WorldState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "show_dialog_on_success": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/peace_lily.json
+++ b/mods/tuxemon/db/item/peace_lily.json
@@ -13,7 +13,9 @@
   "usable_in": [
     "WorldState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "show_dialog_on_success": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/petrified_dung.json
+++ b/mods/tuxemon/db/item/petrified_dung.json
@@ -13,7 +13,9 @@
   "usable_in": [
     "WorldState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "show_dialog_on_success": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/pyramidion.json
+++ b/mods/tuxemon/db/item/pyramidion.json
@@ -13,7 +13,9 @@
   "usable_in": [
     "WorldState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "show_dialog_on_success": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/rhincus_fossil.json
+++ b/mods/tuxemon/db/item/rhincus_fossil.json
@@ -14,7 +14,7 @@
     "WorldState"
   ],
   "behaviors": {
-    "consumable": false
+    "show_dialog_on_success": false
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/sea_girdle.json
+++ b/mods/tuxemon/db/item/sea_girdle.json
@@ -13,7 +13,9 @@
   "usable_in": [
     "WorldState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "show_dialog_on_success": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/shammer_fossil.json
+++ b/mods/tuxemon/db/item/shammer_fossil.json
@@ -14,7 +14,7 @@
     "WorldState"
   ],
   "behaviors": {
-    "consumable": false
+    "show_dialog_on_success": false
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/stovepipe.json
+++ b/mods/tuxemon/db/item/stovepipe.json
@@ -13,7 +13,9 @@
   "usable_in": [
     "WorldState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "show_dialog_on_success": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/sweet_sand.json
+++ b/mods/tuxemon/db/item/sweet_sand.json
@@ -13,7 +13,9 @@
   "usable_in": [
     "WorldState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "show_dialog_on_success": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tectonic_drill.json
+++ b/mods/tuxemon/db/item/tectonic_drill.json
@@ -13,7 +13,9 @@
   "usable_in": [
     "WorldState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "show_dialog_on_success": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/thunderstone.json
+++ b/mods/tuxemon/db/item/thunderstone.json
@@ -13,7 +13,9 @@
   "usable_in": [
     "WorldState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "show_dialog_on_success": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/water_booster.json
+++ b/mods/tuxemon/db/item/water_booster.json
@@ -13,7 +13,9 @@
   "usable_in": [
     "WorldState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "show_dialog_on_success": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/wood_booster.json
+++ b/mods/tuxemon/db/item/wood_booster.json
@@ -13,7 +13,9 @@
   "usable_in": [
     "WorldState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "show_dialog_on_success": false
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/tuxemon/client.py
+++ b/tuxemon/client.py
@@ -557,6 +557,10 @@ class LocalPygameClient:
         """Remove a state"""
         self.state_manager.remove_state(state)
 
+    def remove_state_by_name(self, state: str) -> None:
+        """Remove a state by name"""
+        self.state_manager.remove_state_by_name(state)
+
     @overload
     def push_state(self, state_name: str, **kwargs: Any) -> State:
         pass

--- a/tuxemon/state.py
+++ b/tuxemon/state.py
@@ -497,22 +497,50 @@ class StateManager:
             self._state_stack.remove(state)
             state.shutdown()
 
+    def remove_state_by_name(self, state_name: str) -> None:
+        """
+        Remove a state from the stack by its name.
+
+        Parameters:
+            state_name: The name of the state to remove.
+        """
+
+        try:
+            for index, state in enumerate(self._state_stack):
+                if state.name == state_name:
+                    if index == 0:
+                        self.pop_state()
+                    else:
+                        self._state_stack.remove(state)
+                        state.shutdown()
+                    return
+        except IndexError:
+            logger.critical(
+                "Attempted to remove state which is not in the stack",
+            )
+            raise RuntimeError
+
+        # If the state wasn't found, raise an error
+        raise ValueError(f"State with name '{state_name}' not found")
+
     @overload
-    def push_state(self, state_name: str, **kwargs: Any) -> State:
+    def push_state(
+        self, state_name: str, **kwargs: Optional[dict[str, Any]]
+    ) -> State:
         pass
 
     @overload
     def push_state(
         self,
         state_name: StateType,
-        **kwargs: Any,
+        **kwargs: Optional[dict[str, Any]],
     ) -> StateType:
         pass
 
     def push_state(
         self,
         state_name: Union[str, StateType],
-        **kwargs: Any,
+        **kwargs: Optional[dict[str, Any]],
     ) -> State:
         """
         Pause currently running state and start new one.
@@ -553,21 +581,23 @@ class StateManager:
         return instance
 
     @overload
-    def replace_state(self, state_name: str, **kwargs: Any) -> State:
+    def replace_state(
+        self, state_name: str, **kwargs: Optional[dict[str, Any]]
+    ) -> State:
         pass
 
     @overload
     def replace_state(
         self,
         state_name: StateType,
-        **kwargs: Any,
+        **kwargs: Optional[dict[str, Any]],
     ) -> StateType:
         pass
 
     def replace_state(
         self,
         state_name: Union[str, State],
-        **kwargs: Any,
+        **kwargs: Optional[dict[str, Any]],
     ) -> State:
         """
         Replace the currently running state with a new one.


### PR DESCRIPTION
PR adds a new method to state.py called **remove_state_by_name**, which lets us delete a specific state without relying on luck. To be honest, the old way of using **pop_state** was a bit of a gamble, especially when starting a transition after using an evolution item #2390. It was always a bit unsettling, knowing that **pop_state** might remove the transition itself. This new method solves that problem.

I also made some improvements to the evolution items and the item menu. One of the key changes is that the dialogue display is now handled by a separate method, which makes things a bit more organized and easier to manage.