### PR TITLE
fix change_bg

### DIFF
--- a/tuxemon/event/actions/change_bg.py
+++ b/tuxemon/event/actions/change_bg.py
@@ -83,7 +83,11 @@ class ChangeBgAction(EventAction):
                 return
             if self.category == "image":
                 self.image = CATEGORY_PATHS[self.category].format(self.image)
-            elif self.image in db.database[self.category]:
+            elif self.image in db.database["monster"]:
+                self.image = CATEGORY_PATHS[self.category].format(self.image)
+            elif self.image in db.database["template"]:
+                self.image = CATEGORY_PATHS[self.category].format(self.image)
+            elif self.image in db.database["item"]:
                 self.image = CATEGORY_PATHS[self.category].format(self.image)
             else:
                 logger.error(


### PR DESCRIPTION
PR fixes change_bg and gets rid of a typehint (it was created in the previous PR), because database accepts only literals, and this is the fastest solution without losing too much time on it.

```
tuxemon/event/actions/change_bg.py:91:
error: Invalid index type "str" for "dict[Literal['economy', 'element', 'shape', 'template', 'mission', 'encounter', 'dialogue', 
'environment', 'item', 'monster', 'music', 'animation', 'npc', 'sounds', 'condition', 'technique'], dict[str, Any]]"; 
expected type "Literal['economy', 'element', 'shape', 'template', 'mission', 'encounter', 'dialogue', 'environment', 'item', 
'monster', 'music', 'animation', 'npc', 'sounds', 'condition', 'technique']"  [index]
```
