### PR TITLE
fix time handler

### DIFF
--- a/tests/tuxemon/test_time_handler.py
+++ b/tests/tuxemon/test_time_handler.py
@@ -21,10 +21,10 @@ class TestTimeFunctions(unittest.TestCase):
 
     def test_calculate_day_night_cycle(self):
         test_cases = [
-            (datetime(2022, 1, 1, 0, 0, 0), "night"),
-            (datetime(2022, 1, 1, 6, 0, 0), "day"),
-            (datetime(2022, 1, 1, 18, 0, 0), "night"),
-            (datetime(2022, 1, 1, 12, 0, 0), "day"),
+            (datetime(2022, 1, 1, 0, 0, 0), "false"),
+            (datetime(2022, 1, 1, 6, 0, 0), "true"),
+            (datetime(2022, 1, 1, 18, 0, 0), "false"),
+            (datetime(2022, 1, 1, 12, 0, 0), "true"),
         ]
         for time, expected in test_cases:
             self.assertEqual(calculate_day_night_cycle(time), expected)

--- a/tuxemon/player.py
+++ b/tuxemon/player.py
@@ -71,8 +71,8 @@ class Player(NPC):
         )
         self.game_variables["year"] = current_time.strftime("%Y")
         self.game_variables["weekday"] = current_time.strftime("%A")
-        self.game_variables["leap_year"] = time_handler.is_leap_year(
-            current_time.year
+        self.game_variables["leap_year"] = (
+            "true" if time_handler.is_leap_year(current_time.year) else "false"
         )
         self.game_variables["daytime"] = (
             time_handler.calculate_day_night_cycle(current_time)

--- a/tuxemon/time_handler.py
+++ b/tuxemon/time_handler.py
@@ -24,11 +24,11 @@ def calculate_day_night_cycle(time: datetime) -> str:
     """
     hour = time.hour
     if hour < 6:
-        return "night"
+        return "false"
     elif 6 <= hour < 18:
-        return "day"
+        return "true"
     else:
-        return "night"
+        return "false"
 
 
 def calculate_day_stage_of_day(time: datetime) -> str:


### PR DESCRIPTION
PR fixes time handler. I made a mistake with the daytime setting and only caught it today while testing random encounters out in the field #2448. The same goes for leap_year, better to save as string than boolean.