### PR TITLE
combat recharging

### DIFF
--- a/mods/tuxemon/l18n/cs_CZ/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/cs_CZ/LC_MESSAGES/base.po
@@ -134,9 +134,6 @@ msgstr "Chytil jsi {name}!"
 msgid "combat_capturing_fail"
 msgstr "{name} se vymanil!"
 
-msgid "combat_recharging"
-msgstr "{name} potřebuje přestávku, než znovu použije {move}..."
-
 msgid "combat_replacement"
 msgstr "Vyber náhradníka!"
 

--- a/mods/tuxemon/l18n/de_DE/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/de_DE/LC_MESSAGES/base.po
@@ -213,10 +213,6 @@ msgstr "Du hast {name} gefangen!"
 msgid "combat_capturing_fail"
 msgstr "{name} ist ausgebrochen!"
 
-msgid "combat_recharging"
-msgstr ""
-"{name} braucht eine Pause, bevor {move} wieder eingesetzt werden kann..."
-
 msgid "combat_replacement"
 msgstr "Wähle einen Ersatz!"
 

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -886,9 +886,6 @@ msgstr "You captured {name}!"
 msgid "combat_capturing_fail"
 msgstr "{name} broke free!"
 
-msgid "combat_recharging"
-msgstr "{name} needs a break before using {move} again..."
-
 msgid "combat_replacement"
 msgstr "Choose a replacement!"
 

--- a/mods/tuxemon/l18n/eo/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/eo/LC_MESSAGES/base.po
@@ -134,9 +134,6 @@ msgstr "{name} estas kaptita!"
 msgid "combat_capturing_fail"
 msgstr "{name} liberiĝis!"
 
-msgid "combat_recharging"
-msgstr ""
-
 msgid "combat_replacement"
 msgstr "Elektu anstataŭon!"
 

--- a/mods/tuxemon/l18n/es_ES/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/es_ES/LC_MESSAGES/base.po
@@ -204,9 +204,6 @@ msgstr "¡Has capturado a {name}!"
 msgid "combat_capturing_fail"
 msgstr "¡{name} consiguió liberarse!"
 
-msgid "combat_recharging"
-msgstr "{name} necesita descansar antes de poder usar {move} de nuevo..."
-
 msgid "combat_replacement"
 msgstr "¡Escoge otro Tuxemon!"
 

--- a/mods/tuxemon/l18n/es_MX/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/es_MX/LC_MESSAGES/base.po
@@ -134,9 +134,6 @@ msgstr "¡Has capturado a {name}!"
 msgid "combat_capturing_fail"
 msgstr "¡{name} se liberó!"
 
-msgid "combat_recharging"
-msgstr "{name} necesita un descanso antes de usar {move} nuevamente..."
-
 msgid "combat_replacement"
 msgstr "¡Selecciona un reemplazo!"
 

--- a/mods/tuxemon/l18n/fi/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/fi/LC_MESSAGES/base.po
@@ -69,9 +69,6 @@ msgstr "{user} enempää ei voida parantaa."
 msgid "combat_defeat"
 msgstr "Sinut päihitettiin!"
 
-msgid "combat_recharging"
-msgstr "{name} tarvitsee lepotauon ennen {move} uudelleen..."
-
 msgid "attack_resisted"
 msgstr "Hyökkäys torjuttiin!"
 

--- a/mods/tuxemon/l18n/fr_FR/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/fr_FR/LC_MESSAGES/base.po
@@ -134,9 +134,6 @@ msgstr "Tu as capturé {name} !"
 msgid "combat_capturing_fail"
 msgstr "{name} s'est libéré !"
 
-msgid "combat_recharging"
-msgstr "{name} a besoin d'une pause avant d'utiliser {move} à nouveau..."
-
 msgid "combat_replacement"
 msgstr "Choisis un remplaçant !"
 

--- a/mods/tuxemon/l18n/it_IT/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/it_IT/LC_MESSAGES/base.po
@@ -160,9 +160,6 @@ msgstr "Hai catturato {name}!"
 msgid "combat_capturing_fail"
 msgstr "{name} si è liberato!"
 
-msgid "combat_recharging"
-msgstr "{name} ha bisogno di riposare prima di usare ancora {move}..."
-
 msgid "combat_replacement"
 msgstr "Fai una sostituzione!"
 

--- a/mods/tuxemon/l18n/nb_NO/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/nb_NO/LC_MESSAGES/base.po
@@ -158,9 +158,6 @@ msgstr "Hva vil {name} gjøre?"
 msgid "combat_replacement"
 msgstr "Velg en erstatning!"
 
-msgid "combat_recharging"
-msgstr "{name} må ha en pause før bruk av {name} igjen…"
-
 msgid "combat_capturing_fail"
 msgstr "{name} kom seg fri!"
 

--- a/mods/tuxemon/l18n/pl/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/pl/LC_MESSAGES/base.po
@@ -258,9 +258,6 @@ msgstr "Ten potwór już został pokonany!"
 msgid "combat_replacement"
 msgstr "Wybierz zamiennik!"
 
-msgid "combat_recharging"
-msgstr "{name} potrzebuje przerwy przed ponownym użyciem ruchu {move}…"
-
 msgid "combat_capturing_fail"
 msgstr "{name} się wydostał!"
 

--- a/mods/tuxemon/l18n/pt_BR/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/pt_BR/LC_MESSAGES/base.po
@@ -1063,9 +1063,6 @@ msgstr "{name} quer batalhar!"
 msgid "combat_capturing_success"
 msgstr "Você capturou {name}!"
 
-msgid "combat_recharging"
-msgstr "{name} precisa de uma folga antes de usar {move} novamente..."
-
 msgid "combat_replacement"
 msgstr "Escolha um substituto!"
 

--- a/mods/tuxemon/l18n/zh_CN/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/zh_CN/LC_MESSAGES/base.po
@@ -211,9 +211,6 @@ msgstr "你捉住了{name}!"
 msgid "combat_capturing_fail"
 msgstr "{name}冲出了精灵球!"
 
-msgid "combat_recharging"
-msgstr "{name}使用前需要休息一下才能再一次使用{move}..."
-
 msgid "combat_replacement"
 msgstr "选择下一个精灵!"
 

--- a/tuxemon/states/combat/combat_menus.py
+++ b/tuxemon/states/combat/combat_menus.py
@@ -225,14 +225,23 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
             for tech in self.monster.moves:
                 tech_name = tech.name
                 tech_color = None
+                tech_enabled = True
 
                 if combat.recharging(tech):
                     tech_name = f"{tech.name} ({abs(tech.next_use)})"
                     tech_color = self.unavailable_color
+                    tech_enabled = False
 
                 tech_image = self.shadow_text(tech_name, fg=tech_color)
-                item = MenuItem(tech_image, None, None, tech)
+                item = MenuItem(tech_image, None, None, tech, tech_enabled)
                 menu.add(item)
+
+            # Update selected_index to the first enabled item
+            enabled_items = [
+                i for i, item in enumerate(menu.menu_items) if item.enabled
+            ]
+            if enabled_items:
+                menu.selected_index = enabled_items[0]
 
             # position the new menu
             menu.anchor("bottom", self.rect.top)
@@ -244,14 +253,6 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
         def choose_target(menu_item: MenuItem[Technique]) -> None:
             # open menu to choose target of technique
             technique = menu_item.game_object
-            if combat.recharging(technique):
-                params = {
-                    "move": technique.name.upper(),
-                    "name": self.monster.name.upper(),
-                }
-                msg = T.format("combat_recharging", params)
-                tools.open_dialog(local_session, [msg])
-                return
 
             # allow to choose target if 1 vs 2 or 2 vs 2
             if len(self.opponents) > 1:


### PR DESCRIPTION
following #2446 and @Sanglorian reply's [here](https://github.com/Tuxemon/Tuxemon/pull/2446#issuecomment-2358034959)

PR makes some significant changes. First, it completely removes the popup **combat_recharging** and gets rid of the various translations. It also adds a simple mechanism that automatically gets the selected index of an item from the menu if that item is disabled. One cool thing to note is that the techniques are no longer selectable - check out the example to see how the cursor changes automatically (I tweaked the movement for testing purposes, so it doesn't behave exactly as it would in the real thing).

https://github.com/user-attachments/assets/aaeaf8b5-8138-4fa8-89be-0ad19f9dcb45