### PR TITLE
fix pygame_menu state

### DIFF
--- a/tuxemon/menu/menu.py
+++ b/tuxemon/menu/menu.py
@@ -10,6 +10,8 @@ from typing import Any, Generic, Literal, Optional, TypeVar, Union
 
 import pygame
 import pygame_menu
+from pygame_menu import baseimage, locals, themes
+from pygame_menu.widgets.core.widget import Widget
 
 from tuxemon import graphics, prepare, state, tools
 from tuxemon.animation import Animation
@@ -47,15 +49,21 @@ T = TypeVar("T", covariant=True)
 
 
 class PygameMenuState(state.State):
+    """
+    A Pygame menu state class.
+    """
+
     transparent = True
-    # colours
+
+    # Colors
     background_color = prepare.BACKGROUND_COLOR
     font_color = prepare.FONT_COLOR
     font_shadow_color = prepare.FONT_SHADOW_COLOR
     scrollbar_color = prepare.SCROLLBAR_COLOR
     scrollbar_slider_color = prepare.SCROLLBAR_SLIDER_COLOR
     transparent_color = prepare.TRANSPARENT_COLOR
-    # font size
+
+    # Font sizes
     font_size_smaller = tools.scale(prepare.FONT_SIZE_SMALLER)
     font_size_small = tools.scale(prepare.FONT_SIZE_SMALL)
     font_size = tools.scale(prepare.FONT_SIZE)
@@ -70,17 +78,28 @@ class PygameMenuState(state.State):
         **kwargs: Any,
     ) -> None:
         super().__init__()
-
         if theme is None:
             theme = get_theme()
 
+        self._initialize_attributes(theme)
+        self._create_menu(width, height, theme, **kwargs)
+
+    def _initialize_attributes(self, theme: pygame_menu.Theme) -> None:
+        """
+        Initializes the attributes of the menu state.
+
+        Parameters:
+            theme: The theme of the menu.
+        """
         self.open = False
         self.escape_key_exits = True
+        self.selected_widget: Optional[Widget] = None
 
-        # fonts
+        # Fonts
         theme.widget_font_size = self.font_size
         theme.title_font_size = self.font_size_big
-        # colors
+
+        # Colors
         theme.widget_font_color = self.font_color
         theme.selection_color = self.font_color
         theme.scrollbar_color = self.scrollbar_color
@@ -89,6 +108,17 @@ class PygameMenuState(state.State):
         theme.title_background_color = self.transparent_color
         theme.widget_font_shadow_color = self.font_shadow_color
 
+    def _create_menu(
+        self, width: int, height: int, theme: pygame_menu.Theme, **kwargs: Any
+    ) -> None:
+        """
+        Creates the Pygame menu.
+
+        Parameters:
+            width: The width of the menu.
+            height: The height of the menu.
+            theme: The theme of the menu.
+        """
         self.menu = pygame_menu.Menu(
             "",
             width,
@@ -105,29 +135,93 @@ class PygameMenuState(state.State):
         # work for controllers.
         self.menu._keyboard_ignore_nonphysical = False
 
+    def _setup_theme(
+        self, background: str, position: str = locals.POSITION_CENTER
+    ) -> themes.Theme:
+        """
+        Sets up a Pygame menu theme with a custom background image.
+
+        Parameters:
+            background: The path to the background image file.
+            position: The position of the background image.
+
+        Returns:
+            pygame_menu.Theme: The configured theme object.
+        """
+        base_image = self._create_image(background, position)
+        theme = get_theme()
+        theme.background_color = base_image
+        return theme
+
+    def _create_image(
+        self, path: str, position: str = locals.POSITION_CENTER
+    ) -> baseimage.BaseImage:
+        """
+        Creates a Pygame menu image.
+
+        Parameters:
+            path: The path to the background image file.
+            position: The position of the background image.
+
+        Returns:
+            pygame_menu.BaseImage: The created background image object.
+        """
+        return pygame_menu.BaseImage(
+            image_path=tools.transform_resource_filename(path),
+            drawing_position=position,
+        )
+
     def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
+        """
+        Processes a player input event.
+
+        Parameters:
+            event: The player input event.
+
+        Returns:
+            Optional[PlayerInput]: The processed event or None if it's not handled.
+        """
         if (
             event.button in {buttons.B, buttons.BACK, intentions.MENU_CANCEL}
             and not self.escape_key_exits
         ):
             return None
 
-        pygame_event = playerinput_to_event(event)
-        if self.open is True and event.pressed and pygame_event is not None:
-            self.menu.update([pygame_event])
+        try:
+            pygame_event = playerinput_to_event(event)
+            if (
+                self.open is True
+                and event.pressed
+                and pygame_event is not None
+            ):
+                self.menu.update([pygame_event])
+                # Get the currently selected widget
+                self.selected_widget = self.menu.get_selected_widget()
+        except Exception as e:
+            # Handle the exception
+            pass
 
         return event if pygame_event is None else None
 
-    def draw(
-        self,
-        surface: pygame.surface.Surface,
-    ) -> None:
+    def draw(self, surface: pygame.surface.Surface) -> None:
+        """
+        Draws the menu on the given surface.
+
+        Parameters:
+            surface: The surface to draw on.
+        """
         self.menu.draw(surface)
 
     def _set_open(self) -> None:
+        """
+        Sets the menu as open.
+        """
         self.open = True
 
     def resume(self) -> None:
+        """
+        Resumes the menu.
+        """
         animation = self.animate_open()
         if animation:
             animation.callback = self._set_open
@@ -135,7 +229,11 @@ class PygameMenuState(state.State):
             self.open = True
 
     def _on_close(self) -> None:
+        """
+        Called when the menu is closed.
+        """
         self.open = False
+        self.reset_theme()
         self.menu.enable()
         animation = self.animate_close()
         if animation:
@@ -143,38 +241,29 @@ class PygameMenuState(state.State):
         else:
             self.client.pop_state()
 
+    def reset_theme(self) -> None:
+        """Reset to original theme (color, alignment, etc.)"""
+        theme = get_theme()
+        theme.scrollarea_position = locals.SCROLLAREA_POSITION_NONE
+        theme.background_color = self.background_color
+        theme.widget_alignment = locals.ALIGN_LEFT
+        theme.title = False
+
     def animate_open(self) -> Optional[Animation]:
         """
-        Called when menu is going to open.
-
-        Menu will not receive input during the animation.
-        Menu will only play this animation once.
-
-        Must return either an Animation or Task to attach callback.
-        Only modify state of the menu Rect.
-        Do not change important state attributes.
+        Animates the menu opening.
 
         Returns:
-            Open animation, if any.
-
+            Optional[Animation]: The animation or None if not implemented.
         """
         return None
 
     def animate_close(self) -> Optional[Animation]:
         """
-        Called when menu is going to open.
-
-        Menu will not receive input during the animation.
-        Menu will play animation only once.
-        Menu will be popped after animation finished.
-
-        Must return either an Animation or Task to attach callback.
-        Only modify state of the menu Rect.
-        Do not change important state attributes.
+        Animates the menu closing.
 
         Returns:
-            Close animation, if any.
-
+            Optional[Animation]: The animation or None if not implemented.
         """
         return None
 

--- a/tuxemon/states/choice/choice_item.py
+++ b/tuxemon/states/choice/choice_item.py
@@ -5,15 +5,13 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from typing import Any
 
-import pygame_menu
-from pygame_menu.locals import POSITION_CENTER, POSITION_EAST
+from pygame_menu.locals import POSITION_EAST
 from pygame_menu.widgets.selection.highlight import HighlightSelection
 
 from tuxemon import prepare
 from tuxemon.db import db
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.menu.theme import get_theme
-from tuxemon.tools import transform_resource_filename
 
 ChoiceMenuGameObj = Callable[[], None]
 
@@ -59,10 +57,7 @@ class ChoiceItem(PygameMenuState):
                 item = db.lookup(slug, table="item")
             except KeyError:
                 raise RuntimeError(f"Item {slug} not found")
-            new_image = pygame_menu.BaseImage(
-                transform_resource_filename(item.sprite),
-                drawing_position=POSITION_CENTER,
-            )
+            new_image = self._create_image(item.sprite)
             new_image.scale(prepare.SCALE * 0.5, prepare.SCALE * 0.5)
             self.menu.add.image(
                 new_image,

--- a/tuxemon/states/choice/choice_monster.py
+++ b/tuxemon/states/choice/choice_monster.py
@@ -7,8 +7,7 @@ from collections.abc import Callable, Sequence
 from functools import partial
 from typing import Any
 
-import pygame_menu
-from pygame_menu.locals import ALIGN_CENTER, POSITION_CENTER, POSITION_EAST
+from pygame_menu.locals import ALIGN_CENTER, POSITION_EAST
 from pygame_menu.widgets.selection.highlight import HighlightSelection
 
 from tuxemon import prepare
@@ -16,7 +15,6 @@ from tuxemon.animation import Animation
 from tuxemon.db import MonsterModel, db
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.menu.theme import get_theme
-from tuxemon.tools import transform_resource_filename
 
 ChoiceMenuGameObj = Callable[[], None]
 
@@ -58,10 +56,7 @@ class ChoiceMonster(PygameMenuState):
             except KeyError:
                 raise RuntimeError(f"Monster {slug} not found")
             path = f"gfx/sprites/battle/{monster.slug}-front.png"
-            new_image = pygame_menu.BaseImage(
-                transform_resource_filename(path),
-                drawing_position=POSITION_CENTER,
-            )
+            new_image = self._create_image(path)
             new_image.scale(prepare.SCALE * 0.4, prepare.SCALE * 0.4)
             self.menu.add.banner(
                 new_image,

--- a/tuxemon/states/choice/choice_npc.py
+++ b/tuxemon/states/choice/choice_npc.py
@@ -6,8 +6,7 @@ import math
 from collections.abc import Callable, Sequence
 from typing import Any
 
-import pygame_menu
-from pygame_menu.locals import ALIGN_CENTER, POSITION_CENTER, POSITION_EAST
+from pygame_menu.locals import ALIGN_CENTER, POSITION_EAST
 from pygame_menu.widgets.selection.highlight import HighlightSelection
 
 from tuxemon import prepare
@@ -15,7 +14,6 @@ from tuxemon.animation import Animation
 from tuxemon.db import db
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.menu.theme import get_theme
-from tuxemon.tools import transform_resource_filename
 
 ChoiceMenuGameObj = Callable[[], None]
 
@@ -53,10 +51,7 @@ class ChoiceNpc(PygameMenuState):
             except KeyError:
                 raise RuntimeError(f"NPC {slug} not found")
             path = f"gfx/sprites/player/{npc.template.combat_front}.png"
-            new_image = pygame_menu.BaseImage(
-                transform_resource_filename(path),
-                drawing_position=POSITION_CENTER,
-            )
+            new_image = self._create_image(path)
             new_image.scale(prepare.SCALE * 0.4, prepare.SCALE * 0.4)
             self.menu.add.image(
                 new_image,

--- a/tuxemon/states/control/__init__.py
+++ b/tuxemon/states/control/__init__.py
@@ -82,13 +82,7 @@ class SetKeyState(PygameMenuState):
         super().__init__(**kwargs)
         self.menu.add.label(T.translate("options_new_input_key0").upper())
         self.button = button
-        self.repristinate()
-
-    def repristinate(self) -> None:
-        """Repristinate original theme (color, alignment, etc.)"""
-        theme = get_theme()
-        theme.scrollarea_position = locals.SCROLLAREA_POSITION_NONE
-        theme.widget_alignment = locals.ALIGN_LEFT
+        self.reset_theme()
 
     def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
         invalid_keys = [
@@ -118,7 +112,7 @@ class SetKeyState(PygameMenuState):
             and pressed_key not in invalid_keys
         ):
             assert self.button and pressed_key
-            local_session.client.pop_state()
+            self.client.pop_state()
             pressed_key_str = pygame.key.name(pressed_key)
             if event.value == pressed_key_str:
                 # Update the configuration file with the new key
@@ -165,13 +159,7 @@ class ControlState(PygameMenuState):
         super().__init__(**kwargs)
         self.initialize_items(self.menu)
         self.reload_controls()
-        self.repristinate()
-
-    def repristinate(self) -> None:
-        """Repristinate original theme (color, alignment, etc.)"""
-        theme = get_theme()
-        theme.scrollarea_position = locals.SCROLLAREA_POSITION_NONE
-        theme.widget_alignment = locals.ALIGN_LEFT
+        self.reset_theme()
 
     def initialize_items(
         self,

--- a/tuxemon/states/idle/color_state.py
+++ b/tuxemon/states/idle/color_state.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 from typing import Optional
 
-import pygame_menu
-from pygame_menu.locals import ALIGN_CENTER, POSITION_CENTER
+from pygame_menu.locals import ALIGN_CENTER
 
-from tuxemon import prepare, tools
+from tuxemon import prepare
 from tuxemon.graphics import string_to_colorlike
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.menu.theme import get_theme
@@ -32,10 +31,7 @@ class ColorState(PygameMenuState):
         native = prepare.NATIVE_RESOLUTION
 
         if image:
-            new_image = pygame_menu.BaseImage(
-                tools.transform_resource_filename(image),
-                drawing_position=POSITION_CENTER,
-            )
+            new_image = self._create_image(image)
             image_size = new_image.get_size()
             if image_size[0] > native[0] or image_size[1] > native[1]:
                 raise ValueError(

--- a/tuxemon/states/idle/image_state.py
+++ b/tuxemon/states/idle/image_state.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 from typing import Optional
 
-import pygame_menu
-from pygame_menu.locals import ALIGN_CENTER, POSITION_CENTER
+from pygame_menu.locals import ALIGN_CENTER
 
-from tuxemon import prepare, tools
+from tuxemon import prepare
 from tuxemon.menu.menu import PygameMenuState
-from tuxemon.menu.theme import get_theme
 from tuxemon.platform.events import PlayerInput
 
 
@@ -24,16 +22,10 @@ class ImageState(PygameMenuState):
 
     def __init__(self, background: str, image: Optional[str] = None) -> None:
         width, height = prepare.SCREEN_SIZE
-        image_path = tools.transform_resource_filename(
-            "gfx/ui/background/" + background + ".png"
-        )
-        theme = get_theme()
-        theme.background_color = pygame_menu.BaseImage(
-            image_path,
-            drawing_position=POSITION_CENTER,
-        )
+        image_path = f"gfx/ui/background/{background}.png"
         native = prepare.NATIVE_RESOLUTION
-        bg_size = theme.background_color.get_size()
+        self._setup_theme(image_path)
+        bg_size = self._create_image(image_path).get_size()
         if bg_size[0] != native[0] or bg_size[1] != native[1]:
             raise ValueError(
                 f"{image_path} {bg_size}: "
@@ -42,10 +34,7 @@ class ImageState(PygameMenuState):
         super().__init__(height=height, width=width)
 
         if image:
-            new_image = pygame_menu.BaseImage(
-                tools.transform_resource_filename(image),
-                drawing_position=POSITION_CENTER,
-            )
+            new_image = self._create_image(image)
             image_size = new_image.get_size()
             if image_size[0] > native[0] or image_size[1] > native[1]:
                 raise ValueError(

--- a/tuxemon/states/journal/journal.py
+++ b/tuxemon/states/journal/journal.py
@@ -8,13 +8,11 @@ from typing import Any, Optional
 
 import pygame_menu
 from pygame_menu import locals
-from pygame_menu.locals import POSITION_CENTER
 
-from tuxemon import prepare, tools
+from tuxemon import prepare
 from tuxemon.db import MonsterModel, SeenStatus, db
 from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
-from tuxemon.menu.theme import get_theme
 from tuxemon.platform.const import buttons
 from tuxemon.platform.events import PlayerInput
 from tuxemon.session import local_session
@@ -105,13 +103,8 @@ class JournalState(PygameMenuState):
 
         width, height = prepare.SCREEN_SIZE
 
-        background = pygame_menu.BaseImage(
-            image_path=tools.transform_resource_filename(prepare.BG_JOURNAL),
-            drawing_position=POSITION_CENTER,
-        )
-        theme = get_theme()
+        theme = self._setup_theme(prepare.BG_JOURNAL)
         theme.scrollarea_position = locals.POSITION_EAST
-        theme.background_color = background
         theme.widget_alignment = locals.ALIGN_LEFT
 
         columns = 2
@@ -146,14 +139,7 @@ class JournalState(PygameMenuState):
         self._page = page
         self._monster_list = monster_list
         self.add_menu_items(self.menu, monster_list)
-        self.repristinate()
-
-    def repristinate(self) -> None:
-        """Repristinate original theme (color, alignment, etc.)"""
-        theme = get_theme()
-        theme.scrollarea_position = locals.SCROLLAREA_POSITION_NONE
-        theme.background_color = self.background_color
-        theme.widget_alignment = locals.ALIGN_LEFT
+        self.reset_theme()
 
     def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
         client = self.client

--- a/tuxemon/states/journal/journal_choice.py
+++ b/tuxemon/states/journal/journal_choice.py
@@ -9,13 +9,11 @@ from typing import Any
 
 import pygame_menu
 from pygame_menu import locals
-from pygame_menu.locals import POSITION_CENTER
 
-from tuxemon import prepare, tools
+from tuxemon import prepare
 from tuxemon.db import MonsterModel, db
 from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
-from tuxemon.menu.theme import get_theme
 from tuxemon.session import local_session
 
 MAX_PAGE = 20
@@ -97,15 +95,8 @@ class JournalChoice(PygameMenuState):
             _lookup_monsters()
         width, height = prepare.SCREEN_SIZE
 
-        background = pygame_menu.BaseImage(
-            image_path=tools.transform_resource_filename(
-                prepare.BG_JOURNAL_CHOICE
-            ),
-            drawing_position=POSITION_CENTER,
-        )
-        theme = get_theme()
+        theme = self._setup_theme(prepare.BG_JOURNAL_CHOICE)
         theme.scrollarea_position = locals.POSITION_EAST
-        theme.background_color = background
         theme.widget_alignment = locals.ALIGN_LEFT
 
         columns = 2
@@ -119,11 +110,4 @@ class JournalChoice(PygameMenuState):
         )
 
         self.add_menu_items(self.menu, box)
-        self.repristinate()
-
-    def repristinate(self) -> None:
-        """Repristinate original theme (color, alignment, etc.)"""
-        theme = get_theme()
-        theme.scrollarea_position = locals.SCROLLAREA_POSITION_NONE
-        theme.background_color = self.background_color
-        theme.widget_alignment = locals.ALIGN_LEFT
+        self.reset_theme()

--- a/tuxemon/states/journal/journal_info.py
+++ b/tuxemon/states/journal/journal_info.py
@@ -6,13 +6,11 @@ from typing import Any, Optional
 
 import pygame_menu
 from pygame_menu import locals
-from pygame_menu.locals import POSITION_CENTER
 
-from tuxemon import formula, prepare, tools
+from tuxemon import formula, prepare
 from tuxemon.db import MonsterModel, SeenStatus, db
 from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
-from tuxemon.menu.theme import get_theme
 from tuxemon.platform.const import buttons
 from tuxemon.platform.events import PlayerInput
 from tuxemon.session import local_session
@@ -109,16 +107,11 @@ class JournalInfoState(PygameMenuState):
             float=True,
         )
         lab4.translate(fix_measure(width, 0.50), fix_measure(height, 0.30))
-        type_image_1 = pygame_menu.BaseImage(
-            tools.transform_resource_filename(
-                f"gfx/ui/icons/element/{monster.types[0].name}_type.png"
-            ),
-        )
+        path1 = f"gfx/ui/icons/element/{monster.types[0].name}_type.png"
+        type_image_1 = self._create_image(path1)
         if len(monster.types) > 1:
-            path = f"gfx/ui/icons/element/{monster.types[1].name}_type.png"
-            type_image_2 = pygame_menu.BaseImage(
-                tools.transform_resource_filename(path),
-            )
+            path2 = f"gfx/ui/icons/element/{monster.types[1].name}_type.png"
+            type_image_2 = self._create_image(path2)
             menu.add.image(type_image_1, float=True).translate(
                 fix_measure(width, 0.17), fix_measure(height, 0.29)
             )
@@ -220,9 +213,7 @@ class JournalInfoState(PygameMenuState):
         # image
         _path = f"gfx/sprites/battle/{monster.slug}-front.png"
         _path = _path if self.caught else prepare.MISSING_IMAGE
-        new_image = pygame_menu.BaseImage(
-            tools.transform_resource_filename(_path),
-        )
+        new_image = self._create_image(_path)
         new_image.scale(prepare.SCALE, prepare.SCALE)
         image_widget = menu.add.image(image_path=new_image.copy())
         image_widget.set_float(origin_position=True)
@@ -239,15 +230,9 @@ class JournalInfoState(PygameMenuState):
         if monster is None:
             raise ValueError("No monster")
         width, height = prepare.SCREEN_SIZE
-        background = pygame_menu.BaseImage(
-            image_path=tools.transform_resource_filename(
-                prepare.BG_JOURNAL_INFO
-            ),
-            drawing_position=POSITION_CENTER,
-        )
-        theme = get_theme()
+
+        theme = self._setup_theme(prepare.BG_JOURNAL_INFO)
         theme.scrollarea_position = locals.POSITION_EAST
-        theme.background_color = background
         theme.widget_alignment = locals.ALIGN_CENTER
 
         super().__init__(height=height, width=width)
@@ -256,14 +241,7 @@ class JournalInfoState(PygameMenuState):
         self.caught = True if checks == SeenStatus.caught else False
         self._monster = monster
         self.add_menu_items(self.menu, monster)
-        self.repristinate()
-
-    def repristinate(self) -> None:
-        """Repristinate original theme (color, alignment, etc.)"""
-        theme = get_theme()
-        theme.scrollarea_position = locals.SCROLLAREA_POSITION_NONE
-        theme.background_color = self.background_color
-        theme.widget_alignment = locals.ALIGN_LEFT
+        self.reset_theme()
 
     def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
         client = self.client

--- a/tuxemon/states/minigame/__init__.py
+++ b/tuxemon/states/minigame/__init__.py
@@ -8,15 +8,12 @@ from functools import partial
 
 import pygame_menu
 from pygame_menu import locals
-from pygame_menu.locals import POSITION_CENTER
 from pygame_menu.widgets.selection.highlight import HighlightSelection
 
-from tuxemon import prepare, tools
+from tuxemon import prepare
 from tuxemon.db import MonsterModel, db
 from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
-from tuxemon.menu.theme import get_theme
-from tuxemon.monster import Monster
 from tuxemon.session import local_session
 from tuxemon.tools import open_dialog
 
@@ -61,10 +58,8 @@ class MinigameState(PygameMenuState):
         tuxemon: MonsterModel
         tuxemon = random.choice(data)
         self.tuxemon = tuxemon
-        new_image = pygame_menu.BaseImage(
-            tools.transform_resource_filename(
-                "gfx/sprites/battle/" + tuxemon.slug + "-front.png"
-            ),
+        new_image = self._create_image(
+            f"gfx/sprites/battle/{tuxemon.slug}-front.png"
         )
         new_image.scale(prepare.SCALE, prepare.SCALE)
         menu.add.image(image_path=new_image.copy())
@@ -107,23 +102,11 @@ class MinigameState(PygameMenuState):
             _lookup_monsters()
         width, height = prepare.SCREEN_SIZE
 
-        background = pygame_menu.BaseImage(
-            image_path=tools.transform_resource_filename(prepare.BG_MINIGAME),
-            drawing_position=POSITION_CENTER,
-        )
-        theme = get_theme()
+        theme = self._setup_theme(prepare.BG_MINIGAME)
         theme.scrollarea_position = locals.POSITION_EAST
-        theme.background_color = background
         theme.widget_alignment = locals.ALIGN_CENTER
 
         super().__init__(height=height, width=width)
 
         self.add_menu_items(self.menu)
-        self.repristinate()
-
-    def repristinate(self) -> None:
-        """Repristinate original theme (color, alignment, etc.)"""
-        theme = get_theme()
-        theme.scrollarea_position = locals.SCROLLAREA_POSITION_NONE
-        theme.background_color = self.background_color
-        theme.widget_alignment = locals.ALIGN_LEFT
+        self.reset_theme()

--- a/tuxemon/states/mission/__init__.py
+++ b/tuxemon/states/mission/__init__.py
@@ -7,13 +7,11 @@ from typing import Any, Optional
 
 import pygame_menu
 from pygame_menu import locals
-from pygame_menu.locals import POSITION_CENTER
 
-from tuxemon import prepare, tools
+from tuxemon import prepare
 from tuxemon.db import MissionStatus
 from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
-from tuxemon.menu.theme import get_theme
 from tuxemon.mission import Mission
 from tuxemon.npc import NPC
 
@@ -35,27 +33,15 @@ class MissionState(PygameMenuState):
         self.character = character
         width, height = prepare.SCREEN_SIZE
 
-        background = pygame_menu.BaseImage(
-            image_path=tools.transform_resource_filename(prepare.BG_MISSIONS),
-            drawing_position=POSITION_CENTER,
-        )
-        theme = get_theme()
+        theme = self._setup_theme(prepare.BG_MISSIONS)
         theme.scrollarea_position = locals.POSITION_EAST
-        theme.background_color = background
         theme.widget_alignment = locals.ALIGN_CENTER
 
         width = int(0.8 * width)
         height = int(0.8 * height)
         super().__init__(height=height, width=width)
         self.initialize_items(self.menu)
-        self.repristinate()
-
-    def repristinate(self) -> None:
-        """Repristinate original theme (color, alignment, etc.)"""
-        theme = get_theme()
-        theme.scrollarea_position = locals.SCROLLAREA_POSITION_NONE
-        theme.background_color = self.background_color
-        theme.widget_alignment = locals.ALIGN_LEFT
+        self.reset_theme()
 
     def initialize_items(
         self,

--- a/tuxemon/states/monster_info/__init__.py
+++ b/tuxemon/states/monster_info/__init__.py
@@ -7,13 +7,11 @@ from typing import Any, Optional
 
 import pygame_menu
 from pygame_menu import locals
-from pygame_menu.locals import POSITION_CENTER
 
-from tuxemon import formula, prepare, tools
+from tuxemon import formula, prepare
 from tuxemon.db import MonsterModel, db
 from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
-from tuxemon.menu.theme import get_theme
 from tuxemon.monster import Monster
 from tuxemon.platform.const import buttons
 from tuxemon.platform.events import PlayerInput
@@ -102,7 +100,7 @@ class MonsterInfoState(PygameMenuState):
         # name
         menu._auto_centering = False
         lab1: Any = menu.add.label(
-            title=str(monster.txmn_id) + ". " + monster.name.upper(),
+            title=f"{monster.txmn_id}. {monster.name.upper()}",
             label_id="name",
             font_size=self.font_size_small,
             align=locals.ALIGN_LEFT,
@@ -112,7 +110,7 @@ class MonsterInfoState(PygameMenuState):
         # level + exp
         exp = monster.total_experience
         lab2: Any = menu.add.label(
-            title="Lv. " + str(monster.level) + " - " + str(exp) + "px",
+            title=f"Lv. {monster.level} - {exp}px",
             label_id="level",
             font_size=self.font_size_smaller,
             align=locals.ALIGN_LEFT,
@@ -132,12 +130,7 @@ class MonsterInfoState(PygameMenuState):
         lab3.translate(fix_measure(width, 0.50), fix_measure(height, 0.20))
         # weight
         lab4: Any = menu.add.label(
-            title=str(mon_weight)
-            + " "
-            + unit_weight
-            + " ("
-            + str(diff_weight)
-            + "%)",
+            title=f"{mon_weight} {unit_weight} ({diff_weight}%)",
             label_id="weight",
             font_size=self.font_size_smaller,
             align=locals.ALIGN_LEFT,
@@ -146,12 +139,7 @@ class MonsterInfoState(PygameMenuState):
         lab4.translate(fix_measure(width, 0.50), fix_measure(height, 0.25))
         # height
         lab5: Any = menu.add.label(
-            title=str(mon_height)
-            + " "
-            + unit_height
-            + " ("
-            + str(diff_height)
-            + "%)",
+            title=f"{mon_height} {unit_height} ({diff_height}%)",
             label_id="height",
             font_size=self.font_size_smaller,
             align=locals.ALIGN_LEFT,
@@ -186,11 +174,11 @@ class MonsterInfoState(PygameMenuState):
         )
         lab8.translate(fix_measure(width, 0.50), fix_measure(height, 0.40))
         # taste
-        tastes = T.translate("tastes") + ": "
-        cold = T.translate("taste_" + monster.taste_cold)
-        warm = T.translate("taste_" + monster.taste_warm)
+        tastes = T.translate("tastes")
+        cold = T.translate(f"taste_{monster.taste_cold}")
+        warm = T.translate(f"taste_{monster.taste_warm}")
         lab9: Any = menu.add.label(
-            title=tastes + cold + ", " + warm,
+            title=f"{tastes}: {cold}, {warm}",
             label_id="taste",
             font_size=self.font_size_smaller,
             align=locals.ALIGN_LEFT,
@@ -221,7 +209,7 @@ class MonsterInfoState(PygameMenuState):
         lab10.translate(fix_measure(width, 0.50), fix_measure(height, 0.50))
         # hp
         lab11: Any = menu.add.label(
-            title=T.translate("short_hp") + ": " + str(monster.hp),
+            title=f"{T.translate('short_hp')}: {monster.hp}",
             label_id="hp",
             font_size=self.font_size_smaller,
             align=locals.ALIGN_LEFT,
@@ -230,7 +218,7 @@ class MonsterInfoState(PygameMenuState):
         lab11.translate(fix_measure(width, 0.80), fix_measure(height, 0.15))
         # armour
         lab12: Any = menu.add.label(
-            title=T.translate("short_armour") + ": " + str(monster.armour),
+            title=f"{T.translate('short_armour')}: {monster.armour}",
             label_id="armour",
             font_size=self.font_size_smaller,
             align=locals.ALIGN_LEFT,
@@ -239,7 +227,7 @@ class MonsterInfoState(PygameMenuState):
         lab12.translate(fix_measure(width, 0.80), fix_measure(height, 0.20))
         # dodge
         lab13: Any = menu.add.label(
-            title=T.translate("short_dodge") + ": " + str(monster.dodge),
+            title=f"{T.translate('short_dodge')}: {monster.dodge}",
             label_id="dodge",
             font_size=self.font_size_smaller,
             align=locals.ALIGN_LEFT,
@@ -248,7 +236,7 @@ class MonsterInfoState(PygameMenuState):
         lab13.translate(fix_measure(width, 0.80), fix_measure(height, 0.25))
         # melee
         lab14: Any = menu.add.label(
-            title=T.translate("short_melee") + ": " + str(monster.melee),
+            title=f"{T.translate('short_melee')}: {monster.melee}",
             label_id="melee",
             font_size=self.font_size_smaller,
             align=locals.ALIGN_LEFT,
@@ -257,7 +245,7 @@ class MonsterInfoState(PygameMenuState):
         lab14.translate(fix_measure(width, 0.80), fix_measure(height, 0.30))
         # ranged
         lab15: Any = menu.add.label(
-            title=T.translate("short_ranged") + ": " + str(monster.ranged),
+            title=f"{T.translate('short_ranged')}: {monster.ranged}",
             label_id="ranged",
             font_size=self.font_size_smaller,
             align=locals.ALIGN_LEFT,
@@ -266,7 +254,7 @@ class MonsterInfoState(PygameMenuState):
         lab15.translate(fix_measure(width, 0.80), fix_measure(height, 0.35))
         # speed
         lab16: Any = menu.add.label(
-            title=T.translate("short_speed") + ": " + str(monster.speed),
+            title=f"{T.translate('short_speed')}: {monster.speed}",
             label_id="speed",
             font_size=self.font_size_smaller,
             align=locals.ALIGN_LEFT,
@@ -315,9 +303,7 @@ class MonsterInfoState(PygameMenuState):
         for elements in labels:
             f.pack(elements)
         # image
-        new_image = pygame_menu.BaseImage(
-            tools.transform_resource_filename(monster.front_battle_sprite),
-        )
+        new_image = self._create_image(monster.front_battle_sprite)
         new_image.scale(prepare.SCALE, prepare.SCALE)
         image_widget = menu.add.image(image_path=new_image.copy())
         image_widget.set_float(origin_position=True)
@@ -325,10 +311,8 @@ class MonsterInfoState(PygameMenuState):
             fix_measure(width, 0.20), fix_measure(height, 0.05)
         )
         # tuxeball
-        tuxeball = pygame_menu.BaseImage(
-            tools.transform_resource_filename(
-                f"gfx/items/{monster.capture_device}.png"
-            ),
+        tuxeball = self._create_image(
+            f"gfx/items/{monster.capture_device}.png"
         )
         capture_device = menu.add.image(image_path=tuxeball)
         capture_device.set_float(origin_position=True)
@@ -348,29 +332,15 @@ class MonsterInfoState(PygameMenuState):
             raise ValueError("No monster")
         width, height = prepare.SCREEN_SIZE
 
-        background = pygame_menu.BaseImage(
-            image_path=tools.transform_resource_filename(
-                prepare.BG_MONSTER_INFO
-            ),
-            drawing_position=POSITION_CENTER,
-        )
-        theme = get_theme()
+        theme = self._setup_theme(prepare.BG_MONSTER_INFO)
         theme.scrollarea_position = locals.POSITION_EAST
-        theme.background_color = background
         theme.widget_alignment = locals.ALIGN_CENTER
 
         super().__init__(height=height, width=width)
         self._source = source
         self._monster = monster
         self.add_menu_items(self.menu, monster)
-        self.repristinate()
-
-    def repristinate(self) -> None:
-        """Repristinate original theme (color, alignment, etc.)"""
-        theme = get_theme()
-        theme.scrollarea_position = locals.SCROLLAREA_POSITION_NONE
-        theme.background_color = self.background_color
-        theme.widget_alignment = locals.ALIGN_LEFT
+        self.reset_theme()
 
     def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
         param: dict[str, Any] = {"source": self._source}

--- a/tuxemon/states/party/__init__.py
+++ b/tuxemon/states/party/__init__.py
@@ -7,12 +7,10 @@ from typing import Any, Optional
 
 import pygame_menu
 from pygame_menu import locals
-from pygame_menu.locals import POSITION_CENTER
 
-from tuxemon import formula, prepare, tools
+from tuxemon import formula, prepare
 from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
-from tuxemon.menu.theme import get_theme
 from tuxemon.monster import Monster
 from tuxemon.platform.const import buttons
 from tuxemon.platform.events import PlayerInput
@@ -44,25 +42,13 @@ class PartyState(PygameMenuState):
             raise ValueError("No monsters in the party")
         width, height = prepare.SCREEN_SIZE
 
-        background = pygame_menu.BaseImage(
-            image_path=tools.transform_resource_filename(prepare.BG_PARTY),
-            drawing_position=POSITION_CENTER,
-        )
-        theme = get_theme()
+        theme = self._setup_theme(prepare.BG_PARTY)
         theme.scrollarea_position = locals.POSITION_EAST
-        theme.background_color = background
         theme.widget_alignment = locals.ALIGN_CENTER
 
         super().__init__(height=height, width=width)
         self.initialize_items(self.menu, monsters)
-        self.repristinate()
-
-    def repristinate(self) -> None:
-        """Repristinate original theme (color, alignment, etc.)"""
-        theme = get_theme()
-        theme.scrollarea_position = locals.SCROLLAREA_POSITION_NONE
-        theme.background_color = self.background_color
-        theme.widget_alignment = locals.ALIGN_LEFT
+        self.reset_theme()
 
     def initialize_items(
         self,

--- a/tuxemon/states/pc_kennel/__init__.py
+++ b/tuxemon/states/pc_kennel/__init__.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, Any, Optional
 
 import pygame_menu
 from pygame_menu import locals
-from pygame_menu.locals import POSITION_CENTER
 from pygame_menu.widgets.selection.highlight import HighlightSelection
 
 from tuxemon import prepare
@@ -19,15 +18,10 @@ from tuxemon.db import PlagueType
 from tuxemon.locale import T
 from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.menu import PygameMenuState
-from tuxemon.menu.theme import get_theme
 from tuxemon.session import local_session
 from tuxemon.state import State
 from tuxemon.states.monster import MonsterMenuState
-from tuxemon.tools import (
-    open_choice_dialog,
-    open_dialog,
-    transform_resource_filename,
-)
+from tuxemon.tools import open_choice_dialog, open_dialog
 
 logger = logging.getLogger(__name__)
 
@@ -197,10 +191,7 @@ class MonsterTakeState(PygameMenuState):
         for monster in _sorted:
             label = T.translate(monster.name).upper()
             iid = monster.instance_id.hex
-            new_image = pygame_menu.BaseImage(
-                transform_resource_filename(monster.front_battle_sprite),
-                drawing_position=POSITION_CENTER,
-            )
+            new_image = self._create_image(monster.front_battle_sprite)
             new_image.scale(prepare.SCALE * 0.5, prepare.SCALE * 0.5)
             menu.add.banner(
                 new_image,
@@ -232,13 +223,8 @@ class MonsterTakeState(PygameMenuState):
     def __init__(self, box_name: str) -> None:
         width, height = prepare.SCREEN_SIZE
 
-        background = pygame_menu.BaseImage(
-            image_path=transform_resource_filename(prepare.BG_PC_KENNEL),
-            drawing_position=POSITION_CENTER,
-        )
-        theme = get_theme()
+        theme = self._setup_theme(prepare.BG_PC_KENNEL)
         theme.scrollarea_position = locals.POSITION_EAST
-        theme.background_color = background
         theme.widget_alignment = locals.ALIGN_CENTER
 
         # menu
@@ -269,15 +255,7 @@ class MonsterTakeState(PygameMenuState):
             menu_items_map.append(monster)
 
         self.add_menu_items(self.menu, menu_items_map)
-        self.repristinate()
-
-    def repristinate(self) -> None:
-        """Repristinate original theme (color, alignment, etc.)"""
-        theme = get_theme()
-        theme.scrollarea_position = locals.SCROLLAREA_POSITION_NONE
-        theme.background_color = self.background_color
-        theme.widget_alignment = locals.ALIGN_LEFT
-        theme.title = False
+        self.reset_theme()
 
 
 class MonsterBoxState(PygameMenuState):

--- a/tuxemon/states/pc_locker/__init__.py
+++ b/tuxemon/states/pc_locker/__init__.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, Any, Optional
 
 import pygame_menu
 from pygame_menu import locals
-from pygame_menu.locals import POSITION_CENTER
 from pygame_menu.widgets.selection.highlight import HighlightSelection
 
 from tuxemon import prepare
@@ -20,15 +19,10 @@ from tuxemon.locale import T
 from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.menu.quantity import QuantityMenu
-from tuxemon.menu.theme import get_theme
 from tuxemon.session import local_session
 from tuxemon.state import State
 from tuxemon.states.items.item_menu import ItemMenuState
-from tuxemon.tools import (
-    open_choice_dialog,
-    open_dialog,
-    transform_resource_filename,
-)
+from tuxemon.tools import open_choice_dialog, open_dialog
 
 logger = logging.getLogger(__name__)
 
@@ -224,10 +218,7 @@ class ItemTakeState(PygameMenuState):
             sum_total.append(itm.quantity)
             label = T.translate(itm.name).upper() + " x" + str(itm.quantity)
             iid = itm.instance_id.hex
-            new_image = pygame_menu.BaseImage(
-                transform_resource_filename(itm.sprite),
-                drawing_position=POSITION_CENTER,
-            )
+            new_image = self._create_image(itm.sprite)
             new_image.scale(prepare.SCALE, prepare.SCALE)
             menu.add.banner(
                 new_image,
@@ -250,13 +241,8 @@ class ItemTakeState(PygameMenuState):
     def __init__(self, box_name: str) -> None:
         width, height = prepare.SCREEN_SIZE
 
-        background = pygame_menu.BaseImage(
-            image_path=transform_resource_filename(prepare.BG_PC_LOCKER),
-            drawing_position=POSITION_CENTER,
-        )
-        theme = get_theme()
+        theme = self._setup_theme(prepare.BG_PC_LOCKER)
         theme.scrollarea_position = locals.POSITION_EAST
-        theme.background_color = background
         theme.widget_alignment = locals.ALIGN_CENTER
 
         # menu
@@ -287,15 +273,7 @@ class ItemTakeState(PygameMenuState):
             menu_items_map.append(item)
 
         self.add_menu_items(self.menu, menu_items_map)
-        self.repristinate()
-
-    def repristinate(self) -> None:
-        """Repristinate original theme (color, alignment, etc.)"""
-        theme = get_theme()
-        theme.scrollarea_position = locals.SCROLLAREA_POSITION_NONE
-        theme.background_color = self.background_color
-        theme.widget_alignment = locals.ALIGN_LEFT
-        theme.title = False
+        self.reset_theme()
 
 
 class ItemBoxState(PygameMenuState):

--- a/tuxemon/states/phone/phone.py
+++ b/tuxemon/states/phone/phone.py
@@ -9,15 +9,13 @@ from typing import Any
 
 import pygame_menu
 from pygame_menu import locals
-from pygame_menu.locals import POSITION_CENTER
 from pygame_menu.widgets.selection.highlight import HighlightSelection
 
-from tuxemon import prepare, tools
+from tuxemon import prepare
 from tuxemon.db import MapType
 from tuxemon.item.item import Item
 from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
-from tuxemon.menu.theme import get_theme
 from tuxemon.session import local_session
 from tuxemon.tools import open_dialog
 
@@ -102,10 +100,7 @@ class NuPhone(PygameMenuState):
                 change = (
                     _change_state("NuPhoneMap") if trackers else _no_trackers
                 )
-            new_image = pygame_menu.BaseImage(
-                tools.transform_resource_filename(item.sprite),
-                drawing_position=POSITION_CENTER,
-            )
+            new_image = self._create_image(item.sprite)
             new_image.scale(prepare.SCALE, prepare.SCALE)
             # image of the app
             menu.add.banner(
@@ -129,13 +124,8 @@ class NuPhone(PygameMenuState):
     def __init__(self) -> None:
         width, height = prepare.SCREEN_SIZE
 
-        background = pygame_menu.BaseImage(
-            image_path=tools.transform_resource_filename(prepare.BG_PHONE),
-            drawing_position=POSITION_CENTER,
-        )
-        theme = get_theme()
+        theme = self._setup_theme(prepare.BG_PHONE)
         theme.scrollarea_position = locals.POSITION_EAST
-        theme.background_color = background
         theme.widget_alignment = locals.ALIGN_CENTER
 
         # menu
@@ -161,12 +151,4 @@ class NuPhone(PygameMenuState):
         )
 
         self.add_menu_items(self.menu, menu_items_map)
-        self.repristinate()
-
-    def repristinate(self) -> None:
-        """Repristinate original theme (color, alignment, etc.)"""
-        theme = get_theme()
-        theme.scrollarea_position = locals.SCROLLAREA_POSITION_NONE
-        theme.background_color = self.background_color
-        theme.widget_alignment = locals.ALIGN_LEFT
-        theme.title = False
+        self.reset_theme()

--- a/tuxemon/states/phone/phone_banking.py
+++ b/tuxemon/states/phone/phone_banking.py
@@ -8,13 +8,11 @@ from typing import Any
 
 import pygame_menu
 from pygame_menu import locals
-from pygame_menu.locals import POSITION_CENTER
 from pygame_menu.widgets.selection.highlight import HighlightSelection
 
-from tuxemon import prepare, tools
+from tuxemon import prepare
 from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
-from tuxemon.menu.theme import get_theme
 from tuxemon.session import local_session
 from tuxemon.tools import open_choice_dialog, open_dialog
 
@@ -165,15 +163,8 @@ class NuPhoneBanking(PygameMenuState):
     def __init__(self) -> None:
         width, height = prepare.SCREEN_SIZE
 
-        background = pygame_menu.BaseImage(
-            image_path=tools.transform_resource_filename(
-                prepare.BG_PHONE_BANKING
-            ),
-            drawing_position=POSITION_CENTER,
-        )
-        theme = get_theme()
+        theme = self._setup_theme(prepare.BG_PHONE_BANKING)
         theme.scrollarea_position = locals.POSITION_EAST
-        theme.background_color = background
         theme.widget_alignment = locals.ALIGN_CENTER
 
         # menu
@@ -187,12 +178,4 @@ class NuPhoneBanking(PygameMenuState):
         )
 
         self.add_menu_items(self.menu)
-        self.repristinate()
-
-    def repristinate(self) -> None:
-        """Repristinate original theme (color, alignment, etc.)"""
-        theme = get_theme()
-        theme.scrollarea_position = locals.SCROLLAREA_POSITION_NONE
-        theme.background_color = self.background_color
-        theme.widget_alignment = locals.ALIGN_LEFT
-        theme.title = False
+        self.reset_theme()

--- a/tuxemon/states/phone/phone_contacts.py
+++ b/tuxemon/states/phone/phone_contacts.py
@@ -8,13 +8,11 @@ from typing import Any
 
 import pygame_menu
 from pygame_menu import locals
-from pygame_menu.locals import POSITION_CENTER
 from pygame_menu.widgets.selection.highlight import HighlightSelection
 
-from tuxemon import prepare, tools
+from tuxemon import prepare
 from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
-from tuxemon.menu.theme import get_theme
 from tuxemon.session import local_session
 from tuxemon.tools import open_choice_dialog, open_dialog
 
@@ -65,7 +63,7 @@ class NuPhoneContacts(PygameMenuState):
         # slug and phone number from the tuple
         for slug, phone in self.player.contacts.items():
             menu.add.button(
-                title=T.translate(slug) + " " + phone,
+                title=f"{T.translate(slug)} {phone}",
                 action=partial(choice, slug, phone),
                 button_id=slug,
                 font_size=self.font_size_small,
@@ -79,15 +77,8 @@ class NuPhoneContacts(PygameMenuState):
     def __init__(self) -> None:
         width, height = prepare.SCREEN_SIZE
 
-        background = pygame_menu.BaseImage(
-            image_path=tools.transform_resource_filename(
-                prepare.BG_PHONE_CONTACTS
-            ),
-            drawing_position=POSITION_CENTER,
-        )
-        theme = get_theme()
+        theme = self._setup_theme(prepare.BG_PHONE_CONTACTS)
         theme.scrollarea_position = locals.POSITION_EAST
-        theme.background_color = background
         theme.widget_alignment = locals.ALIGN_CENTER
 
         # menu
@@ -101,12 +92,4 @@ class NuPhoneContacts(PygameMenuState):
         )
 
         self.add_menu_items(self.menu)
-        self.repristinate()
-
-    def repristinate(self) -> None:
-        """Repristinate original theme (color, alignment, etc.)"""
-        theme = get_theme()
-        theme.scrollarea_position = locals.SCROLLAREA_POSITION_NONE
-        theme.background_color = self.background_color
-        theme.widget_alignment = locals.ALIGN_LEFT
-        theme.title = False
+        self.reset_theme()

--- a/tuxemon/states/phone/phone_map.py
+++ b/tuxemon/states/phone/phone_map.py
@@ -7,13 +7,10 @@ from typing import Any
 
 import pygame_menu
 from pygame_menu import locals
-from pygame_menu.locals import POSITION_CENTER
-from pygame_menu.widgets.selection.highlight import HighlightSelection
 
-from tuxemon import prepare, tools
+from tuxemon import prepare
 from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
-from tuxemon.menu.theme import get_theme
 from tuxemon.session import local_session
 
 MenuGameObj = Callable[[], Any]
@@ -57,9 +54,7 @@ class NuPhoneMap(PygameMenuState):
             "phone_map", prepare.PHONE_MAP
         )
         # map
-        new_image = pygame_menu.BaseImage(
-            tools.transform_resource_filename(phone_map)
-        )
+        new_image = self._create_image(phone_map)
         new_image.scale(prepare.SCALE, prepare.SCALE)
         menu.add.image(image_path=new_image.copy())
         underline = False
@@ -93,13 +88,8 @@ class NuPhoneMap(PygameMenuState):
     def __init__(self) -> None:
         width, height = prepare.SCREEN_SIZE
 
-        background = pygame_menu.BaseImage(
-            image_path=tools.transform_resource_filename(prepare.BG_PHONE_MAP),
-            drawing_position=POSITION_CENTER,
-        )
-        theme = get_theme()
+        theme = self._setup_theme(prepare.BG_PHONE_MAP)
         theme.scrollarea_position = locals.POSITION_EAST
-        theme.background_color = background
         theme.widget_alignment = locals.ALIGN_CENTER
 
         # menu
@@ -113,12 +103,4 @@ class NuPhoneMap(PygameMenuState):
         )
 
         self.add_menu_items(self.menu)
-        self.repristinate()
-
-    def repristinate(self) -> None:
-        """Repristinate original theme (color, alignment, etc.)"""
-        theme = get_theme()
-        theme.scrollarea_position = locals.SCROLLAREA_POSITION_NONE
-        theme.background_color = self.background_color
-        theme.widget_alignment = locals.ALIGN_LEFT
-        theme.title = False
+        self.reset_theme()

--- a/tuxemon/states/start/__init__.py
+++ b/tuxemon/states/start/__init__.py
@@ -12,12 +12,10 @@ from typing import Any, Union
 import pygame
 import pygame_menu
 from pygame_menu import locals
-from pygame_menu.locals import POSITION_CENTER
 
-from tuxemon import formula, prepare, tools
+from tuxemon import formula, prepare
 from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
-from tuxemon.menu.theme import get_theme
 from tuxemon.save import get_index_of_latest_save
 from tuxemon.session import local_session
 from tuxemon.state import State
@@ -52,7 +50,6 @@ class StartState(PygameMenuState):
     ) -> None:
         # If there is a save, then move the cursor to "Load game" first
         index = get_index_of_latest_save()
-        self.menu._onclose = None
         config = prepare.CONFIG
 
         def new_game() -> None:
@@ -76,7 +73,6 @@ class StartState(PygameMenuState):
         def exit_game() -> None:
             self.client.exit = True
 
-        self.menu._last_selected_type
         if index is not None:
             menu.add.button(
                 title=T.translate("menu_load"),
@@ -107,25 +103,11 @@ class StartState(PygameMenuState):
     def __init__(self) -> None:
         width, height = prepare.SCREEN_SIZE
 
-        background = pygame_menu.BaseImage(
-            image_path=tools.transform_resource_filename(
-                prepare.BG_START_SCREEN
-            ),
-            drawing_position=POSITION_CENTER,
-        )
-        theme = get_theme()
+        theme = self._setup_theme(prepare.BG_START_SCREEN)
         theme.scrollarea_position = locals.POSITION_EAST
-        theme.background_color = background
         theme.widget_alignment = locals.ALIGN_CENTER
 
         super().__init__(height=height, width=width)
 
         self.add_menu_items(self.menu)
-        self.repristinate()
-
-    def repristinate(self) -> None:
-        """Repristinate original theme (color, alignment, etc.)"""
-        theme = get_theme()
-        theme.scrollarea_position = locals.SCROLLAREA_POSITION_NONE
-        theme.background_color = self.background_color
-        theme.widget_alignment = locals.ALIGN_LEFT
+        self.reset_theme()


### PR DESCRIPTION
PR that cleans up the various states that use Pygame menus. The goal is to lay the groundwork for fixing and refactoring the bag (#2304). I started by breaking out some methods to make the code more readable and reduce duplication. For example, I moved the `repristinate` method into the main class, which made a huge difference in cutting down on repeated code. But I didn't stop there! I figured, why not centralize all the common code while I'm at it? So, I also centralized the background (theme) creation and image creation.

`self.selected_widget = self.menu.get_selected_widget()` is really important, now we can track like the old menu