### PR TITLE
fix fusion.py (import)

### DIFF
--- a/tuxemon/fusion.py
+++ b/tuxemon/fusion.py
@@ -12,12 +12,14 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, Optional
+from typing import Any, Optional, TypeAlias
+
+Image: TypeAlias = Any
 
 try:
     from PIL import Image
 except ImportError:
-    Image = Any
+    pass
 import json
 
 


### PR DESCRIPTION
PR just reduced the number of type hints by 22. It's amazing how much of an impact a small tweak can have. We're making great progress in the ongoing battle against type hints #1211. I still remember when mypy --strict was over 500, and now we're down to below 80. I'll be back when we'll drop 3.9.