### PR TITLE
transitions

### DIFF
--- a/tuxemon/states/transition/__init__.py
+++ b/tuxemon/states/transition/__init__.py
@@ -4,5 +4,12 @@ import logging
 
 from .fade import FadeInTransition, FadeOutTransition
 from .flash import FlashTransition
+from .mosaic import MosaicTransition
+from .negative import NegativeTransition
+from .pixelation import PixelationTransition
+from .static import StaticTransition
+from .swirl import SwirlTransition
+from .wipe import WipeTransition
+from .zoom import ZoomInTransition, ZoomOutTransition
 
 logger = logging.getLogger(__name__)

--- a/tuxemon/states/transition/fade.py
+++ b/tuxemon/states/transition/fade.py
@@ -30,6 +30,16 @@ class FadeTransitionBase(State):
         caller: Optional[State] = None,
         color: ColorLike = prepare.BLACK_COLOR,
     ) -> None:
+        """
+        Parameters:
+            state_duration: The duration of the transition state in seconds.
+                If not provided, a default value will be used.
+            fade_duration: The duration of the fade animation in seconds.
+                If not provided, a default value will be used.
+            caller: The state that initiated the transition. If not provided,
+                it will be set to None.
+            color: The color to use for the fade transition. Defaults to black.
+        """
         super().__init__()
 
         logger.debug("Initializing fade transition")

--- a/tuxemon/states/transition/flash.py
+++ b/tuxemon/states/transition/flash.py
@@ -20,13 +20,26 @@ class FlashTransition(State):
 
     force_draw = True
 
-    def __init__(self, color: ColorLike = prepare.WHITE_COLOR) -> None:
+    def __init__(
+        self,
+        color: ColorLike = prepare.WHITE_COLOR,
+        flash_time: float = 0.2,
+        max_flash_count: int = 7,
+    ) -> None:
+        """
+        Parameters:
+            color: The color to use for the flash effect. Defaults to white.
+            flash_time: The time in seconds between flashes. Defaults to 0.2
+                seconds.
+            max_flash_count: The maximum number of times the flash effect will
+                repeat. Defaults to 7.
+        """
         super().__init__()
         logger.info("Initializing battle transition")
-        self.flash_time = 0.2  # Time in seconds between flashes
+        self.flash_time = flash_time
         self.flash_state = "up"
         self.transition_alpha = 0.0
-        self.max_flash_count = 7
+        self.max_flash_count = max_flash_count
         self.flash_count = 0
         self.client.rumble.rumble(-1, length=1.5)
         self.color = color
@@ -64,9 +77,7 @@ class FlashTransition(State):
 
         if self.flash_count > self.max_flash_count:
             logger.info(
-                "Flashed "
-                + str(self.flash_count)
-                + " times. Stopping transition.",
+                f"Flashed {self.flash_count} times. Stopping transition."
             )
             self.client.pop_state()
 

--- a/tuxemon/states/transition/mosaic.py
+++ b/tuxemon/states/transition/mosaic.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2024 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+import random
+from typing import Optional
+
+import pygame
+
+from tuxemon import prepare
+from tuxemon.platform.events import PlayerInput
+from tuxemon.state import State
+
+logger = logging.getLogger(__name__)
+
+
+class MosaicTransition(State):
+    """The state responsible for the mosaic transitions."""
+
+    force_draw = True
+
+    def __init__(self, duration: float = 1.0, tile_size: int = 10) -> None:
+        """
+        Parameters:
+            duration: The time in seconds. Defaults to 1.0 seconds.
+            tile_size: The size of the mosaic tile. Defaults to 10.
+        """
+        super().__init__()
+        logger.info("Initializing Mosaic transition")
+        self.duration = duration
+        self.start_time = 0.0
+        self.elapsed_time = 0.0
+        self.tile_size = tile_size
+        self.tiles: list[pygame.Rect] = []
+        self.tile_surfaces: list[pygame.Surface] = []
+        self.resume()
+
+    def resume(self) -> None:
+        self.screenshot = pygame.Surface.copy(prepare.SCREEN)
+        for x in range(0, self.screenshot.get_width(), self.tile_size):
+            for y in range(0, self.screenshot.get_height(), self.tile_size):
+                rect = pygame.Rect(x, y, self.tile_size, self.tile_size)
+                self.tiles.append(rect)
+                self.tile_surfaces.append(self.screenshot.subsurface(rect))
+
+    def update(self, time_delta: float) -> None:
+        """
+        Update function for state.
+
+        Parameters:
+            time_delta: Time since last update in seconds
+
+        """
+        self.elapsed_time += time_delta
+        if self.elapsed_time > self.duration:
+            logger.info("Mosaic transition finished.")
+            self.client.pop_state()
+
+    def draw(self, surface: pygame.surface.Surface) -> None:
+        for i, tile in enumerate(self.tiles):
+            if random.random() < self.elapsed_time / self.duration:
+                surface.blit(self.tile_surfaces[i], tile)
+            else:
+                pygame.draw.rect(surface, (0, 0, 0), tile)
+
+    def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
+        # prevent other states from getting input
+        return None

--- a/tuxemon/states/transition/negative.py
+++ b/tuxemon/states/transition/negative.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2024 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import pygame
+
+from tuxemon.platform.events import PlayerInput
+from tuxemon.state import State
+
+logger = logging.getLogger(__name__)
+
+
+class NegativeTransition(State):
+    """The state responsible for the negative transitions."""
+
+    force_draw = True
+
+    def __init__(self, duration: float = 1.0) -> None:
+        """
+        Parameters:
+            duration: The time in seconds. Defaults to 1.0 seconds.
+        """
+        super().__init__()
+        logger.info("Initializing negative transition")
+        self.duration = duration
+        self.start_time = 0.0
+        self.elapsed_time = 0.0
+
+    def update(self, time_delta: float) -> None:
+        """
+        Update function for state.
+
+        Parameters:
+            time_delta: Time since last update in seconds
+
+        """
+        self.elapsed_time += time_delta
+        if self.elapsed_time > self.duration:
+            logger.info("Negative colors transition finished.")
+            self.client.pop_state()
+
+    def draw(self, surface: pygame.surface.Surface) -> None:
+        for x in range(surface.get_width()):
+            for y in range(surface.get_height()):
+                r, g, b, a = surface.get_at((x, y))
+                r = 255 - r
+                g = 255 - g
+                b = 255 - b
+                surface.set_at((x, y), (r, g, b, a))
+
+    def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
+        # prevent other states from getting input
+        return None

--- a/tuxemon/states/transition/pixelation.py
+++ b/tuxemon/states/transition/pixelation.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2024 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import pygame
+
+from tuxemon.platform.events import PlayerInput
+from tuxemon.state import State
+
+logger = logging.getLogger(__name__)
+
+
+class PixelationTransition(State):
+    """The state responsible for the pixelation transitions."""
+
+    force_draw = True
+
+    def __init__(
+        self, duration: float = 1.0, scale_factor: float = 10.0
+    ) -> None:
+        """
+        Parameters:
+            duration: The time in seconds. Defaults to 1.0 seconds.
+            scale_factor: The level of pixelation or blockiness applied
+                to the screen, with higher values resulting in a more
+                extreme effect.
+        """
+        super().__init__()
+        logger.info("Initializing Pixelation transition")
+        self.duration = duration
+        self.scale_factor = scale_factor
+        self.start_time = 0.0
+        self.elapsed_time = 0.0
+
+    def update(self, time_delta: float) -> None:
+        """
+        Update function for state.
+
+        Parameters:
+            time_delta: Time since last update in seconds
+
+        """
+        self.elapsed_time += time_delta
+        if self.elapsed_time > self.duration:
+            logger.info("Pixelation transition finished.")
+            self.client.pop_state()
+
+    def draw(self, surface: pygame.surface.Surface) -> None:
+        small_screen = pygame.transform.scale(
+            surface,
+            (
+                surface.get_width() // self.scale_factor,
+                surface.get_height() // self.scale_factor,
+            ),
+        )
+        surface.blit(
+            pygame.transform.scale(small_screen, surface.get_size()), (0, 0)
+        )
+
+    def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
+        # prevent other states from getting input
+        return None

--- a/tuxemon/states/transition/static.py
+++ b/tuxemon/states/transition/static.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2024 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+import random
+from typing import Optional
+
+import pygame
+
+from tuxemon import prepare
+from tuxemon.platform.events import PlayerInput
+from tuxemon.state import State
+
+logger = logging.getLogger(__name__)
+
+
+class StaticTransition(State):
+    """The state responsible for the static transition."""
+
+    force_draw = True
+
+    def __init__(self, duration: float = 1.0) -> None:
+        """
+        Parameters:
+            duration: The time in seconds. Defaults to 1.0 seconds.
+        """
+        super().__init__()
+        logger.info("Initializing Static transition")
+        self.duration = duration
+        self.start_time = 0.0
+        self.elapsed_time = 0.0
+        self.screenshot: Optional[pygame.Surface] = None
+
+    def resume(self) -> None:
+        self.screenshot = pygame.Surface.copy(prepare.SCREEN)
+
+    def update(self, time_delta: float) -> None:
+        self.elapsed_time += time_delta
+        if self.elapsed_time > self.duration:
+            logger.info("Static transition finished.")
+            self.client.pop_state()
+
+    def draw(self, surface: pygame.surface.Surface) -> None:
+        surface.fill((0, 0, 0))
+        for _ in range(5000):
+            x = random.randint(0, surface.get_width())
+            y = random.randint(0, surface.get_height())
+            surface.set_at(
+                (x, y),
+                (
+                    random.randint(0, 255),
+                    random.randint(0, 255),
+                    random.randint(0, 255),
+                ),
+            )
+
+    def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
+        return None

--- a/tuxemon/states/transition/swirl.py
+++ b/tuxemon/states/transition/swirl.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2024 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import pygame
+
+from tuxemon import prepare
+from tuxemon.platform.events import PlayerInput
+from tuxemon.state import State
+
+logger = logging.getLogger(__name__)
+
+
+class SwirlTransition(State):
+    """The state responsible for the swirl transitions."""
+
+    force_draw = True
+
+    def __init__(
+        self, image: pygame.Surface, scale: float = 1.2, speed: float = 50.0
+    ) -> None:
+        """
+        Parameters:
+            image: The image to be used for the swirl effect.
+            scale: The initial scale factor of the image. Defaults to 1.2,
+                meaning the image will start at 120% of its original size.
+            speed: The rate of rotation in degrees per second. Defaults to 50.
+        """
+        super().__init__()
+        logger.info("Initializing Swirl transition")
+        self.image = image
+        self.center_x = prepare.SCREEN.get_width() // 2
+        self.center_y = prepare.SCREEN.get_height() // 2
+        self.angle = 0.0
+        self.scale = scale
+        self.speed = speed
+
+    def update(self, time_delta: float) -> None:
+        self.angle += self.speed * time_delta
+        self.scale += 0.01 * time_delta
+        if self.angle > 360:
+            logger.info("Swirl transition finished.")
+            self.client.pop_state()
+
+    def draw(self, surface: pygame.Surface) -> None:
+        surface.fill((0, 0, 0))
+        rotated_image = pygame.transform.rotate(self.image, self.angle)
+        scaled_image = pygame.transform.scale(
+            rotated_image,
+            (
+                int(rotated_image.get_width() * self.scale),
+                int(rotated_image.get_height() * self.scale),
+            ),
+        )
+        rect = scaled_image.get_rect(center=(self.center_x, self.center_y))
+        surface.blit(scaled_image, rect)
+
+    def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
+        return None

--- a/tuxemon/states/transition/wipe.py
+++ b/tuxemon/states/transition/wipe.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2024 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import pygame
+
+from tuxemon import prepare
+from tuxemon.graphics import ColorLike
+from tuxemon.platform.events import PlayerInput
+from tuxemon.state import State
+
+logger = logging.getLogger(__name__)
+
+
+class WipeTransition(State):
+    """The state responsible for the wipe transitions."""
+
+    force_draw = True
+
+    def __init__(
+        self,
+        image: pygame.Surface,
+        direction: str,
+        speed: int = 250,
+        color: ColorLike = prepare.BLACK_COLOR,
+    ) -> None:
+        """
+        Parameters:
+            image: The image to be used for the wipe effect.
+            direction: The direction. Can be either "right", "left", "up" or
+                "down"
+            speed: The pixels per second. Defaults to 250.
+            color: The color to use for the flash effect. Defaults to black.
+        """
+        super().__init__()
+        logger.info("Initializing Wipe transition")
+        self.image = image
+        self.direction = direction
+        self.wipe_x = 0.0
+        self.wipe_y = 0.0
+        self.color = color
+        self.speed = speed
+        self.height = prepare.SCREEN.get_height()
+        self.width = prepare.SCREEN.get_width()
+
+    def update(self, time_delta: float) -> None:
+        self.update_wipe_position(time_delta)
+        self.check_boundary()
+
+    def update_wipe_position(self, time_delta: float) -> None:
+        direction_map = {
+            "left": (1, 0),
+            "right": (-1, 0),
+            "up": (0, 1),
+            "down": (0, -1),
+        }
+        dx, dy = direction_map[self.direction]
+        self.wipe_x += dx * self.speed * time_delta
+        self.wipe_y += dy * self.speed * time_delta
+
+    def check_boundary(self) -> None:
+        if (
+            self.direction in ["left", "right"]
+            and abs(self.wipe_x) >= self.width
+        ) or (
+            self.direction in ["up", "down"]
+            and abs(self.wipe_y) >= self.height
+        ):
+            logger.info("Wipe transition finished.")
+            self.client.pop_state()
+
+    def draw(self, surface: pygame.Surface) -> None:
+        surface.blit(self.image, (0, 0))
+        if self.direction in ["left", "right"]:
+            pygame.draw.rect(
+                surface, self.color, (self.wipe_x, 0, self.width, self.height)
+            )
+        else:
+            pygame.draw.rect(
+                surface, self.color, (0, self.wipe_y, self.width, self.height)
+            )
+
+    def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
+        return None

--- a/tuxemon/states/transition/zoom.py
+++ b/tuxemon/states/transition/zoom.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2024 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import pygame
+
+from tuxemon import prepare
+from tuxemon.platform.events import PlayerInput
+from tuxemon.state import State
+
+logger = logging.getLogger(__name__)
+
+
+class ZoomOutTransition(State):
+    """The state responsible for the zoom out transitions."""
+
+    force_draw = True
+
+    def __init__(
+        self, image: pygame.Surface, scale: float = 0.1, speed: float = 0.5
+    ) -> None:
+        """
+        Parameters:
+            image: The image to be used for the zoom out effect.
+            scale: The initial scale factor of the image. Defaults to 0.1,
+                meaning the image will start at 10% of its original size.
+            speed: The rate at which the image scales down per second.
+                Defaults to 0.5, meaning the image will decrease in size by 50%
+                every second.
+        """
+        super().__init__()
+        logger.info("Initializing Zoom Out transition")
+        self.image = image
+        self.scale = scale
+        self.speed = speed  # scale factor per second
+
+    def update(self, time_delta: float) -> None:
+        if self.scale < 1.0:
+            self.scale += self.speed * time_delta
+        else:
+            self.scale = 1.0
+
+        if self.scale >= 1.0:
+            logger.info("Zoom Out transition finished.")
+            self.client.pop_state()
+
+    def draw(self, surface: pygame.Surface) -> None:
+        scaled_image = pygame.transform.scale(
+            self.image,
+            (
+                int(self.image.get_width() * self.scale),
+                int(self.image.get_height() * self.scale),
+            ),
+        )
+        rect = scaled_image.get_rect(
+            center=(
+                prepare.SCREEN.get_width() // 2,
+                prepare.SCREEN.get_height() // 2,
+            )
+        )
+        surface.blit(scaled_image, rect)
+
+    def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
+        return None
+
+
+class ZoomInTransition(State):
+    """The state responsible for the zoom in transitions."""
+
+    force_draw = True
+
+    def __init__(
+        self, image: pygame.Surface, scale: float = 1.0, speed: float = 0.5
+    ) -> None:
+        """
+        Parameters:
+            image: The image to be used for the zoom in effect.
+            scale: The initial scale factor of the image. Defaults to 1.0,
+                meaning the image will start at 100% of its original size.
+            speed: The rate at which the image scales down per second.
+                Defaults to 0.5, meaning the image will decrease in size by 50%
+                every second.
+        """
+        super().__init__()
+        logger.info("Initializing Zoom In transition")
+        self.image = image
+        self.scale = scale
+        self.speed = speed  # scale factor per second
+
+    def update(self, time_delta: float) -> None:
+        if self.scale > 0.1:
+            self.scale -= self.speed * time_delta
+        else:
+            self.scale = 0.1
+
+        if self.scale <= 0.1:
+            logger.info("Zoom In transition finished.")
+            self.client.pop_state()
+
+    def draw(self, surface: pygame.Surface) -> None:
+        scaled_image = pygame.transform.scale(
+            self.image,
+            (
+                int(self.image.get_width() * self.scale),
+                int(self.image.get_height() * self.scale),
+            ),
+        )
+        rect = scaled_image.get_rect(
+            center=(
+                prepare.SCREEN.get_width() // 2,
+                prepare.SCREEN.get_height() // 2,
+            )
+        )
+        surface.blit(scaled_image, rect)
+
+    def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
+        return None


### PR DESCRIPTION
PR made some tweaks to the **FlashTransition** to make it more flexible and modder-friendly. I've moved some hardcoded parameters to injected ones, so they can be easily changed later on. I've also added descriptions for the fade and flash init transitions, which should make things clearer. On top of that, I've finally implemented the new transitions I've been working on over the past few weeks. @Sanglorian might recall me asking about the background color for flashbacks - well, these new transitions are the part result of that work, and they'll allow us to introduce some specific events in a more interesting way. Some can be changed even more, it's a starting point.

I've been thinking about how we can trigger the different transitions, and I realized that the screen_transition event action is currently hardcoded to fade. One possible solution could be to use the **change_state** event action, which is what we use for the PCState, but that would just add more clutter to it. A better approach might be to introduce a new event action, maybe something like 'transition', that would allow us to trigger different transitions in a more elegant way.

Some examples (other are too heavy to be uploaded and the negative color doesn't work when I try to record the screen):
this below can be right, left, up or down

https://github.com/user-attachments/assets/cb49a4da-894e-4722-8daa-edb6d1545395


https://github.com/user-attachments/assets/689cefca-2157-4b68-a2ef-ce94d1daf937


https://github.com/user-attachments/assets/9708c0ce-7077-447a-ae70-7bd426d15bae


https://github.com/user-attachments/assets/1ab8f47e-825c-42f9-b477-188071b3bc09
