### PR TITLE
prop_healing (tech effect) + healing_power cap

### DIFF
--- a/mods/tuxemon/db/technique/battery_discharge.json
+++ b/mods/tuxemon/db/technique/battery_discharge.json
@@ -7,7 +7,7 @@
     "healing user"
   ],
   "flip_axes": "",
-  "healing_power": 4,
+  "healing_power": 3.0,
   "is_fast": false,
   "potency": 0.0,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/blossom.json
+++ b/mods/tuxemon/db/technique/blossom.json
@@ -7,7 +7,7 @@
     "damage"
   ],
   "flip_axes": "",
-  "healing_power": 2,
+  "healing_power": 2.0,
   "is_fast": false,
   "potency": 1,
   "power": 1.25,

--- a/mods/tuxemon/db/technique/hibernate.json
+++ b/mods/tuxemon/db/technique/hibernate.json
@@ -4,10 +4,9 @@
   "animation": null,
   "effects": [
     "give noddingoff,user",
-    "healing user"
+    "prop_healing user,0.66"
   ],
   "flip_axes": "",
-  "healing_power": 8,
   "is_fast": false,
   "potency": 1,
   "power": 0,

--- a/mods/tuxemon/db/technique/life_surge.json
+++ b/mods/tuxemon/db/technique/life_surge.json
@@ -7,7 +7,7 @@
     "healing target"
   ],
   "flip_axes": "",
-  "healing_power": 4,
+  "healing_power": 3.0,
   "is_fast": false,
   "potency": 1,
   "power": 0,

--- a/mods/tuxemon/db/technique/mending.json
+++ b/mods/tuxemon/db/technique/mending.json
@@ -6,7 +6,7 @@
     "healing user"
   ],
   "flip_axes": "",
-  "healing_power": 2,
+  "healing_power": 2.0,
   "is_fast": false,
   "potency": 1,
   "power": 0,

--- a/mods/tuxemon/db/technique/mystic_blending.json
+++ b/mods/tuxemon/db/technique/mystic_blending.json
@@ -8,7 +8,7 @@
     "healing user"
   ],
   "flip_axes": "",
-  "healing_power": 4,
+  "healing_power": 3.0,
   "is_fast": false,
   "potency": 1,
   "power": 0,

--- a/mods/tuxemon/db/technique/panjandrum.json
+++ b/mods/tuxemon/db/technique/panjandrum.json
@@ -3,7 +3,7 @@
   "accuracy": 0.75,
   "animation": "explosion_mushroom_128",
   "effects": [
-    "prop_damage target,4"
+    "prop_damage target,0.25"
   ],
   "flip_axes": "",
   "is_fast": false,

--- a/mods/tuxemon/db/technique/refresh.json
+++ b/mods/tuxemon/db/technique/refresh.json
@@ -7,7 +7,7 @@
     "healing user"
   ],
   "flip_axes": "",
-  "healing_power": 4,
+  "healing_power": 3.0,
   "is_fast": false,
   "potency": 1,
   "power": 0,

--- a/mods/tuxemon/db/technique/sudden_glow.json
+++ b/mods/tuxemon/db/technique/sudden_glow.json
@@ -8,7 +8,7 @@
     "healing user"
   ],
   "flip_axes": "",
-  "healing_power": 2,
+  "healing_power": 2.0,
   "is_fast": false,
   "potency": 1,
   "power": 0,

--- a/mods/tuxemon/db/technique/wallow.json
+++ b/mods/tuxemon/db/technique/wallow.json
@@ -7,7 +7,7 @@
     "healing user"
   ],
   "flip_axes": "",
-  "healing_power": 2,
+  "healing_power": 2.0,
   "is_fast": false,
   "potency": 0.9,
   "power": 0,

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -706,8 +706,8 @@ class TechniqueModel(BaseModel):
         True,
         description="Whether or not this technique will be picked by random",
     )
-    healing_power: int = Field(
-        0,
+    healing_power: float = Field(
+        0.0,
         description="Value of healing power.",
         ge=prepare.HEALING_POWER_RANGE[0],
         le=prepare.HEALING_POWER_RANGE[1],

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -187,11 +187,11 @@ def simple_heal(
     Returns:
         int: The calculated healing amount.
     """
-    base_heal = (pre.COEFF_DAMAGE + monster.level) * technique.healing_power
+    base_heal = pre.COEFF_DAMAGE + monster.level * technique.healing_power
     if additional_factors:
         factor_multiplier = math.prod(additional_factors.values())
-        base_heal = int(base_heal * factor_multiplier)
-    return base_heal
+        base_heal = base_heal * factor_multiplier
+    return int(base_heal)
 
 
 def simple_recover(target: Monster, divisor: int) -> int:

--- a/tuxemon/prepare.py
+++ b/tuxemon/prepare.py
@@ -272,7 +272,7 @@ RECHARGE_RANGE: tuple[int, int] = (0, 5)
 POTENCY_RANGE: tuple[float, float] = (0.0, 1.0)
 ACCURACY_RANGE: tuple[float, float] = (0.0, 1.0)
 POWER_RANGE: tuple[float, float] = (0.0, 3.0)
-HEALING_POWER_RANGE: tuple[int, int] = (0, 10)
+HEALING_POWER_RANGE: tuple[float, float] = (0.0, 3.0)
 
 # Combat
 # Hud right/left lines

--- a/tuxemon/technique/effects/prop_healing.py
+++ b/tuxemon/technique/effects/prop_healing.py
@@ -12,32 +12,32 @@ if TYPE_CHECKING:
     from tuxemon.technique.technique import Technique
 
 
-class PropDamageEffectResult(TechEffectResult):
+class PropHealingEffectResult(TechEffectResult):
     pass
 
 
 @dataclass
-class PropDamageEffect(TechEffect):
+class PropHealingEffect(TechEffect):
     """
-    Proportional Damage:
-    This effect does damage to the enemy equal
+    Proportional Healing:
+    This effect does healing to the user equal
     to % of the target's / user's maximum HP.
 
     Parameters:
         objective: User HP or target HP.
         proportional: The percentage of the max HP
 
-    eg prop_damage target,0.25 (1/4 max enemy HP)
+    eg prop_healing target,0.25 (1/4 max enemy HP)
 
     """
 
-    name = "prop_damage"
+    name = "prop_healing"
     objective: str
     proportional: float
 
     def apply(
         self, tech: Technique, user: Monster, target: Monster
-    ) -> PropDamageEffectResult:
+    ) -> PropHealingEffectResult:
         tech.hit = tech.accuracy >= (
             tech.combat_state._random_tech_hit.get(user, 0.0)
             if tech.combat_state
@@ -45,15 +45,13 @@ class PropDamageEffect(TechEffect):
         )
         if tech.hit:
             reference_hp = target.hp if self.objective == "target" else user.hp
-            amount = float(reference_hp) * self.proportional
-            target.current_hp -= int(amount)
-        else:
-            amount = 0
+            amount = (reference_hp) * self.proportional
+            user.current_hp += int(amount)
 
         return {
-            "damage": int(amount),
+            "damage": 0,
             "element_multiplier": 0.0,
-            "should_tackle": tech.hit,
+            "should_tackle": False,
             "success": tech.hit,
             "extra": None,
         }

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -59,7 +59,7 @@ class Technique:
         self.potency = 0.0
         self.power = 1.0
         self.range = Range.melee
-        self.healing_power = 0
+        self.healing_power = 0.0
         self.recharge_length = 0
         self.sfx = ""
         self.sort = ""


### PR DESCRIPTION
PR made some changes to **healing_power**. @Sanglorian it's set to **3.0** the **healing_power** cap. So anything above 3 is rounded down to 3. Also, I changed **hibernate** from 8 to 0. This is because we needed a new effect for healing, similar to the one we have for damage. I created a new effect called **prop_healing** which heals proportionally based on the user or target's max HP. This was, hibernate will heal 66% of the max HP as you requested [here](https://github.com/Tuxemon/Tuxemon/pull/2450#issuecomment-2365690221). Let me know if this is ok.