### PR TITLE
transfer (tech effect)

### DIFF
--- a/tuxemon/technique/effects/transfer.py
+++ b/tuxemon/technique/effects/transfer.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2024 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from tuxemon.combat import has_status
+from tuxemon.technique.techeffect import TechEffect, TechEffectResult
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
+    from tuxemon.technique.technique import Technique
+
+
+class TransferEffectResult(TechEffectResult):
+    pass
+
+
+@dataclass
+class TransferEffect(TechEffect):
+    """
+    Transfers the condition from the user to the target.
+
+    If the user has the condition, they lose that condition and the target
+    gains it.
+    """
+
+    name = "transfer"
+    condition: str
+
+    def apply(
+        self, tech: Technique, user: Monster, target: Monster
+    ) -> TransferEffectResult:
+        tech.hit = tech.accuracy >= (
+            tech.combat_state._random_tech_hit.get(user, 0.0)
+            if tech.combat_state
+            else 0.0
+        )
+        done = False
+        if tech.hit and has_status(user, self.condition):
+            target.status = user.status
+            user.status = []
+            done = True
+        return {
+            "success": done,
+            "damage": 0,
+            "element_multiplier": 0.0,
+            "should_tackle": False,
+            "extra": None,
+        }


### PR DESCRIPTION
PR implements a new tech effect called **transfer**. A new effect inspired by @Sanglorian's idea for the 'suck_poison' technique. Here's how it works: if the user has a poisoned condition, they'll lose it and the target will gain it. I actually had a similar idea myself, so it wasn't too hard to implement - I just needed to tweak a few details. The best part is that this effect can transfer any condition: eg `transfer poison` or `transfer burn` or `transfer whatever`. You just need to specify it in the technique's JSON. One important thing to note is that the condition will only be transferred if the technique actually hits - if it misses, nothing will happen. I'm planning to implement this new effect in `suck_poison` in PR #2437 . 