### PR TITLE
active state names

### DIFF
--- a/tuxemon/client.py
+++ b/tuxemon/client.py
@@ -610,3 +610,8 @@ class LocalPygameClient:
     def current_state(self) -> Optional[State]:
         """Current State object, or None"""
         return self.state_manager.current_state
+
+    @property
+    def active_state_names(self) -> Sequence[str]:
+        """List of names of active states"""
+        return self.state_manager.get_active_state_names()

--- a/tuxemon/event/actions/char_look.py
+++ b/tuxemon/event/actions/char_look.py
@@ -65,8 +65,8 @@ class CharLookAction(EventAction):
         def _look() -> None:
             # Suspend looking around if a dialog window is open
             if any(
-                state.name in ("WorldMenuState", "DialogState", "ChoiceState")
-                for state in self.session.client.active_states
+                state_name in ("WorldMenuState", "DialogState", "ChoiceState")
+                for state_name in self.session.client.active_state_names
             ):
                 return
 

--- a/tuxemon/event/actions/char_wander.py
+++ b/tuxemon/event/actions/char_wander.py
@@ -74,9 +74,11 @@ class CharWanderAction(EventAction):
                 return
 
             # Suspend wandering if a dialog window is open
-            for state in client.active_states:
-                if state.name == "WorldMenuState":
-                    return
+            if any(
+                state_name in ("WorldMenuState", "DialogState", "ChoiceState")
+                for state_name in self.session.client.active_state_names
+            ):
+                return
 
             # Choose a random direction that is free and walk toward it
             origin = (character.tile_pos[0], character.tile_pos[1])

--- a/tuxemon/event/actions/remove_state.py
+++ b/tuxemon/event/actions/remove_state.py
@@ -34,8 +34,11 @@ class RemoveStateAction(EventAction):
             # obligatory "should not happen"
             raise RuntimeError
         if not self.state_name:
-            for ele in self.session.client.active_states:
-                if ele.name != "WorldState" and ele.name != "BackgroundState":
-                    self.session.client.remove_state(ele)
-        if current_state.name == self.state_name:
+            for name in self.session.client.active_state_names:
+                if name not in ["WorldState", "BackgroundState"]:
+                    self.session.client.remove_state_by_name(name)
+        if (
+            self.state_name
+            and self.state_name in self.session.client.active_state_names
+        ):
             self.session.client.pop_state()

--- a/tuxemon/event/conditions/music_playing.py
+++ b/tuxemon/event/conditions/music_playing.py
@@ -38,14 +38,11 @@ class MusicPlayingCondition(EventCondition):
         """
         song = condition.parameters[0]
 
-        # currently no way to query the names of states in the state game
-        # stack.
-        # so we find names here.  possibly might make api to do this later.
-        names = {i.name for i in session.client.active_states}
         combat_states = {"FlashTransition", "CombatState"}
-
-        # means "if any element of combat_states is in names"
-        if not names.isdisjoint(combat_states):
+        if any(
+            state in combat_states
+            for state in session.client.active_state_names
+        ):
             return True
 
         if session.client.current_music.status == MusicStatus.paused:

--- a/tuxemon/state.py
+++ b/tuxemon/state.py
@@ -716,3 +716,7 @@ class StateManager:
                 return queued_state
 
         raise ValueError(f"Missing queued state {state_name}")
+
+    def get_active_state_names(self) -> Sequence[str]:
+        """List of names of active states."""
+        return [state.name for state in self._state_stack]

--- a/tuxemon/states/items/item_menu.py
+++ b/tuxemon/states/items/item_menu.py
@@ -106,7 +106,6 @@ class ItemMenuState(Menu[Item]):
             menu_item: Selected menu item.
         """
         item = menu_item.game_object
-        active_state_names = [a.name for a in self.client.active_states]
 
         # Check if the item can be used on any monster
         if not any(item.validate(m) for m in local_session.player.monsters):
@@ -114,7 +113,9 @@ class ItemMenuState(Menu[Item]):
             error_message = self.get_error_message(item)
             tools.open_dialog(local_session, [error_message])
         # Check if the item can be used in the current state
-        elif not any(s.name in active_state_names for s in item.usable_in):
+        elif not any(
+            s.name in self.client.active_state_names for s in item.usable_in
+        ):
             error_message = T.format(
                 "item_cannot_use_here", {"name": item.name}
             )


### PR DESCRIPTION
PR solves a TODO in music_playing. Then I realized the new method could be useful in other parts of the code too, so I decided to replace it. I also applied the same check to `char_wander` and `char_look`, which should now prevent other NPCs from moving / looking around as well.