### PR TITLE
fix 2460 swimming sprite

### DIFF
--- a/mods/tuxemon/maps/spyder.yaml
+++ b/mods/tuxemon/maps/spyder.yaml
@@ -154,23 +154,13 @@ events:
     - is char_in player,surfable
     - not char_sprite player,swimmer
     type: "event"
-  Not surfable Boy:
+  Not surfable:
     actions:
-    - set_template player,adventurer,adventurer
+    - set_template player,default
     - set_variable swimming:no
     conditions:
     - not char_in player,surfable
     - is char_sprite player,swimmer
-    - is variable_set gender_choice:gender_male
-    type: "event"
-  Not surfable Girl:
-    actions:
-    - set_template player,heroine,heroine
-    - set_variable swimming:no
-    conditions:
-    - not char_in player,surfable
-    - is char_sprite player,swimmer
-    - is variable_set gender_choice:gender_female
     type: "event"
   Allow Swim:
     actions:

--- a/tuxemon/event/actions/set_template.py
+++ b/tuxemon/event/actions/set_template.py
@@ -23,10 +23,9 @@ class SetTemplateAction(EventAction):
 
     Eg if you put xxx, it's going to be xxx_back.png
 
-    if you choose a feminine sprite, then it's advisable:
-        heroine
-    if you choose a masculine sprite, then it's advisable:
-        adventurer
+    By using default:
+        set_template player,default
+    it's going to reassign the default sprite
 
     Script usage:
         .. code-block::
@@ -35,7 +34,7 @@ class SetTemplateAction(EventAction):
 
     Script parameters:
         character: Either "player" or npc slug name (e.g. "npc_maple").
-        sprite: must be inside mods/tuxemon/sprites (default = original)
+        sprite: must be inside mods/tuxemon/sprites
         eg: adventurer_brown_back.png -> adventurer
         combat_front: must be inside mods/tuxemon/gfx/sprites/player
         eg: adventurer.png -> adventurer
@@ -53,9 +52,26 @@ class SetTemplateAction(EventAction):
             logger.error(f"{self.character} not found")
             return
 
-        character.template.sprite_name = self.sprite
-        logger.info(f"{character.name}'s sprite is {self.sprite}")
-        if self.combat_front:
-            character.template.combat_front = self.combat_front
-            logger.info(f"{character.name}'s front is {self.combat_front}")
+        if self.sprite == "default":
+            gender = character.game_variables.get("race_choice", "")
+            sprite_mapping = {
+                "gender_enby": ("enbyasian", "enbyasian"),
+                "gender_whatever": ("penguin", "penguin"),
+                "black_female": ("brownheroine_brown", "heroineblack"),
+                "black_male": ("adventurerblack", "adventurerblack"),
+                "white_female": ("heroine", "heroine"),
+                "white_male": ("adventurer", "adventurer"),
+            }
+            sprite_name, combat_front = sprite_mapping.get(
+                gender, (None, None)
+            )
+            if sprite_name:
+                character.template.sprite_name = sprite_name
+                character.template.combat_front = combat_front
+        else:
+            character.template.sprite_name = self.sprite
+            logger.info(f"{character.name}'s sprite is {self.sprite}")
+            if self.combat_front:
+                character.template.combat_front = self.combat_front
+                logger.info(f"{character.name}'s front is {self.combat_front}")
         character.load_sprites()


### PR DESCRIPTION
PR fixes #2460 (urgent issue @ultidonki ).

Basically, we're dealing with the fallout from adding new sprites and the `race_choice` introduced for diversity reasons. It might be a good idea to tackle the swimmer sprite too. I mean, if we're going to have a penguin character, it's only logical that we'd want a penguin swimmer sprite to match, right?

next step: find the right location for moving the dictionary out of set template and new swimmer sprites?
