### PR TITLE
Give stronger Nudiflot if no tuxemon in Candy town

### DIFF
--- a/mods/tuxemon/maps/spyder_candy_cafe.tmx
+++ b/mods/tuxemon/maps/spyder_candy_cafe.tmx
@@ -99,7 +99,7 @@
   <object id="41" name="Box empty" type="event" x="112" y="32" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog spyder_barmaid_cafe3"/>
-    <property name="act40" value="add_monster nudiflot_male,10"/>
+    <property name="act40" value="add_monster nudiflot_male,25"/>
     <property name="act50" value="set_variable cafe_done:yes"/>
     <property name="act55" value="unlock_controls"/>
     <property name="act60" value="pathfind spyder_candycafe_nora,8,10"/>


### PR DESCRIPTION
In Candy Town, all your current Tuxemon get taken away, and if you don't have any in your Kennel, you get a level 10 Nudiflot.

However, all the tuxemon in the nearby dungeons and villages are level 25-ish, and I think level 20-ish in the previous route (B?). So I've made the Nudiflot you receive stronger (level 25). 

This will make it easier to catch other tuxemon and build up a team without getting instantly defeated by the level 25 tuxemon you'll probably meet. I considered making it higher but the important thing here is catching more tuxemon, not defeating them, so having a similar level to them is probably better. :smile: 