### PR TITLE
change map

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Update package list
+      run: |
+        sudo apt update
+
     # Command copied from flathub build process
     - name: Validate appdata file
       run: |


### PR DESCRIPTION
PR refactors `change_map` method in **WorldState** by breaking down the `change_map` method into two separate ones, a better separation of concerns, and it reduces coupling, the `change_map` is now decoupled from the map loading logic, which is handled by the `load_and_update_map` method, this makes easier to modify or replace the map loading logic without affecting the `change_map` method. It doesn't change anything, but it'll let us change map without the player by creating a specific event action.