### PR TITLE
class Teleporter

### DIFF
--- a/tuxemon/event/actions/char_face.py
+++ b/tuxemon/event/actions/char_face.py
@@ -58,7 +58,7 @@ class CharFaceAction(EventAction):
         if character.isplayer:
             world_state = self.session.client.get_state_by_name(WorldState)
             if world_state.in_transition:
-                world_state.delayed_facing = direction
+                world_state.teleporter.delayed_facing = direction
             else:
                 character.facing = direction
         else:

--- a/tuxemon/event/actions/delayed_teleport.py
+++ b/tuxemon/event/actions/delayed_teleport.py
@@ -44,7 +44,7 @@ class DelayedTeleportAction(EventAction):
     def start(self) -> None:
         world = self.session.client.get_state_by_name(WorldState)
 
-        if world.delayed_teleport:
+        if world.teleporter.delayed_teleport:
             logger.error("Stop, there is a teleport in progress")
             return
 
@@ -54,8 +54,8 @@ class DelayedTeleportAction(EventAction):
             return
 
         char.remove_collision(char.tile_pos)
-        world.delayed_char = char
-        world.delayed_teleport = True
-        world.delayed_mapname = self.map_name
-        world.delayed_x = self.position_x
-        world.delayed_y = self.position_y
+        world.teleporter.delayed_char = char
+        world.teleporter.delayed_teleport = True
+        world.teleporter.delayed_mapname = self.map_name
+        world.teleporter.delayed_x = self.position_x
+        world.teleporter.delayed_y = self.position_y

--- a/tuxemon/event/actions/teleport.py
+++ b/tuxemon/event/actions/teleport.py
@@ -6,7 +6,6 @@ import logging
 from dataclasses import dataclass
 from typing import final
 
-from tuxemon import prepare
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.states.world.worldstate import WorldState
@@ -50,30 +49,15 @@ class TeleportAction(EventAction):
 
         # Check to see if we're also performing a transition. If we are, wait
         # to perform the teleport at the apex of the transition
-        # TODO: This only needs to happen once.
         if world.in_transition:
-            world.delayed_char = char
-            world.delayed_mapname = self.map_name
-            world.delayed_teleport = True
-            world.delayed_x = self.x
-            world.delayed_y = self.y
+            if not world.teleporter.delayed_teleport:
+                world.teleporter.delayed_char = char
+                world.teleporter.delayed_teleport = True
+                world.teleporter.delayed_mapname = self.map_name
+                world.teleporter.delayed_x = self.x
+                world.teleporter.delayed_y = self.y
         else:
-            # If we're not doing a transition, then just do the teleport
-            map_path = prepare.fetch("maps", self.map_name)
-
-            if world.current_map is None:
-                world.change_map(map_path)
-
-            elif map_path != world.current_map.filename:
-                world.change_map(map_path)
-                logger.debug(f"Load {map_path}")
-
-            logger.debug(f"Stop {char.slug}'s movements")
-            char.cancel_path()
-
-            logger.debug(f"Set {char.slug}'s position")
-            logger.debug(f"Tile: ({self.x},{self.y})")
-            char.set_position((self.x, self.y))
-
-            logger.debug(f"Unlock {char.slug}'s controls")
-            world.unlock_controls(char)
+            # Teleport the character immediately
+            world.teleporter.teleport_character(
+                world, char, self.map_name, self.x, self.y
+            )

--- a/tuxemon/event/actions/transition_teleport.py
+++ b/tuxemon/event/actions/transition_teleport.py
@@ -41,14 +41,14 @@ class TransitionTeleportAction(EventAction):
     rgb: Optional[str] = None
 
     def start(self) -> None:
-        world = self.session.client.get_state_by_name(WorldState)
+        self.world = self.session.client.get_state_by_name(WorldState)
 
-        if world.npcs:
-            for _npc in world.npcs:
+        if self.world.npcs:
+            for _npc in self.world.npcs:
                 if _npc.moving or _npc.path:
-                    world.npcs.remove(_npc)
+                    self.world.npcs.remove(_npc)
 
-        if world.delayed_teleport:
+        if self.world.teleporter.delayed_teleport:
             self.stop()
             return
 
@@ -70,7 +70,9 @@ class TransitionTeleportAction(EventAction):
         else:
             self.transition.cleanup()
             # set the delayed teleport
-            action = self.session.client.event_engine
-            params = ["player", self.map_name, self.x, self.y]
-            action.execute_action("delayed_teleport", params)
+            self.world.teleporter.delayed_char = None
+            self.world.teleporter.delayed_teleport = True
+            self.world.teleporter.delayed_mapname = self.map_name
+            self.world.teleporter.delayed_x = self.x
+            self.world.teleporter.delayed_y = self.y
             self.stop()

--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -510,9 +510,9 @@ class WorldState(state.State):
                 bubble = (surface, bubble_rect, 100)
                 screen_surfaces.append(bubble)
 
-    def set_layer(self) -> None:
+    def set_layer(self, surface: pygame.surface.Surface) -> None:
         self.layer.fill(self.layer_color)
-        self.screen.blit(self.layer, (0, 0))
+        surface.blit(self.layer, (0, 0))
 
     def map_drawing(self, surface: pygame.surface.Surface) -> None:
         """Draw the map tiles in a layered order."""
@@ -545,7 +545,7 @@ class WorldState(state.State):
         self.draw_map_and_sprites(surface, screen_surfaces)
 
         # Add transparent layer
-        self.set_layer()
+        self.set_layer(surface)
 
         # Draw collision map for debug purposes
         if prepare.CONFIG.collision_map:

--- a/tuxemon/teleporter.py
+++ b/tuxemon/teleporter.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2024 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Optional
+
+from tuxemon import prepare
+from tuxemon.db import Direction
+
+if TYPE_CHECKING:
+    from tuxemon.npc import NPC
+    from tuxemon.states.world.worldstate import WorldState
+
+logger = logging.getLogger(__name__)
+
+
+class Teleporter:
+    """
+    Manages teleportation of characters in the game world.
+
+    This class provides methods for teleporting characters to specific locations,
+    as well as handling delayed teleportations that occur during screen transitions.
+
+    Attributes:
+        delayed_teleport: Whether a delayed teleportation is pending.
+        delayed_char: The character to teleport, or None if the player.
+        delayed_mapname: The name of the map to teleport to.
+        delayed_x: The X position to teleport to.
+        delayed_y: The Y position to teleport to.
+        delayed_facing: The direction to face after teleporting.
+
+    """
+
+    def __init__(self) -> None:
+        self.delayed_teleport = False
+        self.delayed_char: Optional[NPC] = None
+        self.delayed_mapname = ""
+        self.delayed_x = 0
+        self.delayed_y = 0
+        self.delayed_facing: Optional[Direction] = None
+
+    def handle_delayed_teleport(
+        self, world: WorldState, character: NPC
+    ) -> None:
+        """
+        Handle a delayed teleportation during a screen transition.
+
+        Parameters:
+            world: The current game state.
+            char: The character to teleport, or None if the player.
+
+        """
+        if self.delayed_teleport:
+            self.teleport_character(
+                world,
+                self.delayed_char or character,
+                self.delayed_mapname,
+                self.delayed_x,
+                self.delayed_y,
+            )
+            if self.delayed_facing:
+                (self.delayed_char or character).facing = self.delayed_facing
+                self.delayed_facing = None
+            self.delayed_teleport = False
+
+    def teleport_character(
+        self,
+        world: WorldState,
+        character: NPC,
+        map_name: str,
+        x: int,
+        y: int,
+    ) -> None:
+        """
+        Teleport a character to a specific map and tile coordinates.
+
+        Parameters:
+            world: The current game state.
+            char: The character to teleport.
+            map_name: The name of the map to teleport to.
+            x: The X coordinate of the map to teleport to.
+            y: The Y coordinate of the map to teleport to.
+
+        Raises:
+            ValueError: If the character is outside the boundaries of the new map.
+        """
+        world.stop_char(character)
+        world.lock_controls(character)
+
+        target_map = prepare.fetch("maps", map_name)
+
+        if (
+            world.current_map is None
+            or target_map != world.current_map.filename
+        ):
+            world.change_map(target_map)
+            logger.debug(f"Loaded map '{target_map}'")
+
+            if not world.boundary_checker.is_within_boundaries((x, y)):
+                raise ValueError(
+                    f"Character is outside the boundaries of the map at ({x}, {y})"
+                )
+
+        logger.debug(f"Stopping {character.slug}'s movements")
+        character.cancel_path()
+
+        logger.debug(f"Setting {character.slug}'s position to ({x}, {y})")
+        character.set_position((x, y))
+
+        logger.debug(f"Unlocking {character.slug}'s controls")
+        world.unlock_controls(character)


### PR DESCRIPTION
So I dug into the code (after #2472) and noticed that the `change_map` method was popping up in two places - the teleport event action and `handle_delayed_teleport`. I took a closer look at both and found that `handle_delayed_teleport` was missing a couple of important things, like the locking system and `cancel_path`. That reminded me of issue #1909, which @kerizane opened, and it seems like a pretty plausible explanation for the problem. 

To fix it, I moved the `teleport_character` code outside of the World class and into its own method. Now, it checks if the destination coordinates are within the map boundaries. If they're not, it raises a `ValueError` right away.

To get this working, I also moved the delayed teleport logic, which had the added bonus of completely eliminating all 'delayed_' attributes from the World class. This means we've successfully consolidated all teleportation-related code into a single, dedicated class - the Teleporter class.

It's a much cleaner and more organized approach, and it's great to see everything related to teleporting in one place.