### PR TITLE
flatpak (fix appdata failing) + small fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Update package list
+      run: |
+        sudo apt update
+
     # Command copied from flathub build process
     - name: Validate appdata file
       run: |

--- a/mods/tuxemon/db/item/tm_all_in.json
+++ b/mods/tuxemon/db/item/tm_all_in.json
@@ -9,7 +9,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tm_generic.png",
   "category": "technique",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tm_blade.json
+++ b/mods/tuxemon/db/item/tm_blade.json
@@ -9,7 +9,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tm_generic.png",
   "category": "technique",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tm_panjandrum.json
+++ b/mods/tuxemon/db/item/tm_panjandrum.json
@@ -9,7 +9,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tm_generic.png",
   "category": "technique",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tm_scope.json
+++ b/mods/tuxemon/db/item/tm_scope.json
@@ -9,7 +9,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tm_generic.png",
   "category": "technique",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tm_shadow_boxing.json
+++ b/mods/tuxemon/db/item/tm_shadow_boxing.json
@@ -9,7 +9,6 @@
   "sort": "utility",
   "sprite": "gfx/items/tm_generic.png",
   "category": "technique",
-  "type": "Consumable",
   "usable_in": [
     "WorldState"
   ],


### PR DESCRIPTION
The build.yaml was failing and the error message indicated that the package `xdg-desktop-portal` is not available in the specified version (`1.14.4-1ubuntu2~22.04.1`) and the package manager is unable to fetch it. This is due to the package being updated to a newer version (`1.14.4-1ubuntu2~22.04.2`).

To resolve this issue, I added a step to update the package list before installing the required packages.

```
    - name: Update package list
      run: |
        sudo apt update
```

fixes a few JSON files 