### PR TITLE
behavior throwable (item) + animation throwing 

### DIFF
--- a/mods/tuxemon/db/item/tuxeball.json
+++ b/mods/tuxemon/db/item/tuxeball.json
@@ -14,7 +14,9 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "throwable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_ancient.json
+++ b/mods/tuxemon/db/item/tuxeball_ancient.json
@@ -14,7 +14,9 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "throwable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_candy.json
+++ b/mods/tuxemon/db/item/tuxeball_candy.json
@@ -14,7 +14,9 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "throwable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_crusher.json
+++ b/mods/tuxemon/db/item/tuxeball_crusher.json
@@ -14,7 +14,9 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "throwable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_earth.json
+++ b/mods/tuxemon/db/item/tuxeball_earth.json
@@ -14,7 +14,9 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "throwable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_female.json
+++ b/mods/tuxemon/db/item/tuxeball_female.json
@@ -14,7 +14,9 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "throwable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_fire.json
+++ b/mods/tuxemon/db/item/tuxeball_fire.json
@@ -14,7 +14,9 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "throwable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_hardened.json
+++ b/mods/tuxemon/db/item/tuxeball_hardened.json
@@ -15,7 +15,7 @@
     "MainCombatMenuState"
   ],
   "behaviors": {
-    "consumable": false
+    "throwable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/tuxeball_hearty.json
+++ b/mods/tuxemon/db/item/tuxeball_hearty.json
@@ -14,7 +14,9 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "throwable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_lavish.json
+++ b/mods/tuxemon/db/item/tuxeball_lavish.json
@@ -14,7 +14,9 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "throwable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_male.json
+++ b/mods/tuxemon/db/item/tuxeball_male.json
@@ -14,7 +14,9 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "throwable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_metal.json
+++ b/mods/tuxemon/db/item/tuxeball_metal.json
@@ -14,7 +14,9 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "throwable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_neuter.json
+++ b/mods/tuxemon/db/item/tuxeball_neuter.json
@@ -14,7 +14,9 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "throwable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_omni.json
+++ b/mods/tuxemon/db/item/tuxeball_omni.json
@@ -14,7 +14,9 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "throwable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_park.json
+++ b/mods/tuxemon/db/item/tuxeball_park.json
@@ -14,7 +14,9 @@
   "usable_in": [
     "MainParkMenuState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "throwable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_peppy.json
+++ b/mods/tuxemon/db/item/tuxeball_peppy.json
@@ -14,7 +14,9 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "throwable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_refined.json
+++ b/mods/tuxemon/db/item/tuxeball_refined.json
@@ -14,7 +14,9 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "throwable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_salty.json
+++ b/mods/tuxemon/db/item/tuxeball_salty.json
@@ -14,7 +14,9 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "throwable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_water.json
+++ b/mods/tuxemon/db/item/tuxeball_water.json
@@ -14,7 +14,9 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "throwable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_wood.json
+++ b/mods/tuxemon/db/item/tuxeball_wood.json
@@ -14,7 +14,9 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "throwable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_xero.json
+++ b/mods/tuxemon/db/item/tuxeball_xero.json
@@ -14,7 +14,9 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "throwable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball_zesty.json
+++ b/mods/tuxemon/db/item/tuxeball_zesty.json
@@ -14,7 +14,9 @@
   "usable_in": [
     "MainCombatMenuState"
   ],
-  "behaviors": {},
+  "behaviors": {
+    "throwable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -228,6 +228,9 @@ class ItemBehaviors(BaseModel):
     show_dialog_on_success: bool = Field(
         True, description="Whether to show a dialogue after a successful use."
     )
+    throwable: bool = Field(
+        False, description="Whether or not this item is throwable."
+    )
 
 
 class ItemModel(BaseModel):

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -945,7 +945,6 @@ class CombatState(CombatAnimations):
             item_sprite = self._method_cache.get(method, False)
             # handle the capture device
             if method.category == ItemCategory.capture and item_sprite:
-                # retrieve tuxeball
                 message += "\n" + T.translate("attempting_capture")
                 action_time = result_item["num_shakes"] + 1.8
                 self.animate_capture_monster(
@@ -956,6 +955,9 @@ class CombatState(CombatAnimations):
                     item_sprite,
                 )
             else:
+                if method.behaviors.throwable:
+                    item = self.animate_throwing(target, method)
+                    self.task(item.kill, 1.5)
                 msg_type = (
                     "use_success" if result_item["success"] else "use_failure"
                 )

--- a/tuxemon/states/combat/combat_animations.py
+++ b/tuxemon/states/combat/combat_animations.py
@@ -732,6 +732,33 @@ class CombatAnimations(ABC, Menu[None]):
             params = {"name": self.players[1].monsters[0].name.upper()}
             self.alert(T.format("combat_wild_appeared", params))
 
+    def animate_throwing(
+        self,
+        monster: Monster,
+        item: Item,
+    ) -> Sprite:
+        """
+        Animation for throwing the item.
+
+        Parameters:
+            monster: The monster being targeted.
+            item: The item thrown at the monster.
+
+        Returns:
+            The animated item sprite.
+
+        """
+        monster_sprite = self._monster_sprite_map[monster]
+        sprite = self.load_sprite(item.sprite)
+        animate = partial(
+            self.animate, sprite.rect, transition="in_quad", duration=1.0
+        )
+        graphics.scale_sprite(sprite, 0.4)
+        sprite.rect.center = scale(0), scale(0)
+        animate(x=monster_sprite.rect.centerx)
+        animate(y=monster_sprite.rect.centery)
+        return sprite
+
     def animate_capture_monster(
         self,
         is_captured: bool,
@@ -752,14 +779,10 @@ class CombatAnimations(ABC, Menu[None]):
 
         """
         monster_sprite = self._monster_sprite_map[monster]
-        capdev = self.load_sprite(item.sprite)
+        capdev = self.animate_throwing(monster, item)
         animate = partial(
             self.animate, capdev.rect, transition="in_quad", duration=1.0
         )
-        graphics.scale_sprite(capdev, 0.4)
-        capdev.rect.center = scale(0), scale(0)
-        animate(x=monster_sprite.rect.centerx)
-        animate(y=monster_sprite.rect.centery)
         self.task(partial(toggle_visible, monster_sprite), 1.0)
 
         # TODO: cache this sprite from the first time it's used.

--- a/tuxemon/states/combat/combat_menus.py
+++ b/tuxemon/states/combat/combat_menus.py
@@ -12,7 +12,7 @@ import pygame
 from pygame.rect import Rect
 
 from tuxemon import combat, graphics, tools
-from tuxemon.db import ElementType, ItemCategory, State, TechSort
+from tuxemon.db import ElementType, State, TechSort
 from tuxemon.locale import T
 from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.menu import Menu, PopUpMenu
@@ -165,7 +165,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
             item = menu_item.game_object
             self.client.pop_state()  # close the item menu
             if State["MainCombatMenuState"] in item.usable_in:
-                if item.category == ItemCategory.capture:
+                if item.behaviors.throwable:
                     enemy = self.opponents[0]
                     surface = pygame.Surface(self.rect.size)
                     mon = MenuItem(surface, None, None, enemy)
@@ -196,7 +196,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
 
             # close all the open menus
             self.client.pop_state()  # close target chooser
-            if item.category != ItemCategory.capture:
+            if not item.behaviors.throwable:
                 self.client.pop_state()  # close the monster action menu
 
         choose_item()


### PR DESCRIPTION
This PR introduces a new behavior flag called **throwable**, which opens up a world of possibilities for items that can be tossed around. Until now, only the trusty Tuxeball could be thrown, but with this update, we're unlocking the potential for even more exciting scenarios. As part of this change, I've also extracted the throwing animation from the capture animation (you know, the one where the Tuxeball flies through the air just before the monster disappears?) so that it can be reused for any other item that's marked as throwable.