### PR TITLE
perform_action (combat.py) + others

### DIFF
--- a/mods/tuxemon/maps/spyder.yaml
+++ b/mods/tuxemon/maps/spyder.yaml
@@ -304,7 +304,7 @@ events:
     actions:
     - set_party_status player
     conditions:
-    - is current_state MainCombatMenuState:WorldState
+    - is current_state MainCombatMenuState:WorldMenuState
     - is party_size player,greater_than,0
     type: "event"
   Cheat Code ApexPlayer:

--- a/tuxemon/combat.py
+++ b/tuxemon/combat.py
@@ -202,20 +202,6 @@ def defeated(character: NPC) -> bool:
     return fainted_party(character.monsters)
 
 
-def check_moves(monster: Monster, levels: int) -> Optional[str]:
-    """
-    Checks if during the levelling up there is/are new tech/s to learn.
-    If there is/are new tech/s it returns the message, otherwise None.
-    """
-    techs = monster.update_moves(levels)
-    if techs:
-        tech_list = ", ".join(tech.name.upper() for tech in techs)
-        params = {"name": monster.name.upper(), "tech": tech_list}
-        message = T.format("tuxemon_new_tech", params)
-        return message
-    return None
-
-
 def award_money(loser: Monster, winner: Monster) -> int:
     """
     It calculates money to be awarded. It allows multiple methods.

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -526,7 +526,8 @@ class Monster:
 
         """
         new_level = self.level - levels_earned
-        learned_techniques = []
+        new_moves = self.moves.copy()
+        new_techniques = []
         for move in self.moveset:
             if (
                 move.technique not in (m.slug for m in self.moves)
@@ -534,10 +535,11 @@ class Monster:
             ):
                 technique = Technique()
                 technique.load(move.technique)
-                learned_techniques.append(technique)
-                self.learn(technique)
+                new_moves.append(technique)
+                new_techniques.append(technique)
 
-        return learned_techniques
+        self.moves = new_moves
+        return new_techniques
 
     def experience_required(self, level_ofs: int = 0) -> int:
         """

--- a/tuxemon/states/combat/combat_animations.py
+++ b/tuxemon/states/combat/combat_animations.py
@@ -252,7 +252,7 @@ class CombatAnimations(ABC, Menu[None]):
                 icon.kill()
             self._status_icons[monster].clear()
             del self._monster_sprite_map[monster]
-            del self.hud[monster]
+            self.delete_hud(monster)
 
         self.animate_monster_leave(monster)
         self.task(kill_monster, 2)
@@ -795,7 +795,7 @@ class CombatAnimations(ABC, Menu[None]):
             self._monster_sprite_map[monster].kill()
             self.hud[monster].kill()
             del self._monster_sprite_map[monster]
-            del self.hud[monster]
+            self.delete_hud(monster)
 
         def shake_ball(initial_delay: float) -> None:
             # Define reusable shake animation functions
@@ -869,6 +869,15 @@ class CombatAnimations(ABC, Menu[None]):
             capture_capsule(breakout_delay)
             blink_monster(breakout_delay)
             show_failure(breakout_delay)
+
+    def delete_hud(self, monster: Monster) -> None:
+        """
+        Removes the specified monster's entry from the HUD.
+
+        Parameters:
+            monster: The monster to remove from the HUD.
+        """
+        del self.hud[monster]
 
     def update_hud(self, character: NPC, animate: bool = True) -> None:
         """


### PR DESCRIPTION
This PR focuses on refactoring the `perform_action` method in `combat.py`. Before diving into that, we're also simplifying the `show_monster_action_menu` function by breaking out the rectangle calculation into its own separate step.

The `perform_action` method has been a bit of a beast for a while now, and this PR is the first step in making it more manageable and easier to understand. We're starting by extracting the `play_animation` method, which was duplicated in each section of the original code. From there, we're creating three new methods, each handling a specific type of action. This should make the code more modular and easier to follow.

This PR has been updated with some significant changes. I've refactored the '`faint_monster`' method, which was getting a bit too long, as well as the '`animate_party_status`' method. I've also removed the '`check_moves`' method since it's no longer needed, as we can now get that info directly from '`update_moves`'. The most exciting change, though, is that the experience bar will now be animated before the HUD is updated.