### PR TITLE
track battle (combat.py)

### DIFF
--- a/tuxemon/combat.py
+++ b/tuxemon/combat.py
@@ -424,73 +424,136 @@ def track_battles(
     Returns:
         Message to display.
     """
-    _won = OutputBattle.won.value
-    _lost = OutputBattle.lost.value
-    _draw = OutputBattle.draw.value
+    battle_outcomes = {
+        "won": OutputBattle.won.value,
+        "lost": OutputBattle.lost.value,
+        "draw": OutputBattle.draw.value,
+    }
+
+    if output not in battle_outcomes:
+        raise ValueError("Invalid battle output")
+
     if output == "won":
-        winner = player
-        losers = players
-        info = {"name": winner.name.upper()}
-        if trainer_battle:
-            # register battle
-            for _loser in losers:
-                set_battle(session, OutputBattle.won, winner, _loser)
-            # set variables
-            if winner.isplayer:
-                set_var(session, "battle_last_result", _won)
-                set_var(session, "battle_last_winner", "player")
-                client = session.client.event_engine
-                var = ["player", prize]
-                client.execute_action("modify_money", var, True)
-                if prize > 0:
-                    set_var(session, "battle_last_prize", str(prize))
-                    info = {
-                        "name": winner.name.upper(),
-                        "prize": str(prize),
-                        "currency": "$",
-                    }
-                    return T.format("combat_victory_trainer", info)
-                else:
-                    return T.format("combat_victory", info)
+        return _handle_win(session, player, players, prize, trainer_battle)
+    elif output == "lost":
+        return _handle_loss(session, player, players, trainer_battle)
+    else:
+        return _handle_draw(session, player, players, trainer_battle)
+
+
+def _handle_win(
+    session: Session,
+    winner: NPC,
+    losers: Sequence[NPC],
+    prize: int,
+    trainer_battle: bool,
+) -> str:
+    """
+    Handles the case where the human player won the battle.
+
+    Parameters:
+        session: Session
+        winner: The human player.
+        losers: All the players that lost.
+        prize: Amount of money (prize) after fighting.
+        trainer_battle: Whether a trainer or wild encounter.
+
+    Returns:
+        Message to display.
+    """
+    info = {"name": winner.name.upper()}
+
+    if trainer_battle:
+        for loser in losers:
+            set_battle(session, OutputBattle.won, winner, loser)
+
+        if winner.isplayer:
+            set_var(session, "battle_last_result", OutputBattle.won.value)
+            set_var(session, "battle_last_winner", "player")
+            client = session.client.event_engine
+            var = ["player", prize]
+            client.execute_action("modify_money", var, True)
+
+            if prize > 0:
+                set_var(session, "battle_last_prize", str(prize))
+                info["prize"] = str(prize)
+                info["currency"] = "$"
+                return T.format("combat_victory_trainer", info)
             else:
-                set_var(session, "battle_last_winner", winner.slug)
-                set_var(session, "battle_last_trainer", winner.slug)
                 return T.format("combat_victory", info)
         else:
-            # wild monster
-            info = {"name": winner.name.upper()}
-            if winner.slug == "random_encounter_dummy":
-                info = {"name": winner.monsters[0].name.upper()}
+            set_var(session, "battle_last_winner", winner.slug)
+            set_var(session, "battle_last_trainer", winner.slug)
             return T.format("combat_victory", info)
-    elif output == "lost":
-        loser = player
-        winners = players
-        info = {"name": loser.name.upper()}
-        set_var(session, "teleport_clinic", _lost)
-        if trainer_battle:
-            # set variables
-            if loser.isplayer:
-                set_var(session, "battle_last_result", _lost)
-                set_var(session, "battle_last_loser", "player")
-            else:
-                set_var(session, "battle_last_loser", loser.slug)
-                set_var(session, "battle_last_trainer", loser.slug)
-            # register battle
-            for _winner in winners:
-                set_battle(session, OutputBattle.lost, loser, _winner)
-            return T.format("combat_defeat", info)
-        return ""
     else:
-        # draw
-        defeat = list(players)
-        defeat.remove(player)
-        set_var(session, "teleport_clinic", _lost)
-        if trainer_battle:
-            set_var(session, "battle_last_result", _draw)
-            for _player in defeat:
-                set_var(session, "battle_last_trainer", _player.slug)
-                set_battle(session, OutputBattle.draw, player, _player)
-        return T.translate("combat_draw")
+        if winner.slug == "random_encounter_dummy":
+            info["name"] = winner.monsters[0].name.upper()
+        return T.format("combat_victory", info)
+
+
+def _handle_loss(
+    session: Session,
+    loser: NPC,
+    winners: Sequence[NPC],
+    trainer_battle: bool,
+) -> str:
+    """
+    Handles the case where the human player lost the battle.
+
+    Parameters:
+        session: Session
+        loser: The human player.
+        winners: All the players that won.
+        trainer_battle: Whether a trainer or wild encounter.
+
+    Returns:
+        Message to display.
+    """
+    info = {"name": loser.name.upper()}
+    set_var(session, "teleport_clinic", OutputBattle.lost.value)
+
+    if trainer_battle:
+        if loser.isplayer:
+            set_var(session, "battle_last_result", OutputBattle.lost.value)
+            set_var(session, "battle_last_loser", "player")
+        else:
+            set_var(session, "battle_last_loser", loser.slug)
+            set_var(session, "battle_last_trainer", loser.slug)
+
+        for winner in winners:
+            set_battle(session, OutputBattle.lost, loser, winner)
+        return T.format("combat_defeat", info)
+    return ""
+
+
+def _handle_draw(
+    session: Session,
+    player: NPC,
+    players: Sequence[NPC],
+    trainer_battle: bool,
+) -> str:
+    """
+    Handles the case where the battle was a draw.
+
+    Parameters:
+        session: Session
+        player: The human player.
+        players: All the players.
+        trainer_battle: Whether a trainer or wild encounter.
+
+    Returns:
+        Message to display.
+    """
+    defeat = list(players)
+    defeat.remove(player)
+    set_var(session, "teleport_clinic", OutputBattle.draw.value)
+
+    if trainer_battle:
+        set_var(session, "battle_last_result", OutputBattle.draw.value)
+        for player_defeated in defeat:
+            set_var(session, "battle_last_trainer", player_defeated.slug)
+            set_battle(session, OutputBattle.draw, player, player_defeated)
+    return T.translate("combat_draw")
 
 
 def set_var(session: Session, key: str, value: str) -> None:


### PR DESCRIPTION
PR is a start in refactoring the `track_battles` function. By breaking it down into separate methods for each scenario - win, lose, and draw - the code becomes much more readable and maintainable. It's a solid first step, and I'm already thinking ahead to potentially dedicating a whole class to handling the output - that's definitely something to explore further.