### PR TITLE
cinema mode (event actions)

### DIFF
--- a/tuxemon/event/actions/start_cinema_mode.py
+++ b/tuxemon/event/actions/start_cinema_mode.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import final
+from typing import Optional, final
 
 from tuxemon.event.eventaction import EventAction
+from tuxemon.states.world.worldstate import WorldState
 
 
 @final
@@ -14,15 +15,31 @@ class StartCinemaModeAction(EventAction):
     """
     Start cinema mode by animating black bars to narrow the aspect ratio.
 
+    For a cinematic experience, specify the width of the horizontal and
+    vertical black bars as a ratio of the screen resolution.
+    For example, to achieve a 2.39:1 aspect ratio on a 1920x1080 screen,
+    you would set the horizontal ratio to 0.42 (1920 / 1080 * (16/9 - 2.39/1))
+    and the vertical ratio to 0 (no vertical bars).
+
+    By default only bar up and down.
+
     Script usage:
         .. code-block::
 
-            start_cinema_mode
+            start_cinema_mode [aspect_y_ratio][,aspect_x_ratio]
 
+    Script parameters:
+        aspect_y_ratio: The width of the horizontal black bars as a ratio of
+            the screen resolution. Default standard cinema mode.
+        aspect_x_ratio: The width of the vertical black bars as a ratio of
+            the screen resolution. Default None.
     """
 
     name = "start_cinema_mode"
+    aspect_y_ratio: Optional[float] = 2.39
+    aspect_x_ratio: Optional[float] = None
 
     def start(self) -> None:
-        player = self.session.player
-        player.game_variables["cinema_mode"] = "on"
+        world = self.session.client.get_state_by_name(WorldState)
+        world.cinema_y_ratio = self.aspect_y_ratio
+        world.cinema_x_ratio = self.aspect_x_ratio

--- a/tuxemon/event/actions/stop_cinema_mode.py
+++ b/tuxemon/event/actions/stop_cinema_mode.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import final
 
 from tuxemon.event.eventaction import EventAction
+from tuxemon.states.world.worldstate import WorldState
 
 
 @final
@@ -24,5 +25,6 @@ class StopCinemaModeAction(EventAction):
     name = "stop_cinema_mode"
 
     def start(self) -> None:
-        player = self.session.player
-        player.game_variables["cinema_mode"] = "off"
+        world = self.session.client.get_state_by_name(WorldState)
+        world.cinema_x_ratio = None
+        world.cinema_y_ratio = None

--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -160,6 +160,8 @@ class WorldState(state.State):
 
         # bubble above the player's head
         self.bubble: dict[NPC, pygame.surface.Surface] = {}
+        self.cinema_x_ratio: Optional[float] = None
+        self.cinema_y_ratio: Optional[float] = None
 
         ######################################################################
         #                       Fullscreen Animations                        #
@@ -482,17 +484,43 @@ class WorldState(state.State):
             surface, surface.get_rect(), screen_surfaces
         )
 
-    def apply_cinema_mode(self, surface: pygame.surface.Surface) -> None:
-        """Apply cinema mode if necessary."""
-        top_bar = pygame.Surface((self.resolution[0], self.resolution[1] / 6))
-        bottom_bar = pygame.Surface(
-            (self.resolution[0], self.resolution[1] / 6)
-        )
-        top_bar.fill(prepare.BLACK_COLOR)
-        bottom_bar.fill(prepare.BLACK_COLOR)
-        surface.blit(top_bar, (0, 0))
-        bottom = surface.get_rect().bottom - self.resolution[1] / 6
-        surface.blit(bottom_bar, (0, bottom))
+    def apply_vertical_bars(
+        self, surface: pygame.surface.Surface, aspect_ratio: float
+    ) -> None:
+        """
+        Add vertical black bars to the top and bottom of the screen
+        to achieve a cinematic aspect ratio.
+        """
+        screen_aspect_ratio = self.resolution[0] / self.resolution[1]
+        if screen_aspect_ratio < aspect_ratio:
+            bar_height = int(
+                self.resolution[1]
+                * (1 - screen_aspect_ratio / aspect_ratio)
+                / 2
+            )
+            bar = pygame.Surface((self.resolution[0], bar_height))
+            bar.fill(prepare.BLACK_COLOR)
+            surface.blit(bar, (0, 0))
+            surface.blit(bar, (0, self.resolution[1] - bar_height))
+
+    def apply_horizontal_bars(
+        self, surface: pygame.surface.Surface, aspect_ratio: float
+    ) -> None:
+        """
+        Add horizontal black bars to the left and right of the screen
+        to achieve a cinematic aspect ratio.
+        """
+        screen_aspect_ratio = self.resolution[1] / self.resolution[0]
+        if screen_aspect_ratio < aspect_ratio:
+            bar_width = int(
+                self.resolution[0]
+                * (1 - screen_aspect_ratio / aspect_ratio)
+                / 2
+            )
+            bar = pygame.Surface((bar_width, self.resolution[1]))
+            bar.fill(prepare.BLACK_COLOR)
+            surface.blit(bar, (0, 0))
+            surface.blit(bar, (self.resolution[0] - bar_width, 0))
 
     def set_bubble(
         self, screen_surfaces: list[tuple[pygame.surface.Surface, Rect, int]]
@@ -552,9 +580,10 @@ class WorldState(state.State):
             self.debug_drawing(surface)
 
         # Apply cinema mode
-        cinema = self.player.game_variables.get("cinema_mode", "")
-        if cinema == "on":
-            self.apply_cinema_mode(surface)
+        if self.cinema_x_ratio is not None:
+            self.apply_horizontal_bars(surface, self.cinema_x_ratio)
+        if self.cinema_y_ratio is not None:
+            self.apply_vertical_bars(surface, self.cinema_y_ratio)
 
     def get_sprites(self, npc: NPC, layer: int) -> list[WorldSurfaces]:
         """


### PR DESCRIPTION
PR removes all references to the player and game variables from the map drawing function. This change allows for better management of cinema mode in the game world. To achieve this, I've renamed the method to 'apply vertical and horizontal bars' and introduced a float attribute that modders can use to customize the cinema mode experience.

By default, setting the value to 2.39 will trigger the traditional cinema mode with bars at the top and bottom. However, modders are free to experiment with different values and combinations to create unique effects. For example, they can choose to leave the horizontal bars untouched or try out other configurations to suit their needs.

@kerizane with this we can close #375? From what I understood it's a mix of Camera (already merged) + bars (this PR)

Some tests:

`    <property name="act1" value="start_cinema_mode 2.39,2.39"/>`

![Screenshot_2024-10-05_14-18-35](https://github.com/user-attachments/assets/2d2b63ae-27e1-4b7e-9f1b-14e472f98b14)

`    <property name="act1" value="start_cinema_mode 5"/>`

![Screenshot_2024-10-05_14-17-57](https://github.com/user-attachments/assets/291952c7-28ee-4346-bebe-10b6f89d4d95)

`    <property name="act1" value="start_cinema_mode 2.39"/>`

![Screenshot_2024-10-05_14-17-22](https://github.com/user-attachments/assets/b7c04ef3-170f-48c9-a322-8a798becff76)
