### PR TITLE
fix 2487 + fix 2490

### DIFF
--- a/mods/tuxemon/maps/spyder.yaml
+++ b/mods/tuxemon/maps/spyder.yaml
@@ -48,6 +48,7 @@ events:
     - format_variable cathedral_fee,int
     - modify_money bill_cathedral,,cathedral_fee
     conditions:
+    - is char_defeated player
     - is location_type clinic
     - is variable_set teleport_clinic:lost
     - is current_state WorldState

--- a/mods/tuxemon/maps/spyder_candy_hospital3.tmx
+++ b/mods/tuxemon/maps/spyder_candy_hospital3.tmx
@@ -134,6 +134,7 @@
     <property name="act58" value="set_monster_attribute add_monster,gender,male"/>
     <property name="act60" value="start_battle player,spyder_billie"/>
     <property name="act61" value="translated_dialog spyder_hospital_billie2"/>
+    <property name="act62" value="set_party_attribute player,plague,inoculated"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
     <property name="cond3" value="not variable_set hospitalcure:yes"/>

--- a/tuxemon/event/actions/quarantine.py
+++ b/tuxemon/event/actions/quarantine.py
@@ -45,6 +45,7 @@ class QuarantineAction(EventAction):
             infect = PlagueType.infected
             plague = [mon for mon in player.monsters if mon.plague == infect]
             for _monster in plague:
+                _monster.plague = PlagueType.inoculated
                 player.monster_boxes[self.name].append(_monster)
                 player.remove_monster(_monster)
                 logger.info(f"{_monster} has been quarantined")


### PR DESCRIPTION
PR fixes #2487 I noticed that the quarantine event was healing the monster and making it inoculated when it was removed, but not when it was sent to the quarantine box. To fix this, I added a line of code to make all monsters inoculated as soon as they're sent to the box. I also added another line to the CURE event in the hospital, which now inoculates the entire party. This should resolve the issue for now, but I'm not entirely happy with the current plague mechanism, so this is just a temporary fix. I'm planning to revisit and make it more flexible in the future.

PR fixes #2490 after digging into the issue, I found the problem with the autohealing action - it was missing a crucial condition. It needed to check if the player's party was completely defeated before triggering. Adding that condition should fix the issue. I was also able to reproduce the problem using an old savegame, which helped confirm the solution.