### PR TITLE
transition (remove_collision + check)

### DIFF
--- a/tuxemon/event/actions/delayed_teleport.py
+++ b/tuxemon/event/actions/delayed_teleport.py
@@ -53,7 +53,6 @@ class DelayedTeleportAction(EventAction):
             logger.error(f"{self.character} not found")
             return
 
-        char.remove_collision(char.tile_pos)
         world.teleporter.delayed_char = char
         world.teleporter.delayed_teleport = True
         world.teleporter.delayed_mapname = self.map_name

--- a/tuxemon/event/actions/transition_teleport.py
+++ b/tuxemon/event/actions/transition_teleport.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Optional, final
 
 from tuxemon.event.eventaction import EventAction
-from tuxemon.prepare import TRANS_TIME
+from tuxemon.prepare import TRANS_TIME, fetch
 from tuxemon.states.world.worldstate import WorldState
 
 
@@ -43,7 +43,9 @@ class TransitionTeleportAction(EventAction):
     def start(self) -> None:
         self.world = self.session.client.get_state_by_name(WorldState)
 
-        if self.world.npcs:
+        target_map = fetch("maps", self.map_name)
+
+        if self.world.npcs and self.world.current_map.filename != target_map:
             for _npc in self.world.npcs:
                 if _npc.moving or _npc.path:
                     self.world.npcs.remove(_npc)

--- a/tuxemon/teleporter.py
+++ b/tuxemon/teleporter.py
@@ -90,6 +90,9 @@ class Teleporter:
 
         target_map = prepare.fetch("maps", map_name)
 
+        logger.debug(f"Removing {character.slug}'s collision zone")
+        character.remove_collision(character.tile_pos)
+
         if (
             world.current_map is None
             or target_map != world.current_map.filename


### PR DESCRIPTION
This PR addresses an issue with **transition_teleport** when it's used within **the same map**. To fix this, I've added a check to see if the map is indeed the same, and if so, we can skip removing the NPC since the player will be removed as well. I've also moved the **remove_collision** logic from the **delayed_teleport** event action to the main **teleporter**, and added a debug log for good measure.





