### PR TITLE
fix method use (bug)

### DIFF
--- a/tuxemon/condition/condition.py
+++ b/tuxemon/condition/condition.py
@@ -271,7 +271,15 @@ class Condition:
         # Loop through all the effects of this condition and execute the effect's function.
         for effect in self.effects:
             result = effect.apply(self, target)
-            meta_result.update(result)
+            meta_result["success"] = (
+                meta_result["success"] or result["success"]
+            )
+            if result["condition"] is not None:
+                meta_result["condition"] = result["condition"]
+            if result["technique"] is not None:
+                meta_result["technique"] = result["technique"]
+            if result["extra"] is not None:
+                meta_result["extra"] = result["extra"]
 
         return meta_result
 

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -238,7 +238,12 @@ class Item:
         # Loop through all the effects of this technique and execute the effect's function.
         for effect in self.effects:
             result = effect.apply(self, target)
-            meta_result.update(result)
+            meta_result["success"] = (
+                meta_result["success"] or result["success"]
+            )
+            meta_result["num_shakes"] += result["num_shakes"]
+            if result["extra"] is not None:
+                meta_result["extra"] = result["extra"]
 
         # If this is a consumable item, remove it from the player's inventory.
         if (

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -298,7 +298,16 @@ class Technique:
         # Loop through all the effects of this technique and execute the effect's function.
         for effect in self.effects:
             result = effect.apply(self, user, target)
-            meta_result.update(result)
+            meta_result["success"] = (
+                meta_result["success"] or result["success"]
+            )
+            meta_result["should_tackle"] = (
+                meta_result["should_tackle"] or result["should_tackle"]
+            )
+            meta_result["damage"] += result["damage"]
+            meta_result["element_multiplier"] *= result["element_multiplier"]
+            if result["extra"] is not None:
+                meta_result["extra"] = result["extra"]
 
         self.next_use = self.recharge_length
 


### PR DESCRIPTION
PR fixes a bug. A bug I came across while refactoring the technique effects in PR 2516. I was testing and noticed that when multiple effects were applied, the values were getting overwritten, causing some important data to get lost.
```
  "effects": [
    "damage",
    "switch target,wood"
  ],
```
For example, if an **effects** field had both '**damage**' and '**switch**', the '**damage**' value would get overwritten and default to **0**. This was causing some pretty annoying issues, especially since the damage data is used to determine which monster hit the opponent and affects the experience points. Issue with **should_tackle** too.
```
  "effects": [
    "switch target,wood"
    "damage"
  ],
```
But if '**switch**' came first, the message about changing elements wouldn't display at all, because the '**extra**' field would get overwritten with None.

I've fixed the issue, but I'm not entirely satisfied yet. I'm thinking about making some additional improvements to the TechEffectResult (and Item and Condition) classes. One idea I had was to use a list for the 'extra' field instead of an Optional[str], and maybe even replace the TypedDict with a dataclass.

If anyone has some suggestions or ideas, I'd love to hear them.