### PR TITLE
update technique effects ('fly_off' and 'land')

### DIFF
--- a/mods/tuxemon/db/technique/altitude.json
+++ b/mods/tuxemon/db/technique/altitude.json
@@ -7,7 +7,7 @@
 	  	"not status stuck"
 	],
 	"effects": [
-		"fly_off hawk"
+		"disappear hawk"
 	],
   "flip_axes": "",
   "is_fast": true,
@@ -32,7 +32,7 @@
     "wood",
     "earth"
   ],
-  "use_failure": "combat_miss",
-  "use_success": null,
+  "use_failure": "altitude_fail",
+  "use_success": "altitude_success",
   "use_tech": "combat_used_x"
 }

--- a/mods/tuxemon/db/technique/hawk.json
+++ b/mods/tuxemon/db/technique/hawk.json
@@ -3,7 +3,7 @@
   "accuracy": 1,
   "animation": "slash_power",
   "effects": [
-    "land",
+    "appear",
     "damage"
   ],
   "flip_axes": "",

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -835,9 +835,6 @@ msgstr "Phone keeps ringing but no answer!"
 
 ## NOTIFICATION TRANSLATIONS ##
 # Combat notifications
-msgid "combat_fly"
-msgstr "{name} flies up high!"
-
 msgid "combat_scope"
 msgstr "AR:{AR} DE:{DE} ME:{ME} RD:{RD} SD:{SD}"
 
@@ -1345,6 +1342,12 @@ msgstr "All In"
 
 msgid "altitude_description"
 msgstr "Fly high out of reach, then dive with a powerful attack."
+
+msgid "altitude_success"
+msgstr "{user} flies up high!"
+
+msgid "altitude_fail"
+msgstr "{user} fails to gain altitude!"
 
 msgid "altitude"
 msgstr "Altitude"

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -865,30 +865,29 @@ class CombatState(CombatAnimations):
                 message += "\n" + result_status["extra"]
             if result_status["condition"]:
                 user.apply_status(result_status["condition"])
-        # successful techniques
-        if result_tech["success"]:
-            m: Union[str, None] = None
-            # extra output
-            if result_tech["extra"]:
-                m = T.translate(result_tech["extra"])
-            if m:
-                message += "\n" + m
-                action_time += compute_text_animation_time(message)
-        # not successful techniques
-        if not result_tech["success"]:
+
+        if result_tech["success"] and method.use_success:
+            template = getattr(method, "use_success")
+            m = T.format(template, context)
+        elif not result_tech["success"] and method.use_failure:
             template = getattr(method, "use_failure")
             m = T.format(template, context)
-            # extra output
-            if result_tech["extra"]:
-                m = T.translate(result_tech["extra"])
+        else:
+            m = None
+
+        if result_tech["extra"]:
+            m = (m or "") + "\n" + T.translate(result_tech["extra"])
+
+        if m:
             message += "\n" + m
             action_time += compute_text_animation_time(message)
+
         self.play_sound_effect(method.sfx)
         # animation own_monster, technique doesn't tackle
         hit_delay += 0.5
         if method.target["own_monster"]:
             target_sprite = self._monster_sprite_map.get(user, None)
-        # TODO: a real check or some params to test if should tackle, etc
+
         if result_tech["should_tackle"]:
             user_sprite = self._monster_sprite_map.get(user, None)
             if user_sprite:
@@ -907,15 +906,13 @@ class CombatState(CombatAnimations):
                     hit_delay + 0.6,
                 )
 
-            # Track damage
             self.enqueue_damage(user, target, result_tech["damage"])
 
-            # monster infected
             if PlagueType.infected in user.plague.values():
                 params = {"target": user.name.upper()}
                 m = T.format("combat_state_plague1", params)
                 message += "\n" + m
-            # allows tackle to special range techniques too
+
             if method.range != "special":
                 element_damage_key = prepare.MULT_MAP.get(
                     result_tech["element_multiplier"]
@@ -924,20 +921,7 @@ class CombatState(CombatAnimations):
                     m = T.translate(element_damage_key)
                     message += "\n" + m
                     action_time += compute_text_animation_time(message)
-            else:
-                msg_type = (
-                    "use_success" if result_tech["success"] else "use_failure"
-                )
-                context = {
-                    "user": getattr(user, "name", ""),
-                    "name": method.name,
-                    "target": target.name,
-                }
-                template = getattr(method, msg_type)
-                tmpl = T.format(template, context)
-                if template:
-                    message += "\n" + tmpl
-                    action_time += compute_text_animation_time(message)
+
         self.text_animations_queue.append(
             (partial(self.alert, message), action_time)
         )
@@ -989,11 +973,6 @@ class CombatState(CombatAnimations):
             msg_type = (
                 "use_success" if result_item["success"] else "use_failure"
             )
-            context = {
-                "user": getattr(user, "name", ""),
-                "name": method.name,
-                "target": target.name,
-            }
             template = getattr(method, msg_type)
             tmpl = T.format(template, context)
             # extra output

--- a/tuxemon/technique/effects/appear.py
+++ b/tuxemon/technique/effects/appear.py
@@ -12,44 +12,44 @@ if TYPE_CHECKING:
     from tuxemon.technique.technique import Technique
 
 
-class LandEffectResult(TechEffectResult):
+class AppearEffectResult(TechEffectResult):
     pass
 
 
 @dataclass
-class LandEffect(TechEffect):
+class AppearEffect(TechEffect):
     """
-    Tuxemon lands.
+    Tuxemon re-appears, it follows "disappear".
 
     """
 
-    name = "land"
+    name = "appear"
 
     def apply(
         self, tech: Technique, user: Monster, target: Monster
-    ) -> LandEffectResult:
+    ) -> AppearEffectResult:
         combat = tech.combat_state
         assert combat
-        # Check if the user is flying
+        # Check if the user is disappeared
         user_sprite = combat._monster_sprite_map.get(user, None)
         if user_sprite and not user_sprite.visible:
-            # Make the user land
+            # Make the user appear
             user_sprite.visible = True
             user.out_of_range = False
 
-        # Check if the target is flying
+        # Check if the target is disappeared
         target_sprite = combat._monster_sprite_map.get(target, None)
         if target_sprite and not target_sprite.visible:
-            # If the target is flying, don't tackle
-            target_is_flying = True
+            # If the target is disappeared, don't tackle
+            target_is_disappeared = True
         else:
-            target_is_flying = False
+            target_is_disappeared = False
 
         # Return the result
         return {
-            "success": not target_is_flying,
+            "success": not target_is_disappeared,
             "damage": 0,
             "element_multiplier": 0.0,
-            "should_tackle": not target_is_flying,
+            "should_tackle": not target_is_disappeared,
             "extra": None,
         }

--- a/tuxemon/technique/effects/disappear.py
+++ b/tuxemon/technique/effects/disappear.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from tuxemon.locale import T
 from tuxemon.states.combat.combat_classes import EnqueuedAction
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
 from tuxemon.technique.technique import Technique
@@ -14,34 +13,32 @@ if TYPE_CHECKING:
     from tuxemon.monster import Monster
 
 
-class FlyOffEffectResult(TechEffectResult):
+class DisappearEffectResult(TechEffectResult):
     pass
 
 
 @dataclass
-class FlyOffEffect(TechEffect):
+class DisappearEffect(TechEffect):
     """
-    Tuxemon flies off.
+    Tuxemon disappears. It's followed by "appear".
 
     Parameters:
         attack: slug technique (attack when lands).
-
     """
 
-    name = "fly_off"
+    name = "disappear"
     attack: str
 
     def apply(
         self, tech: Technique, user: Monster, target: Monster
-    ) -> FlyOffEffectResult:
-        user_is_flying = False
+    ) -> DisappearEffectResult:
         combat = tech.combat_state
         assert combat
 
         # Get the user's sprite
         user_sprite = combat._monster_sprite_map.get(user, None)
         if user_sprite and user_sprite.visible:
-            # Make the user fly
+            # Make the user disappear
             user_sprite.visible = False
             user.out_of_range = True
             # Create a new technique to land the user
@@ -50,17 +47,11 @@ class FlyOffEffect(TechEffect):
             # Add the land action to the pending queue
             land_action = EnqueuedAction(user, land_technique, target)
             combat._pending_queue.append(land_action)
-        else:
-            # If the user is already flying, don't do anything
-            user_is_flying = True
-
-        params = {"name": user.name.upper()}
-        extra = T.format("combat_fly", params)
 
         return {
-            "success": not user_is_flying,
+            "success": user.out_of_range,
             "damage": 0,
             "element_multiplier": 0.0,
             "should_tackle": False,
-            "extra": extra,
+            "extra": None,
         }


### PR DESCRIPTION
PR updates and changes name to 'fly_off' and 'land' effects (technique)t.

The main goal was to make the technique effects more generic and less hardcoded. To achieve this, I've renamed the 'fly_off' effect to '**disappear**' and the 'land' effect to '**appear**'. This change makes the logic more flexible and opens up possibilities for future moves that use similar mechanisms, such as '**burrow**' or '**dive**'.

While testing the changes, I noticed a few opportunities to simplify the code. For instance, I realized that the extra code in 'fly_off' was unnecessary, as we can use the existing '**use_success**' field instead. This led me to take a closer look at the combat.py file, where I was able to remove some redundant code related to displaying messages. This cleanup helps to make the code more efficient and easier to maintain.