### PR TITLE
cooldown types

### DIFF
--- a/tuxemon/technique/effects/cooldown.py
+++ b/tuxemon/technique/effects/cooldown.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from tuxemon.db import ElementType
 from tuxemon.event.conditions.common import CommonCondition
 from tuxemon.prepare import RECHARGE_RANGE
 from tuxemon.technique.techeffect import TechEffect, TechEffectResult
@@ -75,13 +76,20 @@ class CoolDownEffect(TechEffect):
             )
             moves_to_update = [move for mon in monsters for move in mon.moves]
 
-        moves_to_update = [
-            move
-            for move in moves_to_update
-            if not CommonCondition().check_parameter(
-                move, self.parameter, self.value
-            )
-        ]
+        if self.parameter == "types":
+            moves_to_update = [
+                move
+                for move in moves_to_update
+                if move.has_type(ElementType(self.value))
+            ]
+        else:
+            moves_to_update = [
+                move
+                for move in moves_to_update
+                if not CommonCondition().check_parameter(
+                    move, self.parameter, self.value
+                )
+            ]
 
         _update_moves(moves_to_update, self.next_use)
         if self.next_use > 0:


### PR DESCRIPTION
PR updates 'cooldown' effect. @Sanglorian has a great idea that we could make the effect even better. Now, we you can easily adjust the recharge (technique) for different types.

`"cooldown user,3,types,metal"` targeting the moves that contain metal in the types