### PR TITLE
fix levels (combat.py)

### DIFF
--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -876,7 +876,11 @@ class CombatState(CombatAnimations):
             m = None
 
         if result_tech["extra"]:
-            m = (m or "") + "\n" + T.translate(result_tech["extra"])
+            m = (
+                (m or "")
+                + ("\n" if m else "")
+                + T.translate(result_tech["extra"])
+            )
 
         if m:
             message += "\n" + m
@@ -1072,6 +1076,7 @@ class CombatState(CombatAnimations):
         """
         winners = get_winners(monster, self._damage_map)
         if winners:
+            new_techniques = []
             for winner in winners:
                 # Award money and experience
                 awarded_mon = award_money(monster, winner)
@@ -1081,10 +1086,9 @@ class CombatState(CombatAnimations):
 
                 if winner.owner and winner.owner.isplayer:
                     levels = winner.give_experience(awarded_exp)
+                    new_techniques = winner.update_moves(levels)
                     if self.is_trainer_battle:
                         self._prize += awarded_mon
-                else:
-                    levels = 0
 
                 # Log experience gain
                 if winner.owner and winner.owner.isplayer:
@@ -1097,23 +1101,22 @@ class CombatState(CombatAnimations):
                         self._xp_message = T.format("combat_gain_exp", params)
 
                 # Update HUD and handle level up
-                self.update_hud_and_level_up(winner, levels)
+                self.update_hud_and_level_up(winner, new_techniques)
 
-    def update_hud_and_level_up(self, winner: Monster, levels: int) -> None:
+    def update_hud_and_level_up(
+        self, winner: Monster, techniques: list[Technique]
+    ) -> None:
         """
         Update the HUD and handle level ups for the winner.
 
         Parameters:
             winner: Monster that won the battle.
-            levels: Number of levels gained.
+            techniques: List of learned techniques.
 
         """
         if winner in self.monsters_in_play_right:
-            new_techniques = winner.update_moves(levels)
-            if new_techniques:
-                tech_list = ", ".join(
-                    tech.name.upper() for tech in new_techniques
-                )
+            if techniques:
+                tech_list = ", ".join(tech.name.upper() for tech in techniques)
                 params = {"name": winner.name.upper(), "tech": tech_list}
                 mex = T.format("tuxemon_new_tech", params)
                 if self._xp_message is not None:
@@ -1305,8 +1308,8 @@ class CombatState(CombatAnimations):
         # clear action queue
         self._action_queue.clear_queue()
         self._action_queue.clear_history()
-        self._pending_queue = list()
-        self._damage_map = list()
+        self._pending_queue = []
+        self._damage_map = []
 
     def end_combat(self) -> None:
         """End the combat."""


### PR DESCRIPTION
I found a bug while testing for #2527 and this pull request fixes it. The issue was that when two monsters leveled up after a battle, only the last one would get the technique. This was happening because the levels were being overwritten. To fix this, I've changed the code to pass the list of learned techniques instead of the levels. This should resolve the bug, but I've noticed that the message still doesn't display entirely. However, that's being addressed in a separate PR related to the callback, so we can tackle that issue next.

I've tweaked the string concatenation code and it's now fixed the issue where an extra value would cause an empty line to appear.

unrelated: @Sanglorian what if we made it so that monsters learn techniques at uneven levels and evolve at even levels (or vice versa)? Since there are fewer evolutions to modify than techniques in the moveset, it might be easier to implement evolving at uneven levels. This could be a nice quality of life improvement. I could also add a simple test to make sure everything works as expected. What do you think?