### PR TITLE
test + at_level (evolutions) + level_learned (moveset)

### DIFF
--- a/mods/tuxemon/db/monster/aardart.json
+++ b/mods/tuxemon/db/monster/aardart.json
@@ -3,23 +3,23 @@
     "category": "anteater",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "tonguespear"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "hibernate"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "evasion"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "stampede"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "lantern"
         },
         {
@@ -27,7 +27,7 @@
             "technique": "assault"
         },
 	    {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "feint"
         },
 	    {
@@ -35,7 +35,7 @@
             "technique": "sand_spray"
         },
 	    {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "mudslide"
         }
     ],

--- a/mods/tuxemon/db/monster/aardorn.json
+++ b/mods/tuxemon/db/monster/aardorn.json
@@ -3,23 +3,23 @@
     "category": "snout",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "tonguespear"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "hibernate"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "evasion"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "stampede"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "lantern"
         },
         {
@@ -27,7 +27,7 @@
             "technique": "assault"
         },
 	    {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "feint"
         },
 	    {
@@ -35,7 +35,7 @@
             "technique": "sand_spray"
         },
 	    {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "mudslide"
         }
     ],

--- a/mods/tuxemon/db/monster/abesnaki.json
+++ b/mods/tuxemon/db/monster/abesnaki.json
@@ -3,23 +3,23 @@
     "category": "shield-mask",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "spit_poison"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "crystal"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "sleep_bomb"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "ruby"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "kindling_flame"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "nest"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "magma"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "surge"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "chameleon"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "salamander"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "glower"
         },
         {

--- a/mods/tuxemon/db/monster/agnidon.json
+++ b/mods/tuxemon/db/monster/agnidon.json
@@ -3,23 +3,23 @@
     "category": "false_dragon",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_claw"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_ball"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "one_two"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "saber"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "fume"
         },
         {
@@ -27,7 +27,7 @@
             "technique": "kindling_flame"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "energy_claws"
         },
         {
@@ -35,11 +35,11 @@
             "technique": "breathe_fire"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "take_cover"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "muddle"
         },
         {

--- a/mods/tuxemon/db/monster/agnigon.json
+++ b/mods/tuxemon/db/monster/agnigon.json
@@ -3,23 +3,23 @@
     "category": "false_dragon",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_claw"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_ball"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "one_two"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "saber"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "fume"
         },
         {
@@ -27,7 +27,7 @@
             "technique": "kindling_flame"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "energy_claws"
         },
         {
@@ -35,11 +35,11 @@
             "technique": "breathe_fire"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "take_cover"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "muddle"
         },
         {

--- a/mods/tuxemon/db/monster/agnite.json
+++ b/mods/tuxemon/db/monster/agnite.json
@@ -3,23 +3,23 @@
     "category": "false_dragon",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_claw"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_ball"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "one_two"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "saber"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "fume"
         },
         {
@@ -27,7 +27,7 @@
             "technique": "kindling_flame"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "energy_claws"
         },
         {
@@ -35,11 +35,11 @@
             "technique": "breathe_fire"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "take_cover"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "muddle"
         },
         {

--- a/mods/tuxemon/db/monster/agnsher.json
+++ b/mods/tuxemon/db/monster/agnsher.json
@@ -3,23 +3,23 @@
     "category": "threat",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_shield"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sunburst"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "salamander"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "energy_claws"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "surge"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "invictus"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "shapechange"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "berserk"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "fiery"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "torch"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "proboscis"
         },
         {

--- a/mods/tuxemon/db/monster/allagon.json
+++ b/mods/tuxemon/db/monster/allagon.json
@@ -3,23 +3,23 @@
     "category": "dragon",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "viper"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "insanity"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "undertaker"
         },
         {
@@ -31,15 +31,15 @@
             "technique": "rust_bomb"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "shuriken"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 60,
+            "level_learned": 61,
             "technique": "amnesia"
         },
         {
@@ -47,7 +47,7 @@
             "technique": "muddle"
         },
         {
-            "level_learned": 68,
+            "level_learned": 70,
             "technique": "bullet"
         }
     ],

--- a/mods/tuxemon/db/monster/altie.json
+++ b/mods/tuxemon/db/monster/altie.json
@@ -3,23 +3,23 @@
     "category": "alien",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "demiurge"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "strike"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "arcane_eye"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "bullet"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "meltdown"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "crystal"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "muddle"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "neutralize"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "ruby"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "lightning_spheres"
         },
         {

--- a/mods/tuxemon/db/monster/ambuwl.json
+++ b/mods/tuxemon/db/monster/ambuwl.json
@@ -3,23 +3,23 @@
     "category": "restorative",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "peck"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "mending"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "mudslide"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "stampede"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "evasion"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "lantern"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "life_surge"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "breath"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "neutralize"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "fledgling"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "tip"
         },
         {

--- a/mods/tuxemon/db/monster/ampystoma.json
+++ b/mods/tuxemon/db/monster/ampystoma.json
@@ -3,23 +3,23 @@
     "category": "lightning_salamander",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "starfall"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "midnight_mantle"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "spit_poison"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "frostbite"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "snowstorm"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "torch"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "flood"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "ice_shield"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "goad"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "grinding"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "proboscis"
         },
         {

--- a/mods/tuxemon/db/monster/angesnow.json
+++ b/mods/tuxemon/db/monster/angesnow.json
@@ -3,23 +3,23 @@
     "category": "driven_snow",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "frostbite"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "goad"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "beam"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "orbs"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "neutralize"
         },
         {

--- a/mods/tuxemon/db/monster/angrito.json
+++ b/mods/tuxemon/db/monster/angrito.json
@@ -3,27 +3,27 @@
     "category": "enraged_emotion",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "blade"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "strike"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "fire_ball"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "fire_claw"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "flamethrower"
         }
     ],

--- a/mods/tuxemon/db/monster/anoleaf.json
+++ b/mods/tuxemon/db/monster/anoleaf.json
@@ -3,27 +3,27 @@
     "category": "sprout",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sting"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "feint"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "assault"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "chameleon"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "whirlwind"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "splinter"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "peregrine"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "pseudopod"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "wing_tip"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "all_in"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "invictus"
         }
     ],

--- a/mods/tuxemon/db/monster/anu.json
+++ b/mods/tuxemon/db/monster/anu.json
@@ -3,23 +3,23 @@
     "category": "dream_fox",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "shuriken"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "muddle"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "lineage"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "bubble_trap"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "slice"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "meltdown"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "lightning_spheres"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "peregrine"
         },
         {

--- a/mods/tuxemon/db/monster/apeoro.json
+++ b/mods/tuxemon/db/monster/apeoro.json
@@ -3,31 +3,31 @@
     "category": "old_block",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sleep_bomb"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "terror"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "insanity"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "bubble_trap"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "strike"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "constrict"
         },
         {

--- a/mods/tuxemon/db/monster/araignee.json
+++ b/mods/tuxemon/db/monster/araignee.json
@@ -3,23 +3,23 @@
     "category": "weaver",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "web"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "petrify"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "beam"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "muddle"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "platinum"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "lineage"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "rust_bomb"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "meltdown"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "insanity"
         },
         {

--- a/mods/tuxemon/db/monster/arthrobolt.json
+++ b/mods/tuxemon/db/monster/arthrobolt.json
@@ -3,11 +3,11 @@
     "category": "foreman",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "bullet"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "static_field"
         },
         {
@@ -15,15 +15,15 @@
             "technique": "shuriken"
         },
         {
-            "level_learned": 6,
+            "level_learned": 7,
             "technique": "clamp_on"
         },
         {
-            "level_learned": 8,
+            "level_learned": 10,
             "technique": "muddle"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "bubble_trap"
         },
         {
@@ -31,11 +31,11 @@
             "technique": "beam"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "surge"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "thunderclap"
         }
     ],

--- a/mods/tuxemon/db/monster/asudopt.json
+++ b/mods/tuxemon/db/monster/asudopt.json
@@ -3,15 +3,15 @@
     "category": "god_penguin",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "peck"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "solar_synthesis"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "wing_tip"
         },
         {
@@ -19,11 +19,11 @@
             "technique": "peregrine"
         },
         {
-            "level_learned": 14,
+            "level_learned": 13,
             "technique": "whirlwind"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "flamethrower"
         }
     ],

--- a/mods/tuxemon/db/monster/av8r.json
+++ b/mods/tuxemon/db/monster/av8r.json
@@ -3,23 +3,23 @@
     "category": "heliotrope",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "beam"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "levitate"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "peck"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "radiance"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "battery_discharge"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "wing_tip"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "glower"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "shrapnel"
         }
     ],

--- a/mods/tuxemon/db/monster/axolightl.json
+++ b/mods/tuxemon/db/monster/axolightl.json
@@ -3,23 +3,23 @@
     "category": "inchoate",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "starfall"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "midnight_mantle"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "spit_poison"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "frostbite"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "snowstorm"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "torch"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "flood"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "ice_shield"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "goad"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "grinding"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "proboscis"
         },
         {

--- a/mods/tuxemon/db/monster/b_ver_1.json
+++ b/mods/tuxemon/db/monster/b_ver_1.json
@@ -3,23 +3,23 @@
     "category": "gnawer",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "beam"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "levitate"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "strike"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "radiance"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "battery_discharge"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "glower"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "shrapnel"
         }
     ],

--- a/mods/tuxemon/db/monster/babysnitch.json
+++ b/mods/tuxemon/db/monster/babysnitch.json
@@ -3,15 +3,15 @@
     "category": "fuminous",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "assault"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "berserk"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "canine"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "energy_claws"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "invictus"
         }
     ],

--- a/mods/tuxemon/db/monster/baddrscratch.json
+++ b/mods/tuxemon/db/monster/baddrscratch.json
@@ -3,15 +3,15 @@
     "category": "fuminous",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "assault"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "berserk"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "canine"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "energy_claws"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "invictus"
         }
     ],

--- a/mods/tuxemon/db/monster/bamboon.json
+++ b/mods/tuxemon/db/monster/bamboon.json
@@ -3,31 +3,31 @@
     "category": "prehensile",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "muddle"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "clamp_on"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "poison_courtship"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "stabilo"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "ram"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "blade"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "peck"
         },
         {

--- a/mods/tuxemon/db/monster/banling.json
+++ b/mods/tuxemon/db/monster/banling.json
@@ -3,23 +3,23 @@
     "category": "sepulchre",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "one_two"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "overgrowth"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "shadow_boxing"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "sting"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "sylvan"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "pseudopod"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "splinter"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "blossom"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "whirlwind"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "walls"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "fester"
         },
         {

--- a/mods/tuxemon/db/monster/bansaken.json
+++ b/mods/tuxemon/db/monster/bansaken.json
@@ -3,23 +3,23 @@
     "category": "sepulchre",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "one_two"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "overgrowth"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "shadow_boxing"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "sting"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "sylvan"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "pseudopod"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "splinter"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "blossom"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "whirlwind"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "walls"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "fester"
         },
         {

--- a/mods/tuxemon/db/monster/banvengeance.json
+++ b/mods/tuxemon/db/monster/banvengeance.json
@@ -3,23 +3,23 @@
     "category": "sepulchre",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "one_two"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "overgrowth"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "shadow_boxing"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "sting"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "sylvan"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "pseudopod"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "splinter"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "blossom"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "whirlwind"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "walls"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "fester"
         },
         {

--- a/mods/tuxemon/db/monster/baobaraffe.json
+++ b/mods/tuxemon/db/monster/baobaraffe.json
@@ -3,23 +3,23 @@
     "category": "tree_giraffe",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "solar_synthesis"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sting"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "negation"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "clairaudience"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "overfeed"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "invictus"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "fluff_up"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "blossom"
         },
         {

--- a/mods/tuxemon/db/monster/baoby.json
+++ b/mods/tuxemon/db/monster/baoby.json
@@ -3,23 +3,23 @@
     "category": "thirsty_okapi",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "solar_synthesis"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sting"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "negation"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "clairaudience"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "overfeed"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "invictus"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "fluff_up"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "blossom"
         },
         {

--- a/mods/tuxemon/db/monster/bearloch.json
+++ b/mods/tuxemon/db/monster/bearloch.json
@@ -3,23 +3,23 @@
     "category": "threat",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "greenstone"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "beam"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "strike"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "meltdown"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "clairaudience"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "undertaker"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "overfeed"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "radiance"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "battery_discharge"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "sting"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "stabilo"
         },
         {

--- a/mods/tuxemon/db/monster/bedoo.json
+++ b/mods/tuxemon/db/monster/bedoo.json
@@ -3,23 +3,23 @@
     "category": "bed_trap",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "whirlwind"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "hibernate"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "flood"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "tonguespear"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "chill_mist"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "frostbite"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "orbs"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "biting_winds"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "mobbing"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "shapechange"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "muck"
         },
         {

--- a/mods/tuxemon/db/monster/beenstalker.json
+++ b/mods/tuxemon/db/monster/beenstalker.json
@@ -3,27 +3,27 @@
     "category": "scarytale",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "solar_synthesis"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fester"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "sylvan"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "pseudopod"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "one_two"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "sting"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "invictus"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "fluff_up"
         }
     ],

--- a/mods/tuxemon/db/monster/bewhich.json
+++ b/mods/tuxemon/db/monster/bewhich.json
@@ -3,15 +3,15 @@
     "category": "hexer",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "muddle"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "mind_vise"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "terror"
         },
         {
@@ -19,11 +19,11 @@
             "technique": "time_crisis"
         },
         {
-            "level_learned": 14,
+            "level_learned": 13,
             "technique": "phantasmal_force"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "changeling"
         }
     ],

--- a/mods/tuxemon/db/monster/bigfin.json
+++ b/mods/tuxemon/db/monster/bigfin.json
@@ -3,23 +3,23 @@
     "category": "island",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "goad"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flood"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "geyser"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "grinding"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "flow"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "refresh"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "font"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "starfall"
         }
     ],

--- a/mods/tuxemon/db/monster/birdling.json
+++ b/mods/tuxemon/db/monster/birdling.json
@@ -3,27 +3,27 @@
     "category": "bird_brain",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wing_tip"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "peck"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "air_chain"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "altitude"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "fluff_up"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "peregrine"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "whirlwind"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "one_two"
         }
     ],

--- a/mods/tuxemon/db/monster/blasdoor.json
+++ b/mods/tuxemon/db/monster/blasdoor.json
@@ -3,23 +3,23 @@
     "category": "trapdoor",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "bullet"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "muddle"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "wall_of_steel"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "lineage"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "strike"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "terror"
         },
         {
@@ -39,7 +39,7 @@
             "technique": "rust_bomb"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "crystal"
         }
     ],

--- a/mods/tuxemon/db/monster/bolt.json
+++ b/mods/tuxemon/db/monster/bolt.json
@@ -3,11 +3,11 @@
     "category": "hardware",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "bullet"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "static_field"
         },
         {
@@ -15,15 +15,15 @@
             "technique": "shuriken"
         },
         {
-            "level_learned": 6,
+            "level_learned": 7,
             "technique": "clamp_on"
         },
         {
-            "level_learned": 8,
+            "level_learned": 10,
             "technique": "muddle"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "bubble_trap"
         },
         {
@@ -31,11 +31,11 @@
             "technique": "beam"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "surge"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "thunderclap"
         }
     ],

--- a/mods/tuxemon/db/monster/boltnu.json
+++ b/mods/tuxemon/db/monster/boltnu.json
@@ -3,27 +3,27 @@
     "category": "screwdriver",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "goad"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "strike"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "time_crisis"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "slice"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "electrical_storm"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "muddle"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "wall_of_steel"
         }
     ],

--- a/mods/tuxemon/db/monster/botbot.json
+++ b/mods/tuxemon/db/monster/botbot.json
@@ -3,23 +3,23 @@
     "category": "socket",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "beam"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "levitate"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "strike"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "radiance"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "battery_discharge"
         }
     ],

--- a/mods/tuxemon/db/monster/boxali.json
+++ b/mods/tuxemon/db/monster/boxali.json
@@ -3,23 +3,23 @@
     "category": "macropod",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "strike"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "punch"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "riposte"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "time_crisis"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "all_in"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "terror"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "whirlwind"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "undertaker"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "meltdown"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "blade"
         },
         {

--- a/mods/tuxemon/db/monster/boxorox.json
+++ b/mods/tuxemon/db/monster/boxorox.json
@@ -3,15 +3,15 @@
     "category": "pugilist",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "punch"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "evasion"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "shadow_boxing"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "hammerhead"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "one_two"
         }
     ],

--- a/mods/tuxemon/db/monster/brachifor.json
+++ b/mods/tuxemon/db/monster/brachifor.json
@@ -3,23 +3,23 @@
     "category": "petrified",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "one_two"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "invictus"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "peregrine"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "all_in"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "peck"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "pseudopod"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "overgrowth"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "wing_tip"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "fester"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "sylvan"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "greenstone"
         },
         {

--- a/mods/tuxemon/db/monster/breem.json
+++ b/mods/tuxemon/db/monster/breem.json
@@ -3,15 +3,15 @@
     "category": "parasitized",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sting"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "overgrowth"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "spit_poison"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "poison_courtship"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "viper"
         }
     ],

--- a/mods/tuxemon/db/monster/brewdin.json
+++ b/mods/tuxemon/db/monster/brewdin.json
@@ -3,23 +3,23 @@
     "category": "genie",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "constrict"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "changeling"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "platinum"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "ruby"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "bullet"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "undertaker"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "insanity"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "battery_discharge"
         },
         {

--- a/mods/tuxemon/db/monster/bricgard.json
+++ b/mods/tuxemon/db/monster/bricgard.json
@@ -3,23 +3,23 @@
     "category": "brick_wall",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "ram"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "boulder"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "riposte"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "assault"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "thunderball"
         },
         {
@@ -27,7 +27,7 @@
             "technique": "glower"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "wall_of_steel"
         },
         {
@@ -35,11 +35,11 @@
             "technique": "surge"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "stampede"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "earthquake"
         },
         {

--- a/mods/tuxemon/db/monster/brickhemoth.json
+++ b/mods/tuxemon/db/monster/brickhemoth.json
@@ -3,23 +3,23 @@
     "category": "brick_wall",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "ram"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "boulder"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "riposte"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "assault"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "thunderball"
         },
         {
@@ -27,7 +27,7 @@
             "technique": "glower"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "wall_of_steel"
         },
         {
@@ -35,11 +35,11 @@
             "technique": "surge"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "stampede"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "earthquake"
         },
         {

--- a/mods/tuxemon/db/monster/brumi.json
+++ b/mods/tuxemon/db/monster/brumi.json
@@ -3,15 +3,15 @@
     "category": "hexer",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "muddle"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "mind_vise"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "terror"
         },
         {
@@ -19,11 +19,11 @@
             "technique": "time_crisis"
         },
         {
-            "level_learned": 14,
+            "level_learned": 13,
             "technique": "phantasmal_force"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "changeling"
         }
     ],

--- a/mods/tuxemon/db/monster/budaye.json
+++ b/mods/tuxemon/db/monster/budaye.json
@@ -3,23 +3,23 @@
     "category": "mutual",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "muddle"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "clamp_on"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "poison_courtship"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "stabilo"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "ram"
         }
     ],

--- a/mods/tuxemon/db/monster/bugnin.json
+++ b/mods/tuxemon/db/monster/bugnin.json
@@ -3,11 +3,11 @@
     "category": "honour",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "clamp_on"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shrapnel"
         },
         {
@@ -15,15 +15,15 @@
             "technique": "splinter"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "font"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "peregrine"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "sting"
         },
         {
@@ -31,11 +31,11 @@
             "technique": "undertaker"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "blade"
         },
         {
@@ -43,7 +43,7 @@
             "technique": "sleep_bomb"
         },
         {
-            "level_learned": 45,
+            "level_learned": 46,
             "technique": "vorpal"
         }
     ],

--- a/mods/tuxemon/db/monster/bumbulus.json
+++ b/mods/tuxemon/db/monster/bumbulus.json
@@ -3,23 +3,23 @@
     "category": "veiled",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flood"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "whirlwind"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "venomous_tentacle"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "midnight_mantle"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "muck"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "mobbing"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "kraken"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "poison_courtship"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "ice_shield"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "shapechange"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "chill_mist"
         },
         {

--- a/mods/tuxemon/db/monster/burrlock.json
+++ b/mods/tuxemon/db/monster/burrlock.json
@@ -3,15 +3,15 @@
     "category": "biting_pear",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "saber"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "solar_synthesis"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "tip"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "stabilo"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "perfect_cut"
         }
     ],

--- a/mods/tuxemon/db/monster/bursa.json
+++ b/mods/tuxemon/db/monster/bursa.json
@@ -3,23 +3,23 @@
     "category": "too_hot",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "bubble_trap"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "amnesia"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "muddle"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "berserk"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "one_two"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "fire_ball"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "all_in"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "give_all"
         },
         {

--- a/mods/tuxemon/db/monster/cacaburr.json
+++ b/mods/tuxemon/db/monster/cacaburr.json
@@ -3,15 +3,15 @@
     "category": "biting_pear",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "saber"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "solar_synthesis"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "tip"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "stabilo"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "perfect_cut"
         }
     ],

--- a/mods/tuxemon/db/monster/cackleen.json
+++ b/mods/tuxemon/db/monster/cackleen.json
@@ -3,15 +3,15 @@
     "category": "witch_spirit",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "muddle"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "mind_vise"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "terror"
         },
         {
@@ -19,11 +19,11 @@
             "technique": "time_crisis"
         },
         {
-            "level_learned": 14,
+            "level_learned": 13,
             "technique": "phantasmal_force"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "changeling"
         }
     ],

--- a/mods/tuxemon/db/monster/cairfrey.json
+++ b/mods/tuxemon/db/monster/cairfrey.json
@@ -3,23 +3,23 @@
     "category": "host",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "pseudopod"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "refresh"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "stampede"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "mending"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "greenstone"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "muddle"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "quicksand"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "crystal"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "muck"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "amnesia"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "bubble_trap"
         },
         {

--- a/mods/tuxemon/db/monster/caper.json
+++ b/mods/tuxemon/db/monster/caper.json
@@ -3,23 +3,23 @@
     "category": "kid",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "goad"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flood"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "geyser"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "grinding"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "flow"
         },
         {
@@ -27,19 +27,19 @@
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "font"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "starfall"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "tsunami"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "ice_storm"
         }
     ],

--- a/mods/tuxemon/db/monster/capinyah.json
+++ b/mods/tuxemon/db/monster/capinyah.json
@@ -3,23 +3,23 @@
     "category": "woodwose",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "punch"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fluff_up"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "sting"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "overgrowth"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "walls"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "orbs"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "changeling"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "phantasmal_force"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "clairaudience"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "splinter"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "one_two"
         },
         {
@@ -51,11 +51,11 @@
             "technique": "blossom"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "pseudopod"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "sylvan"
         },
         {

--- a/mods/tuxemon/db/monster/capiti.json
+++ b/mods/tuxemon/db/monster/capiti.json
@@ -3,23 +3,23 @@
     "category": "woodwose",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "punch"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fluff_up"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "sting"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "overgrowth"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "walls"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "orbs"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "changeling"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "phantasmal_force"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "clairaudience"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "splinter"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "one_two"
         },
         {
@@ -51,11 +51,11 @@
             "technique": "blossom"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "pseudopod"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "sylvan"
         },
         {

--- a/mods/tuxemon/db/monster/cardiling.json
+++ b/mods/tuxemon/db/monster/cardiling.json
@@ -3,27 +3,27 @@
     "category": "firebird",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "breathe_fire"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "give_all"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "one_two"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "saber"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "fire_claw"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "kindling_flame"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "peregrine"
         },
         {
-            "level_learned": 28,
+            "level_learned": 31,
             "technique": "ten_thousand_feathers"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "berserk"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "all_in"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "flamethrower"
         }
     ],

--- a/mods/tuxemon/db/monster/cardinale.json
+++ b/mods/tuxemon/db/monster/cardinale.json
@@ -3,27 +3,27 @@
     "category": "firebird",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "breathe_fire"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "give_all"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "one_two"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "saber"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "fire_claw"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "kindling_flame"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "berserk"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "all_in"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "flamethrower"
         }
     ],

--- a/mods/tuxemon/db/monster/cardiwing.json
+++ b/mods/tuxemon/db/monster/cardiwing.json
@@ -3,27 +3,27 @@
     "category": "firebird",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "breathe_fire"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "give_all"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "one_two"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "saber"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "fire_claw"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "kindling_flame"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "peregrine"
         },
         {
-            "level_learned": 28,
+            "level_learned": 31,
             "technique": "ten_thousand_feathers"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "berserk"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "all_in"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "flamethrower"
         }
     ],

--- a/mods/tuxemon/db/monster/cataspike.json
+++ b/mods/tuxemon/db/monster/cataspike.json
@@ -3,11 +3,11 @@
     "category": "pointy",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "bullet"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shuriken"
         },
         {
@@ -15,31 +15,31 @@
             "technique": "wallow"
         },
         {
-            "level_learned": 6,
+            "level_learned": 7,
             "technique": "hibernate"
         },
         {
-            "level_learned": 8,
+            "level_learned": 10,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 10,
+            "level_learned": 13,
             "technique": "blade"
         },
         {
-            "level_learned": 12,
+            "level_learned": 16,
             "technique": "viper"
         },
         {
-            "level_learned": 16,
+            "level_learned": 19,
             "technique": "lineage"
         },
         {
-            "level_learned": 20,
+            "level_learned": 22,
             "technique": "muddle"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "eyebite"
         },
         {

--- a/mods/tuxemon/db/monster/cateye.json
+++ b/mods/tuxemon/db/monster/cateye.json
@@ -3,23 +3,23 @@
     "category": "sentinel",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "amnesia"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "eyebite"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "mind_vise"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "crystal"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "sleep_bomb"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "ruby"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "acid"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "slice"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "bullet"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "radiance"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "lineage"
         },
         {

--- a/mods/tuxemon/db/monster/chenipode.json
+++ b/mods/tuxemon/db/monster/chenipode.json
@@ -3,27 +3,27 @@
     "category": "travel_bug",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "rock"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "clamp_on"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "quicksand"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "tip"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "take_cover"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "avalanche"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "sand_spray"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "hammerhead"
         }
     ],

--- a/mods/tuxemon/db/monster/cherubat.json
+++ b/mods/tuxemon/db/monster/cherubat.json
@@ -3,23 +3,23 @@
     "category": "patu",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wing_tip"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "berserk"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "amnesia"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "all_in"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "one_two"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "lineage"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "rust_bomb"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "slice"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "blade"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "strike"
         },
         {

--- a/mods/tuxemon/db/monster/chibiro.json
+++ b/mods/tuxemon/db/monster/chibiro.json
@@ -3,23 +3,23 @@
     "category": "false_turnip",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sting"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fluff_up"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "overgrowth"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "fester"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "stonehenge"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "blossom"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "chameleon"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "sylvan"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "radiance"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "cat_calling"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "splinter"
         },
         {

--- a/mods/tuxemon/db/monster/chillimp.json
+++ b/mods/tuxemon/db/monster/chillimp.json
@@ -3,27 +3,27 @@
     "category": "frost_ape",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "ice_claw"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "punch"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "flow"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "snowstorm"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "flood"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "chill_mist"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "frostbite"
         }
     ],

--- a/mods/tuxemon/db/monster/chloragon.json
+++ b/mods/tuxemon/db/monster/chloragon.json
@@ -3,23 +3,23 @@
     "category": "dragon",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "all_in"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "web"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "greenstone"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "negation"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "overfeed"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "hibernate"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "sting"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "one_two"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "fluff_up"
         },
         {
-            "level_learned": 56,
+            "level_learned": 55,
             "technique": "whirlwind"
         },
         {
-            "level_learned": 60,
+            "level_learned": 61,
             "technique": "wing_tip"
         },
         {

--- a/mods/tuxemon/db/monster/chrome_robo.json
+++ b/mods/tuxemon/db/monster/chrome_robo.json
@@ -3,23 +3,23 @@
     "category": "threat",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "electrical_storm"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "strike"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "beam"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "rust_bomb"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "meltdown"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "blade"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "lightning_spheres"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "bullet"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "time_crisis"
         },
         {

--- a/mods/tuxemon/db/monster/chromeye.json
+++ b/mods/tuxemon/db/monster/chromeye.json
@@ -3,23 +3,23 @@
     "category": "mixed_emotion",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "blade"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "strike"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "wall_of_steel"
         }
     ],

--- a/mods/tuxemon/db/monster/claymorior.json
+++ b/mods/tuxemon/db/monster/claymorior.json
@@ -3,23 +3,23 @@
     "category": "terracotta",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "mending"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "rock"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "stampede"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "icicle_spear"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "muck"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "shadow_boxing"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "stonehenge"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "saber"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "undertaker"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "shuriken"
         },
         {

--- a/mods/tuxemon/db/monster/coaldiak.json
+++ b/mods/tuxemon/db/monster/coaldiak.json
@@ -3,27 +3,27 @@
     "category": "ursus",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "rock"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_ball"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "fire_claw"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "one_two"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "flamethrower"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "give_all"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "supernova"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "electrical_storm"
         }
     ],

--- a/mods/tuxemon/db/monster/cobarett.json
+++ b/mods/tuxemon/db/monster/cobarett.json
@@ -3,15 +3,15 @@
     "category": "comet_snake",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_claw"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wall_fire"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "venom"
         },
         {
@@ -19,11 +19,11 @@
             "technique": "spit_poison"
         },
         {
-            "level_learned": 14,
+            "level_learned": 13,
             "technique": "fire_ball"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "flamethrower"
         }
     ],

--- a/mods/tuxemon/db/monster/cochini.json
+++ b/mods/tuxemon/db/monster/cochini.json
@@ -3,23 +3,23 @@
     "category": "tasty",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "stampede"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "thunderball"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "hammerhead"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "ice_claw"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "quicksand"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "changeling"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "lust"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "canine"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "mudslide"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "electrical_storm"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "sand_spray"
         },
         {

--- a/mods/tuxemon/db/monster/cocrune.json
+++ b/mods/tuxemon/db/monster/cocrune.json
@@ -3,15 +3,15 @@
     "category": "diptera",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "boulder"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "grinding"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "petrify"
         },
         {
@@ -19,11 +19,11 @@
             "technique": "stonehenge"
         },
         {
-            "level_learned": 14,
+            "level_learned": 13,
             "technique": "take_cover"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "electroplate"
         }
     ],

--- a/mods/tuxemon/db/monster/coleorus.json
+++ b/mods/tuxemon/db/monster/coleorus.json
@@ -3,23 +3,23 @@
     "category": "timeless",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "avalanche"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "peck"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "fluff_up"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "peck"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "web"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "venom"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "cat_calling"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "clairaudience"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "air_chain"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "chameleon"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "barking"
         },
         {

--- a/mods/tuxemon/db/monster/conglolem.json
+++ b/mods/tuxemon/db/monster/conglolem.json
@@ -3,23 +3,23 @@
     "category": "golem",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "all_in"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fester"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "sylvan"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "stonehenge"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "clairaudience"
         },
         {
@@ -27,7 +27,7 @@
             "technique": "negation"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "greenstone"
         },
         {
@@ -35,7 +35,7 @@
             "technique": "breath"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "lantern"
         },
         {
@@ -43,7 +43,7 @@
             "technique": "surge"
         },
         {
-            "level_learned": 38,
+            "level_learned": 37,
             "technique": "mudslide"
         },
         {
@@ -51,7 +51,7 @@
             "technique": "earthquake"
         },
         {
-            "level_learned": 56,
+            "level_learned": 55,
             "technique": "thunderball"
         }
     ],

--- a/mods/tuxemon/db/monster/conifrost.json
+++ b/mods/tuxemon/db/monster/conifrost.json
@@ -3,23 +3,23 @@
     "category": "taiga",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "solar_synthesis"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "chill_mist"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "whirlwind"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "starfall"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "frostbite"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "snowstorm"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "geyser"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "biting_winds"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "goad"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "tonguespear"
         },
         {

--- a/mods/tuxemon/db/monster/conileaf.json
+++ b/mods/tuxemon/db/monster/conileaf.json
@@ -3,23 +3,23 @@
     "category": "pitcher",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "solar_synthesis"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "pseudopod"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "overgrowth"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "assault"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "wing_tip"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "sting"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "sylvan"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "assault"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "all_in"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "chameleon"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "shadow_boxing"
         },
         {

--- a/mods/tuxemon/db/monster/coproblight.json
+++ b/mods/tuxemon/db/monster/coproblight.json
@@ -3,23 +3,23 @@
     "category": "skull_poo",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fester"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fume"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "spit_poison"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "electroplate"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "ants"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "cat_calling"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "tsunami"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "biting_winds"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "cloud_aether"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "greenstone"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "quicksand"
         },
         {

--- a/mods/tuxemon/db/monster/corvix.json
+++ b/mods/tuxemon/db/monster/corvix.json
@@ -3,27 +3,27 @@
     "category": "horned_raptor",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wing_tip"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "berserk"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "lineage"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "slice"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "one_two"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "amnesia"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "rust_bomb"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "all_in"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "one_million_talons"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "blade"
         }
     ],

--- a/mods/tuxemon/db/monster/cowpignon.json
+++ b/mods/tuxemon/db/monster/cowpignon.json
@@ -3,23 +3,23 @@
     "category": "enhancement",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "hammerhead"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "solar_synthesis"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "petrify"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "pseudopod"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "amnesia"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "negation"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "whirlwind"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "stabilo"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "radiance"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "phantasmal_force"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "splinter"
         },
         {

--- a/mods/tuxemon/db/monster/crankus.json
+++ b/mods/tuxemon/db/monster/crankus.json
@@ -3,23 +3,23 @@
     "category": "cranky",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "goad"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flood"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "geyser"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "grinding"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "flow"
         },
         {
@@ -27,19 +27,19 @@
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "font"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "starfall"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "tsunami"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "ice_storm"
         }
     ],

--- a/mods/tuxemon/db/monster/criniotherme.json
+++ b/mods/tuxemon/db/monster/criniotherme.json
@@ -3,27 +3,27 @@
     "category": "mercury",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "one_two"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_claw"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "salamander"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "breathe_fire"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "all_in"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "eyebite"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "glower"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "flamethrower"
         }
     ],

--- a/mods/tuxemon/db/monster/crustagu.json
+++ b/mods/tuxemon/db/monster/crustagu.json
@@ -3,23 +3,23 @@
     "category": "grandfather",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "font"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "midnight_mantle"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "flow"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "flood"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "starfall"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "ice_claw"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "snowstorm"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "mobbing"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "orbs"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "kraken"
         },
         {

--- a/mods/tuxemon/db/monster/d0llf1n.json
+++ b/mods/tuxemon/db/monster/d0llf1n.json
@@ -3,23 +3,23 @@
     "category": "glitched",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "goad"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flood"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "flow"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "frostbite"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "spit_poison"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "midnight_mantle"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "orbs"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "shapechange"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "ice_storm"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "kraken"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "ice_shield"
         },
         {

--- a/mods/tuxemon/db/monster/dandicub.json
+++ b/mods/tuxemon/db/monster/dandicub.json
@@ -3,27 +3,27 @@
     "category": "floret",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "pseudopod"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "overgrowth"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "sylvan"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "fester"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "sleeping_powder"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "energy_claws"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "one_two"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "all_in"
         }
     ],

--- a/mods/tuxemon/db/monster/dandylion.json
+++ b/mods/tuxemon/db/monster/dandylion.json
@@ -3,27 +3,27 @@
     "category": "lions_tooth",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "pseudopod"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "overgrowth"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "sylvan"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "fester"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "sleeping_powder"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "energy_claws"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "one_two"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "all_in"
         }
     ],

--- a/mods/tuxemon/db/monster/dankush.json
+++ b/mods/tuxemon/db/monster/dankush.json
@@ -3,23 +3,23 @@
     "category": "zaza",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "solar_synthesis"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "muddle"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "sleep_bomb"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "sylvan"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "overgrowth"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "nest"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "stabilo"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "surge"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "chameleon"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "salamander"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "sleeping_powder"
         },
         {

--- a/mods/tuxemon/db/monster/dark_robo.json
+++ b/mods/tuxemon/db/monster/dark_robo.json
@@ -3,23 +3,23 @@
     "category": "threat",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "electrical_storm"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "rust_bomb"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "radiance"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "constrict"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "slice"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "bubble_trap"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "gold_digger"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "time_crisis"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "terror"
         },
         {

--- a/mods/tuxemon/db/monster/delfeco.json
+++ b/mods/tuxemon/db/monster/delfeco.json
@@ -3,23 +3,23 @@
     "category": "joyful_dolphin",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "goad"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flood"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "geyser"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "grinding"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "flow"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "splinter"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "web"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "chill_mist"
         }
     ],

--- a/mods/tuxemon/db/monster/demosnow.json
+++ b/mods/tuxemon/db/monster/demosnow.json
@@ -3,23 +3,23 @@
     "category": "tempted",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "frostbite"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "goad"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "torch"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "orbs"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "muck"
         },
         {

--- a/mods/tuxemon/db/monster/devidin.json
+++ b/mods/tuxemon/db/monster/devidin.json
@@ -3,15 +3,15 @@
     "category": "dog_toothed",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "muddle"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "mind_vise"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "stonehenge"
         },
         {
@@ -19,11 +19,11 @@
             "technique": "invictus"
         },
         {
-            "level_learned": 14,
+            "level_learned": 13,
             "technique": "phantasmal_force"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "terror"
         }
     ],

--- a/mods/tuxemon/db/monster/devidra.json
+++ b/mods/tuxemon/db/monster/devidra.json
@@ -3,15 +3,15 @@
     "category": "dog_toothed",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "muddle"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "mind_vise"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "stonehenge"
         },
         {
@@ -19,11 +19,11 @@
             "technique": "invictus"
         },
         {
-            "level_learned": 14,
+            "level_learned": 13,
             "technique": "phantasmal_force"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "terror"
         }
     ],

--- a/mods/tuxemon/db/monster/deviraptor.json
+++ b/mods/tuxemon/db/monster/deviraptor.json
@@ -3,15 +3,15 @@
     "category": "dog_toothed",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "muddle"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "mind_vise"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "stonehenge"
         },
         {
@@ -19,11 +19,11 @@
             "technique": "invictus"
         },
         {
-            "level_learned": 14,
+            "level_learned": 13,
             "technique": "phantasmal_force"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "terror"
         }
     ],

--- a/mods/tuxemon/db/monster/dinoflop.json
+++ b/mods/tuxemon/db/monster/dinoflop.json
@@ -3,23 +3,23 @@
     "category": "volte-face",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "boulder"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "ram"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "rock"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "thunderball"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "mudslide"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "fume"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "air_chain"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "stampede"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "clamp_on"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "electroplate"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "breathe_fire"
         },
         {

--- a/mods/tuxemon/db/monster/djinnbo.json
+++ b/mods/tuxemon/db/monster/djinnbo.json
@@ -3,23 +3,23 @@
     "category": "vengeance",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "petrify"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "give_all"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "flamethrower"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "saber"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "fire_claw"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "tinder"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "lava"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "fire_ball"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "magma"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "wall_fire"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "nest"
         },
         {

--- a/mods/tuxemon/db/monster/doctsky.json
+++ b/mods/tuxemon/db/monster/doctsky.json
@@ -3,23 +3,23 @@
     "category": "erythrocyte",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "barking"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "ram"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "revenge_stance"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "canine"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "hibernate"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "mystic_blending"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "take_cover"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "life_surge"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "sand_spray"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "fluff_up"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "all_in"
         },
         {

--- a/mods/tuxemon/db/monster/dollfin.json
+++ b/mods/tuxemon/db/monster/dollfin.json
@@ -3,23 +3,23 @@
     "category": "joyful",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "goad"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flood"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "geyser"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "grinding"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "flow"
         }
     ],

--- a/mods/tuxemon/db/monster/dracune.json
+++ b/mods/tuxemon/db/monster/dracune.json
@@ -3,11 +3,11 @@
     "category": "cloaked",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "proboscis"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "spit_poison"
         },
         {
@@ -15,15 +15,15 @@
             "technique": "refresh"
         },
         {
-            "level_learned": 6,
+            "level_learned": 7,
             "technique": "font"
         },
         {
-            "level_learned": 8,
+            "level_learned": 10,
             "technique": "hibernate"
         },
         {
-            "level_learned": 10,
+            "level_learned": 13,
             "technique": "goad"
         },
         {
@@ -31,11 +31,11 @@
             "technique": "geyser"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "sleeping_powder"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "venomous_tentacle"
         },
         {

--- a/mods/tuxemon/db/monster/dragarbor.json
+++ b/mods/tuxemon/db/monster/dragarbor.json
@@ -3,23 +3,23 @@
     "category": "dragon",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "all_in"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "web"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "greenstone"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "negation"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "overfeed"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "hibernate"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "sting"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "one_two"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "fluff_up"
         },
         {
-            "level_learned": 56,
+            "level_learned": 55,
             "technique": "whirlwind"
         },
         {
-            "level_learned": 60,
+            "level_learned": 61,
             "technique": "wing_tip"
         },
         {

--- a/mods/tuxemon/db/monster/drashimi.json
+++ b/mods/tuxemon/db/monster/drashimi.json
@@ -3,27 +3,27 @@
     "category": "dragon_roll",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "spit_poison"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flow"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "grinding"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "muck"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "flood"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "icicle_spear"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "font"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "starfall"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "ice_claw"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "chill_mist"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "frostbite"
         }
     ],

--- a/mods/tuxemon/db/monster/drokoro.json
+++ b/mods/tuxemon/db/monster/drokoro.json
@@ -3,23 +3,23 @@
     "category": "dragon",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "tinder"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "berserk"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "breathe_fire"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "fire_shield"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "firestorm"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "give_all"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "one_two"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "all_in"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "chameleon"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "muddle"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "supernova"
         },
         {

--- a/mods/tuxemon/db/monster/duggot.json
+++ b/mods/tuxemon/db/monster/duggot.json
@@ -3,15 +3,15 @@
     "category": "unwelcome_mouthful",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sting"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "overgrowth"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "spit_poison"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "poison_courtship"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "viper"
         }
     ],

--- a/mods/tuxemon/db/monster/dune_pincher.json
+++ b/mods/tuxemon/db/monster/dune_pincher.json
@@ -3,23 +3,23 @@
     "category": "hermit",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flood"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "avalanche"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "refresh"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "poison_courtship"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "mobbing"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "ice_shield"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "spit_poison"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "chill_mist"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "muck"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "kraken"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "icicle_spear"
         },
         {

--- a/mods/tuxemon/db/monster/eaglace.json
+++ b/mods/tuxemon/db/monster/eaglace.json
@@ -3,23 +3,23 @@
     "category": "cirrus",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "ice_claw"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "peck"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "orbs"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "flow"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "energy_field"
         },
         {
@@ -27,7 +27,7 @@
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "biting_winds"
         },
         {
@@ -35,11 +35,11 @@
             "technique": "flood"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "font"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "chill_mist"
         },
         {

--- a/mods/tuxemon/db/monster/elofly.json
+++ b/mods/tuxemon/db/monster/elofly.json
@@ -3,27 +3,27 @@
     "category": "cloudburst",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "goad"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "biting_winds"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "shapechange"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "chill_mist"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "fume"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "altitude"
         },
         {
@@ -31,15 +31,15 @@
             "technique": "flood"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "flow"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "ten_thousand_feathers"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "thunderclap"
         },
         {

--- a/mods/tuxemon/db/monster/elostorm.json
+++ b/mods/tuxemon/db/monster/elostorm.json
@@ -3,27 +3,27 @@
     "category": "cloudburst",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "goad"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "biting_winds"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "shapechange"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "chill_mist"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "fume"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "altitude"
         },
         {
@@ -31,15 +31,15 @@
             "technique": "flood"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "flow"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "ten_thousand_feathers"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "thunderclap"
         },
         {

--- a/mods/tuxemon/db/monster/elowind.json
+++ b/mods/tuxemon/db/monster/elowind.json
@@ -3,27 +3,27 @@
     "category": "cloudburst",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "goad"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "biting_winds"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "shapechange"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "chill_mist"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "fume"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "altitude"
         },
         {
@@ -31,15 +31,15 @@
             "technique": "flood"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "flow"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "ten_thousand_feathers"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "thunderclap"
         },
         {

--- a/mods/tuxemon/db/monster/embazook.json
+++ b/mods/tuxemon/db/monster/embazook.json
@@ -3,23 +3,23 @@
     "category": "gunner",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_ball"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "boulder"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "one_two"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "fire_claw"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "tinder"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "static_field"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "kindling_flame"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "flamethrower"
         }
     ],

--- a/mods/tuxemon/db/monster/embra.json
+++ b/mods/tuxemon/db/monster/embra.json
@@ -3,23 +3,23 @@
     "category": "flicker",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_ball"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "refresh"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "fire_shield"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "one_two"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "tinder"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "kindling_flame"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "arcane_eye"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "fire_claw"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "magma"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "berserk"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "fume"
         },
         {

--- a/mods/tuxemon/db/monster/enduros.json
+++ b/mods/tuxemon/db/monster/enduros.json
@@ -3,23 +3,23 @@
     "category": "defensive",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "riposte"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "punch"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "rock"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "stampede"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "mending"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "surge"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "fledgling"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "ram"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "assault"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "pit"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "canine"
         },
         {

--- a/mods/tuxemon/db/monster/equill.json
+++ b/mods/tuxemon/db/monster/equill.json
@@ -3,15 +3,15 @@
     "category": "cave_dweller",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "stampede"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wallow"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "hibernate"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "mudslide"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "earthquake"
         }
     ],

--- a/mods/tuxemon/db/monster/eruptibus.json
+++ b/mods/tuxemon/db/monster/eruptibus.json
@@ -3,23 +3,23 @@
     "category": "hot_rock",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_ball"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "boulder"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "one_two"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "fire_claw"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "tinder"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "berserk"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "hibernate"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "energy_field"
         }
     ],

--- a/mods/tuxemon/db/monster/eskipup.json
+++ b/mods/tuxemon/db/monster/eskipup.json
@@ -3,15 +3,15 @@
     "category": "frosty",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "ice_claw"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "ice_shield"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "canine"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "ice_storm"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "frostbite"
         }
     ],

--- a/mods/tuxemon/db/monster/exapode.json
+++ b/mods/tuxemon/db/monster/exapode.json
@@ -3,27 +3,27 @@
     "category": "big_frightfear",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "rock"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "clamp_on"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "quicksand"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "tip"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "take_cover"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "avalanche"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "sand_spray"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "hammerhead"
         }
     ],

--- a/mods/tuxemon/db/monster/exclawvate.json
+++ b/mods/tuxemon/db/monster/exclawvate.json
@@ -3,27 +3,27 @@
     "category": "digger",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "goad"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "strike"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "time_crisis"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "slice"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "electrical_storm"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "muddle"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "wall_of_steel"
         }
     ],

--- a/mods/tuxemon/db/monster/eyenemy.json
+++ b/mods/tuxemon/db/monster/eyenemy.json
@@ -3,27 +3,27 @@
     "category": "pupil",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "amnesia"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "spit_poison"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "ruby"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "sleep_bomb"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "glower"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "eyebite"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "bullet"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "strike"
         }
     ],

--- a/mods/tuxemon/db/monster/eyesore.json
+++ b/mods/tuxemon/db/monster/eyesore.json
@@ -3,27 +3,27 @@
     "category": "overseer",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "amnesia"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "spit_poison"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "ruby"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "sleep_bomb"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "glower"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "eyebite"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "bullet"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "strike"
         }
     ],

--- a/mods/tuxemon/db/monster/f7u1t3ra.json
+++ b/mods/tuxemon/db/monster/f7u1t3ra.json
@@ -3,23 +3,23 @@
     "category": "glitched",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fluff_up"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sting"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "splinter"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "chameleon"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "spit_poison"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "shadow_boxing"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "stabilo"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "walls"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "pseudopod"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "air_chain"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "feline"
         },
         {

--- a/mods/tuxemon/db/monster/fancair.json
+++ b/mods/tuxemon/db/monster/fancair.json
@@ -3,27 +3,27 @@
     "category": "deadly_fan",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "bullet"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "muddle"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "bubble_trap"
         },
         {

--- a/mods/tuxemon/db/monster/ferricran.json
+++ b/mods/tuxemon/db/monster/ferricran.json
@@ -3,23 +3,23 @@
     "category": "dragon",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "viper"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "insanity"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "undertaker"
         },
         {
@@ -31,15 +31,15 @@
             "technique": "rust_bomb"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "shuriken"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 60,
+            "level_learned": 61,
             "technique": "amnesia"
         },
         {
@@ -47,7 +47,7 @@
             "technique": "muddle"
         },
         {
-            "level_learned": 68,
+            "level_learned": 70,
             "technique": "bullet"
         }
     ],

--- a/mods/tuxemon/db/monster/firomenis.json
+++ b/mods/tuxemon/db/monster/firomenis.json
@@ -3,23 +3,23 @@
     "category": "dragon_moth",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_ball"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "kindling_flame"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "muddle"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "breathe_fire"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "chameleon"
         },
         {
@@ -27,7 +27,7 @@
             "technique": "fire_claw"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "webs_wind"
         },
         {
@@ -35,11 +35,11 @@
             "technique": "sunburst"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "magma"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "arcane_eye"
         },
         {

--- a/mods/tuxemon/db/monster/flacono.json
+++ b/mods/tuxemon/db/monster/flacono.json
@@ -3,27 +3,27 @@
     "category": "horned_raptor",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wing_tip"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "berserk"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "lineage"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "slice"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "one_two"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "amnesia"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "rust_bomb"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "all_in"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "one_million_talons"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "blade"
         }
     ],

--- a/mods/tuxemon/db/monster/flambear.json
+++ b/mods/tuxemon/db/monster/flambear.json
@@ -3,23 +3,23 @@
     "category": "too_hot",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "bubble_trap"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "amnesia"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "muddle"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "berserk"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "one_two"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "fire_ball"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "all_in"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "give_all"
         },
         {

--- a/mods/tuxemon/db/monster/flisces.json
+++ b/mods/tuxemon/db/monster/flisces.json
@@ -3,23 +3,23 @@
     "category": "cypselurus",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flow"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "proboscis"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "goad"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "ice_claw"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "grinding"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "blood_bond"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "geyser"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "tonguespear"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "frostbite"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "venomous_tentacle"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "flood"
         },
         {

--- a/mods/tuxemon/db/monster/flounce.json
+++ b/mods/tuxemon/db/monster/flounce.json
@@ -3,15 +3,15 @@
     "category": "firestarter",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_claw"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wall_fire"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "canine"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "fire_ball"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "flamethrower"
         }
     ],

--- a/mods/tuxemon/db/monster/flummack.json
+++ b/mods/tuxemon/db/monster/flummack.json
@@ -3,15 +3,15 @@
     "category": "cannibal_cake",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "overfeed"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "bullet"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "ice_shield"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "fire_shield"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "take_cover"
         }
     ],

--- a/mods/tuxemon/db/monster/flummby.json
+++ b/mods/tuxemon/db/monster/flummby.json
@@ -3,15 +3,15 @@
     "category": "pastry",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "overfeed"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "bullet"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "ice_shield"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "fire_shield"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "take_cover"
         }
     ],

--- a/mods/tuxemon/db/monster/fluoresfin.json
+++ b/mods/tuxemon/db/monster/fluoresfin.json
@@ -3,27 +3,27 @@
     "category": "light_fin",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flow"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sudden_glow"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "grinding"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "geyser"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "glower"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "goad"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "starfall"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "flood"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "static_field"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "proboscis"
         }
     ],

--- a/mods/tuxemon/db/monster/fluttaflap.json
+++ b/mods/tuxemon/db/monster/fluttaflap.json
@@ -3,11 +3,11 @@
     "category": "sanguine",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "proboscis"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "spit_poison"
         },
         {
@@ -15,15 +15,15 @@
             "technique": "refresh"
         },
         {
-            "level_learned": 6,
+            "level_learned": 7,
             "technique": "font"
         },
         {
-            "level_learned": 8,
+            "level_learned": 10,
             "technique": "hibernate"
         },
         {
-            "level_learned": 10,
+            "level_learned": 13,
             "technique": "goad"
         },
         {
@@ -31,11 +31,11 @@
             "technique": "geyser"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "sleeping_powder"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "venomous_tentacle"
         },
         {

--- a/mods/tuxemon/db/monster/foofle.json
+++ b/mods/tuxemon/db/monster/foofle.json
@@ -3,23 +3,23 @@
     "category": "woolly",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "spit_poison"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "hammerhead"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "refresh"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "lust"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "ice_claw"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "crystal"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "assault"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "nest"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "avalanche"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "mystic_blending"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "platinum"
         },
         {

--- a/mods/tuxemon/db/monster/fordin.json
+++ b/mods/tuxemon/db/monster/fordin.json
@@ -3,23 +3,23 @@
     "category": "petrified",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "one_two"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "invictus"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "peregrine"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "all_in"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "peck"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "pseudopod"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "overgrowth"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "wing_tip"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "fester"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "sylvan"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "greenstone"
         },
         {

--- a/mods/tuxemon/db/monster/forturtle.json
+++ b/mods/tuxemon/db/monster/forturtle.json
@@ -3,31 +3,31 @@
     "category": "oracle_bone",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "rock"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "energy_field"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "tinder"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "muck"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "sleep_bomb"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "thunderclap"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "shadow_boxing"
         },
         {

--- a/mods/tuxemon/db/monster/foxfire.json
+++ b/mods/tuxemon/db/monster/foxfire.json
@@ -3,23 +3,23 @@
     "category": "smoke",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "give_all"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fume"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "fluff_up"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "breathe_fire"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "one_two"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "torch"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "lava"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "all_in"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "invictus"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "electrical_storm"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "supernova"
         },
         {

--- a/mods/tuxemon/db/monster/foxko.json
+++ b/mods/tuxemon/db/monster/foxko.json
@@ -3,23 +3,23 @@
     "category": "threat",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "gust"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "chameleon"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "all_in"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "pseudopod"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "sunburst"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "negation"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "salamander"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "berserk"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "shadow_boxing"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "conjurer"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "torch"
         },
         {

--- a/mods/tuxemon/db/monster/fribbit.json
+++ b/mods/tuxemon/db/monster/fribbit.json
@@ -3,23 +3,23 @@
     "category": "rueful",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "goad"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flood"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "geyser"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "grinding"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "flow"
         },
         {
@@ -27,19 +27,19 @@
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "font"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "starfall"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "tsunami"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "ice_storm"
         }
     ],

--- a/mods/tuxemon/db/monster/frondly.json
+++ b/mods/tuxemon/db/monster/frondly.json
@@ -3,31 +3,31 @@
     "category": "helping_hand",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "muddle"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "clamp_on"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "poison_courtship"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "stabilo"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "ram"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "fester"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "splinter"
         },
         {

--- a/mods/tuxemon/db/monster/fruitera.json
+++ b/mods/tuxemon/db/monster/fruitera.json
@@ -3,23 +3,23 @@
     "category": "tiny_bat",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fluff_up"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sting"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "splinter"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "spit_poison"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "invictus"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "solar_synthesis"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "fester"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "blossom"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "greenstone"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "chameleon"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "whirlwind"
         },
         {

--- a/mods/tuxemon/db/monster/furnursus.json
+++ b/mods/tuxemon/db/monster/furnursus.json
@@ -3,27 +3,27 @@
     "category": "fireplace",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "rock"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_ball"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "fire_claw"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "one_two"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "flamethrower"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "give_all"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "supernova"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "tinder"
         }
     ],

--- a/mods/tuxemon/db/monster/fuzzina.json
+++ b/mods/tuxemon/db/monster/fuzzina.json
@@ -3,23 +3,23 @@
     "category": "toy",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "stampede"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sand_spray"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "surge"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "ruby"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "icicle_spear"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "crystal"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "stonehenge"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "thunderclap"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "electroplate"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "tsunami"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "greenstone"
         },
         {

--- a/mods/tuxemon/db/monster/fuzzlet.json
+++ b/mods/tuxemon/db/monster/fuzzlet.json
@@ -3,23 +3,23 @@
     "category": "toy",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "stampede"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sand_spray"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "surge"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "ruby"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "icicle_spear"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "crystal"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "stonehenge"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "thunderclap"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "electroplate"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "tsunami"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "greenstone"
         },
         {

--- a/mods/tuxemon/db/monster/galasces.json
+++ b/mods/tuxemon/db/monster/galasces.json
@@ -3,15 +3,15 @@
     "category": "sea_angel",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flood"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "rot"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "crystal"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "venomous_tentacle"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "spit_poison"
         }
     ],

--- a/mods/tuxemon/db/monster/galnec.json
+++ b/mods/tuxemon/db/monster/galnec.json
@@ -3,23 +3,23 @@
     "category": "dry_desert",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "mudslide"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "ram"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "rock"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "stampede"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "evasion"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "lantern"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "mending"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "breath"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "sylvan"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "fledgling"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "tip"
         },
         {

--- a/mods/tuxemon/db/monster/gastronium.json
+++ b/mods/tuxemon/db/monster/gastronium.json
@@ -3,15 +3,15 @@
     "category": "plutonium",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "venomous_tentacle"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "viper"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "shrapnel"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "rust_bomb"
         }
     ],

--- a/mods/tuxemon/db/monster/gectile.json
+++ b/mods/tuxemon/db/monster/gectile.json
@@ -3,27 +3,27 @@
     "category": "climbing",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sting"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "feint"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "assault"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "chameleon"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "whirlwind"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "splinter"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "peregrine"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "pseudopod"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "wing_tip"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "all_in"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "invictus"
         }
     ],

--- a/mods/tuxemon/db/monster/ghosteeth.json
+++ b/mods/tuxemon/db/monster/ghosteeth.json
@@ -3,23 +3,23 @@
     "category": "cheshire",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fester"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "blood_bond"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "chill_mist"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "whirlwind"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "amnesia"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "beam"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "wing_tip"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "crystal"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "undertaker"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "shuriken"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "bubble_trap"
         },
         {

--- a/mods/tuxemon/db/monster/gladiatorbug.json
+++ b/mods/tuxemon/db/monster/gladiatorbug.json
@@ -3,11 +3,11 @@
     "category": "bustuarius",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "clamp_on"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shrapnel"
         },
         {
@@ -15,15 +15,15 @@
             "technique": "splinter"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "font"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "peregrine"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "sting"
         }
     ],

--- a/mods/tuxemon/db/monster/gliffary.json
+++ b/mods/tuxemon/db/monster/gliffary.json
@@ -3,15 +3,15 @@
     "category": "toothsome",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "muddle"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "phantasmal_force"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "mind_vise"
         },
         {
@@ -19,11 +19,11 @@
             "technique": "changeling"
         },
         {
-            "level_learned": 14,
+            "level_learned": 13,
             "technique": "terror"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "orbs"
         }
     ],

--- a/mods/tuxemon/db/monster/glombroc.json
+++ b/mods/tuxemon/db/monster/glombroc.json
@@ -3,23 +3,23 @@
     "category": "aggregate",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "all_in"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fester"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "sylvan"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "stonehenge"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "clairaudience"
         },
         {
@@ -27,7 +27,7 @@
             "technique": "negation"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "greenstone"
         },
         {
@@ -35,7 +35,7 @@
             "technique": "breath"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "lantern"
         },
         {
@@ -43,7 +43,7 @@
             "technique": "surge"
         },
         {
-            "level_learned": 38,
+            "level_learned": 37,
             "technique": "mudslide"
         },
         {
@@ -51,7 +51,7 @@
             "technique": "earthquake"
         },
         {
-            "level_learned": 56,
+            "level_learned": 55,
             "technique": "thunderball"
         }
     ],

--- a/mods/tuxemon/db/monster/gourda.json
+++ b/mods/tuxemon/db/monster/gourda.json
@@ -3,15 +3,15 @@
     "category": "pumpkin",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "blossom"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "solar_synthesis"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "overgrowth"
         },
         {
@@ -19,11 +19,11 @@
             "technique": "stabilo"
         },
         {
-            "level_learned": 14,
+            "level_learned": 13,
             "technique": "overfeed"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "nest"
         }
     ],

--- a/mods/tuxemon/db/monster/graffiki.json
+++ b/mods/tuxemon/db/monster/graffiki.json
@@ -3,23 +3,23 @@
     "category": "gamut",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "bubble_trap"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "changeling"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "muddle"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "shuriken"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "arcane_eye"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "ruby"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "crystal"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "beam"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "lightning_spheres"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "sunburst"
         },
         {

--- a/mods/tuxemon/db/monster/grimachin.json
+++ b/mods/tuxemon/db/monster/grimachin.json
@@ -3,23 +3,23 @@
     "category": "spook",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "blade"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "lineage"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "rust_bomb"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "terror"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "fume"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "strike"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "energy_field"
         },
         {

--- a/mods/tuxemon/db/monster/grinflare.json
+++ b/mods/tuxemon/db/monster/grinflare.json
@@ -3,23 +3,23 @@
     "category": "igneous",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "boulder"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sand_spray"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "electroplate"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "stonehenge"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "avalanche"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "fire_claw"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "give_all"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "flamethrower"
         }
     ],

--- a/mods/tuxemon/db/monster/grintot.json
+++ b/mods/tuxemon/db/monster/grintot.json
@@ -3,23 +3,23 @@
     "category": "pebble",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "boulder"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sand_spray"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "electroplate"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "stonehenge"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "avalanche"
         }
     ],

--- a/mods/tuxemon/db/monster/grintrock.json
+++ b/mods/tuxemon/db/monster/grintrock.json
@@ -3,23 +3,23 @@
     "category": "thunderstone",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "boulder"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sand_spray"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "electroplate"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "stonehenge"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "avalanche"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "surge"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "stampede"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "hammerhead"
         }
     ],

--- a/mods/tuxemon/db/monster/grumpi.json
+++ b/mods/tuxemon/db/monster/grumpi.json
@@ -3,23 +3,23 @@
     "category": "gummy",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "constrict"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "one_two"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "all_in"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "avalanche"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "clamp_on"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "mudslide"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "quicksand"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "biting_winds"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "invictus"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "venomous_tentacle"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "pit"
         },
         {

--- a/mods/tuxemon/db/monster/gryfix.json
+++ b/mods/tuxemon/db/monster/gryfix.json
@@ -3,27 +3,27 @@
     "category": "horned_raptor",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wing_tip"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "berserk"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "lineage"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "slice"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "one_two"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "amnesia"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "rust_bomb"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "all_in"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "one_million_talons"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "blade"
         }
     ],

--- a/mods/tuxemon/db/monster/hampotamos.json
+++ b/mods/tuxemon/db/monster/hampotamos.json
@@ -3,23 +3,23 @@
     "category": "hungry",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wallow"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "mudslide"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "ram"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "surge"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "quicksand"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "strangulation"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "tsunami"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "avalanche"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "assault"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "canine"
         },
         {

--- a/mods/tuxemon/db/monster/happito.json
+++ b/mods/tuxemon/db/monster/happito.json
@@ -3,27 +3,27 @@
     "category": "ecstatic_emotion",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "blade"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "strike"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "mudslide"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "ram"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "rock"
         }
     ],

--- a/mods/tuxemon/db/monster/hatchling.json
+++ b/mods/tuxemon/db/monster/hatchling.json
@@ -3,27 +3,27 @@
     "category": "egg",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wing_tip"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "peck"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "air_chain"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "altitude"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "fluff_up"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "peregrine"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "whirlwind"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "one_two"
         }
     ],

--- a/mods/tuxemon/db/monster/hectapod.json
+++ b/mods/tuxemon/db/monster/hectapod.json
@@ -3,23 +3,23 @@
     "category": "sea_storm",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "goad"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flood"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "geyser"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "tonguespear"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "flow"
         },
         {
@@ -27,15 +27,15 @@
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "starfall"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "tsunami"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "ice_storm"
         }
     ],

--- a/mods/tuxemon/db/monster/heronquak.json
+++ b/mods/tuxemon/db/monster/heronquak.json
@@ -3,23 +3,23 @@
     "category": "crested",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "ice_claw"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "peck"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "orbs"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "flow"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "energy_field"
         },
         {
@@ -27,7 +27,7 @@
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "biting_winds"
         },
         {
@@ -35,11 +35,11 @@
             "technique": "flood"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "font"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "chill_mist"
         },
         {

--- a/mods/tuxemon/db/monster/hissiorite.json
+++ b/mods/tuxemon/db/monster/hissiorite.json
@@ -3,15 +3,15 @@
     "category": "meteor_snake",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_claw"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wall_fire"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "venom"
         },
         {
@@ -19,11 +19,11 @@
             "technique": "spit_poison"
         },
         {
-            "level_learned": 14,
+            "level_learned": 13,
             "technique": "fire_ball"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "flamethrower"
         }
     ],

--- a/mods/tuxemon/db/monster/hoarse.json
+++ b/mods/tuxemon/db/monster/hoarse.json
@@ -3,15 +3,15 @@
     "category": "field_dweller",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "stampede"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wallow"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "hibernate"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "mudslide"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "earthquake"
         }
     ],

--- a/mods/tuxemon/db/monster/hoarseshoo.json
+++ b/mods/tuxemon/db/monster/hoarseshoo.json
@@ -3,15 +3,15 @@
     "category": "attercob",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "stampede"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wallow"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "hibernate"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "mudslide"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "earthquake"
         }
     ],

--- a/mods/tuxemon/db/monster/hotline.json
+++ b/mods/tuxemon/db/monster/hotline.json
@@ -3,23 +3,23 @@
     "category": "ma_bell",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "electrical_storm"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "sleep_bomb"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "meltdown"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "shuriken"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "beam"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "bullet"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "bubble_trap"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "tinder"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "terror"
         },
         {

--- a/mods/tuxemon/db/monster/houndice.json
+++ b/mods/tuxemon/db/monster/houndice.json
@@ -3,15 +3,15 @@
     "category": "snowy",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "ice_claw"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "ice_shield"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "canine"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "ice_storm"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "frostbite"
         }
     ],

--- a/mods/tuxemon/db/monster/howl.json
+++ b/mods/tuxemon/db/monster/howl.json
@@ -3,23 +3,23 @@
     "category": "athena",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "assault"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "crystal"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "breath"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "peck"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "greenstone"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "frostbite"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "muck"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "rock"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "fledgling"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "strangulation"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "platinum"
         },
         {

--- a/mods/tuxemon/db/monster/hydrone.json
+++ b/mods/tuxemon/db/monster/hydrone.json
@@ -3,23 +3,23 @@
     "category": "short_circuit",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "electrical_storm"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "muddle"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "radiance"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "lightning_spheres"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "peregrine"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "time_crisis"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "viper"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "crystal"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "slice"
         },
         {

--- a/mods/tuxemon/db/monster/ignibus.json
+++ b/mods/tuxemon/db/monster/ignibus.json
@@ -3,23 +3,23 @@
     "category": "hot_rock",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_ball"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "boulder"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "one_two"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "fire_claw"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "tinder"
         }
     ],

--- a/mods/tuxemon/db/monster/imbrickcile.json
+++ b/mods/tuxemon/db/monster/imbrickcile.json
@@ -3,23 +3,23 @@
     "category": "brick",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "ram"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "boulder"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "riposte"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "assault"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "thunderball"
         },
         {
@@ -27,7 +27,7 @@
             "technique": "glower"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "wall_of_steel"
         },
         {
@@ -35,11 +35,11 @@
             "technique": "surge"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "stampede"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "earthquake"
         },
         {

--- a/mods/tuxemon/db/monster/incandesfin.json
+++ b/mods/tuxemon/db/monster/incandesfin.json
@@ -3,27 +3,27 @@
     "category": "light_fin",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flow"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sudden_glow"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "grinding"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "geyser"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "glower"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "goad"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "starfall"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "flood"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "static_field"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "proboscis"
         }
     ],

--- a/mods/tuxemon/db/monster/jelillow.json
+++ b/mods/tuxemon/db/monster/jelillow.json
@@ -3,23 +3,23 @@
     "category": "jelly_pillow",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "whirlwind"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "hibernate"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "flood"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "tonguespear"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "chill_mist"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "frostbite"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "orbs"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "biting_winds"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "mobbing"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "shapechange"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "muck"
         },
         {
@@ -53,7 +53,7 @@
     ],
     "evolutions": [
         {
-            "at_level": 40,
+            "at_level": 41,
             "monster_slug": "bedoo"
         }
     ],

--- a/mods/tuxemon/db/monster/jeluna.json
+++ b/mods/tuxemon/db/monster/jeluna.json
@@ -3,15 +3,15 @@
     "category": "moon_phase",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "midnight_mantle"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shooting_star"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "radiance"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "supernova"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "sunburst"
         }
     ],

--- a/mods/tuxemon/db/monster/jemuar.json
+++ b/mods/tuxemon/db/monster/jemuar.json
@@ -3,23 +3,23 @@
     "category": "precious_boulder",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "ram"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "boulder"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "mudslide"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "assault"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "thunderball"
         },
         {
@@ -27,7 +27,7 @@
             "technique": "glower"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "ice_claw"
         },
         {
@@ -35,11 +35,11 @@
             "technique": "surge"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "stampede"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "earthquake"
         },
         {

--- a/mods/tuxemon/db/monster/joulraton.json
+++ b/mods/tuxemon/db/monster/joulraton.json
@@ -3,23 +3,23 @@
     "category": "amped",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "berserk"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "pseudopod"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "bubble_trap"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "all_in"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "surge"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "give_all"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "magma"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "lava"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "sunburst"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "conjurer"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "supernova"
         },
         {

--- a/mods/tuxemon/db/monster/k9.json
+++ b/mods/tuxemon/db/monster/k9.json
@@ -3,23 +3,23 @@
     "category": "cute",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "beam"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "levitate"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "strike"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "radiance"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "battery_discharge"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "constrict"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "glower"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "shrapnel"
         }
     ],

--- a/mods/tuxemon/db/monster/katacoon.json
+++ b/mods/tuxemon/db/monster/katacoon.json
@@ -3,11 +3,11 @@
     "category": "stance",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "clamp_on"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shrapnel"
         },
         {
@@ -15,15 +15,15 @@
             "technique": "splinter"
         },
         {
-            "level_learned": 6,
+            "level_learned": 7,
             "technique": "font"
         },
         {
-            "level_learned": 8,
+            "level_learned": 10,
             "technique": "peregrine"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "sting"
         }
     ],

--- a/mods/tuxemon/db/monster/katapill.json
+++ b/mods/tuxemon/db/monster/katapill.json
@@ -3,11 +3,11 @@
     "category": "beat",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "clamp_on"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shrapnel"
         },
         {
@@ -15,15 +15,15 @@
             "technique": "splinter"
         },
         {
-            "level_learned": 6,
+            "level_learned": 7,
             "technique": "font"
         },
         {
-            "level_learned": 8,
+            "level_learned": 10,
             "technique": "peregrine"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "sting"
         }
     ],

--- a/mods/tuxemon/db/monster/kernel.json
+++ b/mods/tuxemon/db/monster/kernel.json
@@ -3,23 +3,23 @@
     "category": "virtual",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "electrical_storm"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "rust_bomb"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "radiance"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "constrict"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "slice"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "bubble_trap"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "gold_digger"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "time_crisis"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "terror"
         },
         {

--- a/mods/tuxemon/db/monster/knindling.json
+++ b/mods/tuxemon/db/monster/knindling.json
@@ -3,15 +3,15 @@
     "category": "firestarter",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_claw"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wall_fire"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "canine"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "fire_ball"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "flamethrower"
         }
     ],

--- a/mods/tuxemon/db/monster/komodraw.json
+++ b/mods/tuxemon/db/monster/komodraw.json
@@ -3,23 +3,23 @@
     "category": "quickdraw",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "riposte"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "bullet"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "sudden_glow"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "flamethrower"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "shrapnel"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "beam"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "supernova"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "breathe_fire"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "chameleon"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "wall_fire"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "fire_shield"
         },
         {

--- a/mods/tuxemon/db/monster/komoduel.json
+++ b/mods/tuxemon/db/monster/komoduel.json
@@ -3,23 +3,23 @@
     "category": "gunslinger",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "riposte"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "bullet"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "sudden_glow"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "flamethrower"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "shrapnel"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "beam"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "supernova"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "breathe_fire"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "chameleon"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "wall_fire"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "fire_shield"
         },
         {

--- a/mods/tuxemon/db/monster/konuit.json
+++ b/mods/tuxemon/db/monster/konuit.json
@@ -3,15 +3,15 @@
     "category": "marsupial",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "blossom"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "solar_synthesis"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "overgrowth"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "stabilo"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "nest"
         }
     ],

--- a/mods/tuxemon/db/monster/l3gk0.json
+++ b/mods/tuxemon/db/monster/l3gk0.json
@@ -3,23 +3,23 @@
     "category": "glitched",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "overgrowth"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "blossom"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "boulder"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "all_in"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "pseudopod"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "fester"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "splinter"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "feline"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "air_chain"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "radiance"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "orbs"
         },
         {

--- a/mods/tuxemon/db/monster/lambert.json
+++ b/mods/tuxemon/db/monster/lambert.json
@@ -3,23 +3,23 @@
     "category": "gumnut",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sting"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "blossom"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "poison_courtship"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "splinter"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "boulder"
         },
         {
@@ -27,7 +27,7 @@
             "technique": "overgrowth"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "peregrine"
         },
         {
@@ -35,11 +35,11 @@
             "technique": "spit_poison"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "thunderball"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "shadow_boxing"
         },
         {

--- a/mods/tuxemon/db/monster/lapinou.json
+++ b/mods/tuxemon/db/monster/lapinou.json
@@ -3,23 +3,23 @@
     "category": "thlay",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "invictus"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "rust_bomb"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "ruby"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "sunburst"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "bubble_trap"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "time_crisis"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "platinum"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "beam"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "negation"
         },
         {

--- a/mods/tuxemon/db/monster/legko.json
+++ b/mods/tuxemon/db/monster/legko.json
@@ -3,23 +3,23 @@
     "category": "lizard",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sting"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "blossom"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "poison_courtship"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "splinter"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "boulder"
         },
         {
@@ -27,7 +27,7 @@
             "technique": "overgrowth"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "peregrine"
         },
         {
@@ -35,11 +35,11 @@
             "technique": "spit_poison"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "thunderball"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "shadow_boxing"
         },
         {

--- a/mods/tuxemon/db/monster/legoplaste.json
+++ b/mods/tuxemon/db/monster/legoplaste.json
@@ -3,15 +3,15 @@
     "category": "amoeba",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "constrict"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "venomous_tentacle"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "pseudopod"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "slime"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "kraken"
         }
     ],

--- a/mods/tuxemon/db/monster/lendos.json
+++ b/mods/tuxemon/db/monster/lendos.json
@@ -3,23 +3,23 @@
     "category": "vision",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "muddle"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "mind_vise"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "rust_bomb"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "radiance"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "meltdown"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "amnesia"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "lineage"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "whirlwind"
         },
         {
@@ -39,15 +39,15 @@
             "technique": "acid"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "lightning_spheres"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "sleep_bomb"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "peregrine"
         }
     ],

--- a/mods/tuxemon/db/monster/lesmagu.json
+++ b/mods/tuxemon/db/monster/lesmagu.json
@@ -3,23 +3,23 @@
     "category": "vagrant",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "font"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "midnight_mantle"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "flow"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "flood"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "starfall"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "ice_claw"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "snowstorm"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "mobbing"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "orbs"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "kraken"
         },
         {

--- a/mods/tuxemon/db/monster/lightmare.json
+++ b/mods/tuxemon/db/monster/lightmare.json
@@ -3,27 +3,27 @@
     "category": "nightmare_fuel",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flow"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sudden_glow"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "grinding"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "geyser"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "glower"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "goad"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "starfall"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "flood"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "static_field"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "proboscis"
         }
     ],

--- a/mods/tuxemon/db/monster/loliferno.json
+++ b/mods/tuxemon/db/monster/loliferno.json
@@ -3,27 +3,27 @@
     "category": "spirit_fire",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "supernova"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "chill_mist"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "muddle"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "invictus"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "midnight_mantle"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "flamethrower"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "rock"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "fire_ball"
         }
     ],

--- a/mods/tuxemon/db/monster/lucifice.json
+++ b/mods/tuxemon/db/monster/lucifice.json
@@ -3,23 +3,23 @@
     "category": "ninth_circle",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "frostbite"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "goad"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "torch"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "orbs"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "muck"
         },
         {
@@ -31,11 +31,11 @@
             "technique": "grinding"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "tsunami"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "snowstorm"
         },
         {

--- a/mods/tuxemon/db/monster/lunight.json
+++ b/mods/tuxemon/db/monster/lunight.json
@@ -3,23 +3,23 @@
     "category": "quasar",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "beam"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_ball"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "arcane_eye"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "acid"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "strike"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "lineage"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "sleep_bomb"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "radiance"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "gold_digger"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "muddle"
         },
         {

--- a/mods/tuxemon/db/monster/manosting.json
+++ b/mods/tuxemon/db/monster/manosting.json
@@ -3,23 +3,23 @@
     "category": "balloon",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "venomous_tentacle"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "whirlwind"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "flood"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "tonguespear"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "spit_poison"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "poison_courtship"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "font"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "flow"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "ice_claw"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "frostbite"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "biting_winds"
         },
         {

--- a/mods/tuxemon/db/monster/marvantis.json
+++ b/mods/tuxemon/db/monster/marvantis.json
@@ -3,15 +3,15 @@
     "category": "mantid",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "clamp_on"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "changeling"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "ants"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "blood_nets"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "energy_claws"
         }
     ],

--- a/mods/tuxemon/db/monster/marvillar.json
+++ b/mods/tuxemon/db/monster/marvillar.json
@@ -3,15 +3,15 @@
     "category": "ant_mimic",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "clamp_on"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "changeling"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "ants"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "blood_nets"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "energy_claws"
         }
     ],

--- a/mods/tuxemon/db/monster/masknake.json
+++ b/mods/tuxemon/db/monster/masknake.json
@@ -3,23 +3,23 @@
     "category": "serpents_tooth",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "starfall"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "beam"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "supernova"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "lava"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "firestorm"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "magma"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "thunderclap"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "muddle"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "chameleon"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "fire_claw"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "bubble_trap"
         },
         {

--- a/mods/tuxemon/db/monster/mauai.json
+++ b/mods/tuxemon/db/monster/mauai.json
@@ -3,31 +3,31 @@
     "category": "anubis",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "riposte"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "feint"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "shuriken"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "slice"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "sand_spray"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "insanity"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "lineage"
         },
         {

--- a/mods/tuxemon/db/monster/medipup.json
+++ b/mods/tuxemon/db/monster/medipup.json
@@ -3,23 +3,23 @@
     "category": "erythrocyte",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "barking"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "ram"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "revenge_stance"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "canine"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "hibernate"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "mystic_blending"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "take_cover"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "life_surge"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "sand_spray"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "fluff_up"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "all_in"
         },
         {

--- a/mods/tuxemon/db/monster/medushock.json
+++ b/mods/tuxemon/db/monster/medushock.json
@@ -3,23 +3,23 @@
     "category": "jellyfish",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "lightning_spheres"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "rot"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "flood"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "surge"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "fire_shield"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "energy_claws"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "one_two"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "thunderclap"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "give_all"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "salamander"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "shadow_boxing"
         },
         {

--- a/mods/tuxemon/db/monster/megafruitera.json
+++ b/mods/tuxemon/db/monster/megafruitera.json
@@ -3,23 +3,23 @@
     "category": "flying_fox_bat",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fluff_up"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sting"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "splinter"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "spit_poison"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "invictus"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "solar_synthesis"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "fester"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "blossom"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "greenstone"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "chameleon"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "whirlwind"
         },
         {

--- a/mods/tuxemon/db/monster/memnomnom.json
+++ b/mods/tuxemon/db/monster/memnomnom.json
@@ -3,23 +3,23 @@
     "category": "relic",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "eyebite"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "feint"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "shuriken"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "slice"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "sand_spray"
         }
     ],

--- a/mods/tuxemon/db/monster/merlicun.json
+++ b/mods/tuxemon/db/monster/merlicun.json
@@ -3,23 +3,23 @@
     "category": "dragon_worm",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_ball"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "kindling_flame"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "muddle"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "breathe_fire"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "chameleon"
         },
         {
@@ -31,11 +31,11 @@
             "technique": "sunburst"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "magma"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "arcane_eye"
         },
         {

--- a/mods/tuxemon/db/monster/metesaur.json
+++ b/mods/tuxemon/db/monster/metesaur.json
@@ -3,23 +3,23 @@
     "category": "meteor",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "peck"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "kindling_flame"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "sand_spray"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "stampede"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "fire_shield"
         },
         {
@@ -27,15 +27,15 @@
             "technique": "arcane_eye"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "breathe_fire"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "peregrine"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "all_in"
         },
         {

--- a/mods/tuxemon/db/monster/metoxic.json
+++ b/mods/tuxemon/db/monster/metoxic.json
@@ -3,15 +3,15 @@
     "category": "toxic_flag",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "spit_poison"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "venomous_tentacle"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "viper"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "poison_courtship"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "biting_winds"
         }
     ],

--- a/mods/tuxemon/db/monster/miaownolith.json
+++ b/mods/tuxemon/db/monster/miaownolith.json
@@ -3,31 +3,31 @@
     "category": "desolate",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "eyebite"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "feint"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "shuriken"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "slice"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "sand_spray"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "petrify"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "fluff_up"
         },
         {
@@ -35,7 +35,7 @@
             "technique": "overgrowth"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "oedipus"
         }
     ],

--- a/mods/tuxemon/db/monster/mingdyn.json
+++ b/mods/tuxemon/db/monster/mingdyn.json
@@ -3,23 +3,23 @@
     "category": "dragon",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_ball"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "amnesia"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "salamander"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "surge"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "muddle"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "kindling_flame"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "fire_claw"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "wall_fire"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "gold_digger"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "energy_claws"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "arcane_eye"
         },
         {

--- a/mods/tuxemon/db/monster/mk01_alpha.json
+++ b/mods/tuxemon/db/monster/mk01_alpha.json
@@ -3,23 +3,23 @@
     "category": "threat",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "electrical_storm"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "beam"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "blade"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "acid"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "platinum"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "crystal"
         },
         {

--- a/mods/tuxemon/db/monster/mk01_beta.json
+++ b/mods/tuxemon/db/monster/mk01_beta.json
@@ -3,23 +3,23 @@
     "category": "threat",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "electrical_storm"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "amnesia"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "battery_discharge"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "strike"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "crystal"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "undertaker"
         },
         {

--- a/mods/tuxemon/db/monster/mk01_delta.json
+++ b/mods/tuxemon/db/monster/mk01_delta.json
@@ -3,23 +3,23 @@
     "category": "threat",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "electrical_storm"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "beam"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "blade"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "acid"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "platinum"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "crystal"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "lineage"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "terror"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "sunburst"
         },
         {

--- a/mods/tuxemon/db/monster/mk01_gamma.json
+++ b/mods/tuxemon/db/monster/mk01_gamma.json
@@ -3,23 +3,23 @@
     "category": "threat",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "electrical_storm"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "beam"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "blade"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "acid"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "platinum"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "crystal"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "lineage"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "terror"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "sunburst"
         },
         {

--- a/mods/tuxemon/db/monster/mk01_omega.json
+++ b/mods/tuxemon/db/monster/mk01_omega.json
@@ -3,23 +3,23 @@
     "category": "threat",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "electrical_storm"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "amnesia"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "battery_discharge"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "strike"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "crystal"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "undertaker"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "lineage"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "slice"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "viper"
         },
         {

--- a/mods/tuxemon/db/monster/mk01_proto.json
+++ b/mods/tuxemon/db/monster/mk01_proto.json
@@ -3,19 +3,19 @@
     "category": "threat",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "electrical_storm"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "amnesia"
         }
     ],

--- a/mods/tuxemon/db/monster/moloch.json
+++ b/mods/tuxemon/db/monster/moloch.json
@@ -3,23 +3,23 @@
     "category": "devil",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sting"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "blossom"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "poison_courtship"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "splinter"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "boulder"
         },
         {
@@ -27,7 +27,7 @@
             "technique": "overgrowth"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "peregrine"
         },
         {
@@ -35,11 +35,11 @@
             "technique": "spit_poison"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "thunderball"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "shadow_boxing"
         },
         {

--- a/mods/tuxemon/db/monster/mrmoswitch.json
+++ b/mods/tuxemon/db/monster/mrmoswitch.json
@@ -3,23 +3,23 @@
     "category": "gremlin",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "beam"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "levitate"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "strike"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "radiance"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "battery_discharge"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "glower"
         }
     ],

--- a/mods/tuxemon/db/monster/myrmison.json
+++ b/mods/tuxemon/db/monster/myrmison.json
@@ -3,15 +3,15 @@
     "category": "myrmidon",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "clamp_on"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "energy_claws"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "ants"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "blood_nets"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "sting"
         }
     ],

--- a/mods/tuxemon/db/monster/mystikapi.json
+++ b/mods/tuxemon/db/monster/mystikapi.json
@@ -3,23 +3,23 @@
     "category": "prescient",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "blade"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "muddle"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "peregrine"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "insanity"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "bullet"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "sleep_bomb"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "undertaker"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "viper"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "constrict"
         },
         {

--- a/mods/tuxemon/db/monster/narcileaf.json
+++ b/mods/tuxemon/db/monster/narcileaf.json
@@ -3,27 +3,27 @@
     "category": "gardener",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "pseudopod"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "take_cover"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "ants"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "blossom"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "sting"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "sleeping_powder"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "fester"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "solar_synthesis"
         }
     ],

--- a/mods/tuxemon/db/monster/nebufin.json
+++ b/mods/tuxemon/db/monster/nebufin.json
@@ -3,15 +3,15 @@
     "category": "sea_angel",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flood"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "rot"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "crystal"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "venomous_tentacle"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "spit_poison"
         }
     ],

--- a/mods/tuxemon/db/monster/ned.json
+++ b/mods/tuxemon/db/monster/ned.json
@@ -3,15 +3,15 @@
     "category": "red_hands",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "punch"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "hammerhead"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "invictus"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "shadow_boxing"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "one_two"
         }
     ],

--- a/mods/tuxemon/db/monster/neutrito.json
+++ b/mods/tuxemon/db/monster/neutrito.json
@@ -3,31 +3,31 @@
     "category": "calm_emotion",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "blade"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "strike"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "amnesia"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "peregrine"
         },
         {

--- a/mods/tuxemon/db/monster/nimbulex.json
+++ b/mods/tuxemon/db/monster/nimbulex.json
@@ -3,23 +3,23 @@
     "category": "veiled",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flood"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "whirlwind"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "venomous_tentacle"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "midnight_mantle"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "muck"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "mobbing"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "kraken"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "poison_courtship"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "ice_shield"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "shapechange"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "chill_mist"
         },
         {

--- a/mods/tuxemon/db/monster/ninjasmine.json
+++ b/mods/tuxemon/db/monster/ninjasmine.json
@@ -3,23 +3,23 @@
     "category": "every_thorn",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "solar_synthesis"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fester"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "splinter"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "one_two"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "blossom"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "stabilo"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "clairaudience"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "sting"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "radiance"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "poison_courtship"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "assault"
         },
         {

--- a/mods/tuxemon/db/monster/noctalo.json
+++ b/mods/tuxemon/db/monster/noctalo.json
@@ -3,27 +3,27 @@
     "category": "nightcrawler",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "midnight_mantle"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "rot"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "goad"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "font"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "take_cover"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "starfall"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "font"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "chill_mist"
         }
     ],

--- a/mods/tuxemon/db/monster/noctula.json
+++ b/mods/tuxemon/db/monster/noctula.json
@@ -3,27 +3,27 @@
     "category": "nightcrawler",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "midnight_mantle"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "rot"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "goad"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "font"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "take_cover"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "starfall"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "font"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "chill_mist"
         }
     ],

--- a/mods/tuxemon/db/monster/nostray.json
+++ b/mods/tuxemon/db/monster/nostray.json
@@ -3,27 +3,27 @@
     "category": "proboscis",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "proboscis"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "chill_mist"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "font"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "goad"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "snowstorm"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "flow"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "kraken"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "flood"
         }
     ],

--- a/mods/tuxemon/db/monster/novaquarius.json
+++ b/mods/tuxemon/db/monster/novaquarius.json
@@ -3,15 +3,15 @@
     "category": "sea_angel",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flood"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "rot"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "crystal"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "venomous_tentacle"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "spit_poison"
         }
     ],

--- a/mods/tuxemon/db/monster/nudiflot_female.json
+++ b/mods/tuxemon/db/monster/nudiflot_female.json
@@ -3,31 +3,31 @@
     "category": "flopped",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "suck_poison"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "feint"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "muck"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "fiery"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "flood"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "sleep_bomb"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "bubble_trap"
         },
         {

--- a/mods/tuxemon/db/monster/nudiflot_male.json
+++ b/mods/tuxemon/db/monster/nudiflot_male.json
@@ -3,31 +3,31 @@
     "category": "flotsam",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "suck_poison"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "feint"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "muck"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "fiery"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "flood"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "rot"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "bubble_trap"
         },
         {

--- a/mods/tuxemon/db/monster/nudikill.json
+++ b/mods/tuxemon/db/monster/nudikill.json
@@ -3,31 +3,31 @@
     "category": "dark_bishop",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "suck_poison"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "feint"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "muck"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "fiery"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "flood"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "rot"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "bubble_trap"
         },
         {

--- a/mods/tuxemon/db/monster/nudimind.json
+++ b/mods/tuxemon/db/monster/nudimind.json
@@ -3,31 +3,31 @@
     "category": "reverie",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "suck_poison"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "feint"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "muck"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "fiery"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "flood"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "sleep_bomb"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "bubble_trap"
         },
         {

--- a/mods/tuxemon/db/monster/nuenflu.json
+++ b/mods/tuxemon/db/monster/nuenflu.json
@@ -3,23 +3,23 @@
     "category": "snowball",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "starfall"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "blood_bond"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "midnight_mantle"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "ice_claw"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "snowstorm"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "mobbing"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "geyser"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "flood"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "ice_shield"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "goad"
         },
         {

--- a/mods/tuxemon/db/monster/nut.json
+++ b/mods/tuxemon/db/monster/nut.json
@@ -3,11 +3,11 @@
     "category": "hardware",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "bullet"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "static_field"
         },
         {
@@ -15,15 +15,15 @@
             "technique": "shuriken"
         },
         {
-            "level_learned": 6,
+            "level_learned": 7,
             "technique": "clamp_on"
         },
         {
-            "level_learned": 8,
+            "level_learned": 10,
             "technique": "muddle"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "bubble_trap"
         },
         {
@@ -31,11 +31,11 @@
             "technique": "beam"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "surge"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "thunderclap"
         }
     ],

--- a/mods/tuxemon/db/monster/octabode.json
+++ b/mods/tuxemon/db/monster/octabode.json
@@ -3,23 +3,23 @@
     "category": "hermit",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flood"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flow"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "mobbing"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "orbs"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "spit_poison"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "font"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "goad"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "feint"
         },
         {

--- a/mods/tuxemon/db/monster/ouroboutlet.json
+++ b/mods/tuxemon/db/monster/ouroboutlet.json
@@ -3,31 +3,31 @@
     "category": "infinite_energy",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "strike"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "surge"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "viper"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "radiance"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "constrict"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "amnesia"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "shuriken"
         },
         {

--- a/mods/tuxemon/db/monster/pairagrim.json
+++ b/mods/tuxemon/db/monster/pairagrim.json
@@ -3,23 +3,23 @@
     "category": "bird",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "peck"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "whirlwind"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "assault"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "negation"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "gust"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "wing_tip"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "fluff_up"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "peregrine"
         },
         {

--- a/mods/tuxemon/db/monster/pairagrin.json
+++ b/mods/tuxemon/db/monster/pairagrin.json
@@ -3,23 +3,23 @@
     "category": "bird",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "peck"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "whirlwind"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "assault"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "negation"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "gust"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "wing_tip"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "fluff_up"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "peregrine"
         },
         {

--- a/mods/tuxemon/db/monster/pantherafira.json
+++ b/mods/tuxemon/db/monster/pantherafira.json
@@ -3,27 +3,27 @@
     "category": "mercury",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "one_two"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_claw"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "salamander"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "breathe_fire"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "all_in"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "eyebite"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "glower"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "flamethrower"
         }
     ],

--- a/mods/tuxemon/db/monster/pearamanca.json
+++ b/mods/tuxemon/db/monster/pearamanca.json
@@ -3,15 +3,15 @@
     "category": "biting_pear",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "energy_claws"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "solar_synthesis"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "changeling"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "blossom"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "overgrowth"
         }
     ],

--- a/mods/tuxemon/db/monster/pharfan.json
+++ b/mods/tuxemon/db/monster/pharfan.json
@@ -3,23 +3,23 @@
     "category": "little_elephant",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wallow"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flow"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "stampede"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "goad"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "tonguespear"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "geyser"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "spit_poison"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "biting_winds"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "ice_claw"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "chill_mist"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "tsunami"
         },
         {

--- a/mods/tuxemon/db/monster/picc.json
+++ b/mods/tuxemon/db/monster/picc.json
@@ -3,23 +3,23 @@
     "category": "bladder",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "beam"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "levitate"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "strike"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "radiance"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "battery_discharge"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "constrict"
         }
     ],

--- a/mods/tuxemon/db/monster/pigabyte.json
+++ b/mods/tuxemon/db/monster/pigabyte.json
@@ -3,23 +3,23 @@
     "category": "electric_pig",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "electrical_storm"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "sleep_bomb"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "meltdown"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "shuriken"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "beam"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "bullet"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "bubble_trap"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "wing_tip"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "terror"
         },
         {

--- a/mods/tuxemon/db/monster/pilthropus.json
+++ b/mods/tuxemon/db/monster/pilthropus.json
@@ -3,23 +3,23 @@
     "category": "tool_maker",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "strike"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "riposte"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "blade"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "mudslide"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "fester"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "crystal"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "platinum"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "lantern"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "battery_acid"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "thunderball"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "snowstorm"
         },
         {

--- a/mods/tuxemon/db/monster/pipis.json
+++ b/mods/tuxemon/db/monster/pipis.json
@@ -3,27 +3,27 @@
     "category": "echo",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "rot"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "splinter"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "overfeed"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "one_two"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "take_cover"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "all_in"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "blossom"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "peck"
         }
     ],

--- a/mods/tuxemon/db/monster/poinchin.json
+++ b/mods/tuxemon/db/monster/poinchin.json
@@ -3,23 +3,23 @@
     "category": "spiny",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flood"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flow"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "goad"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "muck"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "font"
         }
     ],

--- a/mods/tuxemon/db/monster/polyrock.json
+++ b/mods/tuxemon/db/monster/polyrock.json
@@ -3,23 +3,23 @@
     "category": "grasshopper",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "punch"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "all_in"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "one_two"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "ram"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "fester"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "avalanche"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "assault"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "thunderclap"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "pit"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "meltdown"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "hammerhead"
         },
         {

--- a/mods/tuxemon/db/monster/possessun.json
+++ b/mods/tuxemon/db/monster/possessun.json
@@ -3,23 +3,23 @@
     "category": "visitor",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "pseudopod"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "refresh"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "stampede"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "mending"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "greenstone"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "muddle"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "quicksand"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "crystal"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "muck"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "amnesia"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "bubble_trap"
         },
         {

--- a/mods/tuxemon/db/monster/potturmeist.json
+++ b/mods/tuxemon/db/monster/potturmeist.json
@@ -3,23 +3,23 @@
     "category": "pottery",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "bullet"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "muddle"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "wall_of_steel"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "lineage"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "ruby"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "terror"
         },
         {
@@ -39,7 +39,7 @@
             "technique": "phantasmal_force"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "crystal"
         }
     ],

--- a/mods/tuxemon/db/monster/potturney.json
+++ b/mods/tuxemon/db/monster/potturney.json
@@ -3,23 +3,23 @@
     "category": "pottery",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "bullet"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "muddle"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "wall_of_steel"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "lineage"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "ruby"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "terror"
         },
         {
@@ -39,7 +39,7 @@
             "technique": "phantasmal_force"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "crystal"
         }
     ],

--- a/mods/tuxemon/db/monster/propellercat.json
+++ b/mods/tuxemon/db/monster/propellercat.json
@@ -3,23 +3,23 @@
     "category": "eureka",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wing_tip"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "fluff_up"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "strike"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "blade"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "beam"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "acid"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "bubble_trap"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "sleep_bomb"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "arcane_eye"
         },
         {

--- a/mods/tuxemon/db/monster/prophetoise.json
+++ b/mods/tuxemon/db/monster/prophetoise.json
@@ -3,31 +3,31 @@
     "category": "dragon_bone",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "rock"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "energy_field"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "tinder"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "muck"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "sleep_bomb"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "thunderclap"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "shadow_boxing"
         },
         {

--- a/mods/tuxemon/db/monster/puparmor.json
+++ b/mods/tuxemon/db/monster/puparmor.json
@@ -3,11 +3,11 @@
     "category": "fortified",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "bullet"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shuriken"
         },
         {
@@ -15,31 +15,31 @@
             "technique": "wallow"
         },
         {
-            "level_learned": 6,
+            "level_learned": 7,
             "technique": "hibernate"
         },
         {
-            "level_learned": 8,
+            "level_learned": 10,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 10,
+            "level_learned": 13,
             "technique": "blade"
         },
         {
-            "level_learned": 12,
+            "level_learned": 16,
             "technique": "viper"
         },
         {
-            "level_learned": 16,
+            "level_learned": 19,
             "technique": "lineage"
         },
         {
-            "level_learned": 20,
+            "level_learned": 22,
             "technique": "muddle"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "eyebite"
         },
         {

--- a/mods/tuxemon/db/monster/pyraminx.json
+++ b/mods/tuxemon/db/monster/pyraminx.json
@@ -3,31 +3,31 @@
     "category": "noble",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "eyebite"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "feint"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "shuriken"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "slice"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "sand_spray"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "rot"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "blade"
         },
         {

--- a/mods/tuxemon/db/monster/pythock.json
+++ b/mods/tuxemon/db/monster/pythock.json
@@ -3,23 +3,23 @@
     "category": "puppet_master",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "strike"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "surge"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "lineage"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "rust_bomb"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "terror"
         },
         {
@@ -27,7 +27,7 @@
             "technique": "frostbite"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "battery_acid"
         },
         {
@@ -35,7 +35,7 @@
             "technique": "sudden_glow"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "shrapnel"
         }
     ],

--- a/mods/tuxemon/db/monster/pythonova.json
+++ b/mods/tuxemon/db/monster/pythonova.json
@@ -3,15 +3,15 @@
     "category": "nova_snake",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_claw"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wall_fire"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "venom"
         },
         {
@@ -19,11 +19,11 @@
             "technique": "spit_poison"
         },
         {
-            "level_learned": 14,
+            "level_learned": 13,
             "technique": "fire_ball"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "flamethrower"
         }
     ],

--- a/mods/tuxemon/db/monster/pythwire.json
+++ b/mods/tuxemon/db/monster/pythwire.json
@@ -3,23 +3,23 @@
     "category": "power_socket",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "strike"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "surge"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "viper"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "radiance"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "constrict"
         }
     ],

--- a/mods/tuxemon/db/monster/qetzlrokilus.json
+++ b/mods/tuxemon/db/monster/qetzlrokilus.json
@@ -3,23 +3,23 @@
     "category": "long_winged",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "peck"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "kindling_flame"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "sand_spray"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "stampede"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "fire_shield"
         },
         {
@@ -27,15 +27,15 @@
             "technique": "arcane_eye"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "breathe_fire"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "peregrine"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "all_in"
         },
         {

--- a/mods/tuxemon/db/monster/r0ck1tt3n.json
+++ b/mods/tuxemon/db/monster/r0ck1tt3n.json
@@ -3,23 +3,23 @@
     "category": "glitched",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "ram"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "boulder"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "thunderball"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "lust"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "thunderclap"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "fester"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "crystal"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "cavity"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "tsunami"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "meltdown"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "pit"
         },
         {

--- a/mods/tuxemon/db/monster/rabbitosaur.json
+++ b/mods/tuxemon/db/monster/rabbitosaur.json
@@ -3,27 +3,27 @@
     "category": "rabbit",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "thunderball"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shadow_boxing"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "quicksand"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "fledgling"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "one_two"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "stampede"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "electrical_storm"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "snowstorm"
         }
     ],

--- a/mods/tuxemon/db/monster/regalance.json
+++ b/mods/tuxemon/db/monster/regalance.json
@@ -3,23 +3,23 @@
     "category": "terracotta",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "mending"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "rock"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "stampede"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "icicle_spear"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "muck"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "shadow_boxing"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "stonehenge"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "saber"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "undertaker"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "shuriken"
         },
         {

--- a/mods/tuxemon/db/monster/rhincus.json
+++ b/mods/tuxemon/db/monster/rhincus.json
@@ -3,23 +3,23 @@
     "category": "missing_link",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "hammerhead"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wing_tip"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "peck"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "avalanche"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "air_chain"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "fester"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "ram"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "icicle_spear"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "greenstone"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "altitude"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "slime"
         },
         {

--- a/mods/tuxemon/db/monster/rhinocarpe.json
+++ b/mods/tuxemon/db/monster/rhinocarpe.json
@@ -3,23 +3,23 @@
     "category": "big_head",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "goad"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flow"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "venomous_tentacle"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "grinding"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "mobbing"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "starfall"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "frostbite"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "font"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "flood"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "tsunami"
         },
         {

--- a/mods/tuxemon/db/monster/rinocereed.json
+++ b/mods/tuxemon/db/monster/rinocereed.json
@@ -3,23 +3,23 @@
     "category": "calf",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "all_in"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "assault"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "greenstone"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "sylvan"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "pseudopod"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "stonehenge"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "shadow_boxing"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "one_two"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "fester"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "clairaudience"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "invictus"
         },
         {

--- a/mods/tuxemon/db/monster/rockat.json
+++ b/mods/tuxemon/db/monster/rockat.json
@@ -3,23 +3,23 @@
     "category": "sleek_boulder",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "ram"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "boulder"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "mudslide"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "assault"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "thunderball"
         },
         {
@@ -27,7 +27,7 @@
             "technique": "glower"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "ice_claw"
         },
         {
@@ -35,11 +35,11 @@
             "technique": "surge"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "stampede"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "earthquake"
         },
         {

--- a/mods/tuxemon/db/monster/rockitten.json
+++ b/mods/tuxemon/db/monster/rockitten.json
@@ -3,23 +3,23 @@
     "category": "cute_boulder",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "ram"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "boulder"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "mudslide"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "assault"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "thunderball"
         },
         {
@@ -27,7 +27,7 @@
             "technique": "glower"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "ice_claw"
         },
         {
@@ -35,11 +35,11 @@
             "technique": "surge"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "stampede"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "earthquake"
         },
         {

--- a/mods/tuxemon/db/monster/rocktot.json
+++ b/mods/tuxemon/db/monster/rocktot.json
@@ -3,23 +3,23 @@
     "category": "threat",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "stampede"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "ram"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "hammerhead"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "ants"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "sand_spray"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "fester"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "stonehenge"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "meltdown"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "evasion"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "greenstone"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "strangulation"
         },
         {

--- a/mods/tuxemon/db/monster/rosarin.json
+++ b/mods/tuxemon/db/monster/rosarin.json
@@ -3,23 +3,23 @@
     "category": "every_thorn",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "solar_synthesis"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fester"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "splinter"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "one_two"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "blossom"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "stabilo"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "clairaudience"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "sting"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "radiance"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "poison_courtship"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "assault"
         },
         {

--- a/mods/tuxemon/db/monster/ruffalo.json
+++ b/mods/tuxemon/db/monster/ruffalo.json
@@ -3,15 +3,15 @@
     "category": "buffalo",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "stampede"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wallow"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "hibernate"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "mudslide"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "earthquake"
         }
     ],

--- a/mods/tuxemon/db/monster/runesquito.json
+++ b/mods/tuxemon/db/monster/runesquito.json
@@ -3,15 +3,15 @@
     "category": "diptera",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "boulder"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "grinding"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "petrify"
         },
         {
@@ -19,11 +19,11 @@
             "technique": "stonehenge"
         },
         {
-            "level_learned": 14,
+            "level_learned": 13,
             "technique": "take_cover"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "electroplate"
         }
     ],

--- a/mods/tuxemon/db/monster/ruption.json
+++ b/mods/tuxemon/db/monster/ruption.json
@@ -3,23 +3,23 @@
     "category": "bonfire",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_ball"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "refresh"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "fire_shield"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "one_two"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "tinder"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "kindling_flame"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "arcane_eye"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "fire_claw"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "magma"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "berserk"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "fume"
         },
         {

--- a/mods/tuxemon/db/monster/sadito.json
+++ b/mods/tuxemon/db/monster/sadito.json
@@ -3,31 +3,31 @@
     "category": "lamenting_emotion",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "mind_vise"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "blade"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "strike"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "shuriken"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "frostbite"
         },
         {

--- a/mods/tuxemon/db/monster/sampsack.json
+++ b/mods/tuxemon/db/monster/sampsack.json
@@ -3,23 +3,23 @@
     "category": "brawn",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "punch"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "all_in"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "strike"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "invictus"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "shuriken"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "blade"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "constrict"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "undertaker"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "time_crisis"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "arcane_eye"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "platinum"
         },
         {

--- a/mods/tuxemon/db/monster/sampsage.json
+++ b/mods/tuxemon/db/monster/sampsage.json
@@ -3,23 +3,23 @@
     "category": "brains",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sleep_bomb"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "bubble_trap"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "strike"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "shuriken"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "bullet"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "muddle"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "terror"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "undertaker"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "lineage"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "time_crisis"
         },
         {

--- a/mods/tuxemon/db/monster/sapragon.json
+++ b/mods/tuxemon/db/monster/sapragon.json
@@ -3,23 +3,23 @@
     "category": "dragon",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "all_in"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "web"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "greenstone"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "negation"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "overfeed"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "hibernate"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "sting"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "one_two"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "fluff_up"
         },
         {
-            "level_learned": 56,
+            "level_learned": 55,
             "technique": "whirlwind"
         },
         {
-            "level_learned": 60,
+            "level_learned": 61,
             "technique": "wing_tip"
         },
         {

--- a/mods/tuxemon/db/monster/sapsnap.json
+++ b/mods/tuxemon/db/monster/sapsnap.json
@@ -3,31 +3,31 @@
     "category": "barbed",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "solar_synthesis"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "hammerhead"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "greenstone"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "assault"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "fluff_up"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "one_two"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "all_in"
         },
         {

--- a/mods/tuxemon/db/monster/saurchin.json
+++ b/mods/tuxemon/db/monster/saurchin.json
@@ -3,31 +3,31 @@
     "category": "spiny",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flood"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flow"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "goad"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "muck"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "font"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "midnight_mantle"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "venomous_tentacle"
         },
         {

--- a/mods/tuxemon/db/monster/scarlant.json
+++ b/mods/tuxemon/db/monster/scarlant.json
@@ -3,15 +3,15 @@
     "category": "myrmidon",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "clamp_on"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "energy_claws"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "ants"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "blood_nets"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "sting"
         }
     ],

--- a/mods/tuxemon/db/monster/sclairus.json
+++ b/mods/tuxemon/db/monster/sclairus.json
@@ -3,23 +3,23 @@
     "category": "fallow",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "avalanche"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "peck"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "blossom"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "spit_poison"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "whirlwind"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "assault"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "air_chain"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "orbs"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "venom"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "chameleon"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "clairaudience"
         },
         {

--- a/mods/tuxemon/db/monster/seirein.json
+++ b/mods/tuxemon/db/monster/seirein.json
@@ -3,27 +3,27 @@
     "category": "spirit_fire",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "supernova"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "chill_mist"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "muddle"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "invictus"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "midnight_mantle"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "flamethrower"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "rock"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "fire_ball"
         }
     ],

--- a/mods/tuxemon/db/monster/selket.json
+++ b/mods/tuxemon/db/monster/selket.json
@@ -3,27 +3,27 @@
     "category": "sand_scorpion",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "clamp_on"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "rock"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "crystal"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "petrify"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "take_cover"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "quicksand"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "fester"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "avalanche"
         }
     ],

--- a/mods/tuxemon/db/monster/selmatek.json
+++ b/mods/tuxemon/db/monster/selmatek.json
@@ -3,27 +3,27 @@
     "category": "sand_steed",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "clamp_on"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "rock"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "crystal"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "petrify"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "take_cover"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "quicksand"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "fester"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "avalanche"
         }
     ],

--- a/mods/tuxemon/db/monster/seraphice.json
+++ b/mods/tuxemon/db/monster/seraphice.json
@@ -3,23 +3,23 @@
     "category": "carol",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "frostbite"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "goad"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "beam"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "orbs"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "neutralize"
         },
         {
@@ -31,11 +31,11 @@
             "technique": "sudden_glow"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "hibernate"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "icicle_spear"
         },
         {

--- a/mods/tuxemon/db/monster/shammer.json
+++ b/mods/tuxemon/db/monster/shammer.json
@@ -3,23 +3,23 @@
     "category": "fossil",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "hammerhead"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "mudslide"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "quicksand"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "ice_claw"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "rock"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "avalanche"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "lust"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "meltdown"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "electroplate"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "platinum"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "blood_nets"
         },
         {

--- a/mods/tuxemon/db/monster/sharpfin.json
+++ b/mods/tuxemon/db/monster/sharpfin.json
@@ -3,23 +3,23 @@
     "category": "rip",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "goad"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flood"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "geyser"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "grinding"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "flow"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "splinter"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "web"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "chill_mist"
         }
     ],

--- a/mods/tuxemon/db/monster/shelagu.json
+++ b/mods/tuxemon/db/monster/shelagu.json
@@ -3,23 +3,23 @@
     "category": "sheltering",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "font"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "midnight_mantle"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "flow"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "flood"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "starfall"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "ice_claw"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "snowstorm"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "mobbing"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "orbs"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "kraken"
         },
         {

--- a/mods/tuxemon/db/monster/sheye.json
+++ b/mods/tuxemon/db/monster/sheye.json
@@ -3,15 +3,15 @@
     "category": "crabby_mussel",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flood"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "ice_shield"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "terror"
         },
         {
@@ -19,11 +19,11 @@
             "technique": "phantasmal_force"
         },
         {
-            "level_learned": 14,
+            "level_learned": 13,
             "technique": "mind_vise"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "flow"
         }
     ],

--- a/mods/tuxemon/db/monster/shnark.json
+++ b/mods/tuxemon/db/monster/shnark.json
@@ -3,27 +3,27 @@
     "category": "disguised",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "proboscis"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "chill_mist"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "font"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "goad"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "snowstorm"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "flow"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "kraken"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "flood"
         }
     ],

--- a/mods/tuxemon/db/monster/shrab.json
+++ b/mods/tuxemon/db/monster/shrab.json
@@ -3,15 +3,15 @@
     "category": "muscly_crab",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flood"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "ice_shield"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "terror"
         },
         {
@@ -19,11 +19,11 @@
             "technique": "phantasmal_force"
         },
         {
-            "level_learned": 14,
+            "level_learned": 13,
             "technique": "mind_vise"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "flow"
         }
     ],

--- a/mods/tuxemon/db/monster/shull.json
+++ b/mods/tuxemon/db/monster/shull.json
@@ -3,15 +3,15 @@
     "category": "myrmidon",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "clamp_on"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "energy_claws"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "ants"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "blood_nets"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "sting"
         }
     ],

--- a/mods/tuxemon/db/monster/shybulb.json
+++ b/mods/tuxemon/db/monster/shybulb.json
@@ -3,27 +3,27 @@
     "category": "gardener",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "pseudopod"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "take_cover"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "ants"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "blossom"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "sting"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "sleeping_powder"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "fester"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "solar_synthesis"
         }
     ],

--- a/mods/tuxemon/db/monster/skwib.json
+++ b/mods/tuxemon/db/monster/skwib.json
@@ -3,23 +3,23 @@
     "category": "naive",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flood"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flow"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "mobbing"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "orbs"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "spit_poison"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "font"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "goad"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "feint"
         },
         {

--- a/mods/tuxemon/db/monster/slichen.json
+++ b/mods/tuxemon/db/monster/slichen.json
@@ -3,23 +3,23 @@
     "category": "gel",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "all_in"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fester"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "sylvan"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "stonehenge"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "clairaudience"
         },
         {
@@ -27,7 +27,7 @@
             "technique": "negation"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "greenstone"
         },
         {
@@ -35,7 +35,7 @@
             "technique": "breath"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "lantern"
         },
         {
@@ -43,7 +43,7 @@
             "technique": "surge"
         },
         {
-            "level_learned": 38,
+            "level_learned": 37,
             "technique": "mudslide"
         },
         {
@@ -51,7 +51,7 @@
             "technique": "earthquake"
         },
         {
-            "level_learned": 56,
+            "level_learned": 55,
             "technique": "thunderball"
         }
     ],

--- a/mods/tuxemon/db/monster/sludgehog.json
+++ b/mods/tuxemon/db/monster/sludgehog.json
@@ -3,23 +3,23 @@
     "category": "garbage",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fester"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "venomous_tentacle"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "energy_claws"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "thunderball"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "sand_spray"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "sylvan"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "frostbite"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "electroplate"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "lust"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "blood_nets"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "stonehenge"
         },
         {

--- a/mods/tuxemon/db/monster/snaki.json
+++ b/mods/tuxemon/db/monster/snaki.json
@@ -3,27 +3,27 @@
     "category": "false_serpent",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "venomous_tentacle"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "biting_winds"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "goad"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "flood"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "midnight_mantle"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "tonguespear"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "chill_mist"
         }
     ],

--- a/mods/tuxemon/db/monster/snarlon.json
+++ b/mods/tuxemon/db/monster/snarlon.json
@@ -3,23 +3,23 @@
     "category": "westerly",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sudden_glow"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "energy_field"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "sand_spray"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "electrical_storm"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "battery_acid"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "ram"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "platinum"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "fledgling"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "meltdown"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "mystic_blending"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "lust"
         },
         {

--- a/mods/tuxemon/db/monster/snock.json
+++ b/mods/tuxemon/db/monster/snock.json
@@ -3,23 +3,23 @@
     "category": "sock",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "strike"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "surge"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "lineage"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "rust_bomb"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "terror"
         },
         {
@@ -27,7 +27,7 @@
             "technique": "frostbite"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "battery_acid"
         },
         {
@@ -35,7 +35,7 @@
             "technique": "sudden_glow"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "shrapnel"
         }
     ],

--- a/mods/tuxemon/db/monster/snokari.json
+++ b/mods/tuxemon/db/monster/snokari.json
@@ -3,27 +3,27 @@
     "category": "hydra",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "venomous_tentacle"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "biting_winds"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "goad"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "flood"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "midnight_mantle"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "tonguespear"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "chill_mist"
         }
     ],

--- a/mods/tuxemon/db/monster/snowrilla.json
+++ b/mods/tuxemon/db/monster/snowrilla.json
@@ -3,27 +3,27 @@
     "category": "yeti",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "ice_claw"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "punch"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "flow"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "snowstorm"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "flood"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "chill_mist"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "frostbite"
         }
     ],

--- a/mods/tuxemon/db/monster/sockeserp.json
+++ b/mods/tuxemon/db/monster/sockeserp.json
@@ -3,31 +3,31 @@
     "category": "power_socket_snake",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "strike"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "surge"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "viper"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "radiance"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "constrict"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "rust_bomb"
         },
         {

--- a/mods/tuxemon/db/monster/solight.json
+++ b/mods/tuxemon/db/monster/solight.json
@@ -3,23 +3,23 @@
     "category": "pulsar",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "beam"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "fire_claw"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "energy_claws"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "give_all"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "electrical_storm"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "lava"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "arcane_eye"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "fire_shield"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "kindling_flame"
         },
         {

--- a/mods/tuxemon/db/monster/spectera.json
+++ b/mods/tuxemon/db/monster/spectera.json
@@ -3,23 +3,23 @@
     "category": "flying_fox_bat",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fluff_up"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sting"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "splinter"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "spit_poison"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "invictus"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "solar_synthesis"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "fester"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "blossom"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "greenstone"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "chameleon"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "whirlwind"
         },
         {

--- a/mods/tuxemon/db/monster/sphake.json
+++ b/mods/tuxemon/db/monster/sphake.json
@@ -3,15 +3,15 @@
     "category": "galvanised",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "rust_bomb"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "mudslide"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "take_cover"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "earthquake"
         }
     ],

--- a/mods/tuxemon/db/monster/spighter.json
+++ b/mods/tuxemon/db/monster/spighter.json
@@ -3,23 +3,23 @@
     "category": "eyerachnid",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fluff_up"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sting"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "splinter"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "blossom"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "overgrowth"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "shadow_boxing"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "wing_tip"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "pseudopod"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "whirlwind"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "phantasmal_force"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "poison_courtship"
         },
         {

--- a/mods/tuxemon/db/monster/spirain.json
+++ b/mods/tuxemon/db/monster/spirain.json
@@ -3,27 +3,27 @@
     "category": "water_sprite",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "supernova"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "chill_mist"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "muddle"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "invictus"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "midnight_mantle"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "flamethrower"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "rock"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "fire_ball"
         }
     ],

--- a/mods/tuxemon/db/monster/spoilurm.json
+++ b/mods/tuxemon/db/monster/spoilurm.json
@@ -3,23 +3,23 @@
     "category": "detritus",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fester"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sting"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "web"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "wing_tip"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "spit_poison"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "chameleon"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "clock"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "peck"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "poison_courtship"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "radiance"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "stabilo"
         },
         {

--- a/mods/tuxemon/db/monster/sprightly.json
+++ b/mods/tuxemon/db/monster/sprightly.json
@@ -3,15 +3,15 @@
     "category": "rootball",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "blossom"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "solar_synthesis"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "overgrowth"
         },
         {
@@ -19,11 +19,11 @@
             "technique": "stabilo"
         },
         {
-            "level_learned": 14,
+            "level_learned": 13,
             "technique": "life_surge"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "nest"
         }
     ],

--- a/mods/tuxemon/db/monster/sprorm.json
+++ b/mods/tuxemon/db/monster/sprorm.json
@@ -3,15 +3,15 @@
     "category": "galvanised",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "rust_bomb"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "mudslide"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "take_cover"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "earthquake"
         }
     ],

--- a/mods/tuxemon/db/monster/spycozeus.json
+++ b/mods/tuxemon/db/monster/spycozeus.json
@@ -3,23 +3,23 @@
     "category": "willpower",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "invictus"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "shuriken"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "slice"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "beam"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "wing_tip"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "terror"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "lineage"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "lightning_spheres"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "sunburst"
         },
         {

--- a/mods/tuxemon/db/monster/squabbit.json
+++ b/mods/tuxemon/db/monster/squabbit.json
@@ -3,27 +3,27 @@
     "category": "rabbit",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "thunderball"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shadow_boxing"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "quicksand"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "fledgling"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "one_two"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "stampede"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "electrical_storm"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "snowstorm"
         }
     ],

--- a/mods/tuxemon/db/monster/squink.json
+++ b/mods/tuxemon/db/monster/squink.json
@@ -3,23 +3,23 @@
     "category": "sea_spray",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "goad"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flood"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "geyser"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "tonguespear"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "flow"
         },
         {
@@ -27,15 +27,15 @@
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "starfall"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "tsunami"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "ice_storm"
         }
     ],

--- a/mods/tuxemon/db/monster/statursus.json
+++ b/mods/tuxemon/db/monster/statursus.json
@@ -3,27 +3,27 @@
     "category": "inner_fire",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "rock"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_ball"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "fire_claw"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "one_two"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "flamethrower"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "give_all"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "supernova"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "electrical_storm"
         }
     ],

--- a/mods/tuxemon/db/monster/stegofor.json
+++ b/mods/tuxemon/db/monster/stegofor.json
@@ -3,23 +3,23 @@
     "category": "petrified",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "one_two"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "invictus"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "peregrine"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "all_in"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "peck"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "pseudopod"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "overgrowth"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "wing_tip"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "fester"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "sylvan"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "greenstone"
         },
         {

--- a/mods/tuxemon/db/monster/stomic.json
+++ b/mods/tuxemon/db/monster/stomic.json
@@ -3,15 +3,15 @@
     "category": "radioactive",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "venomous_tentacle"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "viper"
         },
         {
@@ -19,7 +19,7 @@
             "technique": "shrapnel"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "rust_bomb"
         }
     ],

--- a/mods/tuxemon/db/monster/stonifly.json
+++ b/mods/tuxemon/db/monster/stonifly.json
@@ -3,15 +3,15 @@
     "category": "diptera",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "boulder"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "grinding"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "petrify"
         },
         {
@@ -19,17 +19,17 @@
             "technique": "stonehenge"
         },
         {
-            "level_learned": 14,
+            "level_learned": 13,
             "technique": "take_cover"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "electroplate"
         }
     ],
     "evolutions": [
         {
-            "at_level": 10,
+            "at_level": 9,
             "monster_slug": "cocrune"
         }
     ],

--- a/mods/tuxemon/db/monster/strella.json
+++ b/mods/tuxemon/db/monster/strella.json
@@ -3,27 +3,27 @@
     "category": "trailing",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "rot"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "splinter"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "overfeed"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "one_two"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "take_cover"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "all_in"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "blossom"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "peck"
         }
     ],

--- a/mods/tuxemon/db/monster/sumchon.json
+++ b/mods/tuxemon/db/monster/sumchon.json
@@ -3,11 +3,11 @@
     "category": "wrestling",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "clamp_on"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shrapnel"
         },
         {
@@ -15,15 +15,15 @@
             "technique": "splinter"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "font"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "peregrine"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "sting"
         },
         {
@@ -31,11 +31,11 @@
             "technique": "fluff_up"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "invictus"
         },
         {
@@ -43,7 +43,7 @@
             "technique": "blade"
         },
         {
-            "level_learned": 45,
+            "level_learned": 46,
             "technique": "suplex"
         }
     ],

--- a/mods/tuxemon/db/monster/tadcool.json
+++ b/mods/tuxemon/db/monster/tadcool.json
@@ -3,23 +3,23 @@
     "category": "alarm",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "goad"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flood"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "geyser"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "grinding"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "flow"
         },
         {
@@ -27,19 +27,19 @@
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "font"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "starfall"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "tsunami"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "ice_storm"
         }
     ],

--- a/mods/tuxemon/db/monster/tarpeur.json
+++ b/mods/tuxemon/db/monster/tarpeur.json
@@ -3,27 +3,27 @@
     "category": "restful",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "hibernate"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sting"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "chameleon"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "sylvan"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "fluff_up"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "hammerhead"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "shadow_boxing"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "life_surge"
         }
     ],

--- a/mods/tuxemon/db/monster/taupypus.json
+++ b/mods/tuxemon/db/monster/taupypus.json
@@ -3,23 +3,23 @@
     "category": "flatfoot",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "biting_winds"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "flood"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "goad"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "midnight_mantle"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "ice_shield"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "font"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "mobbing"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "poison_courtship"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "ice_storm"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "venomous_tentacle"
         },
         {

--- a/mods/tuxemon/db/monster/teddisun.json
+++ b/mods/tuxemon/db/monster/teddisun.json
@@ -3,23 +3,23 @@
     "category": "cute_teddy",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_ball"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "hammerhead"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "supernova"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "fire_claw"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "magma"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "kindling_flame"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "lava"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "firestorm"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "breathe_fire"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "electrical_storm"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "sunburst"
         },
         {

--- a/mods/tuxemon/db/monster/tetrchimp.json
+++ b/mods/tuxemon/db/monster/tetrchimp.json
@@ -3,31 +3,31 @@
     "category": "chip",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sleep_bomb"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "terror"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "insanity"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "bubble_trap"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "strike"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "constrict"
         },
         {

--- a/mods/tuxemon/db/monster/thumpurn.json
+++ b/mods/tuxemon/db/monster/thumpurn.json
@@ -3,15 +3,15 @@
     "category": "lagomorph",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "breathe_fire"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_ball"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "fire_claw"
         },
         {
@@ -19,11 +19,11 @@
             "technique": "mudslide"
         },
         {
-            "level_learned": 14,
+            "level_learned": 13,
             "technique": "earthquake"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "flamethrower"
         }
     ],

--- a/mods/tuxemon/db/monster/tigrock.json
+++ b/mods/tuxemon/db/monster/tigrock.json
@@ -3,23 +3,23 @@
     "category": "ex_machina",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "blade"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "lineage"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "rust_bomb"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "terror"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "fume"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "strike"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "energy_field"
         },
         {

--- a/mods/tuxemon/db/monster/tikoal.json
+++ b/mods/tuxemon/db/monster/tikoal.json
@@ -3,31 +3,31 @@
     "category": "taboo",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_ball"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "blossom"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "saber"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "gust"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "petrify"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "rock"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "berserk"
         },
         {

--- a/mods/tuxemon/db/monster/tikorch.json
+++ b/mods/tuxemon/db/monster/tikorch.json
@@ -3,31 +3,31 @@
     "category": "taboo",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_ball"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "blossom"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "saber"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "gust"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "petrify"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "rock"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "berserk"
         },
         {

--- a/mods/tuxemon/db/monster/tobishimi.json
+++ b/mods/tuxemon/db/monster/tobishimi.json
@@ -3,27 +3,27 @@
     "category": "dragon_roll",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "spit_poison"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flow"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "grinding"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "muck"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "flood"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "icicle_spear"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "font"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "starfall"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "ice_claw"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "chill_mist"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "frostbite"
         }
     ],

--- a/mods/tuxemon/db/monster/tornicane.json
+++ b/mods/tuxemon/db/monster/tornicane.json
@@ -3,27 +3,27 @@
     "category": "water_sprite",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "supernova"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "chill_mist"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "muddle"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "invictus"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "midnight_mantle"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "flamethrower"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "rock"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "fire_ball"
         }
     ],

--- a/mods/tuxemon/db/monster/toufigel.json
+++ b/mods/tuxemon/db/monster/toufigel.json
@@ -3,23 +3,23 @@
     "category": "powder",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "ice_claw"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "snowstorm"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "ram"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "sand_spray"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "avalanche"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "slime"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "evasion"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "biting_winds"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "earthquake"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "greenstone"
         },
         {

--- a/mods/tuxemon/db/monster/tourbidi.json
+++ b/mods/tuxemon/db/monster/tourbidi.json
@@ -3,23 +3,23 @@
     "category": "elf_ring",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "ring"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "midnight_mantle"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "sleeping_powder"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "walls"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "peregrine"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "web"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "all_in"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "whirlwind"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "ants"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "stabilo"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "one_two"
         },
         {

--- a/mods/tuxemon/db/monster/toxiris.json
+++ b/mods/tuxemon/db/monster/toxiris.json
@@ -3,23 +3,23 @@
     "category": "every_thorn",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "solar_synthesis"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fester"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "splinter"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "one_two"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "blossom"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "stabilo"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "clairaudience"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "sting"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "radiance"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "poison_courtship"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "assault"
         },
         {

--- a/mods/tuxemon/db/monster/trapsnap.json
+++ b/mods/tuxemon/db/monster/trapsnap.json
@@ -3,31 +3,31 @@
     "category": "barb",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "solar_synthesis"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "hammerhead"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "greenstone"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "assault"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "fluff_up"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "one_two"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "all_in"
         },
         {

--- a/mods/tuxemon/db/monster/tsushimi.json
+++ b/mods/tuxemon/db/monster/tsushimi.json
@@ -3,27 +3,27 @@
     "category": "dragon_roll",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "spit_poison"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flow"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "grinding"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "muck"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "flood"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "icicle_spear"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "font"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "starfall"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "ice_claw"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "chill_mist"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "frostbite"
         }
     ],

--- a/mods/tuxemon/db/monster/tumblebee.json
+++ b/mods/tuxemon/db/monster/tumblebee.json
@@ -3,27 +3,27 @@
     "category": "drone",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "strike"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "web"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "sleep_bomb"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "platinum"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "constrict"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "amnesia"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "overgrowth"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "whirlwind"
         }
     ],

--- a/mods/tuxemon/db/monster/tumbledillo.json
+++ b/mods/tuxemon/db/monster/tumbledillo.json
@@ -3,23 +3,23 @@
     "category": "ermine",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shadow_boxing"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "ice_claw"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "frostbite"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "electrical_storm"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "surge"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "fester"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "evasion"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "mending"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "quicksand"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "electroplate"
         },
         {

--- a/mods/tuxemon/db/monster/tumblequill.json
+++ b/mods/tuxemon/db/monster/tumblequill.json
@@ -3,23 +3,23 @@
     "category": "urchin",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shadow_boxing"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "ice_claw"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "frostbite"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "electrical_storm"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "surge"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "fester"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "evasion"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "mending"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "quicksand"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "electroplate"
         },
         {

--- a/mods/tuxemon/db/monster/tumbleworm.json
+++ b/mods/tuxemon/db/monster/tumbleworm.json
@@ -3,27 +3,27 @@
     "category": "buzzkill",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "strike"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "web"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "sleep_bomb"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "platinum"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "constrict"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "amnesia"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "overgrowth"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "whirlwind"
         }
     ],

--- a/mods/tuxemon/db/monster/turnipper.json
+++ b/mods/tuxemon/db/monster/turnipper.json
@@ -3,27 +3,27 @@
     "category": "scarytale",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "solar_synthesis"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fester"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "sylvan"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "pseudopod"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "one_two"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "sting"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "invictus"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "fluff_up"
         }
     ],

--- a/mods/tuxemon/db/monster/tux.json
+++ b/mods/tuxemon/db/monster/tux.json
@@ -3,23 +3,23 @@
     "category": "penguin",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "tux_attack"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flow"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "peck"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "frostbite"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "font"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "starfall"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "grinding"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "blood_bond"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "mobbing"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "flood"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "tsunami"
         },
         {

--- a/mods/tuxemon/db/monster/tweesher.json
+++ b/mods/tuxemon/db/monster/tweesher.json
@@ -3,23 +3,23 @@
     "category": "halcyon",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "ice_claw"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "peck"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "orbs"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "flow"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "energy_field"
         },
         {
@@ -27,7 +27,7 @@
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "biting_winds"
         },
         {
@@ -35,11 +35,11 @@
             "technique": "flood"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "font"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "chill_mist"
         },
         {

--- a/mods/tuxemon/db/monster/uf0.json
+++ b/mods/tuxemon/db/monster/uf0.json
@@ -3,23 +3,23 @@
     "category": "space_cutie",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "lightning_spheres"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "petrify"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "beam"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "time_crisis"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "platinum"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "lineage"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "rust_bomb"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "meltdown"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "insanity"
         },
         {

--- a/mods/tuxemon/db/monster/uglip.json
+++ b/mods/tuxemon/db/monster/uglip.json
@@ -3,23 +3,23 @@
     "category": "deepsea",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "goad"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flow"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "venomous_tentacle"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "grinding"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "mobbing"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "starfall"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "frostbite"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "blood_bond"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "flood"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "tsunami"
         },
         {

--- a/mods/tuxemon/db/monster/uneye.json
+++ b/mods/tuxemon/db/monster/uneye.json
@@ -3,23 +3,23 @@
     "category": "vision",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "muddle"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "mind_vise"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "rust_bomb"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "radiance"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "meltdown"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "amnesia"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "lineage"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "whirlwind"
         },
         {
@@ -39,15 +39,15 @@
             "technique": "acid"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "lightning_spheres"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "sleep_bomb"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "peregrine"
         }
     ],

--- a/mods/tuxemon/db/monster/uprout.json
+++ b/mods/tuxemon/db/monster/uprout.json
@@ -3,15 +3,15 @@
     "category": "rootball",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "blossom"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "solar_synthesis"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "overgrowth"
         },
         {
@@ -19,11 +19,11 @@
             "technique": "stabilo"
         },
         {
-            "level_learned": 14,
+            "level_learned": 13,
             "technique": "life_surge"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "nest"
         }
     ],

--- a/mods/tuxemon/db/monster/urcheedle.json
+++ b/mods/tuxemon/db/monster/urcheedle.json
@@ -3,23 +3,23 @@
     "category": "spiked",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "tonguespear"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "torch"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "flow"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "frostbite"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "mobbing"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "venomous_tentacle"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "grinding"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "ice_claw"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "poison_courtship"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "flood"
         },
         {

--- a/mods/tuxemon/db/monster/urcine.json
+++ b/mods/tuxemon/db/monster/urcine.json
@@ -3,23 +3,23 @@
     "category": "temper",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "thunderball"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "boulder"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "shadow_boxing"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "blossom"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "spit_poison"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "splinter"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "pseudopod"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "phantasmal_force"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "poison_courtship"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "orbs"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "wing_tip"
         },
         {

--- a/mods/tuxemon/db/monster/vamporm.json
+++ b/mods/tuxemon/db/monster/vamporm.json
@@ -3,11 +3,11 @@
     "category": "clot",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "proboscis"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "spit_poison"
         },
         {
@@ -15,15 +15,15 @@
             "technique": "refresh"
         },
         {
-            "level_learned": 6,
+            "level_learned": 7,
             "technique": "font"
         },
         {
-            "level_learned": 8,
+            "level_learned": 10,
             "technique": "hibernate"
         },
         {
-            "level_learned": 10,
+            "level_learned": 13,
             "technique": "goad"
         },
         {
@@ -31,11 +31,11 @@
             "technique": "geyser"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "sleeping_powder"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "venomous_tentacle"
         },
         {

--- a/mods/tuxemon/db/monster/velocitile.json
+++ b/mods/tuxemon/db/monster/velocitile.json
@@ -3,27 +3,27 @@
     "category": "restless",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sting"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "feint"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "assault"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "chameleon"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "whirlwind"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "splinter"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "peregrine"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "pseudopod"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "wing_tip"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "all_in"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "invictus"
         }
     ],

--- a/mods/tuxemon/db/monster/vigueur.json
+++ b/mods/tuxemon/db/monster/vigueur.json
@@ -3,27 +3,27 @@
     "category": "energised",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "hibernate"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "sting"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "chameleon"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "sylvan"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "fluff_up"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "hammerhead"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "shadow_boxing"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "life_surge"
         }
     ],

--- a/mods/tuxemon/db/monster/vivicinder.json
+++ b/mods/tuxemon/db/monster/vivicinder.json
@@ -3,23 +3,23 @@
     "category": "lit",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "stone_rot"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "hammerhead"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "quicksand"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "spit_poison"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "wallow"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "salamander"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "flamethrower"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "refresh"
         }
     ],

--- a/mods/tuxemon/db/monster/vividactil.json
+++ b/mods/tuxemon/db/monster/vividactil.json
@@ -3,23 +3,23 @@
     "category": "exhumed",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "stone_rot"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "hammerhead"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "quicksand"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "spit_poison"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "wallow"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "wing_tip"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "peck"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "frostbite"
         }
     ],

--- a/mods/tuxemon/db/monster/vivipere.json
+++ b/mods/tuxemon/db/monster/vivipere.json
@@ -3,23 +3,23 @@
     "category": "potentia",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "stone_rot"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "hammerhead"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "quicksand"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "spit_poison"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "wallow"
         }
     ],

--- a/mods/tuxemon/db/monster/viviphyta.json
+++ b/mods/tuxemon/db/monster/viviphyta.json
@@ -3,23 +3,23 @@
     "category": "germinated",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "stone_rot"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "hammerhead"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "quicksand"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "spit_poison"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "wallow"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "fester"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "sting"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "web"
         }
     ],

--- a/mods/tuxemon/db/monster/vivisource.json
+++ b/mods/tuxemon/db/monster/vivisource.json
@@ -3,23 +3,23 @@
     "category": "purified",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "stone_rot"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "hammerhead"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "quicksand"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "spit_poison"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "wallow"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "flood"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "chill_mist"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "goad"
         }
     ],

--- a/mods/tuxemon/db/monster/viviteel.json
+++ b/mods/tuxemon/db/monster/viviteel.json
@@ -3,23 +3,23 @@
     "category": "galvanised",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "stone_rot"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "hammerhead"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "quicksand"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "spit_poison"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "wallow"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "rust_bomb"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "constrict"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "perfect_cut"
         }
     ],

--- a/mods/tuxemon/db/monster/vivitrans.json
+++ b/mods/tuxemon/db/monster/vivitrans.json
@@ -3,23 +3,23 @@
     "category": "sublimated",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "stone_rot"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "hammerhead"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "quicksand"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "spit_poison"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "wallow"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "chill_mist"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "bubble_trap"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "frostbite"
         }
     ],

--- a/mods/tuxemon/db/monster/vivitron.json
+++ b/mods/tuxemon/db/monster/vivitron.json
@@ -3,23 +3,23 @@
     "category": "sparked",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "stone_rot"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "hammerhead"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "quicksand"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "spit_poison"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "wallow"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "electrical_storm"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "sudden_glow"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "battery_acid"
         }
     ],

--- a/mods/tuxemon/db/monster/volcoli.json
+++ b/mods/tuxemon/db/monster/volcoli.json
@@ -3,23 +3,23 @@
     "category": "seasonal",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "supernova"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "flamethrower"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "sudden_glow"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "sleep_bomb"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "fire_claw"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "fire_shield"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "shadow_boxing"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "lava"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "thunderclap"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "give_all"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "conjurer"
         },
         {

--- a/mods/tuxemon/db/monster/volconey.json
+++ b/mods/tuxemon/db/monster/volconey.json
@@ -3,15 +3,15 @@
     "category": "roaming",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "breathe_fire"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fire_ball"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "fire_claw"
         },
         {
@@ -19,11 +19,11 @@
             "technique": "mudslide"
         },
         {
-            "level_learned": 14,
+            "level_learned": 13,
             "technique": "earthquake"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "flamethrower"
         }
     ],

--- a/mods/tuxemon/db/monster/vulpyre.json
+++ b/mods/tuxemon/db/monster/vulpyre.json
@@ -3,23 +3,23 @@
     "category": "firefox",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "give_all"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fume"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "fluff_up"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "breathe_fire"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "one_two"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "torch"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "lava"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "all_in"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "invictus"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "electrical_storm"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "supernova"
         },
         {

--- a/mods/tuxemon/db/monster/waysprite.json
+++ b/mods/tuxemon/db/monster/waysprite.json
@@ -3,23 +3,23 @@
     "category": "wavering",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "frostbite"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "goad"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "beam"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "orbs"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "neutralize"
         }
     ],

--- a/mods/tuxemon/db/monster/weavifly.json
+++ b/mods/tuxemon/db/monster/weavifly.json
@@ -3,11 +3,11 @@
     "category": "brood",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "bullet"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shuriken"
         },
         {
@@ -15,31 +15,31 @@
             "technique": "wallow"
         },
         {
-            "level_learned": 6,
+            "level_learned": 7,
             "technique": "hibernate"
         },
         {
-            "level_learned": 8,
+            "level_learned": 10,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 10,
+            "level_learned": 13,
             "technique": "blade"
         },
         {
-            "level_learned": 12,
+            "level_learned": 16,
             "technique": "viper"
         },
         {
-            "level_learned": 16,
+            "level_learned": 19,
             "technique": "lineage"
         },
         {
-            "level_learned": 20,
+            "level_learned": 22,
             "technique": "muddle"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "eyebite"
         },
         {

--- a/mods/tuxemon/db/monster/weedlantis.json
+++ b/mods/tuxemon/db/monster/weedlantis.json
@@ -3,15 +3,15 @@
     "category": "reef",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "blossom"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "solar_synthesis"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "overgrowth"
         },
         {
@@ -19,11 +19,11 @@
             "technique": "flood"
         },
         {
-            "level_learned": 14,
+            "level_learned": 13,
             "technique": "stabilo"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "nest"
         }
     ],

--- a/mods/tuxemon/db/monster/weedsea.json
+++ b/mods/tuxemon/db/monster/weedsea.json
@@ -3,15 +3,15 @@
     "category": "seaweed",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "blossom"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "solar_synthesis"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "overgrowth"
         },
         {
@@ -19,11 +19,11 @@
             "technique": "flood"
         },
         {
-            "level_learned": 14,
+            "level_learned": 13,
             "technique": "stabilo"
         },
         {
-            "level_learned": 18,
+            "level_learned": 19,
             "technique": "nest"
         }
     ],

--- a/mods/tuxemon/db/monster/wendigger.json
+++ b/mods/tuxemon/db/monster/wendigger.json
@@ -3,27 +3,27 @@
     "category": "scarytale",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "solar_synthesis"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fester"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "sylvan"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "pseudopod"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "one_two"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "sting"
         },
         {
@@ -31,7 +31,7 @@
             "technique": "invictus"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "fluff_up"
         }
     ],

--- a/mods/tuxemon/db/monster/windeye.json
+++ b/mods/tuxemon/db/monster/windeye.json
@@ -3,31 +3,31 @@
     "category": "tower",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "bullet"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "muddle"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "bubble_trap"
         },
         {
-            "level_learned": 26,
+            "level_learned": 25,
             "technique": "adamantine"
         },
         {

--- a/mods/tuxemon/db/monster/wolffsky.json
+++ b/mods/tuxemon/db/monster/wolffsky.json
@@ -3,23 +3,23 @@
     "category": "lupine",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "fluff_up"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "ice_claw"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "stonehenge"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "barking"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "canine"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "frostbite"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "icicle_spear"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "fume"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "greenstone"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "invictus"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "ice_storm"
         },
         {

--- a/mods/tuxemon/db/monster/woodoor.json
+++ b/mods/tuxemon/db/monster/woodoor.json
@@ -3,23 +3,23 @@
     "category": "portal",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "bullet"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "muddle"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "wall_of_steel"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "lineage"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "strike"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "terror"
         },
         {
@@ -39,7 +39,7 @@
             "technique": "rust_bomb"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "crystal"
         }
     ],

--- a/mods/tuxemon/db/monster/wrougon.json
+++ b/mods/tuxemon/db/monster/wrougon.json
@@ -3,23 +3,23 @@
     "category": "dragon",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "viper"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "insanity"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "undertaker"
         },
         {
@@ -31,15 +31,15 @@
             "technique": "rust_bomb"
         },
         {
-            "level_learned": 44,
+            "level_learned": 43,
             "technique": "shuriken"
         },
         {
-            "level_learned": 48,
+            "level_learned": 46,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 60,
+            "level_learned": 61,
             "technique": "amnesia"
         },
         {
@@ -47,7 +47,7 @@
             "technique": "muddle"
         },
         {
-            "level_learned": 68,
+            "level_learned": 70,
             "technique": "bullet"
         }
     ],

--- a/mods/tuxemon/db/monster/xeon.json
+++ b/mods/tuxemon/db/monster/xeon.json
@@ -3,23 +3,23 @@
     "category": "threat",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "electrical_storm"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "peregrine"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "crystal"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "muddle"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "strike"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "shadow_boxing"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "whirlwind"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "lightning_spheres"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "undertaker"
         },
         {

--- a/mods/tuxemon/db/monster/xeon_2.json
+++ b/mods/tuxemon/db/monster/xeon_2.json
@@ -3,23 +3,23 @@
     "category": "threat",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "electrical_storm"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "wall_of_steel"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "shrapnel"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "peregrine"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "shuriken"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "beam"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "ruby"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "amnesia"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "blade"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "bubble_trap"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "platinum"
         },
         {

--- a/mods/tuxemon/db/monster/yiinaang.json
+++ b/mods/tuxemon/db/monster/yiinaang.json
@@ -3,23 +3,23 @@
     "category": "balance",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "supernova"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "midnight_mantle"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "electrical_storm"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "firestorm"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "magma"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "energy_claws"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "bubble_trap"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "muddle"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "snowstorm"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "one_two"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "arcane_eye"
         },
         {

--- a/mods/tuxemon/db/monster/ziggurat.json
+++ b/mods/tuxemon/db/monster/ziggurat.json
@@ -3,23 +3,23 @@
     "category": "mazerunner",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "ice_claw"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "ants"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "strangulation"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "hammerhead"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "biting_winds"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "breath"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "stampede"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "mending"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "muck"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "cat_calling"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "electrical_storm"
         },
         {

--- a/mods/tuxemon/db/monster/zunna.json
+++ b/mods/tuxemon/db/monster/zunna.json
@@ -3,23 +3,23 @@
     "category": "slurpy",
     "moveset": [
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "constrict"
         },
         {
-            "level_learned": 2,
+            "level_learned": 1,
             "technique": "goad"
         },
         {
-            "level_learned": 6,
+            "level_learned": 4,
             "technique": "strike"
         },
         {
-            "level_learned": 8,
+            "level_learned": 7,
             "technique": "perfect_cut"
         },
         {
-            "level_learned": 12,
+            "level_learned": 13,
             "technique": "shrapnel"
         },
         {
@@ -27,11 +27,11 @@
             "technique": "muddle"
         },
         {
-            "level_learned": 20,
+            "level_learned": 19,
             "technique": "sleep_bomb"
         },
         {
-            "level_learned": 24,
+            "level_learned": 25,
             "technique": "wing_tip"
         },
         {
@@ -39,11 +39,11 @@
             "technique": "crystal"
         },
         {
-            "level_learned": 32,
+            "level_learned": 31,
             "technique": "battery_discharge"
         },
         {
-            "level_learned": 36,
+            "level_learned": 37,
             "technique": "clamp_on"
         },
         {


### PR DESCRIPTION
From @Sanglorian [reply](https://github.com/Tuxemon/Tuxemon/pull/2528#issuecomment-2430392707)

PR updates the 'level_learned' and 'at_level' fields. It also adds new tests to 'test_jsons_monster' to catch potential issues. The 'level_learned' field in the moveset will follow a specific sequence (1, 3, 4, 7, 10, ..., 100), while 'at_level' will have more flexibility without a predefined sequence. Additionally, a new test has been included to flag 'double' levels, where a level appears in both the moveset and evolution, to ensure consistency and accuracy. Moveset only exception is 1 (allowing 2 techniques at level 1).

The only evolution levels changed are: Jelillow (from 40 to 41), Stonifly (from 10 to 9)

Is it ok @Sanglorian ? Do you want some additional check?