### PR TITLE
test jsons technique

### DIFF
--- a/mods/tuxemon/db/technique/pseudopod.json
+++ b/mods/tuxemon/db/technique/pseudopod.json
@@ -8,7 +8,7 @@
   ],
   "flip_axes": "x",
   "is_fast": false,
-  "potency": 0.0,
+  "potency": 0.7,
   "power": 1.25,
   "range": "reach",
   "recharge": 1,

--- a/tests/tuxemon/test_jsons_technique.py
+++ b/tests/tuxemon/test_jsons_technique.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2024 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import json
+import os
+import unittest
+from typing import Any
+
+from tuxemon import prepare
+
+ALL_TECHNIQUES: int = 196
+MAX_TECH_ID: int = 190
+# effects with simple_damage_calculate()
+SIMPLE_DAMAGE_EFFECT = ("damage", "retaliate", "revenge", "money", "splash")
+# effects with simple_heal()
+SIMPLE_HEAL_EFFECT = ("healing", "photogenesis")
+
+
+def process_json_data(directory: str) -> list[dict[str, Any]]:
+    data_list = []
+    directory = f"{prepare.fetch('db')}/{directory}/"
+    for filename in os.listdir(directory):
+        if filename.endswith(".json"):
+            filepath = os.path.join(directory, filename)
+            with open(filepath, "r") as f:
+                data_list.append(json.load(f))
+    return data_list
+
+
+class TestTechniqueJSON(unittest.TestCase):
+    def setUp(self) -> None:
+        sample_data = "technique"
+        self.data_list = process_json_data(sample_data)
+
+    def test_nr_jsons(self) -> None:
+        self.assertEqual(len(self.data_list), ALL_TECHNIQUES)
+
+    def test_missing_tech_ids(self) -> None:
+        numbers = []
+        for data in self.data_list:
+            tech_id = data["tech_id"]
+            if tech_id > 0:
+                numbers.append(tech_id)
+
+        all_numbers = set(range(1, MAX_TECH_ID))
+        given_numbers = set(numbers)
+        missing = all_numbers - given_numbers
+        if missing:
+            self.fail(f"There are missing tech_ids: {missing}")
+
+    def test_duplicate_tech_ids(self) -> None:
+        numbers = []
+        for data in self.data_list:
+            tech_id = data["tech_id"]
+            if tech_id > 0:
+                numbers.append(tech_id)
+
+        duplicates = []
+        counts = [0] * (max(numbers) + 1)
+        for num in numbers:
+            counts[num] += 1
+            if counts[num] > 1:
+                duplicates.append(num)
+        if duplicates:
+            self.fail(f"There are duplicates tech_ids: {duplicates}")
+
+    def test_effects_simple_damage_special(self) -> None:
+        techniques = []
+        for data in self.data_list:
+            slug = data["slug"]
+            effects = data["effects"]
+            ranges = data["range"]
+            if (
+                effects
+                and effects[0] in SIMPLE_DAMAGE_EFFECT
+                and ranges == "special"
+            ):
+                techniques.append(
+                    f"{slug}'s 'special' range cannot be used with {SIMPLE_DAMAGE_EFFECT} effects"
+                )
+        if techniques:
+            print("The following techniques:")
+            for technique in techniques:
+                print(technique)
+            self.fail(
+                f"The 'effect' field cannot contain: {SIMPLE_DAMAGE_EFFECT}."
+            )
+
+    def test_effects_simple_damage_power(self) -> None:
+        techniques = []
+        for data in self.data_list:
+            slug = data["slug"]
+            effects = data["effects"]
+            power = data["power"]
+            if effects and effects[0] in SIMPLE_DAMAGE_EFFECT and power == 0:
+                techniques.append(f"{slug}'s power is {power}")
+        if techniques:
+            print("The following techniques:")
+            for technique in techniques:
+                print(technique)
+            self.fail(f"The 'power' attribute must be > 0.")
+
+    def test_effects_simple_heal_healing_power(self) -> None:
+        techniques = []
+        for data in self.data_list:
+            slug = data["slug"]
+            effects = data["effects"]
+            if (
+                effects
+                and effects[0] in SIMPLE_HEAL_EFFECT
+                and data["healing_power"]
+                and data["healing_power"] == 0
+            ):
+                healing_power = data["healing_power"]
+                techniques.append(f"{slug}'s healing power is {healing_power}")
+        if techniques:
+            print("The following techniques:")
+            for technique in techniques:
+                print(technique)
+            self.fail(f"The 'healing_power' attribute must be > 0.")
+
+    def test_effects_combinations(self) -> None:
+        techniques = {}
+        combinations = {
+            (
+                "damage",
+                "healing",
+            ): "The 'damage' and 'healing' effect cannot be used together.",
+        }
+        for data in self.data_list:
+            slug = data["slug"]
+            effects = data["effects"]
+            if effects:
+                for combination, error_message in combinations.items():
+                    if all(effect in effects for effect in combination):
+                        techniques.setdefault(error_message, []).append(
+                            f"{slug}'s effects: {effects}."
+                        )
+        for error_message, technique_list in techniques.items():
+            print("The following techniques:")
+            for technique in technique_list:
+                print(technique)
+            self.fail(error_message)
+
+    def test_effects_give(self) -> None:
+        techniques = []
+        for data in self.data_list:
+            slug = data["slug"]
+            effects = data["effects"]
+            potency = data["potency"]
+            if effects:
+                for effect in effects:
+                    if effect.startswith("give") and potency == 0.0:
+                        techniques.append(f"{slug}'s potency is {potency}")
+        if techniques:
+            print("The following techniques:")
+            for technique in techniques:
+                print(technique)
+            self.fail(f"The 'potency' attribute must be > 0.")

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -860,28 +860,6 @@ class TechniqueModel(BaseModel):
             return v
         raise ValueError(f"no translation exists with msgid: {v}")
 
-    # Custom validation for range
-    @field_validator("range")
-    def range_validation(
-        cls: TechniqueModel, v: Range, info: ValidationInfo
-    ) -> Range:
-        # Special indicates that we are not doing damage
-        if v == Range.special and any(
-            effect in info.data["effects"]
-            for effect in [
-                "damage",
-                "area",
-                "retaliate",
-                "revenge",
-                "money",
-                "splash",
-            ]
-        ):
-            raise ValueError(
-                '"special" range cannot be used with effects "damage", "area", "retaliate", "revenge", "money", or "splash"'
-            )
-        return v
-
     @field_validator("animation")
     def animation_exists(
         cls: TechniqueModel, v: Optional[str]


### PR DESCRIPTION
split out from #2527 

PR adds test for technique files JSON. I've included standard tests to catch duplicates and missing tech_ids, as well as a test to verify the 'range' technique has the correct effects (damage and other using simple_damage_calculate). This was previously in db.py, but I've moved it here so we can catch any issues before merging. I've also added tests to check for valid combinations (which will be necessary later when 'healing' loses its attributes) and a couple of tests to ensure moves with simple_damage_calculate have a power greater than 0 and those with simple_heal have a healing_power greater than 0.