### PR TITLE
nsis (build.yaml)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Install nsis
         run: |
-          Invoke-WebRequest -Uri "https://sourceforge.net/projects/nsis/files/NSIS%203/3.09/nsis-3.09-setup.exe" -OutFile "nsis.exe"
+          Invoke-WebRequest -Uri "https://sourceforge.net/projects/nsis/files/NSIS%203/3.10/nsis-3.10-setup.exe" -OutFile "nsis.exe"
 
       - name: Build Installer
         run: |
@@ -149,7 +149,7 @@ jobs:
     if: ${{ github.ref == 'refs/heads/development' || (github.event_name == 'push' && github.ref_type == 'tag' && startswith(github.ref_name, 'v'))  }}
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4.1.7 # must stick at v3 until flatpak-github-actions/flatpak-builder updates also to v4!
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
 


### PR DESCRIPTION
PR updates the link. From what I understand, 'NSIS' has some issues, but the link should be updated to point to the latest version. I have also removed the ".1.7" since we are already at the 4.1.8, but by keeping v4, it's fine until v5.
