### PR TITLE
monster_boxes and item_boxes

### DIFF
--- a/tests/tuxemon/test_boxes.py
+++ b/tests/tuxemon/test_boxes.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2024 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import unittest
+from uuid import uuid4
+
+from tuxemon.boxes import MonsterBoxes
+from tuxemon.monster import Monster
+from tuxemon.states.pc_kennel import HIDDEN_LIST
+
+
+class TestBoxes(unittest.TestCase):
+
+    def setUp(self):
+        self.monster_boxes = MonsterBoxes()
+        self.monster1 = Monster()
+        self.monster1.instance_id = uuid4()
+        self.monster2 = Monster()
+        self.monster2.instance_id = uuid4()
+        self.box_id1 = "box1"
+        self.box_id2 = "box2"
+
+    def test_add_monster(self):
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        self.assertIn(self.box_id1, self.monster_boxes.boxes)
+        self.assertIn(self.monster1, self.monster_boxes.boxes[self.box_id1])
+
+    def test_remove_monster(self):
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        self.monster_boxes.remove_monster(self.monster1)
+        self.assertNotIn(self.monster1, self.monster_boxes.boxes[self.box_id1])
+
+    def test_remove_monster_from(self):
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        self.monster_boxes.remove_monster_from(self.box_id1, self.monster1)
+        self.assertNotIn(self.monster1, self.monster_boxes.boxes[self.box_id1])
+
+    def test_get_monsters_by_iid(self):
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        self.assertEqual(
+            self.monster_boxes.get_monsters_by_iid(self.monster1.instance_id),
+            self.monster1,
+        )
+
+    def test_get_monsters(self):
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        self.monster_boxes.add_monster(self.box_id1, self.monster2)
+        self.assertEqual(
+            self.monster_boxes.get_monsters(self.box_id1),
+            [self.monster1, self.monster2],
+        )
+
+    def test_has_box(self):
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        self.assertTrue(self.monster_boxes.has_box(self.box_id1))
+
+    def test_get_box_ids(self):
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        self.monster_boxes.add_monster(self.box_id2, self.monster2)
+        self.assertEqual(
+            self.monster_boxes.get_box_ids(), [self.box_id1, self.box_id2]
+        )
+
+    def test_get_box_size(self):
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        self.monster_boxes.add_monster(self.box_id1, self.monster2)
+        self.assertEqual(self.monster_boxes.get_box_size(self.box_id1), 2)
+
+    def test_get_box_name(self):
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        self.assertEqual(
+            self.monster_boxes.get_box_name(self.monster1.instance_id),
+            self.box_id1,
+        )
+
+    def test_get_all_monsters(self):
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        self.monster_boxes.add_monster(self.box_id2, self.monster2)
+        self.assertEqual(
+            self.monster_boxes.get_all_monsters(),
+            [self.monster1, self.monster2],
+        )
+
+    def test_get_all_monsters_hidden(self):
+        HIDDEN_LIST.append(self.box_id1)
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        self.monster_boxes.add_monster(self.box_id2, self.monster2)
+        self.assertEqual(
+            self.monster_boxes.get_all_monsters_hidden(), [self.monster1]
+        )
+
+    def test_get_all_monsters_visible(self):
+        HIDDEN_LIST.append(self.box_id1)
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        self.monster_boxes.add_monster(self.box_id2, self.monster2)
+        self.assertEqual(
+            self.monster_boxes.get_all_monsters_visible(), [self.monster2]
+        )
+
+    def test_is_box_full(self):
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        self.assertTrue(
+            self.monster_boxes.is_box_full(self.box_id1, max_capacity=1)
+        )
+        self.monster_boxes.remove_monster_from(self.box_id1, self.monster1)
+        self.assertFalse(
+            self.monster_boxes.is_box_full(self.box_id1, max_capacity=1)
+        )
+
+    def test_move_monster(self):
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        self.monster_boxes.move_monster(
+            self.box_id1, self.box_id2, self.monster1
+        )
+        self.assertIn(self.monster1, self.monster_boxes.boxes[self.box_id2])
+
+    def test_merge_boxes(self):
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        self.monster_boxes.add_monster(self.box_id1, self.monster2)
+        self.monster_boxes.merge_boxes(self.box_id1, self.box_id2)
+        self.assertEqual(self.monster_boxes.get_monsters(self.box_id1), [])
+        self.assertEqual(
+            self.monster_boxes.get_monsters(self.box_id2),
+            [self.monster1, self.monster2],
+        )
+
+    def test_create_box(self):
+        self.monster_boxes.create_box(self.box_id1)
+        self.assertIn(self.box_id1, self.monster_boxes.boxes)
+
+    def test_remove_box(self):
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        self.monster_boxes.remove_box(self.box_id1)
+        self.assertNotIn(self.box_id1, self.monster_boxes.boxes)
+
+    def test_swap_with_external_monster(self):
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        external_monster = Monster()
+        swapped_monster = self.monster_boxes.swap_with_external_monster(
+            self.box_id1, self.monster1, external_monster
+        )
+        self.assertEqual(swapped_monster, self.monster1)
+        self.assertEqual(
+            self.monster_boxes.get_monsters(self.box_id1), [external_monster]
+        )
+
+    def test_swap_with_external_monster_not_found(self):
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        external_monster = Monster()
+        with self.assertRaises(ValueError):
+            self.monster_boxes.swap_with_external_monster(
+                self.box_id1, "non_existent_monster", external_monster
+            )
+
+    def test_swap_with_external_monster_invalid_box_id(self):
+        external_monster = Monster()
+        with self.assertRaises(ValueError):
+            self.monster_boxes.swap_with_external_monster(
+                "non_existent_box_id", self.monster1, external_monster
+            )
+
+    def test_swap_with_external_monster_by_iid(self):
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        external_monster = Monster()
+        swapped_monster = self.monster_boxes.swap_with_external_monster_by_iid(
+            self.monster1.instance_id, external_monster
+        )
+        self.assertEqual(swapped_monster, self.monster1)
+        self.assertEqual(
+            self.monster_boxes.get_monsters(self.box_id1), [external_monster]
+        )
+
+    def test_swap_with_external_monster_by_iid_not_found(self):
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        external_monster = Monster()
+        with self.assertRaises(ValueError):
+            self.monster_boxes.swap_with_external_monster_by_iid(
+                "non_existent_monster", external_monster
+            )
+
+    def test_create_and_merge_box(self):
+        for _ in range(10):
+            self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        self.assertTrue(self.monster_boxes.is_box_full(self.box_id1, 10))
+        self.monster_boxes.create_and_merge_box(self.box_id1)
+        self.assertIn(f"{self.box_id1}1", self.monster_boxes.get_box_ids())
+        self.assertEqual(
+            len(self.monster_boxes.get_monsters(f"{self.box_id1}1")), 10
+        )
+        self.assertEqual(len(self.monster_boxes.get_monsters(self.box_id1)), 0)

--- a/tests/tuxemon/test_catch_release.py
+++ b/tests/tuxemon/test_catch_release.py
@@ -3,6 +3,7 @@
 import unittest
 from unittest import mock
 
+from tuxemon.boxes import MonsterBoxes
 from tuxemon.monster import Monster
 from tuxemon.npc import NPC
 from tuxemon.prepare import KENNEL, PARTY_LIMIT
@@ -12,8 +13,8 @@ def mockNPC(self) -> None:
     self.monsters = []
     self.isplayer = True
     self.game_variables = {}
-    self.monster_boxes = {}
-    self.monster_boxes[KENNEL] = []
+    self.monster_boxes = MonsterBoxes()
+    self.monster_boxes.create_box(KENNEL)
 
 
 class TestCatchTuxemon(unittest.TestCase):
@@ -24,7 +25,7 @@ class TestCatchTuxemon(unittest.TestCase):
 
     def test_release_one(self):
         self.assertEqual(len(self.npc.monsters), 0)
-        self.assertEqual(len(self.npc.monster_boxes[KENNEL]), 0)
+        self.assertEqual(self.npc.monster_boxes.get_box_size(KENNEL), 0)
 
         monster = Monster()
         self.npc.add_monster(monster, len(self.npc.monsters))
@@ -71,9 +72,9 @@ class TestCatchTuxemon(unittest.TestCase):
         monsterF = Monster()
         self.npc.add_monster(monsterF, len(self.npc.monsters))
         self.assertEqual(len(self.npc.monsters), PARTY_LIMIT)
-        self.assertEqual(len(self.npc.monster_boxes[KENNEL]), 0)
+        self.assertEqual(self.npc.monster_boxes.get_box_size(KENNEL), 0)
 
         monsterG = Monster()
         self.npc.add_monster(monsterG, len(self.npc.monsters))
         self.assertEqual(len(self.npc.monsters), PARTY_LIMIT)
-        self.assertEqual(len(self.npc.monster_boxes[KENNEL]), 1)
+        self.assertEqual(self.npc.monster_boxes.get_box_size(KENNEL), 1)

--- a/tests/tuxemon/test_monster_actions.py
+++ b/tests/tuxemon/test_monster_actions.py
@@ -97,7 +97,6 @@ class TestMonsterActions(unittest.TestCase):
             local_session.player = Player()
             self.player = local_session.player
             self.player.monsters = []
-            self.player.monster_boxes = {}
             self._monster_model = {"agnite": self._agnite}
             self._monster_model["nut"] = self._nut
             self._shape_model = {"dragon": self._dragon}

--- a/tuxemon/boxes.py
+++ b/tuxemon/boxes.py
@@ -1,0 +1,366 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2024 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING, Optional
+
+from tuxemon import prepare
+from tuxemon.item.item import decode_items, encode_items
+from tuxemon.monster import decode_monsters, encode_monsters
+from tuxemon.states.pc_kennel import HIDDEN_LIST
+from tuxemon.states.pc_locker import HIDDEN_LIST_LOCKER
+
+if TYPE_CHECKING:
+    from tuxemon.item.item import Item
+    from tuxemon.monster import Monster
+    from tuxemon.npc import NPCState
+
+
+class ItemBoxes:
+    """
+    A class to manage a collection of item boxes.
+    """
+
+    def __init__(self) -> None:
+        self.boxes: dict[str, list[Item]] = {}
+
+    def create_box(self, box_id: str) -> None:
+        """
+        Creates a new item box with the given ID.
+        """
+        self.boxes[box_id] = []
+
+    def add_item(self, box_id: str, item: Item) -> None:
+        """
+        Adds an item to a box with the given ID.
+        If the box does not exist, it will be created.
+        """
+        if box_id not in self.boxes:
+            self.create_box(box_id)
+        self.boxes[box_id].append(item)
+
+    def remove_item(self, item: Item) -> None:
+        """
+        Removes an item from all boxes.
+        """
+        for box in self.boxes.values():
+            if item in box:
+                box.remove(item)
+                return
+
+    def remove_item_from(self, box_id: str, item: Item) -> None:
+        """
+        Removes an item from a box with the given ID.
+        """
+        if box_id in self.boxes:
+            self.boxes[box_id].remove(item)
+
+    def get_items_by_iid(self, instance_id: uuid.UUID) -> Optional[Item]:
+        """
+        Gets an item by its instance ID.
+        """
+        return next(
+            (
+                m
+                for box in self.boxes.values()
+                for m in box
+                if m.instance_id == instance_id
+            ),
+            None,
+        )
+
+    def save(self, state: NPCState) -> None:
+        """
+        Saves the state of the item boxes.
+        """
+        state["item_boxes"] = {}
+        for box_id, items in self.boxes.items():
+            state["item_boxes"][box_id] = encode_items(items)
+
+    def load(self, save_data: NPCState) -> None:
+        """
+        Loads the state of the item boxes from a saved state.
+        """
+        self.boxes = {}
+        for box_id, encoded_items in save_data["item_boxes"].items():
+            self.boxes[box_id] = decode_items(encoded_items)
+
+    def move_item(
+        self, source_box_id: str, target_box_id: str, item: Item
+    ) -> None:
+        """
+        Moves an item from one box to another.
+        """
+        if source_box_id in self.boxes and item in self.boxes[source_box_id]:
+            self.remove_item_from(source_box_id, item)
+            self.add_item(target_box_id, item)
+
+    def get_items(self, box_id: str) -> list[Item]:
+        """
+        Gets all items in a box with the given ID.
+        """
+        return self.boxes.get(box_id, [])
+
+    def get_box_size(self, box_id: str) -> int:
+        """
+        Gets the number of items in a box with the given ID.
+        """
+        return len(self.get_items(box_id))
+
+    def has_box(self, box_id: str) -> bool:
+        """
+        Checks if a box with the given ID exists.
+        """
+        return box_id in self.boxes
+
+    def get_all_items(self) -> list[Item]:
+        """
+        Gets all items in all boxes.
+        """
+        return [item for box in self.boxes.values() for item in box]
+
+    def get_all_items_hidden(self) -> list[Item]:
+        """
+        Gets all items in hidden boxes.
+        """
+        return [
+            item
+            for key, box in self.boxes.items()
+            if key in HIDDEN_LIST_LOCKER
+            for item in box
+        ]
+
+    def get_all_items_visible(self) -> list[Item]:
+        """
+        Gets all items in visible boxes.
+        """
+        return [
+            item
+            for key, box in self.boxes.items()
+            if key not in HIDDEN_LIST_LOCKER
+            for item in box
+        ]
+
+
+class MonsterBoxes:
+    """
+    A class to manage a collection of monster boxes.
+    """
+
+    def __init__(self) -> None:
+        self.boxes: dict[str, list[Monster]] = {}
+
+    def create_box(self, box_id: str) -> None:
+        """
+        Creates a new monster box with the given ID.
+        """
+        self.boxes[box_id] = []
+
+    def remove_box(self, box_id: str) -> None:
+        """
+        Removes a monster box with the given ID.
+        """
+        if box_id in self.boxes:
+            del self.boxes[box_id]
+
+    def add_monster(self, box_id: str, monster: Monster) -> None:
+        """
+        Adds a monster to a box with the given ID.
+        If the box does not exist, it will be created.
+        """
+        if box_id not in self.boxes:
+            self.create_box(box_id)
+        self.boxes[box_id].append(monster)
+
+    def remove_monster(self, monster: Monster) -> None:
+        """
+        Removes a monster from all boxes.
+        """
+        for box in self.boxes.values():
+            if monster in box:
+                box.remove(monster)
+                return
+
+    def remove_monster_from(self, box_id: str, monster: Monster) -> None:
+        """
+        Removes a monster from a box with the given ID.
+        """
+        if box_id in self.boxes:
+            self.boxes[box_id].remove(monster)
+
+    def get_monsters_by_iid(self, instance_id: uuid.UUID) -> Optional[Monster]:
+        """
+        Gets a monster by its instance ID.
+        """
+        return next(
+            (
+                m
+                for box in self.boxes.values()
+                for m in box
+                if m.instance_id == instance_id
+            ),
+            None,
+        )
+
+    def get_monsters(self, box_id: str) -> list[Monster]:
+        """
+        Gets all monsters in a box with the given ID.
+        """
+        return self.boxes.get(box_id, [])
+
+    def has_box(self, box_id: str) -> bool:
+        """
+        Checks if a box with the given ID exists.
+        """
+        return box_id in self.boxes
+
+    def get_box_ids(self) -> list[str]:
+        """
+        Gets all box IDs.
+        """
+        return list(self.boxes.keys())
+
+    def get_box_size(self, box_id: str) -> int:
+        """
+        Gets the number of monsters in a box with the given ID.
+        """
+        return len(self.get_monsters(box_id))
+
+    def get_box_name(self, instance_id: uuid.UUID) -> Optional[str]:
+        """
+        Gets the ID of the box that contains a monster with the given instance ID.
+        """
+        return next(
+            (
+                box
+                for box, monsters in self.boxes.items()
+                for m in monsters
+                if m.instance_id == instance_id
+            ),
+            None,
+        )
+
+    def get_all_monsters(self) -> list[Monster]:
+        """
+        Gets all monsters in all boxes.
+        """
+        return [monster for box in self.boxes.values() for monster in box]
+
+    def get_all_monsters_hidden(self) -> list[Monster]:
+        """
+        Gets all monsters in hidden boxes.
+        """
+        return [
+            monster
+            for key, box in self.boxes.items()
+            if key in HIDDEN_LIST
+            for monster in box
+        ]
+
+    def get_all_monsters_visible(self) -> list[Monster]:
+        """
+        Gets all monsters in visible boxes.
+        """
+        return [
+            monster
+            for key, box in self.boxes.items()
+            if key not in HIDDEN_LIST
+            for monster in box
+        ]
+
+    def is_box_full(
+        self, box_id: str, max_capacity: int = prepare.MAX_KENNEL
+    ) -> bool:
+        """
+        Checks if a box is full.
+        """
+        return box_id in self.boxes and len(self.boxes[box_id]) >= max_capacity
+
+    def move_monster(
+        self, source_box_id: str, target_box_id: str, monster: Monster
+    ) -> None:
+        """
+        Moves a monster from one box to another.
+        """
+        if (
+            source_box_id in self.boxes
+            and monster in self.boxes[source_box_id]
+        ):
+            self.remove_monster_from(source_box_id, monster)
+            self.add_monster(target_box_id, monster)
+
+    def merge_boxes(self, source_box_id: str, target_box_id: str) -> None:
+        """
+        Merge the contents of two boxes into a single box.
+        """
+        if target_box_id not in self.boxes:
+            self.create_box(target_box_id)
+        if source_box_id in self.boxes:
+            self.boxes[target_box_id].extend(self.boxes[source_box_id])
+            del self.boxes[source_box_id]
+
+    def create_and_merge_box(self, box_id: str) -> None:
+        """
+        Moves the content of the given box into a new box with an
+        incremented label (e.g., Kennel0 -> Kennel1).
+        """
+        i = (
+            len(
+                [
+                    box_id
+                    for box_id in self.get_box_ids()
+                    if box_id.startswith(box_id)
+                    and box_id != box_id
+                    and self.is_box_full(box_id)
+                ]
+            )
+            + 1
+        )
+        new_box_id = f"{box_id}{i}"
+        self.create_box(new_box_id)
+        self.merge_boxes(box_id, new_box_id)
+
+    def swap_with_external_monster(
+        self, box_id: str, monster_in_box: Monster, external_monster: Monster
+    ) -> Monster:
+        """
+        Swaps a monster in a box with an external monster.
+        """
+        if box_id in self.boxes:
+            self.remove_monster_from(box_id, monster_in_box)
+            self.add_monster(box_id, external_monster)
+            return monster_in_box
+        else:
+            raise ValueError("Monster not found in box.")
+
+    def swap_with_external_monster_by_iid(
+        self, instance_id: uuid.UUID, external_monster: Monster
+    ) -> Monster:
+        """
+        Swaps a monster in a box with an external monster by instance ID.
+        """
+        monster = self.get_monsters_by_iid(instance_id)
+        box_id = self.get_box_name(instance_id)
+        if monster is not None and box_id is not None:
+            return self.swap_with_external_monster(
+                box_id, monster, external_monster
+            )
+        else:
+            raise ValueError("Monster not found in box.")
+
+    def save(self, state: NPCState) -> None:
+        """
+        Saves the state of the monster boxes.
+        """
+        state["monster_boxes"] = {}
+        for box_id, monsters in self.boxes.items():
+            state["monster_boxes"][box_id] = encode_monsters(monsters)
+
+    def load(self, save_data: NPCState) -> None:
+        """
+        Loads the state of the monster boxes from a saved state.
+        """
+        self.boxes = {}
+        for box_id, encoded_monsters in save_data["monster_boxes"].items():
+            self.boxes[box_id] = decode_monsters(encoded_monsters)

--- a/tuxemon/event/actions/clear_kennel.py
+++ b/tuxemon/event/actions/clear_kennel.py
@@ -47,17 +47,11 @@ class ClearKennelAction(EventAction):
                 f"{kennel} cannot be cleared.",
             )
         else:
-            if kennel in player.monster_boxes:
-                monsters_kennel = player.monster_boxes[kennel]
+            if player.monster_boxes.has_box(kennel):
                 if transfer is None:
-                    player.monster_boxes.pop(kennel)
+                    player.monster_boxes.remove_box(kennel)
                 else:
-                    if transfer in player.monster_boxes:
-                        for mon in monsters_kennel:
-                            player.monster_boxes[transfer].append(mon)
-                            player.monster_boxes.pop(kennel)
-                    else:
-                        player.monster_boxes[transfer] = monsters_kennel
-                        player.monster_boxes.pop(kennel)
+                    player.monster_boxes.merge_boxes(kennel, transfer)
+                    player.monster_boxes.remove_box(kennel)
             else:
                 return

--- a/tuxemon/event/actions/create_kennel.py
+++ b/tuxemon/event/actions/create_kennel.py
@@ -34,5 +34,5 @@ class CreateKennelAction(EventAction):
 
     def start(self) -> None:
         player = self.session.player
-        if self.kennel not in player.monster_boxes.keys():
-            player.monster_boxes[self.kennel] = []
+        if not player.monster_boxes.has_box(self.kennel):
+            player.monster_boxes.create_box(self.kennel)

--- a/tuxemon/event/actions/give_experience.py
+++ b/tuxemon/event/actions/give_experience.py
@@ -60,7 +60,7 @@ class GiveExperienceAction(EventAction):
             monster_id = uuid.UUID(player.game_variables[variable])
             monster = get_monster_by_iid(self.session, monster_id)
             if monster is None:
-                monster = player.find_monster_in_storage(monster_id)
+                monster = player.monster_boxes.get_monsters_by_iid(monster_id)
                 if monster is None:
                     logger.error("Monster not found")
                     return

--- a/tuxemon/event/actions/info.py
+++ b/tuxemon/event/actions/info.py
@@ -52,7 +52,7 @@ class InfoAction(EventAction):
         monster_id = uuid.UUID(player.game_variables[variable])
         monster = get_monster_by_iid(self.session, monster_id)
         if monster is None:
-            monster = player.find_monster_in_storage(monster_id)
+            monster = player.monster_boxes.get_monsters_by_iid(monster_id)
             if monster is None:
                 logger.error("Monster not found")
                 return

--- a/tuxemon/event/actions/quarantine.py
+++ b/tuxemon/event/actions/quarantine.py
@@ -38,8 +38,8 @@ class QuarantineAction(EventAction):
 
     def start(self) -> None:
         player = self.session.player
-        if self.name not in player.monster_boxes.keys():
-            player.monster_boxes[self.name] = []
+        if not player.monster_boxes.has_box(self.name):
+            player.monster_boxes.create_box(self.name)
         if self.value == "in":
             infect = PlagueType.infected
             plague = [
@@ -50,16 +50,16 @@ class QuarantineAction(EventAction):
             ]
             for _monster in plague:
                 _monster.plague[self.plague_slug] = PlagueType.inoculated
-                player.monster_boxes[self.name].append(_monster)
+                player.monster_boxes.add_monster(self.name, _monster)
                 player.remove_monster(_monster)
                 logger.info(f"{_monster} has been quarantined")
         elif self.value == "out":
-            if self.name not in player.monster_boxes:
+            if not player.monster_boxes.has_box(self.name):
                 logger.info(f"Box {self.name} does not exist")
                 return
             box = [
                 mon
-                for mon in player.monster_boxes[self.name]
+                for mon in player.monster_boxes.get_monsters(self.name)
                 if self.plague_slug in mon.plague
             ]
             if not box:
@@ -69,14 +69,18 @@ class QuarantineAction(EventAction):
                 for _monster in box:
                     _monster.plague[self.plague_slug] = PlagueType.inoculated
                     player.add_monster(_monster, len(player.monsters))
-                    player.monster_boxes[self.name].remove(_monster)
+                    player.monster_boxes.remove_monster_from(
+                        self.name, _monster
+                    )
                     logger.info(f"{_monster} has been inoculated")
             elif self.amount > 0 and self.amount <= len(box):
                 sample = random.sample(box, self.amount)
                 for _monster in sample:
                     _monster.plague[self.plague_slug] = PlagueType.inoculated
                     player.add_monster(_monster, len(player.monsters))
-                    player.monster_boxes[self.name].remove(_monster)
+                    player.monster_boxes.remove_monster_from(
+                        self.name, _monster
+                    )
                     logger.info(f"{_monster} has been inoculated")
             else:
                 logger.info(f"Invalid sample size")

--- a/tuxemon/event/actions/set_kennel_visible.py
+++ b/tuxemon/event/actions/set_kennel_visible.py
@@ -47,7 +47,7 @@ class SetKennelVisibleAction(EventAction):
                 f"{kennel} cannot be made invisible.",
             )
         else:
-            if kennel in player.monster_boxes:
+            if player.monster_boxes.has_box(kennel):
                 if visible == "true":
                     if kennel in HIDDEN_LIST:
                         HIDDEN_LIST.remove(kennel)

--- a/tuxemon/event/actions/set_monster_attribute.py
+++ b/tuxemon/event/actions/set_monster_attribute.py
@@ -46,7 +46,7 @@ class SetMonsterAttributeAction(EventAction):
         monster_id = uuid.UUID(player.game_variables[self.variable])
         monster = get_monster_by_iid(self.session, monster_id)
         if monster is None:
-            monster = player.find_monster_in_storage(monster_id)
+            monster = player.monster_boxes.get_monsters_by_iid(monster_id)
             if monster is None:
                 logger.error("Monster not found")
                 return

--- a/tuxemon/event/actions/spawn_monster.py
+++ b/tuxemon/event/actions/spawn_monster.py
@@ -55,14 +55,14 @@ class SpawnMonsterAction(EventAction):
 
         mother = get_monster_by_iid(
             self.session, mother_id
-        ) or player.find_monster_in_storage(mother_id)
+        ) or player.monster_boxes.get_monsters_by_iid(mother_id)
         if mother is None:
             logger.debug(f"Mother {mother_id} not found.")
             return
 
         father = get_monster_by_iid(
             self.session, father_id
-        ) or player.find_monster_in_storage(father_id)
+        ) or player.monster_boxes.get_monsters_by_iid(father_id)
         if father is None:
             logger.debug(f"Father {father_id} not found.")
             return

--- a/tuxemon/event/actions/store_monster.py
+++ b/tuxemon/event/actions/store_monster.py
@@ -58,11 +58,15 @@ class StoreMonsterAction(EventAction):
         if box is None:
             store = KENNEL
         else:
-            if box not in character.monster_boxes.keys():
+            if not player.monster_boxes.has_box(self.name):
                 logger.error(f"No box found with name {box}")
                 return
             else:
                 store = box
         logger.info(f"{monster.name} stored in {store} box!")
-        character.monster_boxes[store].append(monster)
-        character.remove_monster(monster)
+        if not character.monster_boxes.is_box_full(store):
+            logger.error(f"Box {store} is full.")
+            return
+        else:
+            character.monster_boxes.add_monster(store, monster)
+            character.remove_monster(monster)

--- a/tuxemon/event/actions/withdraw_monster.py
+++ b/tuxemon/event/actions/withdraw_monster.py
@@ -46,11 +46,11 @@ class WithdrawMonsterAction(EventAction):
             return
 
         monster_id = uuid.UUID(player.game_variables[self.variable])
-        monster = player.find_monster_in_storage(monster_id)
+        monster = player.monster_boxes.get_monsters_by_iid(monster_id)
         if monster is None:
             logger.error("Monster not found")
             return
-        player.remove_monster_from_storage(monster)
+        player.monster_boxes.remove_monster(monster)
 
         character = get_npc(self.session, self.character)
         if character is None:

--- a/tuxemon/event/conditions/has_kennel.py
+++ b/tuxemon/event/conditions/has_kennel.py
@@ -40,7 +40,7 @@ class HasKennelCondition(EventCondition):
         if character is None:
             logger.error(f"{_character} not found")
             return False
-        if kennel_name not in character.monster_boxes.keys():
+        if not character.monster_boxes.has_box(kennel_name):
             raise ValueError(f"{kennel_name} doesn't exist.")
-        party_size = len(character.monster_boxes[kennel_name])
+        party_size = character.monster_boxes.get_box_size(kennel_name)
         return compare(check, party_size, number)

--- a/tuxemon/event/conditions/kennel.py
+++ b/tuxemon/event/conditions/kennel.py
@@ -50,7 +50,7 @@ class KennelCondition(EventCondition):
         elif option == "hidden":
             return kennel_name in HIDDEN_LIST
         elif option == "exist":
-            return kennel_name in character.monster_boxes.keys()
+            return character.monster_boxes.has_box(kennel_name)
         else:
             logger.error(f"The option {option} must be among {OPTIONS}")
             return False

--- a/tuxemon/states/monster_info/__init__.py
+++ b/tuxemon/states/monster_info/__init__.py
@@ -28,25 +28,6 @@ def _lookup_monsters() -> None:
             lookup_cache[mon] = results
 
 
-def find_box_name(instance_id: uuid.UUID) -> Optional[str]:
-    """
-    Finds a monster in the npc's storage boxes and return the box name.
-
-    Parameters:
-        instance_id: The instance_id of the monster.
-
-    Returns:
-        Box name, or None.
-
-    """
-    box_map = {
-        m.instance_id: box
-        for box, monsters in local_session.player.monster_boxes.items()
-        for m in monsters
-    }
-    return box_map.get(instance_id)
-
-
 def fix_measure(measure: int, percentage: float) -> int:
     """it returns the correct measure based on percentage"""
     return round(measure * percentage)
@@ -373,9 +354,11 @@ class MonsterInfoState(PygameMenuState):
 
     def _get_monsters(self) -> list[Monster]:
         if self._source == "MonsterTakeState":
-            box = find_box_name(self._monster.instance_id)
+            box = local_session.player.monster_boxes.get_box_name(
+                self._monster.instance_id
+            )
             if box is None:
                 raise ValueError("Box doesn't exist")
-            return local_session.player.monster_boxes[box]
+            return local_session.player.monster_boxes.get_monsters(box)
         else:
             return local_session.player.monsters

--- a/tuxemon/states/monster_moves/__init__.py
+++ b/tuxemon/states/monster_moves/__init__.py
@@ -35,25 +35,6 @@ def _lookup_monsters() -> None:
             lookup_cache[mon] = results
 
 
-def find_box_name(instance_id: uuid.UUID) -> Optional[str]:
-    """
-    Finds a monster in the npc's storage boxes and return the box name.
-
-    Parameters:
-        instance_id: The instance_id of the monster.
-
-    Returns:
-        Box name, or None.
-
-    """
-    box_map = {
-        m.instance_id: box
-        for box, monsters in local_session.player.monster_boxes.items()
-        for m in monsters
-    }
-    return box_map.get(instance_id)
-
-
 def fix_measure(measure: int, percentage: float) -> int:
     """it returns the correct measure based on percentage"""
     return round(measure * percentage)
@@ -308,9 +289,11 @@ class MonsterMovesState(PygameMenuState):
 
     def _get_monsters(self) -> list[Monster]:
         if self._source == "MonsterTakeState":
-            box = find_box_name(self._monster.instance_id)
+            box = local_session.player.monster_boxes.get_box_name(
+                self._monster.instance_id
+            )
             if box is None:
                 raise ValueError("Box doesn't exist")
-            return local_session.player.monster_boxes[box]
+            return local_session.player.monster_boxes.get_monsters(box)
         else:
             return local_session.player.monsters

--- a/tuxemon/states/pc/__init__.py
+++ b/tuxemon/states/pc/__init__.py
@@ -44,10 +44,10 @@ class PCState(PygameMenuState):
         player = local_session.player
 
         # it creates the kennel and locker (new players)
-        if kennel not in player.monster_boxes.keys():
-            player.monster_boxes[kennel] = []
-        if locker not in player.item_boxes.keys():
-            player.item_boxes[locker] = []
+        if not player.monster_boxes.has_box(kennel):
+            player.monster_boxes.create_box(kennel)
+        if not player.item_boxes.has_box(locker):
+            player.item_boxes.create_box(locker)
 
         def change_state(state: str, **kwargs: Any) -> partial[State]:
             return partial(self.client.replace_state, state, **kwargs)
@@ -78,18 +78,8 @@ class PCState(PygameMenuState):
 
         multiplayer = change_state("MultiplayerMenu")
 
-        _nr_monsters = [
-            len(mons)
-            for box, mons in player.monster_boxes.items()
-            if box not in HIDDEN_LIST
-        ]
-        nr_monsters = sum(_nr_monsters)
-        _nr_items = [
-            len(itm)
-            for box, itm in player.item_boxes.items()
-            if box not in HIDDEN_LIST_LOCKER
-        ]
-        nr_items = sum(_nr_items)
+        nr_monsters = len(player.monster_boxes.get_all_monsters_visible())
+        nr_items = len(player.item_boxes.get_all_items_visible())
 
         menu: list[tuple[str, MenuGameObj]] = []
         if nr_monsters > 0:


### PR DESCRIPTION
This PR is the first step in decoupling some of our operations by separating the monster and item boxes into their own classes. It's similar to what we did with Evolution.

You'll notice that there's still some duplication between MonsterBoxes and ItemBoxes, like the add monster/item methods, but we can tackle that later by introducing a third class, Boxes, and having MonsterBoxes inherit from it.

I've added a test to make sure everything is working as expected, and I also took the opportunity to fix a couple of small issues on the PC locker and kennel pages. Additionally, I've added a few methods to MonsterBoxes that will come in handy down the line.

This change also helps to clean up the NPC class, which was previously handling some of this logic - now it's more focused on its core responsibilities.