### PR TITLE
update choice states (monster, item, state, etc.)

### DIFF
--- a/tuxemon/states/choice/choice_item.py
+++ b/tuxemon/states/choice/choice_item.py
@@ -14,6 +14,14 @@ from tuxemon.menu.menu import PygameMenuState
 from tuxemon.menu.theme import get_theme
 
 ChoiceMenuGameObj = Callable[[], None]
+LENGTH_NAME_ITEM = 10
+MAX_MENU_ELEMENTS = 7
+MAX_MENU_HEIGHT_PERCENTAGE = 0.8
+SCALE_SPRITE = 0.5
+WINDOW_WIDTH_PERCENTAGE_LONG = 0.4
+WINDOW_WIDTH_PERCENTAGE_SHORT = 0.3
+TRANSLATE_PERCENTAGE_LONG = 0.4
+TRANSLATE_PERCENTAGE_SHORT = 0.3
 
 
 def fix_measure(measure: int, percentage: float) -> int:
@@ -36,41 +44,64 @@ class ChoiceItem(PygameMenuState):
         theme = get_theme()
         theme.scrollarea_position = POSITION_EAST
 
-        width, height = prepare.SCREEN_SIZE
-
-        # define size window height
-        if len(menu) >= 7:
-            height = int(height * 0.8)
-        else:
-            height = int(height * (len(menu) / 7) * 0.8)
-
-        # define size window width (longest word)
-        name_item = max(len(element[0]) for element in menu)
-        percentage_width = 0.4 if name_item > 10 else 0.3
-        percentage_translate = 0.30 if name_item > 10 else 0.4
-        width = int(width * percentage_width)
-
-        super().__init__(width=width, height=height, **kwargs)
+        self.width, self.height, self.translate_percentage = (
+            self.calculate_window_size(menu)
+        )
+        super().__init__(width=self.width, height=self.height, **kwargs)
 
         for name, slug, callback in menu:
-            try:
-                item = db.lookup(slug, table="item")
-            except KeyError:
-                raise RuntimeError(f"Item {slug} not found")
-            new_image = self._create_image(item.sprite)
-            new_image.scale(prepare.SCALE * 0.5, prepare.SCALE * 0.5)
-            self.menu.add.image(
-                new_image,
-            )
-            self.menu.add.button(
-                name,
-                callback,
-                font_size=self.font_size_smaller,
-                float=True,
-                selection_effect=HighlightSelection(),
-            ).translate(
-                fix_measure(width, percentage_translate),
-                fix_measure(height, 0.05),
-            )
+            self.add_item_menu_item(name, slug, callback)
 
         self.escape_key_exits = escape_key_exits
+
+    def calculate_window_size(
+        self, menu: Sequence[tuple[str, str, Callable[[], None]]]
+    ) -> tuple[int, int, float]:
+        _width, _height = prepare.SCREEN_SIZE
+
+        if len(menu) >= MAX_MENU_ELEMENTS:
+            height = _height * MAX_MENU_HEIGHT_PERCENTAGE
+        else:
+            height = (
+                _height
+                * (len(menu) / MAX_MENU_ELEMENTS)
+                * MAX_MENU_HEIGHT_PERCENTAGE
+            )
+
+        name_item = max(len(element[0]) for element in menu)
+        if name_item > LENGTH_NAME_ITEM:
+            width = _width * WINDOW_WIDTH_PERCENTAGE_LONG
+            translate_percentage = TRANSLATE_PERCENTAGE_SHORT
+        else:
+            width = _width * WINDOW_WIDTH_PERCENTAGE_SHORT
+            translate_percentage = TRANSLATE_PERCENTAGE_LONG
+
+        return int(width), int(height), translate_percentage
+
+    def add_item_menu_item(
+        self,
+        name: str,
+        slug: str,
+        callback: Callable[[], None],
+    ) -> None:
+        try:
+            item = db.lookup(slug, table="item")
+        except KeyError:
+            raise RuntimeError(f"Item {slug} not found")
+        new_image = self._create_image(item.sprite)
+        new_image.scale(
+            prepare.SCALE * SCALE_SPRITE, prepare.SCALE * SCALE_SPRITE
+        )
+        self.menu.add.image(
+            new_image,
+        )
+        self.menu.add.button(
+            name,
+            callback,
+            font_size=self.font_size_smaller,
+            float=True,
+            selection_effect=HighlightSelection(),
+        ).translate(
+            fix_measure(self.width, self.translate_percentage),
+            fix_measure(self.height, 0.05),
+        )

--- a/tuxemon/states/choice/choice_monster.py
+++ b/tuxemon/states/choice/choice_monster.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import math
 from collections.abc import Callable, Sequence
-from functools import partial
 from typing import Any
 
 from pygame_menu.locals import ALIGN_CENTER, POSITION_EAST
@@ -12,11 +11,19 @@ from pygame_menu.widgets.selection.highlight import HighlightSelection
 
 from tuxemon import prepare
 from tuxemon.animation import Animation
-from tuxemon.db import MonsterModel, db
+from tuxemon.db import db
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.menu.theme import get_theme
 
 ChoiceMenuGameObj = Callable[[], None]
+MAX_MENU_ELEMENTS = 15
+MAX_MENU_HEIGHT_PERCENTAGE = 0.8
+ANIMATION_DURATION = 0.2
+ANIMATION_SIZE = 1.0
+MENU_WIDGETS = 3
+MENU_COLUMNS = 5
+SCALE_SPRITE = 0.4
+VERTICAL_FILL = 15
 
 
 class ChoiceMonster(PygameMenuState):
@@ -32,49 +39,57 @@ class ChoiceMonster(PygameMenuState):
         **kwargs: Any,
     ) -> None:
         theme = get_theme()
-        if len(menu) > 15:
+        if len(menu) > MAX_MENU_ELEMENTS:
             theme.scrollarea_position = POSITION_EAST
 
-        columns = 5
-        num_widgets = 3
-        rows = math.ceil(len(menu) / columns) * num_widgets
-        super().__init__(columns=columns, rows=rows, **kwargs)
-
-        client = self.client
-        action = client.event_engine
-
-        def open_journal(monster: MonsterModel) -> None:
-            _set_tuxepedia = ["player", monster.slug, "caught"]
-            action.execute_action("set_tuxepedia", _set_tuxepedia, True)
-            param = {"monster": monster}
-            client.push_state("JournalInfoState", kwargs=param)
-            action.execute_action("clear_tuxepedia", [monster.slug], True)
+        rows = math.ceil(len(menu) / MENU_COLUMNS) * MENU_WIDGETS
+        super().__init__(columns=MENU_COLUMNS, rows=rows, **kwargs)
 
         for name, slug, callback in menu:
-            try:
-                monster = db.lookup(slug, table="monster")
-            except KeyError:
-                raise RuntimeError(f"Monster {slug} not found")
-            path = f"gfx/sprites/battle/{monster.slug}-front.png"
-            new_image = self._create_image(path)
-            new_image.scale(prepare.SCALE * 0.4, prepare.SCALE * 0.4)
-            self.menu.add.banner(
-                new_image,
-                partial(open_journal, monster),
-                align=ALIGN_CENTER,
-                selection_effect=HighlightSelection(),
-            )
-            self.menu.add.button(
-                name,
-                callback,
-                font_size=self.font_size_small,
-                align=ALIGN_CENTER,
-                selection_effect=HighlightSelection(),
-            )
-            self.menu.add.vertical_fill(15)
+            self.add_monster_menu_item(name, slug, callback)
 
         self.animation_size = 0.0
         self.escape_key_exits = escape_key_exits
+
+    def add_monster_menu_item(
+        self,
+        name: str,
+        slug: str,
+        callback: Callable[[], None],
+    ) -> None:
+        try:
+            monster = db.lookup(slug, table="monster")
+        except KeyError:
+            raise RuntimeError(f"Monster {slug} not found")
+
+        path = f"gfx/sprites/battle/{monster.slug}-front.png"
+        new_image = self._create_image(path)
+        new_image.scale(
+            prepare.SCALE * SCALE_SPRITE, prepare.SCALE * SCALE_SPRITE
+        )
+
+        def open_journal() -> None:
+            action = self.client.event_engine
+            _set_tuxepedia = ["player", monster.slug, "caught"]
+            action.execute_action("set_tuxepedia", _set_tuxepedia, True)
+            param = {"monster": monster}
+            self.client.push_state("JournalInfoState", kwargs=param)
+            action.execute_action("clear_tuxepedia", [monster.slug], True)
+
+        self.menu.add.banner(
+            new_image,
+            open_journal,
+            align=ALIGN_CENTER,
+            selection_effect=HighlightSelection(),
+        )
+        self.menu.add.button(
+            name,
+            callback,
+            font_size=self.font_size_small,
+            align=ALIGN_CENTER,
+            selection_effect=HighlightSelection(),
+        )
+        self.menu.add.vertical_fill(VERTICAL_FILL)
 
     def update_animation_size(self) -> None:
         width, height = prepare.SCREEN_SIZE
@@ -83,11 +98,10 @@ class ChoiceMonster(PygameMenuState):
         _width = widgets_size[0]
         _height = widgets_size[1]
 
-        # block width if more than screen width
         if _width >= width:
             _width = width
         if _height >= height:
-            _height = int(height * 0.8)
+            _height = int(height * MAX_MENU_HEIGHT_PERCENTAGE)
 
         self.menu.resize(
             max(1, int(_width * self.animation_size)),
@@ -104,7 +118,9 @@ class ChoiceMonster(PygameMenuState):
         """
         self.animation_size = 0.0
 
-        ani = self.animate(self, animation_size=1.0, duration=0.2)
+        ani = self.animate(
+            self, animation_size=ANIMATION_SIZE, duration=ANIMATION_DURATION
+        )
         ani.update_callback = self.update_animation_size
 
         return ani

--- a/tuxemon/states/choice/choice_npc.py
+++ b/tuxemon/states/choice/choice_npc.py
@@ -16,6 +16,14 @@ from tuxemon.menu.menu import PygameMenuState
 from tuxemon.menu.theme import get_theme
 
 ChoiceMenuGameObj = Callable[[], None]
+MAX_MENU_ELEMENTS = 12
+MAX_MENU_HEIGHT_PERCENTAGE = 0.8
+ANIMATION_DURATION = 0.2
+ANIMATION_SIZE = 1.0
+MENU_WIDGETS = 3
+MENU_COLUMNS = 4
+SCALE_SPRITE = 0.4
+VERTICAL_FILL = 10
 
 
 def fix_measure(measure: int, percentage: float) -> int:
@@ -36,41 +44,49 @@ class ChoiceNpc(PygameMenuState):
         **kwargs: Any,
     ) -> None:
         theme = get_theme()
-        if len(menu) > 12:
+        if len(menu) > MAX_MENU_ELEMENTS:
             theme.scrollarea_position = POSITION_EAST
 
-        columns = 4
-        num_widgets = 3
-        rows = math.ceil(len(menu) / columns) * num_widgets
+        rows = math.ceil(len(menu) / MENU_COLUMNS) * MENU_WIDGETS
 
-        super().__init__(columns=columns, rows=rows, **kwargs)
+        super().__init__(columns=MENU_COLUMNS, rows=rows, **kwargs)
 
         for name, slug, callback in menu:
-            try:
-                npc = db.lookup(slug, table="npc")
-            except KeyError:
-                raise RuntimeError(f"NPC {slug} not found")
-            path = f"gfx/sprites/player/{npc.template.combat_front}.png"
-            new_image = self._create_image(path)
-            new_image.scale(prepare.SCALE * 0.4, prepare.SCALE * 0.4)
-            self.menu.add.image(
-                new_image,
-                align=ALIGN_CENTER,
-            )
-            # replace slug not translated
-            if name == slug:
-                name = "???"
-            self.menu.add.button(
-                name,
-                callback,
-                font_size=self.font_size_smaller,
-                align=ALIGN_CENTER,
-                selection_effect=HighlightSelection(),
-            )
-            self.menu.add.vertical_fill(10)
+            self.add_npc_menu_item(name, slug, callback)
 
         self.animation_size = 0.0
         self.escape_key_exits = escape_key_exits
+
+    def add_npc_menu_item(
+        self,
+        name: str,
+        slug: str,
+        callback: Callable[[], None],
+    ) -> None:
+        try:
+            npc = db.lookup(slug, table="npc")
+        except KeyError:
+            raise RuntimeError(f"NPC {slug} not found")
+        path = f"gfx/sprites/player/{npc.template.combat_front}.png"
+        new_image = self._create_image(path)
+        new_image.scale(
+            prepare.SCALE * SCALE_SPRITE, prepare.SCALE * SCALE_SPRITE
+        )
+        self.menu.add.image(
+            new_image,
+            align=ALIGN_CENTER,
+        )
+        # replace slug not translated
+        if name == slug:
+            name = "???"
+        self.menu.add.button(
+            name,
+            callback,
+            font_size=self.font_size_smaller,
+            align=ALIGN_CENTER,
+            selection_effect=HighlightSelection(),
+        )
+        self.menu.add.vertical_fill(VERTICAL_FILL)
 
     def update_animation_size(self) -> None:
         width, height = prepare.SCREEN_SIZE
@@ -79,11 +95,10 @@ class ChoiceNpc(PygameMenuState):
         _width = widgets_size[0]
         _height = widgets_size[1]
 
-        # block width if more than screen width
         if _width >= width:
             _width = width
         if _height >= height:
-            _height = int(height * 0.8)
+            _height = int(height * MAX_MENU_HEIGHT_PERCENTAGE)
 
         self.menu.resize(
             max(1, int(_width * self.animation_size)),
@@ -100,7 +115,9 @@ class ChoiceNpc(PygameMenuState):
         """
         self.animation_size = 0.0
 
-        ani = self.animate(self, animation_size=1.0, duration=0.2)
+        ani = self.animate(
+            self, animation_size=ANIMATION_SIZE, duration=ANIMATION_DURATION
+        )
         ani.update_callback = self.update_animation_size
 
         return ani

--- a/tuxemon/states/choice/choice_state.py
+++ b/tuxemon/states/choice/choice_state.py
@@ -5,10 +5,18 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from typing import Any
 
+from pygame_menu.locals import POSITION_EAST
+
+from tuxemon import prepare
 from tuxemon.animation import Animation
 from tuxemon.menu.menu import PygameMenuState
+from tuxemon.menu.theme import get_theme
 
 ChoiceMenuGameObj = Callable[[], None]
+MAX_MENU_ELEMENTS = 13
+MAX_MENU_HEIGHT_PERCENTAGE = 0.8
+ANIMATION_DURATION = 0.2
+ANIMATION_SIZE = 1.0
 
 
 class ChoiceState(PygameMenuState):
@@ -27,19 +35,33 @@ class ChoiceState(PygameMenuState):
         escape_key_exits: bool = False,
         **kwargs: Any,
     ) -> None:
+        theme = get_theme()
+        if len(menu) > MAX_MENU_ELEMENTS:
+            theme.scrollarea_position = POSITION_EAST
+
         super().__init__(**kwargs)
 
-        for _key, label, callback in menu:
-            self.menu.add.button(label, callback)
+        for _, label, callback in menu:
+            self.menu.add.button(label, callback, font_size=self.font_size)
 
         self.animation_size = 0.0
         self.escape_key_exits = escape_key_exits
 
     def update_animation_size(self) -> None:
         widgets_size = self.menu.get_size(widget=True)
+        width, height = prepare.SCREEN_SIZE
+
+        _width = widgets_size[0]
+        _height = widgets_size[1]
+
+        if _width >= width:
+            _width = width
+        if _height >= height:
+            _height = int(height * MAX_MENU_HEIGHT_PERCENTAGE)
+
         self.menu.resize(
-            max(1, int(widgets_size[0] * self.animation_size)),
-            max(1, int(widgets_size[1] * self.animation_size)),
+            max(1, int(_width * self.animation_size)),
+            max(1, int(_height * self.animation_size)),
         )
 
     def animate_open(self) -> Animation:
@@ -52,7 +74,9 @@ class ChoiceState(PygameMenuState):
         """
         self.animation_size = 0.0
 
-        ani = self.animate(self, animation_size=1.0, duration=0.2)
+        ani = self.animate(
+            self, animation_size=ANIMATION_SIZE, duration=ANIMATION_DURATION
+        )
         ani.update_callback = self.update_animation_size
 
         return ani

--- a/tuxemon/states/journal/journal_info.py
+++ b/tuxemon/states/journal/journal_info.py
@@ -199,7 +199,8 @@ class JournalInfoState(PygameMenuState):
             )
             f.translate(fix_measure(width, 0.02), fix_measure(height, 0.80))
             f._relax = True
-            elements = [ele.monster_slug for ele in monster.evolutions]
+            slugs = [ele.monster_slug for ele in monster.evolutions]
+            elements = list(dict.fromkeys(slugs))
             labels = [
                 menu.add.label(
                     title=f"{T.translate(ele).upper()}",

--- a/tuxemon/states/monster_info/__init__.py
+++ b/tuxemon/states/monster_info/__init__.py
@@ -291,7 +291,8 @@ class MonsterInfoState(PygameMenuState):
         )
         f.translate(fix_measure(width, 0.02), fix_measure(height, 0.80))
         f._relax = True
-        elements = [ele.monster_slug for ele in monster.evolutions]
+        slugs = [ele.monster_slug for ele in monster.evolutions]
+        elements = list(dict.fromkeys(slugs))
         labels = [
             menu.add.label(
                 title=f"{T.translate(ele).upper()}",


### PR DESCRIPTION
PR updates choice states.

First, I've removed all the magic numbers from the code and replaced them with constants at the top of the page, which makes everything much cleaner and easier to understand. I've also extracted a new method to declutter the init code, making it more modular and manageable. 

Additionally, I've fixed a bug that was causing issues with the monster info and journal info. Specifically, if a monster had the same evolution twice (like when it can evolve using two different items), it would show up twice, but that's now been addressed. 

Lastly, I've made some improvements to the `translated_dialog_choice`. If there are more than 13 elements, a scroll bar will now appear, which prevents the screen from crashing. The scroll bar is also capped at 80% of the screen height, so everything should be much more stable.