### PR TITLE
Adding Tech Shops to Candy and Cotton Scoops

### DIFF
--- a/mods/tuxemon/db/economy/spyder_scoops.json
+++ b/mods/tuxemon/db/economy/spyder_scoops.json
@@ -33,24 +33,44 @@
         "cost": 20
       },
       {
-        "item_name": "tm_avalanche",
-        "price": 2000,
-        "cost": 400,
-        "inventory": 20
-      },
-      {
-        "item_name": "tm_blossom",
-        "price": 1000,
-        "cost": 200,
-        "inventory": 20
-      },
-      {
         "item_name": "tuxeball",
         "price": 50,
         "cost": 10
       }
     ]
   },
+  {
+    "slug": "spyder_cotton_tech",
+    "items": [
+      {
+        "item_name": "miaow_milk",
+        "price": 2000,
+        "cost": 400
+      },
+      {
+        "item_name": "pyramidion",
+        "price": 2000,
+        "cost": 400
+      },
+	  {
+        "item_name": "ox_stick",
+        "price": 2000,
+        "cost": 400
+      },
+      {
+        "item_name": "tm_avalanche",
+        "price": 2000,
+        "cost": 400,
+        "inventory": 1
+      },
+      {
+        "item_name": "tm_blossom",
+        "price": 1000,
+        "cost": 200,
+        "inventory": 1
+      }
+    ]
+  },  
   {
     "slug": "spyder_leather_scoop",
     "items": [
@@ -202,6 +222,45 @@
         "price": 300,
         "cost": 60,
         "variables": ["daytime:false"]
+      }
+    ]
+  }
+    {
+    "slug": "spyder_candy_tech",
+    "items": [
+      {
+        "item_name": "peace_lily",
+        "price": 2000,
+        "cost": 400
+      },
+      {
+        "item_name": "lucky_bamboo",
+        "price": 2000,
+        "cost": 400
+      },
+      {
+        "item_name": "tm_frostbite",
+        "price": 2000,
+        "cost": 400,
+		"inventory": 1
+      },
+      {
+        "item_name": "tm_supernova",
+        "price": 2000,
+        "cost": 400,
+		"inventory": 1
+      },
+      {
+        "item_name": "tm_vorpal",
+        "price": 2000,
+        "cost": 400,
+        "inventory": 1
+      },
+      {
+        "item_name": "tm_cavity",
+        "price": 2000,
+        "cost": 400,
+		"inventory": 1
       }
     ]
   }

--- a/mods/tuxemon/db/item/tm_cavity.json
+++ b/mods/tuxemon/db/item/tm_cavity.json
@@ -1,0 +1,19 @@
+{
+  "conditions": [
+    "not has_tech cavity"
+  ],
+  "effects": [
+    "learn_tm cavity"
+  ],
+  "slug": "tm_cavity",
+  "sort": "utility",
+  "sprite": "gfx/items/tm_generic.png",
+  "category": "technique",
+  "usable_in": [
+    "WorldState"
+  ],
+  "behaviors": {},
+  "use_failure": "generic_failure",
+  "use_item": "combat_used_x",
+  "use_success": "generic_success"
+}

--- a/mods/tuxemon/db/item/tm_frostbite.json
+++ b/mods/tuxemon/db/item/tm_frostbite.json
@@ -1,0 +1,19 @@
+{
+  "conditions": [
+    "not has_tech frostbite"
+  ],
+  "effects": [
+    "learn_tm frostbite"
+  ],
+  "slug": "tm_frostbite",
+  "sort": "utility",
+  "sprite": "gfx/items/tm_water.png",
+  "category": "technique",
+  "usable_in": [
+    "WorldState"
+  ],
+  "behaviors": {},
+  "use_failure": "generic_failure",
+  "use_item": "combat_used_x",
+  "use_success": "generic_success"
+}

--- a/mods/tuxemon/db/item/tm_supernova.json
+++ b/mods/tuxemon/db/item/tm_supernova.json
@@ -1,0 +1,19 @@
+{
+  "conditions": [
+    "not has_tech supernova"
+  ],
+  "effects": [
+    "learn_tm supernova"
+  ],
+  "slug": "tm_supernova",
+  "sort": "utility",
+  "sprite": "gfx/items/tm_fire.png",
+  "category": "technique",
+  "usable_in": [
+    "WorldState"
+  ],
+  "behaviors": {},
+  "use_failure": "generic_failure",
+  "use_item": "combat_used_x",
+  "use_success": "generic_success"
+}

--- a/mods/tuxemon/db/item/tm_vorpal.json
+++ b/mods/tuxemon/db/item/tm_vorpal.json
@@ -1,0 +1,19 @@
+{
+  "conditions": [
+    "not has_tech vorpal"
+  ],
+  "effects": [
+    "learn_tm vorpal"
+  ],
+  "slug": "tm_vorpal",
+  "sort": "utility",
+  "sprite": "gfx/items/tm_metal.png",
+  "category": "technique",
+  "usable_in": [
+    "WorldState"
+  ],
+  "behaviors": {},
+  "use_failure": "generic_failure",
+  "use_item": "combat_used_x",
+  "use_success": "generic_success"
+}

--- a/mods/tuxemon/db/npc/spyder_candy_town_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_candy_town_npcs.json
@@ -90,6 +90,26 @@
   
   },
   {
+    "slug": "spyder_candyscoop_techie",
+    "template": 
+      {
+        "sprite_name": "postboy",
+        "combat_front": "adventurer",
+        "slug": "postboy"
+      }
+  
+  },
+  {
+    "slug": "spyder_cottonscoop_techie",
+    "template": 
+      {
+        "sprite_name": "postboy",
+        "combat_front": "adventurer",
+        "slug": "postboy"
+      }
+  
+  },
+  {
     "slug": "spyder_candyinn_cott",
     "template": 
       {

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -10539,7 +10539,10 @@ msgid "spyder_data_pc10"
 msgstr "11000001"
 
 msgid "spyder_scoop_welcome"
-msgstr "Welcome!"
+msgstr "Welcome to the Scoop Store!"
+
+msgid "spyder_tech_welcome"
+msgstr "Welcome to the Tech Shop!"
 
 msgid "spyder_scoop_sign"
 msgstr "Scoop HQ: Almost good enough to eat!"

--- a/mods/tuxemon/maps/spyder.world
+++ b/mods/tuxemon/maps/spyder.world
@@ -217,6 +217,14 @@
             "x": 2240,
             "y": 3240
         },
+		{
+            "fileName": "spyder_candy_scoop.tmx",
+            "height": 0,
+            "width": 0,
+            "x": -1220,
+            "y": 2240
+
+        },
         {
             "fileName": "spyder_cotton_tunnel.tmx",
             "height": 0,

--- a/mods/tuxemon/maps/spyder_candy_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_candy_scoop.tmx
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="36">
+<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="41">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
+  <property name="map_type" value="shop"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="candy_scoop"/>
-  <property name="map_type" value="shop"/>
  </properties>
  <tileset firstgid="1" source="../gfx/tilesets/core_city_and_country.tsx"/>
  <tileset firstgid="1441" source="../gfx/tilesets/core_indoor_floors.tsx"/>
@@ -18,7 +18,7 @@
  </layer>
  <layer id="2" name="Layer 2" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eJxjYICAIjUGhmI1BqwAl9xEoNgkHHrQ5eSh9C4VCL0KSK8G4jUquNnuQHVKQHwTquckkD4FxKdVcLNBwAtJDymAEj3+GhAcAKVBAMaG8UFAVJWBQVwVv5mJQDOTSHCLPFBtAxA3qkDY6MCci4HBAootuRB65gPxAqieDnVUPalAdWlQnM6F3V4AfHomoQ==
+   eJxjYICAIjUGhmI1BqwAl9xEoNgkHHrQ5eSh9C4VCL0KSK8G4jUquNnuUD03oXpOAulTQHxaBTebAU0PKYASPf4aEBwApUEAxobxRVUZGGYD1Yur4jczEagmiQS3yAPVNgBxowqEjQ7MuRgYLKDYkguhZz4QL4Dq6VBH1ZMKVJcGxelc2O0FAHaqJvQ=
   </data>
  </layer>
  <layer id="3" name="Layer 3" width="13" height="11">
@@ -28,7 +28,7 @@
  </layer>
  <layer id="5" name="Above Player" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eJxjYKAveKlKuh4ONeq7Ax8w0IBgQygNAjA2jA8C1SoMDPNU6Os2XMBbHcHOVMetjpoAAKSpBgo=
+   eJxjYKAveKlKuh4ONdL1zFMhXQ8MGGhAsCGUBgEYG8avBppfo0KZPdQE3uoIdqY6bnXUBABUwwds
   </data>
  </layer>
  <objectgroup color="#ff0000" id="4" name="Collisions">
@@ -36,8 +36,7 @@
   <object id="11" type="collision" x="48" y="0" width="160" height="48"/>
   <object id="14" type="collision" x="64" y="48" width="144" height="16"/>
   <object id="18" type="collision" x="16" y="112" width="16" height="16"/>
-  <object id="19" type="collision" x="0" y="0" width="32" height="64"/>
-  <object id="27" type="collision" x="16" y="64" width="16" height="16"/>
+  <object id="27" type="collision" x="0" y="112" width="16" height="16"/>
   <object id="32" type="collision" x="64" y="96" width="64" height="16"/>
   <object id="33" type="collision" x="0" y="160" width="16" height="16"/>
   <object id="34" type="collision" x="160" y="128" width="32" height="32"/>
@@ -89,6 +88,30 @@
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
     <property name="act3" value="open_shop spyder_candyscoop_clint"/>
     <property name="behav1" value="talk spyder_candyscoop_clint"/>
+   </properties>
+  </object>
+  <object id="36" name="Open Tech Shop" type="event" x="32" y="64" width="16" height="16">
+   <properties>
+    <property name="act1" value="char_face spyder_candyscoop_techie,right"/>
+    <property name="act2" value="translated_dialog spyder_tech_welcome"/>
+    <property name="act3" value="open_shop spyder_candyscoop_techie"/>
+    <property name="cond1" value="is char_facing_tile player"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+   </properties>
+  </object>
+  <object id="37" name="Create Techie" type="event" x="16" y="64" width="16" height="16">
+   <properties>
+    <property name="act1" value="create_npc spyder_candyscoop_techie,1,6"/>
+    <property name="act2" value="char_face spyder_candyscoop_techie,right"/>
+    <property name="act3" value="set_economy spyder_candyscoop_techie,spyder_candy_tech"/>
+    <property name="cond1" value="not char_exists spyder_candyscoop_techie"/>
+   </properties>
+  </object>
+  <object id="40" name="Talk/Open Tech Shop" type="event" x="0" y="48" width="16" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_scoop_tech_welcome"/>
+    <property name="act3" value="open_shop spyder_candyscoop_techie"/>
+    <property name="behav1" value="talk spyder_candyscoop_techie"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_cotton_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_scoop.tmx
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="36">
+<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="39">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
+  <property name="map_type" value="shop"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="cotton_scoop"/>
-  <property name="map_type" value="shop"/>
  </properties>
  <tileset firstgid="1" source="../gfx/tilesets/core_city_and_country.tsx"/>
  <tileset firstgid="1441" source="../gfx/tilesets/core_indoor_floors.tsx"/>
@@ -18,7 +18,7 @@
  </layer>
  <layer id="2" name="Layer 2" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eJxjYICAIjUGhmI1BqwAl9xEoNgkHHrQ5eSh9C4VCL0KSK8G4jUquNnuQHVKQHwTquckkD4FxKdVcLNBwAtJDymAEj3+GhAcAKVBAMaG8UFAVJWBQVwVv5mJQDOTSHCLPFBtAxA3qkDY6MCci4HBAootuRB65gPxAqieDnVUPalAdWlQnM6F3V4AfHomoQ==
+   eJxjYICAIjUGhmI1BqwAl9xEoNgkHHrQ5eSh9C4VCL0KSK8G4jUquNnuUD03oXpOAulTQHxaBTebAU0PKYASPf4aEBwApUEAxobxRVUh6sVV8ZuZCFSTRIJb5IFqG4C4UQXCRgfmXAwMFlBsyYXQMx+IF0D1dKij6kkFqkuD4nQu7PYCAKgSJzI=
   </data>
  </layer>
  <layer id="3" name="Layer 3" width="13" height="11">
@@ -28,7 +28,7 @@
  </layer>
  <layer id="5" name="Above Player" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eJxjYKAveKlKuh4ONeq7Ax8w0IBgQygNAjA2jA8C1SoMDPNU6Os2XMBbHcHOVMetjpoAAKSpBgo=
+   eJxjYKAveKlKuh4ONdL1zFMhXQ8MGGhAsCGUBgEYG8avBppfo0K6PbMpcBc+4K2OYGeq41ZHTQAA7NMIKw==
   </data>
  </layer>
  <objectgroup color="#ff0000" id="4" name="Collisions">
@@ -37,7 +37,7 @@
   <object id="14" type="collision" x="64" y="48" width="144" height="16"/>
   <object id="18" type="collision" x="16" y="112" width="16" height="16"/>
   <object id="19" type="collision" x="0" y="0" width="32" height="64"/>
-  <object id="27" type="collision" x="16" y="64" width="16" height="16"/>
+  <object id="27" type="collision" x="0" y="112" width="16" height="16"/>
   <object id="32" type="collision" x="0" y="160" width="16" height="16"/>
   <object id="33" type="collision" x="64" y="96" width="64" height="16"/>
   <object id="34" type="collision" x="144" y="96" width="48" height="16"/>
@@ -141,6 +141,30 @@
     <property name="act3" value="open_shop spyder_cottonscoop_joe"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
+   </properties>
+  </object>
+  <object id="36" name="Open Tech Shop" type="event" x="32" y="64" width="16" height="16">
+   <properties>
+    <property name="act1" value="char_face spyder_cottonscoop_techie,right"/>
+    <property name="act2" value="translated_dialog spyder_tech_welcome"/>
+    <property name="act3" value="open_shop spyder_cottonscoop_techie"/>
+    <property name="cond1" value="is char_facing_tile player"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+   </properties>
+  </object>
+  <object id="37" name="Create Techie" type="event" x="16" y="64" width="16" height="16">
+   <properties>
+    <property name="act1" value="create_npc spyder_cottonscoop_techie,1,6"/>
+    <property name="act2" value="char_face spyder_cottonscoop_techie,right"/>
+    <property name="act3" value="set_economy spyder_cottonscoop_techie,spyder_cotton_tech"/>
+    <property name="cond1" value="not char_exists spyder_cottonscoop_techie"/>
+   </properties>
+  </object>
+  <object id="38" name="Talk/Open Tech Shop" type="event" x="0" y="48" width="16" height="16">
+   <properties>
+    <property name="act2" value="translated_dialog spyder_scoop_tech_welcome"/>
+    <property name="act3" value="open_shop spyder_candyscoop_techie"/>
+    <property name="behav1" value="talk spyder_candyscoop_techie"/>
    </properties>
   </object>
  </objectgroup>


### PR DESCRIPTION
I hope I've done this correctly, I'm afraid I can't run Tuxemon on my system at the moment to confirm that it's working. 

If these two work, I'll replicate them for the other towns. 

I wanted to make a place for TMs specifically to be sold, as we've got a lot of techniques that could become TMs and I didn't want them blocking the more basic items in the Scoop stores. 

I also wanted to make the evolution items for the "new" starters available. 

**Yet to do**
I'd also like these shops to sell the "new" starters. Is there a way to add tuxemon for sale in an economy, or does that need to be done through a separate process? 