### PR TITLE
conditions + methods in Enqueue

### DIFF
--- a/tuxemon/condition/effects/feedback.py
+++ b/tuxemon/condition/effects/feedback.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Union
 
 from tuxemon.combat import fainted
 from tuxemon.condition.condeffect import CondEffect, CondEffectResult
@@ -15,14 +14,12 @@ from tuxemon.technique.technique import Technique
 @dataclass
 class FeedBackEffect(CondEffect):
     """
-
-    Feedback:
-    Each time you are hit by a Special move
-    the attacker takes 1/8th your maximum HP in damage
+    Each time you are hit by a Special move the attacker takes damage equal to
+    your maximum HP divided by the divisor.
 
     Parameters:
-        divisor: The divisor.
-
+        divisor: The divisor used to calculate the damage.
+        ranges: The ranges of moves that trigger the effect.
     """
 
     name = "feedback"
@@ -31,38 +28,31 @@ class FeedBackEffect(CondEffect):
 
     def apply(self, condition: Condition, target: Monster) -> CondEffectResult:
         done: bool = False
+        ranges = self.ranges.split(":")
         assert condition.combat_state
         combat = condition.combat_state
-        log = combat._action_queue.history
+        log = combat._action_queue
         turn = combat._turn
-        ranges = self.ranges.split(":")
-        # check log actions
-        attacker: Union[Monster, None] = None
-        hit: bool = False
-        for ele in log:
-            _turn, action = ele
-            if _turn == turn:
-                method = action.method
-                # progress
-                if (
-                    isinstance(method, Technique)
-                    and isinstance(action.user, Monster)
-                    and method.hit
-                    and method.range in ranges
-                    and action.target.instance_id == target.instance_id
-                ):
-                    attacker = action.user
-                    hit = True
+        action = log.get_last_action(turn, target, "target")
 
         if (
-            condition.phase == "perform_action_status"
-            and attacker
-            and hit
-            and not fainted(attacker)
+            action
+            and isinstance(action.method, Technique)
+            and isinstance(action.user, Monster)
         ):
-            damage = target.hp // self.divisor
-            attacker.current_hp = max(0, attacker.current_hp - damage)
-            done = True
+            method = action.method
+            attacker = action.user
+
+            if (
+                condition.phase == "perform_action_status"
+                and method.hit
+                and method.range in ranges
+                and action.target.instance_id == target.instance_id
+                and not fainted(attacker)
+            ):
+                damage = target.hp // self.divisor
+                attacker.current_hp = max(0, attacker.current_hp - damage)
+                done = True
         return CondEffectResult(
             name=condition.name,
             success=done,

--- a/tuxemon/condition/effects/prickly.py
+++ b/tuxemon/condition/effects/prickly.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Union
 
 from tuxemon.combat import fainted
 from tuxemon.condition.condeffect import CondEffect, CondEffectResult
@@ -15,14 +14,12 @@ from tuxemon.technique.technique import Technique
 @dataclass
 class PricklyBackEffect(CondEffect):
     """
-
-    Prickly:
-    Each time you are hit by a Physical move
-    the attacker takes 1/8th your maximum HP in damage
+    Each time you are hit by a Physical move the attacker takes damage equal to
+    your maximum HP divided by the divisor.
 
     Parameters:
-        divisor: The divisor.
-
+        divisor: The divisor used to calculate the damage.
+        ranges: The ranges of moves that trigger the effect.
     """
 
     name = "prickly"
@@ -31,38 +28,31 @@ class PricklyBackEffect(CondEffect):
 
     def apply(self, condition: Condition, target: Monster) -> CondEffectResult:
         done: bool = False
+        ranges = self.ranges.split(":")
         assert condition.combat_state
         combat = condition.combat_state
-        log = combat._action_queue.history
+        log = combat._action_queue
         turn = combat._turn
-        ranges = self.ranges.split(":")
-        # check log actions
-        attacker: Union[Monster, None] = None
-        hit: bool = False
-        for ele in log:
-            _turn, action = ele
-            if _turn == turn:
-                method = action.method
-                # progress
-                if (
-                    isinstance(method, Technique)
-                    and isinstance(action.user, Monster)
-                    and method.hit
-                    and method.range in ranges
-                    and action.target.instance_id == target.instance_id
-                ):
-                    attacker = action.user
-                    hit = True
+        action = log.get_last_action(turn, target, "target")
 
         if (
-            condition.phase == "perform_action_status"
-            and attacker
-            and hit
-            and not fainted(attacker)
+            action
+            and isinstance(action.method, Technique)
+            and isinstance(action.user, Monster)
         ):
-            damage = target.hp // self.divisor
-            attacker.current_hp = max(0, attacker.current_hp - damage)
-            done = True
+            method = action.method
+            attacker = action.user
+
+            if (
+                condition.phase == "perform_action_status"
+                and method.hit
+                and method.range in ranges
+                and action.target.instance_id == target.instance_id
+                and not fainted(attacker)
+            ):
+                damage = target.hp // self.divisor
+                attacker.current_hp = max(0, attacker.current_hp - damage)
+                done = True
         return CondEffectResult(
             name=condition.name,
             success=done,

--- a/tuxemon/condition/effects/retaliate.py
+++ b/tuxemon/condition/effects/retaliate.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from tuxemon.combat import fainted
 from tuxemon.condition.condeffect import CondEffect, CondEffectResult
@@ -20,12 +20,12 @@ if TYPE_CHECKING:
 @dataclass
 class RetaliateEffect(CondEffect):
     """
-
     Retaliate:
-    Keep track of all damage you take between entering
-    this state and next doing damage. You do additional
-    damage equal to damage taken.
+    Accumulate all damage taken between entering this state and next dealing
+    damage. The accumulated damage is then added to your next attack, dealing
+    additional damage to the target.
 
+    Note: The accumulated damage is reset after the next attack.
     """
 
     name = "retaliate"
@@ -34,39 +34,28 @@ class RetaliateEffect(CondEffect):
         done: bool = False
         assert condition.combat_state
         combat = condition.combat_state
-        log = combat._action_queue.history
+        log = combat._action_queue
         turn = combat._turn
-        # check log actions
-        attacker: Union[Monster, None] = None
-        damage: int = 0
-        hit: bool = False
-        for ele in log:
-            _turn, action = ele
-            if _turn == turn:
-                method = action.method
-                # progress
-                if (
-                    isinstance(method, Technique)
-                    and isinstance(action.user, Monster)
-                    and method.hit
-                    and action.target.instance_id == target.instance_id
-                    and method.range != Range.special
-                ):
-                    attacker = action.user
-                    hit = True
-                    dam, mul = simple_damage_calculate(
-                        method, attacker, target
-                    )
-                    damage = dam
+        action = log.get_last_action(turn, target, "target")
 
         if (
-            condition.phase == "perform_action_status"
-            and attacker
-            and hit
-            and not fainted(attacker)
+            action
+            and isinstance(action.method, Technique)
+            and isinstance(action.user, Monster)
         ):
-            attacker.current_hp = max(0, attacker.current_hp - damage)
-            done = True
+            method = action.method
+            attacker = action.user
+            dam, mul = simple_damage_calculate(method, attacker, target)
+
+            if (
+                condition.phase == "perform_action_status"
+                and method.hit
+                and action.target.instance_id == target.instance_id
+                and method.range != Range.special
+                and not fainted(attacker)
+            ):
+                attacker.current_hp = max(0, attacker.current_hp - dam)
+                done = True
         return CondEffectResult(
             name=condition.name,
             success=done,

--- a/tuxemon/states/combat/combat_classes.py
+++ b/tuxemon/states/combat/combat_classes.py
@@ -174,6 +174,50 @@ class ActionQueue:
         new_action = EnqueuedAction(user, method, target)
         self._action_queue[index] = new_action
 
+    def get_last_action(
+        self, turn: int, monster: Monster, field: str
+    ) -> Optional[EnqueuedAction]:
+        """
+        Retrieves the last action involving the specified monster in the given turn.
+
+        Parameters:
+            turn: The turn number to search in.
+            monster: The monster to search for.
+            field: The field to search in ('user' or 'target').
+
+        Returns:
+            The last matching action, or None if not found.
+        """
+
+        if field not in ("user", "target"):
+            raise ValueError(f"{field} must be 'user' or 'target'")
+
+        for _turn, action in reversed(self._action_history):
+            if _turn == turn and (
+                field == "user"
+                and action.user == monster
+                or field == "target"
+                and action.target == monster
+            ):
+                return action
+
+        return None
+
+    def get_all_actions_by_turn(self, turn: int) -> list[EnqueuedAction]:
+        """
+        Retrieves all actions that occurred in the specified turn.
+
+        Parameters:
+            turn: The turn number to retrieve actions for.
+
+        Returns:
+            A list of actions that occurred in the specified turn.
+        """
+
+        return [
+            action for _turn, action in self._action_history if _turn == turn
+        ]
+
 
 class DamageReport(NamedTuple):
     attack: Monster


### PR DESCRIPTION
PR introduces new methods to the EnqueueAction class, making it easier to retrieve specific actions based on certain parameters. Additionally, it updates a series of conditions by utilizing these methods, resulting in a simpler and more streamlined process. It's worth noting that Prickly, Feedback, and Elemental Shield are distinct conditions, but they share an identical underlying mechanism. Although it might be possible to consolidate these conditions into a single file, I have been advised against doing so in this [instance](https://github.com/Tuxemon/Tuxemon/pull/1932#issuecomment-1593533413).