### PR TITLE
Fix softlock 

### DIFF
--- a/tuxemon/states/journal/journal_info.py
+++ b/tuxemon/states/journal/journal_info.py
@@ -254,10 +254,10 @@ class JournalInfoState(PygameMenuState):
             key=lambda x: x.txmn_id,
         )
 
-        if not monster_models:
-            return None
-
         if event.button in (buttons.RIGHT, buttons.LEFT) and event.pressed:
+            if not monster_models:
+                return None
+            
             current_monster_index = monster_models.index(self._monster)
             new_index = (
                 (current_monster_index + 1) % len(monster_models)


### PR DESCRIPTION
The merge #2541 fixes the issue #2540  (the one where the game crashes at the start) but leaves the player softlock when not having a tuxemon in it's party. 

This can be noticed when starting the game and selecting the space above the tuxemon to open it's character sheet, or when the player chooses their first tuxemon in the trash-bins next to the shop at the beginning of the game  (no control responds, forcing the player to exit the game in both cases).