### PR TITLE
combat variables

### DIFF
--- a/tuxemon/condition/effects/confused.py
+++ b/tuxemon/condition/effects/confused.py
@@ -39,15 +39,15 @@ class ConfusedEffect(CondEffect):
 
         extra: list[str] = []
         tech: list[Technique] = []
-        player = target.owner
-        assert player
-        if CONFUSED_KEY in player.game_variables:
-            player.game_variables[CONFUSED_KEY] = "off"
+        combat = condition.combat_state
+        assert combat
+        if CONFUSED_KEY in combat._combat_variables:
+            combat._combat_variables[CONFUSED_KEY] = "off"
 
         if condition.phase == "pre_checking" and random.random() > self.chance:
             user = condition.link
             assert user
-            player.game_variables[CONFUSED_KEY] = "on"
+            combat._combat_variables[CONFUSED_KEY] = "on"
             available_techniques = _get_available_techniques(user)
             if available_techniques:
                 chosen_technique = random.choice(available_techniques)
@@ -59,10 +59,10 @@ class ConfusedEffect(CondEffect):
 
         if (
             condition.phase == "perform_action_tech"
-            and player.game_variables[CONFUSED_KEY] == "on"
+            and combat._combat_variables[CONFUSED_KEY] == "on"
         ):
             replacement = Technique()
-            slug = player.game_variables.get("action_tech", "skip")
+            slug = combat._combat_variables.get("action_tech", "skip")
             replacement.load(slug)
             extra = _get_extra_message(target, replacement)
 

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -38,7 +38,7 @@ import random
 from collections.abc import Iterable, MutableMapping, Sequence
 from functools import partial
 from itertools import chain
-from typing import Literal, Optional, Union
+from typing import Any, Literal, Optional, Union
 
 import pygame
 from pygame.rect import Rect
@@ -170,6 +170,7 @@ class CombatState(CombatAnimations):
             tuple[str, tuple[float, float]], Sprite
         ] = {}
         self._random_tech_hit: dict[Monster, float] = {}
+        self._combat_variables: dict[str, Any] = {}
 
         super().__init__(players, graphics)
         self.is_trainer_battle = combat_type == "trainer"
@@ -1317,6 +1318,7 @@ class CombatState(CombatAnimations):
         self._action_queue.clear_history()
         self._pending_queue = []
         self._damage_map = []
+        self._combat_variables = {}
 
     def end_combat(self) -> None:
         """End the combat."""

--- a/tuxemon/states/combat/combat_menus.py
+++ b/tuxemon/states/combat/combat_menus.py
@@ -302,7 +302,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                 return
 
             # Pre-check the technique for validity
-            self.character.game_variables["action_tech"] = technique.slug
+            self.combat._combat_variables["action_tech"] = technique.slug
             technique = combat.pre_checking(
                 self.monster, technique, target, self.combat
             )

--- a/tuxemon/states/journal/journal_info.py
+++ b/tuxemon/states/journal/journal_info.py
@@ -257,7 +257,7 @@ class JournalInfoState(PygameMenuState):
         if event.button in (buttons.RIGHT, buttons.LEFT) and event.pressed:
             if not monster_models:
                 return None
-            
+
             current_monster_index = monster_models.index(self._monster)
             new_index = (
                 (current_monster_index + 1) % len(monster_models)


### PR DESCRIPTION
PR introduces a `_combat_variables` dictionary in the `CombatState` class, analogous to the `game_variables` dictionary in the `NPC` class. This addition aims to isolate temporary combat-related data from the main game variables, preventing data mixing and ensuring a clean separation of concerns.