### PR TITLE
scoops maps (Spyder)

### DIFF
--- a/mods/tuxemon/maps/spyder_candy_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_candy_scoop.tmx
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="36">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="36">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
+  <property name="map_type" value="shop"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="candy_scoop"/>
-  <property name="map_type" value="shop"/>
  </properties>
  <tileset firstgid="1" source="../gfx/tilesets/core_city_and_country.tsx"/>
  <tileset firstgid="1441" source="../gfx/tilesets/core_indoor_floors.tsx"/>
@@ -18,7 +18,7 @@
  </layer>
  <layer id="2" name="Layer 2" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eJxjYICAIjUGhmI1BqwAl9xEoNgkHHrQ5eSh9C4VCL0KSK8G4jUquNnuQHVKQHwTquckkD4FxKdVcLNBwAtJDymAEj3+GhAcAKVBAMaG8UFAVJWBQVwVv5mJQDOTSHCLPFBtAxA3qkDY6MCci4HBAootuRB65gPxAqieDnVUPalAdWlQnM6F3V4AfHomoQ==
+   eJxjYICAIjUGhmI1BqwAl9xEoNgkHHrQ5eSh9C4VCL0KSK8G4jUquNnuUD03oXpOAulTQHxaBTebAU0PKYAUPdUqqHr8NSA4AEqDAIwN44uqMjDMBqoXV8VvdiJQTRIJbpEHqm0A4kYVCBsdmHMxMFhAsSUXQs98IF4A1dOhjqonFaguDYrTubDbCwAYESeT
   </data>
  </layer>
  <layer id="3" name="Layer 3" width="13" height="11">
@@ -28,16 +28,14 @@
  </layer>
  <layer id="5" name="Above Player" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eJxjYKAveKlKuh4ONeq7Ax8w0IBgQygNAjA2jA8C1SoMDPNU6Os2XMBbHcHOVMetjpoAAKSpBgo=
+   eJxjYKAveKlKuh4ONdL1zFMhXQ8MGGhAsCGUBgEYG8YHgRoVyuyhJvBWR7Az1XGroyYAALNcBs0=
   </data>
  </layer>
  <objectgroup color="#ff0000" id="4" name="Collisions">
-  <object id="10" type="collision" x="32" y="0" width="16" height="128"/>
-  <object id="11" type="collision" x="48" y="0" width="160" height="48"/>
+  <object id="10" type="collision" x="32" y="48" width="16" height="80"/>
+  <object id="11" type="collision" x="48" y="32" width="16" height="16"/>
   <object id="14" type="collision" x="64" y="48" width="144" height="16"/>
-  <object id="18" type="collision" x="16" y="112" width="16" height="16"/>
-  <object id="19" type="collision" x="0" y="0" width="32" height="64"/>
-  <object id="27" type="collision" x="16" y="64" width="16" height="16"/>
+  <object id="18" type="collision" x="0" y="112" width="32" height="16"/>
   <object id="32" type="collision" x="64" y="96" width="64" height="16"/>
   <object id="33" type="collision" x="0" y="160" width="16" height="16"/>
   <object id="34" type="collision" x="160" y="128" width="32" height="32"/>
@@ -82,13 +80,6 @@
     <property name="act3" value="open_shop spyder_candyscoop_clint"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
-   </properties>
-  </object>
-  <object id="31" name="Talk/Open Shop" type="event" x="0" y="80" width="16" height="16">
-   <properties>
-    <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
-    <property name="act3" value="open_shop spyder_candyscoop_clint"/>
-    <property name="behav1" value="talk spyder_candyscoop_clint"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_cotton_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_scoop.tmx
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="36">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="36">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
+  <property name="map_type" value="shop"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="cotton_scoop"/>
-  <property name="map_type" value="shop"/>
  </properties>
  <tileset firstgid="1" source="../gfx/tilesets/core_city_and_country.tsx"/>
  <tileset firstgid="1441" source="../gfx/tilesets/core_indoor_floors.tsx"/>
@@ -18,7 +18,7 @@
  </layer>
  <layer id="2" name="Layer 2" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eJxjYICAIjUGhmI1BqwAl9xEoNgkHHrQ5eSh9C4VCL0KSK8G4jUquNnuQHVKQHwTquckkD4FxKdVcLNBwAtJDymAEj3+GhAcAKVBAMaG8UFAVJWBQVwVv5mJQDOTSHCLPFBtAxA3qkDY6MCci4HBAootuRB65gPxAqieDnVUPalAdWlQnM6F3V4AfHomoQ==
+   eJxjYICAIjUGhmI1BqwAl9xEoNgkHHrQ5eSh9C4VCL0KSK8G4jUquNnuUD03oXpOAulTQHxaBTebAU0PKYAUPdUqqHr8NSA4AEqDAIwN44uqMjDMBqoXV8VvdiJQTRIJbpEHqm0A4kYVCBsdmHMxMFhAsSUXQs98IF4A1dOhjqonFaguDYrTubDbCwAYESeT
   </data>
  </layer>
  <layer id="3" name="Layer 3" width="13" height="11">
@@ -28,16 +28,14 @@
  </layer>
  <layer id="5" name="Above Player" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eJxjYKAveKlKuh4ONeq7Ax8w0IBgQygNAjA2jA8C1SoMDPNU6Os2XMBbHcHOVMetjpoAAKSpBgo=
+   eJxjYKAveKlKuh4ONdL1zFMhXQ8MGGhAsCGUBgEYG8YHgRoVyuyhJvBWR7Az1XGroyYAALNcBs0=
   </data>
  </layer>
  <objectgroup color="#ff0000" id="4" name="Collisions">
-  <object id="10" type="collision" x="32" y="0" width="16" height="128"/>
-  <object id="11" type="collision" x="48" y="0" width="160" height="48"/>
+  <object id="10" type="collision" x="32" y="48" width="16" height="80"/>
+  <object id="11" type="collision" x="48" y="32" width="16" height="16"/>
   <object id="14" type="collision" x="64" y="48" width="144" height="16"/>
-  <object id="18" type="collision" x="16" y="112" width="16" height="16"/>
-  <object id="19" type="collision" x="0" y="0" width="32" height="64"/>
-  <object id="27" type="collision" x="16" y="64" width="16" height="16"/>
+  <object id="18" type="collision" x="0" y="112" width="32" height="16"/>
   <object id="32" type="collision" x="0" y="160" width="16" height="16"/>
   <object id="33" type="collision" x="64" y="96" width="64" height="16"/>
   <object id="34" type="collision" x="144" y="96" width="48" height="16"/>
@@ -52,7 +50,7 @@
     <property name="cond2" value="is char_facing player,down"/>
    </properties>
   </object>
-  <object id="20" name="Create Shopkeeper" type="event" x="0" y="64" width="16" height="16">
+  <object id="20" name="Create Shopkeeper" type="event" x="16" y="96" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_cottonscoop_joe,1,6"/>
     <property name="act2" value="char_face spyder_cottonscoop_joe,right"/>
@@ -60,20 +58,20 @@
     <property name="cond1" value="not char_exists spyder_cottonscoop_joe"/>
    </properties>
   </object>
-  <object id="21" name="Create Assistant" type="event" x="48" y="80" width="16" height="16">
+  <object id="21" name="Create Assistant" type="event" x="112" y="128" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_shopassistant,7,8"/>
     <property name="cond1" value="not char_exists spyder_shopassistant"/>
    </properties>
   </object>
-  <object id="22" name="Assistant Talk" type="event" x="112" y="112" width="16" height="16">
+  <object id="22" name="Assistant Talk" type="event" x="112" y="96" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_cottonscoop_shopassistant"/>
     <property name="behav1" value="talk spyder_shopassistant"/>
     <property name="cond1" value="is variable_set visitcottonmart:yes"/>
    </properties>
   </object>
-  <object id="23" name="Devices, no explain" type="event" x="128" y="128" width="16" height="16">
+  <object id="23" name="Devices, no explain" type="event" x="96" y="96" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_cottonscoop_devicenoexplan"/>
     <property name="act2" value="pathfind spyder_cottonscoop_joe,1,6"/>
@@ -81,7 +79,7 @@
     <property name="cond1" value="is variable_set heardcapture:yes"/>
    </properties>
   </object>
-  <object id="25" name="Devices, explain" type="event" x="32" y="128" width="16" height="16">
+  <object id="25" name="Devices, explain" type="event" x="32" y="48" width="16" height="16">
    <properties>
     <property name="act1" value="char_stop player"/>
     <property name="act11" value="lock_controls"/>
@@ -94,7 +92,7 @@
     <property name="cond1" value="is variable_set heardcapture:no"/>
    </properties>
   </object>
-  <object id="26" name="Receive capture device" type="event" x="16" y="96" width="16" height="16">
+  <object id="26" name="Receive capture device" type="event" x="32" y="32" width="16" height="16">
    <properties>
     <property name="act1" value="char_stop player"/>
     <property name="act11" value="lock_controls"/>
@@ -116,13 +114,6 @@
    <properties>
     <property name="act1" value="play_music music_cathedral_theme"/>
     <property name="cond1" value="not music_playing music_cathedral_theme"/>
-   </properties>
-  </object>
-  <object id="29" name="Talk/Open Shop" type="event" x="0" y="80" width="16" height="16">
-   <properties>
-    <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
-    <property name="act3" value="open_shop spyder_cottonscoop_joe"/>
-    <property name="behav1" value="talk spyder_cottonscoop_joe"/>
    </properties>
   </object>
   <object id="30" name="Open Shop" type="event" x="32" y="96" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_flower_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_flower_scoop.tmx
@@ -18,7 +18,7 @@
  </layer>
  <layer id="2" name="Layer 2" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eJxjYICAIjUGhmI1BqwAl9xEoNgkHHrQ5eSh9C4VCL0KSK8G4jUquNnuQHVKQHwTquckkD4FxKdVcLNBwAtJDymAEj3+GhAcAKVBAMaG8UFAVJWBQVwVv5mJQDOTSHCLPFBtAxA3qkDY6MCci4HBAootuRB65gPxAqieDnVUPalAdWlQnM6F3V4AfHomoQ==
+   eJxjYICAIjUGhmI1BqwAl9xEoNgkHHrQ5eSh9C4VCL0KSK8G4jUquNnuUD03oXpOAulTQHxaBTebAU0PKYAUPdUqqHr8NSA4AEqDAIwN44uqMjDMBqoXV8VvdiJQTRIJbpEHqm0A4kYVCBsdmHMxMFhAsSUXQs98IF4A1dOhjqonFaguDYrTubDbCwAYESeT
   </data>
  </layer>
  <layer id="3" name="Layer 3" width="13" height="11">
@@ -28,16 +28,14 @@
  </layer>
  <layer id="5" name="Above Player" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eJxjYKAveKlKuh4ONeq7Ax8w0IBgQygNAjA2jA8C1SoMDPNU6Os2XMBbHcHOVMetjpoAAKSpBgo=
+   eJxjYKAveKlKuh4ONdL1zFMhXQ8MGGhAsCGUBgEYG8YHgRoVyuyhJvBWR7Az1XGroyYAALNcBs0=
   </data>
  </layer>
  <objectgroup color="#ff0000" id="4" name="Collisions">
   <object id="10" type="collision" x="32" y="48" width="16" height="80"/>
-  <object id="11" type="collision" x="48" y="32" width="160" height="16"/>
+  <object id="11" type="collision" x="48" y="32" width="16" height="16"/>
   <object id="14" type="collision" x="64" y="48" width="144" height="16"/>
-  <object id="18" type="collision" x="16" y="112" width="16" height="16"/>
-  <object id="19" type="collision" x="0" y="48" width="32" height="16"/>
-  <object id="27" type="collision" x="16" y="64" width="16" height="16"/>
+  <object id="18" type="collision" x="0" y="112" width="32" height="16"/>
   <object id="32" type="collision" x="64" y="96" width="64" height="16"/>
   <object id="33" type="collision" x="144" y="96" width="48" height="16"/>
   <object id="34" type="collision" x="160" y="128" width="32" height="32"/>

--- a/mods/tuxemon/maps/spyder_flower_scoop.yaml
+++ b/mods/tuxemon/maps/spyder_flower_scoop.yaml
@@ -47,13 +47,6 @@ events:
     x: 1
     y: 7
     type: "event"
-  Talk/Open Shop:
-    actions:
-    - translated_dialog spyder_scoop_welcome
-    - open_shop spyder_flowerscoop_jarod
-    behav:
-    - talk spyder_flowerscoop_jarod
-    type: "event"
   Flashback:
     actions:
     - lock_controls

--- a/mods/tuxemon/maps/spyder_leather_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_leather_scoop.tmx
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="27">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="28">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
+  <property name="map_type" value="shop"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="leather_scoop"/>
-  <property name="map_type" value="shop"/>
  </properties>
  <tileset firstgid="1" source="../gfx/tilesets/core_city_and_country.tsx"/>
  <tileset firstgid="1441" source="../gfx/tilesets/core_indoor_floors.tsx"/>
@@ -28,19 +28,20 @@
  </layer>
  <layer id="4" name="Above Player" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eAFjYKAveKVKun2caqTrobYOb3VME2tUGBjmATElAJu5lJgH0quEhCk1C59+AIjjA+s=
+   eAFjYKAveKVKun2caqTrmadCuh58OrzVMWVrgHZQag82czFtIk1ECagchknTSZpqAJaWBK0=
   </data>
  </layer>
  <objectgroup color="#ff0000" id="5" name="Collisions">
   <object id="12" type="collision" x="0" y="160" width="64" height="16"/>
-  <object id="13" type="collision" x="0" y="0" width="48" height="128"/>
-  <object id="14" type="collision" x="48" y="0" width="160" height="48"/>
+  <object id="13" type="collision" x="32" y="48" width="16" height="80"/>
+  <object id="14" type="collision" x="48" y="32" width="16" height="16"/>
   <object id="18" type="collision" x="128" y="160" width="16" height="16"/>
   <object id="22" type="collision" x="80" y="112" width="32" height="32"/>
   <object id="23" type="collision" x="144" y="80" width="32" height="32"/>
   <object id="24" type="collision" x="160" y="128" width="32" height="32"/>
   <object id="25" type="collision" x="64" y="48" width="96" height="16"/>
   <object id="26" type="collision" x="176" y="48" width="32" height="16"/>
+  <object id="27" type="collision" x="0" y="112" width="32" height="16"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="6" name="Events">
   <object id="15" name="Teleport to Leather Town" type="event" x="80" y="160" width="32" height="16">

--- a/mods/tuxemon/maps/spyder_paper_mart.tmx
+++ b/mods/tuxemon/maps/spyder_paper_mart.tmx
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="23">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="23">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
+  <property name="map_type" value="shop"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="paper_mart"/>
-  <property name="map_type" value="shop"/>
  </properties>
  <tileset firstgid="1" source="../gfx/tilesets/core_indoor_walls.tsx"/>
  <tileset firstgid="3865" source="../gfx/tilesets/core_indoor_floors.tsx"/>
@@ -17,17 +17,17 @@
  </layer>
  <layer id="2" name="Tile Layer 2" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eAFjYKAvkJQn3r49cgwMu4HYkgQ9MNOpqacUaP9voDtguBzJPT+B4sQCmDnI+onVi0sdzExsbsOlhxTxi0h+RdcHAE89ECg=
+   eAFjYKAvkJQn3r49cgwMu4HYkgQ9MNOpqacUaP9voDtguBzJPaTYAzMHWT/MveTSMDOxuY1cM5H1XUTyK7I4iA0AkykPaQ==
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eAFjYBj8QEqedDeSo+eWHOn23CVDD+m2DE4dAMmQAmY=
+   eAFjYBj8QEqedDfSS08kGW4j3TeDUwcAZbsBJA==
   </data>
  </layer>
  <layer id="4" name="Above player" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eAFjYBhZ4LYcA8MdJHwXyCYHwMwhRy8uPTAzYe4j1224zKe2OABalQu4
+   eAFjYBie4J8cdn/dBorfQcJ3cajDrhshCjMHlz0IlcSzYGbC3Eeu24i3kTKVAPz3DfA=
   </data>
  </layer>
  <layer id="5" name="Above player" width="13" height="11">

--- a/mods/tuxemon/maps/spyder_paper_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_paper_scoop.tmx
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="66">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="66">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
+  <property name="map_type" value="shop"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="paper_scoop"/>
-  <property name="map_type" value="shop"/>
  </properties>
  <tileset firstgid="1" source="../gfx/tilesets/core_indoor_floors.tsx"/>
  <tileset firstgid="3865" source="../gfx/tilesets/core_indoor_walls.tsx"/>
@@ -17,17 +17,17 @@
  </layer>
  <layer id="2" name="Tile Layer 2" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eAFjYKAvkJIn3r49cgwMu4HYkgQ9MNOpqacUaP9voDtguBzJPT+B4sQCmDnI+onVi0sdzExsbsOlhxTxi0h+RdcHAFEJECk=
+   eAFjYKAvkJIn3r49cgwMu4HYkgQ9MNOpqacUaP9voDtguBzJPaTYAzMHWT/MveTSMDOxuY1cM5H1XUTyK7I4iA0AlPUPag==
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eAFjYBj8QEqedDeSo+eWHOn23CVDD+m2DE4dAMmQAmY=
+   eAFjYBj8QEqedDfSS08kGW4j3TeDUwcAZbsBJA==
   </data>
  </layer>
  <layer id="4" name="Above player" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eAFjYBhZ4LYcA8MdJHwXyCYHwMwhRy8uPTAzYe4j1224zKe2OABalQu4
+   eAFjYBie4J8cdn/dBorfQcJ3cajDrhshCjMHlz0IlcSzYGbC3Eeu24i3kTKVAPz3DfA=
   </data>
  </layer>
  <layer id="5" name="Above player" width="13" height="11">
@@ -36,7 +36,7 @@
   </data>
  </layer>
  <objectgroup color="#ff0000" id="6" name="Collisions">
-  <object id="11" type="collision" x="0" y="16" width="208" height="32"/>
+  <object id="11" type="collision" x="0" y="32" width="208" height="16"/>
   <object id="21" type="collision" x="32" y="48" width="16" height="64"/>
   <object id="22" type="collision" x="0" y="112" width="48" height="16"/>
   <object id="24" type="collision" x="128" y="80" width="80" height="16"/>

--- a/mods/tuxemon/maps/spyder_timber_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_timber_scoop.tmx
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="37">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="37">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
+  <property name="map_type" value="shop"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="timber_scoop"/>
-  <property name="map_type" value="shop"/>
  </properties>
  <tileset firstgid="1" source="../gfx/tilesets/core_city_and_country.tsx"/>
  <tileset firstgid="1441" source="../gfx/tilesets/core_indoor_floors.tsx"/>
@@ -18,7 +18,7 @@
  </layer>
  <layer id="2" name="Layer 2" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eJxjYICAIjUGhmI1BqwAl9xEoNgkHHrQ5eSh9C4VCL0KSK8G4jUquNnuQHVKQHwTquckkD4FxKdVcLNBwAtJDymAEj3+GhAcAKVBAMaG8UFAVJWBQVwVv5mJQDOTSHCLPFBtAxA3qkDY6MCci4HBAootuRB65gPxAqieDnVUPalAdWlQnM6F3V4AfHomoQ==
+   eJxjYICAIjUGhmI1BqwAl9xEoNgkHHrQ5eSh9C4VCL0KSK8G4jUquNnuUD03oXpOAulTQHxaBTebAU0PKYAUPdUqqHr8NSA4AEqDAIwN44uqMjDMBqoXV8VvdiJQTRIJbpEHqm0A4kYVCBsdmHMxMFhAsSUXQs98IF4A1dOhjqonFaguDYrTubDbCwAYESeT
   </data>
  </layer>
  <layer id="3" name="Layer 3" width="13" height="11">
@@ -28,16 +28,14 @@
  </layer>
  <layer id="5" name="Above Player" width="13" height="11">
   <data encoding="base64" compression="zlib">
-   eJxjYKAveKlKuh4ONeq7Ax8w0IBgQygNAjA2jA8C1SoMDPNU6Os2XMBbHcHOVMetjpoAAKSpBgo=
+   eJxjYKAveKlKuh4ONdL1zFMhXQ8MGGhAsCGUBgEYG8YHgRoVyuyhJvBWR7Az1XGroyYAALNcBs0=
   </data>
  </layer>
  <objectgroup color="#ff0000" id="4" name="Collisions">
-  <object id="10" type="collision" x="32" y="0" width="16" height="128"/>
-  <object id="11" type="collision" x="48" y="0" width="160" height="48"/>
+  <object id="10" type="collision" x="32" y="48" width="16" height="80"/>
+  <object id="11" type="collision" x="48" y="32" width="16" height="16"/>
   <object id="14" type="collision" x="64" y="48" width="144" height="16"/>
-  <object id="18" type="collision" x="16" y="112" width="16" height="16"/>
-  <object id="19" type="collision" x="0" y="0" width="32" height="64"/>
-  <object id="27" type="collision" x="16" y="64" width="16" height="16"/>
+  <object id="18" type="collision" x="0" y="112" width="32" height="16"/>
   <object id="33" type="collision" x="160" y="128" width="32" height="32"/>
   <object id="34" type="collision" x="0" y="160" width="16" height="16"/>
   <object id="35" type="collision" x="64" y="96" width="64" height="16"/>
@@ -82,13 +80,6 @@
     <property name="act3" value="open_shop spyder_timberscoop_leandro"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
-   </properties>
-  </object>
-  <object id="32" name="Talk/Open Shop" type="event" x="0" y="80" width="16" height="16">
-   <properties>
-    <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
-    <property name="act3" value="open_shop spyder_timberscoop_leandro"/>
-    <property name="behav1" value="talk spyder_timberscoop_leandro"/>
    </properties>
   </object>
  </objectgroup>

--- a/tuxemon/states/journal/journal_info.py
+++ b/tuxemon/states/journal/journal_info.py
@@ -257,7 +257,7 @@ class JournalInfoState(PygameMenuState):
         if event.button in (buttons.RIGHT, buttons.LEFT) and event.pressed:
             if not monster_models:
                 return None
-            
+
             current_monster_index = monster_models.index(self._monster)
             new_index = (
                 (current_monster_index + 1) % len(monster_models)


### PR DESCRIPTION
PR incorporates changes from #2538, affecting the scoop and all related areas. Key updates include:
- Blocking access to the behind-counter area, allowing interaction with the shopkeeper only from the counter.
- Adding an additional payment terminal.
- Removing the event action with behavior, as the path is now blocked.
- Simplifying and removing some collision lines.