### PR TITLE
cut scenes intro (Spyder)

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -8314,6 +8314,30 @@ msgstr "Please, now return the form to the Shop Assistant, so we can give you th
 msgid "spyder_intro_shopkeeper4"
 msgstr "I'm sorry, you are not a Gold member. This offer is for Gold members only."
 
+msgid "spyder_preintro00"
+msgstr "Alright, let's get this over with. This is the tenth take. Can we please just nail this already?"
+
+msgid "spyder_preintro01"
+msgstr "I swear, if I have to say 'deluxe Tuxemon' one more time, I'm going to lose it. Can't we come up with something more original?"
+
+msgid "spyder_preintro02"
+msgstr "We're just going to end up with a bunch of cheesy, over-the-top marketing nonsense. Can't we aim higher than that?"
+
+msgid "spyder_preintro03"
+msgstr "I'm starting to think that our marketing team has no idea what they're doing. 'Deluxe Tuxemon'? That's the best we can come up with?"
+
+msgid "spyder_preintro04"
+msgstr "Okay, fine. Let's just get this done. But can we please, for the love of all things, try to sound at least somewhat sincere?"
+
+msgid "spyder_postintro00"
+msgstr "Well, that's a wrap. I hope that spot will bring in the sales we need.\n To be honest, I'm not entirely convinced that this 'deluxe Tuxemon' angle is going to fly.\n I mean, are people really going to pay a premium for a creature that can evolve instantly?\n And what's to stop them from just buying the tokens and evolving their own Tuxemon?"
+
+msgid "spyder_postintro01"
+msgstr "And, the Tuxemon themselves are just a bunch of cute, marketable creatures designed to separate kids from their parents' money.\n I mean, we're creating a whole ecosystem around these things, and it's all just a big cash grab.\n We're exploiting people's desire for novelty and their willingness to spend money on anything that's trendy."
+
+msgid "spyder_postintro02"
+msgstr "But hey, it's a lucrative business, and we're just giving people what they want."
+
 # spyder dialogs
 msgid "spyder_papertown_stopthere"
 msgstr "Hey! What do you think you're doing?\n It's not safe to go into the wilds unless you have a tuxemon.\n Come buy one from our shop."
@@ -11656,8 +11680,12 @@ msgstr "Billie has added their tuxemon data to TUXEPEDIA."
 
 msgid "spyder_wayfarerinn_sign"
 msgstr "Welcome to the Wayfarer Inn! "
+
 msgid "spyder_omnichannel_note"
 msgstr "Haha, suckers - you'll never find me. \n It's on the Omnichannel CEO's letterhead."
+
+msgid "spyder_omnichannel_intro"
+msgstr "The PC contains a file named 'Cut Intro'. Would you like to watch the cut scenes?"
 
 msgid "spyder_walled_osman"
 msgstr "Osman"

--- a/mods/tuxemon/maps/spyder_omnichannel4.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel4.tmx
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="git" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="14" height="21" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="46">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="14" height="21" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="50">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
+  <property name="map_type" value="dungeon"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="omnichannel4"/>
-  <property name="map_type" value="dungeon"/>
  </properties>
  <tileset firstgid="1" name="Office_interiors_shadowless_16x16" tilewidth="16" tileheight="16" tilecount="528" columns="22">
   <image source="../gfx/tilesets/Office_interiors_shadowless_16x16.png" width="352" height="384"/>
@@ -29,7 +29,7 @@
  </layer>
  <layer id="5" name="Tile Layer 3" width="14" height="21">
   <data encoding="base64" compression="zlib">
-   eAG9kr1qQkEQhdc/tE1SKOQJzCtETR4gChprITbeiCHetDGFhVprY5XHSWNvGfAVJGKdb8gsDHK3UDADhzN77jmzd9l1LlzpjHMZEKpyyrkbIJXPOlcAUpdkrsBa16J9mf6OzL3miugl8028oWqSaWku5EnSe2SiE3K3DKuAKqjp4Hd4pH2ImnxogUfQVtMcXmgvlON/Bpz7xZy9hx6BZ9AHtqrpv9U1uRGZD5Ozvob6vOZzfm35Aa9Hx/Si1Q/m2Ny5+lcGx4rhEZtM8M4U0yNy57Ruef+rhDcXqzY2mz9xl129zxS8ScjN0L7JLE0uxvumuQt4j0felS/pP8EPws6LAZZ35cv2Xvtv/gXUmh65
+   eAG9k71qAlEUhK9/mFYtFHyC5BWixgeIgj91IGk0aeLamsZCrWNj5ePY2FsKvoIo1n4Hz4WD2RUM6IFx5s7O3N3i6Fz0xBPOJUDUPMacewIy6aRzD0AmSycHVnoWb2H0C52q9vL4BfNMslHToNPUXlQmzO/Q6f6j98xlJVAGFb14AP+otjQ0hwa6CVqgrf4vPFUtlOJ71vDMeB10F3yCL+OLLMdPRpHeDrk/Hf/81jXnH/ieP1t+JevxZrR4tbN7bO9W+puLA0XvipeMyE4U4yt6t4xu2f9lyM4F6g3Ny9/Z/w/9D8TgTUhvgne+LwHZvvYy8IGM7JUf0XNwaV98VvbKj9XeuzcfAd/cILM=
   </data>
  </layer>
  <layer id="6" name="Tile Layer 4" width="14" height="21">
@@ -139,6 +139,48 @@
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
     <property name="cond3" value="is has_item player,spyder_pass"/>
+   </properties>
+  </object>
+  <object id="46" name="Intro 2" type="event" x="192" y="256" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_omnichannel_intro"/>
+    <property name="act2" value="translated_dialog_choice yes:no,cut_scenes2"/>
+    <property name="cond1" value="is char_facing_tile player"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="not variable_set cut_scenes2:yes"/>
+   </properties>
+  </object>
+  <object id="47" name="Watch 2" type="event" x="176" y="256" width="16" height="16">
+   <properties>
+    <property name="act10" value="change_bg gradient_blue,ceo,template"/>
+    <property name="act25" value="translated_dialog spyder_postintro00"/>
+    <property name="act26" value="translated_dialog spyder_postintro01"/>
+    <property name="act27" value="translated_dialog spyder_postintro02"/>
+    <property name="act30" value="change_bg"/>
+    <property name="act31" value="set_variable cut_scenes2:null"/>
+    <property name="cond1" value="is variable_set cut_scenes2:yes"/>
+   </properties>
+  </object>
+  <object id="48" name="Intro 1" type="event" x="192" y="96" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_omnichannel_intro"/>
+    <property name="act2" value="translated_dialog_choice yes:no,cut_scenes1"/>
+    <property name="cond1" value="is char_facing_tile player"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="not variable_set cut_scenes1:yes"/>
+   </properties>
+  </object>
+  <object id="49" name="Watch 1" type="event" x="176" y="96" width="16" height="16">
+   <properties>
+    <property name="act10" value="change_bg gradient_blue,ceo,template"/>
+    <property name="act20" value="translated_dialog spyder_preintro00"/>
+    <property name="act21" value="translated_dialog spyder_preintro01"/>
+    <property name="act22" value="translated_dialog spyder_preintro02"/>
+    <property name="act23" value="translated_dialog spyder_preintro03"/>
+    <property name="act24" value="translated_dialog spyder_preintro04"/>
+    <property name="act30" value="change_bg"/>
+    <property name="act31" value="set_variable cut_scenes1:null"/>
+    <property name="cond1" value="is variable_set cut_scenes1:yes"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/taba_town.tmx
+++ b/mods/tuxemon/maps/taba_town.tmx
@@ -281,7 +281,9 @@
     <property name="act20" value="create_npc nurse2,38,39,stand"/>
     <property name="act30" value="char_face nurse1,down"/>
     <property name="act40" value="char_face nurse2,down"/>
-    <property name="cond10" value="not variable_set thewifedidspeak:yes"/>
+    <property name="cond10" value="not char_exists nurse1"/>
+    <property name="cond20" value="not char_exists nurse2"/>
+    <property name="cond30" value="not variable_set thewifedidspeak:yes"/>
    </properties>
   </object>
   <object id="126" name="nopenotyet" type="event" x="592" y="640" width="32" height="16">
@@ -699,13 +701,6 @@
     <property name="act3" value="set_variable comeinside:stahp"/>
     <property name="act4" value="set_variable backhome:no"/>
     <property name="cond1" value="is variable_set comeinside:dope"/>
-   </properties>
-  </object>
-  <object id="132" name="martgreeter" type="event" x="336" y="208" width="16" height="16">
-   <properties>
-    <property name="act10" value="create_npc taba_greeter,29,12,stand"/>
-    <property name="act20" value="char_face taba_greeter,down"/>
-    <property name="cond1" value="not char_exists taba_greeter"/>
    </properties>
   </object>
   <object id="147" name="mydogishurt" type="event" x="672" y="608" width="16" height="16">

--- a/tuxemon/event/actions/change_bg.py
+++ b/tuxemon/event/actions/change_bg.py
@@ -97,8 +97,9 @@ class ChangeBgAction(EventAction):
 
         if client.current_state.name != str(ImageState):
             if self.background is None:
-                client.pop_state()
-                return
+                if len(client.state_manager.active_states) > 2:
+                    client.pop_state()
+                    return
             else:
                 _background = self.background.split(":")
                 if len(_background) == 1:

--- a/tuxemon/states/journal/journal_info.py
+++ b/tuxemon/states/journal/journal_info.py
@@ -257,7 +257,7 @@ class JournalInfoState(PygameMenuState):
         if event.button in (buttons.RIGHT, buttons.LEFT) and event.pressed:
             if not monster_models:
                 return None
-            
+
             current_monster_index = monster_models.index(self._monster)
             new_index = (
                 (current_monster_index + 1) % len(monster_models)


### PR DESCRIPTION
PR adds cut scenes related to the intro (Spyder) that can be viewed from a computer in Omnichannel HQ. This update also addresses a few minor issues to prevent error messages in Taba Town and fixes a crash caused by incorrect world state handling.

https://github.com/user-attachments/assets/ee9abfb1-deca-49a5-93d0-de4a5c4aae84


