### PR TITLE
standard cost (JSON)

### DIFF
--- a/mods/tuxemon/db/item/ancient_tea.json
+++ b/mods/tuxemon/db/item/ancient_tea.json
@@ -7,6 +7,7 @@
   "sort": "potion",
   "sprite": "gfx/items/ancient_tea.png",
   "category": "none",
+  "cost": 3150,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/boost_armour.json
+++ b/mods/tuxemon/db/item/boost_armour.json
@@ -7,6 +7,7 @@
   "sort": "utility",
   "sprite": "gfx/items/boost_armour.png",
   "category": "stats",
+  "cost": 550,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/boost_dodge.json
+++ b/mods/tuxemon/db/item/boost_dodge.json
@@ -7,6 +7,7 @@
   "sort": "utility",
   "sprite": "gfx/items/boost_dodge.png",
   "category": "stats",
+  "cost": 550,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/boost_melee.json
+++ b/mods/tuxemon/db/item/boost_melee.json
@@ -7,6 +7,7 @@
   "sort": "utility",
   "sprite": "gfx/items/boost_melee.png",
   "category": "stats",
+  "cost": 550,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/boost_ranged.json
+++ b/mods/tuxemon/db/item/boost_ranged.json
@@ -7,6 +7,7 @@
   "sort": "utility",
   "sprite": "gfx/items/boost_ranged.png",
   "category": "stats",
+  "cost": 550,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/boost_speed.json
+++ b/mods/tuxemon/db/item/boost_speed.json
@@ -7,6 +7,7 @@
   "sort": "utility",
   "sprite": "gfx/items/boost_speed.png",
   "category": "stats",
+  "cost": 550,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/cureall.json
+++ b/mods/tuxemon/db/item/cureall.json
@@ -11,6 +11,7 @@
   "sort": "potion",
   "sprite": "gfx/items/orange.png",
   "category": "potion",
+  "cost": 1500,
   "usable_in": [
     "MainCombatMenuState",
     "WorldState"

--- a/mods/tuxemon/db/item/fire_berry.json
+++ b/mods/tuxemon/db/item/fire_berry.json
@@ -9,6 +9,7 @@
   "sort": "utility",
   "sprite": "gfx/items/berry.png",
   "category": "elements",
+  "cost": 450,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/flintstone.json
+++ b/mods/tuxemon/db/item/flintstone.json
@@ -10,6 +10,7 @@
   "sort": "utility",
   "sprite": "gfx/items/flintstone.png",
   "category": "morph",
+  "cost": 2000,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/imperial_potion.json
+++ b/mods/tuxemon/db/item/imperial_potion.json
@@ -10,6 +10,7 @@
   "sort": "potion",
   "sprite": "gfx/items/imperial_potion.png",
   "category": "potion",
+  "cost": 1000,
   "usable_in": [
     "MainCombatMenuState",
     "WorldState"

--- a/mods/tuxemon/db/item/imperial_tea.json
+++ b/mods/tuxemon/db/item/imperial_tea.json
@@ -7,6 +7,7 @@
   "sort": "potion",
   "sprite": "gfx/items/imperial_tea.png",
   "category": "none",
+  "cost": 3450,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/lima_pie.json
+++ b/mods/tuxemon/db/item/lima_pie.json
@@ -10,6 +10,7 @@
   "sort": "utility",
   "sprite": "gfx/items/lima_pie.png",
   "category": "morph",
+  "cost": 2000,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/lucky_bamboo.json
+++ b/mods/tuxemon/db/item/lucky_bamboo.json
@@ -10,6 +10,7 @@
   "sort": "utility",
   "sprite": "gfx/items/lucky_bamboo.png",
   "category": "morph",
+  "cost": 2000,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/mega_potion.json
+++ b/mods/tuxemon/db/item/mega_potion.json
@@ -10,6 +10,7 @@
   "sort": "potion",
   "sprite": "gfx/items/mega_potion.png",
   "category": "potion",
+  "cost": 400,
   "usable_in": [
     "MainCombatMenuState",
     "WorldState"

--- a/mods/tuxemon/db/item/metal_cherry.json
+++ b/mods/tuxemon/db/item/metal_cherry.json
@@ -9,6 +9,7 @@
   "sort": "utility",
   "sprite": "gfx/items/cherry.png",
   "category": "elements",
+  "cost": 450,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/miaow_milk.json
+++ b/mods/tuxemon/db/item/miaow_milk.json
@@ -10,6 +10,7 @@
   "sort": "utility",
   "sprite": "gfx/items/miaow_milk.png",
   "category": "morph",
+  "cost": 2000,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/mm_earth.json
+++ b/mods/tuxemon/db/item/mm_earth.json
@@ -9,6 +9,7 @@
   "sort": "utility",
   "sprite": "gfx/items/mm_earth.png",
   "category": "technique",
+  "cost": 1000,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/mm_fire.json
+++ b/mods/tuxemon/db/item/mm_fire.json
@@ -9,6 +9,7 @@
   "sort": "utility",
   "sprite": "gfx/items/mm_fire.png",
   "category": "technique",
+  "cost": 1000,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/mm_metal.json
+++ b/mods/tuxemon/db/item/mm_metal.json
@@ -9,6 +9,7 @@
   "sort": "utility",
   "sprite": "gfx/items/mm_metal.png",
   "category": "technique",
+  "cost": 1000,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/mm_water.json
+++ b/mods/tuxemon/db/item/mm_water.json
@@ -9,6 +9,7 @@
   "sort": "utility",
   "sprite": "gfx/items/mm_water.png",
   "category": "technique",
+  "cost": 1000,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/mm_wood.json
+++ b/mods/tuxemon/db/item/mm_wood.json
@@ -9,6 +9,7 @@
   "sort": "utility",
   "sprite": "gfx/items/mm_wood.png",
   "category": "technique",
+  "cost": 1000,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/mystery_tea.json
+++ b/mods/tuxemon/db/item/mystery_tea.json
@@ -7,6 +7,7 @@
   "sort": "potion",
   "sprite": "gfx/items/mystery_tea.png",
   "category": "none",
+  "cost": 1050,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/ox_stick.json
+++ b/mods/tuxemon/db/item/ox_stick.json
@@ -10,6 +10,7 @@
   "sort": "utility",
   "sprite": "gfx/items/ox_stick.png",
   "category": "morph",
+  "cost": 2000,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/peace_lily.json
+++ b/mods/tuxemon/db/item/peace_lily.json
@@ -10,6 +10,7 @@
   "sort": "utility",
   "sprite": "gfx/items/peace_lily.png",
   "category": "morph",
+  "cost": 2000,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/potion.json
+++ b/mods/tuxemon/db/item/potion.json
@@ -10,6 +10,7 @@
   "sort": "potion",
   "sprite": "gfx/items/potion.png",
   "category": "potion",
+  "cost": 50,
   "usable_in": [
     "MainCombatMenuState",
     "WorldState"

--- a/mods/tuxemon/db/item/pyramidion.json
+++ b/mods/tuxemon/db/item/pyramidion.json
@@ -10,6 +10,7 @@
   "sort": "utility",
   "sprite": "gfx/items/pyramidion.png",
   "category": "morph",
+  "cost": 2000,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/raise_armour.json
+++ b/mods/tuxemon/db/item/raise_armour.json
@@ -7,6 +7,7 @@
   "sort": "utility",
   "sprite": "gfx/items/raise_armour.png",
   "category": "stats",
+  "cost": 10000,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/raise_dodge.json
+++ b/mods/tuxemon/db/item/raise_dodge.json
@@ -7,6 +7,7 @@
   "sort": "utility",
   "sprite": "gfx/items/raise_dodge.png",
   "category": "stats",
+  "cost": 10000,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/raise_hp.json
+++ b/mods/tuxemon/db/item/raise_hp.json
@@ -7,6 +7,7 @@
   "sort": "utility",
   "sprite": "gfx/items/raise_hp.png",
   "category": "stats",
+  "cost": 10000,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/raise_melee.json
+++ b/mods/tuxemon/db/item/raise_melee.json
@@ -7,6 +7,7 @@
   "sort": "utility",
   "sprite": "gfx/items/raise_melee.png",
   "category": "stats",
+  "cost": 10000,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/raise_ranged.json
+++ b/mods/tuxemon/db/item/raise_ranged.json
@@ -7,6 +7,7 @@
   "sort": "utility",
   "sprite": "gfx/items/raise_ranged.png",
   "category": "stats",
+  "cost": 10000,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/raise_speed.json
+++ b/mods/tuxemon/db/item/raise_speed.json
@@ -7,6 +7,7 @@
   "sort": "utility",
   "sprite": "gfx/items/raise_speed.png",
   "category": "stats",
+  "cost": 10000,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/restoration.json
+++ b/mods/tuxemon/db/item/restoration.json
@@ -11,6 +11,7 @@
   "sort": "potion",
   "sprite": "gfx/items/apple.png",
   "category": "potion",
+  "cost": 700,
   "usable_in": [
     "MainCombatMenuState",
     "WorldState"

--- a/mods/tuxemon/db/item/revive.json
+++ b/mods/tuxemon/db/item/revive.json
@@ -11,6 +11,7 @@
   "sort": "potion",
   "sprite": "gfx/items/revive.png",
   "category": "potion",
+  "cost": 1500,
   "usable_in": [
     "MainCombatMenuState",
     "WorldState"

--- a/mods/tuxemon/db/item/sea_girdle.json
+++ b/mods/tuxemon/db/item/sea_girdle.json
@@ -10,6 +10,7 @@
   "sort": "utility",
   "sprite": "gfx/items/sea_girdle.png",
   "category": "morph",
+  "cost": 2000,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/stovepipe.json
+++ b/mods/tuxemon/db/item/stovepipe.json
@@ -10,6 +10,7 @@
   "sort": "utility",
   "sprite": "gfx/items/stovepipe.png",
   "category": "morph",
+  "cost": 2000,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/sweet_sand.json
+++ b/mods/tuxemon/db/item/sweet_sand.json
@@ -10,6 +10,7 @@
   "sort": "utility",
   "sprite": "gfx/items/sweet_sand.png",
   "category": "morph",
+  "cost": 2000,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tea.json
+++ b/mods/tuxemon/db/item/tea.json
@@ -7,6 +7,7 @@
   "sort": "potion",
   "sprite": "gfx/items/tea.png",
   "category": "none",
+  "cost": 300,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tectonic_drill.json
+++ b/mods/tuxemon/db/item/tectonic_drill.json
@@ -10,6 +10,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tectonic_drill.png",
   "category": "morph",
+  "cost": 2000,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/thunderstone.json
+++ b/mods/tuxemon/db/item/thunderstone.json
@@ -10,6 +10,7 @@
   "sort": "utility",
   "sprite": "gfx/items/thunderstone.png",
   "category": "morph",
+  "cost": 2000,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tm_all_in.json
+++ b/mods/tuxemon/db/item/tm_all_in.json
@@ -9,6 +9,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tm_generic.png",
   "category": "technique",
+  "cost": 2500,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tm_avalanche.json
+++ b/mods/tuxemon/db/item/tm_avalanche.json
@@ -10,6 +10,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tm_earth.png",
   "category": "technique",
+  "cost": 2500,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tm_blade.json
+++ b/mods/tuxemon/db/item/tm_blade.json
@@ -9,6 +9,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tm_generic.png",
   "category": "technique",
+  "cost": 2500,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tm_blossom.json
+++ b/mods/tuxemon/db/item/tm_blossom.json
@@ -10,6 +10,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tm_wood.png",
   "category": "technique",
+  "cost": 2500,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tm_cavity.json
+++ b/mods/tuxemon/db/item/tm_cavity.json
@@ -9,6 +9,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tm_generic.png",
   "category": "technique",
+  "cost": 2500,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tm_earth.json
+++ b/mods/tuxemon/db/item/tm_earth.json
@@ -7,6 +7,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tm_earth.png",
   "category": "technique",
+  "cost": 2500,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tm_fire.json
+++ b/mods/tuxemon/db/item/tm_fire.json
@@ -7,6 +7,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tm_fire.png",
   "category": "technique",
+  "cost": 2500,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tm_frostbite.json
+++ b/mods/tuxemon/db/item/tm_frostbite.json
@@ -9,6 +9,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tm_water.png",
   "category": "technique",
+  "cost": 2500,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tm_metal.json
+++ b/mods/tuxemon/db/item/tm_metal.json
@@ -7,6 +7,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tm_metal.png",
   "category": "technique",
+  "cost": 2500,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tm_panjandrum.json
+++ b/mods/tuxemon/db/item/tm_panjandrum.json
@@ -9,6 +9,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tm_generic.png",
   "category": "technique",
+  "cost": 2500,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tm_scope.json
+++ b/mods/tuxemon/db/item/tm_scope.json
@@ -9,6 +9,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tm_generic.png",
   "category": "technique",
+  "cost": 2500,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tm_shadow_boxing.json
+++ b/mods/tuxemon/db/item/tm_shadow_boxing.json
@@ -9,6 +9,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tm_generic.png",
   "category": "technique",
+  "cost": 2500,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tm_supernova.json
+++ b/mods/tuxemon/db/item/tm_supernova.json
@@ -9,6 +9,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tm_fire.png",
   "category": "technique",
+  "cost": 2500,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tm_surf.json
+++ b/mods/tuxemon/db/item/tm_surf.json
@@ -11,6 +11,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tm_water.png",
   "category": "technique",
+  "cost": 2500,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tm_vorpal.json
+++ b/mods/tuxemon/db/item/tm_vorpal.json
@@ -9,6 +9,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tm_metal.png",
   "category": "technique",
+  "cost": 2500,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tm_water.json
+++ b/mods/tuxemon/db/item/tm_water.json
@@ -7,6 +7,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tm_water.png",
   "category": "technique",
+  "cost": 2500,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tm_wood.json
+++ b/mods/tuxemon/db/item/tm_wood.json
@@ -7,6 +7,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tm_wood.png",
   "category": "technique",
+  "cost": 2500,
   "usable_in": [
     "WorldState"
   ],

--- a/mods/tuxemon/db/item/tuxeball.json
+++ b/mods/tuxemon/db/item/tuxeball.json
@@ -11,6 +11,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball.png",
   "category": "capture",
+  "cost": 100,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_candy.json
+++ b/mods/tuxemon/db/item/tuxeball_candy.json
@@ -11,6 +11,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_candy.png",
   "category": "capture",
+  "cost": 1000,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_crusher.json
+++ b/mods/tuxemon/db/item/tuxeball_crusher.json
@@ -11,6 +11,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_crusher.png",
   "category": "capture",
+  "cost": 400,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_diurnal.json
+++ b/mods/tuxemon/db/item/tuxeball_diurnal.json
@@ -11,6 +11,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_diurnal.png",
   "category": "capture",
+  "cost": 350,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_earth.json
+++ b/mods/tuxemon/db/item/tuxeball_earth.json
@@ -11,6 +11,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_earth.png",
   "category": "capture",
+  "cost": 250,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_female.json
+++ b/mods/tuxemon/db/item/tuxeball_female.json
@@ -11,6 +11,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_female.png",
   "category": "capture",
+  "cost": 250,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_fire.json
+++ b/mods/tuxemon/db/item/tuxeball_fire.json
@@ -11,6 +11,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_fire.png",
   "category": "capture",
+  "cost": 250,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_gambler.json
+++ b/mods/tuxemon/db/item/tuxeball_gambler.json
@@ -11,6 +11,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_gambler.png",
   "category": "capture",
+  "cost": 400,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_grand.json
+++ b/mods/tuxemon/db/item/tuxeball_grand.json
@@ -11,6 +11,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_grand.png",
   "category": "capture",
+  "cost": 500,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_hardened.json
+++ b/mods/tuxemon/db/item/tuxeball_hardened.json
@@ -11,6 +11,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_hardened.png",
   "category": "capture",
+  "cost": 350,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_hearty.json
+++ b/mods/tuxemon/db/item/tuxeball_hearty.json
@@ -11,6 +11,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_hearty.png",
   "category": "capture",
+  "cost": 450,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_lavish.json
+++ b/mods/tuxemon/db/item/tuxeball_lavish.json
@@ -11,6 +11,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_lavish.png",
   "category": "capture",
+  "cost": 300,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_majestic.json
+++ b/mods/tuxemon/db/item/tuxeball_majestic.json
@@ -11,6 +11,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_majestic.png",
   "category": "capture",
+  "cost": 600,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_male.json
+++ b/mods/tuxemon/db/item/tuxeball_male.json
@@ -11,6 +11,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_male.png",
   "category": "capture",
+  "cost": 250,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_metal.json
+++ b/mods/tuxemon/db/item/tuxeball_metal.json
@@ -11,6 +11,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_metal.png",
   "category": "capture",
+  "cost": 250,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_neuter.json
+++ b/mods/tuxemon/db/item/tuxeball_neuter.json
@@ -11,6 +11,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_neuter.png",
   "category": "capture",
+  "cost": 250,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_noble.json
+++ b/mods/tuxemon/db/item/tuxeball_noble.json
@@ -11,6 +11,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_noble.png",
   "category": "capture",
+  "cost": 200,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_nocturnal.json
+++ b/mods/tuxemon/db/item/tuxeball_nocturnal.json
@@ -11,6 +11,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_nocturnal.png",
   "category": "capture",
+  "cost": 350,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_omni.json
+++ b/mods/tuxemon/db/item/tuxeball_omni.json
@@ -11,6 +11,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_omni.png",
   "category": "capture",
+  "cost": 250,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_peppy.json
+++ b/mods/tuxemon/db/item/tuxeball_peppy.json
@@ -11,6 +11,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_peppy.png",
   "category": "capture",
+  "cost": 450,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_refined.json
+++ b/mods/tuxemon/db/item/tuxeball_refined.json
@@ -11,6 +11,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_refined.png",
   "category": "capture",
+  "cost": 450,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_salty.json
+++ b/mods/tuxemon/db/item/tuxeball_salty.json
@@ -11,6 +11,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_salty.png",
   "category": "capture",
+  "cost": 450,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_water.json
+++ b/mods/tuxemon/db/item/tuxeball_water.json
@@ -11,6 +11,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_water.png",
   "category": "capture",
+  "cost": 250,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_wood.json
+++ b/mods/tuxemon/db/item/tuxeball_wood.json
@@ -11,6 +11,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_wood.png",
   "category": "capture",
+  "cost": 250,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_xero.json
+++ b/mods/tuxemon/db/item/tuxeball_xero.json
@@ -11,6 +11,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_xero.png",
   "category": "capture",
+  "cost": 300,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/db/item/tuxeball_zesty.json
+++ b/mods/tuxemon/db/item/tuxeball_zesty.json
@@ -11,6 +11,7 @@
   "sort": "utility",
   "sprite": "gfx/items/tuxeball_zesty.png",
   "category": "capture",
+  "cost": 450,
   "usable_in": [
     "MainCombatMenuState"
   ],

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -163,7 +163,7 @@ msgid "tuxeball_crusher"
 msgstr "Crusher Tuxeball"
 
 msgid "tuxeball_crusher_description"
-msgstr "This Tuxeball breaks through defenses and increases the catch rate the higher the opposing Tuxemon's defense is. It will fail to catch if a protection move is used."
+msgstr "This Tuxeball breaks through defenses and increases the catch rate the higher the opposing Tuxemon's defense is. It will fail to catch if a protective condition is in place."
 
 msgid "tuxeball_xero"
 msgstr "Xero Tuxeball"

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -232,7 +232,7 @@ class ItemBehaviors(BaseModel):
 
 class ItemModel(BaseModel):
     model_config = ConfigDict(title="Item")
-    slug: str = Field(..., description="Slug to use")
+    slug: str = Field(..., description="The slug of the item")
     use_item: str = Field(
         ...,
         description="Slug to determine which text is displayed when this item is used",
@@ -264,14 +264,19 @@ class ItemModel(BaseModel):
     )
     flip_axes: Literal["", "x", "y", "xy"] = Field(
         "",
-        description="Axes along which technique animation should be flipped",
+        description="Axes along which item animation should be flipped",
     )
     animation: Optional[str] = Field(
-        None, description="Animation to play for this technique"
+        None, description="Animation to play for this item"
     )
     world_menu: tuple[int, str, str] = Field(
         None,
         description="Item adds to World Menu a button (position, label -inside the PO -,state, eg. 3:nu_phone:PhoneState)",
+    )
+    cost: Optional[int] = Field(
+        None,
+        description="The standard cost of the item.",
+        gt=0,
     )
 
     # Validate fields that refer to translated text

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -60,6 +60,7 @@ class Item:
         self.use_success = ""
         self.use_failure = ""
         self.usable_in: Sequence[State] = []
+        self.cost: Optional[int] = None
 
         # load effect and condition plugins if it hasn't been done already
         if not Item.effects_classes:
@@ -103,6 +104,7 @@ class Item:
         # misc attributes (not translated!)
         self.world_menu = results.world_menu
         self.behaviors = results.behaviors
+        self.cost = results.cost
         self.sort = results.sort
         self.category = results.category or ItemCategory.none
         self.sprite = results.sprite


### PR DESCRIPTION
PR adds a 'cost' field to the items JSON, which represents the standard cost of an item. This cost will be displayed when the item is not available in the shop, specifically when the player intends to resell the item to the shop. This implementation lays the groundwork for the changes proposed in #2553.

@Sanglorian, I noticed that some new tuxeballs (e.g. Gambler, Noble) were missing from Tuxepedia, so I've added them. Please feel free to fill in the standard cost for these items.