### PR TITLE
scoop (Spyder)

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -9579,72 +9579,136 @@ msgid "spyder_timber_dante1"
 msgstr "Hey buddy! Cool to see you again. "
 msgid "spyder_timber_dante2"
 msgstr "Hey buddy! \n Are you planning to break into these HQ? Cool! \n Make sure you're well prepared before you do, because it's difficult to get out once you're inside! \n You'll need to call your mom to let her know you're safe. Use this app!"
+
 msgid "spyder_scoop_lanth1"
 msgstr "Look how happy the tuxemon are, living so close to one another!"
+
 msgid "spyder_scoop_lanth2"
 msgstr "Typical activist troublemaker. "
+
 msgid "spyder_scoop_paine1"
 msgstr "I feel so terrible that the disease got out. "
+
 msgid "spyder_scoop_paine2"
 msgstr "If those Enforcers hadn't come in and exposed their pet tuxemon to the disease, it would never have left the facility!"
+
 msgid "spyder_scoop_rubid1"
 msgstr "This is actually the most humane way to keep tuxemon."
+
 msgid "spyder_scoop_rubid2"
 msgstr "Studies show that tuxemon find battling more stressful than living in these conditions. "
+
 msgid "spyder_scoop_berys1"
 msgstr "You will notice that none of the tuxemon out here are sick - they were all kept in the containment unit."
+
 msgid "spyder_scoop_berys2"
 msgstr "Scoop did not release the disease! I promise you. "
+
 msgid "spyder_scoop_turner1"
 msgstr "Some of these people will tell you that Enforcers let the disease get out. Don't believe them!"
+
 msgid "spyder_scoop_turner2"
 msgstr "Remember, we had nothing to do with the disease getting out!"
 
 msgid "spyder_scoop_asta1"
 msgstr "Why yes, I am the inventor of the Extreme Restraints. \n What are they, I hear you ask? \n Only a set of manacles so powerful that even a dragon could not escape them. \n They are being used in the containment unit to make sure none of the infected tuxemon escape."
+
 msgid "spyder_scoop_asta2"
 msgstr "Are you sure you want to leave Scoop HQ?"
 
+msgid "spyder_scoop_cctv"
+msgstr "The PC contains a file named 'CCTV'. Would you like to watch it?"
+
+msgid "spyder_scoop_arachne_flashback1"
+msgstr "Nash: The Extreme Restraints are our most secure containment system yet.\n With these manacles, even the strongest tuxemon won't be able to break free from the containment unit."
+
+msgid "spyder_scoop_arachne_flashback2"
+msgstr "Reese: Good. We can't afford any more escapes, not with this disease outbreak spiraling out of control.\n These Restraints better be as effective as you claim."
+
+msgid "spyder_scoop_arachne_flashback3"
+msgstr "Nash: I guarantee it. The materials and design are impenetrable.\n As long as we keep the tuxemon locked up tight in these Restraints, the disease won't be going anywhere."
+
+msgid "spyder_scoop_arachne_flashback4"
+msgstr "Arachne: What do we have here? Looks like you've got quite the fancy set of restraints, don't you?"
+
+msgid "spyder_scoop_arachne_flashback5"
+msgstr "Nash: Who are you? How did you get in here?"
+
+msgid "spyder_scoop_arachne_flashback6"
+msgstr "Arachne: I'm here to relieve you of those lovely Extreme Restraints you've got. They'll make a fine addition to my collection."
+
+msgid "spyder_scoop_arachne_flashback7"
+msgstr "Reese: Stop right there! Those Restraints are crucial to containing the tuxemon outbreak.\n You have no idea what kind of damage you could cause if you take them."
+
+msgid "spyder_scoop_arachne_flashback8"
+msgstr "Arachne: Oh, I think I have a pretty good idea. And I don't really care about your little tuxemon problem. These Restraints are mine now."
+
+msgid "spyder_scoop_arachne_flashback9"
+msgstr "Nash: No, come back! We can't let those Restraints fall into the wrong hands!"
+
+msgid "spyder_scoop_arachne_flashback10"
+msgstr "Reese: This is a disaster - without the Extreme Restraints, the containment unit is useless.\n The tuxemon could break free at any moment!"
+
 msgid "spyder_scoop_alyssa1"
 msgstr "As soon as disease was detected, we moved the infected tuxemon to this containment unit."
+
 msgid "spyder_scoop_alyssa2"
 msgstr "I'm telling you, we kept the disease under control!"
+
 msgid "spyder_scoop_taggart1"
 msgstr "Someone stole the Extreme Restraints we invented to keep tuxemon in the containment unit! Was it you?"
+
 msgid "spyder_scoop_taggart2"
 msgstr "If you didn't steal the Extreme Restraints, who did? "
+
 msgid "spyder_scoop_donald1"
 msgstr "The sick tuxemon we were keeping here in quarantine got out and broke into the storeroom beyond! How will we secure the storeroom?"
+
 msgid "spyder_scoop_donald2"
 msgstr "You might just be strong enough to contain the escaped tuxemon. Please - do it for us. "
+
 msgid "spyder_scoop_orba1"
 msgstr "Yikes! What are you doing here?"
+
 msgid "spyder_scoop_orba2"
 msgstr "What am I doing here, for that matter?"
+
 msgid "spyder_scoop_haf1"
 msgstr "I chased the people who stole the Restraints into this room. But then the sick tuxemon got in, and now we're all stuck!"
+
 msgid "spyder_scoop_weaver1"
 msgstr "I would never have taken the Restraints off those coughing tuxemon if I knew they'd chase us in here!"
+
 msgid "spyder_scoop_weaver2"
 msgstr "Yikes! It turns out crime doesn't pay!"
+
 msgid "spyder_scoop_arachne1"
 msgstr "Oi! Can't you see we're in the middle of a villainous scheme?"
+
 msgid "spyder_scoop_arachne2"
 msgstr "It's too late! I have the Extreme Restraints and there's nothing you can do about it. "
+
 msgid "spyder_scoop_landrace1"
 msgstr "Graar!"
+
 msgid "spyder_scoop_landrace2"
 msgstr "Ufff."
+
 msgid "spyder_scoop_landrace3"
 msgstr "Thanks for getting rid of that brute that was blocking the way! \n Now we can escape with the Extreme Restraints! "
+
 msgid "spyder_scoop_cochini1"
 msgstr "Oink! Oink! "
+
 msgid "spyder_scoop_cochini2"
 msgstr "Oink."
+
 msgid "spyder_scoop_lapinou1"
 msgstr "Aiya!"
+
 msgid "spyder_scoop_lapinou2"
 msgstr "Mhm ah!"
+
 msgid "spyder_tunnelb_beryll1"
 msgstr "I love collecting rocks and stones."
 msgid "spyder_tunnelb_beryll2"

--- a/mods/tuxemon/maps/spyder_scoop3.tmx
+++ b/mods/tuxemon/maps/spyder_scoop3.tmx
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="12" height="12" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="30">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="12" height="12" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="35">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
+  <property name="map_type" value="dungeon"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="scoop3"/>
-  <property name="map_type" value="dungeon"/>
  </properties>
  <tileset firstgid="1" source="../gfx/tilesets/core_city_and_country.tsx"/>
  <tileset firstgid="1441" source="../gfx/tilesets/core_indoor_floors.tsx"/>
@@ -17,7 +17,7 @@
  </layer>
  <layer id="2" name="Tile Layer 4" width="12" height="12">
   <data encoding="base64" compression="zlib">
-   eAGVjjsOgzAQREfKGSCXCTScIn3gOiko+BwEko6GezErPBQrkM1IzyOvn1YGgIpY1PttPzVT27QNgrp7Aj35Es3UQT3KnInMRLHZnbweQEFKYhkyYCRX+dCrSRP8H92/82M7/O6zHd5Jua/8Rwq2y7yULImednn/nesl3hsCHRui
+   eAGNjsENgkAURCehBcFmlItVcEfb4cBBoBDEmwnaiDTC/LBjNhuBneQxy9/HDwBwIRb18rY8NVPbtHaC+n4EGlIRzdRO/ZU5PXkQxWbjAXiTrZwTICcn8qU7Ob9NgY6EudK7kZL4Geg+A39th/+df/63w7+PPX/4HzHYPvNi8or0tCv0i0w3+z0D4mQfPg==
   </data>
  </layer>
  <layer id="3" name="Tile Layer 2" width="12" height="12">
@@ -39,6 +39,7 @@
   <object id="10" type="collision" x="0" y="128" width="160" height="16"/>
   <object id="11" type="collision" x="176" y="128" width="16" height="16"/>
   <object id="12" type="collision" x="144" y="144" width="16" height="32"/>
+  <object id="30" type="collision" x="160" y="48" width="32" height="16"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="5" name="Event">
   <properties>
@@ -157,6 +158,56 @@
     <property name="act10" value="set_variable scoopdonald:yes"/>
     <property name="cond1" value="not variable_set scoopdonald:yes"/>
     <property name="cond2" value="is char_at player"/>
+   </properties>
+  </object>
+  <object id="33" name="Intro" type="event" x="160" y="48" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_scoop_cctv"/>
+    <property name="act2" value="translated_dialog_choice yes:no,cctv_scoop"/>
+    <property name="cond1" value="is char_facing_tile player"/>
+    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="not variable_set cctv_scoop:yes"/>
+   </properties>
+  </object>
+  <object id="34" name="Watch" type="event" x="160" y="32" width="16" height="16">
+   <properties>
+    <property name="act10" value="set_template player,invisible"/>
+    <property name="act11" value="lock_controls"/>
+    <property name="act12" value="set_layer 102:51:0:128"/>
+    <property name="act13" value="create_npc spyder_scoop_nash,5,4"/>
+    <property name="act14" value="char_face spyder_scoop_nash,right"/>
+    <property name="act15" value="create_npc spyder_scoop_reese,6,4"/>
+    <property name="act16" value="char_face spyder_scoop_reese,left"/>
+    <property name="act20" value="translated_dialog spyder_scoop_arachne_flashback1"/>
+    <property name="act21" value="translated_dialog spyder_scoop_arachne_flashback2"/>
+    <property name="act22" value="translated_dialog spyder_scoop_arachne_flashback3"/>
+    <property name="act23" value="create_npc spyder_scoop_arachne,6,3"/>
+    <property name="act24" value="char_face spyder_scoop_arachne,down"/>
+    <property name="act25" value="translated_dialog spyder_scoop_arachne_flashback4"/>
+    <property name="act26" value="char_face spyder_scoop_reese,up"/>
+    <property name="act27" value="char_face spyder_scoop_nash,up"/>
+    <property name="act28" value="translated_dialog spyder_scoop_arachne_flashback5"/>
+    <property name="act29" value="translated_dialog spyder_scoop_arachne_flashback6"/>
+    <property name="act30" value="translated_dialog spyder_scoop_arachne_flashback7"/>
+    <property name="act31" value="translated_dialog spyder_scoop_arachne_flashback8"/>
+    <property name="act32" value="add_monster cardiwing,35,spyder_scoop_arachne,5,10"/>
+    <property name="act33" value="add_monster spighter,35,spyder_scoop_arachne,5,10"/>
+    <property name="act34" value="add_monster abesnaki,35,spyder_scoop_arachne,5,10"/>
+    <property name="act35" value="add_monster rockat,35,spyder_scoop_reese,5,10"/>
+    <property name="act37" value="start_battle spyder_scoop_reese,spyder_scoop_arachne"/>
+    <property name="act38" value="char_face spyder_scoop_arachne,up"/>
+    <property name="act39" value="remove_npc spyder_scoop_arachne"/>
+    <property name="act40" value="translated_dialog spyder_scoop_arachne_flashback9"/>
+    <property name="act41" value="translated_dialog spyder_scoop_arachne_flashback10"/>
+    <property name="act42" value="pathfind spyder_scoop_reese,6,3"/>
+    <property name="act43" value="pathfind spyder_scoop_nash,5,3"/>
+    <property name="act44" value="remove_npc spyder_scoop_reese"/>
+    <property name="act45" value="remove_npc spyder_scoop_nash"/>
+    <property name="act51" value="set_variable cctv_scoop:null"/>
+    <property name="act52" value="set_layer"/>
+    <property name="act53" value="unlock_controls"/>
+    <property name="act54" value="set_template player,default"/>
+    <property name="cond1" value="is variable_set cctv_scoop:yes"/>
    </properties>
   </object>
  </objectgroup>


### PR DESCRIPTION
PR adds a flashback scene accessible from a PC in the Scoop map, revealing the events surrounding the theft of the Extreme Restraints and filling a plot gap. @Sanglorian, is this ok to merge?

https://github.com/user-attachments/assets/b49adf4e-2aff-4589-a27a-bc50553f7288

