### PR TITLE
Fix bug in xero accolyte Corren battle

### DIFF
--- a/mods/tuxemon/maps/taba_ba_br_1.tmx
+++ b/mods/tuxemon/maps/taba_ba_br_1.tmx
@@ -196,10 +196,9 @@
    <properties>
     <property name="act10" value="translated_dialog acolyte1loss"/>
     <property name="act20" value="wait 0.5"/>
-    <property name="act21" value="screen_transition 3"/>
-    <property name="act30" value="teleport_faint"/>
-    <property name="act40" value="set_variable redo:please"/>
-    <property name="act50" value="unlock_controls"/>
+    <property name="act21" value="teleport_faint"/>
+    <property name="act30" value="set_variable redo:please"/>
+    <property name="act40" value="unlock_controls"/>
     <property name="cond1" value="is variable_set battle_last_result:lost"/>
     <property name="cond2" value="is variable_set battle_last_trainer:acolyte"/>
     <property name="cond4" value="not variable_set redo:please"/>


### PR DESCRIPTION
If you manage to lose against accolyte Corren in the xero campaign (the first accolyte), the game doesn't teleport you to a healing center and just leaves the player stuck. 

What happens is that the game is looping on trying to set up a transition, after having already set up a transition.

The fix here is to just remove the screen transition action inside the map data, and the game teleports the player to a healing center once he loses, as expected.

Maybe a check could be done in order to prevent this looping transition issue in the future? 