### PR TITLE
PartyMemberModel + load_party()

### DIFF
--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -1039,6 +1039,11 @@ class PartyMemberModel(BaseModel):
         ..., description="Experience required modifier", gt=0
     )
     gender: GenderType = Field(..., description="Gender of the monster")
+    variables: Optional[list[str]] = Field(
+        None,
+        description="List of variables that affect the presence of the monster.",
+        min_length=1,
+    )
 
     @field_validator("slug")
     def monster_exists(cls: PartyMemberModel, v: str) -> str:
@@ -1046,16 +1051,37 @@ class PartyMemberModel(BaseModel):
             return v
         raise ValueError(f"the monster {v} doesn't exist in the db")
 
+    @field_validator("variables")
+    def variables_exists(
+        cls: PartyMemberModel, v: Optional[Sequence[str]]
+    ) -> Optional[Sequence[str]]:
+        if v is None:
+            return v
+        return has.validate_variables(v)
+
 
 class BagItemModel(BaseModel):
     slug: str = Field(..., description="Slug of the item")
     quantity: int = Field(..., description="Quantity of the item")
+    variables: Optional[Sequence[str]] = Field(
+        None,
+        description="List of variables that affect the item.",
+        min_length=1,
+    )
 
     @field_validator("slug")
     def item_exists(cls: BagItemModel, v: str) -> str:
         if has.db_entry("item", v):
             return v
         raise ValueError(f"the item {v} doesn't exist in the db")
+
+    @field_validator("variables")
+    def variables_exists(
+        cls: BagItemModel, v: Optional[Sequence[str]]
+    ) -> Optional[Sequence[str]]:
+        if v is None:
+            return v
+        return has.validate_variables(v)
 
 
 class NpcTemplateModel(BaseModel):

--- a/tuxemon/event/actions/create_npc.py
+++ b/tuxemon/event/actions/create_npc.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Optional, final
+from typing import Any, Optional, final
 
+from tuxemon.db import NpcModel, PartyMemberModel, db
 from tuxemon.event.eventaction import EventAction
+from tuxemon.item.item import Item
+from tuxemon.monster import Monster
 from tuxemon.npc import NPC
 from tuxemon.states.world.worldstate import WorldState
 
@@ -55,6 +59,75 @@ class CreateNpcAction(EventAction):
         client.execute_action(
             "char_position", [slug, self.tile_pos_x, self.tile_pos_y], True
         )
-
         npc.behavior = self.behavior
-        npc.load_party()
+        npc_details = load_party(slug)
+        npc.template = npc_details.template
+        npc.forfeit = npc_details.forfeit
+        game_variables = self.session.player.game_variables
+        if npc_details.monsters:
+            load_party_monsters(npc, npc_details, game_variables)
+        if npc_details.items:
+            load_party_items(npc, npc_details, game_variables)
+        npc.load_sprites()
+
+
+lookup_cache: dict[str, NpcModel] = {}
+
+
+def load_party(slug: str) -> NpcModel:
+    if slug in lookup_cache:
+        return lookup_cache[slug]
+    else:
+        npc_details = db.lookup(slug, "npc")
+        lookup_cache[slug] = npc_details
+        return npc_details
+
+
+def load_party_monsters(
+    npc: NPC, party: NpcModel, game_variables: dict[str, Any]
+) -> None:
+    """Loads the NPC's party monsters from the database."""
+    npc.monsters = []
+    for npc_monster in party.monsters:
+        if npc_monster.variables and check_variables(
+            npc_monster.variables, game_variables
+        ):
+            monster = party_monster(npc_monster)
+            npc.add_monster(monster, len(npc.monsters))
+
+
+def party_monster(npc_monster: PartyMemberModel) -> Monster:
+    """Creates a new monster object from the database details."""
+    monster = Monster()
+    monster.load_from_db(npc_monster.slug)
+    monster.money_modifier = npc_monster.money_mod
+    monster.experience_modifier = npc_monster.exp_req_mod
+    monster.set_level(npc_monster.level)
+    monster.set_moves(npc_monster.level)
+    monster.current_hp = monster.hp
+    monster.gender = npc_monster.gender
+    return monster
+
+
+def load_party_items(
+    npc: NPC, bag: NpcModel, game_variables: dict[str, Any]
+) -> None:
+    """Loads the NPC's items from the database."""
+    npc.items = []
+    for npc_item in bag.items:
+        if npc_item.variables and check_variables(
+            npc_item.variables, game_variables
+        ):
+            item = Item(save_data=npc_item.model_dump())
+            item.quantity = npc_item.quantity
+            npc.add_item(item)
+
+
+def check_variables(
+    npc_vars: Sequence[str], game_variables: dict[str, Any]
+) -> bool:
+    return all(
+        key in game_variables and game_variables[key] == value
+        for variable in npc_vars
+        for key, value in [variable.split(":")]
+    )

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -697,7 +697,6 @@ class Monster:
             return
 
         self.load_from_db(save_data["slug"])
-        self.plague = save_data["plague"]
 
         self.moves = []
         for move in decode_moves(save_data.get("moves")):
@@ -713,6 +712,8 @@ class Monster:
                 self.instance_id = uuid.UUID(value)
             elif key in SIMPLE_PERSISTANCE_ATTRIBUTES:
                 setattr(self, key, value)
+            elif key == "plague" and value:
+                self.plague = value
 
         self.load_sprites()
 

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -707,44 +707,6 @@ class NPC(Entity[NPCState]):
             self.monsters[index_1],
         )
 
-    def load_party(self) -> None:
-        """Loads the party of this npc from their npc.json entry."""
-        for monster in self.monsters:
-            self.remove_monster(monster)
-
-        self.monsters = []
-
-        # Look up the NPC's details from our NPC database
-        npc_details = db.lookup(self.slug, "npc")
-        self.forfeit = npc_details.forfeit
-        npc_party = npc_details.monsters
-        for npc_monster_details in npc_party:
-            # This seems slightly wrong. The only usable element in
-            # npc_monsters_details, which is a PartyMemberModel, is "slug"
-            monster = Monster(save_data=npc_monster_details.model_dump())
-            monster.money_modifier = npc_monster_details.money_mod
-            monster.experience_modifier = npc_monster_details.exp_req_mod
-            monster.set_level(npc_monster_details.level)
-            monster.set_moves(npc_monster_details.level)
-            monster.current_hp = monster.hp
-            monster.gender = npc_monster_details.gender
-
-            # Add our monster to the NPC's party
-            self.add_monster(monster, len(npc_party))
-
-        # load NPC bag
-        for item in self.items:
-            self.remove_item(item)
-        self.items = []
-        npc_bag = npc_details.items
-        for npc_itm_details in npc_bag:
-            itm = Item(save_data=npc_itm_details.model_dump())
-            itm.quantity = npc_itm_details.quantity
-
-        # load NPC template
-        self.template = npc_details.template
-        self.load_sprites()
-
     def has_tech(self, tech: Optional[str]) -> bool:
         """
         Returns TRUE if there is the technique in the party.


### PR DESCRIPTION
PR refactors the **load_party** function by moving it inside the **create_npc** event action. This change allows for caching the NPC model, reducing the need for constant database calls.

Additionally, the following enhancements have been made to the **PartyMemberModel** class:
- Field Variables: Added field variables for both monsters and items, enabling modders to set attributes directly in the JSON file.

These changes provide greater flexibility for modders, allowing them to load different monsters by selecting various variables. Furthermore, this approach helps to avoid creating too many events in the maps files, streamlining the event management process.

In the example below, you can see an NPC with two associated monsters. Each monster will appear with the corresponding combination of variables (all set to True). This functionality allows for greater personalization, enabling the use of different starters or monsters based on criteria such as gender, season, difficulty, or any other relevant factors for the main NPCs (modder choice).

npc.json
```
  {
    "slug": "scientist",
    "template": {
      "sprite_name": "scientist",
      "combat_front": "scientist",
      "slug": "scientist"
    },
    "monsters": [
      {
        "slug": "pairagrin",
        "level": 5,
        "money_mod": 1,
        "exp_req_mod": 1,
        "gender": "male",
        "variables": [ "gender_choice:gender_female"] ---> Optional field, no mandatory
      },
      {
        "slug": "pairagrin",
        "level": 15,
        "money_mod": 1,
        "exp_req_mod": 1,
        "gender": "female",
        "variables": [ "gender_choice:gender_male"] ---> Optional field, no mandatory
      }
    ]
  },
```