### PR TITLE
fix 2405

### DIFF
--- a/tuxemon/prepare.py
+++ b/tuxemon/prepare.py
@@ -232,6 +232,8 @@ MAX_LOCKER: int = 30  # nr max of pc items
 # Items
 INFINITE_ITEMS: int = -1
 MAX_TYPES_BAG: int = 99  # eg 5 capture devices, 1 type and 5 items
+# Items menu
+MAX_MENU_ITEMS: int = 11
 
 # Monsters
 MAX_LEVEL: int = 999


### PR DESCRIPTION
PR fixes #2405 by introducing pagination to the inventory screen. When the number of items exceeds 11, users can now navigate between pages by clicking the left and right arrow buttons. This change replaces the previous behavior of scrolling up and down with left and right arrow clicks, providing a more intuitive and user-friendly experience for managing large inventories.

https://github.com/user-attachments/assets/49f5d1f7-ba2d-47cb-906a-bd4917de1c00