### PR TITLE
refactor calc_dialog_rect + positon parameter (dialog)

### DIFF
--- a/tuxemon/event/actions/translated_dialog.py
+++ b/tuxemon/event/actions/translated_dialog.py
@@ -29,13 +29,16 @@ class TranslatedDialogAction(EventAction):
     Script usage:
         .. code-block::
 
-            translated_dialog <text>[,avatar][,style]
+            translated_dialog <text>[,avatar][,position][,style]
 
     Script parameters:
         text: Text of the dialog.
         avatar: Monster avatar. If it is a number, the monster is the
             corresponding monster slot in the player's party.
             If it is a string, we're referring to a monster by name.
+        position: Position of the dialog box. Can be 'top', 'bottom', 'center',
+            'topleft', 'topright', 'bottomleft', 'bottomright', 'right', 'left'.
+            Default 'bottom'.
         style: a predefined style in db/dialogue/dialogue.json
 
     """
@@ -43,6 +46,7 @@ class TranslatedDialogAction(EventAction):
     name = "translated_dialog"
     raw_parameters: str
     avatar: Union[int, str, None] = None
+    position: Optional[str] = None
     style: Optional[str] = None
 
     def start(self) -> None:
@@ -60,12 +64,14 @@ class TranslatedDialogAction(EventAction):
             "font_shadow": string_to_colorlike(style.font_shadow_color),
             "border": style.border_path,
         }
+        position = self.position if self.position else "bottom"
 
         open_dialog(
             session=self.session,
             text=key,
             avatar=avatar_sprite,
             colors=colors,
+            position=position,
         )
 
     def update(self) -> None:

--- a/tuxemon/tools.py
+++ b/tuxemon/tools.py
@@ -130,7 +130,9 @@ def scale(number: int) -> int:
     return prepare.SCALE * number
 
 
-def calc_dialog_rect(screen_rect: pygame.rect.Rect) -> pygame.rect.Rect:
+def calc_dialog_rect(
+    screen_rect: pygame.rect.Rect, position: str
+) -> pygame.rect.Rect:
     """
     Return a rect that is the area for a dialog box on the screen.
 
@@ -139,19 +141,44 @@ def calc_dialog_rect(screen_rect: pygame.rect.Rect) -> pygame.rect.Rect:
 
     Parameters:
         screen_rect: Rectangle of the screen.
+        position: Position of the dialog box. Can be 'top', 'bottom', 'center',
+            'topleft', 'topright', 'bottomleft', 'bottomright', 'right', 'left'.
 
     Returns:
         Rectangle for a dialog.
-
     """
     rect = screen_rect.copy()
     if prepare.CONFIG.large_gui:
         rect.height = int(rect.height * 0.4)
-        rect.bottomleft = screen_rect.bottomleft
     else:
         rect.height = int(rect.height * 0.25)
         rect.width = int(rect.width * 0.8)
-        rect.center = screen_rect.centerx, rect.centery * 7
+
+    if position == "top":
+        rect.top = screen_rect.top
+        rect.centerx = screen_rect.centerx
+    elif position == "bottom":
+        rect.bottom = screen_rect.bottom
+        rect.centerx = screen_rect.centerx
+    elif position == "center":
+        rect.center = screen_rect.center
+    elif position == "topleft":
+        rect.topleft = screen_rect.topleft
+    elif position == "topright":
+        rect.topright = screen_rect.topright
+    elif position == "bottomleft":
+        rect.bottomleft = screen_rect.bottomleft
+    elif position == "bottomright":
+        rect.bottomright = screen_rect.bottomright
+    elif position == "left":
+        rect.left = screen_rect.left
+        rect.centery = screen_rect.centery
+    elif position == "right":
+        rect.right = screen_rect.right
+        rect.centery = screen_rect.centery
+    else:
+        raise ValueError("Invalid position.")
+
     return rect
 
 
@@ -160,6 +187,7 @@ def open_dialog(
     text: Sequence[str],
     avatar: Optional[Sprite] = None,
     colors: dict[str, Any] = {},
+    position: str = "bottom",
 ) -> State:
     """
     Open a dialog with the standard window size.
@@ -168,6 +196,9 @@ def open_dialog(
         session: Game session.
         text: List of strings.
         avatar: Optional avatar sprite.
+        colors: Dictionary containing background color, font color, etc.
+        position: Position of the dialog box. Can be 'top', 'bottom', 'center',
+            'topleft', 'topright', 'bottomleft', 'bottomright'.
 
     Returns:
         The pushed dialog state.
@@ -175,7 +206,7 @@ def open_dialog(
     """
     from tuxemon.states.dialog import DialogState
 
-    rect = calc_dialog_rect(session.client.screen.get_rect())
+    rect = calc_dialog_rect(session.client.screen.get_rect(), position)
     return session.client.push_state(
         DialogState(
             text=text,


### PR DESCRIPTION
PR refactors the `calc_dialog_rect` function to include a `position` parameter, allowing for more flexibility in positioning dialog boxes on the screen. Specifically:
* Added a `position` parameter to the `calc_dialog_rect` function, which can take one of the following values: "top", "bottom", "center", "topleft", "topright", "bottomleft", "bottomright", "left", "right"
* Updated the function to position the dialog box according to the specified position
* Removed hardcoded positioning logic, making the function more reusable and flexible

The main reason: enables the possibility to use different positioning of dialog boxes to deliver a better experience to the players when there is a dialogue among two or more NPCs (eg flashbacks), allowing for a clearer understanding of who says what and enhancing the overall narrative flow

https://github.com/user-attachments/assets/37a23f58-0e1e-492f-b82b-4812fa5b5bc2

video above generated by: 
```
    <property name="act11" value="translated_dialog spyder_papertown_sunnyside"/>
    <property name="act12" value="translated_dialog spyder_papertown_sunnyside,,bottomright"/>
    <property name="act13" value="translated_dialog spyder_papertown_sunnyside,,right"/>
    <property name="act14" value="translated_dialog spyder_papertown_sunnyside,,topright"/>
    <property name="act15" value="translated_dialog spyder_papertown_sunnyside,,top"/>
    <property name="act16" value="translated_dialog spyder_papertown_sunnyside,,topleft"/>
    <property name="act17" value="translated_dialog spyder_papertown_sunnyside,,left"/>
    <property name="act18" value="translated_dialog spyder_papertown_sunnyside,,bottomleft"/>
    <property name="act19" value="translated_dialog spyder_papertown_sunnyside,,center"/>
    <property name="act20" value="translated_dialog spyder_papertown_sunnyside"/>
    <property name="cond1" value="is char_facing_tile player"/>
    <property name="cond2" value="is button_pressed K_RETURN"/>
```