### PR TITLE
Billie's House (Spyder)

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -11344,6 +11344,15 @@ msgstr "Home sweet home!"
 msgid "spyder_papertown_rival"
 msgstr "Billie's House"
 
+msgid "spyder_rivalbedroom_bed"
+msgstr "Bed is messy, but it looks like she's been sleeping well. There's a tuxemon plushie on her pillow."
+
+msgid "spyder_rivalbedroom_bookshelf"
+msgstr "The bookshelf is filled with tuxemon strategy guides and training manuals."
+
+msgid "spyder_rivalbedroom_weights"
+msgstr "There's a diagram on the wall nearby that shows how to use the weight to train a tuxemon's strength."
+
 msgid "spyder_rivalbedroom_radio_morning"
 msgstr "Morning: A Pop song is playing. It's called \"Omni Love: A Journey Through Channels of the Heart\"."
 
@@ -11367,6 +11376,33 @@ msgstr "For Billie, from Grandma. Memories of Grandpa Bernard."
 
 msgid "spyder_rivaloffice_haiku"
 msgstr "It's a haiku: From Rock to Kitten, Evolution's dance unfolds, Transformation blooms."
+
+msgid "spyder_billie_tv_flashback_trigger"
+msgstr "Watch something else? A recorded episode of Tuxemon League is available."
+
+msgid "spyder_billie_tv_flashback1"
+msgstr "Reporter: Wow, what a clash! Crimson's Agnigon is really putting the pressure on Sapphire's Fribbit!\n Look at that! Agnigon unleashed a devastating Breathe Fire!"
+
+msgid "spyder_billie_tv_flashback2"
+msgstr "Billie: Overrated. Agnigon's moves are predictable. Any decent trainer could see that coming."
+
+msgid "spyder_billie_tv_flashback3"
+msgstr "Reporter: Fribbit is taking a beating! But look at that! Fribbit counters with a powerful Ice Storm! It's a direct hit!"
+
+msgid "spyder_billie_tv_flashback4"
+msgstr "Billie: Ice Storm? Weak."
+
+msgid "spyder_billie_tv_flashback5"
+msgstr "Reporter: This is getting intense! Agnigon is down! Fribbit wins! What a stunning upset!"
+
+msgid "spyder_billie_tv_flashback6"
+msgstr "Billie: Amateur. Agnigon should have used Supernova. A direct hit would have ended the fight in seconds."
+
+msgid "spyder_billie_tv_flashback7"
+msgstr "Reporter: This was an incredible display of skill and strategy from Sapphire."
+
+msgid "spyder_billie_tv_flashback8"
+msgstr "Billie: Skill? Luck. Any decent trainer could have predicted Agnigon's downfall."
 
 msgid "spyder_billie_flashback_trigger"
 msgstr "Do you want to uncover a piece of Billie's backstory?"

--- a/mods/tuxemon/maps/spyder_paper_rival_bedroom.yaml
+++ b/mods/tuxemon/maps/spyder_paper_rival_bedroom.yaml
@@ -74,3 +74,34 @@ events:
     x: 0
     y: 5
     type: "event"
+  Bookshelf:
+    actions:
+    - translated_dialog spyder_rivalbedroom_bookshelf
+    conditions:
+    - is char_facing_tile player
+    - is button_pressed K_RETURN
+    x: 5
+    y: 2
+    width: 2
+    height: 1
+    type: "event"
+  Weights:
+    actions:
+    - translated_dialog spyder_rivalbedroom_weights
+    conditions:
+    - is char_facing_tile player
+    - is button_pressed K_RETURN
+    x: 1
+    y: 6
+    type: "event"
+  Bed:
+    actions:
+    - translated_dialog spyder_rivalbedroom_bed
+    conditions:
+    - is char_facing_tile player
+    - is button_pressed K_RETURN
+    x: 5
+    y: 5
+    width: 2
+    height: 2
+    type: "event"

--- a/mods/tuxemon/maps/spyder_paper_rival_downstairs.yaml
+++ b/mods/tuxemon/maps/spyder_paper_rival_downstairs.yaml
@@ -38,6 +38,9 @@ events:
   TV:
     actions:
     - translated_dialog spyder_rivaldownstairs_tv
+    - translated_dialog spyder_billie_tv_flashback_trigger
+    - translated_dialog_choice no:yes,billie_tv
+    - set_variable flashback:on
     conditions:
     - is char_facing_tile player
     - is button_pressed K_RETURN
@@ -45,6 +48,34 @@ events:
     height: 1
     x: 4
     y: 7
+    type: "event"
+  TV Yes:
+    actions:
+    - lock_controls
+    - set_template player,invisible
+    - char_position player,6,8
+    - char_face player,left
+    - set_layer 102:51:0:128
+    - create_npc spyder_billie,4,8
+    - char_face spyder_billie,up
+    - wait 1
+    - translated_dialog spyder_billie_tv_flashback1,,top
+    - translated_dialog spyder_billie_tv_flashback2
+    - translated_dialog spyder_billie_tv_flashback3,,top
+    - translated_dialog spyder_billie_tv_flashback4
+    - translated_dialog spyder_billie_tv_flashback5,,top
+    - translated_dialog spyder_billie_tv_flashback6
+    - translated_dialog spyder_billie_tv_flashback7,,top
+    - translated_dialog spyder_billie_tv_flashback8
+    - wait 1
+    - remove_npc spyder_billie
+    - set_layer
+    - unlock_controls
+    - set_template player,default
+    - set_variable flashback:off
+    - clear_variable billie_tv
+    conditions:
+    - is variable_set billie_tv:yes
     type: "event"
   Flashback:
     actions:


### PR DESCRIPTION
Waiting #2568 

PR adds interactions for Billie's room, including her bed, bookshelf, and weights (still missing). It also includes a flashback sequence that plays when the player interacts with the TV that reveals more about Billie's personality and background.

descriptions:
- Bed: "Bed is messy, but it looks like she's been sleeping well. There's a tuxemon plushie on her pillow."
- Bookshelf: "The bookshelf is filled with tuxemon strategy guides and training manuals."
- Weights: "There's a diagram on the wall nearby that shows how to use the weight to train a tuxemon's strength."

flashback: 

https://github.com/user-attachments/assets/4fa5cf43-58af-4c7f-832f-2cf3ff4a0533

@Sanglorian I've also tested the new dialog position and I think it's a big improvement. It helps the player to understand better who is speaking and adds a nice touch of realism to the game. I'm currently using a top-down approach. Do you think this works well?

Additionally, the fight scene. Do you think it's too short, or does it feel like a good length to you? Are there any other suggestions you have for improving the scene or adding more depth to the story?

Let me know your thoughts.