### PR TITLE
tuxepedia flashbacks (Spyder)

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -11536,6 +11536,156 @@ msgstr "You're doing the right thing now. You're trying to make it right. I'm he
 msgid "spyder_leather_sarah7"
 msgstr "I hope so. I really do. But it's hard to shake off the feeling of guilt. It's hard to forget what we've done."
 
+msgid "spyder_tuxepedia_trigger1"
+msgstr "Sorry, I was lost in thought.\n The idea of Tuxepedia has come a long way, but I still remember how it all started.\n Would you like to hear about it?"
+
+msgid "spyder_tuxepedia_trigger2"
+msgstr "I was thinking about the early days of the Tuxepedia project. We were all so excited to start building something that could change the world.\n Want to hear about it?"
+
+msgid "spyder_tuxepedia_trigger3"
+msgstr "We faced some tough challenges when we were building the Tuxepedia.\n The Pillars were trying to stop us, and we had to find creative ways to overcome the obstacles.\n Would you like to hear about how we managed to stay one step ahead?"
+
+msgid "spyder_tuxepedia_trigger4"
+msgstr "The launch of the Tuxepedia was a huge milestone for us.\n We finally had a working database, and we were able to share it with the world.\n It's a great story - would you like to hear about it?"
+
+msgid "spyder_tuxepedia_ending1"
+msgstr "Ah, I think I've told you enough about the Tuxepedia's past for now."
+
+msgid "spyder_tuxepedia_ending2"
+msgstr "Now that you know the story!"
+
+msgid "spyder_tuxepedia_ending3"
+msgstr "I think I've shared enough of our early struggles with you."
+
+msgid "spyder_tuxepedia_ending4"
+msgstr "Now that the Tuxepedia is up and running, I'm excited to see how it will continue to grow and evolve."
+
+msgid "spyder_tuxepedia_idea1"
+msgstr "Evelyn: We need a way to catalog all the tuxemon out there. Something that's accessible to everyone, not just the Pillars."
+
+msgid "spyder_tuxepedia_idea2"
+msgstr "Liam: I've been thinking about that. What if we create a database that's open-source? Anyone can contribute, anyone can access it."
+
+msgid "spyder_tuxepedia_idea3"
+msgstr "Maya: But how do we make sure the information is accurate? We can't just let anyone add whatever they want."
+
+msgid "spyder_tuxepedia_idea4"
+msgstr "Evelyn: We can create a system of moderators, people who are experts in their field.\n They can review and verify the information before it's added to the database."
+
+msgid "spyder_tuxepedia_idea5"
+msgstr "Julian: And what about the Pillars? They're not going to be happy about us creating something that undermines their control."
+
+msgid "spyder_tuxepedia_idea6"
+msgstr "Liam: We'll just have to be careful. We can start small, build a community of supporters.\n Once we have enough momentum, the Pillars won't be able to stop us."
+
+msgid "spyder_tuxepedia_idea7"
+msgstr "Maya: I like it. But what are we going to call this thing?"
+
+msgid "spyder_tuxepedia_idea8"
+msgstr "Evelyn: How about 'Tuxepedia'? It's a play on 'encyclopedia' and 'tuxemon'."
+
+msgid "spyder_tuxepedia_idea9"
+msgstr "Julian: One more thing, I've always thought of it as 'Tuxepedia' rather than 'The Tuxepedia'."
+
+msgid "spyder_tuxepedia_idea10"
+msgstr "Liam: Ah, I see what you mean. But I think 'The Tuxepedia' sounds more formal and official."
+
+msgid "spyder_tuxepedia_idea11"
+msgstr "Maya: Yeah, I agree with Evelyn. 'The Tuxepedia' it is, then."
+
+msgid "spyder_tuxepedia_idea12"
+msgstr "Evelyn: Alright, let's get to work. We've got a lot of ground to cover before we can make this a reality."
+
+msgid "spyder_tuxepedia_project1"
+msgstr "Evelyn: I've been working on a new algorithm called 'TuxemonNet'.\n A neural network that can analyze tuxemon characteristics and automatically categorize them.\n This is more than just a tool; it's a key to unlocking the true potential of tuxemon research.\n This algorithm will be open-source, allowing other researchers to build upon it and contribute to the project.\n I think I've finally cracked it!\n I was up all night testing it, and the algorithm identified 95% of the tuxemon in the test dataset, even those with subtle variations."
+
+msgid "spyder_tuxepedia_project2"
+msgstr "Liam: That's amazing! Let me take a look. How does it handle the different types of tuxemon?"
+
+msgid "spyder_tuxepedia_project3"
+msgstr "Evelyn: I've been testing it with a small dataset, and it's working beautifully.\n We can use this to create a robust and scalable database.\n I've also been thinking about how we can use machine learning to improve the algorithm over time."
+
+msgid "spyder_tuxepedia_project4"
+msgstr "Liam: This is exactly what we needed. We can finally start building the Tuxepedia.\n I've been working on the user interface, and I think we can make it really intuitive and user-friendly."
+
+msgid "spyder_tuxepedia_project5"
+msgstr "Maya: I'm so excited to see this come together. We're going to change the way people think about tuxemon.\n I've been talking to some of the other researchers, and they're all really interested in what we're doing."
+
+msgid "spyder_tuxepedia_project6"
+msgstr "Julian: I've already started working on the backend. We'll need to make sure it's secure and can handle a large volume of data.\n I've been looking into some of the latest security protocols, and I think we can make it really robust."
+
+msgid "spyder_tuxepedia_project7"
+msgstr "Liam: I'll start reaching out to other tuxemon enthusiasts and researchers. We'll need to build a community around this project.\n I've already started talking to some of the online forums, and there's a lot of interest."
+
+msgid "spyder_tuxepedia_project8"
+msgstr "Maya: This is it. We're finally making progress. Let's keep pushing forward! We can make this happen, and it's going to be amazing."
+
+msgid "spyder_tuxepedia_project9"
+msgstr "Evelyn: I've been thinking about how we can use this to help the tuxemon community.\n We can create a platform for people to share their knowledge and research, and really advance the field."
+
+msgid "spyder_tuxepedia_project10"
+msgstr "Julian: We're going to make this happen. We're going to create something amazing, and it's going to change the world."
+
+msgid "spyder_tuxepedia_issues1"
+msgstr "Liam: We've got a problem.\n One of our informants within the Pillars told us they're spreading rumors that our research could destabilize the tuxemon ecosystem.\n They're saying that our project is a threat to their control, and they're going to do everything they can to stop us."
+
+msgid "spyder_tuxepedia_issues2"
+msgstr "Evelyn: We can't let them stop us. We have to find a way to keep going. We've come too far to give up now."
+
+msgid "spyder_tuxepedia_issues3"
+msgstr "Julian: I think our strength lies in the community itself. The Tuxepedia is a collective effort, and that's what makes it resilient.\n If the Pillars try to sabotage it, they'll be up against the entire community."
+
+msgid "spyder_tuxepedia_issues4"
+msgstr "Maya: But what if they try to insert false information or manipulate the data?\n How can we trust that the information on The Tuxepedia is accurate?"
+
+msgid "spyder_tuxepedia_issues5"
+msgstr "Liam: That's the beauty of it. With so many eyes on The Tuxepedia, any falsehoods or inaccuracies will be quickly corrected.\n The community will self-regulate and ensure the information is trustworthy."
+
+msgid "spyder_tuxepedia_issues6"
+msgstr "Evelyn: And it's not just about the information itself, but also about the people who contribute to it.\n We have a diverse group of contributors from all over, and that diversity is what makes The Tuxepedia strong."
+
+msgid "spyder_tuxepedia_issues7"
+msgstr "Julian: Exactly.\n The Pillars might try to infiltrate our community, but they'll be hard-pressed to manipulate the collective effort of so many people.\n We're not just a single entity that can be taken down - we're a network of individuals working together."
+
+msgid "spyder_tuxepedia_issues8"
+msgstr "Maya: I think that's what makes The Tuxepedia so powerful.\n It's not just a repository of information - it's a symbol of what can be achieved when people work together towards a common goal."
+
+msgid "spyder_tuxepedia_issues9"
+msgstr "Liam: We're not going to let the Pillars stop us.\n We're going to keep pushing forward, and we're going to make this happen. Together, we can achieve something amazing."
+
+msgid "spyder_tuxepedia_issues10"
+msgstr "Evelyn: We're in this together, and together, we're unstoppable."
+
+msgid "spyder_tuxepedia_launch1"
+msgstr "Liam: It's finally here. The first version of the Tuxepedia is live! We did it, guys. We actually did it."
+
+msgid "spyder_tuxepedia_launch2"
+msgstr "Evelyn: We did it! We actually did it! I'm so proud of us. We've worked so hard to get to this point.\n Now, let's see if we can keep it running. We need to anticipate their next move. They won't let this go easily."
+
+msgid "spyder_tuxepedia_launch3"
+msgstr "Maya: My heart is pounding. I can't believe we actually did it. We're going to change the way people think about tuxemon.\n I've been talking to some of the other researchers, and they're all really interested in what we're doing. This is just the beginning.\n Imagine a world where every tuxemon trainer has access to this vast repository of knowledge."
+
+msgid "spyder_tuxepedia_launch4"
+msgstr "Julian: And it's just the beginning. We've got so much more to do.\n We can add more features, more data... the possibilities are endless."
+
+msgid "spyder_tuxepedia_launch5"
+msgstr "Liam: I've already started thinking about the next version.\n We can add more advanced search features, and maybe even integrate with some of the other tuxemon databases."
+
+msgid "spyder_tuxepedia_launch6"
+msgstr "Evelyn: Let's not get ahead of ourselves. We need to celebrate this achievement first. We've earned it."
+
+msgid "spyder_tuxepedia_launch7"
+msgstr "Maya: I've got champagne. Let's pop the cork and celebrate! We can toast to the Tuxepedia, and to the future of tuxemon research."
+
+msgid "spyder_tuxepedia_launch8"
+msgstr "Julian: To the Tuxepedia! May it bring knowledge and power to the people! And to the future of tuxemon research, may it be bright and exciting!"
+
+msgid "spyder_tuxepedia_launch9"
+msgstr "Liam: Cheers to that! We did it, guys. We actually did it."
+
+msgid "spyder_tuxepedia_launch10"
+msgstr "Evelyn: We're just getting started. This is just the beginning.\n Imagine a world where every tuxemon trainer has access to this vast repository of knowledge."
+
 msgid "spyder_leathercafe_sign"
 msgstr "Open Air Cafe and Marketplace"
 

--- a/mods/tuxemon/maps/spyder_candy_cafe.yaml
+++ b/mods/tuxemon/maps/spyder_candy_cafe.yaml
@@ -156,3 +156,41 @@ events:
     - is char_sprite player,invisible
     - is variable_set incident_greenwash:done
     type: "event"
+  Create Trigger:
+    actions:
+    - create_npc spyder_cottoncafe_hillary,1,8
+    - char_face spyder_cottoncafe_hillary,right
+    conditions:
+    - not char_exists spyder_cottoncafe_hillary
+    type: "event"
+  Talk Trigger 1:
+    actions:
+    - translated_dialog spyder_tuxepedia_trigger4
+    - translated_dialog_choice yes:no,tuxepedia_launch
+    behav:
+    - talk spyder_cottoncafe_hillary
+    conditions:
+    - not variable_set tuxepedia_launch:done
+    type: "event"
+  Talk Trigger 2:
+    actions:
+    - translated_dialog spyder_tuxepedia_ending4
+    behav:
+    - talk spyder_cottoncafe_hillary
+    conditions:
+    - is variable_set tuxepedia_launch:done
+    type: "event"
+  Flashback Yes:
+    actions:
+    - transition_teleport spyder_leather_scoop.tmx,10,7
+    - set_variable flashback:on
+    conditions:
+    - is variable_set tuxepedia_launch:yes
+    type: "event"
+  Default Template:
+    actions:
+    - set_template player,default
+    conditions:
+    - is char_sprite player,invisible
+    - is variable_set tuxepedia_launch:done
+    type: "event"

--- a/mods/tuxemon/maps/spyder_flower_petshop.tmx
+++ b/mods/tuxemon/maps/spyder_flower_petshop.tmx
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="14" height="9" tilewidth="16" tileheight="16" infinite="0" nextlayerid="10" nextobjectid="54">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="14" height="9" tilewidth="16" tileheight="16" infinite="0" nextlayerid="10" nextobjectid="59">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
+  <property name="map_type" value="notype"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="flower_petshop"/>
-  <property name="map_type" value="notype"/>
  </properties>
  <tileset firstgid="1" name="Interiors_16x16" tilewidth="16" tileheight="16" tilecount="2592" columns="16">
   <image source="../gfx/tilesets/Interiors_16x16.png" width="256" height="2592"/>
@@ -256,6 +256,42 @@
     <property name="act3" value="clear_variable petshopbuy"/>
     <property name="act4" value="modify_money player,-500"/>
     <property name="cond1" value="is variable_set petshopbuy:ziggurat"/>
+   </properties>
+  </object>
+  <object id="54" name="Talk Trigger 1" type="event" x="0" y="32" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_tuxepedia_trigger3"/>
+    <property name="act2" value="translated_dialog_choice yes:no,tuxepedia_issues"/>
+    <property name="behav1" value="talk spyder_cottoncafe_cayden"/>
+    <property name="cond1" value="not variable_set tuxepedia_issues:done"/>
+   </properties>
+  </object>
+  <object id="55" name="Talk Trigger 2" type="event" x="0" y="48" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_tuxepedia_ending3"/>
+    <property name="behav1" value="talk spyder_cottoncafe_cayden"/>
+    <property name="cond1" value="is variable_set tuxepedia_issues:done"/>
+   </properties>
+  </object>
+  <object id="56" name="Flashback Yes" type="event" x="0" y="64" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport spyder_leather_scoop.tmx,10,7"/>
+    <property name="act2" value="set_variable flashback:on"/>
+    <property name="cond1" value="is variable_set tuxepedia_issues:yes"/>
+   </properties>
+  </object>
+  <object id="57" name="Create Trigger" type="event" x="16" y="48" width="16" height="16">
+   <properties>
+    <property name="act1" value="create_npc spyder_cottoncafe_cayden,1,3"/>
+    <property name="act2" value="char_face spyder_cottoncafe_cayden,right"/>
+    <property name="cond1" value="not char_exists spyder_cottoncafe_cayden"/>
+   </properties>
+  </object>
+  <object id="58" name="Default Template" type="event" x="0" y="80" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_template player,default"/>
+    <property name="cond1" value="is char_sprite player,invisible"/>
+    <property name="cond2" value="is variable_set tuxepedia_issues:done"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_leather_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_leather_scoop.tmx
@@ -43,46 +43,4 @@
   <object id="26" type="collision" x="176" y="48" width="32" height="16"/>
   <object id="27" type="collision" x="0" y="112" width="32" height="16"/>
  </objectgroup>
- <objectgroup color="#ffff00" id="6" name="Events">
-  <object id="15" name="Teleport to Leather Town" type="event" x="80" y="160" width="32" height="16">
-   <properties>
-    <property name="act1" value="transition_teleport spyder_leather_town.tmx,15,10,0.3"/>
-    <property name="act2" value="char_face player,down"/>
-    <property name="cond1" value="is char_at player"/>
-    <property name="cond2" value="is char_facing player,down"/>
-   </properties>
-  </object>
-  <object id="17" name="Route Music" type="event" x="0" y="0" width="16" height="16">
-   <properties>
-    <property name="act1" value="play_music music_cathedral_theme"/>
-    <property name="cond1" value="not music_playing music_cathedral_theme"/>
-   </properties>
-  </object>
-  <object id="19" name="Open Shop" type="event" x="32" y="96" width="16" height="16">
-   <properties>
-    <property name="act1" value="char_face spyder_leatherscoop_blake,right"/>
-    <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
-    <property name="act3" value="open_shop spyder_leatherscoop_blake"/>
-    <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
-   </properties>
-  </object>
-  <object id="20" name="Open Shop" type="event" x="16" y="112" width="16" height="16">
-   <properties>
-    <property name="act1" value="char_face spyder_leatherscoop_blake,down"/>
-    <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
-    <property name="act3" value="open_shop spyder_leatherscoop_blake"/>
-    <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
-   </properties>
-  </object>
-  <object id="21" name="Create Shopkeeper" type="event" x="16" y="96" width="16" height="16">
-   <properties>
-    <property name="act1" value="create_npc spyder_leatherscoop_blake,1,6"/>
-    <property name="act2" value="char_face spyder_leatherscoop_blake,right"/>
-    <property name="act3" value="set_economy spyder_leatherscoop_blake,spyder_leather_scoop"/>
-    <property name="cond1" value="not char_exists spyder_leatherscoop_blake"/>
-   </properties>
-  </object>
- </objectgroup>
 </map>

--- a/mods/tuxemon/maps/spyder_leather_scoop.yaml
+++ b/mods/tuxemon/maps/spyder_leather_scoop.yaml
@@ -1,0 +1,203 @@
+events:
+  Route Music:
+    actions:
+    - play_music music_cathedral_theme
+    conditions:
+    - not music_playing music_cathedral_theme
+    type: "event"
+  Teleport to Leather Town:
+    actions:
+    - transition_teleport spyder_leather_town.tmx,15,10,0.3
+    - char_face player,down
+    conditions:
+    - is char_at player
+    - is char_facing player,down
+    x: 5
+    y: 10
+    height: 1
+    width: 2
+    type: "event"
+  Create Shopkeeper:
+    actions:
+    - create_npc spyder_leatherscoop_blake,1,6
+    - char_face spyder_leatherscoop_blake,right
+    - set_economy spyder_leatherscoop_blake,spyder_leather_scoop
+    conditions:
+    - not char_exists spyder_leatherscoop_blake
+    type: "event"
+  Open Shop 1:
+    actions:
+    - char_face spyder_leatherscoop_blake,right
+    - translated_dialog spyder_scoop_welcome
+    - open_shop spyder_leatherscoop_blake
+    conditions:
+    - is char_facing_tile player
+    - is button_pressed K_RETURN
+    x: 2
+    y: 6
+    type: "event"
+  Open Shop 2:
+    actions:
+    - char_face spyder_leatherscoop_blake,down
+    - translated_dialog spyder_scoop_welcome
+    - open_shop spyder_leatherscoop_blake
+    conditions:
+    - is char_facing_tile player
+    - is button_pressed K_RETURN
+    x: 1
+    y: 7
+    type: "event"
+  Tuxepedia Idea:
+    actions:
+    - lock_controls
+    - set_template player,invisible
+    - set_layer 102:51:0:128
+    - create_npc spyder_cottoncafe_hillary,8,6
+    - create_npc spyder_cottoncafe_wilford,8,5
+    - create_npc spyder_cottoncafe_cayden,11,6
+    - create_npc spyder_cottoncafe_juliana,11,5
+    - char_face spyder_cottoncafe_hillary,right
+    - char_face spyder_cottoncafe_wilford,right
+    - char_face spyder_cottoncafe_cayden,left
+    - char_face spyder_cottoncafe_juliana,left
+    - wait 1
+    - translated_dialog spyder_tuxepedia_idea1,,bottomleft
+    - translated_dialog spyder_tuxepedia_idea2,,topleft
+    - translated_dialog spyder_tuxepedia_idea3,,topright
+    - translated_dialog spyder_tuxepedia_idea4,,bottomleft
+    - translated_dialog spyder_tuxepedia_idea5,,bottomright
+    - translated_dialog spyder_tuxepedia_idea6,,topleft
+    - translated_dialog spyder_tuxepedia_idea7,,topright
+    - translated_dialog spyder_tuxepedia_idea8,,bottomleft
+    - translated_dialog spyder_tuxepedia_idea9,,bottomright
+    - translated_dialog spyder_tuxepedia_idea10,,topleft
+    - translated_dialog spyder_tuxepedia_idea11,,topright
+    - translated_dialog spyder_tuxepedia_idea12,,bottomleft
+    - wait 1
+    - set_variable tuxepedia_idea:done
+    - set_layer
+    - unlock_controls
+    - set_variable flashback:off
+    - remove_npc spyder_cottoncafe_hillary
+    - remove_npc spyder_cottoncafe_wilford
+    - remove_npc spyder_cottoncafe_cayden
+    - remove_npc spyder_cottoncafe_juliana
+    - transition_teleport spyder_timber_cafe.tmx,3,9
+    - char_face player,up
+    conditions:
+    - is variable_set tuxepedia_idea:yes
+    type: "event"
+  Tuxepedia Project:
+    actions:
+    - lock_controls
+    - set_template player,invisible
+    - set_layer 102:51:0:128
+    - create_npc spyder_cottoncafe_hillary,8,6
+    - create_npc spyder_cottoncafe_wilford,8,5
+    - create_npc spyder_cottoncafe_cayden,11,6
+    - create_npc spyder_cottoncafe_juliana,11,5
+    - char_face spyder_cottoncafe_hillary,right
+    - char_face spyder_cottoncafe_wilford,right
+    - char_face spyder_cottoncafe_cayden,left
+    - char_face spyder_cottoncafe_juliana,left
+    - wait 1
+    - translated_dialog spyder_tuxepedia_project1,,bottomleft
+    - translated_dialog spyder_tuxepedia_project2,,topleft
+    - translated_dialog spyder_tuxepedia_project3,,bottomleft
+    - translated_dialog spyder_tuxepedia_project4,,topleft
+    - translated_dialog spyder_tuxepedia_project5,,topright
+    - translated_dialog spyder_tuxepedia_project6,,bottomright
+    - translated_dialog spyder_tuxepedia_project7,,topleft
+    - translated_dialog spyder_tuxepedia_project8,,topright
+    - translated_dialog spyder_tuxepedia_project9,,bottomleft
+    - translated_dialog spyder_tuxepedia_project10,,bottomright
+    - wait 1
+    - remove_npc spyder_cottoncafe_hillary
+    - remove_npc spyder_cottoncafe_wilford
+    - remove_npc spyder_cottoncafe_cayden
+    - remove_npc spyder_cottoncafe_juliana
+    - set_variable tuxepedia_project:done
+    - set_layer
+    - unlock_controls
+    - set_variable flashback:off
+    - transition_teleport spyder_leather_town.tmx,3,16
+    - char_face player,right
+    conditions:
+    - is variable_set tuxepedia_project:yes
+    type: "event"
+  Tuxepedia Issues:
+    actions:
+    - lock_controls
+    - set_template player,invisible
+    - set_layer 102:51:0:128
+    - create_npc spyder_cottoncafe_hillary,8,6
+    - create_npc spyder_cottoncafe_wilford,8,5
+    - create_npc spyder_cottoncafe_cayden,11,6
+    - create_npc spyder_cottoncafe_juliana,11,5
+    - char_face spyder_cottoncafe_hillary,right
+    - char_face spyder_cottoncafe_wilford,right
+    - char_face spyder_cottoncafe_cayden,left
+    - char_face spyder_cottoncafe_juliana,left
+    - wait 1
+    - translated_dialog spyder_tuxepedia_issues1,,topleft
+    - translated_dialog spyder_tuxepedia_issues2,,bottomleft
+    - translated_dialog spyder_tuxepedia_issues3,,bottomright
+    - translated_dialog spyder_tuxepedia_issues4,,topright
+    - translated_dialog spyder_tuxepedia_issues5,,topleft
+    - translated_dialog spyder_tuxepedia_issues6,,bottomleft
+    - translated_dialog spyder_tuxepedia_issues7,,bottomright
+    - translated_dialog spyder_tuxepedia_issues8,,topright
+    - translated_dialog spyder_tuxepedia_issues9,,topleft
+    - translated_dialog spyder_tuxepedia_issues10,,bottomleft
+    - wait 1
+    - remove_npc spyder_cottoncafe_hillary
+    - remove_npc spyder_cottoncafe_wilford
+    - remove_npc spyder_cottoncafe_cayden
+    - remove_npc spyder_cottoncafe_juliana
+    - set_variable tuxepedia_issues:done
+    - set_layer
+    - unlock_controls
+    - set_variable flashback:off
+    - transition_teleport spyder_flower_petshop.tmx,2,3
+    - char_face player,left
+    conditions:
+    - is variable_set tuxepedia_issues:yes
+    type: "event"
+  Tuxepedia Launch:
+    actions:
+    - lock_controls
+    - set_template player,invisible
+    - set_layer 102:51:0:128
+    - create_npc spyder_cottoncafe_hillary,8,6
+    - create_npc spyder_cottoncafe_wilford,8,5
+    - create_npc spyder_cottoncafe_cayden,11,6
+    - create_npc spyder_cottoncafe_juliana,11,5
+    - char_face spyder_cottoncafe_hillary,right
+    - char_face spyder_cottoncafe_wilford,right
+    - char_face spyder_cottoncafe_cayden,left
+    - char_face spyder_cottoncafe_juliana,left
+    - wait 1
+    - translated_dialog spyder_tuxepedia_launch1,,topleft
+    - translated_dialog spyder_tuxepedia_launch2,,bottomleft
+    - translated_dialog spyder_tuxepedia_launch3,,topright
+    - translated_dialog spyder_tuxepedia_launch4,,bottomright
+    - translated_dialog spyder_tuxepedia_launch5,,topleft
+    - translated_dialog spyder_tuxepedia_launch6,,bottomleft
+    - translated_dialog spyder_tuxepedia_launch7,,topright
+    - translated_dialog spyder_tuxepedia_launch8,,bottomright
+    - translated_dialog spyder_tuxepedia_launch9,,topleft
+    - translated_dialog spyder_tuxepedia_launch10,,bottomleft
+    - wait 1
+    - remove_npc spyder_cottoncafe_hillary
+    - remove_npc spyder_cottoncafe_wilford
+    - remove_npc spyder_cottoncafe_cayden
+    - remove_npc spyder_cottoncafe_juliana
+    - set_variable tuxepedia_launch:done
+    - set_layer
+    - unlock_controls
+    - set_variable flashback:off
+    - transition_teleport spyder_candy_cafe.tmx,1,9
+    - char_face player,right
+    conditions:
+    - is variable_set tuxepedia_launch:yes
+    type: "event"

--- a/mods/tuxemon/maps/spyder_leather_town.tmx
+++ b/mods/tuxemon/maps/spyder_leather_town.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="339">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="344">
  <properties>
   <property name="east" value="citypark"/>
   <property name="edges" value="clamped"/>
@@ -548,6 +548,42 @@
     <property name="act1" value="translated_dialog spyder_leather_sarah_no"/>
     <property name="behav1" value="talk spyder_leathermuseum_visitor"/>
     <property name="cond1" value="is variable_set sarah_flashback:no"/>
+   </properties>
+  </object>
+  <object id="339" name="Talk Trigger 1" type="event" x="16" y="240" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_tuxepedia_trigger2"/>
+    <property name="act2" value="translated_dialog_choice yes:no,tuxepedia_project"/>
+    <property name="behav1" value="talk spyder_cottoncafe_wilford"/>
+    <property name="cond1" value="not variable_set tuxepedia_project:done"/>
+   </properties>
+  </object>
+  <object id="340" name="Talk Trigger 2" type="event" x="16" y="256" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_tuxepedia_ending2"/>
+    <property name="behav1" value="talk spyder_cottoncafe_wilford"/>
+    <property name="cond1" value="is variable_set tuxepedia_project:done"/>
+   </properties>
+  </object>
+  <object id="341" name="Flashback Yes" type="event" x="16" y="272" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport spyder_leather_scoop.tmx,10,7"/>
+    <property name="act2" value="set_variable flashback:on"/>
+    <property name="cond1" value="is variable_set tuxepedia_project:yes"/>
+   </properties>
+  </object>
+  <object id="342" name="Create Trigger" type="event" x="48" y="240" width="16" height="16">
+   <properties>
+    <property name="act1" value="create_npc spyder_cottoncafe_wilford,3,15"/>
+    <property name="act2" value="char_face spyder_cottoncafe_wilford,right"/>
+    <property name="cond1" value="not char_exists spyder_cottoncafe_wilford"/>
+   </properties>
+  </object>
+  <object id="343" name="Default Template" type="event" x="16" y="288" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_template player,default"/>
+    <property name="cond1" value="is char_sprite player,invisible"/>
+    <property name="cond2" value="is variable_set tuxepedia_project:done"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_timber_cafe.yaml
+++ b/mods/tuxemon/maps/spyder_timber_cafe.yaml
@@ -144,3 +144,41 @@ events:
     conditions:
     - is variable_set florists_cafe:yes
     type: "event"
+  Create Trigger:
+    actions:
+    - create_npc spyder_cottoncafe_juliana,3,8
+    - char_face spyder_cottoncafe_juliana,right
+    conditions:
+    - not char_exists spyder_cottoncafe_juliana
+    type: "event"
+  Talk Trigger 1:
+    actions:
+    - translated_dialog spyder_tuxepedia_trigger1
+    - translated_dialog_choice yes:no,tuxepedia_idea
+    behav:
+    - talk spyder_cottoncafe_juliana
+    conditions:
+    - not variable_set tuxepedia_idea:done
+    type: "event"
+  Talk Trigger 2:
+    actions:
+    - translated_dialog spyder_tuxepedia_ending1
+    behav:
+    - talk spyder_cottoncafe_juliana
+    conditions:
+    - is variable_set tuxepedia_idea:done
+    type: "event"
+  Flashback Yes:
+    actions:
+    - transition_teleport spyder_leather_scoop.tmx,10,7
+    - set_variable flashback:on
+    conditions:
+    - is variable_set tuxepedia_idea:yes
+    type: "event"
+  Default Template:
+    actions:
+    - set_template player,default
+    conditions:
+    - is char_sprite player,invisible
+    - is variable_set tuxepedia_idea:done
+    type: "event"


### PR DESCRIPTION
waiting #2568 

PR fills a narrative gap in the game by introducing the creation of Tuxepedia through four flashbacks, each triggered in a different location. These flashbacks feature four key founders of Tuxepedia:

• Evelyn: a founder and key contributor to the conversation
• Liam: a founder and driving force behind the project
• Maya: a founder and voice of caution
• Julian: a founder and strategist who considers the project's potential risks and challenges

During these flashbacks, the founders are seen discussing around a table in the Leather Scoop, but they only appear during these brief moments. The four flashbacks cover the following pivotal moments in Tuxepedia's creation:

• A brainstorming session where the founders share their vision and ideas for Tuxepedia
• A breakthrough discovery that helps launch the project
• The founders facing opposition from the Pillars and finding creative ways to overcome obstacles
• The launch of the first version of Tuxepedia, with the founders celebrating their achievement and looking to the future

@Sanglorian, feel free to review the dialogues and founder names in this pull request.

Regarding the dialogues, I was thinking of arranging the dialog boxes in a way that mirrors the table layout of the founders. Specifically, each of the four founders (Evelyn, Liam, Maya, and Julian) would have their dialogue appear at a corresponding corner of the screen, creating a visual connection to their seating arrangement.