### PR TITLE
translation mode

### DIFF
--- a/tuxemon/config.py
+++ b/tuxemon/config.py
@@ -59,6 +59,7 @@ class TuxemonConfig:
             "net_controller_enabled",
         )
         self.locale = cfg.get("game", "locale")
+        self.translation_mode = cfg.get("game", "translation_mode")
         self.dev_tools = cfg.getboolean("game", "dev_tools")
         self.recompile_translations = cfg.getboolean(
             "game",
@@ -212,6 +213,7 @@ def get_defaults() -> Mapping[str, Any]:
                         ("cli_enabled", "False"),
                         ("net_controller_enabled", "False"),
                         ("locale", "en_US"),
+                        ("translation_mode", "none"),
                         ("dev_tools", "False"),
                         ("recompile_translations", "True"),
                         ("compress_save", "None"),


### PR DESCRIPTION
PR adds a new `translation_mode` option to `tuxemon.cfg` as requested in #2469. The default value is `'none'`, but users can choose to set it to `'all'` to check all existing translations (e.g., `fr`, `de`, `es`, etc.) or specify a single locale (e.g., `'eo'`).

When `translation_mode` is set to `'all'`, the console will print a message for each missing translation, similar to:
```
Translation doesn't exist for 'cs_CZ': spyder_papertown_homemaker1
Translation doesn't exist for 'nb_NO': spyder_papertown_homemaker1
Translation doesn't exist for 'eo': spyder_papertown_homemaker1
Translation doesn't exist for 'pl': spyder_papertown_homemaker1
Translation doesn't exist for 'fi': spyder_papertown_homemaker1
Translation doesn't exist for 'ja': spyder_papertown_homemaker1
```
Alternatively, when a single locale name is specified (e.g., `'eo'`), the console will print:
```
Translation doesn't exist for 'eo': spyder_papertown_homemaker1
```
If the specified single locale name does not exist, a ValueError will be raised, indicating that the locale is not supported.
```
Locale 'lmao' doesn't exist.
```
This feature helps identify missing translations while playing and makes it easier to maintain and update the game's localization.