### PR TITLE
Modifier(BaseModel)

### DIFF
--- a/mods/tuxemon/db/condition/blinded.json
+++ b/mods/tuxemon/db/condition/blinded.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "category": "negative",
   "effects": [
     "statchange"

--- a/mods/tuxemon/db/condition/blinded.json
+++ b/mods/tuxemon/db/condition/blinded.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "category": "negative",
   "effects": [
     "statchange"

--- a/mods/tuxemon/db/condition/burn.json
+++ b/mods/tuxemon/db/condition/burn.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [
+  "modifiers": [
     {
       "attribute": "type",
       "values": ["fire"],

--- a/mods/tuxemon/db/condition/burn.json
+++ b/mods/tuxemon/db/condition/burn.json
@@ -1,5 +1,17 @@
 {
   "animation": null,
+  "damage_modifiers": [
+    {
+      "attribute": "type",
+      "values": ["fire"],
+      "multiplier": 0.0
+    },
+    {
+      "attribute": "type",
+      "values": ["frost"],
+      "multiplier": 2.0
+    }
+  ],
   "category": "negative",
   "effects": [
     "burnt 8"

--- a/mods/tuxemon/db/condition/chargedup.json
+++ b/mods/tuxemon/db/condition/chargedup.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "category": "positive",
   "effects": [
     "statchange",

--- a/mods/tuxemon/db/condition/chargedup.json
+++ b/mods/tuxemon/db/condition/chargedup.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "category": "positive",
   "effects": [
     "statchange",

--- a/mods/tuxemon/db/condition/charging.json
+++ b/mods/tuxemon/db/condition/charging.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "category": "positive",
   "effects": [
     "charging"

--- a/mods/tuxemon/db/condition/charging.json
+++ b/mods/tuxemon/db/condition/charging.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "category": "positive",
   "effects": [
     "charging"

--- a/mods/tuxemon/db/condition/confused.json
+++ b/mods/tuxemon/db/condition/confused.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "category": "negative",
   "effects": [
     "confused 0.5"

--- a/mods/tuxemon/db/condition/confused.json
+++ b/mods/tuxemon/db/condition/confused.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "category": "negative",
   "effects": [
     "confused 0.5"

--- a/mods/tuxemon/db/condition/diehard.json
+++ b/mods/tuxemon/db/condition/diehard.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "category": "positive",
   "effects": [
     "diehard 1"

--- a/mods/tuxemon/db/condition/diehard.json
+++ b/mods/tuxemon/db/condition/diehard.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "category": "positive",
   "effects": [
     "diehard 1"

--- a/mods/tuxemon/db/condition/elementalshield.json
+++ b/mods/tuxemon/db/condition/elementalshield.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "category": "positive",
   "effects": [
     "elemental_shield 16,special"

--- a/mods/tuxemon/db/condition/elementalshield.json
+++ b/mods/tuxemon/db/condition/elementalshield.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "category": "positive",
   "effects": [
     "elemental_shield 16,special"

--- a/mods/tuxemon/db/condition/eliminated.json
+++ b/mods/tuxemon/db/condition/eliminated.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_eliminated.png",

--- a/mods/tuxemon/db/condition/eliminated.json
+++ b/mods/tuxemon/db/condition/eliminated.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_eliminated.png",

--- a/mods/tuxemon/db/condition/enraged.json
+++ b/mods/tuxemon/db/condition/enraged.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "category": "positive",
   "effects": [
     "statchange",

--- a/mods/tuxemon/db/condition/enraged.json
+++ b/mods/tuxemon/db/condition/enraged.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "category": "positive",
   "effects": [
     "statchange",

--- a/mods/tuxemon/db/condition/exhausted.json
+++ b/mods/tuxemon/db/condition/exhausted.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "category": "negative",
   "effects": [
     "statchange",

--- a/mods/tuxemon/db/condition/exhausted.json
+++ b/mods/tuxemon/db/condition/exhausted.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "category": "negative",
   "effects": [
     "statchange",

--- a/mods/tuxemon/db/condition/faint.json
+++ b/mods/tuxemon/db/condition/faint.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "category": "neutral",
   "effects": [],
   "flip_axes": "",

--- a/mods/tuxemon/db/condition/faint.json
+++ b/mods/tuxemon/db/condition/faint.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "category": "neutral",
   "effects": [],
   "flip_axes": "",

--- a/mods/tuxemon/db/condition/feedback.json
+++ b/mods/tuxemon/db/condition/feedback.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "category": "positive",
   "effects": [
     "feedback 8,ranged:reach"

--- a/mods/tuxemon/db/condition/feedback.json
+++ b/mods/tuxemon/db/condition/feedback.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "category": "positive",
   "effects": [
     "feedback 8,ranged:reach"

--- a/mods/tuxemon/db/condition/festering.json
+++ b/mods/tuxemon/db/condition/festering.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "category": "negative",
   "effects": [
     "festering"

--- a/mods/tuxemon/db/condition/festering.json
+++ b/mods/tuxemon/db/condition/festering.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "category": "negative",
   "effects": [
     "festering"

--- a/mods/tuxemon/db/condition/flinching.json
+++ b/mods/tuxemon/db/condition/flinching.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "category": "negative",
   "effects": [
     "flinching 0.5"

--- a/mods/tuxemon/db/condition/flinching.json
+++ b/mods/tuxemon/db/condition/flinching.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "category": "negative",
   "effects": [
     "flinching 0.5"

--- a/mods/tuxemon/db/condition/focused.json
+++ b/mods/tuxemon/db/condition/focused.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "category": "positive",
   "effects": [
     "statchange"

--- a/mods/tuxemon/db/condition/focused.json
+++ b/mods/tuxemon/db/condition/focused.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "category": "positive",
   "effects": [
     "statchange"

--- a/mods/tuxemon/db/condition/grabbed.json
+++ b/mods/tuxemon/db/condition/grabbed.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "category": "negative",
 	"conditions": [
 	  	"is current_hp >,0"

--- a/mods/tuxemon/db/condition/grabbed.json
+++ b/mods/tuxemon/db/condition/grabbed.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "category": "negative",
 	"conditions": [
 	  	"is current_hp >,0"

--- a/mods/tuxemon/db/condition/hardshell.json
+++ b/mods/tuxemon/db/condition/hardshell.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "category": "positive",
   "effects": [
     "statchange"

--- a/mods/tuxemon/db/condition/hardshell.json
+++ b/mods/tuxemon/db/condition/hardshell.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "category": "positive",
   "effects": [
     "statchange"

--- a/mods/tuxemon/db/condition/harpooned.json
+++ b/mods/tuxemon/db/condition/harpooned.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "category": "negative",
   "effects": [
     "harpooned 8"

--- a/mods/tuxemon/db/condition/harpooned.json
+++ b/mods/tuxemon/db/condition/harpooned.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "category": "negative",
   "effects": [
     "harpooned 8"

--- a/mods/tuxemon/db/condition/lifeleech.json
+++ b/mods/tuxemon/db/condition/lifeleech.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "category": "negative",
 	"conditions": [
 	  	"is current_hp >,0"

--- a/mods/tuxemon/db/condition/lifeleech.json
+++ b/mods/tuxemon/db/condition/lifeleech.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "category": "negative",
 	"conditions": [
 	  	"is current_hp >,0"

--- a/mods/tuxemon/db/condition/lockdown.json
+++ b/mods/tuxemon/db/condition/lockdown.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "category": "negative",
   "effects": [
     "lockdown"

--- a/mods/tuxemon/db/condition/lockdown.json
+++ b/mods/tuxemon/db/condition/lockdown.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "category": "negative",
   "effects": [
     "lockdown"

--- a/mods/tuxemon/db/condition/noddingoff.json
+++ b/mods/tuxemon/db/condition/noddingoff.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "category": "negative",
   "effects": [
     "noddingoff 0.5"

--- a/mods/tuxemon/db/condition/noddingoff.json
+++ b/mods/tuxemon/db/condition/noddingoff.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "category": "negative",
   "effects": [
     "noddingoff 0.5"

--- a/mods/tuxemon/db/condition/poison.json
+++ b/mods/tuxemon/db/condition/poison.json
@@ -1,5 +1,12 @@
 {
   "animation": "drip_green",
+  "damage_modifiers": [
+    {
+      "attribute": "type",
+      "values": ["venom"],
+      "multiplier": 0.0
+    }
+  ],
   "category": "negative",
   "effects": [
     "poisoned 8"

--- a/mods/tuxemon/db/condition/poison.json
+++ b/mods/tuxemon/db/condition/poison.json
@@ -1,6 +1,6 @@
 {
   "animation": "drip_green",
-  "damage_modifiers": [
+  "modifiers": [
     {
       "attribute": "type",
       "values": ["venom"],

--- a/mods/tuxemon/db/condition/prickly.json
+++ b/mods/tuxemon/db/condition/prickly.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "category": "positive",
   "effects": [
     "prickly 8,touch:melee"

--- a/mods/tuxemon/db/condition/prickly.json
+++ b/mods/tuxemon/db/condition/prickly.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "category": "positive",
   "effects": [
     "prickly 8,touch:melee"

--- a/mods/tuxemon/db/condition/recover.json
+++ b/mods/tuxemon/db/condition/recover.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "category": "positive",
   "effects": [
     "recover 16"

--- a/mods/tuxemon/db/condition/recover.json
+++ b/mods/tuxemon/db/condition/recover.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "category": "positive",
   "effects": [
     "recover 16"

--- a/mods/tuxemon/db/condition/retaliate.json
+++ b/mods/tuxemon/db/condition/retaliate.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "category": "positive",
   "effects": [
     "retaliate"

--- a/mods/tuxemon/db/condition/retaliate.json
+++ b/mods/tuxemon/db/condition/retaliate.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "category": "positive",
   "effects": [
     "retaliate"

--- a/mods/tuxemon/db/condition/revenge.json
+++ b/mods/tuxemon/db/condition/revenge.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "category": "positive",
   "effects": [
     "revenge"

--- a/mods/tuxemon/db/condition/revenge.json
+++ b/mods/tuxemon/db/condition/revenge.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "category": "positive",
   "effects": [
     "revenge"

--- a/mods/tuxemon/db/condition/slow.json
+++ b/mods/tuxemon/db/condition/slow.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "category": "negative",
   "effects": [
     "statchange"

--- a/mods/tuxemon/db/condition/slow.json
+++ b/mods/tuxemon/db/condition/slow.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "category": "negative",
   "effects": [
     "statchange"

--- a/mods/tuxemon/db/condition/sniping.json
+++ b/mods/tuxemon/db/condition/sniping.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "category": "positive",
   "effects": [
     "statchange",

--- a/mods/tuxemon/db/condition/sniping.json
+++ b/mods/tuxemon/db/condition/sniping.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "category": "positive",
   "effects": [
     "statchange",

--- a/mods/tuxemon/db/condition/softened.json
+++ b/mods/tuxemon/db/condition/softened.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "category": "negative",
   "effects": [
     "statchange"

--- a/mods/tuxemon/db/condition/softened.json
+++ b/mods/tuxemon/db/condition/softened.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "category": "negative",
   "effects": [
     "statchange"

--- a/mods/tuxemon/db/condition/stuck.json
+++ b/mods/tuxemon/db/condition/stuck.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "category": "negative",
 	"conditions": [
 	  	"is current_hp >,0"

--- a/mods/tuxemon/db/condition/stuck.json
+++ b/mods/tuxemon/db/condition/stuck.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "category": "negative",
 	"conditions": [
 	  	"is current_hp >,0"

--- a/mods/tuxemon/db/condition/tired.json
+++ b/mods/tuxemon/db/condition/tired.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "category": "negative",
   "effects": [
     "tired"

--- a/mods/tuxemon/db/condition/tired.json
+++ b/mods/tuxemon/db/condition/tired.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "category": "negative",
   "effects": [
     "tired"

--- a/mods/tuxemon/db/condition/wasting.json
+++ b/mods/tuxemon/db/condition/wasting.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "category": "negative",
   "effects": [
     "wasting 16"

--- a/mods/tuxemon/db/condition/wasting.json
+++ b/mods/tuxemon/db/condition/wasting.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "category": "negative",
   "effects": [
     "wasting 16"

--- a/mods/tuxemon/db/condition/wild.json
+++ b/mods/tuxemon/db/condition/wild.json
@@ -1,6 +1,6 @@
 {
   "animation": null,
-  "damage_modifiers": [],
+  "modifiers": [],
   "category": "negative",
   "effects": [
     "wild 0.25,8"

--- a/mods/tuxemon/db/condition/wild.json
+++ b/mods/tuxemon/db/condition/wild.json
@@ -1,5 +1,6 @@
 {
   "animation": null,
+  "damage_modifiers": [],
   "category": "negative",
   "effects": [
     "wild 0.25,8"

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -1154,6 +1154,9 @@ msgstr "{target} is harmful to make contact with."
 msgid "combat_state_feedback_get"
 msgstr "{target} is turning ranged attacks back on the attacker."
 
+msgid "combat_state_immune"
+msgstr "{target} is immune to {method}"
+
 # Generic notifications
 msgid "empty_slot"
 msgstr "Empty Slot"

--- a/tests/tuxemon/test_monster_actions.py
+++ b/tests/tuxemon/test_monster_actions.py
@@ -74,19 +74,12 @@ class TestMonsterActions(unittest.TestCase):
         upper_catch_resistance=1.25,
     )
     _faint = ConditionModel(
+        damage_modifiers=[],
         flip_axes="",
         sfx="sfx_faint",
         slug="faint",
         range="special",
         sort="meta",
-        target={
-            "enemy_monster": False,
-            "enemy_team": False,
-            "enemy_trainer": False,
-            "own_monster": False,
-            "own_team": False,
-            "own_trainer": False,
-        },
         cond_id=0,
     )
 

--- a/tests/tuxemon/test_monster_actions.py
+++ b/tests/tuxemon/test_monster_actions.py
@@ -74,7 +74,7 @@ class TestMonsterActions(unittest.TestCase):
         upper_catch_resistance=1.25,
     )
     _faint = ConditionModel(
-        damage_modifiers=[],
+        modifiers=[],
         flip_axes="",
         sfx="sfx_faint",
         slug="faint",

--- a/tuxemon/condition/condition.py
+++ b/tuxemon/condition/condition.py
@@ -111,7 +111,7 @@ class Condition:
         self.counter = self.counter
         self.steps = self.steps
 
-        self.damage_modifiers = results.damage_modifiers
+        self.modifiers = results.modifiers
         # monster stats
         self.statspeed = results.statspeed
         self.stathp = results.stathp

--- a/tuxemon/condition/condition.py
+++ b/tuxemon/condition/condition.py
@@ -111,6 +111,7 @@ class Condition:
         self.counter = self.counter
         self.steps = self.steps
 
+        self.damage_modifiers = results.damage_modifiers
         # monster stats
         self.statspeed = results.statspeed
         self.stathp = results.stathp

--- a/tuxemon/condition/effects/burnt.py
+++ b/tuxemon/condition/effects/burnt.py
@@ -6,7 +6,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from tuxemon.condition.condeffect import CondEffect, CondEffectResult
-from tuxemon.formula import condition_weakest_link
+from tuxemon.formula import weakest_link
+from tuxemon.locale import T
 
 if TYPE_CHECKING:
     from tuxemon.condition.condition import Condition
@@ -28,12 +29,17 @@ class BurntEffect(CondEffect):
 
     def apply(self, condition: Condition, target: Monster) -> CondEffectResult:
         burnt: bool = False
+        params = {"target": target.name, "method": condition.name}
         if condition.phase == "perform_action_status":
             damage = target.hp / self.divisor
-            mult = condition_weakest_link(condition.damage_modifiers, target)
+            mult = weakest_link(condition.modifiers, target)
             damage *= mult
-            target.current_hp = max(0, target.current_hp - int(damage))
-            burnt = True
+            if damage > 0:
+                burnt = True
+                target.current_hp = max(0, target.current_hp - int(damage))
+            else:
+                condition.use_failure = T.format("combat_state_immune", params)
+                target.status = []
 
         return CondEffectResult(
             name=condition.name,

--- a/tuxemon/condition/effects/burnt.py
+++ b/tuxemon/condition/effects/burnt.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from tuxemon.condition.condeffect import CondEffect, CondEffectResult
+from tuxemon.formula import condition_weakest_link
 
 if TYPE_CHECKING:
     from tuxemon.condition.condition import Condition
@@ -28,8 +29,10 @@ class BurntEffect(CondEffect):
     def apply(self, condition: Condition, target: Monster) -> CondEffectResult:
         burnt: bool = False
         if condition.phase == "perform_action_status":
-            damage = target.hp // self.divisor
-            target.current_hp = max(0, target.current_hp - damage)
+            damage = target.hp / self.divisor
+            mult = condition_weakest_link(condition.damage_modifiers, target)
+            damage *= mult
+            target.current_hp = max(0, target.current_hp - int(damage))
             burnt = True
 
         return CondEffectResult(

--- a/tuxemon/condition/effects/poisoned.py
+++ b/tuxemon/condition/effects/poisoned.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from tuxemon.condition.condeffect import CondEffect, CondEffectResult
+from tuxemon.formula import condition_weakest_link
 
 if TYPE_CHECKING:
     from tuxemon.condition.condition import Condition
@@ -28,8 +29,10 @@ class PoisonedEffect(CondEffect):
     def apply(self, condition: Condition, target: Monster) -> CondEffectResult:
         poisoned: bool = False
         if condition.phase == "perform_action_status":
-            damage = target.hp // self.divisor
-            target.current_hp = max(0, target.current_hp - damage)
+            damage = target.hp / self.divisor
+            mult = condition_weakest_link(condition.damage_modifiers, target)
+            damage *= mult
+            target.current_hp = max(0, target.current_hp - int(damage))
             poisoned = True
 
         return CondEffectResult(

--- a/tuxemon/condition/effects/poisoned.py
+++ b/tuxemon/condition/effects/poisoned.py
@@ -6,7 +6,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from tuxemon.condition.condeffect import CondEffect, CondEffectResult
-from tuxemon.formula import condition_weakest_link
+from tuxemon.formula import weakest_link
+from tuxemon.locale import T
 
 if TYPE_CHECKING:
     from tuxemon.condition.condition import Condition
@@ -28,12 +29,17 @@ class PoisonedEffect(CondEffect):
 
     def apply(self, condition: Condition, target: Monster) -> CondEffectResult:
         poisoned: bool = False
+        params = {"target": target.name, "method": condition.name}
         if condition.phase == "perform_action_status":
             damage = target.hp / self.divisor
-            mult = condition_weakest_link(condition.damage_modifiers, target)
+            mult = weakest_link(condition.modifiers, target)
             damage *= mult
-            target.current_hp = max(0, target.current_hp - int(damage))
-            poisoned = True
+            if damage > 0:
+                poisoned = True
+                target.current_hp = max(0, target.current_hp - int(damage))
+            else:
+                condition.use_failure = T.format("combat_state_immune", params)
+                target.status = []
 
         return CondEffectResult(
             name=condition.name,

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -712,7 +712,14 @@ class TechCategory(str, Enum):
     notype = "notype"
 
 
-# TechSort defines the sort of technique a technique is.
+class DamageModifier(BaseModel):
+    attribute: str = Field(..., description="Condition, type, tag, etc.")
+    values: Sequence[str] = Field([], description="Values (eg. fire, etc)")
+    multiplier: float = Field(
+        1.0, description="Damage multiplier", ge=0.0, le=2.0
+    )
+
+
 class TechSort(str, Enum):
     damage = "damage"
     meta = "meta"
@@ -928,6 +935,9 @@ class ConditionModel(BaseModel):
     )
     duration: int = Field(
         0, description="How many turns the condition is supposed to last"
+    )
+    damage_modifiers: list[DamageModifier] = Field(
+        ..., description="Damage multipliers"
     )
 
     # Optional fields

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -725,12 +725,15 @@ class TechCategory(str, Enum):
     notype = "notype"
 
 
-class DamageModifier(BaseModel):
-    attribute: str = Field(..., description="Condition, type, tag, etc.")
-    values: Sequence[str] = Field([], description="Values (eg. fire, etc)")
-    multiplier: float = Field(
-        1.0, description="Damage multiplier", ge=0.0, le=2.0
+class Modifier(BaseModel):
+    attribute: str = Field(
+        ..., description="Attribute being modified (type, etc.)"
     )
+    values: Sequence[str] = Field(
+        [],
+        description="Values associated with the modification (eg. fire, etc.)",
+    )
+    multiplier: float = Field(1.0, description="Multiplier", ge=0.0, le=2.0)
 
 
 class TechSort(str, Enum):
@@ -949,9 +952,7 @@ class ConditionModel(BaseModel):
     duration: int = Field(
         0, description="How many turns the condition is supposed to last"
     )
-    damage_modifiers: list[DamageModifier] = Field(
-        ..., description="Damage multipliers"
-    )
+    modifiers: list[Modifier] = Field(..., description="Damage multipliers")
 
     # Optional fields
     category: Optional[CategoryCondition] = Field(

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Optional
 from tuxemon import prepare as pre
 
 if TYPE_CHECKING:
-    from tuxemon.db import ElementType
+    from tuxemon.db import DamageModifier, ElementType
     from tuxemon.element import Element
     from tuxemon.monster import Monster
     from tuxemon.technique.technique import Technique
@@ -167,6 +167,37 @@ def simple_damage_calculate(
     move_strength = technique.power * mult
     damage = int(user_strength * move_strength / target_resist)
     return damage, mult
+
+
+def condition_weakest_link(
+    damage_modifiers: list[DamageModifier], monster: Monster
+) -> float:
+    """
+    Returns the smallest damage multiplier that applies to the given monster.
+
+    This function iterates over the damage modifiers and checks if the monster's type
+    matches any of the modifier's values. If a match is found, the function updates the
+    multiplier to the smallest value found.
+
+    Parameters:
+        damage_modifiers: A list of damage modifiers.
+        monster: The monster to check.
+
+    Returns:
+        The smallest damage multiplier that applies to the monster.
+    """
+    multiplier: float = 1.0
+    if damage_modifiers:
+        for modifier in damage_modifiers:
+            if modifier.attribute == "type":
+                if any(t.name in modifier.values for t in monster.types):
+                    multiplier = min(multiplier, modifier.multiplier)
+            elif modifier.attribute == "tag":
+                if any(t in modifier.values for t in monster.tags):
+                    multiplier = min(multiplier, modifier.multiplier)
+            else:
+                raise ValueError(f"{modifier.attribute} isn't implemented.")
+    return multiplier
 
 
 def simple_heal(

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Optional
 from tuxemon import prepare as pre
 
 if TYPE_CHECKING:
-    from tuxemon.db import DamageModifier, ElementType
+    from tuxemon.db import ElementType, Modifier
     from tuxemon.element import Element
     from tuxemon.monster import Monster
     from tuxemon.technique.technique import Technique
@@ -169,26 +169,26 @@ def simple_damage_calculate(
     return damage, mult
 
 
-def condition_weakest_link(
-    damage_modifiers: list[DamageModifier], monster: Monster
-) -> float:
+def weakest_link(modifiers: list[Modifier], monster: Monster) -> float:
     """
-    Returns the smallest damage multiplier that applies to the given monster.
+    Returns the smallest damage multiplier that applies to the given
+    monster.
 
-    This function iterates over the damage modifiers and checks if the monster's type
-    matches any of the modifier's values. If a match is found, the function updates the
-    multiplier to the smallest value found.
+    This function iterates over the damage modifiers and checks if the
+    monster's type matches any of the modifier's values. If a match is
+    found, the function updates the multiplier to the smallest value
+    found.
 
     Parameters:
-        damage_modifiers: A list of damage modifiers.
+        modifiers: A list of damage modifiers.
         monster: The monster to check.
 
     Returns:
         The smallest damage multiplier that applies to the monster.
     """
     multiplier: float = 1.0
-    if damage_modifiers:
-        for modifier in damage_modifiers:
+    if modifiers:
+        for modifier in modifiers:
             if modifier.attribute == "type":
                 if any(t.name in modifier.values for t in monster.types):
                     multiplier = min(multiplier, modifier.multiplier)
@@ -198,6 +198,139 @@ def condition_weakest_link(
             else:
                 raise ValueError(f"{modifier.attribute} isn't implemented.")
     return multiplier
+
+
+def strongest_link(modifiers: list[Modifier], monster: Monster) -> float:
+    """
+    Returns the largest damage multiplier that applies to the given
+    monster.
+
+    This function iterates over the damage modifiers and checks if the
+    monster's type matches any of the modifier's values. If a match is
+    found, the function updates the multiplier to the largest value found.
+
+    Parameters:
+        modifiers: A list of damage modifiers.
+        monster: The monster to check.
+
+    Returns:
+        The largest damage multiplier that applies to the monster.
+    """
+    multiplier: Optional[float] = None
+    if modifiers:
+        for modifier in modifiers:
+            if modifier.attribute == "type":
+                if any(t.name in modifier.values for t in monster.types):
+                    multiplier = (
+                        max(multiplier, modifier.multiplier)
+                        if multiplier is not None
+                        else modifier.multiplier
+                    )
+            elif modifier.attribute == "tag":
+                if any(t in modifier.values for t in monster.tags):
+                    multiplier = (
+                        max(multiplier, modifier.multiplier)
+                        if multiplier is not None
+                        else modifier.multiplier
+                    )
+            else:
+                raise ValueError(f"{modifier.attribute} isn't implemented.")
+    return multiplier if multiplier is not None else 1.0
+
+
+def cumulative_damage(modifiers: list[Modifier], monster: Monster) -> float:
+    """
+    Returns the cumulative product of all applicable damage multipliers for
+    the given monster.
+
+    This function iterates over the damage modifiers and checks if the monster's
+    type matches any of the modifier's values. If a match is found, the function
+    multiplies the current multiplier with the modifier's multiplier.
+
+    Parameters:
+        modifiers: A list of damage modifiers.
+        monster: The monster to check.
+
+    Returns:
+        The cumulative product of all applicable damage multipliers.
+    """
+    multiplier: float = 1.0
+    if modifiers:
+        for modifier in modifiers:
+            if modifier.attribute == "type":
+                if any(t.name in modifier.values for t in monster.types):
+                    multiplier *= modifier.multiplier
+            elif modifier.attribute == "tag":
+                if any(t in modifier.values for t in monster.tags):
+                    multiplier *= modifier.multiplier
+            else:
+                raise ValueError(f"{modifier.attribute} isn't implemented.")
+    return multiplier
+
+
+def average_damage(modifiers: list[Modifier], monster: Monster) -> float:
+    """
+    Returns the average of all applicable damage multipliers for the given
+    monster.
+
+    This function iterates over the damage modifiers and checks if the monster's
+    type matches any of the modifier's values. If a match is found, the function
+    adds the modifier's multiplier to a list and calculates the average at the
+    end.
+
+    Parameters:
+        modifiers: A list of damage modifiers.
+        monster: The monster to check.
+
+    Returns:
+        The average of all applicable damage multipliers.
+    """
+    applicable_modifiers = []
+    if modifiers:
+        for modifier in modifiers:
+            if modifier.attribute == "type":
+                if any(t.name in modifier.values for t in monster.types):
+                    applicable_modifiers.append(modifier.multiplier)
+            elif modifier.attribute == "tag":
+                if any(t in modifier.values for t in monster.tags):
+                    applicable_modifiers.append(modifier.multiplier)
+            else:
+                raise ValueError(f"{modifier.attribute} isn't implemented.")
+
+    if applicable_modifiers:
+        return sum(applicable_modifiers) / len(applicable_modifiers)
+    else:
+        return 1.0
+
+
+def first_applicable_damage(
+    modifiers: list[Modifier], monster: Monster
+) -> float:
+    """
+    Returns the first applicable damage multiplier for the given monster.
+
+    This function iterates over the damage modifiers and checks if the monster's
+    type matches any of the modifier's values. If a match is found, the function
+    returns the modifier's multiplier immediately.
+
+    Parameters:
+        modifiers: A list of damage modifiers.
+        monster: The monster to check.
+
+    Returns:
+        The first applicable damage multiplier.
+    """
+    if modifiers:
+        for modifier in modifiers:
+            if modifier.attribute == "type":
+                if any(t.name in modifier.values for t in monster.types):
+                    return modifier.multiplier
+            elif modifier.attribute == "tag":
+                if any(t in modifier.values for t in monster.tags):
+                    return modifier.multiplier
+            else:
+                raise ValueError(f"{modifier.attribute} isn't implemented.")
+    return 1.0
 
 
 def simple_heal(

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -209,6 +209,7 @@ class Monster:
         self.category = T.translate(f"cat_{self.cat}")
         self.shape = results.shape or MonsterShape.default
         self.stage = results.stage or EvolutionStage.standalone
+        self.tags = results.tags
         self.taste_cold = self.set_taste_cold(self.taste_cold)
         self.taste_warm = self.set_taste_warm(self.taste_warm)
         self.steps = self.steps

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -1027,6 +1027,9 @@ class CombatState(CombatAnimations):
             if condition.use_failure:
                 template = getattr(condition, "use_failure")
                 message = T.format(template, context)
+        if result.extras:
+            templates = [T.translate(extra) for extra in result.extras]
+            message = message + "\n" + "\n".join(templates)
         action_time += compute_text_animation_time(message)
         self.text_animations_queue.append(
             (partial(self.alert, message), action_time)


### PR DESCRIPTION
PR:
- introduces a new data model `Modifier` to represent damage modifiers with attributes, values, and multipliers
- implements the `weakest_link` and other formulas to calculate damage
- implements the unittest suite for all the formulas

weakest_link -> Returns the smallest damage multiplier that applies to the given monster.
strongest_link -> Returns the largest damage multiplier that applies to the given monster.
cumulative_damage -> Returns the cumulative product of all applicable damage multipliers for the given monster.
average_damage -> Returns the average of all applicable damage multipliers for the given monster.
first_applicable_damage -> Returns the first applicable damage multiplier for the given monster.

weakest_link will be used for the burn and poison condition