### PR TITLE
item and monster dialog center (Spyder)

### DIFF
--- a/mods/tuxemon/maps/spyder_candy_house3.tmx
+++ b/mods/tuxemon/maps/spyder_candy_house3.tmx
@@ -140,7 +140,7 @@
     <property name="act27" value="translated_dialog spyder_candy_eliane4"/>
     <property name="act30" value="set_variable giveegg:yes"/>
     <property name="act31" value="add_item ancient_egg"/>
-    <property name="act32" value="translated_dialog ancient_egg"/>
+    <property name="act32" value="translated_dialog ancient_egg,,center"/>
     <property name="act40" value="pathfind spyder_candy_eliane,3,1"/>
     <property name="act41" value="remove_npc spyder_candy_eliane"/>
     <property name="act50" value="unlock_controls"/>

--- a/mods/tuxemon/maps/spyder_candy_inn2.yaml
+++ b/mods/tuxemon/maps/spyder_candy_inn2.yaml
@@ -151,9 +151,9 @@ events:
   Bee Event Stung Item:
     actions:
     - add_item cureall
-    - translated_dialog cureall
+    - translated_dialog cureall,,center
     - add_item restoration
-    - translated_dialog restoration
+    - translated_dialog restoration,,center
     - set_variable beeevent:end
     conditions:
     - is variable_set beeevent:done

--- a/mods/tuxemon/maps/spyder_candy_town.tmx
+++ b/mods/tuxemon/maps/spyder_candy_town.tmx
@@ -371,7 +371,7 @@
   <object id="194" name="Get cureall" type="event" x="144" y="48" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_candy_eliane3"/>
-    <property name="act2" value="translated_dialog cureall"/>
+    <property name="act2" value="translated_dialog cureall,,center"/>
     <property name="act3" value="add_item elianeoutput"/>
     <property name="act4" value="set_variable elianeoutput:none"/>
     <property name="cond1" value="is variable_set elianeoutput:cureall"/>
@@ -380,7 +380,7 @@
   <object id="192" name="Get restoration" type="event" x="128" y="48" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_candy_eliane3"/>
-    <property name="act2" value="translated_dialog restoration"/>
+    <property name="act2" value="translated_dialog restoration,,center"/>
     <property name="act3" value="add_item elianeoutput"/>
     <property name="act4" value="set_variable elianeoutput:none"/>
     <property name="cond1" value="is variable_set elianeoutput:restoration"/>
@@ -389,7 +389,7 @@
   <object id="173" name="Get potion" type="event" x="112" y="48" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_candy_eliane3"/>
-    <property name="act2" value="translated_dialog potion"/>
+    <property name="act2" value="translated_dialog potion,,center"/>
     <property name="act3" value="add_item elianeoutput"/>
     <property name="act4" value="set_variable elianeoutput:none"/>
     <property name="cond1" value="is variable_set elianeoutput:potion"/>
@@ -398,7 +398,7 @@
   <object id="181" name="Get tea" type="event" x="96" y="48" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_candy_eliane3"/>
-    <property name="act2" value="translated_dialog tea"/>
+    <property name="act2" value="translated_dialog tea,,center"/>
     <property name="act3" value="add_item elianeoutput"/>
     <property name="act4" value="set_variable elianeoutput:none"/>
     <property name="cond1" value="is variable_set elianeoutput:tea"/>

--- a/mods/tuxemon/maps/spyder_citypark.tmx
+++ b/mods/tuxemon/maps/spyder_citypark.tmx
@@ -496,7 +496,7 @@
   </object>
   <object id="86" name="Box1" type="event" x="240" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog potion"/>
+    <property name="act1" value="translated_dialog potion,,center"/>
     <property name="act2" value="add_item potion"/>
     <property name="act3" value="remove_npc spyder_citypark_potion1"/>
     <property name="act4" value="set_variable citypark_potion1:yes"/>
@@ -512,7 +512,7 @@
   </object>
   <object id="88" name="Box2" type="event" x="288" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog potion"/>
+    <property name="act1" value="translated_dialog potion,,center"/>
     <property name="act2" value="add_item potion"/>
     <property name="act3" value="remove_npc spyder_citypark_potion2"/>
     <property name="act4" value="set_variable citypark_potion2:yes"/>
@@ -528,7 +528,7 @@
   </object>
   <object id="90" name="Box3" type="event" x="16" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog restoration"/>
+    <property name="act1" value="translated_dialog restoration,,center"/>
     <property name="act2" value="add_item restoration"/>
     <property name="act3" value="remove_npc spyder_citypark_restoration"/>
     <property name="act4" value="set_variable citypark_restoration:yes"/>
@@ -544,7 +544,7 @@
   </object>
   <object id="92" name="Box4" type="event" x="16" y="256" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog tuxeball"/>
+    <property name="act1" value="translated_dialog tuxeball,,center"/>
     <property name="act2" value="add_item tuxeball"/>
     <property name="act3" value="remove_npc spyder_citypark_cd1"/>
     <property name="act4" value="set_variable citypark_cd1:yes"/>
@@ -560,7 +560,7 @@
   </object>
   <object id="94" name="Box5" type="event" x="96" y="384" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog tuxeball"/>
+    <property name="act1" value="translated_dialog tuxeball,,center"/>
     <property name="act2" value="add_item tuxeball"/>
     <property name="act3" value="remove_npc spyder_citypark_cd2"/>
     <property name="act4" value="set_variable citypark_cd2:yes"/>

--- a/mods/tuxemon/maps/spyder_citypark_house1.tmx
+++ b/mods/tuxemon/maps/spyder_citypark_house1.tmx
@@ -65,6 +65,7 @@
     <property name="act1" value="set_mission player,spyder_maniac_achievement1,add"/>
     <property name="act2" value="set_variable maniac_help:yes"/>
     <property name="act3" value="add_item book_wishes"/>
+    <property name="act4" value="translated_dialog book_wishes,,center"/>
     <property name="cond1" value="is variable_set maniac_achievements:yes"/>
     <property name="cond2" value="not variable_set maniac_help:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_cotton_artshop.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_artshop.tmx
@@ -212,9 +212,10 @@
    <properties>
     <property name="act1" value="set_variable has_sold_painting:yes"/>
     <property name="act2" value="add_item p_monsters_eyes"/>
-    <property name="act3" value="set_variable bought_monsters_eyes:yes"/>
-    <property name="act4" value="modify_money player,-1000"/>
-    <property name="act5" value="remove_noc p_one"/>
+    <property name="act3" value="translated_dialog p_monsters_eyes,,center"/>
+    <property name="act4" value="set_variable bought_monsters_eyes:yes"/>
+    <property name="act5" value="modify_money player,-1000"/>
+    <property name="act6" value="remove_noc p_one"/>
     <property name="cond1" value="is variable_set barmaid_monsters:yes"/>
     <property name="cond2" value="not variable_set bought_monsters_eyes:yes"/>
    </properties>
@@ -223,9 +224,10 @@
    <properties>
     <property name="act1" value="set_variable has_sold_painting:yes"/>
     <property name="act2" value="add_item p_starry_night"/>
-    <property name="act3" value="set_variable bought_starry:yes"/>
-    <property name="act4" value="modify_money player,-1000"/>
-    <property name="act5" value="remove_noc p_two"/>
+    <property name="act3" value="translated_dialog p_starry_night,,center"/>
+    <property name="act4" value="set_variable bought_starry:yes"/>
+    <property name="act5" value="modify_money player,-1000"/>
+    <property name="act6" value="remove_noc p_two"/>
     <property name="cond1" value="is variable_set barmaid_starry:yes"/>
     <property name="cond2" value="not variable_set bought_starry:yes"/>
    </properties>
@@ -234,19 +236,23 @@
    <properties>
     <property name="act1" value="set_variable has_sold_painting:yes"/>
     <property name="act2" value="add_item p_trepidation"/>
-    <property name="act3" value="set_variable bought_trepidation:yes"/>
-    <property name="act4" value="modify_money player,-1000"/>
-    <property name="act5" value="remove_noc p_three"/>
+    <property name="act3" value="translated_dialog p_trepidation,,center"/>
+    <property name="act4" value="set_variable bought_trepidation:yes"/>
+    <property name="act5" value="modify_money player,-1000"/>
+    <property name="act6" value="remove_noc p_three"/>
     <property name="cond1" value="is variable_set barmaid_trepidation:yes"/>
     <property name="cond2" value="not variable_set bought_trepidation:yes"/>
    </properties>
   </object>
   <object id="42" name="Barmaid Sell Bundle" type="event" x="112" y="0" width="16" height="16">
    <properties>
-    <property name="act05" value="set_variable has_sold_paintings:yes"/>
-    <property name="act10" value="add_item p_starry_night"/>
-    <property name="act11" value="add_item p_trepidation"/>
-    <property name="act12" value="add_item p_monsters_eyes"/>
+    <property name="act01" value="set_variable has_sold_paintings:yes"/>
+    <property name="act02" value="add_item p_starry_night"/>
+    <property name="act03" value="translated_dialog p_starry_night,,center"/>
+    <property name="act04" value="add_item p_trepidation"/>
+    <property name="act05" value="translated_dialog p_trepidation,,center"/>
+    <property name="act06" value="add_item p_monsters_eyes"/>
+    <property name="act07" value="translated_dialog p_monsters_eyes,,center"/>
     <property name="act15" value="remove_npc p_one"/>
     <property name="act16" value="remove_npc p_two"/>
     <property name="act17" value="remove_npc p_three"/>

--- a/mods/tuxemon/maps/spyder_cotton_cafe.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_cafe.tmx
@@ -100,6 +100,7 @@
     <property name="act51" value="wait 0.5"/>
     <property name="act52" value="set_variable visitedcottoncafe:yes"/>
     <property name="act53" value="add_item app_tuxepedia"/>
+    <property name="act54" value="translated_dialog app_tuxepedia,,center"/>
     <property name="act88" value="translated_dialog spyder_cotton_tuxepediaintro4"/>
     <property name="act90" value="unlock_controls"/>
     <property name="behav1" value="talk spyder_cottontown_hacker"/>

--- a/mods/tuxemon/maps/spyder_cotton_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_scoop.tmx
@@ -94,19 +94,20 @@
   </object>
   <object id="26" name="Receive capture device" type="event" x="32" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="char_stop player"/>
+    <property name="act10" value="char_stop player"/>
     <property name="act11" value="lock_controls"/>
     <property name="act20" value="pathfind spyder_cottonscoop_joe,5,9"/>
     <property name="act21" value="char_face spyder_cottonscoop_joe,down"/>
     <property name="act22" value="translated_dialog spyder_cottonscoop_deviceoffer"/>
     <property name="act23" value="translated_dialog_choice yes:no,heardcapture"/>
-    <property name="act3" value="add_item tuxeball"/>
+    <property name="act30" value="add_item tuxeball"/>
     <property name="act31" value="add_item tuxeball"/>
     <property name="act32" value="add_item tuxeball"/>
-    <property name="act4" value="add_item tuxeball"/>
-    <property name="act5" value="add_item tuxeball"/>
-    <property name="act7" value="set_variable visitcottonmart:yes"/>
-    <property name="act71" value="unlock_controls"/>
+    <property name="act33" value="add_item tuxeball"/>
+    <property name="act34" value="add_item tuxeball"/>
+    <property name="act35" value="translated_dialog tuxeball,,center"/>
+    <property name="act40" value="set_variable visitcottonmart:yes"/>
+    <property name="act41" value="unlock_controls"/>
     <property name="cond4" value="not variable_set visitcottonmart:yes"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_cotton_town.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_town.tmx
@@ -381,8 +381,11 @@
     <property name="act16" value="char_face player,down"/>
     <property name="act20" value="translated_dialog spyder_cottontown_mom"/>
     <property name="act25" value="add_item nu_phone"/>
+    <property name="act26" value="translated_dialog nu_phone,,center"/>
     <property name="act30" value="add_item app_banking"/>
+    <property name="act31" value="translated_dialog app_banking,,center"/>
     <property name="act35" value="add_item app_map"/>
+    <property name="act36" value="translated_dialog app_map,,center"/>
     <property name="act40" value="pathfind spyder_papertown_mom,23,23"/>
     <property name="act41" value="set_variable spokenmomcotton:yes"/>
     <property name="act42" value="remove_npc spyder_papertown_mom"/>

--- a/mods/tuxemon/maps/spyder_cotton_tunnel.yaml
+++ b/mods/tuxemon/maps/spyder_cotton_tunnel.yaml
@@ -94,7 +94,7 @@ events:
     type: "event"
   Petrified Dung:
     actions:
-    - translated_dialog petrified_dung
+    - translated_dialog petrified_dung,,center
     - add_item petrified_dung
     - remove_npc spyder_cottontunnel_box1
     - set_variable cottontunnel_dung:yes
@@ -110,7 +110,7 @@ events:
     type: "event"
   Candy Tuxeball:
     actions:
-    - translated_dialog tuxeball_candy
+    - translated_dialog tuxeball_candy,,center
     - add_item tuxeball_candy
     - remove_npc spyder_cottontunnel_box2
     - set_variable cottontunnel_candy:yes
@@ -126,7 +126,7 @@ events:
     type: "event"
   Imperial Tea:
     actions:
-    - translated_dialog imperial_tea
+    - translated_dialog imperial_tea,,center
     - add_item imperial_tea
     - remove_npc spyder_cottontunnel_box3
     - set_variable cottontunnel_tea:yes
@@ -142,7 +142,7 @@ events:
     type: "event"
   Imperial Potion:
     actions:
-    - translated_dialog imperial_potion
+    - translated_dialog imperial_potion,,center
     - add_item imperial_potion
     - remove_npc spyder_cottontunnel_box4
     - set_variable cottontunnel_potion:yes
@@ -158,7 +158,7 @@ events:
     type: "event"
   Cureall:
     actions:
-    - translated_dialog cureall
+    - translated_dialog cureall,,center
     - add_item cureall
     - remove_npc spyder_cottontunnel_box5
     - set_variable cottontunnel_cureall:yes
@@ -174,7 +174,7 @@ events:
     type: "event"
   Raise Melee:
     actions:
-    - translated_dialog raise_melee
+    - translated_dialog raise_melee,,center
     - add_item raise_melee
     - remove_npc spyder_cottontunnel_box6
     - set_variable cottontunnel_melee:yes

--- a/mods/tuxemon/maps/spyder_datacenter.tmx
+++ b/mods/tuxemon/maps/spyder_datacenter.tmx
@@ -296,7 +296,8 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_box_goldpass1"/>
     <property name="act2" value="add_item gold_pass"/>
-    <property name="act3" value="remove_npc spyder_box_goldpass"/>
+    <property name="act3" value="translated_dialog gold_pass,,center"/>
+    <property name="act4" value="remove_npc spyder_box_goldpass"/>
     <property name="behav1" value="talk spyder_box_goldpass"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_dojo3.tmx
+++ b/mods/tuxemon/maps/spyder_dojo3.tmx
@@ -144,6 +144,7 @@
     <property name="act20" value="set_monster_health"/>
     <property name="act30" value="set_monster_status"/>
     <property name="act40" value="add_item tm_all_in"/>
+    <property name="act41" value="translated_dialog tm_all_in,,center"/>
     <property name="behav1" value="talk spyder_dojo_saturn"/>
     <property name="cond1" value="not variable_set dojosaturn:yes"/>
    </properties>
@@ -161,6 +162,7 @@
     <property name="act20" value="set_monster_health"/>
     <property name="act30" value="set_monster_status"/>
     <property name="act40" value="add_item tm_blade"/>
+    <property name="act41" value="translated_dialog tm_blade,,center"/>
     <property name="behav1" value="talk spyder_dojo_hephastus"/>
     <property name="cond1" value="not variable_set dojohephastus:yes"/>
    </properties>
@@ -178,6 +180,7 @@
     <property name="act20" value="set_monster_health"/>
     <property name="act30" value="set_monster_status"/>
     <property name="act40" value="add_item tm_panjandrum"/>
+    <property name="act41" value="translated_dialog tm_panjandrum,,center"/>
     <property name="behav1" value="talk spyder_dojo_hermes"/>
     <property name="cond1" value="not variable_set dojohermes:yes"/>
    </properties>
@@ -195,6 +198,7 @@
     <property name="act20" value="set_monster_health"/>
     <property name="act30" value="set_monster_status"/>
     <property name="act40" value="add_item tm_shadow_boxing"/>
+    <property name="act41" value="translated_dialog tm_shadow_boxing,,center"/>
     <property name="behav1" value="talk spyder_dojo_orion"/>
     <property name="cond1" value="not variable_set dojoorion:yes"/>
    </properties>
@@ -212,6 +216,7 @@
     <property name="act20" value="set_monster_health"/>
     <property name="act30" value="set_monster_status"/>
     <property name="act40" value="add_item tm_scope"/>
+    <property name="act41" value="translated_dialog tm_scope,,center"/>
     <property name="behav1" value="talk spyder_dojo_ares"/>
     <property name="cond1" value="not variable_set dojoares:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_dojo4.tmx
+++ b/mods/tuxemon/maps/spyder_dojo4.tmx
@@ -98,6 +98,7 @@
     <property name="act11" value="translated_dialog spyder_dojo_strength"/>
     <property name="act15" value="set_variable dojothrimonster:yes"/>
     <property name="act30" value="add_monster sampsack,35"/>
+    <property name="act31" value="translated_dialog sampsack,,center"/>
     <property name="cond1" value="is variable_set thriquestion:strength"/>
     <property name="cond2" value="not variable_set dojothrimonster:yes"/>
     <property name="cond3" value="not variable_set thriquestion:strategy"/>
@@ -108,6 +109,7 @@
     <property name="act11" value="translated_dialog spyder_dojo_strategy"/>
     <property name="act15" value="set_variable dojothrimonster:yes"/>
     <property name="act30" value="add_monster sampsage,35"/>
+    <property name="act31" value="translated_dialog sampsage,,center"/>
     <property name="cond1" value="is variable_set thriquestion:strategy"/>
     <property name="cond2" value="not variable_set dojothrimonster:yes"/>
     <property name="cond3" value="not variable_set thriquestion:strength"/>

--- a/mods/tuxemon/maps/spyder_dryadsgrove.tmx
+++ b/mods/tuxemon/maps/spyder_dryadsgrove.tmx
@@ -832,9 +832,10 @@
     <property name="act1" value="translated_dialog spyder_dryadsgrove_boy_yes"/>
     <property name="act2" value="set_variable ruff:proceed"/>
     <property name="act3" value="add_monster wolffsky,10"/>
-    <property name="act4" value="set_monster_attribute add_monster,name,RUFF"/>
-    <property name="act5" value="set_monster_attribute add_monster,gender,male"/>
-    <property name="act6" value="set_monster_attribute add_monster,traded,1"/>
+    <property name="act4" value="translated_dialog wolffsky,,center"/>
+    <property name="act5" value="set_monster_attribute add_monster,name,RUFF"/>
+    <property name="act6" value="set_monster_attribute add_monster,gender,male"/>
+    <property name="act7" value="set_monster_attribute add_monster,traded,1"/>
     <property name="cond1" value="is variable_set ruff:yes"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_greenwash.tmx
+++ b/mods/tuxemon/maps/spyder_greenwash.tmx
@@ -77,6 +77,7 @@
     <property name="act23" value="translated_dialog spyder_greenwash_looten4"/>
     <property name="act40" value="set_variable gotaardant:yes"/>
     <property name="act50" value="add_item aardant"/>
+    <property name="act51" value="translated_dialog aardant,,center"/>
     <property name="behav1" value="talk spyder_greenwash_looten"/>
     <property name="cond1" value="not variable_set gotaardant:yes"/>
    </properties>
@@ -174,15 +175,16 @@
   </object>
   <object id="81" name="Talk Broer" type="event" x="112" y="96" width="48" height="16">
    <properties>
-    <property name="act1" value="lock_controls"/>
-    <property name="act2" value="pathfind_to_player spyder_greenwash_broer"/>
-    <property name="act3" value="translated_dialog spyder_greenwash_broer1"/>
-    <property name="act4" value="unlock_controls"/>
-    <property name="act5" value="add_monster coleorus,26,spyder_greenwash_broer,5,10"/>
-    <property name="act6" value="start_battle player,spyder_greenwash_broer"/>
-    <property name="act7" value="translated_dialog spyder_greenwash_broer2"/>
-    <property name="act8" value="add_item potion"/>
-    <property name="act9" value="set_variable greenwashbroer:yes"/>
+    <property name="act01" value="lock_controls"/>
+    <property name="act02" value="pathfind_to_player spyder_greenwash_broer"/>
+    <property name="act03" value="translated_dialog spyder_greenwash_broer1"/>
+    <property name="act04" value="unlock_controls"/>
+    <property name="act05" value="add_monster coleorus,26,spyder_greenwash_broer,5,10"/>
+    <property name="act06" value="start_battle player,spyder_greenwash_broer"/>
+    <property name="act07" value="translated_dialog spyder_greenwash_broer2"/>
+    <property name="act08" value="add_item potion"/>
+    <property name="act09" value="translated_dialog potion,,center"/>
+    <property name="act10" value="set_variable greenwashbroer:yes"/>
     <property name="cond1" value="not variable_set greenwashbroer:yes"/>
     <property name="cond2" value="is char_at player"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_greenwash_level2.tmx
+++ b/mods/tuxemon/maps/spyder_greenwash_level2.tmx
@@ -260,8 +260,9 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_greenwash_fossilisator4"/>
     <property name="act2" value="add_monster rhincus,30"/>
-    <property name="act3" value="add_item rhincus_fossil,-1"/>
-    <property name="act4" value="set_variable got_rhincus:yes"/>
+    <property name="act3" value="translated_dialog rhincus,,center"/>
+    <property name="act4" value="add_item rhincus_fossil,-1"/>
+    <property name="act5" value="set_variable got_rhincus:yes"/>
     <property name="cond1" value="is variable_set rhincus_choice:yes"/>
     <property name="cond2" value="not variable_set got_rhincus:yes"/>
    </properties>
@@ -270,8 +271,9 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_greenwash_fossilisator6"/>
     <property name="act2" value="add_monster shammer,30"/>
-    <property name="act3" value="add_item shammer_fossil,-1"/>
-    <property name="act4" value="set_variable got_shammer:yes"/>
+    <property name="act3" value="translated_dialog shammer,,center"/>
+    <property name="act4" value="add_item shammer_fossil,-1"/>
+    <property name="act5" value="set_variable got_shammer:yes"/>
     <property name="cond1" value="is variable_set shammer_choice:yes"/>
     <property name="cond2" value="not variable_set got_shammer:yes"/>
    </properties>
@@ -292,10 +294,12 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_greenwash_fossilisator9"/>
     <property name="act2" value="add_monster shammer,30"/>
-    <property name="act3" value="add_monster rhincus,30"/>
-    <property name="act4" value="add_item shammer_fossil,-1"/>
-    <property name="act5" value="add_item rhincus_fossil,-1"/>
-    <property name="act6" value="set_variable got_both_fossils:yes"/>
+    <property name="act3" value="translated_dialog shammer,,center"/>
+    <property name="act4" value="add_monster rhincus,30"/>
+    <property name="act5" value="translated_dialog rhincus,,center"/>
+    <property name="act6" value="add_item shammer_fossil,-1"/>
+    <property name="act7" value="add_item rhincus_fossil,-1"/>
+    <property name="act8" value="set_variable got_both_fossils:yes"/>
     <property name="cond1" value="is variable_set both_fossils:yes"/>
     <property name="cond2" value="not variable_set got_both_fossils:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_mansion.tmx
+++ b/mods/tuxemon/maps/spyder_mansion.tmx
@@ -310,7 +310,8 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_mansion_lucy3"/>
     <property name="act2" value="add_item mystery_tea"/>
-    <property name="act3" value="set_variable tealucy:yes"/>
+    <property name="act3" value="translated_dialog mystery_tea,,center"/>
+    <property name="act4" value="set_variable tealucy:yes"/>
     <property name="behav1" value="talk spyder_mansion_lucy"/>
     <property name="cond1" value="is variable_set mansionlucy:yes"/>
     <property name="cond2" value="not variable_set tealucy:yes"/>

--- a/mods/tuxemon/maps/spyder_mansion_top.tmx
+++ b/mods/tuxemon/maps/spyder_mansion_top.tmx
@@ -196,7 +196,8 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_top_magician1"/>
     <property name="act2" value="add_item dojo_pass"/>
-    <property name="act3" value="set_variable dojomagician:yes"/>
+    <property name="act3" value="translated_dialog dojo_pass,,center"/>
+    <property name="act4" value="set_variable dojomagician:yes"/>
     <property name="behav1" value="talk spyder_top_lenny"/>
     <property name="cond1" value="not variable_set dojomagician:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_omnichannel1.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel1.tmx
@@ -171,7 +171,8 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_omnichannel_nurse"/>
     <property name="act2" value="add_item spyder_pass"/>
-    <property name="act3" value="set_variable nurse_spyder:yes"/>
+    <property name="act3" value="translated_dialog spyder_pass,,center"/>
+    <property name="act4" value="set_variable nurse_spyder:yes"/>
     <property name="behav1" value="talk spyder_omnichannel_danita"/>
     <property name="cond1" value="not variable_set nurse_spyder:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_paper_town.tmx
+++ b/mods/tuxemon/maps/spyder_paper_town.tmx
@@ -234,6 +234,7 @@
   <object id="219" name="Chosen - Rockitten" type="event" x="512" y="128" width="16" height="16">
    <properties>
     <property name="act1" value="add_monster rockitten,5"/>
+    <property name="act2" value="translated_dialog rockitten,,center"/>
     <property name="act3" value="set_variable firstfightdue:yes"/>
     <property name="act4" value="set_variable mymonchoice:rockitten"/>
     <property name="cond1" value="is variable_set rockittenchosen:yes"/>
@@ -243,6 +244,7 @@
   <object id="220" name="Chosen - Lambert" type="event" x="512" y="160" width="16" height="16">
    <properties>
     <property name="act1" value="add_monster lambert,5"/>
+    <property name="act2" value="translated_dialog lambert,,center"/>
     <property name="act3" value="set_variable firstfightdue:yes"/>
     <property name="act4" value="set_variable mymonchoice:lambert"/>
     <property name="cond1" value="is variable_set lambertchosen:yes"/>
@@ -252,6 +254,7 @@
   <object id="221" name="Chosen - Nut" type="event" x="512" y="192" width="16" height="16">
    <properties>
     <property name="act1" value="add_monster nut,5"/>
+    <property name="act2" value="translated_dialog nut,,center"/>
     <property name="act3" value="set_variable firstfightdue:yes"/>
     <property name="act4" value="set_variable mymonchoice:nut"/>
     <property name="cond1" value="is variable_set nutchosen:yes"/>
@@ -261,6 +264,7 @@
   <object id="222" name="Chosen - Tweesher" type="event" x="512" y="224" width="16" height="16">
    <properties>
     <property name="act1" value="add_monster tweesher,5"/>
+    <property name="act2" value="translated_dialog tweesher,,center"/>
     <property name="act3" value="set_variable firstfightdue:yes"/>
     <property name="act4" value="set_variable mymonchoice:tweesher"/>
     <property name="cond1" value="is variable_set tweesherchosen:yes"/>
@@ -270,6 +274,7 @@
   <object id="223" name="Chosen - Agnite" type="event" x="512" y="256" width="16" height="16">
    <properties>
     <property name="act1" value="add_monster agnite,5"/>
+    <property name="act2" value="translated_dialog agnite,,center"/>
     <property name="act3" value="set_variable firstfightdue:yes"/>
     <property name="act4" value="set_variable mymonchoice:agnite"/>
     <property name="cond1" value="is variable_set agnitechosen:yes"/>

--- a/mods/tuxemon/maps/spyder_route3.tmx
+++ b/mods/tuxemon/maps/spyder_route3.tmx
@@ -210,7 +210,8 @@
     <property name="act06" value="start_battle player,spyder_route3_zoolander"/>
     <property name="act07" value="translated_dialog spyder_route3_zoolander2"/>
     <property name="act08" value="add_item sledgehammer"/>
-    <property name="act09" value="set_variable zoolanderdefeat:yes"/>
+    <property name="act09" value="translated_dialog sledgehammer,,center"/>
+    <property name="act10" value="set_variable zoolanderdefeat:yes"/>
     <property name="behav1" value="talk spyder_route3_zoolander"/>
     <property name="cond1" value="not variable_set zoolanderdefeat:yes"/>
    </properties>
@@ -432,7 +433,8 @@
     <property name="act08" value="start_battle player,spyder_route3_wanda"/>
     <property name="act09" value="translated_dialog spyder_route3_wanda2"/>
     <property name="act10" value="add_item fishing_rod"/>
-    <property name="act11" value="set_variable route3wanda:yes"/>
+    <property name="act11" value="translated_dialog fishing_rod,,center"/>
+    <property name="act12" value="set_variable route3wanda:yes"/>
     <property name="behav1" value="talk spyder_route3_wanda"/>
     <property name="cond1" value="not variable_set route3wanda:yes"/>
    </properties>
@@ -593,7 +595,8 @@
     <property name="act11" value="start_battle player,spyder_route3_wanda"/>
     <property name="act12" value="translated_dialog spyder_route3_wanda2"/>
     <property name="act13" value="add_item fishing_rod"/>
-    <property name="act14" value="set_variable route3wanda:yes"/>
+    <property name="act14" value="translated_dialog fishing_rod,,center"/>
+    <property name="act15" value="set_variable route3wanda:yes"/>
     <property name="cond1" value="not variable_set route3wanda:yes"/>
     <property name="cond2" value="is char_at player"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_route4.tmx
+++ b/mods/tuxemon/maps/spyder_route4.tmx
@@ -474,7 +474,7 @@
   </object>
   <object id="90" name="Super Potion" type="event" x="272" y="512" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog super_potion"/>
+    <property name="act1" value="translated_dialog super_potion,,center"/>
     <property name="act2" value="add_item super_potion"/>
     <property name="act3" value="remove_npc spyder_route4_super"/>
     <property name="act4" value="set_variable route4_super:yes"/>
@@ -490,7 +490,7 @@
   </object>
   <object id="92" name="Boost Ranged" type="event" x="16" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog boost_ranged"/>
+    <property name="act1" value="translated_dialog boost_ranged,,center"/>
     <property name="act2" value="add_item boost_ranged"/>
     <property name="act3" value="remove_npc spyder_route4_boost"/>
     <property name="act4" value="set_variable route4_boost:yes"/>

--- a/mods/tuxemon/maps/spyder_routea.tmx
+++ b/mods/tuxemon/maps/spyder_routea.tmx
@@ -489,7 +489,7 @@
   </object>
   <object id="114" name="Super Potion" type="event" x="144" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog super_potion"/>
+    <property name="act1" value="translated_dialog super_potion,,center"/>
     <property name="act2" value="add_item super_potion"/>
     <property name="act3" value="remove_npc spyder_routea_super"/>
     <property name="act4" value="set_variable routea_super:yes"/>
@@ -505,7 +505,7 @@
   </object>
   <object id="116" name="Tea" type="event" x="224" y="368" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog tea"/>
+    <property name="act1" value="translated_dialog tea,,center"/>
     <property name="act2" value="add_item tea"/>
     <property name="act3" value="remove_npc spyder_routea_tea"/>
     <property name="act4" value="set_variable routea_tea:yes"/>
@@ -521,7 +521,7 @@
   </object>
   <object id="118" name="Cureall" type="event" x="64" y="464" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog cureall"/>
+    <property name="act1" value="translated_dialog cureall,,center"/>
     <property name="act2" value="add_item cureall"/>
     <property name="act3" value="remove_npc spyder_routea_cureall"/>
     <property name="act4" value="set_variable routea_cureall:yes"/>

--- a/mods/tuxemon/maps/spyder_timber_town.tmx
+++ b/mods/tuxemon/maps/spyder_timber_town.tmx
@@ -136,14 +136,15 @@
   </object>
   <object id="329" name="Stop! - Scoop" type="event" x="464" y="368" width="16" height="16">
    <properties>
-    <property name="act1" value="char_stop player"/>
-    <property name="act3" value="pathfind spyder_dante,29,25"/>
-    <property name="act4" value="translated_dialog spyder_timber_dante2"/>
-    <property name="act5" value="add_item app_contacts"/>
-    <property name="act6" value="add_contacts spyder_papertown_mom,000"/>
-    <property name="act7" value="add_contacts professor,111"/>
-    <property name="act8" value="pathfind spyder_dante,24,31"/>
-    <property name="act9" value="set_variable timberdantewarn:yes"/>
+    <property name="act01" value="char_stop player"/>
+    <property name="act03" value="pathfind spyder_dante,29,25"/>
+    <property name="act04" value="translated_dialog spyder_timber_dante2"/>
+    <property name="act05" value="add_item app_contacts"/>
+    <property name="act06" value="translated_dialog app_contacts,,center"/>
+    <property name="act07" value="add_contacts spyder_papertown_mom,000"/>
+    <property name="act08" value="add_contacts professor,111"/>
+    <property name="act09" value="pathfind spyder_dante,24,31"/>
+    <property name="act10" value="set_variable timberdantewarn:yes"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="not variable_set timberdantewarn:yes"/>
    </properties>
@@ -356,10 +357,11 @@
     <property name="act07" value="char_face spyder_papertown_mom,up"/>
     <property name="act08" value="translated_dialog spyder_timber_mom1"/>
     <property name="act09" value="add_item surfboard"/>
-    <property name="act10" value="translated_dialog spyder_timber_mom2"/>
-    <property name="act11" value="pathfind spyder_papertown_mom,26,23"/>
-    <property name="act12" value="remove_npc spyder_papertown_mom"/>
-    <property name="act13" value="set_variable timbermom:yes"/>
+    <property name="act10" value="translated_dialog surfboard,,center"/>
+    <property name="act11" value="translated_dialog spyder_timber_mom2"/>
+    <property name="act12" value="pathfind spyder_papertown_mom,26,23"/>
+    <property name="act13" value="remove_npc spyder_papertown_mom"/>
+    <property name="act14" value="set_variable timbermom:yes"/>
     <property name="cond1" value="not variable_set timbermom:yes"/>
     <property name="cond2" value="is variable_set scooparachne:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_tunnel_below.tmx
+++ b/mods/tuxemon/maps/spyder_tunnel_below.tmx
@@ -199,7 +199,7 @@
   </object>
   <object id="55" name="Shammer" type="event" x="48" y="608" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog shammer_fossil"/>
+    <property name="act1" value="translated_dialog shammer_fossil,,center"/>
     <property name="act2" value="add_item shammer_fossil"/>
     <property name="act3" value="remove_npc spyder_tunnelb_shammer"/>
     <property name="act4" value="set_variable tunnelb_shammer:yes"/>
@@ -215,7 +215,7 @@
   </object>
   <object id="57" name="Rhincus" type="event" x="256" y="512" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog rhincus_fossil"/>
+    <property name="act1" value="translated_dialog rhincus_fossil,,center"/>
     <property name="act2" value="add_item rhincus_fossil"/>
     <property name="act3" value="remove_npc spyder_tunnelb_rhincus"/>
     <property name="act4" value="set_variable tunnelb_rhincus:yes"/>

--- a/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
+++ b/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
@@ -176,6 +176,7 @@
     <property name="act1" value="translated_dialog spyder_wayfarer1_maniac1"/>
     <property name="act2" value="add_monster botbot,10"/>
     <property name="act3" value="set_variable gotbotbot:yes"/>
+    <property name="act4" value="translated_dialog botbot,,center"/>
     <property name="cond1" value="is variable_set wayfarer1_botbot:yes"/>
     <property name="cond2" value="is variable_set quebotbot:yes"/>
     <property name="cond3" value="not variable_set gotbotbot:yes"/>


### PR DESCRIPTION
This is a follow-up to a previous [discussion](https://github.com/Tuxemon/Tuxemon/pull/2568#issuecomment-2585921522) (PR #2568) where we agreed to use a central announcement dialogue box on the screen to notify players when they receive items or monsters. This update specifically focuses on items, so now when a player receives an item or a monster from a NPC or any other source, the notification will appear in the center of the screen.