### PR TITLE
removal MonsterShape enum

### DIFF
--- a/mods/tuxemon/db/shape/shapes.json
+++ b/mods/tuxemon/db/shape/shapes.json
@@ -1,128 +1,128 @@
 [
-    {
-      "slug": "blob",
-      "armour": 8,
-      "dodge": 4,
-      "hp": 8,
-      "melee": 4,
-      "ranged": 8,
-      "speed": 4
-    },
-    {
-      "slug": "brute",
-      "armour": 7,
-      "dodge": 5,
-      "hp": 7,
-      "melee": 8,
-      "ranged": 4,
-      "speed": 5
-    },
-    {
-      "slug": "dragon",
-      "armour": 7,
-      "dodge": 5,
-      "hp": 6,
-      "melee": 6,
-      "ranged": 6,
-      "speed": 6
-    },
-    {
-      "slug": "flier",
-      "armour": 5,
-      "dodge": 7,
-      "hp": 4,
-      "melee": 8,
-      "ranged": 4,
-      "speed": 8
-    },
-    {
-      "slug": "grub",
-      "armour": 7,
-      "dodge": 5,
-      "hp": 7,
-      "melee": 4,
-      "ranged": 8,
-      "speed": 5
-    },
-    {
-      "slug": "humanoid",
-      "armour": 5,
-      "dodge": 7,
-      "hp": 4,
-      "melee": 4,
-      "ranged": 8,
-      "speed": 8
-    },
-    {
-      "slug": "hunter",
-      "armour": 4,
-      "dodge": 8,
-      "hp": 5,
-      "melee": 8,
-      "ranged": 4,
-      "speed": 7
-    },
-    {
-      "slug": "landrace",
-      "armour": 8,
-      "dodge": 4,
-      "hp": 8,
-      "melee": 8,
-      "ranged": 4,
-      "speed": 4
-    },
-    {
-      "slug": "leviathan",
-      "armour": 8,
-      "dodge": 4,
-      "hp": 8,
-      "melee": 6,
-      "ranged": 6,
-      "speed": 4
-    },
-    {
-      "slug": "piscine",
-      "armour": 6,
-      "dodge": 6,
-      "hp": 8,
-      "melee": 6,
-      "ranged": 6,
-      "speed": 4
-    },
-    {
-      "slug": "polliwog",
-      "armour": 4,
-      "dodge": 8,
-      "hp": 5,
-      "melee": 4,
-      "ranged": 8,
-      "speed": 7
-    },
-    {
-      "slug": "serpent",
-      "armour": 6,
-      "dodge": 6,
-      "hp": 6,
-      "melee": 4,
-      "ranged": 8,
-      "speed": 6
-    },
-    {
-      "slug": "sprite",
-      "armour": 6,
-      "dodge": 6,
-      "hp": 4,
-      "melee": 6,
-      "ranged": 6,
-      "speed": 8
-    },
-    {
-      "slug": "varmint",
-      "armour": 6,
-      "dodge": 6,
-      "hp": 6,
-      "melee": 8,
-      "ranged": 4,
-      "speed": 6
-    }
-  ]
+  {
+    "slug": "blob",
+    "armour": 8,
+    "dodge": 4,
+    "hp": 8,
+    "melee": 4,
+    "ranged": 8,
+    "speed": 4
+  },
+  {
+    "slug": "brute",
+    "armour": 7,
+    "dodge": 5,
+    "hp": 7,
+    "melee": 8,
+    "ranged": 4,
+    "speed": 5
+  },
+  {
+    "slug": "dragon",
+    "armour": 7,
+    "dodge": 5,
+    "hp": 6,
+    "melee": 6,
+    "ranged": 6,
+    "speed": 6
+  },
+  {
+    "slug": "flier",
+    "armour": 5,
+    "dodge": 7,
+    "hp": 4,
+    "melee": 8,
+    "ranged": 4,
+    "speed": 8
+  },
+  {
+    "slug": "grub",
+    "armour": 7,
+    "dodge": 5,
+    "hp": 7,
+    "melee": 4,
+    "ranged": 8,
+    "speed": 5
+  },
+  {
+    "slug": "humanoid",
+    "armour": 5,
+    "dodge": 7,
+    "hp": 4,
+    "melee": 4,
+    "ranged": 8,
+    "speed": 8
+  },
+  {
+    "slug": "hunter",
+    "armour": 4,
+    "dodge": 8,
+    "hp": 5,
+    "melee": 8,
+    "ranged": 4,
+    "speed": 7
+  },
+  {
+    "slug": "landrace",
+    "armour": 8,
+    "dodge": 4,
+    "hp": 8,
+    "melee": 8,
+    "ranged": 4,
+    "speed": 4
+  },
+  {
+    "slug": "leviathan",
+    "armour": 8,
+    "dodge": 4,
+    "hp": 8,
+    "melee": 6,
+    "ranged": 6,
+    "speed": 4
+  },
+  {
+    "slug": "piscine",
+    "armour": 6,
+    "dodge": 6,
+    "hp": 8,
+    "melee": 6,
+    "ranged": 6,
+    "speed": 4
+  },
+  {
+    "slug": "polliwog",
+    "armour": 4,
+    "dodge": 8,
+    "hp": 5,
+    "melee": 4,
+    "ranged": 8,
+    "speed": 7
+  },
+  {
+    "slug": "serpent",
+    "armour": 6,
+    "dodge": 6,
+    "hp": 6,
+    "melee": 4,
+    "ranged": 8,
+    "speed": 6
+  },
+  {
+    "slug": "sprite",
+    "armour": 6,
+    "dodge": 6,
+    "hp": 4,
+    "melee": 6,
+    "ranged": 6,
+    "speed": 8
+  },
+  {
+    "slug": "varmint",
+    "armour": 6,
+    "dodge": 6,
+    "hp": 6,
+    "melee": 8,
+    "ranged": 4,
+    "speed": 6
+  }
+]

--- a/tests/tuxemon/test_monster.py
+++ b/tests/tuxemon/test_monster.py
@@ -3,14 +3,7 @@
 import unittest
 
 from tuxemon import formula, prepare
-from tuxemon.db import (
-    MonsterShape,
-    ShapeModel,
-    TasteCold,
-    TasteWarm,
-    TechniqueModel,
-    db,
-)
+from tuxemon.db import ShapeModel, TasteCold, TasteWarm, TechniqueModel, db
 from tuxemon.monster import Monster
 from tuxemon.prepare import MAX_LEVEL
 from tuxemon.technique.technique import Technique
@@ -79,7 +72,7 @@ class SetStats(MonsterTestBase):
         self.assertEqual(self.mon.hp, self.value)
 
     def test_set_stats_shape(self):
-        self.mon.shape = MonsterShape.dragon
+        self.mon.shape = "dragon"
         self.mon.set_stats()
         _shape = self._shape
         self.assertEqual(self.mon.armour, _shape.armour * self.value)

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -120,24 +120,6 @@ class OutputBattle(str, Enum):
     draw = "draw"
 
 
-class MonsterShape(str, Enum):
-    default = "default"
-    blob = "blob"
-    brute = "brute"
-    dragon = "dragon"
-    flier = "flier"
-    grub = "grub"
-    humanoid = "humanoid"
-    hunter = "hunter"
-    landrace = "landrace"
-    leviathan = "leviathan"
-    piscine = "piscine"
-    polliwog = "polliwog"
-    serpent = "serpent"
-    sprite = "sprite"
-    varmint = "varmint"
-
-
 class SeenStatus(str, Enum):
     unseen = "unseen"
     seen = "seen"
@@ -327,7 +309,7 @@ class ItemModel(BaseModel):
 
 
 class ShapeModel(BaseModel):
-    slug: MonsterShape = Field(..., description="Slug of the shape")
+    slug: str = Field(..., description="Slug of the shape")
     armour: int = Field(..., description="Armour value")
     dodge: int = Field(..., description="Dodge value")
     hp: int = Field(..., description="HP value")
@@ -610,7 +592,7 @@ class MonsterModel(BaseModel, validate_assignment=True):
     sprites: Annotated[
         Optional[MonsterSpritesModel], Field(validate_default=True)
     ] = None
-    shape: MonsterShape = Field(..., description="The shape of the monster")
+    shape: str = Field(..., description="The shape of the monster")
     tags: Sequence[str] = Field(
         ..., description="The tags of the monster", min_length=1
     )
@@ -675,6 +657,12 @@ class MonsterModel(BaseModel, validate_assignment=True):
         if has.translation(f"cat_{v}"):
             return v
         raise ValueError(f"no translation exists with msgid: {v}")
+
+    @field_validator("shape")
+    def shape_exists(cls: MonsterModel, v: str) -> str:
+        if has.db_entry("shape", v):
+            return v
+        raise ValueError(f"the shape {v} doesn't exist in the db")
 
 
 class StatModel(BaseModel):

--- a/tuxemon/event/actions/get_player_monster.py
+++ b/tuxemon/event/actions/get_player_monster.py
@@ -11,7 +11,6 @@ from tuxemon.db import (
     ElementType,
     EvolutionStage,
     GenderType,
-    MonsterShape,
     StatType,
     TasteCold,
     TasteWarm,
@@ -110,11 +109,7 @@ class GetPlayerMonsterAction(EventAction):
                 self.result = True
                 return self.result
             # filter shape
-            if (
-                filter_name == "shape"
-                and value_name in list(MonsterShape)
-                and target.shape == value_name
-            ):
+            if filter_name == "shape" and target.shape == value_name:
                 self.result = True
                 return self.result
             # filter taste warm

--- a/tuxemon/event/actions/random_monster.py
+++ b/tuxemon/event/actions/random_monster.py
@@ -6,7 +6,7 @@ import random as rd
 from dataclasses import dataclass
 from typing import Union, final
 
-from tuxemon.db import EvolutionStage, MonsterModel, MonsterShape, db
+from tuxemon.db import EvolutionStage, MonsterModel, db
 from tuxemon.event.eventaction import EventAction
 
 lookup_cache: dict[str, MonsterModel] = {}
@@ -46,11 +46,8 @@ class RandomMonsterAction(EventAction):
         if not lookup_cache:
             _lookup_monsters()
 
-        valid_shapes = list(MonsterShape)
         valid_evos = list(EvolutionStage)
 
-        if self.shape and self.shape not in valid_shapes:
-            raise ValueError(f"{self.shape} is not a valid shape.")
         if self.evo and self.evo not in valid_evos:
             raise ValueError(f"{self.evo} is not a valid evolution stage.")
 

--- a/tuxemon/item/effects/fishing.py
+++ b/tuxemon/item/effects/fishing.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Union
 
 from tuxemon import prepare
-from tuxemon.db import EvolutionStage, MonsterModel, MonsterShape, db
+from tuxemon.db import EvolutionStage, MonsterModel, db
 from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
 
 if TYPE_CHECKING:
@@ -81,7 +81,7 @@ def _get_basic_monsters() -> list[str]:
         mon.slug
         for mon in lookup_cache.values()
         if mon.stage == EvolutionStage.basic
-        and mon.shape in [MonsterShape.polliwog, MonsterShape.piscine]
+        and mon.shape in ["polliwog", "piscine"]
     ]
 
 
@@ -91,7 +91,7 @@ def _get_advanced_monsters() -> list[str]:
         mon.slug
         for mon in lookup_cache.values()
         if mon.stage in [EvolutionStage.stage1, EvolutionStage.basic]
-        and mon.shape in [MonsterShape.polliwog, MonsterShape.piscine]
+        and mon.shape in ["polliwog", "piscine"]
     ]
 
 
@@ -103,9 +103,9 @@ def _get_pro_monsters() -> list[str]:
         if mon.stage != EvolutionStage.basic
         and mon.shape
         in [
-            MonsterShape.polliwog,
-            MonsterShape.piscine,
-            MonsterShape.leviathan,
+            "polliwog",
+            "piscine",
+            "leviathan",
         ]
     ]
 

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -22,7 +22,6 @@ from tuxemon.db import (
     MonsterEvolutionItemModel,
     MonsterHistoryItemModel,
     MonsterMovesetItemModel,
-    MonsterShape,
     PlagueType,
     ResponseCondition,
     StatType,
@@ -134,7 +133,7 @@ class Monster:
 
         self.types: list[Element] = []
         self.default_types: list[Element] = []
-        self.shape = MonsterShape.default
+        self.shape = ""
         self.randomly = True
         self.out_of_range = False
         self.got_experience = False
@@ -207,7 +206,7 @@ class Monster:
         self.description = T.translate(f"{results.slug}_description")
         self.cat = results.category
         self.category = T.translate(f"cat_{self.cat}")
-        self.shape = results.shape or MonsterShape.default
+        self.shape = results.shape
         self.stage = results.stage or EvolutionStage.standalone
         self.taste_cold = self.set_taste_cold(self.taste_cold)
         self.taste_warm = self.set_taste_warm(self.taste_warm)

--- a/tuxemon/shape.py
+++ b/tuxemon/shape.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
-from tuxemon.db import MonsterShape, db
+from tuxemon.db import db
 
 logger = logging.getLogger(__name__)
 
@@ -14,7 +14,7 @@ class Shape:
     """A shape holds all the values (speed, ranged, etc.)."""
 
     def __init__(self, slug: Optional[str] = None) -> None:
-        self.slug: MonsterShape = MonsterShape.landrace
+        self.slug = slug
         self.armour: int = 1
         self.dodge: int = 1
         self.hp: int = 1
@@ -22,21 +22,17 @@ class Shape:
         self.ranged: int = 1
         self.speed: int = 1
 
-        if slug:
-            self.load(slug)
+        if self.slug:
+            self.load(self.slug)
 
     def load(self, slug: str) -> None:
         """Loads shape."""
 
-        if slug == MonsterShape.default:
-            return
-
         try:
             results = db.lookup(slug, table="shape")
         except KeyError:
-            raise RuntimeError(f"Shape {slug} not found")
+            raise RuntimeError(f"Shape {self.slug} not found")
 
-        self.slug = results.slug
         self.armour = results.armour
         self.dodge = results.dodge
         self.hp = results.hp

--- a/tuxemon/technique/effects/photogenesis.py
+++ b/tuxemon/technique/effects/photogenesis.py
@@ -51,8 +51,7 @@ class PhotogenesisEffect(TechEffect):
         )
 
         hour = int(player.game_variables.get("hour", 0))
-        shape = Shape()
-        shape.load(user.shape.value)
+        shape = Shape(user.shape)
         max_multiplier = shape.hp / 2
 
         multiplier = formula.calculate_time_based_multiplier(


### PR DESCRIPTION
This PR makes the shape system more flexible and moddable by removing the hardcoded `MonsterShape` enum and instead using a string to represent the shape. This change makes it easier for modders to create custom content and adds flexibility to the shape system.