### PR TITLE
fix GiveEffect (technique)

### DIFF
--- a/tuxemon/technique/effects/give.py
+++ b/tuxemon/technique/effects/give.py
@@ -53,11 +53,11 @@ class GiveEffect(TechEffect):
             status = Condition()
             status.load(self.condition)
             status.steps = player.steps
+            status.link = user
 
             monsters = get_target_monsters(objectives, tech, user, target)
             if monsters:
                 for monster in monsters:
-                    status.link = monster
                     monster.apply_status(status)
                 combat.reset_status_icons()
 


### PR DESCRIPTION
PR to fix a small issue in the `GiveEffect` (technique). The problem is that the link is currently related to the target, but it should be related to the user instead. This is causing issues with certain statuses, such as life leech, because both the user and the target need to be able to receive effects.

---

@Sanglorian unrelated:
- does life leech stop working once the monster's health is fully restored?
- the sacrifice effect seems overpowered because it deals damage to the opponent based on a multiplier of the monster's total HP. I think it would be more balanced if the effect only used the monster's current HP (or a percentage of it) to calculate the damage, rather than a multiplier of its total HP. What do you think? I'm talking about Undertaker.
- currently, when a technique's conditions aren't met (field called 'conditions' in the JSON), it can't be used and a popup appears saying the technique is unavailable. This forces the player to choose a different technique. My question is: is this the best approach? Wouldn't it be better to allow the player to use the technique even if it fails, rather than restricting them from using it altogether? This only applies to a small number of techniques.