### PR TITLE
Refactor conditions and effects to use CommonCondition and CommonEffect (Items)

### DIFF
--- a/mods/tuxemon/db/item/ancient_tea.json
+++ b/mods/tuxemon/db/item/ancient_tea.json
@@ -1,7 +1,10 @@
 {
   "conditions": [],
   "effects": [
-    "gain_xp 1277"
+    {
+      "type": "gain_xp",
+      "parameters": ["1277"]
+    }
   ],
   "slug": "ancient_tea",
   "sort": "potion",

--- a/mods/tuxemon/db/item/boost_armour.json
+++ b/mods/tuxemon/db/item/boost_armour.json
@@ -1,7 +1,10 @@
 {
   "conditions": [],
   "effects": [
-    "buff armour,0.2"
+    {
+      "type": "buff",
+      "parameters": ["armour","0.2"]
+    }
   ],
   "slug": "boost_armour",
   "sort": "utility",

--- a/mods/tuxemon/db/item/boost_dodge.json
+++ b/mods/tuxemon/db/item/boost_dodge.json
@@ -1,7 +1,10 @@
 {
   "conditions": [],
   "effects": [
-    "buff dodge,0.2"
+    {
+      "type": "buff",
+      "parameters": ["dodge","0.2"]
+    }
   ],
   "slug": "boost_dodge",
   "sort": "utility",

--- a/mods/tuxemon/db/item/boost_melee.json
+++ b/mods/tuxemon/db/item/boost_melee.json
@@ -1,7 +1,10 @@
 {
   "conditions": [],
   "effects": [
-    "buff melee,0.2"
+    {
+      "type": "buff",
+      "parameters": ["melee","0.2"]
+    }
   ],
   "slug": "boost_melee",
   "sort": "utility",

--- a/mods/tuxemon/db/item/boost_ranged.json
+++ b/mods/tuxemon/db/item/boost_ranged.json
@@ -1,7 +1,10 @@
 {
   "conditions": [],
   "effects": [
-    "buff ranged,0.2"
+    {
+      "type": "buff",
+      "parameters": ["ranged","0.2"]
+    }
   ],
   "slug": "boost_ranged",
   "sort": "utility",

--- a/mods/tuxemon/db/item/boost_speed.json
+++ b/mods/tuxemon/db/item/boost_speed.json
@@ -1,7 +1,10 @@
 {
   "conditions": [],
   "effects": [
-    "buff speed,0.2"
+    {
+      "type": "buff",
+      "parameters": ["speed","0.2"]
+    }
   ],
   "slug": "boost_speed",
   "sort": "utility",

--- a/mods/tuxemon/db/item/booster_tech.json
+++ b/mods/tuxemon/db/item/booster_tech.json
@@ -1,10 +1,19 @@
 {
   "conditions": [
-    "is can_evolve",
-    "is has_path booster_tech"
+    {
+      "type": "can_evolve",
+      "operator": "is"
+    },
+    {
+      "type": "has_path",
+      "parameters": ["booster_tech"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "evolve"
+    {
+      "type": "evolve"
+    }
   ],
   "slug": "booster_tech",
   "sort": "utility",

--- a/mods/tuxemon/db/item/cureall.json
+++ b/mods/tuxemon/db/item/cureall.json
@@ -1,11 +1,24 @@
 {
   "conditions": [
-    "is current_hp <,1.0",
-    "is current_hp >,0"
+    {
+      "type": "current_hp",
+      "parameters": ["<", "1.0"],
+      "operator": "is"
+    },
+    {
+      "type": "current_hp",
+      "parameters": [">", "0"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "heal 1.0,percentage",
-    "restore"
+    {
+      "type": "heal",
+      "parameters": ["1.0","percentage"]
+    },
+    {
+      "type": "restore"
+    }
   ],
   "slug": "cureall",
   "sort": "potion",

--- a/mods/tuxemon/db/item/earth_booster.json
+++ b/mods/tuxemon/db/item/earth_booster.json
@@ -1,10 +1,19 @@
 {
   "conditions": [
-    "is can_evolve",
-    "is has_path earth_booster"
+    {
+      "type": "can_evolve",
+      "operator": "is"
+    },
+    {
+      "type": "has_path",
+      "parameters": ["earth_booster"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "evolve"
+    {
+      "type": "evolve"
+    }
   ],
   "slug": "earth_booster",
   "sort": "utility",

--- a/mods/tuxemon/db/item/fire_berry.json
+++ b/mods/tuxemon/db/item/fire_berry.json
@@ -1,9 +1,16 @@
 {
   "conditions": [
-    "not type fire"
+    {
+      "type": "type",
+      "parameters": ["fire"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "switch fire"
+    {
+      "type": "switch",
+      "parameters": ["fire"]
+    }
   ],
   "slug": "fire_berry",
   "sort": "utility",

--- a/mods/tuxemon/db/item/fire_booster.json
+++ b/mods/tuxemon/db/item/fire_booster.json
@@ -1,10 +1,19 @@
 {
   "conditions": [
-    "is can_evolve",
-    "is has_path fire_booster"
+    {
+      "type": "can_evolve",
+      "operator": "is"
+    },
+    {
+      "type": "has_path",
+      "parameters": ["fire_booster"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "evolve"
+    {
+      "type": "evolve"
+    }
   ],
   "slug": "fire_booster",
   "sort": "utility",

--- a/mods/tuxemon/db/item/fishing_rod.json
+++ b/mods/tuxemon/db/item/fishing_rod.json
@@ -1,9 +1,16 @@
 {
   "conditions": [
-    "is facing_tile surfable"
+    {
+      "type": "facing_tile",
+      "parameters": ["surfable"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "fishing 0.35,5,15"
+    {
+      "type": "fishing",
+      "parameters": ["0.35","5","15"]
+    }
   ],
   "slug": "fishing_rod",
   "sort": "utility",

--- a/mods/tuxemon/db/item/flintstone.json
+++ b/mods/tuxemon/db/item/flintstone.json
@@ -1,10 +1,19 @@
 {
   "conditions": [
-    "is can_evolve",
-    "is has_path flintstone"
+    {
+      "type": "can_evolve",
+      "operator": "is"
+    },
+    {
+      "type": "has_path",
+      "parameters": ["flintstone"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "evolve"
+    {
+      "type": "evolve"
+    }
   ],
   "slug": "flintstone",
   "sort": "utility",

--- a/mods/tuxemon/db/item/hatchet.json
+++ b/mods/tuxemon/db/item/hatchet.json
@@ -1,9 +1,15 @@
 {
   "conditions": [
-    "is facing_sprite log"
+    {
+      "type": "facing_sprite",
+      "parameters": ["log"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "remove"
+    {
+      "type": "remove"
+    }
   ],
   "slug": "hatchet",
   "sort": "utility",

--- a/mods/tuxemon/db/item/imperial_potion.json
+++ b/mods/tuxemon/db/item/imperial_potion.json
@@ -1,10 +1,21 @@
 {
   "conditions": [
-    "is current_hp <,1.0",
-    "is current_hp >,0"
+    {
+      "type": "current_hp",
+      "parameters": ["<", "1.0"],
+      "operator": "is"
+    },
+    {
+      "type": "current_hp",
+      "parameters": [">", "0"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "heal 500,fixed"
+    {
+      "type": "heal",
+      "parameters": ["500","fixed"]
+    }
   ],
   "slug": "imperial_potion",
   "sort": "potion",

--- a/mods/tuxemon/db/item/imperial_tea.json
+++ b/mods/tuxemon/db/item/imperial_tea.json
@@ -1,7 +1,10 @@
 {
   "conditions": [],
   "effects": [
-    "gain_xp 3005"
+    {
+      "type": "gain_xp",
+      "parameters": ["3005"]
+    }
   ],
   "slug": "imperial_tea",
   "sort": "potion",

--- a/mods/tuxemon/db/item/lima_pie.json
+++ b/mods/tuxemon/db/item/lima_pie.json
@@ -1,10 +1,19 @@
 {
   "conditions": [
-    "is can_evolve",
-    "is has_path lima_pie"
+    {
+      "type": "can_evolve",
+      "operator": "is"
+    },
+    {
+      "type": "has_path",
+      "parameters": ["lima_pie"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "evolve"
+    {
+      "type": "evolve"
+    }
   ],
   "slug": "lima_pie",
   "sort": "utility",

--- a/mods/tuxemon/db/item/lucky_bamboo.json
+++ b/mods/tuxemon/db/item/lucky_bamboo.json
@@ -1,10 +1,19 @@
 {
   "conditions": [
-    "is can_evolve",
-    "is has_path lucky_bamboo"
+    {
+      "type": "can_evolve",
+      "operator": "is"
+    },
+    {
+      "type": "has_path",
+      "parameters": ["lucky_bamboo"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "evolve"
+    {
+      "type": "evolve"
+    }
   ],
   "slug": "lucky_bamboo",
   "sort": "utility",

--- a/mods/tuxemon/db/item/mega_potion.json
+++ b/mods/tuxemon/db/item/mega_potion.json
@@ -1,10 +1,21 @@
 {
   "conditions": [
-    "is current_hp <,1.0",
-    "is current_hp >,0"
+    {
+      "type": "current_hp",
+      "parameters": ["<", "1.0"],
+      "operator": "is"
+    },
+    {
+      "type": "current_hp",
+      "parameters": [">", "0"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "heal 200,fixed"
+    {
+      "type": "heal",
+      "parameters": ["200","fixed"]
+    }
   ],
   "slug": "mega_potion",
   "sort": "potion",

--- a/mods/tuxemon/db/item/metal_booster.json
+++ b/mods/tuxemon/db/item/metal_booster.json
@@ -1,10 +1,19 @@
 {
   "conditions": [
-    "is can_evolve",
-    "is has_path metal_booster"
+    {
+      "type": "can_evolve",
+      "operator": "is"
+    },
+    {
+      "type": "has_path",
+      "parameters": ["metal_booster"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "evolve"
+    {
+      "type": "evolve"
+    }
   ],
   "slug": "metal_booster",
   "sort": "utility",

--- a/mods/tuxemon/db/item/metal_cherry.json
+++ b/mods/tuxemon/db/item/metal_cherry.json
@@ -1,9 +1,16 @@
 {
   "conditions": [
-    "not type metal"
+    {
+      "type": "type",
+      "parameters": ["metal"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "switch metal"
+    {
+      "type": "switch",
+      "parameters": ["metal"]
+    }
   ],
   "slug": "metal_cherry",
   "sort": "utility",

--- a/mods/tuxemon/db/item/miaow_milk.json
+++ b/mods/tuxemon/db/item/miaow_milk.json
@@ -1,10 +1,19 @@
 {
   "conditions": [
-    "is can_evolve",
-    "is has_path miaow_milk"
+    {
+      "type": "can_evolve",
+      "operator": "is"
+    },
+    {
+      "type": "has_path",
+      "parameters": ["miaow_milk"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "evolve"
+    {
+      "type": "evolve"
+    }
   ],
   "slug": "miaow_milk",
   "sort": "utility",

--- a/mods/tuxemon/db/item/mm_earth.json
+++ b/mods/tuxemon/db/item/mm_earth.json
@@ -1,9 +1,16 @@
 {
   "conditions": [
-    "is type earth"
+    {
+      "type": "type",
+      "parameters": ["earth"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "learn_mm earth"
+    {
+      "type": "learn_mm",
+      "parameters": ["earth"]
+    }
   ],
   "slug": "mm_earth",
   "sort": "utility",

--- a/mods/tuxemon/db/item/mm_fire.json
+++ b/mods/tuxemon/db/item/mm_fire.json
@@ -1,9 +1,16 @@
 {
   "conditions": [
-    "is type fire"
+    {
+      "type": "type",
+      "parameters": ["fire"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "learn_mm fire"
+    {
+      "type": "learn_mm",
+      "parameters": ["fire"]
+    }
   ],
   "slug": "mm_fire",
   "sort": "utility",

--- a/mods/tuxemon/db/item/mm_metal.json
+++ b/mods/tuxemon/db/item/mm_metal.json
@@ -1,9 +1,16 @@
 {
   "conditions": [
-    "is type metal"
+    {
+      "type": "type",
+      "parameters": ["metal"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "learn_mm metal"
+    {
+      "type": "learn_mm",
+      "parameters": ["metal"]
+    }
   ],
   "slug": "mm_metal",
   "sort": "utility",

--- a/mods/tuxemon/db/item/mm_water.json
+++ b/mods/tuxemon/db/item/mm_water.json
@@ -1,9 +1,16 @@
 {
   "conditions": [
-    "is type water"
+    {
+      "type": "type",
+      "parameters": ["water"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "learn_mm water"
+    {
+      "type": "learn_mm",
+      "parameters": ["water"]
+    }
   ],
   "slug": "mm_water",
   "sort": "utility",

--- a/mods/tuxemon/db/item/mm_wood.json
+++ b/mods/tuxemon/db/item/mm_wood.json
@@ -1,9 +1,16 @@
 {
   "conditions": [
-    "is type wood"
+    {
+      "type": "type",
+      "parameters": ["wood"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "learn_mm wood"
+    {
+      "type": "learn_mm",
+      "parameters": ["wood"]
+    }
   ],
   "slug": "mm_wood",
   "sort": "utility",

--- a/mods/tuxemon/db/item/mystery_tea.json
+++ b/mods/tuxemon/db/item/mystery_tea.json
@@ -1,7 +1,10 @@
 {
   "conditions": [],
   "effects": [
-    "gain_xp 437"
+    {
+      "type": "gain_xp",
+      "parameters": ["437"]
+    }
   ],
   "slug": "mystery_tea",
   "sort": "potion",

--- a/mods/tuxemon/db/item/neptune.json
+++ b/mods/tuxemon/db/item/neptune.json
@@ -1,9 +1,16 @@
 {
   "conditions": [
-    "is facing_tile surfable"
+    {
+      "type": "facing_tile",
+      "parameters": ["surfable"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "fishing 0.65,15,25"
+    {
+      "type": "fishing",
+      "parameters": ["0.65","15","25"]
+    }
   ],
   "slug": "neptune",
   "sort": "utility",

--- a/mods/tuxemon/db/item/omnichannel_badge.json
+++ b/mods/tuxemon/db/item/omnichannel_badge.json
@@ -1,7 +1,14 @@
 {
   "conditions": [
-    "is can_evolve",
-    "is has_path omnichannel_badge"
+    {
+      "type": "can_evolve",
+      "operator": "is"
+    },
+    {
+      "type": "has_path",
+      "parameters": ["omnichannel_badge"],
+      "operator": "is"
+    }
   ],
   "effects": [],
   "slug": "omnichannel_badge",

--- a/mods/tuxemon/db/item/ox_stick.json
+++ b/mods/tuxemon/db/item/ox_stick.json
@@ -1,10 +1,19 @@
 {
   "conditions": [
-    "is can_evolve",
-    "is has_path ox_stick"
+    {
+      "type": "can_evolve",
+      "operator": "is"
+    },
+    {
+      "type": "has_path",
+      "parameters": ["ox_stick"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "evolve"
+    {
+      "type": "evolve"
+    }
   ],
   "slug": "ox_stick",
   "sort": "utility",

--- a/mods/tuxemon/db/item/peace_lily.json
+++ b/mods/tuxemon/db/item/peace_lily.json
@@ -1,10 +1,19 @@
 {
   "conditions": [
-    "is can_evolve",
-    "is has_path peace_lily"
+    {
+      "type": "can_evolve",
+      "operator": "is"
+    },
+    {
+      "type": "has_path",
+      "parameters": ["peace_lily"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "evolve"
+    {
+      "type": "evolve"
+    }
   ],
   "slug": "peace_lily",
   "sort": "utility",

--- a/mods/tuxemon/db/item/petrified_dung.json
+++ b/mods/tuxemon/db/item/petrified_dung.json
@@ -1,10 +1,19 @@
 {
   "conditions": [
-    "is can_evolve",
-    "is has_path petrified_dung"
+    {
+      "type": "can_evolve",
+      "operator": "is"
+    },
+    {
+      "type": "has_path",
+      "parameters": ["petrified_dung"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "evolve"
+    {
+      "type": "evolve"
+    }
   ],
   "slug": "petrified_dung",
   "sort": "utility",

--- a/mods/tuxemon/db/item/poseidon.json
+++ b/mods/tuxemon/db/item/poseidon.json
@@ -1,9 +1,16 @@
 {
   "conditions": [
-    "is facing_tile surfable"
+    {
+      "type": "facing_tile",
+      "parameters": ["surfable"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "fishing 0.85,25,35"
+    {
+      "type": "fishing",
+      "parameters": ["0.85","25","35"]
+    }
   ],
   "slug": "poseidon",
   "sort": "utility",

--- a/mods/tuxemon/db/item/potion.json
+++ b/mods/tuxemon/db/item/potion.json
@@ -1,10 +1,21 @@
 {
   "conditions": [
-    "is current_hp <,1.0",
-    "is current_hp >,0"
+    {
+      "type": "current_hp",
+      "parameters": ["<", "1.0"],
+      "operator": "is"
+    },
+    {
+      "type": "current_hp",
+      "parameters": [">", "0"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "heal 20,fixed"
+    {
+      "type": "heal",
+      "parameters": ["20","fixed"]
+    }
   ],
   "slug": "potion",
   "sort": "potion",

--- a/mods/tuxemon/db/item/pyramidion.json
+++ b/mods/tuxemon/db/item/pyramidion.json
@@ -1,10 +1,19 @@
 {
   "conditions": [
-    "is can_evolve",
-    "is has_path pyramidion"
+    {
+      "type": "can_evolve",
+      "operator": "is"
+    },
+    {
+      "type": "has_path",
+      "parameters": ["pyramidion"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "evolve"
+    {
+      "type": "evolve"
+    }
   ],
   "slug": "pyramidion",
   "sort": "utility",

--- a/mods/tuxemon/db/item/raise_armour.json
+++ b/mods/tuxemon/db/item/raise_armour.json
@@ -1,7 +1,10 @@
 {
   "conditions": [],
   "effects": [
-    "change_stat armour,0.05"
+    {
+      "type": "change_stat",
+      "parameters": ["armour","0.05"]
+    }
   ],
   "slug": "raise_armour",
   "sort": "utility",

--- a/mods/tuxemon/db/item/raise_dodge.json
+++ b/mods/tuxemon/db/item/raise_dodge.json
@@ -1,7 +1,10 @@
 {
   "conditions": [],
   "effects": [
-    "change_stat dodge,0.05"
+    {
+      "type": "change_stat",
+      "parameters": ["dodge","0.05"]
+    }
   ],
   "slug": "raise_dodge",
   "sort": "utility",

--- a/mods/tuxemon/db/item/raise_hp.json
+++ b/mods/tuxemon/db/item/raise_hp.json
@@ -1,7 +1,10 @@
 {
   "conditions": [],
   "effects": [
-    "change_stat hp,0.05"
+    {
+      "type": "change_stat",
+      "parameters": ["hp","0.05"]
+    }
   ],
   "slug": "raise_hp",
   "sort": "utility",

--- a/mods/tuxemon/db/item/raise_melee.json
+++ b/mods/tuxemon/db/item/raise_melee.json
@@ -1,7 +1,10 @@
 {
   "conditions": [],
   "effects": [
-    "change_stat melee,0.05"
+    {
+      "type": "change_stat",
+      "parameters": ["melee","0.05"]
+    }
   ],
   "slug": "raise_melee",
   "sort": "utility",

--- a/mods/tuxemon/db/item/raise_ranged.json
+++ b/mods/tuxemon/db/item/raise_ranged.json
@@ -1,7 +1,10 @@
 {
   "conditions": [],
   "effects": [
-    "change_stat ranged,0.05"
+    {
+      "type": "change_stat",
+      "parameters": ["ranged","0.05"]
+    }
   ],
   "slug": "raise_ranged",
   "sort": "utility",

--- a/mods/tuxemon/db/item/raise_speed.json
+++ b/mods/tuxemon/db/item/raise_speed.json
@@ -1,7 +1,10 @@
 {
   "conditions": [],
   "effects": [
-    "change_stat speed,0.05"
+    {
+      "type": "change_stat",
+      "parameters": ["speed","0.05"]
+    }
   ],
   "slug": "raise_speed",
   "sort": "utility",

--- a/mods/tuxemon/db/item/restoration.json
+++ b/mods/tuxemon/db/item/restoration.json
@@ -1,11 +1,24 @@
 {
   "conditions": [
-    "is has_status",
-    "is current_hp <,1.0",
-    "is current_hp >,0"
+    {
+      "type": "has_status",
+      "operator": "is"
+    },
+    {
+      "type": "current_hp",
+      "parameters": ["<", "1.0"],
+      "operator": "is"
+    },
+    {
+      "type": "current_hp",
+      "parameters": [">", "0"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "restore"
+    {
+      "type": "restore"
+    }
   ],
   "slug": "restoration",
   "sort": "potion",

--- a/mods/tuxemon/db/item/revive.json
+++ b/mods/tuxemon/db/item/revive.json
@@ -1,11 +1,24 @@
 {
   "conditions": [
-    "is current_hp ==,0",
-    "is status faint"
+    {
+      "type": "current_hp",
+      "parameters": ["==", "0"],
+      "operator": "is"
+    },
+    {
+      "type": "status",
+      "parameters": ["faint"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "restore",
-    "heal 20,fixed"
+    {
+      "type": "restore"
+    },
+    {
+      "type": "heal",
+      "parameters": ["20","fixed"]
+    }
   ],
   "slug": "revive",
   "sort": "potion",

--- a/mods/tuxemon/db/item/rhincus_fossil.json
+++ b/mods/tuxemon/db/item/rhincus_fossil.json
@@ -1,10 +1,19 @@
 {
   "conditions": [
-    "is can_evolve",
-    "is has_path rhincus_fossil"
+    {
+      "type": "can_evolve",
+      "operator": "is"
+    },
+    {
+      "type": "has_path",
+      "parameters": ["rhincus_fossil"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "evolve"
+    {
+      "type": "evolve"
+    }
   ],
   "slug": "rhincus_fossil",
   "sort": "utility",

--- a/mods/tuxemon/db/item/scoop_badge.json
+++ b/mods/tuxemon/db/item/scoop_badge.json
@@ -1,7 +1,14 @@
 {
   "conditions": [
-    "is can_evolve",
-    "is has_path scoop_badge"
+    {
+      "type": "can_evolve",
+      "operator": "is"
+    },
+    {
+      "type": "has_path",
+      "parameters": ["scoop_badge"],
+      "operator": "is"
+    }
   ],
   "effects": [],
   "slug": "scoop_badge",

--- a/mods/tuxemon/db/item/sea_girdle.json
+++ b/mods/tuxemon/db/item/sea_girdle.json
@@ -1,10 +1,19 @@
 {
   "conditions": [
-    "is can_evolve",
-    "is has_path sea_girdle"
+    {
+      "type": "can_evolve",
+      "operator": "is"
+    },
+    {
+      "type": "has_path",
+      "parameters": ["sea_girdle"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "evolve"
+    {
+      "type": "evolve"
+    }
   ],
   "slug": "sea_girdle",
   "sort": "utility",

--- a/mods/tuxemon/db/item/shammer_fossil.json
+++ b/mods/tuxemon/db/item/shammer_fossil.json
@@ -1,10 +1,19 @@
 {
   "conditions": [
-    "is can_evolve",
-    "is has_path shammer_fossil"
+    {
+      "type": "can_evolve",
+      "operator": "is"
+    },
+    {
+      "type": "has_path",
+      "parameters": ["shammer_fossil"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "evolve"
+    {
+      "type": "evolve"
+    }
   ],
   "slug": "shammer_fossil",
   "sort": "utility",

--- a/mods/tuxemon/db/item/sledgehammer.json
+++ b/mods/tuxemon/db/item/sledgehammer.json
@@ -1,9 +1,15 @@
 {
   "conditions": [
-    "is facing_sprite boulder"
+    {
+      "type": "facing_sprite",
+      "parameters": ["boulder"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "remove"
+    {
+      "type": "remove"
+    }
   ],
   "slug": "sledgehammer",
   "sort": "utility",

--- a/mods/tuxemon/db/item/stovepipe.json
+++ b/mods/tuxemon/db/item/stovepipe.json
@@ -1,10 +1,19 @@
 {
   "conditions": [
-    "is can_evolve",
-    "is has_path stovepipe"
+    {
+      "type": "can_evolve",
+      "operator": "is"
+    },
+    {
+      "type": "has_path",
+      "parameters": ["stovepipe"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "evolve"
+    {
+      "type": "evolve"
+    }
   ],
   "slug": "stovepipe",
   "sort": "utility",

--- a/mods/tuxemon/db/item/super_potion.json
+++ b/mods/tuxemon/db/item/super_potion.json
@@ -1,10 +1,21 @@
 {
   "conditions": [
-    "is current_hp <,1.0",
-    "is current_hp >,0"
+    {
+      "type": "current_hp",
+      "parameters": ["<", "1.0"],
+      "operator": "is"
+    },
+    {
+      "type": "current_hp",
+      "parameters": [">", "0"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "heal 50,fixed"
+    {
+      "type": "heal",
+      "parameters": ["50","fixed"]
+    }
   ],
   "slug": "super_potion",
   "sort": "potion",

--- a/mods/tuxemon/db/item/sweet_sand.json
+++ b/mods/tuxemon/db/item/sweet_sand.json
@@ -1,10 +1,19 @@
 {
   "conditions": [
-    "is can_evolve",
-    "is has_path sweet_sand"
+    {
+      "type": "can_evolve",
+      "operator": "is"
+    },
+    {
+      "type": "has_path",
+      "parameters": ["sweet_sand"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "evolve"
+    {
+      "type": "evolve"
+    }
   ],
   "slug": "sweet_sand",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tea.json
+++ b/mods/tuxemon/db/item/tea.json
@@ -1,7 +1,10 @@
 {
   "conditions": [],
   "effects": [
-    "gain_xp 107"
+    {
+      "type": "gain_xp",
+      "parameters": ["107"]
+    }
   ],
   "slug": "tea",
   "sort": "potion",

--- a/mods/tuxemon/db/item/tectonic_drill.json
+++ b/mods/tuxemon/db/item/tectonic_drill.json
@@ -1,10 +1,19 @@
 {
   "conditions": [
-    "is can_evolve",
-    "is has_path tectonic_drill"
+    {
+      "type": "can_evolve",
+      "operator": "is"
+    },
+    {
+      "type": "has_path",
+      "parameters": ["tectonic_drill"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "evolve"
+    {
+      "type": "evolve"
+    }
   ],
   "slug": "tectonic_drill",
   "sort": "utility",

--- a/mods/tuxemon/db/item/thunderstone.json
+++ b/mods/tuxemon/db/item/thunderstone.json
@@ -1,10 +1,19 @@
 {
   "conditions": [
-    "is can_evolve",
-    "is has_path thunderstone"
+    {
+      "type": "can_evolve",
+      "operator": "is"
+    },
+    {
+      "type": "has_path",
+      "parameters": ["thunderstone"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "evolve"
+    {
+      "type": "evolve"
+    }
   ],
   "slug": "thunderstone",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tm_all_in.json
+++ b/mods/tuxemon/db/item/tm_all_in.json
@@ -1,9 +1,16 @@
 {
   "conditions": [
-    "not has_tech all_in"
+    {
+      "type": "has_tech",
+      "parameters": ["all_in"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "learn_tm all_in"
+    {
+      "type": "learn_tm",
+      "parameters": ["all_in"]
+    }
   ],
   "slug": "tm_all_in",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tm_avalanche.json
+++ b/mods/tuxemon/db/item/tm_avalanche.json
@@ -1,10 +1,21 @@
 {
   "conditions": [
-    "is type earth:water",
-    "not has_tech avalanche"
+    {
+      "type": "type",
+      "parameters": ["earth:water"],
+      "operator": "is"
+    },
+    {
+      "type": "has_tech",
+      "parameters": ["avalanche"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "learn_tm avalanche"
+    {
+      "type": "learn_tm",
+      "parameters": ["avalanche"]
+    }
   ],
   "slug": "tm_avalanche",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tm_blade.json
+++ b/mods/tuxemon/db/item/tm_blade.json
@@ -1,9 +1,16 @@
 {
   "conditions": [
-    "not has_tech blade"
+    {
+      "type": "has_tech",
+      "parameters": ["blade"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "learn_tm blade"
+    {
+      "type": "learn_tm",
+      "parameters": ["blade"]
+    }
   ],
   "slug": "tm_blade",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tm_blossom.json
+++ b/mods/tuxemon/db/item/tm_blossom.json
@@ -1,10 +1,21 @@
 {
   "conditions": [
-    "is type wood",
-    "not has_tech blossom"
+    {
+      "type": "type",
+      "parameters": ["wood"],
+      "operator": "is"
+    },
+    {
+      "type": "has_tech",
+      "parameters": ["blossom"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "learn_tm blossom"
+    {
+      "type": "learn_tm",
+      "parameters": ["blossom"]
+    }
   ],
   "slug": "tm_blossom",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tm_cavity.json
+++ b/mods/tuxemon/db/item/tm_cavity.json
@@ -1,9 +1,16 @@
 {
   "conditions": [
-    "not has_tech cavity"
+    {
+      "type": "has_tech",
+      "parameters": ["cavity"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "learn_tm cavity"
+    {
+      "type": "learn_tm",
+      "parameters": ["cavity"]
+    }
   ],
   "slug": "tm_cavity",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tm_earth.json
+++ b/mods/tuxemon/db/item/tm_earth.json
@@ -1,6 +1,10 @@
 {
   "conditions": [
-    "is type earth"
+    {
+      "type": "type",
+      "parameters": ["earth"],
+      "operator": "is"
+    }
   ],
   "effects": [],
   "slug": "tm_earth",

--- a/mods/tuxemon/db/item/tm_fire.json
+++ b/mods/tuxemon/db/item/tm_fire.json
@@ -1,6 +1,10 @@
 {
   "conditions": [
-    "is type fire"
+    {
+      "type": "type",
+      "parameters": ["fire"],
+      "operator": "is"
+    }
   ],
   "effects": [],
   "slug": "tm_fire",

--- a/mods/tuxemon/db/item/tm_frostbite.json
+++ b/mods/tuxemon/db/item/tm_frostbite.json
@@ -1,9 +1,16 @@
 {
   "conditions": [
-    "not has_tech frostbite"
+    {
+      "type": "has_tech",
+      "parameters": ["frostbite"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "learn_tm frostbite"
+    {
+      "type": "learn_tm",
+      "parameters": ["frostbite"]
+    }
   ],
   "slug": "tm_frostbite",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tm_metal.json
+++ b/mods/tuxemon/db/item/tm_metal.json
@@ -1,6 +1,10 @@
 {
   "conditions": [
-    "is type metal"
+    {
+      "type": "type",
+      "parameters": ["metal"],
+      "operator": "is"
+    }
   ],
   "effects": [],
   "slug": "tm_metal",

--- a/mods/tuxemon/db/item/tm_panjandrum.json
+++ b/mods/tuxemon/db/item/tm_panjandrum.json
@@ -1,9 +1,16 @@
 {
   "conditions": [
-    "not has_tech panjandrum"
+    {
+      "type": "has_tech",
+      "parameters": ["panjandrum"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "learn_tm panjandrum"
+    {
+      "type": "learn_tm",
+      "parameters": ["panjandrum"]
+    }
   ],
   "slug": "tm_panjandrum",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tm_scope.json
+++ b/mods/tuxemon/db/item/tm_scope.json
@@ -1,9 +1,16 @@
 {
   "conditions": [
-    "not has_tech scope"
+    {
+      "type": "has_tech",
+      "parameters": ["scope"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "learn_tm scope"
+    {
+      "type": "learn_tm",
+      "parameters": ["scope"]
+    }
   ],
   "slug": "tm_scope",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tm_shadow_boxing.json
+++ b/mods/tuxemon/db/item/tm_shadow_boxing.json
@@ -1,9 +1,16 @@
 {
   "conditions": [
-    "not has_tech shadow_boxing"
+    {
+      "type": "has_tech",
+      "parameters": ["shadow_boxing"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "learn_tm shadow_boxing"
+    {
+      "type": "learn_tm",
+      "parameters": ["shadow_boxing"]
+    }
   ],
   "slug": "tm_shadow_boxing",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tm_supernova.json
+++ b/mods/tuxemon/db/item/tm_supernova.json
@@ -1,9 +1,16 @@
 {
   "conditions": [
-    "not has_tech supernova"
+    {
+      "type": "has_tech",
+      "parameters": ["supernova"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "learn_tm supernova"
+    {
+      "type": "learn_tm",
+      "parameters": ["supernova"]
+    }
   ],
   "slug": "tm_supernova",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tm_surf.json
+++ b/mods/tuxemon/db/item/tm_surf.json
@@ -1,11 +1,26 @@
 {
   "conditions": [
-    "is type water",
-    "is shape piscine:polliwog:leviathan",
-    "not has_tech surf"
+    {
+      "type": "type",
+      "parameters": ["water"],
+      "operator": "is"
+    },
+    {
+      "type": "shape",
+      "parameters": ["piscine:polliwog:leviathan"],
+      "operator": "is"
+    },
+    {
+      "type": "has_tech",
+      "parameters": ["surf"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "learn_tm surf"
+    {
+      "type": "learn_tm",
+      "parameters": ["surf"]
+    }
   ],
   "slug": "tm_surf",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tm_vorpal.json
+++ b/mods/tuxemon/db/item/tm_vorpal.json
@@ -1,9 +1,16 @@
 {
   "conditions": [
-    "not has_tech vorpal"
+    {
+      "type": "has_tech",
+      "parameters": ["vorpal"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "learn_tm vorpal"
+    {
+      "type": "learn_tm",
+      "parameters": ["vorpal"]
+    }
   ],
   "slug": "tm_vorpal",
   "sort": "utility",

--- a/mods/tuxemon/db/item/tm_water.json
+++ b/mods/tuxemon/db/item/tm_water.json
@@ -1,6 +1,10 @@
 {
   "conditions": [
-    "is type water"
+    {
+      "type": "type",
+      "parameters": ["water"],
+      "operator": "is"
+    }
   ],
   "effects": [],
   "slug": "tm_water",

--- a/mods/tuxemon/db/item/tm_wood.json
+++ b/mods/tuxemon/db/item/tm_wood.json
@@ -1,6 +1,10 @@
 {
   "conditions": [
-    "is type wood"
+    {
+      "type": "type",
+      "parameters": ["wood"],
+      "operator": "is"
+    }
   ],
   "effects": [],
   "slug": "tm_wood",

--- a/mods/tuxemon/db/item/tuxeball.json
+++ b/mods/tuxemon/db/item/tuxeball.json
@@ -1,10 +1,19 @@
 {
   "conditions": [
-    "is wild_monster",
-    "not category threat"
+    {
+      "type": "wild_monster",
+      "operator": "is"
+    },
+    {
+      "type": "category",
+      "parameters": ["threat"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "capture"
+    {
+      "type": "capture"
+    }
   ],
   "animation": "tuxeball",
   "slug": "tuxeball",

--- a/mods/tuxemon/db/item/tuxeball_ancient.json
+++ b/mods/tuxemon/db/item/tuxeball_ancient.json
@@ -1,10 +1,19 @@
 {
   "conditions": [
-    "is wild_monster",
-    "not category threat"
+    {
+      "type": "wild_monster",
+      "operator": "is"
+    },
+    {
+      "type": "category",
+      "parameters": ["threat"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "capture"
+    {
+      "type": "capture"
+    }
   ],
   "animation": "capture_1",
   "slug": "tuxeball_ancient",

--- a/mods/tuxemon/db/item/tuxeball_candy.json
+++ b/mods/tuxemon/db/item/tuxeball_candy.json
@@ -1,10 +1,19 @@
 {
   "conditions": [
-    "is wild_monster",
-    "not category threat"
+    {
+      "type": "wild_monster",
+      "operator": "is"
+    },
+    {
+      "type": "category",
+      "parameters": ["threat"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "capture"
+    {
+      "type": "capture"
+    }
   ],
   "animation": "capture_1",
   "slug": "tuxeball_candy",

--- a/mods/tuxemon/db/item/tuxeball_crusher.json
+++ b/mods/tuxemon/db/item/tuxeball_crusher.json
@@ -1,10 +1,19 @@
 {
   "conditions": [
-    "is wild_monster",
-    "not category threat"
+    {
+      "type": "wild_monster",
+      "operator": "is"
+    },
+    {
+      "type": "category",
+      "parameters": ["threat"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "capture"
+    {
+      "type": "capture"
+    }
   ],
   "animation": "capture_1",
   "slug": "tuxeball_crusher",

--- a/mods/tuxemon/db/item/tuxeball_diurnal.json
+++ b/mods/tuxemon/db/item/tuxeball_diurnal.json
@@ -1,10 +1,20 @@
 {
   "conditions": [
-    "is wild_monster",
-    "not category threat"
+    {
+      "type": "wild_monster",
+      "operator": "is"
+    },
+    {
+      "type": "category",
+      "parameters": ["threat"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "capture_combined variable,daytime:true,0.2,1.5"
+    {
+      "type": "capture_combined",
+      "parameters": ["variable","daytime:true","0.2","1.5"]
+    }
   ],
   "animation": "capture_1",
   "slug": "tuxeball_diurnal",

--- a/mods/tuxemon/db/item/tuxeball_earth.json
+++ b/mods/tuxemon/db/item/tuxeball_earth.json
@@ -1,10 +1,20 @@
 {
   "conditions": [
-    "is wild_monster",
-    "not category threat"
+    {
+      "type": "wild_monster",
+      "operator": "is"
+    },
+    {
+      "type": "category",
+      "parameters": ["threat"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "capture_combined element,earth,0.2,1.5"
+    {
+      "type": "capture_combined",
+      "parameters": ["element","earth","0.2","1.5"]
+    }
   ],
   "animation": "capture_1",
   "slug": "tuxeball_earth",

--- a/mods/tuxemon/db/item/tuxeball_female.json
+++ b/mods/tuxemon/db/item/tuxeball_female.json
@@ -1,10 +1,20 @@
 {
   "conditions": [
-    "is wild_monster",
-    "not category threat"
+    {
+      "type": "wild_monster",
+      "operator": "is"
+    },
+    {
+      "type": "category",
+      "parameters": ["threat"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "capture_combined gender,female,0.2,1.5"
+    {
+      "type": "capture_combined",
+      "parameters": ["gender","female","0.2","1.5"]
+    }
   ],
   "animation": "capture_1",
   "slug": "tuxeball_female",

--- a/mods/tuxemon/db/item/tuxeball_fire.json
+++ b/mods/tuxemon/db/item/tuxeball_fire.json
@@ -1,10 +1,20 @@
 {
   "conditions": [
-    "is wild_monster",
-    "not category threat"
+    {
+      "type": "wild_monster",
+      "operator": "is"
+    },
+    {
+      "type": "category",
+      "parameters": ["threat"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "capture_combined element,fire,0.2,1.5"
+    {
+      "type": "capture_combined",
+      "parameters": ["element","fire","0.2","1.5"]
+    }
   ],
   "animation": "capture_1",
   "slug": "tuxeball_fire",

--- a/mods/tuxemon/db/item/tuxeball_gambler.json
+++ b/mods/tuxemon/db/item/tuxeball_gambler.json
@@ -1,10 +1,20 @@
 {
   "conditions": [
-    "is wild_monster",
-    "not category threat"
+    {
+      "type": "wild_monster",
+      "operator": "is"
+    },
+    {
+      "type": "category",
+      "parameters": ["threat"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "capture_combined gambler,gambler,0.0,2.0"
+    {
+      "type": "capture_combined",
+      "parameters": ["gambler","gambler","0.0","2.0"]
+    }
   ],
   "animation": "capture_1",
   "slug": "tuxeball_gambler",

--- a/mods/tuxemon/db/item/tuxeball_grand.json
+++ b/mods/tuxemon/db/item/tuxeball_grand.json
@@ -1,10 +1,19 @@
 {
   "conditions": [
-    "is wild_monster",
-    "not category threat"
+    {
+      "type": "wild_monster",
+      "operator": "is"
+    },
+    {
+      "type": "category",
+      "parameters": ["threat"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "capture"
+    {
+      "type": "capture"
+    }
   ],
   "animation": "capture_1",
   "slug": "tuxeball_grand",

--- a/mods/tuxemon/db/item/tuxeball_hardened.json
+++ b/mods/tuxemon/db/item/tuxeball_hardened.json
@@ -1,10 +1,19 @@
 {
   "conditions": [
-    "is wild_monster",
-    "not category threat"
+    {
+      "type": "wild_monster",
+      "operator": "is"
+    },
+    {
+      "type": "category",
+      "parameters": ["threat"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "capture"
+    {
+      "type": "capture"
+    }
   ],
   "animation": "capture_1",
   "slug": "tuxeball_hardened",

--- a/mods/tuxemon/db/item/tuxeball_hearty.json
+++ b/mods/tuxemon/db/item/tuxeball_hearty.json
@@ -1,10 +1,20 @@
 {
   "conditions": [
-    "is wild_monster",
-    "not category threat"
+    {
+      "type": "wild_monster",
+      "operator": "is"
+    },
+    {
+      "type": "category",
+      "parameters": ["threat"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "capture_combined taste_warm,hearty,1,1"
+    {
+      "type": "capture_combined",
+      "parameters": ["taste_warm","hearty","1","1"]
+    }
   ],
   "animation": "capture_1",
   "slug": "tuxeball_hearty",

--- a/mods/tuxemon/db/item/tuxeball_lavish.json
+++ b/mods/tuxemon/db/item/tuxeball_lavish.json
@@ -1,10 +1,19 @@
 {
   "conditions": [
-    "is wild_monster",
-    "not category threat"
+    {
+      "type": "wild_monster",
+      "operator": "is"
+    },
+    {
+      "type": "category",
+      "parameters": ["threat"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "capture"
+    {
+      "type": "capture"
+    }
   ],
   "animation": "capture_1",
   "slug": "tuxeball_lavish",

--- a/mods/tuxemon/db/item/tuxeball_majestic.json
+++ b/mods/tuxemon/db/item/tuxeball_majestic.json
@@ -1,10 +1,19 @@
 {
   "conditions": [
-    "is wild_monster",
-    "not category threat"
+    {
+      "type": "wild_monster",
+      "operator": "is"
+    },
+    {
+      "type": "category",
+      "parameters": ["threat"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "capture"
+    {
+      "type": "capture"
+    }
   ],
   "animation": "capture_1",
   "slug": "tuxeball_majestic",

--- a/mods/tuxemon/db/item/tuxeball_male.json
+++ b/mods/tuxemon/db/item/tuxeball_male.json
@@ -1,10 +1,20 @@
 {
   "conditions": [
-    "is wild_monster",
-    "not category threat"
+    {
+      "type": "wild_monster",
+      "operator": "is"
+    },
+    {
+      "type": "category",
+      "parameters": ["threat"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "capture_combined gender,male,0.2,1.5"
+    {
+      "type": "capture_combined",
+      "parameters": ["gender","male","0.2","1.5"]
+    }
   ],
   "animation": "capture_1",
   "slug": "tuxeball_male",

--- a/mods/tuxemon/db/item/tuxeball_metal.json
+++ b/mods/tuxemon/db/item/tuxeball_metal.json
@@ -1,10 +1,20 @@
 {
   "conditions": [
-    "is wild_monster",
-    "not category threat"
+    {
+      "type": "wild_monster",
+      "operator": "is"
+    },
+    {
+      "type": "category",
+      "parameters": ["threat"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "capture_combined element,metal,0.2,1.5"
+    {
+      "type": "capture_combined",
+      "parameters": ["element","metal","0.2","1.5"]
+    }
   ],
   "animation": "capture_1",
   "slug": "tuxeball_metal",

--- a/mods/tuxemon/db/item/tuxeball_neuter.json
+++ b/mods/tuxemon/db/item/tuxeball_neuter.json
@@ -1,10 +1,20 @@
 {
   "conditions": [
-    "is wild_monster",
-    "not category threat"
+    {
+      "type": "wild_monster",
+      "operator": "is"
+    },
+    {
+      "type": "category",
+      "parameters": ["threat"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "capture_combined gender,neuter,0.2,1.5"
+    {
+      "type": "capture_combined",
+      "parameters": ["gender","neuter","0.2","1.5"]
+    }
   ],
   "animation": "capture_1",
   "slug": "tuxeball_neuter",

--- a/mods/tuxemon/db/item/tuxeball_noble.json
+++ b/mods/tuxemon/db/item/tuxeball_noble.json
@@ -1,10 +1,19 @@
 {
   "conditions": [
-    "is wild_monster",
-    "not category threat"
+    {
+      "type": "wild_monster",
+      "operator": "is"
+    },
+    {
+      "type": "category",
+      "parameters": ["threat"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "capture"
+    {
+      "type": "capture"
+    }
   ],
   "animation": "capture_1",
   "slug": "tuxeball_noble",

--- a/mods/tuxemon/db/item/tuxeball_nocturnal.json
+++ b/mods/tuxemon/db/item/tuxeball_nocturnal.json
@@ -1,10 +1,20 @@
 {
   "conditions": [
-    "is wild_monster",
-    "not category threat"
+    {
+      "type": "wild_monster",
+      "operator": "is"
+    },
+    {
+      "type": "category",
+      "parameters": ["threat"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "capture_combined variable,daytime:false,0.2,1.5"
+    {
+      "type": "capture_combined",
+      "parameters": ["variable","daytime:false","0.2","1.5"]
+    }
   ],
   "animation": "capture_1",
   "slug": "tuxeball_nocturnal",

--- a/mods/tuxemon/db/item/tuxeball_omni.json
+++ b/mods/tuxemon/db/item/tuxeball_omni.json
@@ -1,10 +1,20 @@
 {
   "conditions": [
-    "is wild_monster",
-    "not category threat"
+    {
+      "type": "wild_monster",
+      "operator": "is"
+    },
+    {
+      "type": "category",
+      "parameters": ["threat"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "capture_combined monster,omni,0.3,1.4"
+    {
+      "type": "capture_combined",
+      "parameters": ["monster","omni","0.3","1.4"]
+    }
   ],
   "animation": "capture_1",
   "slug": "tuxeball_omni",

--- a/mods/tuxemon/db/item/tuxeball_park.json
+++ b/mods/tuxemon/db/item/tuxeball_park.json
@@ -1,10 +1,15 @@
 {
   "conditions": [
-    "is wild_monster"
+    {
+      "type": "wild_monster",
+      "operator": "is"
+    }
   ],
   "effects": [
-    "park capture",
-    "capture"
+    {
+      "type": "park",
+      "parameters": ["capture"]
+    }
   ],
   "animation": "capture_1",
   "slug": "tuxeball_park",

--- a/mods/tuxemon/db/item/tuxeball_peppy.json
+++ b/mods/tuxemon/db/item/tuxeball_peppy.json
@@ -1,10 +1,20 @@
 {
   "conditions": [
-    "is wild_monster",
-    "not category threat"
+    {
+      "type": "wild_monster",
+      "operator": "is"
+    },
+    {
+      "type": "category",
+      "parameters": ["threat"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "capture_combined taste_warm,peppy,1,1"
+    {
+      "type": "capture_combined",
+      "parameters": ["taste_warm","peppy","1","1"]
+    }
   ],
   "animation": "capture_1",
   "slug": "tuxeball_peppy",

--- a/mods/tuxemon/db/item/tuxeball_refined.json
+++ b/mods/tuxemon/db/item/tuxeball_refined.json
@@ -1,10 +1,20 @@
 {
   "conditions": [
-    "is wild_monster",
-    "not category threat"
+    {
+      "type": "wild_monster",
+      "operator": "is"
+    },
+    {
+      "type": "category",
+      "parameters": ["threat"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "capture_combined taste_warm,refined,1,1"
+    {
+      "type": "capture_combined",
+      "parameters": ["taste_warm","refined","1","1"]
+    }
   ],
   "animation": "capture_1",
   "slug": "tuxeball_refined",

--- a/mods/tuxemon/db/item/tuxeball_salty.json
+++ b/mods/tuxemon/db/item/tuxeball_salty.json
@@ -1,10 +1,20 @@
 {
   "conditions": [
-    "is wild_monster",
-    "not category threat"
+    {
+      "type": "wild_monster",
+      "operator": "is"
+    },
+    {
+      "type": "category",
+      "parameters": ["threat"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "capture_combined taste_warm,salty,1,1"
+    {
+      "type": "capture_combined",
+      "parameters": ["taste_warm","salty","1","1"]
+    }
   ],
   "animation": "capture_1",
   "slug": "tuxeball_salty",

--- a/mods/tuxemon/db/item/tuxeball_water.json
+++ b/mods/tuxemon/db/item/tuxeball_water.json
@@ -1,10 +1,20 @@
 {
   "conditions": [
-    "is wild_monster",
-    "not category threat"
+    {
+      "type": "wild_monster",
+      "operator": "is"
+    },
+    {
+      "type": "category",
+      "parameters": ["threat"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "capture_combined element,water,0.2,1.5"
+    {
+      "type": "capture_combined",
+      "parameters": ["element","water","0.2","1.5"]
+    }
   ],
   "animation": "capture_1",
   "slug": "tuxeball_water",

--- a/mods/tuxemon/db/item/tuxeball_wood.json
+++ b/mods/tuxemon/db/item/tuxeball_wood.json
@@ -1,10 +1,20 @@
 {
   "conditions": [
-    "is wild_monster",
-    "not category threat"
+    {
+      "type": "wild_monster",
+      "operator": "is"
+    },
+    {
+      "type": "category",
+      "parameters": ["threat"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "capture_combined element,wood,0.2,1.5"
+    {
+      "type": "capture_combined",
+      "parameters": ["element","wood","0.2","1.5"]
+    }
   ],
   "animation": "capture_1",
   "slug": "tuxeball_wood",

--- a/mods/tuxemon/db/item/tuxeball_xero.json
+++ b/mods/tuxemon/db/item/tuxeball_xero.json
@@ -1,10 +1,20 @@
 {
   "conditions": [
-    "is wild_monster",
-    "not category threat"
+    {
+      "type": "wild_monster",
+      "operator": "is"
+    },
+    {
+      "type": "category",
+      "parameters": ["threat"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "capture_combined monster,xero,0.3,1.4"
+    {
+      "type": "capture_combined",
+      "parameters": ["monster","xero","0.3","1.4"]
+    }
   ],
   "animation": "capture_1",
   "slug": "tuxeball_xero",

--- a/mods/tuxemon/db/item/tuxeball_zesty.json
+++ b/mods/tuxemon/db/item/tuxeball_zesty.json
@@ -1,10 +1,20 @@
 {
   "conditions": [
-    "is wild_monster",
-    "not category threat"
+    {
+      "type": "wild_monster",
+      "operator": "is"
+    },
+    {
+      "type": "category",
+      "parameters": ["threat"],
+      "operator": "not"
+    }
   ],
   "effects": [
-    "capture_combined taste_warm,zesty,1,1"
+    {
+      "type": "capture_combined",
+      "parameters": ["taste_warm","zesty","1","1"]
+    }
   ],
   "animation": "capture_1",
   "slug": "tuxeball_zesty",

--- a/mods/tuxemon/db/item/water_booster.json
+++ b/mods/tuxemon/db/item/water_booster.json
@@ -1,10 +1,19 @@
 {
   "conditions": [
-    "is can_evolve",
-    "is has_path water_booster"
+    {
+      "type": "can_evolve",
+      "operator": "is"
+    },
+    {
+      "type": "has_path",
+      "parameters": ["water_booster"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "evolve"
+    {
+      "type": "evolve"
+    }
   ],
   "slug": "water_booster",
   "sort": "utility",

--- a/mods/tuxemon/db/item/wood_booster.json
+++ b/mods/tuxemon/db/item/wood_booster.json
@@ -1,10 +1,19 @@
 {
   "conditions": [
-    "is can_evolve",
-    "is has_path wood_booster"
+    {
+      "type": "can_evolve",
+      "operator": "is"
+    },
+    {
+      "type": "has_path",
+      "parameters": ["wood_booster"],
+      "operator": "is"
+    }
   ],
   "effects": [
-    "evolve"
+    {
+      "type": "evolve"
+    }
   ],
   "slug": "wood_booster",
   "sort": "utility",

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -218,6 +218,27 @@ State = Enum(
 )
 
 
+class CommonCondition(BaseModel):
+    type: str = Field(..., description="The name of the condition")
+    parameters: Sequence[str] = Field(
+        [], description="The parameters that must be met"
+    )
+    operator: str = Field(..., description="The operator 'is' or 'not'.")
+
+    @field_validator("operator")
+    def operator_must_be_is_or_not(cls: CommonCondition, v: str) -> str:
+        if v not in ["is", "not"]:
+            raise ValueError('operator must be either "is" or "not"')
+        return v
+
+
+class CommonEffect(BaseModel):
+    type: str = Field(..., description="The name of the condition")
+    parameters: Sequence[str] = Field(
+        [], description="The parameters that must be met"
+    )
+
+
 class ItemBehaviors(BaseModel):
     consumable: bool = Field(
         True, description="Whether or not this item is consumable."
@@ -263,12 +284,10 @@ class ItemModel(BaseModel):
         ..., description="State(s) where this item can be used."
     )
     behaviors: ItemBehaviors
-    # TODO: We'll need some more advanced validation logic here to parse item
-    # conditions and effects to ensure they are formatted properly.
-    conditions: Sequence[str] = Field(
+    conditions: Sequence[CommonCondition] = Field(
         [], description="Conditions that must be met"
     )
-    effects: Sequence[str] = Field(
+    effects: Sequence[CommonEffect] = Field(
         [], description="Effects this item will have"
     )
     flip_axes: Literal["", "x", "y", "xy"] = Field(
@@ -318,12 +337,6 @@ class ItemModel(BaseModel):
         ):
             return v
         raise ValueError(f"the animation {v} doesn't exist in the db")
-
-    @field_validator("conditions")
-    def check_conditions(cls: ItemModel, v: Sequence[str]) -> Sequence[str]:
-        if not v or has.check_conditions(v):
-            return v
-        raise ValueError(f"the conditions {v} aren't correctly formatted")
 
 
 class ShapeModel(BaseModel):


### PR DESCRIPTION
This PR introduces changes to the conditions and effects fields in the item model, aiming to commonize and simplify their structure. The changes involve replacing the string sequences with sequences of `CommonCondition` and `CommonEffect` objects, respectively. 

These new models, `CommonCondition` and `CommonEffect`, are inspired by the existing `MapCondition` and `MapAction` classes, and are designed to provide a more standardized and flexible way of representing conditions and effects.  The `CommonCondition` model includes fields for the condition type, parameters, and operator, with a validator ensuring that the operator is either "is" or "not". The `CommonEffect` model includes fields for the effect type and parameters.

By introducing these changes, we can simplify the checking of the structure and make it easier to add more conditions and effects in the future. This is the first step in a series of changes, with subsequent pull requests planned to further refine and expand on this work, including the addition of more condition and effect types, as well as techniques for working with them. 

The changes made in this pull request are as follows:
* Updated the conditions field to be a sequence of `CommonCondition` objects
* Updated the effects field to be a sequence of `CommonEffect` objects
* Introduced the `CommonCondition` and `CommonEffect` models, with fields for type, parameters, and operator (for conditions)
* Added a validator to ensure that the operator in `CommonCondition` is either "is" or "not"

These changes lay the groundwork for future improvements and expansions, and will make it easier to work with conditions and effects in a consistent and standardized way.