### PR TITLE
add StepDamageEffect & StepHealingEffect (technique) 

### DIFF
--- a/tuxemon/technique/effects/step_damage.py
+++ b/tuxemon/technique/effects/step_damage.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from tuxemon.combat import get_target_monsters
+from tuxemon.formula import simple_damage_calculate
+from tuxemon.technique.techeffect import TechEffect, TechEffectResult
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
+    from tuxemon.technique.technique import Technique
+
+
+@dataclass
+class StepDamageEffect(TechEffect):
+    """
+    This effect calculates damage to the target based on the number of steps
+    taken by the monster. The damage is scaled using a specified formula, which
+    is logarithmic.
+
+    Parameters:
+        objectives: The targets for this effect, specified as a string
+            (e.g., "enemy_monster" or "enemy_monster:own_monster").
+        scaling_factor: A factor used to scale the damage calculation.
+        scaling_constant: A constant used in the damage calculation formula.
+    """
+
+    name = "step_damage"
+    objectives: str
+    scaling_factor: float
+    scaling_constant: float
+
+    def apply(
+        self, tech: Technique, user: Monster, target: Monster
+    ) -> TechEffectResult:
+        damage = 0
+        monsters: list[Monster] = []
+        combat = tech.combat_state
+        assert combat
+
+        objectives = self.objectives.split(":")
+        tech.hit = tech.accuracy >= combat._random_tech_hit.get(user, 0.0)
+
+        if tech.hit:
+            monsters = get_target_monsters(objectives, tech, user, target)
+
+        if monsters:
+            new_power = self.scaling_factor * math.log(
+                1 + user.steps / self.scaling_constant
+            )
+            tech.power = new_power
+            damage, _ = simple_damage_calculate(tech, user, target)
+
+            for monster in monsters:
+                monster.current_hp = max(0, monster.current_hp - damage)
+                # to avoid double registration in the self._damage_map
+                if monster != target:
+                    combat.enqueue_damage(user, monster, damage)
+
+        return TechEffectResult(
+            name=tech.name,
+            damage=damage,
+            element_multiplier=0.0,
+            should_tackle=tech.hit,
+            success=tech.hit,
+            extras=[],
+        )

--- a/tuxemon/technique/effects/step_healing.py
+++ b/tuxemon/technique/effects/step_healing.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from tuxemon.combat import get_target_monsters
+from tuxemon.formula import simple_heal
+from tuxemon.technique.techeffect import TechEffect, TechEffectResult
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
+    from tuxemon.technique.technique import Technique
+
+
+@dataclass
+class StepHealingEffect(TechEffect):
+    """
+    This effect calculates healing to the target based on the combined
+    step count of the party. The healing is scaled using a specified
+    formula, which is logarithmic.
+
+    Parameters:
+        objectives: The targets for this effect, specified as a string
+            (e.g., "enemy_monster" or "enemy_monster:own_monster").
+        healing_factor: A factor used to scale the healing calculation.
+        scaling_constant: A constant used in the healing calculation formula.
+    """
+
+    name = "step_healing"
+    objectives: str
+    healing_factor: float
+    scaling_constant: float
+
+    def apply(
+        self, tech: Technique, user: Monster, target: Monster
+    ) -> TechEffectResult:
+        monsters: list[Monster] = []
+        extra: list[str] = []
+        done: bool = False
+        combat = tech.combat_state
+        assert combat
+
+        objectives = self.objectives.split(":")
+        tech.hit = tech.accuracy >= combat._random_tech_hit.get(user, 0.0)
+
+        if tech.hit:
+            monsters = get_target_monsters(objectives, tech, user, target)
+
+        if monsters:
+            for monster in monsters:
+                new_power = self.healing_factor * math.log(
+                    1 + user.steps / self.scaling_constant
+                )
+                tech.healing_power = new_power
+                heal = simple_heal(tech, monster)
+                if monster.current_hp < monster.hp:
+                    heal_amount = min(heal, monster.hp - monster.current_hp)
+                    monster.current_hp += heal_amount
+                    done = True
+                elif monster.current_hp == monster.hp:
+                    extra = ["combat_full_health"]
+        return TechEffectResult(
+            name=tech.name,
+            success=done,
+            damage=0,
+            element_multiplier=0.0,
+            should_tackle=False,
+            extras=extra,
+        )


### PR DESCRIPTION
requires #2563 

PR adds two new effects that allow techniques to scale their `power` and `healing_power` based on the number of steps taken by the monster, making them grow stronger as the game progresses. The effects, one for damaging and one for healing, utilize a logarithmic formula to calculate the scaled power.

The formula used is:
new_power = healing_factor * \log(1 + user.steps / scaling_constant)

where the `healing_factor` and `scaling_constant` parameters can be adjusted to fine-tune the effect's behavior.

Below, you can find an image illustrating the growth of the power value based on the number of steps taken. 
https://github.com/user-attachments/assets/b164c557-a1b6-4578-aea4-931d329027b9

The graph shows nine possible combinations of `healing_factor` and `scaling_constant` values, with the central combination being the recommended one (factor 1, constant 1500 steps).

The red points on the graph represent the calculated power values at different step counts, demonstrating how the power grows as the monster walks with the trainer. As shown, the power value can exceed 3.0 at high step counts, but considering the amount of walking required to reach these values, this may not be an issue. However, we can discuss capping the power value at 3.0 if necessary.

From analysis of various savegames, the highest step count observed in Route 3 is approximately 3.5k / 4k steps.

@Sanglorian @HippasusTwo 