### PR TITLE
Add Mute Button to Music Options

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -3035,6 +3035,9 @@ msgstr "Enable"
 msgid "disable"
 msgstr "Disable"
 
+msgid "menu_mute_music"
+msgstr "Mute Music"
+
 msgid "menu_music_volume"
 msgstr "Music Volume"
 

--- a/tuxemon/states/control/__init__.py
+++ b/tuxemon/states/control/__init__.py
@@ -231,9 +231,22 @@ class ControlState(PygameMenuState):
             ),
             font_size=self.font_size_small,
         )
+
         menu.add.button(
             title=T.translate("menu_reset_default").upper(),
             action=reset_config_to_default,
+            font_size=self.font_size_small,
+        )
+
+        def mute_music() -> None:
+            if player:
+                player.game_variables["music_volume"] = 0
+                self.client.current_music.set_volume(0)
+                music.set_value(0)
+
+        menu.add.button(
+            title=T.translate("menu_mute_music").upper(),
+            action=mute_music,
             font_size=self.font_size_small,
         )
 


### PR DESCRIPTION
A mute button has been added to the options menu, allowing users to quickly mute all music. Upon clicking the "Mute Music" button, the music volume is set to zero, and the volume slider in the UI is also updated to reflect this change. It's useful for players who need to silence the game immediately for any reason.
