### PR TITLE
Replace custom mock classes with MagicMock +  update tests

### DIFF
--- a/tests/tuxemon/test_animation.py
+++ b/tests/tuxemon/test_animation.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import unittest
 from collections.abc import Callable
 from unittest.mock import Mock, call

--- a/tests/tuxemon/test_boxes.py
+++ b/tests/tuxemon/test_boxes.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import unittest
+from unittest.mock import MagicMock
 from uuid import uuid4
 
 from tuxemon.boxes import MonsterBoxes
@@ -12,9 +13,9 @@ class TestBoxes(unittest.TestCase):
 
     def setUp(self):
         self.monster_boxes = MonsterBoxes()
-        self.monster1 = Monster()
+        self.monster1 = MagicMock(spec=Monster)
         self.monster1.instance_id = uuid4()
-        self.monster2 = Monster()
+        self.monster2 = MagicMock(spec=Monster)
         self.monster2.instance_id = uuid4()
         self.box_id1 = "box1"
         self.box_id2 = "box2"

--- a/tests/tuxemon/test_formula.py
+++ b/tests/tuxemon/test_formula.py
@@ -2,35 +2,32 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import math
 import unittest
+from unittest.mock import MagicMock, patch
 
 from tuxemon import prepare
+from tuxemon.element import Element
 from tuxemon.formula import (
     calculate_time_based_multiplier,
+    capture,
     set_height,
     set_weight,
+    shake_check,
+    simple_damage_multiplier,
     simple_heal,
     update_stat,
 )
-
-
-class MockMonster1:
-    def __init__(self, melee, ranged, dodge, taste_warm, taste_cold) -> None:
-        self.melee = melee
-        self.ranged = ranged
-        self.dodge = dodge
-        self.taste_warm = taste_warm
-        self.taste_cold = taste_cold
+from tuxemon.monster import Monster
+from tuxemon.technique.technique import Technique
 
 
 class TestUpdateStat(unittest.TestCase):
     def setUp(self):
-        self.monster = MockMonster1(
-            melee=10,
-            ranged=10,
-            dodge=10,
-            taste_warm="salty",
-            taste_cold="flakey",
-        )
+        self.monster = MagicMock(spec=Monster)
+        self.monster.melee = 10.0
+        self.monster.ranged = 10.0
+        self.monster.dodge = 10.0
+        self.monster.taste_warm = "salty"
+        self.monster.taste_cold = "flakey"
 
     def test_update_stat_matching_taste_bonus(self):
         bonus = update_stat(self.monster, "melee")
@@ -45,45 +42,44 @@ class TestUpdateStat(unittest.TestCase):
         self.assertEqual(neuter, 0)
 
 
-class MockTechnique1:
-    def __init__(self, healing_power: float) -> None:
-        self.healing_power = healing_power
-
-
-class MockMonster2:
-    def __init__(self, level: int) -> None:
-        self.level = level
-
-
 class TestSimpleHeal(unittest.TestCase):
+    def setUp(self):
+        self.monster = MagicMock(spec=Monster)
+        self.monster.level = 0.0
+        self.technique = MagicMock(spec=Technique)
+        self.technique.healing_power = 0.0
+
     def test_simple_heal_no_factors(self):
-        technique = MockTechnique1(5)
-        monster = MockMonster2(10)
+        self.technique.healing_power = 5
+        self.monster.level = 10
         expected_heal = (
-            prepare.COEFF_DAMAGE + monster.level * technique.healing_power
+            prepare.COEFF_DAMAGE
+            + self.monster.level * self.technique.healing_power
         )
-        actual_heal = simple_heal(technique, monster)
+        actual_heal = simple_heal(self.technique, self.monster)
         self.assertEqual(int(expected_heal), actual_heal)
 
     def test_simple_heal_with_factors(self):
-        technique = MockTechnique1(3)
-        monster = MockMonster2(15)
+        self.technique.healing_power = 3
+        self.monster.level = 15
         factors = {"boost": 1.2, "penalty": 0.8}
         expected_multiplier = math.prod(factors.values())
         expected_heal = (
-            prepare.COEFF_DAMAGE + monster.level * technique.healing_power
+            prepare.COEFF_DAMAGE
+            + self.monster.level * self.technique.healing_power
         ) * expected_multiplier
-        actual_heal = simple_heal(technique, monster, factors)
+        actual_heal = simple_heal(self.technique, self.monster, factors)
         self.assertEqual(int(expected_heal), actual_heal)
 
     def test_simple_heal_empty_factors(self):
-        technique = MockTechnique1(2)
-        monster = MockMonster2(20)
+        self.technique.healing_power = 2
+        self.monster.level = 20
         factors = {}
         expected_heal = (
-            prepare.COEFF_DAMAGE + monster.level * technique.healing_power
+            prepare.COEFF_DAMAGE
+            + self.monster.level * self.technique.healing_power
         )
-        actual_heal = simple_heal(technique, monster, factors)
+        actual_heal = simple_heal(self.technique, self.monster, factors)
         self.assertEqual(int(expected_heal), actual_heal)
 
 
@@ -143,3 +139,187 @@ class TestSetHeight(unittest.TestCase):
     def test_set_height_randomness(self):
         heights = [set_height(75) for _ in range(100)]
         self.assertGreaterEqual(len(set(heights)), 1)
+
+
+class TestSimpleDamageMultiplier(unittest.TestCase):
+    def setUp(self):
+        self.fire = MagicMock(spec=Element)
+        self.fire.slug = "fire"
+        self.water = MagicMock(spec=Element)
+        self.water.slug = "water"
+        self.grass = MagicMock(spec=Element)
+        self.grass.slug = "grass"
+        self.aether = MagicMock(spec=Element)
+        self.aether.slug = "aether"
+
+    def test_basic_multiplier(self):
+        attack_type = self.fire
+        target_type = self.water
+        attack_type.lookup_multiplier = MagicMock(return_value=2.0)
+        multiplier = simple_damage_multiplier([attack_type], [target_type])
+        self.assertEqual(multiplier, 2.0)
+
+    def test_multiple_attack_types(self):
+        attack_types = [self.fire, self.grass]
+        target_type = self.water
+        attack_types[0].lookup_multiplier = MagicMock(return_value=2.0)
+        attack_types[1].lookup_multiplier = MagicMock(return_value=0.5)
+        multiplier = simple_damage_multiplier(attack_types, [target_type])
+        self.assertEqual(multiplier, 0.5)
+
+    def test_multiple_target_types(self):
+        attack_type = self.fire
+        target_types = [self.water, self.grass]
+        attack_type.lookup_multiplier = MagicMock(side_effect=[2.0, 0.5])
+        multiplier = simple_damage_multiplier([attack_type], target_types)
+        self.assertEqual(multiplier, 2.0)
+
+    def test_aether_type(self):
+        attack_type = self.aether
+        target_type = self.water
+        multiplier = simple_damage_multiplier([attack_type], [target_type])
+        self.assertEqual(multiplier, 1.0)
+
+        attack_type = self.fire
+        target_type = self.aether
+        multiplier = simple_damage_multiplier([attack_type], [target_type])
+        self.assertEqual(multiplier, 1.0)
+
+    def test_additional_factors(self):
+        attack_type = self.fire
+        target_type = self.water
+        attack_type.lookup_multiplier = MagicMock(return_value=2.0)
+        additional_factors = {"boost": 1.5, "nerf": 0.8}
+        multiplier = simple_damage_multiplier(
+            [attack_type], [target_type], additional_factors
+        )
+        self.assertEqual(round(multiplier, 1), 2.4)
+
+
+class TestShakeCheck(unittest.TestCase):
+
+    @patch("random.uniform")
+    def test_shake_check_basic(self, mock_uniform):
+        target = MagicMock(spec=Monster)
+        target.hp = 100
+        target.current_hp = 50
+        target.catch_rate = 100
+        target.lower_catch_resistance = 0.9
+        target.upper_catch_resistance = 1.1
+        mock_uniform.return_value = 1.0
+        status_modifier = 1.0
+        tuxeball_modifier = 1.0
+        result = shake_check(target, status_modifier, tuxeball_modifier)
+        self.assertIsInstance(result, float)
+        self.assertGreater(result, 0)
+
+    @patch("random.uniform")
+    def test_shake_check_different_values(self, mock_uniform):
+        mock_uniform.return_value = 0.5
+        target = MagicMock(spec=Monster)
+        target.hp = 150
+        target.current_hp = 25
+        target.catch_rate = 200
+        target.lower_catch_resistance = 0.8
+        target.upper_catch_resistance = 1.2
+        status_modifier = 1.5
+        tuxeball_modifier = 2.0
+        result = shake_check(target, status_modifier, tuxeball_modifier)
+        self.assertIsInstance(result, float)
+
+    @patch("random.uniform")
+    def test_shake_check_edge_cases(self, mock_uniform):
+        mock_uniform.return_value = 1.0
+        target = MagicMock(spec=Monster)
+        target.hp = 100
+        target.current_hp = 50
+        target.catch_rate = 100
+        target.lower_catch_resistance = 0.9
+        target.upper_catch_resistance = 1.1
+        status_modifier = 1.0
+        tuxeball_modifier = 1.0
+        result = shake_check(target, status_modifier, tuxeball_modifier)
+        self.assertIsInstance(result, float)
+
+        target2 = MagicMock(spec=Monster)
+        target2.hp = 1000
+        target2.current_hp = 1
+        target2.catch_rate = 255
+        target2.lower_catch_resistance = 1.0
+        target2.upper_catch_resistance = 1.0
+        result = shake_check(target2, status_modifier, tuxeball_modifier)
+        self.assertIsInstance(result, float)
+
+    @patch("random.uniform")
+    def test_shake_check_zero_hp(self, mock_uniform):
+        mock_uniform.return_value = 1.0
+        target = MagicMock(spec=Monster)
+        target.hp = 100
+        target.current_hp = 0
+        target.catch_rate = 100
+        target.lower_catch_resistance = 1.0
+        target.upper_catch_resistance = 1.0
+        status_modifier = 1.0
+        tuxeball_modifier = 1.0
+        result = shake_check(target, status_modifier, tuxeball_modifier)
+        self.assertIsInstance(result, float)
+
+
+class TestCapture(unittest.TestCase):
+
+    @patch("random.randint")
+    def test_capture_success(self, mock_randint):
+        mock_randint.return_value = prepare.MAX_SHAKE_RATE // 2
+        shake_check = prepare.MAX_SHAKE_RATE
+        captured, shakes = capture(shake_check)
+        self.assertTrue(captured)
+        self.assertEqual(shakes, prepare.TOTAL_SHAKES)
+
+    @patch("random.randint")
+    def test_capture_failure_first_shake(self, mock_randint):
+        mock_randint.return_value = prepare.MAX_SHAKE_RATE
+        shake_check = 0
+        captured, shakes = capture(shake_check)
+        self.assertFalse(captured)
+        self.assertEqual(shakes, 1)
+
+    @patch("random.randint")
+    def test_capture_failure_middle_shake(self, mock_randint):
+        mock_randint.side_effect = [
+            prepare.MAX_SHAKE_RATE // 4,
+            prepare.MAX_SHAKE_RATE // 4,
+            prepare.MAX_SHAKE_RATE,
+        ]
+        shake_check = prepare.MAX_SHAKE_RATE // 4
+        captured, shakes = capture(shake_check)
+        self.assertFalse(captured)
+        self.assertEqual(shakes, 3)
+
+    @patch("random.randint")
+    def test_capture_failure_last_shake(self, mock_randint):
+        mock_randint.side_effect = [
+            prepare.MAX_SHAKE_RATE // 4,
+            prepare.MAX_SHAKE_RATE // 4,
+            prepare.MAX_SHAKE_RATE // 4,
+            prepare.MAX_SHAKE_RATE,
+        ]
+        shake_check = prepare.MAX_SHAKE_RATE // 4
+        captured, shakes = capture(shake_check)
+        self.assertFalse(captured)
+        self.assertEqual(shakes, prepare.TOTAL_SHAKES)
+
+    @patch("random.randint")
+    def test_capture_edge_case_shake_check_zero(self, mock_randint):
+        mock_randint.return_value = prepare.MAX_SHAKE_RATE // 2
+        shake_check = 0
+        captured, shakes = capture(shake_check)
+        self.assertFalse(captured)
+        self.assertEqual(shakes, 1)
+
+    @patch("random.randint")
+    def test_capture_edge_case_shake_check_max(self, mock_randint):
+        mock_randint.return_value = prepare.MAX_SHAKE_RATE // 2
+        shake_check = prepare.MAX_SHAKE_RATE
+        captured, shakes = capture(shake_check)
+        self.assertTrue(captured)
+        self.assertEqual(shakes, prepare.TOTAL_SHAKES)

--- a/tests/tuxemon/test_surfanim.py
+++ b/tests/tuxemon/test_surfanim.py
@@ -15,153 +15,99 @@ from tuxemon.surfanim import (
 
 
 class TestSurfaceAnimation(unittest.TestCase):
-    def test_init(self):
-        frames = [
+    def setUp(self):
+        pygame.init()
+        self.frames = [
             (pygame.Surface((10, 10)), 1.0),
             (pygame.Surface((20, 20)), 2.0),
         ]
-        animation = SurfaceAnimation(frames)
-        self.assertEqual(animation.loop, True)
-        self.assertEqual(animation.state, STOPPED)
+        self.animation = SurfaceAnimation(self.frames)
+
+    def tearDown(self):
+        pygame.quit()
+
+    def test_init(self):
+        self.assertEqual(self.animation.loop, True)
+        self.assertEqual(self.animation.state, STOPPED)
 
     def test_get_frame(self):
-        frames = [
-            (pygame.Surface((10, 10)), 1.0),
-            (pygame.Surface((20, 20)), 2.0),
-        ]
-        animation = SurfaceAnimation(frames)
-        self.assertEqual(animation.get_frame(0).get_size(), (10, 10))
-        self.assertEqual(animation.get_frame(1).get_size(), (20, 20))
-        self.assertEqual(animation.get_frame(2).get_size(), (0, 0))
-        self.assertEqual(animation.duration, 3.0)
+        self.assertEqual(self.animation.get_frame(0).get_size(), (10, 10))
+        self.assertEqual(self.animation.get_frame(1).get_size(), (20, 20))
+        self.assertEqual(self.animation.get_frame(2).get_size(), (0, 0))
+        self.assertEqual(self.animation.duration, 3.0)
 
     def test_get_current_frame(self):
-        frames = [
-            (pygame.Surface((10, 10)), 1.0),
-            (pygame.Surface((20, 20)), 2.0),
-        ]
-        animation = SurfaceAnimation(frames)
-        animation.play()
-        self.assertEqual(animation.get_current_frame().get_size(), (10, 10))
-        animation.update(1.5)
-        self.assertEqual(animation.get_current_frame().get_size(), (20, 20))
+        self.animation.play()
+        self.assertEqual(
+            self.animation.get_current_frame().get_size(), (10, 10)
+        )
+        self.animation.update(1.5)
+        self.assertEqual(
+            self.animation.get_current_frame().get_size(), (20, 20)
+        )
 
     def test_is_finished(self):
-        frames = [
-            (pygame.Surface((10, 10)), 1.0),
-            (pygame.Surface((20, 20)), 2.0),
-        ]
-        animation = SurfaceAnimation(frames, loop=False)
+        animation = SurfaceAnimation(self.frames, loop=False)
         self.assertFalse(animation.is_finished())
         animation.play()
         animation.update(3.0)
         self.assertTrue(animation.is_finished())
 
     def test_play(self):
-        frames = [
-            (pygame.Surface((10, 10)), 1.0),
-            (pygame.Surface((20, 20)), 2.0),
-        ]
-        animation = SurfaceAnimation(frames)
-        animation.play()
-        self.assertEqual(animation.state, PLAYING)
+        self.animation.play()
+        self.assertEqual(self.animation.state, PLAYING)
 
     def test_pause(self):
-        frames = [
-            (pygame.Surface((10, 10)), 1.0),
-            (pygame.Surface((20, 20)), 2.0),
-        ]
-        animation = SurfaceAnimation(frames)
-        animation.play()
-        animation.pause()
-        self.assertEqual(animation.state, PAUSED)
+        self.animation.play()
+        self.animation.pause()
+        self.assertEqual(self.animation.state, PAUSED)
 
     def test_stop(self):
-        frames = [
-            (pygame.Surface((10, 10)), 1.0),
-            (pygame.Surface((20, 20)), 2.0),
-        ]
-        animation = SurfaceAnimation(frames)
-        animation.play()
-        animation.stop()
-        self.assertEqual(animation.state, STOPPED)
+        self.animation.play()
+        self.animation.stop()
+        self.assertEqual(self.animation.state, STOPPED)
 
     def test_update(self):
-        frames = [
-            (pygame.Surface((10, 10)), 1.0),
-            (pygame.Surface((20, 20)), 2.0),
-        ]
-        animation = SurfaceAnimation(frames)
-        animation.play()
-        animation.update(1.5)
-        self.assertGreaterEqual(animation.elapsed, 1.5 - 0.001)
-        self.assertLessEqual(animation.elapsed, 1.5 + 0.001)
+        self.animation.play()
+        self.animation.update(1.5)
+        self.assertGreaterEqual(self.animation.elapsed, 1.5 - 0.001)
+        self.assertLessEqual(self.animation.elapsed, 1.5 + 0.001)
 
     def test_elapsed(self):
-        frames = [
-            (pygame.Surface((10, 10)), 1.0),
-            (pygame.Surface((20, 20)), 2.0),
-        ]
-        animation = SurfaceAnimation(frames)
-        animation.play()
-        animation.update(1.5)
-        self.assertGreaterEqual(animation.elapsed, 1.5 - 0.001)
-        self.assertLessEqual(animation.elapsed, 1.5 + 0.001)
-        animation.elapsed = 2.5
-        self.assertGreaterEqual(animation.elapsed, 2.5 - 0.001)
-        self.assertLessEqual(animation.elapsed, 2.5 + 0.001)
+        self.animation.play()
+        self.animation.update(1.5)
+        self.assertGreaterEqual(self.animation.elapsed, 1.5 - 0.001)
+        self.assertLessEqual(self.animation.elapsed, 1.5 + 0.001)
+        self.animation.elapsed = 2.5
+        self.assertGreaterEqual(self.animation.elapsed, 2.5 - 0.001)
+        self.assertLessEqual(self.animation.elapsed, 2.5 + 0.001)
 
     def test_frames_played(self):
-        frames = [
-            (pygame.Surface((10, 10)), 1.0),
-            (pygame.Surface((20, 20)), 2.0),
-        ]
-        animation = SurfaceAnimation(frames)
-        animation.play()
-        animation.update(1.5)
-        self.assertEqual(animation.frames_played, 1)
-        animation.frames_played = 0
-        self.assertEqual(animation.frames_played, 0)
+        self.animation.play()
+        self.animation.update(1.5)
+        self.assertEqual(self.animation.frames_played, 1)
+        self.animation.frames_played = 0
+        self.assertEqual(self.animation.frames_played, 0)
 
     def test_rate(self):
-        frames = [
-            (pygame.Surface((10, 10)), 1.0),
-            (pygame.Surface((20, 20)), 2.0),
-        ]
-        animation = SurfaceAnimation(frames)
-        self.assertEqual(animation.rate, 1.0)
-        animation.rate = 2.0
-        self.assertEqual(animation.rate, 2.0)
+        self.assertEqual(self.animation.rate, 1.0)
+        self.animation.rate = 2.0
+        self.assertEqual(self.animation.rate, 2.0)
 
     def test_visibility(self):
-        frames = [
-            (pygame.Surface((10, 10)), 1.0),
-            (pygame.Surface((20, 20)), 2.0),
-        ]
-        animation = SurfaceAnimation(frames)
-        self.assertTrue(animation.visibility)
-        animation.visibility = False
-        self.assertFalse(animation.visibility)
+        self.assertTrue(self.animation.visibility)
+        self.animation.visibility = False
+        self.assertFalse(self.animation.visibility)
 
     def test_get_rect(self):
-        frames = [
-            (pygame.Surface((10, 10)), 1.0),
-            (pygame.Surface((20, 20)), 2.0),
-        ]
-        animation = SurfaceAnimation(frames)
-        rect = animation.get_rect()
+        rect = self.animation.get_rect()
         self.assertEqual(rect.width, 20)
         self.assertEqual(rect.height, 20)
 
     def test_flip(self):
-        frames = [
-            (pygame.Surface((10, 10)), 1.0),
-            (pygame.Surface((20, 20)), 2.0),
-        ]
-        animation = SurfaceAnimation(frames)
-        animation.flip("x")
-        self.assertEqual(animation.get_frame(0).get_size(), (10, 10))
-        self.assertEqual(animation.get_frame(1).get_size(), (20, 20))
+        self.animation.flip("x")
+        self.assertEqual(self.animation.get_frame(0).get_size(), (10, 10))
+        self.assertEqual(self.animation.get_frame(1).get_size(), (20, 20))
 
     def test_clip(self):
         self.assertEqual(clip(5, 2, 10), 5)


### PR DESCRIPTION
PR makes some improvements to a couple of tests. It replaces the manually defined monster classes with MagicMock. This change is similar to what was done in a previous pull request (#2596) for the tests in the formula.py suite.