### PR TITLE
Input System: Decouple Input Management from Main Client

### DIFF
--- a/tuxemon/platform/input_manager.py
+++ b/tuxemon/platform/input_manager.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from collections.abc import Generator
+from typing import TYPE_CHECKING, Optional
+
+from tuxemon.platform.platform_pygame.events import (
+    PygameEventQueueHandler,
+    PygameGamepadInput,
+    PygameKeyboardInput,
+    PygameMouseInput,
+    PygameTouchOverlayInput,
+)
+
+if TYPE_CHECKING:
+    from tuxemon.config import TuxemonConfig
+    from tuxemon.platform.events import PlayerInput
+
+logger = logging.getLogger(__name__)
+
+
+class InputManager:
+    """
+    Manages the input devices for the game.
+    """
+
+    def __init__(self, config: TuxemonConfig) -> None:
+        """
+        Initializes the input manager with the given config.
+        """
+        self.event_queue = PygameEventQueueHandler()
+        self.config = config
+        self.controller_overlay: Optional[PygameTouchOverlayInput] = None
+        self.setup_inputs()
+
+    def setup_inputs(self) -> None:
+        """
+        Sets up the input devices based on the config.
+        """
+        try:
+            self.setup_keyboard()
+            self.setup_gamepad()
+            self.setup_controller_overlay()
+            self.setup_mouse()
+        except Exception as e:
+            logger.error(f"Unexpected error setting up inputs: {e}")
+            raise
+
+    def setup_keyboard(self) -> None:
+        """
+        Sets up the keyboard input device.
+        """
+        if self.config.keyboard_button_map:
+            keyboard = PygameKeyboardInput(self.config.keyboard_button_map)
+            self.event_queue.add_input(0, keyboard)
+            logger.info("Keyboard set up successfully")
+
+    def setup_gamepad(self) -> None:
+        """
+        Sets up the gamepad input device.
+        """
+        if self.config.gamepad_button_map:
+            gamepad = PygameGamepadInput(
+                self.config.gamepad_button_map, self.config.gamepad_deadzone
+            )
+            self.event_queue.add_input(0, gamepad)
+            logger.info("Gamepad set up successfully")
+
+    def setup_controller_overlay(self) -> None:
+        """
+        Sets up the controller overlay input device.
+        """
+        if self.config.controller_overlay:
+            self.controller_overlay = PygameTouchOverlayInput(
+                self.config.controller_transparency
+            )
+            self.controller_overlay.load()
+            self.event_queue.add_input(0, self.controller_overlay)
+            logger.info("Controller overlay set up successfully")
+
+    def setup_mouse(self) -> None:
+        """
+        Sets up the mouse input device.
+        """
+        if not self.config.hide_mouse:
+            self.event_queue.add_input(0, PygameMouseInput())
+            logger.info("Mouse set up successfully")
+
+    def process_events(self) -> Generator[PlayerInput, None, None]:
+        """
+        Processes the input events.
+        """
+        return self.event_queue.process_events()

--- a/tuxemon/states/control/__init__.py
+++ b/tuxemon/states/control/__init__.py
@@ -372,7 +372,9 @@ class ControlState(PygameMenuState):
         prepare.CONFIG = tuxe_config
         local_session.client.config = tuxe_config
         keyboard = PygameKeyboardInput(tuxe_config.keyboard_button_map)
-        local_session.client.input_manager.set_input(0, 0, keyboard)
+        local_session.client.input_manager.event_queue.set_input(
+            0, 0, keyboard
+        )
         local_session.client.event_engine = EventEngine(local_session)
 
     def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:


### PR DESCRIPTION
PR refactors the input handling in the game. Previously, the main game client (`LocalPygameClient`) was responsible for managing all the input devices (keyboard, gamepad, mouse, etc.). This made the client class too complex and harder to maintain.

This change introduces a new class called `InputManager`. The `InputManager` is now solely responsible for setting up and processing all the input events. This makes the main game client much cleaner and more focused on its core responsibilities (game logic, state management, etc.).

Essentially, I've taken all the code related to handling input and moved it into its own separate class. I've also added better error handling for input setup, using proper logging to make debugging easier.