### PR TITLE
Added the options menu to the starting menu

### DIFF
--- a/tuxemon/states/start/__init__.py
+++ b/tuxemon/states/start/__init__.py
@@ -95,6 +95,12 @@ class StartState(PygameMenuState):
             button_id="menu_minigame",
         )
         menu.add.button(
+            title=T.translate("menu_options"),
+            action=change_state("ControlState", main_menu=True),
+            font_size=self.font_size_big,
+            button_id="menu_options",
+        )
+        menu.add.button(
             title=T.translate("exit"),
             action=exit_game,
             font_size=self.font_size_big,


### PR DESCRIPTION
The purpose of this PR is to add the options menu to the start menu.

I removed (only for the start menu) the options that are tied to the music, the temperature and the hemisphere, since these can't be modified if there is not a player character yet. 

I also had to remove `pop_state()` in the function `process_event` from the control state, because this would lead to a black screen if the options menu was closed in the main menu. This now makes it that if the options menu is closed in game, the player is led back to the menu right before it instead of bringing him back to the game.

