### PR TITLE
fix various

### DIFF
--- a/mods/tuxemon/maps/spyder_candy_cafe.yaml
+++ b/mods/tuxemon/maps/spyder_candy_cafe.yaml
@@ -12,7 +12,7 @@ events:
     conditions:
     - is char_at player
     - is char_facing player,down
-    - is party_size player,greater_than,1
+    - is party_size player,greater_than,0
     x: 8
     y: 11
     type: "event"

--- a/tests/tuxemon/test_action_queue.py
+++ b/tests/tuxemon/test_action_queue.py
@@ -248,9 +248,9 @@ class TestSpeedTestFunction(unittest.TestCase):
         technique.is_fast = True
 
         results1 = [
-            speed_monster(self.monster1, technique) for _ in range(1000)
+            speed_monster(self.monster1, technique) for _ in range(10000)
         ]
-        results4 = [speed_monster(monster4, technique) for _ in range(1000)]
+        results4 = [speed_monster(monster4, technique) for _ in range(10000)]
 
         with self.subTest("Comparing different dodge values"):
             self.assertGreaterEqual(min(results1), 1)


### PR DESCRIPTION
PR aims to fix a specific unit test that's been failing rarely. The issue is likely due to a random factor in the `speed_monster` function. To resolve this, I'm increasing the number of iterations used to calculate the average speed modifier. This should help minimize the impact of the random element and make the test more stable.

+ small thing in Candy Cafe (Spyder)