### PR TITLE
Move related functions to tools.py and update button_pressed event

### DIFF
--- a/tests/tuxemon/test_platform_tools.py
+++ b/tests/tuxemon/test_platform_tools.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import unittest
+
+from tuxemon.platform.const import events, intentions
+from tuxemon.platform.events import PlayerInput
+from tuxemon.platform.tools import keymap, translate_input_event
+
+
+class TestTranslateInputEvent(unittest.TestCase):
+    def test_keymap_match(self):
+        event = PlayerInput("button1", "value1", 0.5)
+        keymap["button1"] = "mapped_button1"
+
+        result = translate_input_event(event)
+
+        self.assertEqual(result.button, "mapped_button1")
+        self.assertEqual(result.value, "value1")
+        self.assertEqual(result.hold_time, 0.5)
+
+    def test_keymap_no_match(self):
+        event = PlayerInput("button2", "value2", 0.5)
+
+        result = translate_input_event(event)
+
+        self.assertEqual(result, event)
+
+    def test_unicode_match(self):
+        event = PlayerInput(events.UNICODE, "n", 0.5)
+
+        result = translate_input_event(event)
+
+        self.assertEqual(result.button, intentions.NOCLIP)
+        self.assertEqual(result.value, "n")
+        self.assertEqual(result.hold_time, 0.5)
+
+    def test_unicode_no_match(self):
+        event = PlayerInput(events.UNICODE, "x", 0.5)
+
+        result = translate_input_event(event)
+
+        self.assertEqual(result, event)
+
+    def test_non_unicode(self):
+        event = PlayerInput("button3", "value3", 0.5)
+
+        result = translate_input_event(event)
+
+        self.assertEqual(result, event)

--- a/tuxemon/event/conditions/button_pressed.py
+++ b/tuxemon/event/conditions/button_pressed.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from tuxemon.event import MapCondition
 from tuxemon.event.eventcondition import EventCondition
 from tuxemon.platform.const import intentions
+from tuxemon.platform.const.intentions import constants
 from tuxemon.session import Session
 
 
@@ -34,7 +35,10 @@ class ButtonPressedCondition(EventCondition):
         if button == "K_RETURN":
             button_id = intentions.INTERACT
         else:
-            raise ValueError(f"Cannot support key type: {button}")
+            try:
+                button_id = constants[button]
+            except KeyError:
+                raise ValueError(f"Cannot support key type: {button}")
 
         # Loop through each event
         for event in session.client.key_events:

--- a/tuxemon/platform/const/intentions.py
+++ b/tuxemon/platform/const/intentions.py
@@ -18,3 +18,18 @@ LEFT = 30008
 RIGHT = 30009
 BACK = 30010
 RELOAD_MAP = 30011
+
+constants = {
+    "RUN": 30000,
+    "WORLD_MENU": 30001,
+    "MENU_CANCEL": 30002,
+    "INTERACT": 30003,
+    "SELECT": 30004,
+    "NOCLIP": 30005,
+    "UP": 30006,
+    "DOWN": 30007,
+    "LEFT": 30008,
+    "RIGHT": 30009,
+    "BACK": 30010,
+    "RELOAD_MAP": 30011,
+}

--- a/tuxemon/platform/tools.py
+++ b/tuxemon/platform/tools.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+
+from tuxemon.platform.const import buttons, events, intentions
+from tuxemon.platform.events import PlayerInput
+
+logger = logging.getLogger(__name__)
+
+keymap = {
+    buttons.UP: intentions.UP,
+    buttons.DOWN: intentions.DOWN,
+    buttons.LEFT: intentions.LEFT,
+    buttons.RIGHT: intentions.RIGHT,
+    buttons.A: intentions.INTERACT,
+    buttons.B: intentions.RUN,
+    buttons.START: intentions.WORLD_MENU,
+    buttons.BACK: intentions.WORLD_MENU,
+}
+
+
+def translate_input_event(event: PlayerInput) -> PlayerInput:
+    """
+    Translate the given input event into a PlayerInput object.
+
+    Parameters:
+        event: The input event to be translated.
+
+    Returns:
+
+    Returns:
+        The translated PlayerInput object. If the event cannot be translated,
+        the original event is returned.
+    """
+    try:
+        return PlayerInput(keymap[event.button], event.value, event.hold_time)
+    except KeyError:
+        pass
+
+    unicode_map = {
+        "n": intentions.NOCLIP,
+        "r": intentions.RELOAD_MAP,
+    }
+
+    if event.button == events.UNICODE and event.value in unicode_map:
+        return PlayerInput(
+            unicode_map[event.value], event.value, event.hold_time
+        )
+
+    return event

--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -38,8 +38,9 @@ from tuxemon.map import (
 )
 from tuxemon.map_loader import TMXMapLoader, YAMLEventLoader
 from tuxemon.math import Vector2
-from tuxemon.platform.const import buttons, events, intentions
+from tuxemon.platform.const import intentions
 from tuxemon.platform.events import PlayerInput
+from tuxemon.platform.tools import translate_input_event
 from tuxemon.session import local_session
 from tuxemon.states.world.world_classes import BoundaryChecker
 from tuxemon.states.world.world_menus import WorldMenuState
@@ -104,17 +105,6 @@ CollisionMap = Mapping[
 
 class WorldState(state.State):
     """The state responsible for the world game play"""
-
-    keymap = {
-        buttons.UP: intentions.UP,
-        buttons.DOWN: intentions.DOWN,
-        buttons.LEFT: intentions.LEFT,
-        buttons.RIGHT: intentions.RIGHT,
-        buttons.A: intentions.INTERACT,
-        buttons.B: intentions.RUN,
-        buttons.START: intentions.WORLD_MENU,
-        buttons.BACK: intentions.WORLD_MENU,
-    }
 
     def __init__(
         self,
@@ -321,32 +311,6 @@ class WorldState(state.State):
         self.map_drawing(surface)
         self.fullscreen_animations(surface)
 
-    def translate_input_event(self, event: PlayerInput) -> PlayerInput:
-        try:
-            return PlayerInput(
-                self.keymap[event.button],
-                event.value,
-                event.hold_time,
-            )
-        except KeyError:
-            pass
-
-        if event.button == events.UNICODE:
-            if event.value == "n":
-                return PlayerInput(
-                    intentions.NOCLIP,
-                    event.value,
-                    event.hold_time,
-                )
-            if event.value == "r":
-                return PlayerInput(
-                    intentions.RELOAD_MAP,
-                    event.value,
-                    event.hold_time,
-                )
-
-        return event
-
     def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
         """
         Handles player input events.
@@ -369,7 +333,7 @@ class WorldState(state.State):
             otherwise.
 
         """
-        event = self.translate_input_event(event)
+        event = translate_input_event(event)
 
         if event.button == intentions.WORLD_MENU:
             if event.pressed:


### PR DESCRIPTION
PR:
* new dictionary "`constants`" has been added to the `intentions.py` file
* "`button_pressed`" event action has been updated to use the new constants dictionary
* new file called tools.py has been created in the tuxemon/platform folder. This file now contains the `key_map` and the `translate_input_event` function, which were previously in the `worldstate` file
* refactors `translate_input_event` function
* unittest for `translate_input_event` function

These changes don't affect how the game works, but they do make it easier to use certain commands. For example, you can now use `is button_pressed INTERACT` instead of `is button_pressed K_RETURN` to check if the enter key is pressed. Similarly, you can use is `button_pressed RUN` which is equal to press shift key.

However, there's still a bit of work to be done.
```
    <property name="act1" value="translated_dialog lmaoooooo"/>
    <property name="cond1" value="is char_facing_tile player"/>
    <property name="cond2" value="is button_pressed RUN"/>
```
in this way you can read the sign by clicking shift, it appears the dialogue, but for closing the dialogue, then you still need to click key (enter)