### PR TITLE
Extract mission management from NPC to MissionManager

### DIFF
--- a/tests/tuxemon/test_actions.py
+++ b/tests/tuxemon/test_actions.py
@@ -7,6 +7,7 @@ from tuxemon import prepare
 from tuxemon.client import LocalPygameClient
 from tuxemon.db import Direction, MissionModel, MissionStatus, db
 from tuxemon.event.actions.char_move import parse_path_parameters
+from tuxemon.mission import MissionManager
 from tuxemon.player import Player
 from tuxemon.session import local_session
 
@@ -239,22 +240,23 @@ class TestMissionActions(unittest.TestCase):
             self.action = local_session.client.event_engine
             local_session.player = Player()
             self.player = local_session.player
-            self.player.missions = []
+            self.player.mission_manager = MissionManager()
             self._mission_model = {"no_type": self._mission}
             db.database["mission"] = self._mission_model
+            self.missions = self.player.mission_manager.missions
 
     def test_set_mission_add_success(self):
         _params = ["player", "no_type", "add"]
         self.action.execute_action("set_mission", _params)
-        self.assertEqual(len(self.player.missions), 1)
-        self.assertEqual(self.player.missions[0].slug, "no_type")
-        self.assertEqual(self.player.missions[0].status, self._pending)
+        self.assertEqual(len(self.missions), 1)
+        self.assertEqual(self.missions[0].slug, "no_type")
+        self.assertEqual(self.missions[0].status, self._pending)
 
     def test_set_mission_add_fail(self):
         _params = ["player", "no_type", "jimmy"]
         with self.assertRaises(ValueError):
             self.action.execute_action("set_mission", _params)
-        self.assertEqual(len(self.player.missions), 0)
+        self.assertEqual(len(self.missions), 0)
 
     def test_set_mission_add_multiple(self):
         self._mission_model["town"] = MissionModel(slug="town")
@@ -262,26 +264,26 @@ class TestMissionActions(unittest.TestCase):
         for slug in self._mission_model.keys():
             _params = ["player", slug, "add"]
             self.action.execute_action("set_mission", _params)
-        self.assertEqual(len(self.player.missions), 3)
+        self.assertEqual(len(self.missions), 3)
 
     def test_set_mission_add_status_success(self):
         _params = ["player", "no_type", "add", "completed"]
         self.action.execute_action("set_mission", _params)
-        self.assertEqual(len(self.player.missions), 1)
-        self.assertEqual(self.player.missions[0].status, self._completed)
+        self.assertEqual(len(self.missions), 1)
+        self.assertEqual(self.missions[0].status, self._completed)
 
     def test_set_mission_add_status_fail(self):
         _params = ["player", "no_type", "add", "jimmy"]
         with self.assertRaises(ValueError):
             self.action.execute_action("set_mission", _params)
-        self.assertEqual(len(self.player.missions), 0)
+        self.assertEqual(len(self.missions), 0)
 
     def test_set_mission_change_success(self):
         _params = ["player", "no_type", "add"]
         self.action.execute_action("set_mission", _params)
         _params = ["player", "no_type", "change", "failed"]
         self.action.execute_action("set_mission", _params)
-        self.assertEqual(self.player.missions[0].status, self._failed)
+        self.assertEqual(self.missions[0].status, self._failed)
 
     def test_set_mission_change_fail(self):
         _params = ["player", "no_type", "add"]
@@ -289,14 +291,14 @@ class TestMissionActions(unittest.TestCase):
         _params = ["player", "no_type", "change", "jimmy"]
         with self.assertRaises(ValueError):
             self.action.execute_action("set_mission", _params)
-        self.assertEqual(len(self.player.missions), 1)
+        self.assertEqual(len(self.missions), 1)
 
     def test_set_mission_remove_success(self):
         _params = ["player", "no_type", "add"]
         self.action.execute_action("set_mission", _params)
         _params = ["player", "no_type", "remove"]
         self.action.execute_action("set_mission", _params)
-        self.assertEqual(len(self.player.missions), 0)
+        self.assertEqual(len(self.missions), 0)
 
 
 class TestCharacterActions(unittest.TestCase):

--- a/tests/tuxemon/test_mission.py
+++ b/tests/tuxemon/test_mission.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import unittest
+
+from tuxemon.db import MissionStatus
+from tuxemon.mission import Mission, MissionManager
+
+
+class TestMissionManager(unittest.TestCase):
+    def test_init(self):
+        mission_manager = MissionManager()
+        self.assertEqual(mission_manager.missions, [])
+
+    def test_add_mission(self):
+        mission_manager = MissionManager()
+        mission = Mission()
+        mission_manager.add_mission(mission)
+        self.assertEqual(mission_manager.missions, [mission])
+
+    def test_remove_mission(self):
+        mission_manager = MissionManager()
+        mission = Mission()
+        mission_manager.add_mission(mission)
+        mission_manager.remove_mission(mission)
+        self.assertEqual(mission_manager.missions, [])
+
+    def test_remove_mission_not_found(self):
+        mission_manager = MissionManager()
+        mission = Mission()
+        with self.assertRaises(ValueError):
+            mission_manager.remove_mission(mission)
+
+    def test_find_mission(self):
+        mission_manager = MissionManager()
+        mission = Mission()
+        mission.slug = "test_mission"
+        mission_manager.add_mission(mission)
+        found_mission = mission_manager.find_mission("test_mission")
+        self.assertEqual(found_mission, mission)
+
+    def test_find_mission_not_found(self):
+        mission_manager = MissionManager()
+        found_mission = mission_manager.find_mission("test_mission")
+        self.assertIsNone(found_mission)
+
+    def test_update_status(self):
+        mission = Mission()
+        mission.status = MissionStatus.pending
+        mission.update_status(MissionStatus.completed)
+        self.assertEqual(mission.status, MissionStatus.completed)
+
+    def test_update_status_no_change(self):
+        mission = Mission()
+        mission.status = MissionStatus.pending
+        mission.update_status(MissionStatus.pending)
+        self.assertEqual(mission.status, MissionStatus.pending)

--- a/tuxemon/event/actions/set_mission.py
+++ b/tuxemon/event/actions/set_mission.py
@@ -61,10 +61,10 @@ class SetMissionAction(EventAction):
         mission = Mission()
         mission.load(self.slug)
         mission.status = _status
-        existing = character.find_mission(self.slug)
+        existing = character.mission_manager.find_mission(self.slug)
         if self.operation == "add" and existing is None:
-            character.add_mission(mission)
+            character.mission_manager.add_mission(mission)
         if self.operation == "remove" and existing:
-            character.remove_mission(existing)
+            character.mission_manager.remove_mission(existing)
         if self.operation == "change" and existing:
             existing.status = _status

--- a/tuxemon/event/conditions/check_mission.py
+++ b/tuxemon/event/conditions/check_mission.py
@@ -49,7 +49,7 @@ class CheckMissionCondition(EventCondition):
         # retrieve all missions
         _missions: list[str] = []
         if _mission == "all":
-            _missions = [m.slug for m in character.missions]
+            _missions = [m.slug for m in character.mission_manager.missions]
         else:
             _missions = _mission.split(":")
 
@@ -58,7 +58,7 @@ class CheckMissionCondition(EventCondition):
 
         result = [
             mission
-            for mission in character.missions
+            for mission in character.mission_manager.missions
             if mission.status == _status and mission.slug in _missions
         ]
         return bool(result)

--- a/tuxemon/mission.py
+++ b/tuxemon/mission.py
@@ -15,6 +15,39 @@ SIMPLE_PERSISTANCE_ATTRIBUTES = (
 )
 
 
+class MissionManager:
+    def __init__(self) -> None:
+        self.missions: list[Mission] = []
+
+    def add_mission(self, mission: Mission) -> None:
+        """
+        Adds a mission.
+        """
+        self.missions.append(mission)
+
+    def remove_mission(self, mission: Mission) -> None:
+        """
+        Removes a mission.
+        """
+        self.missions.remove(mission)
+
+    def find_mission(self, mission: str) -> Optional[Mission]:
+        """
+        Finds a mission.
+        """
+        return next(
+            (mis for mis in self.missions if mis.slug == mission), None
+        )
+
+    def encode_missions(self) -> Sequence[Mapping[str, Any]]:
+        return encode_mission(self.missions)
+
+    def load_missions(
+        self, save_data: Optional[Sequence[Mapping[str, Any]]]
+    ) -> None:
+        self.missions = decode_mission(save_data)
+
+
 class Mission:
     """
     Tuxemon mission.
@@ -45,6 +78,12 @@ class Mission:
         self.slug = results.slug
         self.name = T.translate(results.slug)
         self.status = self.status
+
+    def update_status(self, new_status: MissionStatus) -> None:
+        """
+        Updates the mission's status.
+        """
+        self.status = new_status
 
     def get_state(self) -> Mapping[str, Any]:
         """

--- a/tuxemon/states/mission/__init__.py
+++ b/tuxemon/states/mission/__init__.py
@@ -52,7 +52,7 @@ class MissionState(PygameMenuState):
         for status in statuses:
             missions = [
                 mission
-                for mission in self.character.missions
+                for mission in self.character.mission_manager.missions
                 if mission.status == status
             ]
             _status = T.translate(status)

--- a/tuxemon/states/world/world_menus.py
+++ b/tuxemon/states/world/world_menus.py
@@ -73,7 +73,7 @@ class WorldMenuState(PygameMenuState):
         if player.menu_player:
             CharacterState = change("CharacterState", kwargs=param)
             menu.append(("menu_player", CharacterState))
-        if player.missions:
+        if player.mission_manager.missions:
             MissionState = change("MissionState", kwargs=param)
             menu.append(("menu_missions", MissionState))
         if player.menu_save:


### PR DESCRIPTION
PR refactors the NPC class to use a `MissionManager` class to manage its missions instead of having a list of missions. So it lets the NPC tap into all the features of the MissionManager class. No functional changes are introduced by this refactoring, and the existing behavior of the NPC and MissionManager classes remains unchanged. This is also a way to move out methods from an overloaded NPC class.