### PR TITLE
PathfindNode: Pathfinding Logic into Separate File

### DIFF
--- a/tests/tuxemon/test_pathfindnode.py
+++ b/tests/tuxemon/test_pathfindnode.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import unittest
 
-from tuxemon.map import PathfindNode
+from tuxemon.movement import PathfindNode
 
 
 class TestPathfindNode(unittest.TestCase):

--- a/tuxemon/map.py
+++ b/tuxemon/map.py
@@ -527,41 +527,6 @@ def direction_to_list(direction: Optional[str]) -> list[Direction]:
     )
 
 
-class PathfindNode:
-    """Used in path finding search."""
-
-    def __init__(
-        self,
-        value: tuple[int, int],
-        parent: Optional[PathfindNode] = None,
-    ) -> None:
-        self.parent = parent
-        self.value = value
-        if self.parent:
-            self.depth: int = self.parent.depth + 1
-        else:
-            self.depth = 0
-
-    def get_parent(self) -> Optional[PathfindNode]:
-        return self.parent
-
-    def set_parent(self, parent: PathfindNode) -> None:
-        self.parent = parent
-        self.depth = parent.depth + 1
-
-    def get_value(self) -> tuple[int, int]:
-        return self.value
-
-    def get_depth(self) -> int:
-        return self.depth
-
-    def __str__(self) -> str:
-        s = str(self.value)
-        if self.parent is not None:
-            s += str(self.parent)
-        return s
-
-
 class TuxemonMap:
     """
     Contains collisions geometry and events loaded from a file.

--- a/tuxemon/movement.py
+++ b/tuxemon/movement.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class PathfindNode:
+    """Used in path finding search."""
+
+    def __init__(
+        self,
+        value: tuple[int, int],
+        parent: Optional[PathfindNode] = None,
+    ) -> None:
+        self.parent = parent
+        self.value = value
+        if self.parent:
+            self.depth: int = self.parent.depth + 1
+        else:
+            self.depth = 0
+
+    def get_parent(self) -> Optional[PathfindNode]:
+        return self.parent
+
+    def set_parent(self, parent: PathfindNode) -> None:
+        self.parent = parent
+        self.depth = parent.depth + 1
+
+    def get_value(self) -> tuple[int, int]:
+        return self.value
+
+    def get_depth(self) -> int:
+        return self.depth
+
+    def __str__(self) -> str:
+        s = str(self.value)
+        if self.parent is not None:
+            s += str(self.parent)
+        return s

--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -28,7 +28,6 @@ from tuxemon.db import Direction
 from tuxemon.entity import Entity
 from tuxemon.graphics import ColorLike
 from tuxemon.map import (
-    PathfindNode,
     RegionProperties,
     TuxemonMap,
     dirs2,
@@ -38,6 +37,7 @@ from tuxemon.map import (
 )
 from tuxemon.map_loader import TMXMapLoader, YAMLEventLoader
 from tuxemon.math import Vector2
+from tuxemon.movement import PathfindNode
 from tuxemon.platform.const import intentions
 from tuxemon.platform.events import PlayerInput
 from tuxemon.platform.tools import translate_input_event


### PR DESCRIPTION
PR moves the `PathfindNode` class from the **map.py** file to a new file called **movement.py**. This helps keep the code organized by separating the pathfinding logic from the map logic. The movement.py file will also hold other pathfinding-related classes in the future, and this change is the first step in making that happen.