### PR TITLE
Refactor CombatState to Use CombatUI Class (HP bar + EXP bar)

### DIFF
--- a/tests/tuxemon/test_combat.py
+++ b/tests/tuxemon/test_combat.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import unittest
+from unittest.mock import MagicMock, Mock
+
+from tuxemon.states.combat.combat_ui import CombatUI
+
+
+class TestCombatUI(unittest.TestCase):
+
+    def test_init(self):
+        combat_ui = CombatUI()
+        self.assertEqual(combat_ui._hp_bars, {})
+        self.assertEqual(combat_ui._exp_bars, {})
+
+    def test_draw_hp_bars(self):
+        combat_ui = CombatUI()
+        graphics = Mock()
+        graphics.hud.hp_bar_player = True
+        graphics.hud.hp_bar_opponent = True
+        hud = {
+            Mock(player=True): Mock(image=Mock()),
+            Mock(player=False): Mock(image=Mock()),
+        }
+        combat_ui._hp_bars = {monster: Mock() for monster in hud.keys()}
+        combat_ui.create_rect_for_bar = MagicMock(return_value=Mock())
+        combat_ui.draw_hp_bars(graphics, hud)
+        for monster, sprite in hud.items():
+            if sprite.player:
+                combat_ui._hp_bars[monster].draw.assert_called_once_with(
+                    sprite.image, combat_ui.create_rect_for_bar.return_value
+                )
+            else:
+                combat_ui._hp_bars[monster].draw.assert_called_once_with(
+                    sprite.image, combat_ui.create_rect_for_bar.return_value
+                )
+
+    def test_draw_hp_bars_no_player(self):
+        combat_ui = CombatUI()
+        graphics = Mock()
+        graphics.hud.hp_bar_player = False
+        graphics.hud.hp_bar_opponent = True
+        hud = {
+            Mock(player=True): Mock(image=Mock()),
+            Mock(player=False): Mock(image=Mock()),
+        }
+        combat_ui._hp_bars = {monster: Mock() for monster in hud.keys()}
+        combat_ui.create_rect_for_bar = MagicMock(return_value=Mock())
+        combat_ui.draw_hp_bars(graphics, hud)
+        for monster, sprite in hud.items():
+            if sprite.player:
+                self.assertFalse(combat_ui._hp_bars[monster].draw.called)
+            else:
+                combat_ui._hp_bars[monster].draw.assert_called_once_with(
+                    sprite.image, combat_ui.create_rect_for_bar.return_value
+                )
+
+    def test_draw_exp_bars(self):
+        combat_ui = CombatUI()
+        graphics = Mock()
+        graphics.hud.exp_bar_player = True
+        hud = {
+            Mock(player=True): Mock(image=Mock()),
+            Mock(player=False): Mock(image=Mock()),
+        }
+        combat_ui._exp_bars = {monster: Mock() for monster in hud.keys()}
+        combat_ui.create_rect_for_bar = MagicMock(return_value=Mock())
+        combat_ui.draw_exp_bars(graphics, hud)
+        for monster, sprite in hud.items():
+            if sprite.player:
+                combat_ui._exp_bars[monster].draw.assert_called_once_with(
+                    sprite.image, combat_ui.create_rect_for_bar.return_value
+                )
+            else:
+                self.assertFalse(combat_ui._exp_bars[monster].draw.called)
+
+    def test_create_rect_for_bar(self):
+        combat_ui = CombatUI()
+        hud = Mock()
+        hud.image.get_width.return_value = 100
+        rect = combat_ui.create_rect_for_bar(hud, 70, 8, 0)
+        self.assertEqual(rect.width, 350)
+        self.assertEqual(rect.height, 40)
+        self.assertEqual(rect.right, 60)
+        self.assertEqual(rect.top, 0)
+
+    def test_draw_all_ui(self):
+        combat_ui = CombatUI()
+        graphics = Mock()
+        hud = {
+            Mock(player=True): Mock(image=Mock()),
+            Mock(player=False): Mock(image=Mock()),
+        }
+        combat_ui.draw_hp_bars = MagicMock()
+        combat_ui.draw_exp_bars = MagicMock()
+        combat_ui.draw_all_ui(graphics, hud)
+        combat_ui.draw_hp_bars.assert_called_once_with(graphics, hud)
+        combat_ui.draw_exp_bars.assert_called_once_with(graphics, hud)

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -163,7 +163,9 @@ class CombatState(CombatAnimations):
         self._action_queue = ActionQueue()
         self._decision_queue: list[Monster] = []
         self._pending_queue: list[EnqueuedAction] = []
-        self._monster_sprite_map: MutableMapping[Monster, Sprite] = {}
+        self._monster_sprite_map: MutableMapping[
+            Union[NPC, Monster], Sprite
+        ] = {}
         self._layout = dict()  # player => home areas on screen
         self._turn: int = 0
         self._prize: int = 0
@@ -246,51 +248,7 @@ class CombatState(CombatAnimations):
 
         """
         super().draw(surface)
-        self.draw_hp_bars()
-        self.draw_exp_bars()
-
-    def create_rect_for_bar(
-        self, hud: Sprite, width: int, height: int, top_offset: int = 0
-    ) -> Rect:
-        """
-        Creates a Rect object for a bar.
-
-        Parameters:
-            hud: The HUD sprite.
-            width: The width of the bar.
-            height: The height of the bar.
-            top_offset: The top offset of the bar.
-
-        Returns:
-            A Rect object representing the bar.
-        """
-        rect = Rect(0, 0, tools.scale(width), tools.scale(height))
-        rect.right = hud.image.get_width() - tools.scale(8)
-        rect.top += tools.scale(top_offset)
-        return rect
-
-    def draw_hp_bars(self) -> None:
-        """Go through the HP bars and redraw them."""
-        show_player_hp = self.graphics.hud.hp_bar_player
-        show_opponent_hp = self.graphics.hud.hp_bar_opponent
-
-        for monster, hud in self.hud.items():
-            if hud.player and show_player_hp:
-                rect = self.create_rect_for_bar(hud, 70, 8, 18)
-            elif not hud.player and show_opponent_hp:
-                rect = self.create_rect_for_bar(hud, 70, 8, 12)
-            else:
-                continue
-            self._hp_bars[monster].draw(hud.image, rect)
-
-    def draw_exp_bars(self) -> None:
-        """Go through the EXP bars and redraw them."""
-        show_player_exp = self.graphics.hud.exp_bar_player
-
-        for monster, hud in self.hud.items():
-            if hud.player and show_player_exp:
-                rect = self.create_rect_for_bar(hud, 70, 6, 31)
-                self._exp_bars[monster].draw(hud.image, rect)
+        self.ui.draw_all_ui(self.graphics, self.hud)
 
     def determine_phase(
         self,

--- a/tuxemon/states/combat/combat_animations.py
+++ b/tuxemon/states/combat/combat_animations.py
@@ -12,7 +12,7 @@ from abc import ABC
 from collections import defaultdict
 from collections.abc import MutableMapping
 from functools import partial
-from typing import TYPE_CHECKING, Literal, Optional
+from typing import TYPE_CHECKING, Literal, Optional, Union
 
 import pygame
 from pygame.rect import Rect
@@ -24,6 +24,8 @@ from tuxemon.menu.interface import ExpBar, HpBar
 from tuxemon.menu.menu import Menu
 from tuxemon.sprite import CaptureDeviceSprite, Sprite
 from tuxemon.tools import scale, scale_sequence
+
+from .combat_ui import CombatUI
 
 if TYPE_CHECKING:
     from tuxemon.animation import Animation
@@ -74,14 +76,15 @@ class CombatAnimations(ABC, Menu[None]):
         self.monsters_in_play: defaultdict[NPC, list[Monster]] = defaultdict(
             list
         )
-        self._monster_sprite_map: MutableMapping[Monster, Sprite] = {}
+        self._monster_sprite_map: MutableMapping[
+            Union[NPC, Monster], Sprite
+        ] = {}
         self.hud: MutableMapping[Monster, Sprite] = {}
         self.is_trainer_battle = False
         self.capdevs: list[CaptureDeviceSprite] = []
         self.text_animations_queue: list[TimedCallable] = []
         self._text_animation_time_left: float = 0
-        self._hp_bars: MutableMapping[Monster, HpBar] = {}
-        self._exp_bars: MutableMapping[Monster, ExpBar] = {}
+        self.ui = CombatUI()
         self._status_icons: defaultdict[Monster, list[Sprite]] = defaultdict(
             list
         )
@@ -121,7 +124,7 @@ class CombatAnimations(ABC, Menu[None]):
     def blink(self, sprite: Sprite) -> None:
         self.task(partial(toggle_visible, sprite), 0.20, 8)
 
-    def animate_trainer_leave(self, trainer: Monster) -> None:
+    def animate_trainer_leave(self, trainer: Union[NPC, Monster]) -> None:
         """Animate the trainer leaving the screen."""
         sprite = self._monster_sprite_map[trainer]
         side = self.get_side(sprite.rect)
@@ -310,7 +313,7 @@ class CombatAnimations(ABC, Menu[None]):
 
     def animate_hp(self, monster: Monster) -> None:
         value = monster.current_hp / monster.hp
-        hp_bar = self._hp_bars[monster]
+        hp_bar = self.ui._hp_bars[monster]
         self.animate(
             hp_bar,
             value=value,
@@ -323,7 +326,7 @@ class CombatAnimations(ABC, Menu[None]):
         monster: Monster,
         initial: int = 0,
     ) -> None:
-        self._hp_bars[monster] = HpBar(initial)
+        self.ui._hp_bars[monster] = HpBar(initial)
         self.animate_hp(monster)
 
     def animate_exp(self, monster: Monster) -> None:
@@ -334,7 +337,7 @@ class CombatAnimations(ABC, Menu[None]):
         value = max(0, min(1, (diff_value) / (diff_target)))
         if monster.levelling_up:
             value = 1.0
-        exp_bar = self._exp_bars[monster]
+        exp_bar = self.ui._exp_bars[monster]
         self.animate(
             exp_bar,
             value=value,
@@ -347,7 +350,7 @@ class CombatAnimations(ABC, Menu[None]):
         monster: Monster,
         initial: int = 0,
     ) -> None:
-        self._exp_bars[monster] = ExpBar(initial)
+        self.ui._exp_bars[monster] = ExpBar(initial)
         self.animate_exp(monster)
 
     def get_side(self, rect: Rect) -> Literal["left", "right"]:

--- a/tuxemon/states/combat/combat_ui.py
+++ b/tuxemon/states/combat/combat_ui.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from collections.abc import MutableMapping
+from typing import TYPE_CHECKING
+
+from pygame.rect import Rect
+
+from tuxemon import tools
+from tuxemon.menu.interface import ExpBar, HpBar
+from tuxemon.sprite import Sprite
+
+if TYPE_CHECKING:
+    from tuxemon.db import BattleGraphicsModel
+    from tuxemon.monster import Monster
+
+
+class CombatUI:
+    """
+    A class responsible for drawing the combat UI, including HP and EXP bars.
+    """
+
+    def __init__(self) -> None:
+        self._hp_bars: MutableMapping[Monster, HpBar] = {}
+        self._exp_bars: MutableMapping[Monster, ExpBar] = {}
+
+    def draw_hp_bars(
+        self,
+        graphics: BattleGraphicsModel,
+        hud: MutableMapping[Monster, Sprite],
+    ) -> None:
+        """
+        Redraws the HP bars for each monster in the hud dictionary.
+
+        Parameters:
+            graphics: The graphics model for the battle.
+            hud: A dictionary of monsters to sprites.
+        """
+        show_player_hp = graphics.hud.hp_bar_player
+        show_opponent_hp = graphics.hud.hp_bar_opponent
+
+        for monster, _sprite in hud.items():
+            if _sprite.player and show_player_hp:
+                rect = self.create_rect_for_bar(_sprite, 70, 8, 18)
+            elif not _sprite.player and show_opponent_hp:
+                rect = self.create_rect_for_bar(_sprite, 70, 8, 12)
+            else:
+                continue
+            self._hp_bars[monster].draw(_sprite.image, rect)
+
+    def draw_exp_bars(
+        self,
+        graphics: BattleGraphicsModel,
+        hud: MutableMapping[Monster, Sprite],
+    ) -> None:
+        """
+        Redraws the EXP bars for each player monster in the hud dictionary.
+
+        Parameters:
+            graphics: The graphics model for the battle.
+            hud: A dictionary of monsters to sprites.
+        """
+        show_player_exp = graphics.hud.exp_bar_player
+
+        for monster, _sprite in hud.items():
+            if _sprite.player and show_player_exp:
+                rect = self.create_rect_for_bar(_sprite, 70, 6, 31)
+                self._exp_bars[monster].draw(_sprite.image, rect)
+
+    def create_rect_for_bar(
+        self, hud: Sprite, width: int, height: int, top_offset: int = 0
+    ) -> Rect:
+        """
+        Creates a Rect object for a bar.
+
+        Parameters:
+            hud: The sprite for the monster.
+            width: The width of the bar.
+            height: The height of the bar.
+            top_offset: The top offset of the bar. Defaults to 0.
+
+        Returns:
+            A Rect object representing the bar.
+        """
+        rect = Rect(0, 0, tools.scale(width), tools.scale(height))
+        rect.right = hud.image.get_width() - tools.scale(8)
+        rect.top += tools.scale(top_offset)
+        return rect
+
+    def draw_all_ui(
+        self,
+        graphics: BattleGraphicsModel,
+        hud: MutableMapping[Monster, Sprite],
+    ) -> None:
+        """
+        Redraws all the UI elements, including HP and EXP bars.
+
+        Parameters:
+            graphics: The graphics model for the battle.
+            hud: A dictionary of monsters to sprites.
+        """
+        self.draw_hp_bars(graphics, hud)
+        self.draw_exp_bars(graphics, hud)


### PR DESCRIPTION
PR updates the `CombatState`'s draw method to use the `CombatUI` class and adds a file unittest `CombatUI`. To make this work, I've replaced the calls to draw HP and EXP bars with a call to `self.ui.draw_all_ui(surface)` in the CombatState's draw method. It separates the UI rendering logic from the rest of the CombatState logic. 