### PR TITLE
Improved Hook System for State and StateManager

### DIFF
--- a/tests/tuxemon/test_state_manager.py
+++ b/tests/tuxemon/test_state_manager.py
@@ -268,7 +268,6 @@ class EnqueueThenPop(StateManagerTestBase):
         state_c = active.pop()
         self.assertEqual(state_c, self.sm.current_state)
 
-    @skip("need to mock the factory")
     def test_queued_not_in_active_states(self):
         active = set(i.name for i in self.sm.active_states)
         self.assertNotIn("c", active)
@@ -288,3 +287,118 @@ class WhenEmpty(StateManagerTestBase):
 
     def test_no_states_current_state_is_none(self):
         self.assertEqual(self.sm.current_state, None)
+
+
+class TestStateHooks(unittest.TestCase):
+
+    def test_state_hooks(self):
+        state = State()
+        mock_callback = Mock()
+
+        state.register_hook("update", mock_callback)
+        state.update(0.1)
+        mock_callback.assert_called_once_with(0.1)
+        mock_callback.reset_mock()
+
+        state.register_hook("draw", mock_callback)
+        mock_surface = Mock()
+        state.draw(mock_surface)
+        mock_callback.assert_called_once_with(mock_surface)
+        mock_callback.reset_mock()
+
+        state.register_hook("resume", mock_callback)
+        state.resume()
+        mock_callback.assert_called_once()
+        mock_callback.reset_mock()
+
+        state.register_hook("pause", mock_callback)
+        state.pause()
+        mock_callback.assert_called_once()
+        mock_callback.reset_mock()
+
+        state.register_hook("shutdown", mock_callback)
+        state.shutdown()
+        mock_callback.assert_called_once()
+        mock_callback.reset_mock()
+
+        state.unregister_hook("update", mock_callback)
+        state.update(0.1)
+        mock_callback.assert_not_called()
+
+    def test_state_hooks_multiple_callbacks(self):
+        state = State()
+        mock_callback1 = Mock()
+        mock_callback2 = Mock()
+
+        state.register_hook("update", mock_callback1)
+        state.register_hook("update", mock_callback2)
+        state.update(0.1)
+
+        mock_callback1.assert_called_once_with(0.1)
+        mock_callback2.assert_called_once_with(0.1)
+
+    def test_state_hooks_unregister_nonexistent(self):
+        state = State()
+        mock_callback = Mock()
+        state.unregister_hook("update", mock_callback)
+
+    def test_state_hooks_unregister_correct_callback(self):
+        state = State()
+        mock_callback1 = Mock()
+        mock_callback2 = Mock()
+        state.register_hook("update", mock_callback1)
+        state.register_hook("update", mock_callback2)
+        state.unregister_hook("update", mock_callback1)
+        state.update(0.1)
+        mock_callback1.assert_not_called()
+        mock_callback2.assert_called_once()
+
+
+class TestStateManagerHooks(unittest.TestCase):
+
+    def test_global_hooks(self):
+        manager = StateManager("test")
+        mock_callback = Mock()
+
+        manager.register_global_hook("pre_state_update", mock_callback)
+        manager.update(0.1)
+        mock_callback.assert_called_once_with(0.1)
+        mock_callback.reset_mock()
+
+        manager.register_global_hook("post_state_update", mock_callback)
+        manager.update(0.1)
+        mock_callback.assert_called()
+        mock_callback.reset_mock()
+
+        manager.unregister_global_hook("pre_state_update", mock_callback)
+        manager.update(0.1)
+        mock_callback.assert_called_once_with(0.1)
+
+    def test_global_hooks_multiple_callbacks(self):
+        manager = StateManager("test")
+        mock_callback1 = Mock()
+        mock_callback2 = Mock()
+
+        manager.register_global_hook("pre_state_update", mock_callback1)
+        manager.register_global_hook("pre_state_update", mock_callback2)
+        manager.update(0.1)
+
+        mock_callback1.assert_called_once_with(0.1)
+        mock_callback2.assert_called_once_with(0.1)
+
+    def test_global_hooks_unregister_nonexistent(self):
+        manager = StateManager("test")
+        mock_callback = Mock()
+        with self.assertRaises(ValueError):
+            manager.unregister_global_hook("pre_state_update", mock_callback)
+
+    def test_global_hooks_unregister_correct_callback(self):
+        manager = StateManager("test")
+        mock_callback1 = Mock()
+        mock_callback2 = Mock()
+        manager.register_global_hook("pre_state_update", mock_callback1)
+        manager.register_global_hook("pre_state_update", mock_callback2)
+        manager.unregister_global_hook("pre_state_update", mock_callback1)
+        manager.update(0.1)
+        mock_callback1.assert_not_called()
+        mock_callback2.assert_called_once()


### PR DESCRIPTION
PR introduces a new hook system for the `State` and `StateManager` classes (as per TODO). The hook system enables to register and trigger custom callbacks for various events, such as updates, draws, and state changes. This feature is implemented through the addition of a `_hooks` dictionary in the `State` class and a `_global_hooks` dictionary in the `StateManager` class. The PR  includes a test suite to ensure the hook system is working correctly. The tests cover various scenarios, including registering and triggering hooks, registering multiple callbacks, and unregistering hooks.


unrelated: I'm thinking about switching from Python 3.9 to 3.10.