### PR TITLE
Refactor Camera into Camera, CameraManager and CameraInputHandler

### DIFF
--- a/docs/handcrafted/action_list.rst
+++ b/docs/handcrafted/action_list.rst
@@ -5,7 +5,8 @@
 .. autoscriptinfoclass:: tuxemon.event.actions.add_tech.AddTechAction
 .. autoscriptinfoclass:: tuxemon.event.actions.breeding.BreedingAction
 .. autoscriptinfoclass:: tuxemon.event.actions.call_event.CallEventAction
-.. autoscriptinfoclass:: tuxemon.event.actions.camera.CameraAction
+.. autoscriptinfoclass:: tuxemon.event.actions.camera_follow.CameraFollowAction
+.. autoscriptinfoclass:: tuxemon.event.actions.camera_mode.CameraModeAction
 .. autoscriptinfoclass:: tuxemon.event.actions.camera_position.CameraPositionAction
 .. autoscriptinfoclass:: tuxemon.event.actions.change_bg.ChangeBgAction
 .. autoscriptinfoclass:: tuxemon.event.actions.change_state.ChangeStateAction

--- a/tests/tuxemon/test_camera.py
+++ b/tests/tuxemon/test_camera.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import unittest
+from unittest.mock import Mock
+
+from tuxemon import prepare
+from tuxemon.camera import (
+    SPEED_DOWN,
+    SPEED_LEFT,
+    SPEED_RIGHT,
+    SPEED_UP,
+    Camera,
+    CameraInputHandler,
+    CameraManager,
+    project,
+    unproject,
+)
+from tuxemon.math import Vector2
+from tuxemon.platform.const import intentions
+
+# For the entity at position (5.0, 5.0):
+# The project function calculates:
+# cx = int(5.0 * 16) = 80
+# cy = int(5.0 * 16) = 80
+# Then, get_center adds half the tile size to both cx and cy:
+# cx + self.tile_size[0] // 2 = 80 + 8 = 88
+# cy + self.tile_size[1] // 2 = 80 + 8 = 88
+
+
+class TestCamera(unittest.TestCase):
+
+    def setUp(self):
+        prepare.TILE_SIZE = (16, 16)
+        self.entity = Mock()
+        self.entity.position3 = Vector2(5.0, 5.0)
+        self.boundary = Mock()
+        self.boundary.get_boundary_validity.return_value = (True, True)
+        self.camera = Camera(self.entity, self.boundary)
+
+    def test_project(self):
+        self.assertEqual(project((1.0, 2.0)), (16, 32))
+        self.assertEqual(project((0.5, 0.5)), (8, 8))
+
+    def test_unproject(self):
+        self.assertEqual(unproject((16, 32)), (1, 2))
+        self.assertEqual(unproject((8, 8)), (0, 0))
+
+    def test_get_center(self):
+        self.assertEqual(
+            self.camera.get_center(Vector2(5.0, 5.0)), Vector2(88, 88)
+        )
+
+    def test_get_entity_center(self):
+        self.assertEqual(self.camera.get_entity_center(), Vector2(88, 88))
+
+    def test_update_follow(self):
+        self.camera.update()
+        self.assertEqual(self.camera.position, Vector2(88, 88))
+
+    def test_update_unfollow(self):
+        self.camera.update()
+        self.camera.unfollow()
+        self.camera.update()
+        self.assertEqual(self.camera.position, Vector2(88, 88))
+        self.camera.move(dx=10)
+        self.assertNotEqual(self.camera.position, Vector2(88, 88))
+
+    def test_move_absolute(self):
+        self.camera.move(x=10.0, y=10.0)
+        self.assertEqual(self.camera.position, Vector2(168, 168))
+
+    def test_move_relative_valid(self):
+        self.boundary.get_boundary_validity.return_value = (True, True)
+        self.camera.move(dx=16, dy=16)
+        self.assertEqual(self.camera.position, Vector2(104, 104))
+
+    def test_move_relative_invalid_x(self):
+        self.boundary.get_boundary_validity.return_value = (False, True)
+        self.camera.move(dx=16, dy=16)
+        self.assertEqual(self.camera.position, Vector2(88, 104))
+
+    def test_move_relative_invalid_y(self):
+        self.boundary.get_boundary_validity.return_value = (True, False)
+        self.camera.move(dx=16, dy=16)
+        self.assertEqual(self.camera.position, Vector2(104, 88))
+
+    def test_reset_to_entity_center(self):
+        self.camera.move(dx=10, dy=10)
+        self.camera.reset_to_entity_center()
+        self.assertEqual(self.camera.position, Vector2(88, 88))
+        self.assertTrue(self.camera.follows_entity)
+        self.assertFalse(self.camera.free_roaming_enabled)
+
+    def test_switch_to_entity(self):
+        new_entity = Mock()
+        new_entity.position3 = Vector2(10.0, 10.0)
+        self.camera.switch_to_entity(new_entity)
+        self.assertEqual(self.camera.entity, new_entity)
+        self.assertEqual(self.camera.position, Vector2(168, 168))
+        self.assertTrue(self.camera.follows_entity)
+
+    def test_switch_to_original_entity(self):
+        new_entity = Mock()
+        new_entity.position3 = Vector2(10.0, 10.0)
+        self.camera.switch_to_entity(new_entity)
+        self.camera.switch_to_original_entity()
+        self.assertEqual(self.camera.entity, self.entity)
+        self.assertEqual(self.camera.position, Vector2(88, 88))
+        self.assertTrue(self.camera.follows_entity)
+
+    def test_move_up(self):
+        self.camera.move_up()
+        self.assertEqual(self.camera.position.y, 88 - SPEED_UP)
+
+    def test_move_down(self):
+        self.camera.move_down()
+        self.assertEqual(self.camera.position.y, 88 + SPEED_DOWN)
+
+    def test_move_left(self):
+        self.camera.move_left()
+        self.assertEqual(self.camera.position.x, 88 - SPEED_LEFT)
+
+    def test_move_right(self):
+        self.camera.move_right()
+        self.assertEqual(self.camera.position.x, 88 + SPEED_RIGHT)
+
+
+class TestCameraManager(unittest.TestCase):
+    def setUp(self):
+        self.manager = CameraManager()
+        self.camera1 = Mock(spec=Camera)
+        self.camera2 = Mock(spec=Camera)
+
+    def test_add_camera(self):
+        self.manager.add_camera(self.camera1)
+        self.assertIn(self.camera1, self.manager.cameras)
+        self.assertEqual(self.manager.active_camera, self.camera1)
+
+    def test_set_active_camera(self):
+        self.manager.add_camera(self.camera1)
+        self.manager.add_camera(self.camera2)
+        self.manager.set_active_camera(self.camera2)
+        self.assertEqual(self.manager.active_camera, self.camera2)
+
+    def test_update(self):
+        self.manager.add_camera(self.camera1)
+        self.manager.update()
+        self.camera1.update.assert_called_once()
+
+    def test_handle_input(self):
+        self.manager.add_camera(self.camera1)
+        self.camera1.free_roaming_enabled = True
+        event = Mock()
+        self.manager.input_handler.handle_input = Mock()
+        self.manager.handle_input(event)
+        self.manager.input_handler.handle_input.assert_called_once_with(event)
+
+    def test_get_active_camera(self):
+        self.manager.add_camera(self.camera1)
+        self.assertEqual(self.manager.get_active_camera(), self.camera1)
+
+
+class TestCameraInputHandler(unittest.TestCase):
+    def setUp(self):
+        self.camera = Mock(spec=Camera)
+        self.handler = CameraInputHandler(self.camera)
+
+    def test_handle_input_free_roaming_held_up(self):
+        self.camera.free_roaming_enabled = True
+        event = Mock()
+        event.held = True
+        event.pressed = False
+        event.button = intentions.UP
+        self.handler.handle_input(event)
+        self.camera.move_up.assert_called_once()
+
+    def test_handle_input_free_roaming_pressed_down(self):
+        self.camera.free_roaming_enabled = True
+        event = Mock()
+        event.held = False
+        event.pressed = True
+        event.button = intentions.DOWN
+        self.handler.handle_input(event)
+        self.camera.move_down.assert_called_once()
+
+    def test_handle_input_free_roaming_disabled(self):
+        self.camera.free_roaming_enabled = False
+        event = Mock()
+        event.held = True
+        event.button = intentions.UP
+        self.handler.handle_input(event)
+        self.camera.move_up.assert_not_called()
+
+    def test_handle_input_return_event(self):
+        self.camera.free_roaming_enabled = True
+        event = Mock()
+        event.held = True
+        event.button = intentions.UP
+        returned_event = self.handler.handle_input(event)
+        self.assertEqual(event, returned_event)
+
+    def test_handle_input_left(self):
+        self.camera.free_roaming_enabled = True
+        event = Mock()
+        event.held = True
+        event.button = intentions.LEFT
+        self.handler.handle_input(event)
+        self.camera.move_left.assert_called_once()
+
+    def test_handle_input_right(self):
+        self.camera.free_roaming_enabled = True
+        event = Mock()
+        event.held = True
+        event.button = intentions.RIGHT
+        self.handler.handle_input(event)
+        self.camera.move_right.assert_called_once()

--- a/tuxemon/camera.py
+++ b/tuxemon/camera.py
@@ -34,6 +34,113 @@ def unproject(position: Sequence[float]) -> tuple[int, int]:
     )
 
 
+class CameraManager:
+    def __init__(self) -> None:
+        """
+        Initializes the CameraManager with an empty list of cameras and
+        no active camera or input handler.
+        """
+        self.cameras: list[Camera] = []
+        self.active_camera: Optional[Camera] = None
+        self.input_handler: Optional[CameraInputHandler] = None
+
+    def add_camera(self, camera: Camera) -> None:
+        """Adds a new camera to the manager.
+
+        If there is no active camera, the newly added camera is set as the
+        active camera.
+
+        Parameters:
+            camera: The camera instance to be added.
+        """
+        self.cameras.append(camera)
+        if self.active_camera is None:
+            self.set_active_camera(camera)
+
+    def set_active_camera(self, camera: Camera) -> None:
+        """
+        Sets the specified camera as the active camera.
+        This also initializes the input handler for the active camera.
+
+        Parameters:
+            camera: The camera instance to be set as active.
+
+        Raises:
+            ValueError: If the specified camera is not in the list of
+            managed cameras.
+        """
+        if camera in self.cameras:
+            self.active_camera = camera
+            self.input_handler = CameraInputHandler(camera)
+        else:
+            raise ValueError("Camera not managed by this CameraManager.")
+
+    def update(self) -> None:
+        """
+        Updates the active camera, if one is set.
+
+        This method should be called regularly to ensure the active camera's
+        state is updated.
+        """
+        if self.active_camera:
+            self.active_camera.update()
+
+    def handle_input(self, event: PlayerInput) -> Optional[PlayerInput]:
+        """
+        Handles player input events through the active camera's input handler.
+
+        Parameters:
+            event: The input event to be handled.
+
+        Returns:
+            The result of the input handling, or None if no input handler is set.
+        """
+        if self.input_handler:
+            return self.input_handler.handle_input(event)
+        return None
+
+    def get_active_camera(self) -> Optional[Camera]:
+        """
+        Returns the currently active camera.
+
+        Returns:
+            The active camera instance, or None if no camera is active.
+        """
+        return self.active_camera
+
+
+class CameraInputHandler:
+    def __init__(self, camera: Camera):
+        self.camera = camera
+
+    def handle_input(self, event: PlayerInput) -> Optional[PlayerInput]:
+        """
+        Handles entity input events and updates the camera state accordingly.
+
+        Returns the PlayerInput event if processed, otherwise returns None.
+        """
+        if self.camera.free_roaming_enabled:
+            if event.held or event.pressed:
+                self.process_direction(event.button)
+                return event
+        return None
+
+    def process_direction(self, direction: int) -> None:
+        """
+        Moves the camera in a specified direction based on the input event.
+        The direction is determined by the input event's button value, which can
+        be one of the following: UP, DOWN, LEFT, or RIGHT.
+        """
+        if direction == intentions.UP:
+            self.camera.move_up()
+        elif direction == intentions.DOWN:
+            self.camera.move_down()
+        elif direction == intentions.LEFT:
+            self.camera.move_left()
+        elif direction == intentions.RIGHT:
+            self.camera.move_right()
+
+
 class Camera:
     """
     A camera class that follows a entity object in a game or simulation.
@@ -168,27 +275,14 @@ class Camera:
         self.position = self.get_entity_center()
         self.follows_entity = True
 
-    def handle_input(self, event: PlayerInput) -> Optional[PlayerInput]:
-        """Handles entity input events and updates the camera state accordingly."""
-        if self.free_roaming_enabled:
-            if event.held:
-                if not self.follows_entity:
-                    self.move_camera(event.button)
-            elif event.pressed:
-                self.move_camera(event.button)
-        return None
+    def move_up(self) -> None:
+        self.move(dy=-SPEED_UP)
 
-    def move_camera(self, direction: int) -> None:
-        """
-        Moves the camera in a specified direction based on the input event.
-        The direction is determined by the input event's button value, which can
-        be one of the following: UP, DOWN, LEFT, or RIGHT.
-        """
-        if direction == intentions.UP:
-            self.move(dy=-SPEED_UP)
-        elif direction == intentions.DOWN:
-            self.move(dy=SPEED_DOWN)
-        elif direction == intentions.LEFT:
-            self.move(dx=-SPEED_LEFT)
-        elif direction == intentions.RIGHT:
-            self.move(dx=SPEED_RIGHT)
+    def move_down(self) -> None:
+        self.move(dy=SPEED_DOWN)
+
+    def move_left(self) -> None:
+        self.move(dx=-SPEED_LEFT)
+
+    def move_right(self) -> None:
+        self.move(dx=SPEED_RIGHT)

--- a/tuxemon/event/actions/camera_follow.py
+++ b/tuxemon/event/actions/camera_follow.py
@@ -15,14 +15,14 @@ logger = logging.getLogger(__name__)
 
 @final
 @dataclass
-class CameraAction(EventAction):
+class CameraFollowAction(EventAction):
     """
     Centers the camera on a specified NPC or the original entity.
 
     Script usage:
         .. code-block::
 
-            camera [slug]
+            camera_follow [slug]
 
     Script parameters:
         npc_slug: The slug of the character to center the camera on.
@@ -30,17 +30,22 @@ class CameraAction(EventAction):
 
     """
 
-    name = "camera"
+    name = "camera_follow"
     npc_slug: Optional[str] = None
 
     def start(self) -> None:
         self.npc_slug = self.npc_slug or "player"
         character = get_npc(self.session, self.npc_slug)
-
         world = self.session.client.get_state_by_name(WorldState)
+        active_camera = world.camera_manager.get_active_camera()
+
+        if active_camera is None:
+            logger.error("No active camera found.")
+            return
+
         if character is None:
-            world.camera.switch_to_original_entity()
+            active_camera.switch_to_original_entity()
             logger.info("Camera has been reset to the original entity.")
         else:
-            world.camera.switch_to_entity(character)
+            active_camera.switch_to_entity(character)
             logger.info(f"Camera has been set on ({character.slug})")

--- a/tuxemon/event/actions/camera_mode.py
+++ b/tuxemon/event/actions/camera_mode.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import final
+
+from tuxemon.event.eventaction import EventAction
+from tuxemon.states.world.worldstate import WorldState
+
+logger = logging.getLogger(__name__)
+
+
+class CameraMode(Enum):
+    FIXED = "fixed"
+    FREE_ROAMING = "free_roaming"
+
+
+@final
+@dataclass
+class CameraModeAction(EventAction):
+    """
+    Change camera mode: freeroaming or fixed.
+
+    Script usage:
+        .. code-block::
+
+            camera_mode <mode>
+
+    Script parameters:
+        npc_slug: The slug of the character to center the camera on.
+
+    """
+
+    name = "camera_mode"
+    mode: str
+
+    def start(self) -> None:
+        world = self.session.client.get_state_by_name(WorldState)
+        camera = world.camera_manager.get_active_camera()
+        if camera is None:
+            logger.error("No active camera found.")
+            return
+        mode = CameraMode(self.mode)
+        if mode == CameraMode.FREE_ROAMING:
+            camera.free_roaming_enabled = True
+            if camera.follows_entity:
+                camera.unfollow()
+        else:
+            camera.reset_to_entity_center()
+            camera.free_roaming_enabled = False
+        logger.info(f"Camera mode set to {mode}")

--- a/tuxemon/event/actions/camera_position.py
+++ b/tuxemon/event/actions/camera_position.py
@@ -4,18 +4,12 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from enum import Enum
 from typing import Optional, final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.states.world.worldstate import WorldState
 
 logger = logging.getLogger(__name__)
-
-
-class CameraMode(Enum):
-    FIXED = "fixed"
-    FREE_ROAMING = "free_roaming"
 
 
 @final
@@ -27,44 +21,44 @@ class CameraPositionAction(EventAction):
     Script usage:
         .. code-block::
 
-            camera_position <x>,<y>,<mode>
+            camera_position <x>,<y>
 
     Script parameters:
         x,y: the coordinates where the camera needs to be centered.
-        mode: the camera mode, either "fixed" or "free_roaming", default "fixed"
 
     """
 
     name = "camera_position"
     x: Optional[int] = None
     y: Optional[int] = None
-    mode: Optional[str] = "fixed"
 
     def start(self) -> None:
         world = self.session.client.get_state_by_name(WorldState)
-        map_size = self.session.client.map_size
-
         if self.x is not None and self.y is not None:
-            if world.boundary_checker.is_within_boundaries((self.x, self.y)):
-                if world.camera.follows_entity:
-                    world.camera.unfollow()
-                if self.mode in [m.value for m in CameraMode]:
-                    world.camera.free_roaming_enabled = (
-                        self.mode == CameraMode.FREE_ROAMING.value
-                    )
-                else:
-                    logger.warning(
-                        f"Invalid camera mode: {self.mode}. Defaulting to fixed."
-                    )
-                    world.camera.free_roaming_enabled = False
-                world.camera.move(self.x, self.y)
-                logger.info(
-                    f"Camera has been set to ({self.x, self.y}) with mode {self.mode}"
-                )
-            else:
-                logger.error(
-                    f"({self.x, self.y}) is outside the map bounds {map_size}"
-                )
+            self._move_camera(world, self.x, self.y)
         else:
-            world.camera.reset_to_entity_center()
-            logger.info("Camera has been reset to entity's center")
+            self._reset_camera(world)
+
+    def _move_camera(self, world: WorldState, x: int, y: int) -> None:
+        map_size = self.session.client.map_size
+        if not world.boundary_checker.is_within_boundaries((x, y)):
+            logger.error(f"({x, y}) is outside the map bounds {map_size}")
+            return
+        camera = world.camera_manager.get_active_camera()
+        if camera is None:
+            logger.warning("No active camera found.")
+            return
+
+        if camera.follows_entity:
+            camera.unfollow()
+
+        camera.move(self.x, self.y)
+        logger.info(f"Camera has been set to ({x, y})")
+
+    def _reset_camera(self, world: WorldState) -> None:
+        camera = world.camera_manager.get_active_camera()
+        if camera is None:
+            logger.warning("No active camera found.")
+            return
+        camera.reset_to_entity_center()
+        logger.info("Camera has been reset to entity's center")

--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -23,7 +23,7 @@ import pygame
 from pygame.rect import Rect
 
 from tuxemon import networking, prepare, state
-from tuxemon.camera import Camera, project
+from tuxemon.camera import Camera, CameraManager, project
 from tuxemon.db import Direction
 from tuxemon.entity import Entity
 from tuxemon.graphics import ColorLike
@@ -165,6 +165,8 @@ class WorldState(state.State):
             local_session.player = new_player
 
         self.camera = Camera(local_session.player, self.boundary_checker)
+        self.camera_manager = CameraManager()
+        self.camera_manager.add_camera(self.camera)
 
         if map_name:
             self.change_map(map_name)
@@ -375,7 +377,7 @@ class WorldState(state.State):
                         self.stop_char(self.player)
                         return None
             else:
-                return self.camera.handle_input(event)
+                return self.camera_manager.handle_input(event)
 
         if prepare.DEV_TOOLS:
             if event.pressed and event.button == intentions.NOCLIP:


### PR DESCRIPTION
PR refactors the camera system

`CameraManager` class is created. This class acts as the central hub for handling all camera-related operations.
   * It maintains a list of all existing Camera objects
   * It manages the currently active camera, allowing for easy switching between different camera views

`CameraInputHandler` class is created. This class takes a Camera object and handles player input specifically for that camera.
   * This separates the input handling logic from the Camera class, making each class responsible for a single purpose

Event actions:
- Change `camera` to `camera_follow` (to follow other entities or NPCs).
- Split `camera_mode` from `camera_position`; now `camera_mode` will let you set it to free_roaming.