### PR TITLE
Refactor conditions and effects to use CommonCondition and CommonEffect + Modifier(BaseModel) (Technique) 

### DIFF
--- a/mods/tuxemon/db/item/allies_address.json
+++ b/mods/tuxemon/db/item/allies_address.json
@@ -1,4 +1,5 @@
 {
+  "effects": [],
   "slug": "allies_address",
   "sort": "utility",
   "sprite": "gfx/items/key-card.png",

--- a/mods/tuxemon/db/item/reg_papers.json
+++ b/mods/tuxemon/db/item/reg_papers.json
@@ -1,4 +1,5 @@
 {
+  "effects": [],
   "slug": "reg_papers",
   "sort": "utility",
   "sprite": "gfx/items/key-card.png",

--- a/mods/tuxemon/db/technique/acid.json
+++ b/mods/tuxemon/db/technique/acid.json
@@ -3,7 +3,9 @@
   "accuracy": 0.8,
   "animation": "drip_orange",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "acid",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/adamantine.json
+++ b/mods/tuxemon/db/technique/adamantine.json
@@ -3,7 +3,9 @@
   "accuracy": 1,
   "animation": "amethyst",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "adamantine",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/air_chain.json
+++ b/mods/tuxemon/db/technique/air_chain.json
@@ -3,8 +3,13 @@
   "accuracy": 0.6,
   "animation": "triforce_163",
   "effects": [
-    "multiattack 3",
-    "damage"
+    {
+      "type": "multiattack",
+      "parameters": ["3"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "air_chain",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/all_in.json
+++ b/mods/tuxemon/db/technique/all_in.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "sparks_gold_alt",
   "effects": [
-    "give recover,own_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["recover", "own_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "all_in",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/altitude.json
+++ b/mods/tuxemon/db/technique/altitude.json
@@ -3,11 +3,22 @@
   "accuracy": 0.8,
 	"animation": null,
 	"conditions": [
-	  	"not status grabbed",
-	  	"not status stuck"
+    {
+      "type": "status",
+      "parameters": ["grabbed"],
+      "operator": "not"
+    },
+    {
+      "type": "status",
+      "parameters": ["stuck"],
+      "operator": "not"
+    }
 	],
 	"effects": [
-		"disappear hawk"
+    {
+      "type": "disappear",
+      "parameters": ["hawk"]
+    }
 	],
   "flip_axes": "",
   "is_fast": true,
@@ -18,6 +29,7 @@
   "sfx": "sfx_blaster",
   "slug": "altitude",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/amnesia.json
+++ b/mods/tuxemon/db/technique/amnesia.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "sparks_gold_alt",
   "effects": [
-    "give exhausted,enemy_monster:own_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["exhausted", "enemy_monster:own_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_shine",
   "slug": "amnesia",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/ants.json
+++ b/mods/tuxemon/db/technique/ants.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "slash_power",
   "effects": [
-    "switch enemy_monster,earth"
+    {
+      "type": "switch",
+      "parameters": ["enemy_monster", "earth"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "ants",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/arcane_eye.json
+++ b/mods/tuxemon/db/technique/arcane_eye.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "crystal_absorb",
   "effects": [
-    "give elementalshield,own_monster"
+    {
+      "type": "give",
+      "parameters": ["elementalshield", "own_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "arcane_eye",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": false,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/assault.json
+++ b/mods/tuxemon/db/technique/assault.json
@@ -3,7 +3,9 @@
   "accuracy": 0.9,
   "animation": "pound",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": true,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "assault",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/avalanche.json
+++ b/mods/tuxemon/db/technique/avalanche.json
@@ -3,8 +3,14 @@
   "accuracy": 0.8,
   "animation": "rockfall_193",
   "effects": [
-    "give exhausted,enemy_monster",
-    "splash 2"
+    {
+      "type": "give",
+      "parameters": ["exhausted","enemy_monster"]
+    },
+    {
+      "type": "splash",
+      "parameters": ["2"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +21,7 @@
   "sfx": "sfx_crumble3",
   "slug": "avalanche",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/barking.json
+++ b/mods/tuxemon/db/technique/barking.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "pound",
   "effects": [
-    "give flinching,enemy_monster"
+    {
+      "type": "give",
+      "parameters": ["flinching", "enemy_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "barking",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/battery_acid.json
+++ b/mods/tuxemon/db/technique/battery_acid.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "disintegrate_83",
   "effects": [
-    "give poison,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["poison", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_bubbles",
   "slug": "battery_acid",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/battery_discharge.json
+++ b/mods/tuxemon/db/technique/battery_discharge.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "disintegrate_83",
   "effects": [
-    "damage",
-    "prop_healing own_monster,0.2"
+    {
+      "type": "damage"
+    },
+    {
+      "type": "prop_healing",
+      "parameters": ["own_monster", "0.2"]
+    }
   ],
   "flip_axes": "",
   "healing_power": 3.0,
@@ -16,6 +21,7 @@
   "sfx": "sfx_lightning1",
   "slug": "battery_discharge",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/beam.json
+++ b/mods/tuxemon/db/technique/beam.json
@@ -3,8 +3,13 @@
   "accuracy": 1,
   "animation": "crystal",
   "effects": [
-    "give blinded,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["blinded", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_laser_beam",
   "slug": "beam",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/berserk.json
+++ b/mods/tuxemon/db/technique/berserk.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "constantburn",
   "effects": [
-    "give enraged,own_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["enraged", "own_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_growl",
   "slug": "berserk",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/biting_winds.json
+++ b/mods/tuxemon/db/technique/biting_winds.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "explosion_ice_112",
   "effects": [
-    "give softened,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["softened", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_tornado",
   "slug": "biting_winds",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/blade.json
+++ b/mods/tuxemon/db/technique/blade.json
@@ -3,7 +3,9 @@
   "accuracy": 0.85,
   "animation": "slash_power",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "x",
   "is_fast": true,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "blade",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/blood_bond.json
+++ b/mods/tuxemon/db/technique/blood_bond.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "sparks_red",
   "effects": [
-    "give lifeleech,enemy_monster:own_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["lifeleech", "enemy_monster:own_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "blood_bond",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/blood_nets.json
+++ b/mods/tuxemon/db/technique/blood_nets.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "ruby_radiate",
   "effects": [
-    "give lifeleech,enemy_monster"
+    {
+      "type": "give",
+      "parameters": ["lifeleech", "enemy_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "blood_nets",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/blossom.json
+++ b/mods/tuxemon/db/technique/blossom.json
@@ -3,8 +3,13 @@
   "accuracy": 0.85,
   "animation": "gloop_orange",
   "effects": [
-    "damage",
-    "prop_healing own_monster,0.2"
+    {
+      "type": "damage"
+    },
+    {
+      "type": "prop_healing",
+      "parameters": ["own_monster", "0.2"]
+    }
   ],
   "flip_axes": "",
   "healing_power": 2.0,
@@ -16,6 +21,7 @@
   "sfx": "sfx_blaster",
   "slug": "blossom",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/boulder.json
+++ b/mods/tuxemon/db/technique/boulder.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "shield_rock",
   "effects": [
-    "give hardshell,own_monster"
+    {
+      "type": "give",
+      "parameters": ["hardshell", "own_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_crumble2",
   "slug": "boulder",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": false,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/breath.json
+++ b/mods/tuxemon/db/technique/breath.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "crystal_radiate",
   "effects": [
-    "give noddingoff,enemy_monster"
+    {
+      "type": "give",
+      "parameters": ["noddingoff", "enemy_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "breath",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/breathe_fire.json
+++ b/mods/tuxemon/db/technique/breathe_fire.json
@@ -3,7 +3,9 @@
   "accuracy": 0.8,
   "animation": "firelion_right",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "x",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_flames2",
   "slug": "breathe_fire",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/bubble_trap.json
+++ b/mods/tuxemon/db/technique/bubble_trap.json
@@ -3,8 +3,13 @@
   "accuracy": 0.75,
   "animation": "bomb_bright",
   "effects": [
-    "give grabbed,enemy_monster:own_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["grabbed", "enemy_monster:own_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_bubbles",
   "slug": "bubble_trap",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/bubbles.json
+++ b/mods/tuxemon/db/technique/bubbles.json
@@ -3,7 +3,9 @@
   "accuracy": 1.0,
   "animation": "bubbleattack",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_bubbles",
   "slug": "bubbles",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/bullet.json
+++ b/mods/tuxemon/db/technique/bullet.json
@@ -3,7 +3,9 @@
   "accuracy": 0.85,
   "animation": "sparks_red",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": true,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "bullet",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/burrow_blast.json
+++ b/mods/tuxemon/db/technique/burrow_blast.json
@@ -3,11 +3,22 @@
   "accuracy": 0.8,
 	"animation": null,
 	"conditions": [
-	  	"not status grabbed",
-	  	"not status stuck"
+    {
+      "type": "status",
+      "parameters": ["grabbed"],
+      "operator": "not"
+    },
+    {
+      "type": "status",
+      "parameters": ["stuck"],
+      "operator": "not"
+    }
 	],
 	"effects": [
-		"disappear strike"
+    {
+      "type": "disappear",
+      "parameters": ["strike"]
+    }
 	],
   "flip_axes": "",
   "is_fast": true,
@@ -18,6 +29,7 @@
   "sfx": "sfx_blaster",
   "slug": "burrow_blast",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/buzz.json
+++ b/mods/tuxemon/db/technique/buzz.json
@@ -3,8 +3,13 @@
   "accuracy": 1,
   "animation": "disintegrate_83",
   "effects": [
-    "give flinching,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["flinching", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "buzz",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/canine.json
+++ b/mods/tuxemon/db/technique/canine.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "claws_twice_blue",
   "effects": [
-    "give wild,enemy_monster"
+    {
+      "type": "give",
+      "parameters": ["wild", "enemy_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "canine",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/cat_calling.json
+++ b/mods/tuxemon/db/technique/cat_calling.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "calling",
   "effects": [
-    "give harpooned,enemy_monster"
+    {
+      "type": "give",
+      "parameters": ["harpooned", "enemy_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "cat_calling",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/cavity.json
+++ b/mods/tuxemon/db/technique/cavity.json
@@ -3,7 +3,9 @@
   "accuracy": 0.7,
   "animation": "slash_power",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "cavity",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/chameleon.json
+++ b/mods/tuxemon/db/technique/chameleon.json
@@ -3,8 +3,14 @@
   "accuracy": 1,
   "animation": "red_circle",
   "effects": [
-    "give hardshell,own_monster",
-    "switch own_monster,wood"
+    {
+      "type": "give",
+      "parameters": ["hardshell", "own_monster"]
+    },
+    {
+      "type": "switch",
+      "parameters": ["own_monster", "wood"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +21,7 @@
   "sfx": "sfx_blaster",
   "slug": "chameleon",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/changeling.json
+++ b/mods/tuxemon/db/technique/changeling.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "amethyst",
   "effects": [
-    "give recover,own_monster"
+    {
+      "type": "give",
+      "parameters": ["recover", "own_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "changeling",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/chill_mist.json
+++ b/mods/tuxemon/db/technique/chill_mist.json
@@ -3,7 +3,10 @@
   "accuracy": 0.6,
   "animation": "waterspurt",
   "effects": [
-    "splash 2"
+    {
+      "type": "splash",
+      "parameters": ["2"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_tornado",
   "slug": "chill_mist",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/clairaudience.json
+++ b/mods/tuxemon/db/technique/clairaudience.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "metallic_radiate",
   "effects": [
-    "give feedback,own_monster"
+    {
+      "type": "give",
+      "parameters": ["feedback", "own_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "clairaudience",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": false,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/clamp_on.json
+++ b/mods/tuxemon/db/technique/clamp_on.json
@@ -3,8 +3,14 @@
   "accuracy": 1,
   "animation": "bite",
   "effects": [
-    "give diehard,own_monster",
-    "give grabbed,enemy_monster"
+    {
+      "type": "give",
+      "parameters": ["diehard", "own_monster"]
+    },
+    {
+      "type": "give",
+      "parameters": ["grabbed", "enemy_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +21,7 @@
   "sfx": "sfx_blaster",
   "slug": "clamp_on",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/clock.json
+++ b/mods/tuxemon/db/technique/clock.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "clock",
   "effects": [
-    "give confused,enemy_monster"
+    {
+      "type": "give",
+      "parameters": ["confused", "enemy_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "clock",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/cloud_aether.json
+++ b/mods/tuxemon/db/technique/cloud_aether.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "sparks_blue_alt",
   "effects": [
-    "switch enemy_team:own_team,random"
+    {
+      "type": "switch",
+      "parameters": ["enemy_team:own_team", "random"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "cloud_aether",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/conjurer.json
+++ b/mods/tuxemon/db/technique/conjurer.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "pound_bright",
   "effects": [
-    "give grabbed,enemy_monster"
+    {
+      "type": "give",
+      "parameters": ["grabbed", "enemy_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "conjurer",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/constrict.json
+++ b/mods/tuxemon/db/technique/constrict.json
@@ -3,8 +3,13 @@
   "accuracy": 0.85,
   "animation": "icetacle",
   "effects": [
-    "give grabbed,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["grabbed", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "constrict",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/crushing_bite.json
+++ b/mods/tuxemon/db/technique/crushing_bite.json
@@ -3,8 +3,13 @@
   "accuracy": 0.9,
   "animation": "bite_zombie",
   "effects": [
-    "give stuck,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["stuck", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "crushing_bite",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/crystal.json
+++ b/mods/tuxemon/db/technique/crystal.json
@@ -3,7 +3,9 @@
   "accuracy": 0.9,
   "animation": "crystal",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "crystal",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/cutting_leaves.json
+++ b/mods/tuxemon/db/technique/cutting_leaves.json
@@ -3,8 +3,13 @@
   "accuracy": 0.95,
   "animation": "leafstab",
   "effects": [
-    "give grabbed,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["grabbed", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "cutting_leaves",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/demiurge.json
+++ b/mods/tuxemon/db/technique/demiurge.json
@@ -3,9 +3,17 @@
   "accuracy": 0.8,
   "animation": "demiurge",
   "effects": [
-    "give recover,own_monster",
-    "give confused,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["recover", "own_monster"]
+    },
+    {
+      "type": "give",
+      "parameters": ["confused", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -17,6 +25,7 @@
   "sfx": "sfx_blaster",
   "slug": "demiurge",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/depth_charge.json
+++ b/mods/tuxemon/db/technique/depth_charge.json
@@ -3,11 +3,22 @@
   "accuracy": 0.8,
 	"animation": null,
 	"conditions": [
-	  	"not status grabbed",
-	  	"not status stuck"
+    {
+      "type": "status",
+      "parameters": ["grabbed"],
+      "operator": "not"
+    },
+    {
+      "type": "status",
+      "parameters": ["stuck"],
+      "operator": "not"
+    }
 	],
 	"effects": [
-		"disappear strike"
+    {
+      "type": "disappear",
+      "parameters": ["strike"]
+    }
 	],
   "flip_axes": "",
   "is_fast": true,
@@ -18,6 +29,7 @@
   "sfx": "sfx_blaster",
   "slug": "depth_charge",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/diet.json
+++ b/mods/tuxemon/db/technique/diet.json
@@ -3,7 +3,10 @@
   "accuracy": 1.0,
   "animation": "egg_crack",
   "effects": [
-    "give diehard,own_monster"
+    {
+      "type": "give",
+      "parameters": ["diehard", "own_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "diet",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": false,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/divinity_beam.json
+++ b/mods/tuxemon/db/technique/divinity_beam.json
@@ -3,8 +3,13 @@
   "accuracy": 0.99,
   "animation": "divinity_beam",
   "effects": [
-    "give blinded,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["blinded", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "divinity_beam",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/dreamwalk.json
+++ b/mods/tuxemon/db/technique/dreamwalk.json
@@ -3,10 +3,16 @@
   "accuracy": 1.0,
   "animation": "debian_64",
 	"conditions": [
-	  	"is status noddingoff"
+    {
+      "type": "status",
+      "parameters": ["noddingoff"],
+      "operator": "is"
+    }
 	],
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -17,6 +23,7 @@
   "sfx": "sfx_blaster",
   "slug": "dreamwalk",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/earthquake.json
+++ b/mods/tuxemon/db/technique/earthquake.json
@@ -3,7 +3,9 @@
   "accuracy": 0.7,
   "animation": "rockfall_264",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "earthquake",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": true,

--- a/mods/tuxemon/db/technique/egg_smash.json
+++ b/mods/tuxemon/db/technique/egg_smash.json
@@ -3,7 +3,9 @@
   "accuracy": 0.9,
   "animation": "egg_crack",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "egg_smash",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/electric_multibite.json
+++ b/mods/tuxemon/db/technique/electric_multibite.json
@@ -3,9 +3,17 @@
   "accuracy": 0.9,
   "animation": "beartrap",
   "effects": [
-    "give slow,enemy_monster",
-    "multiattack 2",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["slow", "enemy_monster"]
+    },
+    {
+      "type": "multiattack",
+      "parameters": ["2"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": true,
@@ -16,6 +24,7 @@
   "sfx": "sfx_blaster",
   "slug": "electric_multibite",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/electrical_storm.json
+++ b/mods/tuxemon/db/technique/electrical_storm.json
@@ -3,7 +3,10 @@
   "accuracy": 0.75,
   "animation": "lightning_claw",
   "effects": [
-    "splash 2"
+    {
+      "type": "splash",
+      "parameters": ["2"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_lightning2",
   "slug": "electrical_storm",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/electroplate.json
+++ b/mods/tuxemon/db/technique/electroplate.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "pound",
   "effects": [
-    "switch enemy_monster,metal"
+    {
+      "type": "switch",
+      "parameters": ["enemy_monster", "metal"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "electroplate",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/empty.json
+++ b/mods/tuxemon/db/technique/empty.json
@@ -1,29 +1,34 @@
 {
 	"animation": null,
-	"accuracy": 0.0,
+	"accuracy": 0,
 	"effects": [
-	  "empty"
+	  {
+		"type": "empty"
+	  }
 	],
 	"flip_axes": "",
-	"potency": 0.0,
+	"potency": 0,
 	"power": 0,
 	"range": "special",
 	"sfx": "sfx_blaster",
 	"slug": "empty",
 	"sort": "meta",
+	"modifiers": [],
 	"target": {
-		"enemy_monster": false,
-		"enemy_team": false,
-		"enemy_trainer": false,
-		"own_monster": true,
-		"own_team": false,
-		"own_trainer": false
+	  "enemy_monster": false,
+	  "enemy_team": false,
+	  "enemy_trainer": false,
+	  "own_monster": true,
+	  "own_team": false,
+	  "own_trainer": false
 	},
 	"tech_id": 0,
 	"category": "notype",
-	"tags": ["notype"],
+	"tags": [
+	  "notype"
+	],
 	"types": [],
 	"use_failure": "combat_none",
 	"use_success": null,
 	"use_tech": "combat_skip"
-}
+  }

--- a/mods/tuxemon/db/technique/energy_beam.json
+++ b/mods/tuxemon/db/technique/energy_beam.json
@@ -3,8 +3,13 @@
   "accuracy": 1,
   "animation": "energy_beam",
   "effects": [
-    "give burn,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["burn", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "energy_beam",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/energy_claws.json
+++ b/mods/tuxemon/db/technique/energy_claws.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "slash_power",
   "effects": [
-    "give sniping,own_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["sniping", "own_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "x",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "energy_claws",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/energy_field.json
+++ b/mods/tuxemon/db/technique/energy_field.json
@@ -3,8 +3,14 @@
   "accuracy": 1,
   "animation": "screen",
   "effects": [
-    "give charging,own_monster",
-    "give exhausted,enemy_monster"
+    {
+      "type": "give",
+      "parameters": ["charging", "own_monster"]
+    },
+    {
+      "type": "give",
+      "parameters": ["exhausted", "enemy_monster"]
+    }
   ],
   "flip_axes": "x",
   "is_fast": true,
@@ -15,6 +21,7 @@
   "sfx": "sfx_forcefield",
   "slug": "energy_field",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/evasion.json
+++ b/mods/tuxemon/db/technique/evasion.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "x_attack",
   "effects": [
-    "give focused,own_monster"
+    {
+      "type": "give",
+      "parameters": ["focused", "own_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": true,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "evasion",
   "sort": "meta",
+  "modifiers": [],
   "target": {
     "enemy_monster": false,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/eyebite.json
+++ b/mods/tuxemon/db/technique/eyebite.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "bite",
   "effects": [
-    "give exhausted,enemy_monster"
+    {
+      "type": "give",
+      "parameters": ["exhausted", "enemy_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": true,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "eyebite",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/feint.json
+++ b/mods/tuxemon/db/technique/feint.json
@@ -3,9 +3,17 @@
   "accuracy": 1,
   "animation": "lightning_bolt_138",
   "effects": [
-    "give focused,own_monster",
-    "give tired,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["focused", "own_monster"]
+    },
+    {
+      "type": "give",
+      "parameters": ["tired", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -16,6 +24,7 @@
   "sfx": "sfx_blaster",
   "slug": "feint",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/feline.json
+++ b/mods/tuxemon/db/technique/feline.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "claws_twice_red",
   "effects": [
-    "give wild,own_monster"
+    {
+      "type": "give",
+      "parameters": ["wild", "own_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": true,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "feline",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/fester.json
+++ b/mods/tuxemon/db/technique/fester.json
@@ -3,9 +3,17 @@
   "accuracy": 1,
   "animation": "drip_green",
   "effects": [
-    "give poison,own_monster",
-    "give festering,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["poison", "own_monster"]
+    },
+    {
+      "type": "give",
+      "parameters": ["festering", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -16,6 +24,7 @@
   "sfx": "sfx_bubbles",
   "slug": "fester",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": true,

--- a/mods/tuxemon/db/technique/fiery.json
+++ b/mods/tuxemon/db/technique/fiery.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "pound_bright",
   "effects": [
-    "switch enemy_monster,fire"
+    {
+      "type": "switch",
+      "parameters": ["enemy_monster", "fire"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "fiery",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/fire_ball.json
+++ b/mods/tuxemon/db/technique/fire_ball.json
@@ -3,7 +3,9 @@
   "accuracy": 0.9,
   "animation": "fireball_114",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "x",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_flames2",
   "slug": "fire_ball",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/fire_claw.json
+++ b/mods/tuxemon/db/technique/fire_claw.json
@@ -3,8 +3,13 @@
   "accuracy": 0.75,
   "animation": "slash_power",
   "effects": [
-    "give burn,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["burn", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "x",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_flames1",
   "slug": "fire_claw",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/fire_shield.json
+++ b/mods/tuxemon/db/technique/fire_shield.json
@@ -3,8 +3,14 @@
   "accuracy": 0.6,
   "animation": "shield_fire",
   "effects": [
-    "give elementalshield,own_monster",
-    "give burn,enemy_monster"
+    {
+      "type": "give",
+      "parameters": ["elementalshield", "own_monster"]
+    },
+    {
+      "type": "give",
+      "parameters": ["burn", "enemy_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +21,7 @@
   "sfx": "sfx_blaster",
   "slug": "fire_shield",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/firestorm.json
+++ b/mods/tuxemon/db/technique/firestorm.json
@@ -3,7 +3,9 @@
   "accuracy": 0.8,
   "animation": "fire_storm",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "firestorm",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": true,

--- a/mods/tuxemon/db/technique/flamethrower.json
+++ b/mods/tuxemon/db/technique/flamethrower.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "firelion_right",
   "effects": [
-    "give burn,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["burn", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "x",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_flamethrower",
   "slug": "flamethrower",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/fledgling.json
+++ b/mods/tuxemon/db/technique/fledgling.json
@@ -3,7 +3,9 @@
   "accuracy": 0.75,
   "animation": "turquoise_circle",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "fledgling",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/flood.json
+++ b/mods/tuxemon/db/technique/flood.json
@@ -3,7 +3,10 @@
   "accuracy": 0.6,
   "animation": "watershot",
   "effects": [
-    "splash 2"
+    {
+      "type": "splash",
+      "parameters": ["2"]
+    }
   ],
   "flip_axes": "x",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_bubbles",
   "slug": "flood",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": true,

--- a/mods/tuxemon/db/technique/flow.json
+++ b/mods/tuxemon/db/technique/flow.json
@@ -3,7 +3,10 @@
   "accuracy": 0.6,
   "animation": "waterspurt",
   "effects": [
-    "splash 2"
+    {
+      "type": "splash",
+      "parameters": ["2"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_bubbles",
   "slug": "flow",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/flower_armor.json
+++ b/mods/tuxemon/db/technique/flower_armor.json
@@ -3,7 +3,10 @@
   "accuracy": 1.0,
   "animation": "flower",
   "effects": [
-    "give elementalshield,own_monster"
+    {
+      "type": "give",
+      "parameters": ["elementalshield", "own_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "flower_armor",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": false,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/flower_bloom.json
+++ b/mods/tuxemon/db/technique/flower_bloom.json
@@ -3,7 +3,10 @@
   "accuracy": 0.99,
   "animation": "flower",
   "effects": [
-    "splash 2"
+    {
+      "type": "splash",
+      "parameters": ["2"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "flower_bloom",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/fluff_up.json
+++ b/mods/tuxemon/db/technique/fluff_up.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "smokebomb",
   "effects": [
-    "give recover,own_monster"
+    {
+      "type": "give",
+      "parameters": ["recover", "own_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "fluff_up",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/font.json
+++ b/mods/tuxemon/db/technique/font.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "waterspurt",
   "effects": [
-    "give recover,own_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["recover", "own_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "font",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/food_fight.json
+++ b/mods/tuxemon/db/technique/food_fight.json
@@ -3,8 +3,13 @@
   "accuracy": 0.99,
   "animation": "foodthrow",
   "effects": [
-    "damage",
-    "prop_healing own_monster,0.2"
+    {
+      "type": "damage"
+    },
+    {
+      "type": "prop_healing",
+      "parameters": ["own_monster", "0.2"]
+    }
   ],
   "flip_axes": "",
   "healing_power": 0.1,
@@ -16,6 +21,7 @@
   "sfx": "sfx_blaster",
   "slug": "food_fight",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/forfeit.json
+++ b/mods/tuxemon/db/technique/forfeit.json
@@ -1,30 +1,34 @@
 {
 	"animation": null,
-	"accuracy": 0.0,
-	"conditions": [],
+	"accuracy": 0,
 	"effects": [
-		"forfeit"
+	  {
+		"type": "forfeit"
+	  }
 	],
 	"flip_axes": "",
 	"is_fast": true,
-	"potency": 0.0,
-	"power": 0.0,
+	"potency": 0,
+	"power": 0,
 	"range": "special",
 	"sfx": "sfx_blaster",
 	"slug": "menu_forfeit",
 	"sort": "meta",
+	"modifiers": [],
 	"target": {
-		"enemy_monster": false,
-		"enemy_team": false,
-		"enemy_trainer": false,
-		"own_monster": false,
-		"own_team": false,
-		"own_trainer": false
+	  "enemy_monster": false,
+	  "enemy_team": false,
+	  "enemy_trainer": false,
+	  "own_monster": false,
+	  "own_team": false,
+	  "own_trainer": false
 	},
 	"category": "notype",
-	"tags": ["notype"],
+	"tags": [
+	  "notype"
+	],
 	"tech_id": 0,
 	"use_failure": "generic_failure",
 	"use_success": null,
 	"use_tech": "combat_used_x"
-}
+  }

--- a/mods/tuxemon/db/technique/frostbite.json
+++ b/mods/tuxemon/db/technique/frostbite.json
@@ -3,8 +3,14 @@
   "accuracy": 0.8,
   "animation": "lance_ice",
   "effects": [
-    "give poison,enemy_monster",
-    "splash 2"
+    {
+      "type": "give",
+      "parameters": ["poison","enemy_monster"]
+    },
+    {
+      "type": "splash",
+      "parameters": ["2"]
+    }
   ],
   "flip_axes": "xy",
   "is_fast": false,
@@ -15,6 +21,7 @@
   "sfx": "sfx_blaster",
   "slug": "frostbite",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/fume.json
+++ b/mods/tuxemon/db/technique/fume.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "buff_rage",
   "effects": [
-    "give enraged,own_monster"
+    {
+      "type": "give",
+      "parameters": ["enraged", "own_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "fume",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": false,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/fungal_spore.json
+++ b/mods/tuxemon/db/technique/fungal_spore.json
@@ -3,8 +3,13 @@
   "accuracy": 1.0,
   "animation": "pollenbullet",
   "effects": [
-    "give lifeleech,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["lifeleech", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "fungal_spore",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/geyser.json
+++ b/mods/tuxemon/db/technique/geyser.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "smokebomb_plume",
   "effects": [
-    "switch enemy_monster,water"
+    {
+      "type": "switch",
+      "parameters": ["enemy_monster", "water"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "geyser",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/give_all.json
+++ b/mods/tuxemon/db/technique/give_all.json
@@ -3,8 +3,13 @@
   "accuracy": 1,
   "animation": "firelion_front",
   "effects": [
-    "give exhausted,own_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["exhausted", "own_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "give_all",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/glower.json
+++ b/mods/tuxemon/db/technique/glower.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "green_circle",
   "effects": [
-    "give softened,enemy_monster"
+    {
+      "type": "give",
+      "parameters": ["softened", "enemy_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": true,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "glower",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/gnaw.json
+++ b/mods/tuxemon/db/technique/gnaw.json
@@ -3,7 +3,9 @@
   "accuracy": 1.0,
   "animation": "gnaw",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": true,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "gnaw",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/goad.json
+++ b/mods/tuxemon/db/technique/goad.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "buff_rage",
   "effects": [
-    "give enraged,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["enraged", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": true,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "goad",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/gold_digger.json
+++ b/mods/tuxemon/db/technique/gold_digger.json
@@ -3,7 +3,9 @@
   "accuracy": 0.6,
   "animation": "sparks_gold_alt",
   "effects": [
-    "money"
+    {
+      "type": "money"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "gold_digger",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/gourmet.json
+++ b/mods/tuxemon/db/technique/gourmet.json
@@ -3,8 +3,13 @@
   "accuracy": 1.0,
   "animation": "cakechomp",
   "effects": [
-    "give recover,own_monster",
-    "healing"
+    {
+      "type": "give",
+      "parameters": ["recover", "own_monster"]
+    },
+    {
+      "type": "healing"
+    }
   ],
   "flip_axes": "",
   "healing_power": 3.0,
@@ -16,6 +21,7 @@
   "sfx": "sfx_blaster",
   "slug": "gourmet",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": false,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/greenstone.json
+++ b/mods/tuxemon/db/technique/greenstone.json
@@ -3,7 +3,9 @@
   "accuracy": 0.6,
   "animation": "slash_power",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "greenstone",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/grinding.json
+++ b/mods/tuxemon/db/technique/grinding.json
@@ -3,7 +3,9 @@
   "accuracy": 0.75,
   "animation": "bite_zombie",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "grinding",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/gust.json
+++ b/mods/tuxemon/db/technique/gust.json
@@ -3,7 +3,9 @@
   "accuracy": 1,
   "animation": "x_attack",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "gust",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/hallucinogen_spore.json
+++ b/mods/tuxemon/db/technique/hallucinogen_spore.json
@@ -3,8 +3,13 @@
   "accuracy": 0.9,
   "animation": "pollenbullet",
   "effects": [
-    "give confused,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["confused", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "hallucinogen_spore",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/hammerhead.json
+++ b/mods/tuxemon/db/technique/hammerhead.json
@@ -3,7 +3,9 @@
   "accuracy": 1,
   "animation": "slash_power",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "x",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "hammerhead",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/hawk.json
+++ b/mods/tuxemon/db/technique/hawk.json
@@ -3,8 +3,12 @@
   "accuracy": 1,
   "animation": "slash_power",
   "effects": [
-    "appear",
-    "damage"
+    {
+      "type": "appear"
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +19,7 @@
   "sfx": "sfx_blaster",
   "slug": "hawk",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/heavenly_desserts.json
+++ b/mods/tuxemon/db/technique/heavenly_desserts.json
@@ -3,8 +3,13 @@
   "accuracy": 0.9,
   "animation": "cakechomp",
   "effects": [
-    "give recover,own_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["recover", "own_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "heavenly_desserts",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/hibernate.json
+++ b/mods/tuxemon/db/technique/hibernate.json
@@ -3,8 +3,14 @@
   "accuracy": 1,
   "animation": null,
   "effects": [
-    "give noddingoff,own_monster",
-    "prop_healing own_monster,0.66"
+    {
+      "type": "give",
+      "parameters": ["noddingoff", "own_monster"]
+    },
+    {
+      "type": "prop_healing",
+      "parameters": ["own_monster", "0.66"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +21,7 @@
   "sfx": "sfx_blaster",
   "slug": "hibernate",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": false,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/ice_claw.json
+++ b/mods/tuxemon/db/technique/ice_claw.json
@@ -3,7 +3,9 @@
   "accuracy": 0.8,
   "animation": "icetacle",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "ice_claw",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/ice_shield.json
+++ b/mods/tuxemon/db/technique/ice_shield.json
@@ -3,8 +3,14 @@
   "accuracy": 1,
   "animation": "wall_ice",
   "effects": [
-    "give elementalshield,own_monster",
-    "give slow,enemy_monster"
+    {
+      "type": "give",
+      "parameters": ["elementalshield", "own_monster"]
+    },
+    {
+      "type": "give",
+      "parameters": ["slow", "enemy_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +21,7 @@
   "sfx": "sfx_blaster",
   "slug": "ice_shield",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/ice_storm.json
+++ b/mods/tuxemon/db/technique/ice_storm.json
@@ -3,7 +3,9 @@
   "accuracy": 0.6,
   "animation": "ice_storm",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "ice_storm",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": true,

--- a/mods/tuxemon/db/technique/icicle_spear.json
+++ b/mods/tuxemon/db/technique/icicle_spear.json
@@ -3,7 +3,10 @@
   "accuracy": 0.75,
   "animation": "lance_ice",
   "effects": [
-    "splash 2"
+    {
+      "type": "splash",
+      "parameters": ["2"]
+    }
   ],
   "flip_axes": "xy",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "icicle_spear",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/infectious_bite.json
+++ b/mods/tuxemon/db/technique/infectious_bite.json
@@ -3,8 +3,13 @@
   "accuracy": 0.95,
   "animation": "snake_right",
   "effects": [
-    "give festering,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["festering", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": true,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "infectious_bite",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/insanity.json
+++ b/mods/tuxemon/db/technique/insanity.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "gloop_violet",
   "effects": [
-    "give diehard,enemy_monster"
+    {
+      "type": "give",
+      "parameters": ["diehard", "enemy_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "insanity",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/invictus.json
+++ b/mods/tuxemon/db/technique/invictus.json
@@ -3,9 +3,17 @@
   "accuracy": 0.75,
   "animation": "triforce_163",
   "effects": [
-    "give enraged,own_monster",
-    "give grabbed,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["enraged", "own_monster"]
+    },
+    {
+      "type": "give",
+      "parameters": ["grabbed", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "xy",
   "is_fast": false,
@@ -16,6 +24,7 @@
   "sfx": "sfx_blaster",
   "slug": "invictus",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/just_desserts.json
+++ b/mods/tuxemon/db/technique/just_desserts.json
@@ -3,9 +3,17 @@
   "accuracy": 0.7,
   "animation": "foodthrow",
   "effects": [
-    "give revenge,own_monster",
-    "give poison,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["revenge", "own_monster"]
+    },
+    {
+      "type": "give",
+      "parameters": ["poison", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -16,6 +24,7 @@
   "sfx": "sfx_blaster",
   "slug": "just_desserts",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/kindling_flame.json
+++ b/mods/tuxemon/db/technique/kindling_flame.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "constantburn",
   "effects": [
-    "give enraged,own_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["enraged", "own_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "kindling_flame",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/kraken.json
+++ b/mods/tuxemon/db/technique/kraken.json
@@ -3,7 +3,9 @@
   "accuracy": 0.8,
   "animation": "icetacle",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "kraken",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/lantern.json
+++ b/mods/tuxemon/db/technique/lantern.json
@@ -3,7 +3,9 @@
   "accuracy": 0.9,
   "animation": "gloop_orange",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "lantern",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/laser_beam.json
+++ b/mods/tuxemon/db/technique/laser_beam.json
@@ -3,8 +3,13 @@
   "accuracy": 1.0,
   "animation": "energy_beam",
   "effects": [
-    "give blinded,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["blinded", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": true,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "laser_beam",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/lava.json
+++ b/mods/tuxemon/db/technique/lava.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "shield_lava",
   "effects": [
-    "give burn,own_team:enemy_team",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["burn", "own_team:enemy_team"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "lava",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": true,

--- a/mods/tuxemon/db/technique/leaf_barrage.json
+++ b/mods/tuxemon/db/technique/leaf_barrage.json
@@ -3,8 +3,13 @@
   "accuracy": 0.95,
   "animation": "leafstab",
   "effects": [
-    "multiattack 2",
-    "damage"
+    {
+      "type": "multiattack",
+      "parameters": ["2"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "leaf_barrage",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/leaf_stab.json
+++ b/mods/tuxemon/db/technique/leaf_stab.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "leafstab",
   "effects": [
-    "give burn,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["burn", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "leaf_stab",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/levitate.json
+++ b/mods/tuxemon/db/technique/levitate.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": null,
   "effects": [
-    "give sniping,own_team:enemy_team"
+    {
+      "type": "give",
+      "parameters": ["sniping", "own_team:enemy_team"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "levitate",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": false,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/lick_lash.json
+++ b/mods/tuxemon/db/technique/lick_lash.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "pound",
   "effects": [
-    "give flinching,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["flinching", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "lick_lash",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/life_surge.json
+++ b/mods/tuxemon/db/technique/life_surge.json
@@ -3,8 +3,13 @@
   "accuracy": 1,
   "animation": "heal_burst_120",
   "effects": [
-    "give chargedup,own_monster",
-    "healing"
+    {
+      "type": "give",
+      "parameters": ["chargedup", "own_monster"]
+    },
+    {
+      "type": "healing"
+    }
   ],
   "flip_axes": "",
   "healing_power": 3.0,
@@ -16,6 +21,7 @@
   "sfx": "sfx_bubbles",
   "slug": "life_surge",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/lightning_spheres.json
+++ b/mods/tuxemon/db/technique/lightning_spheres.json
@@ -3,7 +3,9 @@
   "accuracy": 0.9,
   "animation": "lightning_spheres",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "lightning_spheres",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/lineage.json
+++ b/mods/tuxemon/db/technique/lineage.json
@@ -3,7 +3,9 @@
   "accuracy": 1.0,
   "animation": "yellow_circle",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "lineage",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/lust.json
+++ b/mods/tuxemon/db/technique/lust.json
@@ -3,7 +3,10 @@
   "accuracy": 1.0,
   "animation": "drip_red",
   "effects": [
-    "give exhausted,enemy_monster"
+    {
+      "type": "give",
+      "parameters": ["exhausted", "enemy_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "lust",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/magma.json
+++ b/mods/tuxemon/db/technique/magma.json
@@ -3,7 +3,9 @@
   "accuracy": 0.8,
   "animation": "flameball_red",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "magma",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": true,

--- a/mods/tuxemon/db/technique/magnetic_body.json
+++ b/mods/tuxemon/db/technique/magnetic_body.json
@@ -3,9 +3,13 @@
   "accuracy": 1.0,
   "animation": "disintegrate_83",
   "effects": [
-    "give grabbed,own_monster",
-    "give grabbed,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["grabbed", "own_monster:enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -16,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "magnetic_body",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/meltdown.json
+++ b/mods/tuxemon/db/technique/meltdown.json
@@ -3,8 +3,13 @@
   "accuracy": 0.7,
   "animation": "meltdown",
   "effects": [
-    "give festering,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["festering", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "meltdown",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/mending.json
+++ b/mods/tuxemon/db/technique/mending.json
@@ -3,7 +3,9 @@
   "accuracy": 1,
   "animation": "x_attack",
   "effects": [
-    "healing"
+    {
+      "type": "healing"
+    }
   ],
   "flip_axes": "",
   "healing_power": 2.0,
@@ -15,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "mending",
   "sort": "meta",
+  "modifiers": [],
   "target": {
     "enemy_monster": false,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/midnight_mantle.json
+++ b/mods/tuxemon/db/technique/midnight_mantle.json
@@ -3,7 +3,9 @@
   "accuracy": 0.6,
   "animation": "claw_blue",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "x",
   "is_fast": true,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "midnight_mantle",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/mind_explosion.json
+++ b/mods/tuxemon/db/technique/mind_explosion.json
@@ -3,9 +3,17 @@
   "accuracy": 1.0,
   "animation": "explosion_mushroom_128",
   "effects": [
-    "give exhausted,own_monster",
-    "give confused,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["exhausted", "own_monster"]
+    },
+    {
+      "type": "give",
+      "parameters": ["confused", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -16,6 +24,7 @@
   "sfx": "sfx_blaster",
   "slug": "mind_explosion",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/mind_vise.json
+++ b/mods/tuxemon/db/technique/mind_vise.json
@@ -3,8 +3,13 @@
   "accuracy": 1,
   "animation": "amethyst",
   "effects": [
-    "give stuck,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["stuck", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "mind_vise",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/mobbing.json
+++ b/mods/tuxemon/db/technique/mobbing.json
@@ -3,7 +3,9 @@
   "accuracy": 1,
   "animation": "pound",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "mobbing",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/muck.json
+++ b/mods/tuxemon/db/technique/muck.json
@@ -3,7 +3,9 @@
   "accuracy": 0.8,
   "animation": "x_attack",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "muck",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/muddle.json
+++ b/mods/tuxemon/db/technique/muddle.json
@@ -3,8 +3,13 @@
   "accuracy": 1,
   "animation": "sparks_white",
   "effects": [
-    "give focused,own_team:enemy_team",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["focused", "own_team:enemy_team"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "muddle",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/mudslide.json
+++ b/mods/tuxemon/db/technique/mudslide.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "spikes_rock",
   "effects": [
-    "give softened,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["softened", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "mudslide",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/mystic_blending.json
+++ b/mods/tuxemon/db/technique/mystic_blending.json
@@ -3,9 +3,17 @@
   "accuracy": 1,
   "animation": "sparks_blue",
   "effects": [
-    "give recover,own_monster",
-    "give focused,enemy_monster",
-    "healing"
+    {
+      "type": "give",
+      "parameters": ["recover", "own_monster"]
+    },
+    {
+      "type": "give",
+      "parameters": ["focused", "enemy_monster"]
+    },
+    {
+      "type": "healing"
+    }
   ],
   "flip_axes": "",
   "healing_power": 3.0,
@@ -17,6 +25,7 @@
   "sfx": "sfx_blaster",
   "slug": "mystic_blending",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": false,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/needle.json
+++ b/mods/tuxemon/db/technique/needle.json
@@ -3,7 +3,9 @@
   "accuracy": 0.9,
   "animation": "needle",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": true,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "needle",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/negation.json
+++ b/mods/tuxemon/db/technique/negation.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "skull_fire",
   "effects": [
-    "give festering,enemy_monster"
+    {
+      "type": "give",
+      "parameters": ["festering", "enemy_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "negation",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/nest.json
+++ b/mods/tuxemon/db/technique/nest.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "ruby_absorb",
   "effects": [
-    "give sniping,own_monster",
-    "healing"
+    {
+      "type": "give",
+      "parameters": ["sniping", "own_monster"]
+    },
+    {
+      "type": "healing"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -16,6 +21,7 @@
   "sfx": "sfx_blaster",
   "slug": "nest",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": false,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/neutralize.json
+++ b/mods/tuxemon/db/technique/neutralize.json
@@ -3,9 +3,14 @@
   "accuracy": 1,
   "animation": null,
   "effects": [
-    "remove all,own_monster",
-    "remove all,enemy_monster",
-    "reverse enemy_team:own_team"
+    {
+      "type": "remove",
+      "parameters": ["all", "own_monster:enemy_monster"]
+    },
+    {
+      "type": "reverse",
+      "parameters": ["enemy_team:own_team"]
+    }
   ],
   "flip_axes": "",
   "is_fast": true,
@@ -16,6 +21,7 @@
   "sfx": "sfx_blaster",
   "slug": "neutralize",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/oedipus.json
+++ b/mods/tuxemon/db/technique/oedipus.json
@@ -3,9 +3,17 @@
   "accuracy": 0.85,
   "animation": "skull_fire",
   "effects": [
-    "give slow,own_monster",
-    "give confused,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["slow", "own_monster"]
+    },
+    {
+      "type": "give",
+      "parameters": ["confused", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -17,6 +25,7 @@
   "sfx": "sfx_blaster",
   "slug": "oedipus",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/one_million_talons.json
+++ b/mods/tuxemon/db/technique/one_million_talons.json
@@ -3,8 +3,13 @@
   "accuracy": 1,
   "animation": "amethyst",
   "effects": [
-    "give flinching,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["flinching", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "one_million_talons",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/one_two.json
+++ b/mods/tuxemon/db/technique/one_two.json
@@ -3,7 +3,9 @@
   "accuracy": 1,
   "animation": "triple_whammy_80",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "one_two",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/orbs.json
+++ b/mods/tuxemon/db/technique/orbs.json
@@ -3,8 +3,13 @@
   "accuracy": 1,
   "animation": "metallic_absorb",
   "effects": [
-    "damage",
-    "switch enemy_monster,random"
+    {
+      "type": "damage"
+    },
+    {
+      "type": "switch",
+      "parameters": ["enemy_monster", "random"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "orbs",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/oven.json
+++ b/mods/tuxemon/db/technique/oven.json
@@ -2,8 +2,23 @@
   "tech_id": 236,
   "accuracy": 0.8,
 	"animation": null,
+	"conditions": [
+    {
+      "type": "status",
+      "parameters": ["grabbed"],
+      "operator": "not"
+    },
+    {
+      "type": "status",
+      "parameters": ["stuck"],
+      "operator": "not"
+    }
+	],
   "effects": [
-		"disappear fireball"
+    {
+      "type": "disappear",
+      "parameters": ["fireball"]
+    }
   ],
   "flip_axes": "",
   "is_fast": true,
@@ -14,6 +29,7 @@
   "sfx": "sfx_blaster",
   "slug": "oven",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/overfeed.json
+++ b/mods/tuxemon/db/technique/overfeed.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": null,
   "effects": [
-    "give slow,enemy_monster"
+    {
+      "type": "give",
+      "parameters": ["slow", "enemy_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_pulse",
   "slug": "overfeed",
   "sort": "meta",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/overgrowth.json
+++ b/mods/tuxemon/db/technique/overgrowth.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "snake_right",
   "effects": [
-    "give grabbed,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["grabbed", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "overgrowth",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/panjandrum.json
+++ b/mods/tuxemon/db/technique/panjandrum.json
@@ -3,7 +3,10 @@
   "accuracy": 0.75,
   "animation": "explosion_mushroom_128",
   "effects": [
-    "prop_damage enemy_monster,0.25"
+    {
+      "type": "prop_damage",
+      "parameters": ["enemy_monster", "0.25"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "panjandrum",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/peck.json
+++ b/mods/tuxemon/db/technique/peck.json
@@ -3,7 +3,9 @@
   "accuracy": 1,
   "animation": "pound",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "peck",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/peregrine.json
+++ b/mods/tuxemon/db/technique/peregrine.json
@@ -3,7 +3,9 @@
   "accuracy": 0.8,
   "animation": "pound_bright",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": true,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "peregrine",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/perfect_cut.json
+++ b/mods/tuxemon/db/technique/perfect_cut.json
@@ -3,7 +3,9 @@
   "accuracy": 0.8,
   "animation": "slash_power",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "x",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "perfect_cut",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/petrify.json
+++ b/mods/tuxemon/db/technique/petrify.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "shield_rock",
   "effects": [
-    "give stuck,enemy_monster"
+    {
+      "type": "give",
+      "parameters": ["stuck", "enemy_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": true,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "petrify",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/phantasmal_force.json
+++ b/mods/tuxemon/db/technique/phantasmal_force.json
@@ -3,7 +3,9 @@
   "accuracy": 0.9,
   "animation": "sparks_green",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "phantasmal_force",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/piece_of_cake.json
+++ b/mods/tuxemon/db/technique/piece_of_cake.json
@@ -3,8 +3,13 @@
   "accuracy": 1.0,
   "animation": "cakechomp",
   "effects": [
-    "give charging,own_monster",
-    "healing"
+    {
+      "type": "give",
+      "parameters": ["charging", "own_monster"]
+    },
+    {
+      "type": "healing"
+    }
   ],
   "flip_axes": "",
   "healing_power": 0.1,
@@ -16,6 +21,7 @@
   "sfx": "sfx_blaster",
   "slug": "piece_of_cake",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": false,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/pit.json
+++ b/mods/tuxemon/db/technique/pit.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "x_attack",
   "effects": [
-    "give harpooned,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["harpooned", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "pit",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/platinum.json
+++ b/mods/tuxemon/db/technique/platinum.json
@@ -3,9 +3,17 @@
   "accuracy": 0.7,
   "animation": "blue_circle",
   "effects": [
-    "give focused,own_monster",
-    "give softened,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["focused", "own_monster"]
+    },
+    {
+      "type": "give",
+      "parameters": ["softened", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -16,6 +24,7 @@
   "sfx": "sfx_blaster",
   "slug": "platinum",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/poison_courtship.json
+++ b/mods/tuxemon/db/technique/poison_courtship.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "drip_red_alt",
   "effects": [
-    "give poison,enemy_monster"
+    {
+      "type": "give",
+      "parameters": ["poison", "enemy_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "poison_courtship",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/pollen_blast.json
+++ b/mods/tuxemon/db/technique/pollen_blast.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "pollenbullet",
   "effects": [
-    "give confused,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["confused", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "pollen_blast",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/potluck.json
+++ b/mods/tuxemon/db/technique/potluck.json
@@ -3,9 +3,17 @@
   "accuracy": 0.9,
   "animation": "cakechomp",
   "effects": [
-    "give exhausted,own_monster",
-    "give noddingoff,enemy_monster",
-    "healing"
+    {
+      "type": "give",
+      "parameters": ["exhausted", "own_monster"]
+    },
+    {
+      "type": "give",
+      "parameters": ["noddingoff", "enemy_monster"]
+    },
+    {
+      "type": "healing"
+    }
   ],
   "flip_axes": "",
   "healing_power": 1.0,
@@ -17,6 +25,7 @@
   "sfx": "sfx_blaster",
   "slug": "potluck",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/pouch.json
+++ b/mods/tuxemon/db/technique/pouch.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "egg_crack",
   "effects": [
-    "cooldown user,0,sort,damage"
+    {
+      "type": "cooldown",
+      "parameters": ["user","0","sort","damage"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "pouch",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": false,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/proboscis.json
+++ b/mods/tuxemon/db/technique/proboscis.json
@@ -3,8 +3,14 @@
   "accuracy": 0.8,
   "animation": "lance_ice",
   "effects": [
-    "give lifeleech,enemy_monster",
-    "splash 2"
+    {
+      "type": "give",
+      "parameters": ["lifeleech", "enemy_monster"]
+    },
+    {
+      "type": "splash",
+      "parameters": ["2"]
+    }
   ],
   "flip_axes": "xy",
   "is_fast": false,
@@ -15,6 +21,7 @@
   "sfx": "sfx_blaster",
   "slug": "proboscis",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/pseudopod.json
+++ b/mods/tuxemon/db/technique/pseudopod.json
@@ -3,8 +3,13 @@
   "accuracy": 1,
   "animation": "snake_right",
   "effects": [
-    "give festering,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["festering", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "x",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "pseudopod",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/punch.json
+++ b/mods/tuxemon/db/technique/punch.json
@@ -3,7 +3,9 @@
   "accuracy": 0.9,
   "animation": "amethyst",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "punch",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/pyrokinesis.json
+++ b/mods/tuxemon/db/technique/pyrokinesis.json
@@ -3,7 +3,9 @@
   "accuracy": 0.8,
   "animation": "pound",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": true,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "pyrokinesis",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/quicksand.json
+++ b/mods/tuxemon/db/technique/quicksand.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "spikes_rock",
   "effects": [
-    "give stuck,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["stuck", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "quicksand",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/radiance.json
+++ b/mods/tuxemon/db/technique/radiance.json
@@ -3,7 +3,9 @@
   "accuracy": 0.95,
   "animation": "pulse_radiate",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "radiance",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/ram.json
+++ b/mods/tuxemon/db/technique/ram.json
@@ -3,7 +3,9 @@
   "accuracy": 0.85,
   "animation": "pound",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "ram",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/refresh.json
+++ b/mods/tuxemon/db/technique/refresh.json
@@ -3,8 +3,13 @@
   "accuracy": 1,
   "animation": "heal_burst_120",
   "effects": [
-    "give recover,own_monster",
-    "healing"
+    {
+      "type": "give",
+      "parameters": ["recover", "own_monster"]
+    },
+    {
+      "type": "healing"
+    }
   ],
   "flip_axes": "",
   "healing_power": 3.0,
@@ -16,6 +21,7 @@
   "sfx": "sfx_blaster",
   "slug": "refresh",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": false,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/revenge_stance.json
+++ b/mods/tuxemon/db/technique/revenge_stance.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "amethyst_absorb",
   "effects": [
-    "give revenge,enemy_monster"
+    {
+      "type": "give",
+      "parameters": ["revenge", "enemy_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "revenge_stance",
   "sort": "meta",
+  "modifiers": [],
   "target": {
     "enemy_monster": false,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/rift_dash.json
+++ b/mods/tuxemon/db/technique/rift_dash.json
@@ -3,11 +3,22 @@
   "accuracy": 0.8,
 	"animation": null,
 	"conditions": [
-	  	"not status grabbed",
-	  	"not status stuck"
+    {
+      "type": "status",
+      "parameters": ["grabbed"],
+      "operator": "not"
+    },
+    {
+      "type": "status",
+      "parameters": ["stuck"],
+      "operator": "not"
+    }
 	],
 	"effects": [
-		"disappear strike"
+    {
+      "type": "disappear",
+      "parameters": ["strike"]
+    }
 	],
   "flip_axes": "",
   "is_fast": true,
@@ -18,6 +29,7 @@
   "sfx": "sfx_blaster",
   "slug": "rift_dash",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/ring.json
+++ b/mods/tuxemon/db/technique/ring.json
@@ -3,8 +3,14 @@
   "accuracy": 0.8,
   "animation": "pulse_absorb",
   "effects": [
-    "give recover,own_monster",
-    "splash 2"
+    {
+      "type": "give",
+      "parameters": ["recover", "own_monster"]
+    },
+    {
+      "type": "splash",
+      "parameters": ["2"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -16,6 +22,7 @@
   "sfx": "sfx_blaster",
   "slug": "ring",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/riposte.json
+++ b/mods/tuxemon/db/technique/riposte.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "amethyst",
   "effects": [
-    "give retaliate,own_monster"
+    {
+      "type": "give",
+      "parameters": ["retaliate", "own_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": true,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "riposte",
   "sort": "meta",
+  "modifiers": [],
   "target": {
     "enemy_monster": false,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/rock.json
+++ b/mods/tuxemon/db/technique/rock.json
@@ -3,7 +3,9 @@
   "accuracy": 1,
   "animation": "crushingball",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "rock",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/rocky_barrage.json
+++ b/mods/tuxemon/db/technique/rocky_barrage.json
@@ -3,8 +3,13 @@
   "accuracy": 0.9,
   "animation": "rockfall_193",
   "effects": [
-    "multiattack 3",
-    "damage"
+    {
+      "type": "multiattack",
+      "parameters": ["3"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "rocky_barrage",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/roll.json
+++ b/mods/tuxemon/db/technique/roll.json
@@ -3,8 +3,13 @@
   "accuracy": 0.9,
   "animation": "rollingball",
   "effects": [
-    "give hardshell,own_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["hardshell", "own_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": true,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "roll",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/rot.json
+++ b/mods/tuxemon/db/technique/rot.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "drip_green",
   "effects": [
-    "give poison,enemy_monster"
+    {
+      "type": "give",
+      "parameters": ["poison", "enemy_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": true,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "rot",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/ruby.json
+++ b/mods/tuxemon/db/technique/ruby.json
@@ -3,7 +3,9 @@
   "accuracy": 0.8,
   "animation": "ruby",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "ruby",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/run.json
+++ b/mods/tuxemon/db/technique/run.json
@@ -2,11 +2,21 @@
 	"animation": null,
 	"accuracy": 0.0,
 	"conditions": [
-	  	"not status grabbed",
-	  	"not status stuck"
+		{
+		  "type": "status",
+		  "parameters": ["grabbed"],
+		  "operator": "not"
+		},
+		{
+		  "type": "status",
+		  "parameters": ["stuck"],
+		  "operator": "not"
+		}
 	],
 	"effects": [
-		"run"
+    {
+      "type": "run"
+    }
 	],
 	"flip_axes": "",
 	"is_fast": true,
@@ -16,6 +26,7 @@
 	"sfx": "sfx_blaster",
 	"slug": "menu_run",
 	"sort": "meta",
+	"modifiers": [],
 	"target": {
 		"enemy_monster": false,
 		"enemy_team": false,

--- a/mods/tuxemon/db/technique/rust_bomb.json
+++ b/mods/tuxemon/db/technique/rust_bomb.json
@@ -3,8 +3,14 @@
   "accuracy": 0.6,
   "animation": "smokebomb_puff_128",
   "effects": [
-    "give poison,enemy_monster",
-    "splash 2"
+    {
+      "type": "give",
+      "parameters": ["poison", "enemy_monster"]
+    },
+    {
+      "type": "splash",
+      "parameters": ["2"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +21,7 @@
   "sfx": "sfx_blaster",
   "slug": "rust_bomb",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/saber.json
+++ b/mods/tuxemon/db/technique/saber.json
@@ -3,7 +3,9 @@
   "accuracy": 0.8,
   "animation": "x_attack",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "saber",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/salamander.json
+++ b/mods/tuxemon/db/technique/salamander.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "whisp_fire",
   "effects": [
-    "give poison,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["poison", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "salamander",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/sand_spray.json
+++ b/mods/tuxemon/db/technique/sand_spray.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "explosion_dusty_96",
   "effects": [
-    "give blinded,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["blinded", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "sand_spray",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/scope.json
+++ b/mods/tuxemon/db/technique/scope.json
@@ -3,7 +3,9 @@
   "accuracy": 1,
   "animation": "meltdown",
   "effects": [
-    "scope"
+    {
+      "type": "scope"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "scope",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/shadow_blast.json
+++ b/mods/tuxemon/db/technique/shadow_blast.json
@@ -3,8 +3,13 @@
   "accuracy": 0.99,
   "animation": "shadow_blast",
   "effects": [
-    "damage",
-    "prop_healing own_monster,0.2"
+    {
+      "type": "prop_healing",
+      "parameters": ["own_monster","0.2"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "healing_power": 0.2,
@@ -16,6 +21,7 @@
   "sfx": "sfx_blaster",
   "slug": "shadow_blast",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/shadow_boxing.json
+++ b/mods/tuxemon/db/technique/shadow_boxing.json
@@ -3,7 +3,9 @@
   "accuracy": 1,
   "animation": "triple_whammy_80",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "shadow_boxing",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/shapechange.json
+++ b/mods/tuxemon/db/technique/shapechange.json
@@ -3,8 +3,13 @@
   "accuracy": 0.7,
   "animation": "x_attack",
   "effects": [
-    "damage",
-    "switch own_monster,random"
+    {
+      "type": "damage"
+    },
+    {
+      "type": "switch",
+      "parameters": ["own_monster", "random"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "shapechange",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/shooting_star.json
+++ b/mods/tuxemon/db/technique/shooting_star.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "blue_circle",
   "effects": [
-    "photogenesis 18,0,6"
+    {
+      "type": "photogenesis",
+      "parameters": ["18", "0", "6"]
+    }
   ],
   "flip_axes": "",
   "healing_power": 2,
@@ -15,6 +18,7 @@
   "sfx": "sfx_blaster",
   "slug": "shooting_star",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": false,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/shrapnel.json
+++ b/mods/tuxemon/db/technique/shrapnel.json
@@ -3,7 +3,10 @@
   "accuracy": 0.6,
   "animation": "explosion_small",
   "effects": [
-    "splash 2"
+    {
+      "type": "splash",
+      "parameters": ["2"]
+    }
   ],
   "flip_axes": "",
   "is_fast": true,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "shrapnel",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/shuriken.json
+++ b/mods/tuxemon/db/technique/shuriken.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "explosion_small",
   "effects": [
-    "give diehard,own_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["diehard", "own_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "shuriken",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/skip.json
+++ b/mods/tuxemon/db/technique/skip.json
@@ -1,7 +1,7 @@
 {
 	"animation": null,
-	"accuracy": 0.0,
 	"effects": [],
+	"accuracy": 0.0,
 	"flip_axes": "",
 	"potency": 0.0,
 	"power": 0,
@@ -9,6 +9,7 @@
 	"sfx": "sfx_blaster",
 	"slug": "skip",
 	"sort": "meta",
+	"modifiers": [],
 	"target": {
 		"enemy_monster": false,
 		"enemy_team": false,

--- a/mods/tuxemon/db/technique/sleep_bomb.json
+++ b/mods/tuxemon/db/technique/sleep_bomb.json
@@ -3,8 +3,13 @@
   "accuracy": 0.75,
   "animation": "sparks_white",
   "effects": [
-    "give noddingoff,own_team:enemy_team",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["noddingoff", "own_team:enemy_team"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "sleep_bomb",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/sleeping_powder.json
+++ b/mods/tuxemon/db/technique/sleeping_powder.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "explosion_dusty_96",
   "effects": [
-    "give noddingoff,enemy_team"
+    {
+      "type": "give",
+      "parameters": ["noddingoff", "enemy_team"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "sleeping_powder",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": false,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/slice.json
+++ b/mods/tuxemon/db/technique/slice.json
@@ -3,7 +3,9 @@
   "accuracy": 0.9,
   "animation": "pound",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "slice",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/slime.json
+++ b/mods/tuxemon/db/technique/slime.json
@@ -3,8 +3,13 @@
   "accuracy": 1,
   "animation": "sparks_green_alt",
   "effects": [
-    "give festering,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["festering", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "slime",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/snowstorm.json
+++ b/mods/tuxemon/db/technique/snowstorm.json
@@ -3,8 +3,14 @@
   "accuracy": 0.6,
   "animation": "explosion_ice_112",
   "effects": [
-    "give exhausted,enemy_monster",
-    "splash 2"
+    {
+      "type": "give",
+      "parameters": ["exhausted", "enemy_monster"]
+    },
+    {
+      "type": "splash",
+      "parameters": ["2"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +21,7 @@
   "sfx": "sfx_blaster",
   "slug": "snowstorm",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/solar_synthesis.json
+++ b/mods/tuxemon/db/technique/solar_synthesis.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "green_circle",
   "effects": [
-    "photogenesis 6,12,18"
+    {
+      "type": "photogenesis",
+      "parameters": ["6", "12", "18"]
+    }
   ],
   "flip_axes": "",
   "healing_power": 2,
@@ -15,6 +18,7 @@
   "sfx": "sfx_blaster",
   "slug": "solar_synthesis",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": false,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/spiky_strike.json
+++ b/mods/tuxemon/db/technique/spiky_strike.json
@@ -3,7 +3,9 @@
   "accuracy": 0.95,
   "animation": "needle",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "spiky_strike",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/spit_poison.json
+++ b/mods/tuxemon/db/technique/spit_poison.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": null,
   "effects": [
-    "give poison,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["poison", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "spit_poison",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/splinter.json
+++ b/mods/tuxemon/db/technique/splinter.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "snake_right",
   "effects": [
-    "give blinded,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["blinded", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "x",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "splinter",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/spyderbite.json
+++ b/mods/tuxemon/db/technique/spyderbite.json
@@ -2,7 +2,10 @@
   "animation": null,
   "accuracy": 0.0,
   "effects": [
-    "plague spyderbite,0.125"
+    {
+      "type": "plague",
+      "parameters": ["spyderbite","0.125"]
+    }
   ],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_spyderbite.png",
@@ -12,6 +15,7 @@
   "sfx": "sfx_pulse",
   "slug": "spyderbite",
   "sort": "meta",
+  "modifiers": [],
   "target": {
     "enemy_monster": false,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/stabilo.json
+++ b/mods/tuxemon/db/technique/stabilo.json
@@ -3,8 +3,13 @@
   "accuracy": 0.6,
   "animation": "amethyst_absorb",
   "effects": [
-    "multiattack 3",
-    "damage"
+    {
+      "type": "multiattack",
+      "parameters": ["3"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "stabilo",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/staff_smash.json
+++ b/mods/tuxemon/db/technique/staff_smash.json
@@ -3,7 +3,9 @@
   "accuracy": 0.8,
   "animation": "pound",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "staff_smash",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/stampede.json
+++ b/mods/tuxemon/db/technique/stampede.json
@@ -3,8 +3,13 @@
   "accuracy": 1,
   "animation": "explosion_dusty_96",
   "effects": [
-    "give tired,own_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["tired", "own_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "stampede",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/starfall.json
+++ b/mods/tuxemon/db/technique/starfall.json
@@ -3,9 +3,17 @@
   "accuracy": 0.8,
   "animation": "lightning_bolt_138",
   "effects": [
-    "give focused,own_monster",
-    "give tired,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["focused", "own_monster"]
+    },
+    {
+      "type": "give",
+      "parameters": ["tired", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -16,6 +24,7 @@
   "sfx": "sfx_blaster",
   "slug": "starfall",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/static_field.json
+++ b/mods/tuxemon/db/technique/static_field.json
@@ -3,8 +3,14 @@
   "accuracy": 1,
   "animation": "disintegrate_83",
   "effects": [
-    "give exhausted,enemy_monster",
-    "give hardshell,own_monster"
+    {
+      "type": "give",
+      "parameters": ["exhausted", "enemy_monster"]
+    },
+    {
+      "type": "give",
+      "parameters": ["hardshell", "own_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +21,7 @@
   "sfx": "sfx_blaster",
   "slug": "static_field",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": false,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/steel_jaws.json
+++ b/mods/tuxemon/db/technique/steel_jaws.json
@@ -3,7 +3,9 @@
   "accuracy": 0.95,
   "animation": "bite",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "steel_jaws",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/stick.json
+++ b/mods/tuxemon/db/technique/stick.json
@@ -3,7 +3,9 @@
   "accuracy": 0.99,
   "animation": "staffstrike",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "stick",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/sting.json
+++ b/mods/tuxemon/db/technique/sting.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "needle",
   "effects": [
-    "give poison,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["poison", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "sting",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/stone_rot.json
+++ b/mods/tuxemon/db/technique/stone_rot.json
@@ -3,7 +3,10 @@
   "accuracy": 0.9,
   "animation": "drip_green",
   "effects": [
-    "give poison,enemy_monster"
+    {
+      "type": "give",
+      "parameters": ["poison", "enemy_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": true,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "stone_rot",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/stonehenge.json
+++ b/mods/tuxemon/db/technique/stonehenge.json
@@ -3,7 +3,10 @@
   "accuracy": 0.8,
   "animation": "pound_rock",
   "effects": [
-    "splash 2"
+    {
+      "type": "splash",
+      "parameters": ["2"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "stonehenge",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/strangulation.json
+++ b/mods/tuxemon/db/technique/strangulation.json
@@ -3,7 +3,9 @@
   "accuracy": 0.8,
   "animation": "x_attack",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "strangulation",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/strike.json
+++ b/mods/tuxemon/db/technique/strike.json
@@ -3,8 +3,12 @@
   "accuracy": 1,
   "animation": "slash_power",
   "effects": [
-    "appear",
-    "damage"
+    {
+      "type": "appear"
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "x",
   "is_fast": false,
@@ -15,6 +19,7 @@
   "sfx": "sfx_blaster",
   "slug": "strike",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/suck_poison.json
+++ b/mods/tuxemon/db/technique/suck_poison.json
@@ -3,8 +3,13 @@
   "accuracy": 1.0,
   "animation": "drip_green",
   "effects": [
-    "transfer poison,user_to_target",
-    "damage"
+    {
+      "type": "transfer",
+      "parameters": ["poison", "user_to_target"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "suck_poison",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/sudden_glow.json
+++ b/mods/tuxemon/db/technique/sudden_glow.json
@@ -3,9 +3,17 @@
   "accuracy": 1,
   "animation": "heal_burst_120",
   "effects": [
-    "give focused,enemy_monster",
-    "give recover,own_monster",
-    "healing"
+    {
+      "type": "give",
+      "parameters": ["focused", "enemy_monster"]
+    },
+    {
+      "type": "give",
+      "parameters": ["recover", "own_monster"]
+    },
+    {
+      "type": "healing"
+    }
   ],
   "flip_axes": "",
   "healing_power": 2.0,
@@ -17,6 +25,7 @@
   "sfx": "sfx_blaster",
   "slug": "sudden_glow",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": false,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/sunburst.json
+++ b/mods/tuxemon/db/technique/sunburst.json
@@ -3,8 +3,13 @@
   "accuracy": 0.9,
   "animation": "explosion_sun_32",
   "effects": [
-    "give blinded,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["blinded", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "sunburst",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/supernova.json
+++ b/mods/tuxemon/db/technique/supernova.json
@@ -3,8 +3,13 @@
   "accuracy": 0.75,
   "animation": "fireball_114",
   "effects": [
-    "give chargedup,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["chargedup", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "x",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "supernova",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/suplex.json
+++ b/mods/tuxemon/db/technique/suplex.json
@@ -3,9 +3,17 @@
   "accuracy": 0.95,
   "animation": "amethyst_radiate",
   "effects": [
-    "give diehard,own_monster",
-    "give exhausted,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["diehard", "own_monster"]
+    },
+    {
+      "type": "give",
+      "parameters": ["exhausted", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": true,
@@ -17,6 +25,7 @@
   "sfx": "sfx_blaster",
   "slug": "suplex",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/surf.json
+++ b/mods/tuxemon/db/technique/surf.json
@@ -3,7 +3,10 @@
   "accuracy": 0.6,
   "animation": "waterfall",
   "effects": [
-    "splash 2"
+    {
+      "type": "splash",
+      "parameters": ["2"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +18,7 @@
   "sfx": "sfx_bubbles",
   "slug": "surf",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": true,

--- a/mods/tuxemon/db/technique/surge.json
+++ b/mods/tuxemon/db/technique/surge.json
@@ -3,8 +3,13 @@
   "accuracy": 0.75,
   "animation": "lightning_bolt_138",
   "effects": [
-    "give tired,own_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["tired", "own_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "surge",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/swap.json
+++ b/mods/tuxemon/db/technique/swap.json
@@ -2,11 +2,21 @@
 	"animation": null,
 	"accuracy": 0.0,
 	"conditions": [
-	  	"not status grabbed",
-	  	"not status stuck"
+    {
+      "type": "status",
+      "parameters": ["grabbed"],
+      "operator": "not"
+    },
+    {
+      "type": "status",
+      "parameters": ["stuck"],
+      "operator": "not"
+    }
 	],
 	"effects": [
-		"swap"
+    {
+      "type": "swap"
+    }
 	],
 	"flip_axes": "",
 	"potency": 0.0,
@@ -15,6 +25,7 @@
 	"sfx": "sfx_blaster",
 	"slug": "swap",
 	"sort": "meta",
+	"modifiers": [],
 	"target": {
 		"enemy_monster": false,
 		"enemy_team": false,

--- a/mods/tuxemon/db/technique/sylvan.json
+++ b/mods/tuxemon/db/technique/sylvan.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "emerald",
   "effects": [
-    "switch enemy_monster,wood"
+    {
+      "type": "switch",
+      "parameters": ["enemy_monster", "wood"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "sylvan",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/tail_lash.json
+++ b/mods/tuxemon/db/technique/tail_lash.json
@@ -3,8 +3,13 @@
   "accuracy": 1,
   "animation": "tail",
   "effects": [
-    "give flinching,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["flinching", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "tail_lash",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/take_cover.json
+++ b/mods/tuxemon/db/technique/take_cover.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "smokebomb",
   "effects": [
-    "give sniping,own_monster"
+    {
+      "type": "give",
+      "parameters": ["sniping", "own_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "take_cover",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": false,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/ten_thousand_feathers.json
+++ b/mods/tuxemon/db/technique/ten_thousand_feathers.json
@@ -3,8 +3,13 @@
   "accuracy": 0.9,
   "animation": "amethyst",
   "effects": [
-    "give charging,own_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["charging", "own_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "ten_thousand_feathers",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/terror.json
+++ b/mods/tuxemon/db/technique/terror.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "x_attack",
   "effects": [
-    "give lockdown,enemy_monster"
+    {
+      "type": "give",
+      "parameters": ["lockdown", "enemy_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "terror",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/thorn_burst.json
+++ b/mods/tuxemon/db/technique/thorn_burst.json
@@ -3,8 +3,13 @@
   "accuracy": 0.95,
   "animation": "needle",
   "effects": [
-    "give stuck,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["stuck", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "thorn_burst",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/thunderball.json
+++ b/mods/tuxemon/db/technique/thunderball.json
@@ -3,8 +3,13 @@
   "accuracy": 1,
   "animation": "pound",
   "effects": [
-    "give flinching,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["flinching", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "thunderball",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/thunderclap.json
+++ b/mods/tuxemon/db/technique/thunderclap.json
@@ -3,8 +3,13 @@
   "accuracy": 0.95,
   "animation": "thunderstrike",
   "effects": [
-    "give exhausted,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["exhausted", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "thunderclap",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/time_crisis.json
+++ b/mods/tuxemon/db/technique/time_crisis.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "x_attack",
   "effects": [
-    "give slow,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["slow", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": true,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "time_crisis",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/tinder.json
+++ b/mods/tuxemon/db/technique/tinder.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": null,
   "effects": [
-    "give burn,enemy_monster"
+    {
+      "type": "give",
+      "parameters": ["burn", "enemy_monster"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "tinder",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/tip.json
+++ b/mods/tuxemon/db/technique/tip.json
@@ -3,8 +3,13 @@
   "accuracy": 1,
   "animation": "green_circle",
   "effects": [
-    "give festering,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["festering", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "tip",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/tonguespear.json
+++ b/mods/tuxemon/db/technique/tonguespear.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "lance_ice",
   "effects": [
-    "give lifeleech,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["lifeleech", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "xy",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "tonguespear",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/torch.json
+++ b/mods/tuxemon/db/technique/torch.json
@@ -3,8 +3,13 @@
   "accuracy": 0.7,
   "animation": "pulse",
   "effects": [
-    "give flinching,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["flinching", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "torch",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/tornado.json
+++ b/mods/tuxemon/db/technique/tornado.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "tornado_bulk",
   "effects": [
-    "give slow,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["slow", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "tornado",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/trample.json
+++ b/mods/tuxemon/db/technique/trample.json
@@ -3,8 +3,13 @@
   "accuracy": 0.9,
   "animation": "triple_whammy_80",
   "effects": [
-    "give stuck,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["stuck", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": true,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "trample",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/tsunami.json
+++ b/mods/tuxemon/db/technique/tsunami.json
@@ -3,7 +3,9 @@
   "accuracy": 0.75,
   "animation": "waterfall",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "tsunami",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": true,

--- a/mods/tuxemon/db/technique/tux_attack.json
+++ b/mods/tuxemon/db/technique/tux_attack.json
@@ -3,7 +3,9 @@
   "accuracy": 1,
   "animation": "tux_attack",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": true,
@@ -15,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "tux_attack",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/ubuntu.json
+++ b/mods/tuxemon/db/technique/ubuntu.json
@@ -3,7 +3,10 @@
   "accuracy": 1,
   "animation": "ubuntu",
   "effects": [
-    "switch enemy_monster,random"
+    {
+      "type": "switch",
+      "parameters": ["enemy_monster", "random"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +17,7 @@
   "sfx": "sfx_blaster",
   "slug": "ubuntu",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/undertaker.json
+++ b/mods/tuxemon/db/technique/undertaker.json
@@ -3,8 +3,14 @@
   "accuracy": 1,
   "animation": "x_attack",
   "effects": [
-    "give prickly,enemy_monster",
-    "sacrifice 1"
+    {
+      "type": "give",
+      "parameters": ["prickly", "enemy_monster"]
+    },
+    {
+      "type": "sacrifice",
+      "parameters": ["1"]
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +21,7 @@
   "sfx": "sfx_blaster",
   "slug": "undertaker",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/venom.json
+++ b/mods/tuxemon/db/technique/venom.json
@@ -3,7 +3,9 @@
   "accuracy": 0.9,
   "animation": "emerald_absorb",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "venom",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/venomous_tentacle.json
+++ b/mods/tuxemon/db/technique/venomous_tentacle.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "tentacles_water",
   "effects": [
-    "give poison,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["poison", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "venomous_tentacle",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/viper.json
+++ b/mods/tuxemon/db/technique/viper.json
@@ -3,7 +3,9 @@
   "accuracy": 0.8,
   "animation": "emerald_radiate",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "viper",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/vorpal.json
+++ b/mods/tuxemon/db/technique/vorpal.json
@@ -3,8 +3,13 @@
   "accuracy": 0.95,
   "animation": "amethyst_radiate",
   "effects": [
-    "give revenge,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["revenge", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": true,
@@ -16,6 +21,7 @@
   "sfx": "sfx_blaster",
   "slug": "vorpal",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/wall_fire.json
+++ b/mods/tuxemon/db/technique/wall_fire.json
@@ -3,9 +3,17 @@
   "accuracy": 0.8,
   "animation": "wall_fire",
   "effects": [
-    "give elementalshield,own_monster",
-    "give burn,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["elementalshield", "own_monster"]
+    },
+    {
+      "type": "give",
+      "parameters": ["burn", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -16,6 +24,7 @@
   "sfx": "sfx_blaster",
   "slug": "wall_fire",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/wall_of_steel.json
+++ b/mods/tuxemon/db/technique/wall_of_steel.json
@@ -3,8 +3,13 @@
   "accuracy": 0.75,
   "animation": "screen",
   "effects": [
-    "give hardshell,own_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["hardshell", "own_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "x",
   "is_fast": true,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "wall_of_steel",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/wallow.json
+++ b/mods/tuxemon/db/technique/wallow.json
@@ -3,8 +3,13 @@
   "accuracy": 1,
   "animation": "waterspurt",
   "effects": [
-    "give focused,own_monster",
-    "healing"
+    {
+      "type": "give",
+      "parameters": ["focused", "own_monster"]
+    },
+    {
+      "type": "healing"
+    }
   ],
   "flip_axes": "",
   "healing_power": 2.0,
@@ -16,6 +21,7 @@
   "sfx": "sfx_blaster",
   "slug": "wallow",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": false,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/walls.json
+++ b/mods/tuxemon/db/technique/walls.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "wall_wood",
   "effects": [
-    "give hardshell,own_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["hardshell", "own_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "walls",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/water_blast.json
+++ b/mods/tuxemon/db/technique/water_blast.json
@@ -3,7 +3,9 @@
   "accuracy": 1,
   "animation": "beam",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "water_blast",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/water_bullet.json
+++ b/mods/tuxemon/db/technique/water_bullet.json
@@ -3,7 +3,9 @@
   "accuracy": 0.9,
   "animation": "waterbullet",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": true,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "water_bullet",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/web.json
+++ b/mods/tuxemon/db/technique/web.json
@@ -3,8 +3,13 @@
   "accuracy": 0.8,
   "animation": "snake_right",
   "effects": [
-    "give grabbed,enemy_monster",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["grabbed", "enemy_monster"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "x",
   "is_fast": false,
@@ -15,6 +20,7 @@
   "sfx": "sfx_blaster",
   "slug": "web",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/webs_wind.json
+++ b/mods/tuxemon/db/technique/webs_wind.json
@@ -3,9 +3,17 @@
   "accuracy": 1,
   "animation": "tornado_bulk",
   "effects": [
-    "give slow,enemy_monster",
-    "multiattack 5",
-    "damage"
+    {
+      "type": "give",
+      "parameters": ["slow", "enemy_monster"]
+    },
+    {
+      "type": "multiattack",
+      "parameters": ["5"]
+    },
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -17,6 +25,7 @@
   "sfx": "sfx_blaster",
   "slug": "webs_wind",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/whirlwind.json
+++ b/mods/tuxemon/db/technique/whirlwind.json
@@ -3,7 +3,9 @@
   "accuracy": 1,
   "animation": "tornado_volume",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": true,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "whirlwind",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/wiggle.json
+++ b/mods/tuxemon/db/technique/wiggle.json
@@ -3,7 +3,9 @@
   "accuracy": 1.0,
   "animation": "tail",
 	"effects": [
-	  "empty"
+    {
+      "type": "empty"
+    }
 	],
   "flip_axes": "",
   "is_fast": true,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "wiggle",
   "sort": "meta",
+  "modifiers": [],
   "target": {
 		"enemy_monster": false,
 		"enemy_team": false,

--- a/mods/tuxemon/db/technique/wing_tip.json
+++ b/mods/tuxemon/db/technique/wing_tip.json
@@ -3,7 +3,9 @@
   "accuracy": 0.8,
   "animation": "pound",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": true,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "wing_tip",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/mods/tuxemon/db/technique/woodsmash.json
+++ b/mods/tuxemon/db/technique/woodsmash.json
@@ -3,7 +3,9 @@
   "accuracy": 0.9,
   "animation": "woodsmash",
   "effects": [
-    "damage"
+    {
+      "type": "damage"
+    }
   ],
   "flip_axes": "",
   "is_fast": false,
@@ -14,6 +16,7 @@
   "sfx": "sfx_blaster",
   "slug": "woodsmash",
   "sort": "damage",
+  "modifiers": [],
   "target": {
     "enemy_monster": true,
     "enemy_team": false,

--- a/tests/tuxemon/test_evolution.py
+++ b/tests/tuxemon/test_evolution.py
@@ -38,6 +38,8 @@ _ram = TechniqueModel(
     use_tech="combat_used_x",
     tags=["animal"],
     category="simple",
+    effects=[],
+    modifiers=[],
 )
 
 _strike = TechniqueModel(
@@ -63,6 +65,8 @@ _strike = TechniqueModel(
     use_tech="combat_used_x",
     tags=["animal"],
     category="simple",
+    effects=[],
+    modifiers=[],
 )
 
 

--- a/tests/tuxemon/test_jsons_technique.py
+++ b/tests/tuxemon/test_jsons_technique.py
@@ -149,7 +149,8 @@ class TestTechniqueJSON(unittest.TestCase):
             potency = data["potency"]
             if effects:
                 for effect in effects:
-                    if effect.startswith("give") and potency == 0.0:
+                    root = effect.get("type", "")
+                    if root == "give" and potency == 0.0:
                         techniques.append(f"{slug}'s potency is {potency}")
         if techniques:
             print("The following techniques:")

--- a/tests/tuxemon/test_monster.py
+++ b/tests/tuxemon/test_monster.py
@@ -164,6 +164,8 @@ class Learn(MonsterTestBase):
         category="simple",
         tags=["animal"],
         use_tech="combat_used_x",
+        effects=[],
+        modifiers=[],
     )
 
     def setUp(self):

--- a/tests/tuxemon/test_monster_actions.py
+++ b/tests/tuxemon/test_monster_actions.py
@@ -77,6 +77,7 @@ class TestMonsterActions(unittest.TestCase):
         upper_catch_resistance=1.25,
     )
     _faint = ConditionModel(
+        effects=[],
         modifiers=[],
         flip_axes="",
         sfx="sfx_faint",

--- a/tuxemon/condition/condition.py
+++ b/tuxemon/condition/condition.py
@@ -168,7 +168,7 @@ class Condition:
             try:
                 effect_class = Condition.effects_classes[effect.type]
             except KeyError:
-                logger.error(f'ItemEffect "{effect.type}" not implemented')
+                logger.error(f'CondEffect "{effect.type}" not implemented')
             else:
                 effects.append(effect_class(*effect.parameters))
         return effects
@@ -196,7 +196,7 @@ class Condition:
                 condition_class = Condition.conditions_classes[condition.type]
             except KeyError:
                 logger.error(
-                    f'ItemCondition "{condition.type}" not implemented'
+                    f'CondCondition "{condition.type}" not implemented'
                 )
                 continue
 

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -276,7 +276,7 @@ class ItemModel(BaseModel):
         [], description="Conditions that must be met"
     )
     effects: Sequence[CommonEffect] = Field(
-        [], description="Effects this item will have"
+        ..., description="Effects this item will have"
     )
     flip_axes: Literal["", "x", "y", "xy"] = Field(
         "",
@@ -792,11 +792,11 @@ class TechniqueModel(BaseModel):
     tags: Sequence[str] = Field(
         ..., description="The tags of the technique", min_length=1
     )
-    conditions: Sequence[str] = Field(
+    conditions: Sequence[CommonCondition] = Field(
         [], description="Conditions that must be met"
     )
-    effects: Sequence[str] = Field(
-        [], description="Effects this technique uses"
+    effects: Sequence[CommonEffect] = Field(
+        ..., description="Effects this technique uses"
     )
     flip_axes: Literal["", "x", "y", "xy"] = Field(
         ...,
@@ -809,6 +809,7 @@ class TechniqueModel(BaseModel):
     sfx: str = Field(
         ..., description="Sound effect to play when this technique is used"
     )
+    modifiers: list[Modifier] = Field(..., description="Various modifiers")
 
     # Optional fields
     use_tech: Optional[str] = Field(
@@ -905,14 +906,6 @@ class TechniqueModel(BaseModel):
             return v
         raise ValueError(f"the animation {v} doesn't exist in the db")
 
-    @field_validator("conditions")
-    def check_conditions(
-        cls: TechniqueModel, v: Sequence[str]
-    ) -> Sequence[str]:
-        if not v or has.check_conditions(v):
-            return v
-        raise ValueError(f"the conditions {v} aren't correctly formatted")
-
     @field_validator("sfx")
     def sfx_tech_exists(cls: TechniqueModel, v: str) -> str:
         if has.db_entry("sounds", v):
@@ -928,7 +921,7 @@ class ConditionModel(BaseModel):
         [], description="Conditions that must be met"
     )
     effects: Sequence[CommonEffect] = Field(
-        [], description="Effects this condition uses"
+        ..., description="Effects this condition uses"
     )
     flip_axes: Literal["", "x", "y", "xy"] = Field(
         ...,
@@ -947,7 +940,7 @@ class ConditionModel(BaseModel):
     duration: int = Field(
         0, description="How many turns the condition is supposed to last"
     )
-    modifiers: list[Modifier] = Field(..., description="Damage multipliers")
+    modifiers: list[Modifier] = Field(..., description="Various modifiers")
 
     # Optional fields
     category: Optional[CategoryCondition] = Field(
@@ -1961,40 +1954,6 @@ class Validator:
                     f"{file} {sprite.size}: It must be equal to {size}"
                 )
         sprite.close()
-        return True
-
-    def check_conditions(self, conditions: Sequence[str]) -> bool:
-        """
-        Check to see if a condition is correctly formatted.
-
-        Parameters:
-            conditions: The sequence containing the conditions
-
-        Returns:
-            True if it's correctly formatted
-
-        """
-        if not conditions:
-            return True
-
-        _conditions = [
-            element
-            for condition in conditions
-            for element in condition.split(" ")
-        ]
-
-        # check nr of elements
-        if len(_conditions) == 1:
-            raise ValueError(
-                f"{_conditions} invalid, it must have at least: 'is' + 'condition'"
-            )
-
-        # check prefix
-        prefix = _conditions[0]
-        _prefix = True if prefix == "is" or _conditions[0] == "not" else False
-        if not _prefix:
-            raise ValueError(f"{prefix} is invalid, it must be: 'is' or 'not'")
-
         return True
 
     def db_entry(self, table: TableName, slug: str) -> bool:


### PR DESCRIPTION
Follows #2593 and #2602

This PR changes the conditions and effects fields in the technique model, aiming to commonize and simplify their structure (like conditions and items). The changes involve replacing the string sequences with sequences of `CommonCondition` and `CommonEffect` objects, respectively. It adds the modifiers to the techniques (as it has been done for conditions #2580)