### PR TITLE
Refactors ActionQueue + ActionHistory

### DIFF
--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -164,7 +164,6 @@ class CombatState(CombatAnimations):
         self._decision_queue: list[Monster] = []
         # player => home areas on screen
         self._layout: dict[NPC, dict[str, list[Rect]]] = {}
-        self._pending_queue: list[EnqueuedAction] = []
         self._monster_sprite_map: MutableMapping[
             Union[NPC, Monster], Sprite
         ] = {}
@@ -489,7 +488,7 @@ class CombatState(CombatAnimations):
         """Take one action from the queue and do it."""
         if not self._action_queue.is_empty():
             action = self._action_queue.pop()
-            self.perform_action(*action)
+            self.perform_action(action.user, action.method, action.target)
             self.task(self.check_party_hp, 1)
             self.task(self.animate_party_status, 3)
             self.task(self.animate_xp_message, 3)

--- a/tuxemon/technique/effects/multiattack.py
+++ b/tuxemon/technique/effects/multiattack.py
@@ -35,16 +35,14 @@ class MultiAttackEffect(TechEffect):
         combat = tech.combat_state
         value = random.random()
         combat._random_tech_hit[user] = value
-        log = combat._action_queue.history
-        turn = combat._turn
         # Track previous actions with the same technique, user, and target
+        log = combat._action_queue.history.get_actions_by_turn(combat._turn)
         track = [
             action
             for action in log
-            if action[0] == turn
-            and action[1].method == tech
-            and action[1].user == user
-            and action[1].target == target
+            if action.method == tech
+            and action.user == user
+            and action.target == target
         ]
         # Check if the technique has been used the maximum number of times
         done = len(track) < self.times


### PR DESCRIPTION
PR refactors the `ActionQueue` class:
* created `ActionHistory` class, this new class now manages the action history, which cleans up the `ActionQueue` class. It provides methods like `add_action`, `get_actions_by_turn`, and others for working with the history
* the `ActionQueue` class now uses the `ActionHistory` class to handle history-related tasks
* some minor code cleanup and adjustments to how the `from_pending_to_action` function works
* unittest both classes