### PR TITLE
CameraShake (Event Action) + Camera Position (Event Condition)

### DIFF
--- a/docs/handcrafted/action_list.rst
+++ b/docs/handcrafted/action_list.rst
@@ -8,6 +8,7 @@
 .. autoscriptinfoclass:: tuxemon.event.actions.camera_follow.CameraFollowAction
 .. autoscriptinfoclass:: tuxemon.event.actions.camera_mode.CameraModeAction
 .. autoscriptinfoclass:: tuxemon.event.actions.camera_position.CameraPositionAction
+.. autoscriptinfoclass:: tuxemon.event.actions.camera_shake.CameraShakeAction
 .. autoscriptinfoclass:: tuxemon.event.actions.change_bg.ChangeBgAction
 .. autoscriptinfoclass:: tuxemon.event.actions.change_state.ChangeStateAction
 .. autoscriptinfoclass:: tuxemon.event.actions.change_taste.ChangeTasteAction

--- a/docs/handcrafted/condition_list.rst
+++ b/docs/handcrafted/condition_list.rst
@@ -1,5 +1,6 @@
 .. autoscriptinfoclass:: tuxemon.event.conditions.battle_is.BattleIsCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.button_pressed.ButtonPressedCondition
+.. autoscriptinfoclass:: tuxemon.event.conditions.camera_position.CameraPositionCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.char_at.CharAtCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.char_defeated.CharDefeatedCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.char_exists.CharExistsCondition

--- a/mods/tuxemon/maps/spyder_greenwash_level3.yaml
+++ b/mods/tuxemon/maps/spyder_greenwash_level3.yaml
@@ -154,6 +154,7 @@ events:
     - set_variable dempsey_flashback:done
     - set_layer
     - unlock_controls
+    - camera_position
     - set_variable flashback:off
     - transition_teleport spyder_greenwash_level2.tmx,13,2
     - char_face player,up

--- a/tests/tuxemon/test_camera.py
+++ b/tests/tuxemon/test_camera.py
@@ -66,7 +66,7 @@ class TestCamera(unittest.TestCase):
         self.assertNotEqual(self.camera.position, Vector2(88, 88))
 
     def test_move_absolute(self):
-        self.camera.move(x=10.0, y=10.0)
+        self.camera.set_position(x=10.0, y=10.0)
         self.assertEqual(self.camera.position, Vector2(168, 168))
 
     def test_move_relative_valid(self):

--- a/tuxemon/camera.py
+++ b/tuxemon/camera.py
@@ -10,9 +10,9 @@ from tuxemon.math import Vector2
 from tuxemon.platform.const import intentions
 
 if TYPE_CHECKING:
+    from tuxemon.boundary import BoundaryChecker
     from tuxemon.entity import Entity
     from tuxemon.platform.events import PlayerInput
-    from tuxemon.states.world.world_classes import BoundaryChecker
 
 SPEED_UP: int = 7
 SPEED_DOWN: int = 7

--- a/tuxemon/camera.py
+++ b/tuxemon/camera.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+import random
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -155,6 +156,8 @@ class Camera:
             boundary.
     """
 
+    FRAME_RATE: int = 60
+
     def __init__(self, entity: Entity[Any], boundary: BoundaryChecker):
         """
         Initializes the camera with a reference to a entity object.
@@ -171,6 +174,8 @@ class Camera:
         self.follows_entity = True
         self.free_roaming_enabled = False
         self.boundary = boundary
+        self.shake_intensity = 0.0
+        self.shake_duration = 0.0
 
     def follow(self) -> None:
         """
@@ -216,33 +221,35 @@ class Camera:
         """
         if self.follows_entity:
             self.position = self.get_entity_center()
+        self.handle_shake()
 
-    def move(
-        self,
-        x: Optional[float] = None,
-        y: Optional[float] = None,
-        dx: int = 0,
-        dy: int = 0,
-    ) -> None:
+    def set_position(self, x: float, y: float) -> None:
         """
-        Moves the camera to a new position or by a certain offset.
+        Moves the camera to a new position.
 
         Parameters:
             x: The new x-coordinate. Defaults to None.
             y: The new y-coordinate. Defaults to None.
+        """
+        self.position = self.get_center(Vector2(x, y))
+
+    def move(self, dx: int = 0, dy: int = 0) -> None:
+        """
+        Moves the camera by a certain offset.
+
+        Parameters:
             dx: The x-offset. Defaults to 0.
             dy: The y-offset. Defaults to 0.
         """
-        if x is not None and y is not None:
-            self.position = self.get_center(Vector2(x, y))
-        else:
-            tile_pos = unproject((self.position.x + dx, self.position.y + dy))
-            is_x_valid, is_y_valid = self.boundary.get_boundary_validity(
-                tile_pos
-            )
-            dx = dx if is_x_valid else 0
-            dy = dy if is_y_valid else 0
+        if dx == 0 and dy == 0:
+            return
+
+        tile_pos = unproject((self.position.x + dx, self.position.y + dy))
+        is_x_valid, is_y_valid = self.boundary.get_boundary_validity(tile_pos)
+
+        if is_x_valid:
             self.position.x += dx
+        if is_y_valid:
             self.position.y += dy
 
     def reset_to_entity_center(self) -> None:
@@ -286,3 +293,32 @@ class Camera:
 
     def move_right(self) -> None:
         self.move(dx=SPEED_RIGHT)
+
+    def shake(self, intensity: float, duration: float) -> None:
+        """
+        Initiates a shake effect with the specified intensity and duration.
+
+        Parameters:
+            intensity: The magnitude of the shake effect.
+            duration: The length of time (in seconds) that the shake effect should last.
+        """
+        self.shake_intensity = intensity
+        self.shake_duration = duration
+
+    def handle_shake(self) -> None:
+        """
+        Applies the shake effect to the camera's position if the shake duration is active.
+        """
+        if self.shake_duration > 0:
+            original_position = Vector2(self.position.x, self.position.y)
+            self.position.x += random.uniform(
+                -self.shake_intensity, self.shake_intensity
+            )
+            self.position.y += random.uniform(
+                -self.shake_intensity, self.shake_intensity
+            )
+
+            self.shake_duration -= 1 / self.FRAME_RATE
+            if self.shake_duration <= 0:
+                self.shake_duration = 0
+                self.position = original_position

--- a/tuxemon/event/actions/camera_follow.py
+++ b/tuxemon/event/actions/camera_follow.py
@@ -27,7 +27,6 @@ class CameraFollowAction(EventAction):
     Script parameters:
         npc_slug: The slug of the character to center the camera on.
         Defaults to None, which centers the camera on the original entity.
-
     """
 
     name = "camera_follow"

--- a/tuxemon/event/actions/camera_mode.py
+++ b/tuxemon/event/actions/camera_mode.py
@@ -30,8 +30,7 @@ class CameraModeAction(EventAction):
             camera_mode <mode>
 
     Script parameters:
-        npc_slug: The slug of the character to center the camera on.
-
+        mode: The mode of the camera: 'free_roaming' or 'fixed'.
     """
 
     name = "camera_mode"

--- a/tuxemon/event/actions/camera_position.py
+++ b/tuxemon/event/actions/camera_position.py
@@ -46,19 +46,19 @@ class CameraPositionAction(EventAction):
             return
         camera = world.camera_manager.get_active_camera()
         if camera is None:
-            logger.warning("No active camera found.")
+            logger.error("No active camera found.")
             return
 
         if camera.follows_entity:
             camera.unfollow()
 
-        camera.move(self.x, self.y)
+        camera.set_position(x, y)
         logger.info(f"Camera has been set to ({x, y})")
 
     def _reset_camera(self, world: WorldState) -> None:
         camera = world.camera_manager.get_active_camera()
         if camera is None:
-            logger.warning("No active camera found.")
+            logger.error("No active camera found.")
             return
         camera.reset_to_entity_center()
         logger.info("Camera has been reset to entity's center")

--- a/tuxemon/event/actions/camera_shake.py
+++ b/tuxemon/event/actions/camera_shake.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import final
+
+from tuxemon.event.eventaction import EventAction
+from tuxemon.prepare import CAMERA_SHAKE_RANGE
+from tuxemon.states.world.worldstate import WorldState
+
+logger = logging.getLogger(__name__)
+
+
+@final
+@dataclass
+class CameraShakeAction(EventAction):
+    """
+    Shake the camera with a precise intensity and duration.
+
+    Script usage:
+        .. code-block::
+
+            camera_shake <intensity>,<duration>
+
+    Script parameters:
+        intensity: The magnitude of the shake effect. A higher value results
+            in a more pronounced shake, while a lower value produces
+            a subtler effect (min 0.0, max 3.0).
+        duration: The length of time (in seconds) that the shake effect
+            should last. The method calculates the number of frames
+            to shake based on an assumed frame rate.
+    """
+
+    name = "camera_shake"
+    intensity: float
+    duration: float
+
+    def start(self) -> None:
+        world = self.session.client.get_state_by_name(WorldState)
+        lower, upper = CAMERA_SHAKE_RANGE
+        if not lower <= self.intensity <= upper:
+            logger.error(
+                f"{self.intensity} must be between {lower} and {upper}",
+            )
+        camera = world.camera_manager.get_active_camera()
+        if camera is None:
+            logger.error("No active camera found.")
+            return
+        camera.shake(self.intensity, self.duration)
+        logger.info("Camera is shaking!")

--- a/tuxemon/event/conditions/camera_position.py
+++ b/tuxemon/event/conditions/camera_position.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from tuxemon.camera import unproject
+from tuxemon.event import MapCondition
+from tuxemon.event.eventcondition import EventCondition
+from tuxemon.session import Session
+from tuxemon.states.world.worldstate import WorldState
+from tuxemon.tools import compare
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CameraPositionCondition(EventCondition):
+    """
+    Check to see if the camera is at the position on the map.
+
+    Script usage:
+        .. code-block::
+
+            is camera_position <tile_pos_x>,<tile_pos_y>
+
+    Script parameters:
+        pos_x: X position of the camera.
+        pos_y: Y position of the camera.
+    """
+
+    name = "camera_position"
+
+    def test(self, session: Session, condition: MapCondition) -> bool:
+        map_size = session.client.map_size
+        pos_x = int(condition.parameters[0])
+        pos_y = int(condition.parameters[1])
+        world = session.client.get_state_by_name(WorldState)
+        camera = world.camera_manager.get_active_camera()
+        if camera is None:
+            logger.error("No active camera found.")
+            return False
+        cx, cy = unproject(camera.position)
+        if not world.boundary_checker.is_within_boundaries((pos_x, pos_y)):
+            logger.error(
+                f"({pos_x, pos_y}) is outside the map bounds {map_size}"
+            )
+            return False
+        return compare("equals", cx, pos_x) and compare("equals", cy, pos_y)

--- a/tuxemon/prepare.py
+++ b/tuxemon/prepare.py
@@ -269,6 +269,9 @@ STATUS_POSITIVE: float = 1.0
 # if the status is negative
 STATUS_NEGATIVE: float = 1.2
 
+# Camera
+CAMERA_SHAKE_RANGE: tuple[float, float] = (0.0, 3.0)
+
 # Techniques
 RECHARGE_RANGE: tuple[int, int] = (0, 5)
 POTENCY_RANGE: tuple[float, float] = (0.0, 1.0)

--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -250,7 +250,7 @@ class WorldState(state.State):
         super().update(time_delta)
         self.update_npcs(time_delta)
         self.map_renderer.update(time_delta)
-        self.camera.update()
+        self.camera_manager.update()
 
         logger.debug("*** Game Loop Started ***")
         logger.debug("Player Variables:" + str(self.player.game_variables))


### PR DESCRIPTION
PR introduces a new event action called 'camera_shake' and an event condition called 'camera_position'. 
- **Camera Shake**:  The `shake` method creates a camera shake effect
- **Camera Position**:  A condition that helps modders control where the active camera is
- refactored the `move` method, I didn't like it, now only handles relative movement (using dx and dy), while if we need to set the camera's position to a specific absolute coordinate, then there is `set_position`

https://github.com/user-attachments/assets/6b01d800-6c2e-4359-b468-986e2bb74c18
