### PR TITLE
Refactor Plugin Loading System

### DIFF
--- a/tests/tuxemon/test_plugin.py
+++ b/tests/tuxemon/test_plugin.py
@@ -1,9 +1,12 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import unittest
-from unittest.mock import MagicMock
+from collections.abc import Iterable
+from unittest.mock import MagicMock, patch
 
 from tuxemon.plugin import (
+    DefaultPluginLoader,
+    FileSystemPluginDiscovery,
     PluginManager,
     PluginObject,
     get_available_classes,
@@ -12,51 +15,43 @@ from tuxemon.plugin import (
 
 
 class TestPluginManager(unittest.TestCase):
-
     def test_init(self):
-        manager = PluginManager()
-        self.assertEqual(manager.folders, [])
+        discovery = FileSystemPluginDiscovery([])
+        loader = DefaultPluginLoader()
+        manager = PluginManager(discovery, loader)
+        self.assertEqual(manager.discovery.folders, [])
         self.assertEqual(manager.modules, [])
-        self.assertEqual(manager.FILE_EXTENSIONS, (".py", ".pyc"))
-        self.assertEqual(manager.EXCLUDE_CLASSES, ["IPlugin"])
-        self.assertEqual(
-            manager.INCLUDE_PATTERNS,
-            [
-                "event.actions",
-                "event.conditions",
-                "item.effects",
-                "item.conditions",
-                "technique.effects",
-                "technique.conditions",
-                "condition.effects",
-                "condition.conditions",
-            ],
-        )
 
     def test_set_plugin_places(self):
-        manager = PluginManager()
         plugin_folders = ["folder1", "folder2"]
-        manager.set_plugin_places(plugin_folders)
-        self.assertEqual(manager.folders, plugin_folders)
+        discovery = FileSystemPluginDiscovery(plugin_folders)
+        loader = DefaultPluginLoader()
+        manager = PluginManager(discovery, loader)
+        self.assertEqual(manager.discovery.folders, plugin_folders)
 
     def test_collect_plugins(self):
-        manager = PluginManager()
-        manager.folders = ["folder1", "folder2"]
+        plugin_folders = ["folder1", "folder2"]
+        discovery = FileSystemPluginDiscovery(plugin_folders)
+        loader = DefaultPluginLoader()
+        manager = PluginManager(discovery, loader)
         manager.collect_plugins()
-        # You can add assertions here based on the actual implementation of collect_plugins
 
     def test_get_all_plugins(self):
-        manager = PluginManager()
+        discovery = FileSystemPluginDiscovery([])
+        loader = DefaultPluginLoader()
+        manager = PluginManager(discovery, loader)
         interface = PluginObject
         plugins = manager.get_all_plugins(interface=interface)
         self.assertIsInstance(plugins, list)
 
     def test_get_classes_from_module(self):
-        manager = PluginManager()
+        discovery = FileSystemPluginDiscovery([])
+        loader = DefaultPluginLoader()
+        manager = PluginManager(discovery, loader)
         module = MagicMock()
         interface = PluginObject
         classes = manager._get_classes_from_module(module, interface)
-        self.assertIsInstance(classes, list)
+        self.assertIsInstance(classes, Iterable)
 
     def test_load_directory(self):
         plugin_folder = "folder1"
@@ -64,9 +59,20 @@ class TestPluginManager(unittest.TestCase):
         self.assertIsInstance(loaded_manager, PluginManager)
 
     def test_get_available_classes(self):
-        manager = PluginManager()
-        manager.set_plugin_places(["folder1"])
-        manager.collect_plugins()
+        plugin_folder = "folder1"
+        manager = load_directory(plugin_folder)
         interface = PluginObject
         classes = get_available_classes(manager, interface=interface)
         self.assertIsInstance(classes, list)
+
+    def test_file_system_plugin_discovery(self):
+        discovery = FileSystemPluginDiscovery([])
+        self.assertEqual(discovery.folders, [])
+        self.assertEqual(discovery.file_extensions, (".py", ".pyc"))
+
+    def test_default_plugin_loader(self):
+        loader = DefaultPluginLoader()
+        module_name = "test_module"
+        with patch("importlib.import_module") as mock_import_module:
+            loader.load_plugin(module_name)
+            mock_import_module.assert_called_once_with(module_name)

--- a/tuxemon/cli/processor.py
+++ b/tuxemon/cli/processor.py
@@ -12,7 +12,12 @@ from tuxemon.cli.clicommand import CLICommand
 from tuxemon.cli.context import InvokeContext
 from tuxemon.cli.exceptions import CommandNotFoundError, ParseError
 from tuxemon.cli.formatter import Formatter
-from tuxemon.plugin import PluginManager, get_available_classes
+from tuxemon.plugin import (
+    DefaultPluginLoader,
+    FileSystemPluginDiscovery,
+    PluginManager,
+    get_available_classes,
+)
 from tuxemon.session import Session
 
 
@@ -122,8 +127,9 @@ class CommandProcessor:
             folder: Folder to search.
 
         """
-        pm = PluginManager()
-        pm.set_plugin_places([folder])
+        discovery = FileSystemPluginDiscovery([folder])
+        loader = DefaultPluginLoader()
+        pm = PluginManager(discovery, loader)
         pm.INCLUDE_PATTERNS = ["commands"]
         pm.EXCLUDE_CLASSES = ["CLICommand"]
         pm.collect_plugins()

--- a/tuxemon/plugin.py
+++ b/tuxemon/plugin.py
@@ -7,6 +7,7 @@ import inspect
 import logging
 import os
 import sys
+from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping, Sequence
 from types import ModuleType
 from typing import (
@@ -45,10 +46,85 @@ class Plugin(Generic[T]):
         self.plugin_object = module
 
 
+class PluginDiscovery(ABC):
+    """
+    Responsible for discovering plugins in a given folder.
+    """
+
+    @abstractmethod
+    def discover_plugins(self) -> list[str]:
+        """Discovers plugin modules."""
+
+    @abstractmethod
+    def set_folders(self, folders: list[str]) -> None:
+        """Sets the folders to search for plugins."""
+
+
+class PluginLoader(ABC):
+    """
+    Responsible for loading plugins from a module.
+    """
+
+    @abstractmethod
+    def load_plugin(self, module_name: str) -> ModuleType:
+        """Loads a plugin module."""
+
+
+class FileSystemPluginDiscovery(PluginDiscovery):
+    FOLDER = "tuxemon"
+    FILE_EXTENSIONS = (".py", ".pyc")
+
+    def __init__(
+        self,
+        folders: list[str],
+        file_extensions: tuple[str, str] = FILE_EXTENSIONS,
+    ):
+        self.folders = folders if folders else []
+        self.file_extensions = file_extensions
+
+    def discover_plugins(self) -> list[str]:
+        """Discovers plugin modules from the file system."""
+        modules = []
+        for folder in self.folders:
+            if not os.path.exists(folder):
+                logger.warning(f"Folder {folder} does not exist")
+                continue
+
+            module_path = self._get_module_path(folder)
+            for file_name in os.listdir(folder):
+                if file_name.endswith(self.file_extensions):
+                    module_name = os.path.splitext(file_name)[0]
+                    modules.append(f"{module_path}.{module_name}")
+        return modules
+
+    def set_folders(self, folders: list[str]) -> None:
+        """Sets the folders to search for plugins."""
+        self.folders = folders
+
+    def _get_module_path(self, folder: str) -> str:
+        """Converts a folder path to a module path."""
+        folder = folder.replace("\\", "/")
+        match = folder[folder.rfind(self.FOLDER) :]
+        if not match:
+            raise RuntimeError(
+                f"Unable to determine plugin module path for: {folder}"
+            )
+        return match.replace("/", ".")
+
+
+class DefaultPluginLoader(PluginLoader):
+    def load_plugin(self, module_name: str) -> ModuleType:
+        """Loads a plugin module using importlib."""
+        try:
+            return importlib.import_module(module_name)
+        except ImportError as e:
+            logger.error(f"Failed to import module {module_name}: {e}")
+            raise
+
+
 class PluginManager:
     """Yapsy semi-compatible plugin manager."""
 
-    FILE_EXTENSIONS = (".py", ".pyc")
     EXCLUDE_CLASSES = ["IPlugin"]
     INCLUDE_PATTERNS = [
         "event.actions",
@@ -61,59 +137,29 @@ class PluginManager:
         "condition.conditions",
     ]
 
-    def __init__(self) -> None:
-        self.folders: list[str] = []
+    def __init__(
+        self, discovery: PluginDiscovery, loader: PluginLoader
+    ) -> None:
+        self.discovery = discovery
+        self.loader = loader
         self.modules: list[str] = []
-
-    def set_plugin_places(self, plugin_folders: Sequence[str]) -> None:
-        """Set plugin search locations."""
-        self.folders = list(plugin_folders)
 
     def collect_plugins(self) -> None:
         """Collect plugins from the specified folders."""
-        for folder in self.folders:
-            logger.debug(f"Searching for plugins: {folder}")
-            if not os.path.exists(folder):
-                logger.warning(f"Folder {folder} does not exist")
-                continue
-
-            module_path = self._get_module_path(folder)
-            for file_name in os.listdir(folder):
-                if file_name.endswith(self.FILE_EXTENSIONS):
-                    module_name = os.path.splitext(file_name)[0]
-                    self.modules.append(f"{module_path}.{module_name}")
-
+        logger.debug("Discovering plugins...")
+        self.modules = self.discovery.discover_plugins()
         logger.debug(f"Modules to load: {self.modules}")
-
-    def _get_module_path(self, folder: str) -> str:
-        """Converts a folder path to a module path."""
-        folder = folder.replace("\\", "/")
-        match = folder[folder.rfind("tuxemon") :]
-        if not match:
-            raise RuntimeError(
-                f"Unable to determine plugin module path for: {folder}"
-            )
-        return match.replace("/", ".")
 
     def get_all_plugins(
         self, *, interface: type[InterfaceValue]
     ) -> Sequence[Plugin[type[InterfaceValue]]]:
         """Get all loaded plugins implementing the given interface."""
-
-        if not isinstance(interface, type):
-            raise TypeError("interface must be a type")
-
         imported_plugins: list[Plugin[type[InterfaceValue]]] = []
         for module_name in self.modules:
-            try:
-                module = importlib.import_module(module_name)
-                imported_plugins.extend(
-                    self._get_plugins_from_module(
-                        module, module_name, interface
-                    )
-                )
-            except ImportError as e:
-                logger.error(f"Failed to import module {module_name}: {e}")
+            module = self.loader.load_plugin(module_name)
+            imported_plugins.extend(
+                self._get_plugins_from_module(module, module_name, interface)
+            )
         return imported_plugins
 
     def _get_plugins_from_module(
@@ -143,6 +189,7 @@ class PluginManager:
     def _get_classes_from_module(
         self, module: ModuleType, interface: type
     ) -> Iterable[tuple[str, type]]:
+        """Retrieves classes from a module that match a given interface."""
         # This is required because of
         # https://github.com/python/typing/issues/822
         #
@@ -166,8 +213,9 @@ def load_directory(plugin_folder: str) -> PluginManager:
     Returns:
         A plugin manager, with the modules already loaded.
     """
-    manager = PluginManager()
-    manager.set_plugin_places([plugin_folder])
+    discovery = FileSystemPluginDiscovery([plugin_folder])
+    loader = DefaultPluginLoader()
+    manager = PluginManager(discovery, loader)
     manager.collect_plugins()
     return manager
 


### PR DESCRIPTION
PR refactors the plugin loading system. Instead of the `PluginManager` directly handling file system operations and module imports, I've introduced separate classes for plugin discovery and loading.
 * `PluginDiscovery` and `FileSystemPluginDiscovery`: these handle finding plugin modules. `FileSystemPluginDiscovery` searches a given folder for Python files, but the `PluginDiscovery` interface allows for other ways to find plugins in the future, like from a database or a network
 * `PluginLoader` and `DefaultPluginLoader`: these handle importing the plugin modules. `DefaultPluginLoader` uses standard Python imports, but again, the `PluginLoader` interface lets us use custom loading logic if needed

Now, if we want to change how plugins are located or loaded, we only need to modify the discovery or loader classes, without touching the core `PluginManager`