### PR TITLE
Refactor Taste

### DIFF
--- a/mods/tuxemon/db/taste/taste.json
+++ b/mods/tuxemon/db/taste/taste.json
@@ -1,0 +1,122 @@
+[
+  {
+    "slug": "mild",
+    "name": "taste_mild",
+    "taste_type": "cold",
+    "modifiers": [
+      {
+        "attribute": "stat",
+        "values": ["speed"],
+        "multiplier": 0.9
+      }
+    ]
+  },
+  {
+    "slug": "sweet",
+    "name": "taste_sweet",
+    "taste_type": "cold",
+    "modifiers": [
+      {
+        "attribute": "stat",
+        "values": ["melee"],
+        "multiplier": 0.9
+      }
+    ]
+  },
+  {
+    "slug": "soft",
+    "name": "taste_soft",
+    "taste_type": "cold",
+    "modifiers": [
+      {
+        "attribute": "stat",
+        "values": ["armour"],
+        "multiplier": 0.9
+      }
+    ]
+  },
+  {
+    "slug": "flakey",
+    "name": "taste_flakey",
+    "taste_type": "cold",
+    "modifiers": [
+      {
+        "attribute": "stat",
+        "values": ["ranged"],
+        "multiplier": 0.9
+      }
+    ]
+  },
+  {
+    "slug": "dry",
+    "name": "taste_dry",
+    "taste_type": "cold",
+    "modifiers": [
+      {
+        "attribute": "stat",
+        "values": ["dodge"],
+        "multiplier": 0.9
+      }
+    ]
+  },
+  {
+    "slug": "peppy",
+    "name": "taste_peppy",
+    "taste_type": "warm",
+    "modifiers": [
+      {
+        "attribute": "stat",
+        "values": ["speed"],
+        "multiplier": 1.1
+      }
+    ]
+  },
+  {
+    "slug": "salty",
+    "name": "taste_salty",
+    "taste_type": "warm",
+    "modifiers": [
+      {
+        "attribute": "stat",
+        "values": ["melee"],
+        "multiplier": 1.1
+      }
+    ]
+  },
+  {
+    "slug": "hearty",
+    "name": "taste_hearty",
+    "taste_type": "warm",
+    "modifiers": [
+      {
+        "attribute": "stat",
+        "values": ["armour"],
+        "multiplier": 1.1
+      }
+    ]
+  },
+  {
+    "slug": "zesty",
+    "name": "taste_zesty",
+    "taste_type": "warm",
+    "modifiers": [
+      {
+        "attribute": "stat",
+        "values": ["ranged"],
+        "multiplier": 1.1
+      }
+    ]
+  },
+  {
+    "slug": "refined",
+    "name": "taste_refined",
+    "taste_type": "warm",
+    "modifiers": [
+      {
+        "attribute": "stat",
+        "values": ["dodge"],
+        "multiplier": 1.1
+      }
+    ]
+  }
+]

--- a/tests/tuxemon/test_evolution.py
+++ b/tests/tuxemon/test_evolution.py
@@ -3,7 +3,12 @@
 import unittest
 from unittest import mock
 
-from tuxemon.db import MonsterEvolutionItemModel, TechniqueModel, db
+from tuxemon.db import (
+    ElementModel,
+    MonsterEvolutionItemModel,
+    TechniqueModel,
+    db,
+)
 from tuxemon.element import Element
 from tuxemon.monster import Monster
 from tuxemon.player import Player

--- a/tests/tuxemon/test_evolution.py
+++ b/tests/tuxemon/test_evolution.py
@@ -3,13 +3,7 @@
 import unittest
 from unittest import mock
 
-from tuxemon.db import (
-    MonsterEvolutionItemModel,
-    TasteCold,
-    TasteWarm,
-    TechniqueModel,
-    db,
-)
+from tuxemon.db import MonsterEvolutionItemModel, TechniqueModel, db
 from tuxemon.monster import Monster
 from tuxemon.player import Player
 from tuxemon.session import local_session
@@ -199,36 +193,36 @@ class TestCanEvolve(unittest.TestCase):
 
     def test_taste_cold_match(self):
         self.mon.owner = self.player
-        self.mon.taste_cold = TasteCold.flakey
+        self.mon.taste_cold = "flakey"
         evo = MonsterEvolutionItemModel(
-            monster_slug="rockat", taste_cold=TasteCold.flakey
+            monster_slug="rockat", taste_cold="flakey"
         )
         context = {"map_inside": True}
         self.assertTrue(self.mon.evolution_handler.can_evolve(evo, context))
 
     def test_taste_cold_mismatch(self):
         self.mon.owner = self.player
-        self.mon.taste_cold = TasteCold.mild
+        self.mon.taste_cold = "mild"
         evo = MonsterEvolutionItemModel(
-            monster_slug="rockat", taste_cold=TasteCold.flakey
+            monster_slug="rockat", taste_cold="flakey"
         )
         context = {"map_inside": True}
         self.assertFalse(self.mon.evolution_handler.can_evolve(evo, context))
 
     def test_taste_warm_match(self):
         self.mon.owner = self.player
-        self.mon.taste_warm = TasteWarm.peppy
+        self.mon.taste_warm = "peppy"
         evo = MonsterEvolutionItemModel(
-            monster_slug="rockat", taste_warm=TasteWarm.peppy
+            monster_slug="rockat", taste_warm="peppy"
         )
         context = {"map_inside": True}
         self.assertTrue(self.mon.evolution_handler.can_evolve(evo, context))
 
     def test_taste_warm_mismatch(self):
         self.mon.owner = self.player
-        self.mon.taste_warm = TasteWarm.peppy
+        self.mon.taste_warm = "peppy"
         evo = MonsterEvolutionItemModel(
-            monster_slug="rockat", taste_warm=TasteWarm.salty
+            monster_slug="rockat", taste_warm="salty"
         )
         context = {"map_inside": True}
         self.assertFalse(self.mon.evolution_handler.can_evolve(evo, context))

--- a/tests/tuxemon/test_monster.py
+++ b/tests/tuxemon/test_monster.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import unittest
+from unittest.mock import MagicMock
 
 from tuxemon import formula, prepare
-from tuxemon.db import ShapeModel, TasteCold, TasteWarm, TechniqueModel, db
+from tuxemon.db import Modifier, ShapeModel, TechniqueModel, db
 from tuxemon.monster import Monster
 from tuxemon.prepare import MAX_LEVEL
+from tuxemon.taste import Taste
 from tuxemon.technique.technique import Technique
 
 
@@ -57,10 +59,53 @@ class SetStats(MonsterTestBase):
         self.mon.name = "agnite"
         self.mon.level = 5
         self.value = self.mon.level + prepare.COEFF_STATS
-        self.malus = int(self.value * prepare.TASTE_RANGE[0])
-        self.bonus = int(self.value * prepare.TASTE_RANGE[1])
         self._shape_model = {"dragon": self._shape}
         db.database["shape"] = self._shape_model
+
+        self.peppy = MagicMock(spec=Taste)
+        self.peppy.slug = "peppy"
+        self.peppy.taste_type = "warm"
+        self.modifier1 = MagicMock(spec=Modifier)
+        self.modifier1.attribute = "stat"
+        self.modifier1.values = ["speed"]
+        self.modifier1.multiplier = 1.1
+        self.peppy.modifiers = [self.modifier1]
+
+        self.mild = MagicMock(spec=Taste)
+        self.mild.slug = "mild"
+        self.mild.taste_type = "warm"
+        self.modifier2 = MagicMock(spec=Modifier)
+        self.modifier2.attribute = "stat"
+        self.modifier2.values = ["speed"]
+        self.modifier2.multiplier = 0.9
+        self.mild.modifiers = [self.modifier2]
+
+        self.flakey = MagicMock(spec=Taste)
+        self.flakey.slug = "flakey"
+        self.flakey.taste_type = "warm"
+        self.modifier3 = MagicMock(spec=Modifier)
+        self.modifier3.attribute = "stat"
+        self.modifier3.values = ["ranged"]
+        self.modifier3.multiplier = 0.9
+        self.flakey.modifiers = [self.modifier3]
+
+        self.refined = MagicMock(spec=Taste)
+        self.refined.slug = "refined"
+        self.refined.taste_type = "warm"
+        self.modifier4 = MagicMock(spec=Modifier)
+        self.modifier4.attribute = "stat"
+        self.modifier4.values = ["dodge"]
+        self.modifier4.multiplier = 1.1
+        self.refined.modifiers = [self.modifier4]
+
+        Taste._tastes = {}
+        Taste._tastes["peppy"] = self.peppy
+        Taste._tastes["mild"] = self.mild
+        Taste._tastes["flakey"] = self.flakey
+        Taste._tastes["refined"] = self.refined
+
+    def tearDown(self):
+        Taste.clear_cache()
 
     def test_set_stats_basic(self):
         self.mon.set_stats()
@@ -83,33 +128,37 @@ class SetStats(MonsterTestBase):
         self.assertEqual(self.mon.hp, _shape.hp * self.value)
 
     def test_set_stats_taste_warm(self):
-        self.mon.taste_warm = TasteWarm.peppy
+        self.mon.taste_warm = self.peppy.slug
         self.mon.set_stats()
         self.assertEqual(self.mon.armour, self.value)
         self.assertEqual(self.mon.dodge, self.value)
         self.assertEqual(self.mon.melee, self.value)
         self.assertEqual(self.mon.ranged, self.value)
-        self.assertEqual(self.mon.speed, self.value + self.bonus)
+        self.assertEqual(self.mon.speed, int(self.value * 1.1))  # Apply bonus
         self.assertEqual(self.mon.hp, self.value)
 
     def test_set_stats_taste_cold(self):
-        self.mon.taste_cold = TasteCold.mild
+        self.mon.taste_cold = self.mild.slug
         self.mon.set_stats()
         self.assertEqual(self.mon.armour, self.value)
         self.assertEqual(self.mon.dodge, self.value)
         self.assertEqual(self.mon.melee, self.value)
         self.assertEqual(self.mon.ranged, self.value)
-        self.assertEqual(self.mon.speed, self.value + self.malus)
+        self.assertEqual(self.mon.speed, int(self.value * 0.9))  # Apply malus
         self.assertEqual(self.mon.hp, self.value)
 
     def test_set_stats_tastes(self):
-        self.mon.taste_cold = TasteCold.flakey
-        self.mon.taste_warm = TasteWarm.refined
+        self.mon.taste_cold = self.flakey.slug
+        self.mon.taste_warm = self.refined.slug
         self.mon.set_stats()
+
+        expected_dodge = int(self.value * 1.1)  # 10% bonus from refined
+        expected_ranged = int(self.value * 0.9)  # 10% malus from flakey
+
         self.assertEqual(self.mon.armour, self.value)
-        self.assertEqual(self.mon.dodge, self.value + self.bonus)
+        self.assertEqual(self.mon.dodge, expected_dodge)
         self.assertEqual(self.mon.melee, self.value)
-        self.assertEqual(self.mon.ranged, self.value + self.malus)
+        self.assertEqual(self.mon.ranged, expected_ranged)
         self.assertEqual(self.mon.speed, self.value)
         self.assertEqual(self.mon.hp, self.value)
 

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -72,24 +72,6 @@ class SkinSprite(str, Enum):
     orc = "orc"
 
 
-class TasteWarm(str, Enum):
-    tasteless = "tasteless"
-    peppy = "peppy"
-    salty = "salty"
-    hearty = "hearty"
-    zesty = "zesty"
-    refined = "refined"
-
-
-class TasteCold(str, Enum):
-    tasteless = "tasteless"
-    mild = "mild"
-    sweet = "sweet"
-    soft = "soft"
-    flakey = "flakey"
-    dry = "dry"
-
-
 class ElementType(str, Enum):
     aether = "aether"
     wood = "wood"
@@ -437,11 +419,11 @@ class MonsterEvolutionItemModel(BaseModel):
         min_length=1,
         max_length=prepare.PARTY_LIMIT - 1,
     )
-    taste_cold: Optional[TasteCold] = Field(
+    taste_cold: Optional[str] = Field(
         None,
         description="The required taste cold value for the monster to evolve.",
     )
-    taste_warm: Optional[TasteWarm] = Field(
+    taste_warm: Optional[str] = Field(
         None,
         description="The required taste warm value for the monster to evolve.",
     )
@@ -465,6 +447,14 @@ class MonsterEvolutionItemModel(BaseModel):
         if not v or has.db_entry("technique", v):
             return v
         raise ValueError(f"the technique {v} doesn't exist in the db")
+
+    @field_validator("taste_cold", "taste_warm")
+    def taste_exists(
+        cls: MonsterEvolutionItemModel, v: Optional[str]
+    ) -> Optional[str]:
+        if not v or has.db_entry("taste", v):
+            return v
+        raise ValueError(f"the taste {v} doesn't exist in the db")
 
     @field_validator("monster_slug")
     def monster_exists(cls: MonsterEvolutionItemModel, v: str) -> str:
@@ -1353,6 +1343,23 @@ class ElementModel(BaseModel):
         raise ValueError(f"the icon {v} doesn't exist in the db")
 
 
+class TasteModel(BaseModel):
+    slug: str = Field(..., description="Slug of the taste")
+    name: str = Field(..., description="Name of the taste")
+    taste_type: Literal["warm", "cold"] = Field(
+        ..., description="Type of taste: 'cold' or 'warm'"
+    )
+    modifiers: Sequence[Modifier] = Field(
+        ..., description="Modifiers associated with the taste"
+    )
+
+    @field_validator("name")
+    def translation_exists_taste(cls: TasteModel, v: str) -> str:
+        if has.translation(v):
+            return v
+        raise ValueError(f"no translation exists with msgid: {v}")
+
+
 class EconomyEntityModel(BaseModel):
     name: str = Field(..., description="Name of the entity")
     price: int = Field(0, description="Price of the entity")
@@ -1455,6 +1462,7 @@ class AnimationModel(BaseModel):
 TableName = Literal[
     "economy",
     "element",
+    "taste",
     "shape",
     "template",
     "mission",
@@ -1474,6 +1482,7 @@ TableName = Literal[
 DataModel = Union[
     EconomyModel,
     ElementModel,
+    TasteModel,
     ShapeModel,
     TemplateModel,
     MissionModel,
@@ -1514,6 +1523,7 @@ class JSONDatabase:
             "animation",
             "economy",
             "element",
+            "taste",
             "shape",
             "template",
             "mission",
@@ -1660,6 +1670,9 @@ class JSONDatabase:
             elif table == "element":
                 element = ElementModel(**item)
                 self.database[table][element.slug] = element
+            elif table == "taste":
+                taste = TasteModel(**item)
+                self.database[table][taste.slug] = taste
             elif table == "shape":
                 shape = ShapeModel(**item)
                 self.database[table][shape.slug] = shape
@@ -1747,6 +1760,10 @@ class JSONDatabase:
 
     @overload
     def lookup(self, slug: str, table: Literal["element"]) -> ElementModel:
+        pass
+
+    @overload
+    def lookup(self, slug: str, table: Literal["taste"]) -> TasteModel:
         pass
 
     @overload
@@ -1850,6 +1867,7 @@ class JSONDatabase:
         self,
         table: Literal[
             "economy",
+            "taste",
             "element",
             "shape",
             "template",

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -447,7 +447,7 @@ class MonsterEvolutionItemModel(BaseModel):
             return v
         raise ValueError(f"the taste {v} doesn't exist in the db")
 
-        @field_validator("element")
+    @field_validator("element")
     def element_exists(
         cls: MonsterEvolutionItemModel, v: Optional[str]
     ) -> Optional[str]:

--- a/tuxemon/event/actions/change_taste.py
+++ b/tuxemon/event/actions/change_taste.py
@@ -8,9 +8,9 @@ import uuid
 from dataclasses import dataclass
 from typing import final
 
-from tuxemon.db import TasteCold, TasteWarm
 from tuxemon.event import get_monster_by_iid
 from tuxemon.event.eventaction import EventAction
+from tuxemon.taste import Taste
 
 logger = logging.getLogger(__name__)
 
@@ -50,17 +50,25 @@ class ChangeTasteAction(EventAction):
             return
 
         if self.taste == "warm":
-            warm = list(TasteWarm)
-            warm.remove(TasteWarm.tasteless)
-            warm.remove(monster.taste_warm)
+            warm = [
+                taste.slug
+                for taste in Taste.get_all_tastes().values()
+                if taste.taste_type == "warm"
+                and taste.slug != monster.taste_warm
+                and taste.slug != "tasteless"
+            ]
             warmer = random.choice(warm)
             logger.info(f"{monster.name}'s {self.taste} taste is {warmer}!")
             monster.taste_warm = warmer
             monster.set_stats()
         elif self.taste == "cold":
-            cold = list(TasteCold)
-            cold.remove(TasteCold.tasteless)
-            cold.remove(monster.taste_cold)
+            cold = [
+                taste.slug
+                for taste in Taste.get_all_tastes().values()
+                if taste.taste_type == "cold"
+                and taste.slug != monster.taste_cold
+                and taste.slug != "tasteless"
+            ]
             colder = random.choice(cold)
             logger.info(f"{monster.name}'s {self.taste} taste is {colder}!")
             monster.taste_cold = colder

--- a/tuxemon/event/actions/get_player_monster.py
+++ b/tuxemon/event/actions/get_player_monster.py
@@ -12,8 +12,6 @@ from tuxemon.db import (
     EvolutionStage,
     GenderType,
     StatType,
-    TasteCold,
-    TasteWarm,
 )
 from tuxemon.event.eventaction import EventAction
 from tuxemon.menu.interface import MenuItem
@@ -113,19 +111,11 @@ class GetPlayerMonsterAction(EventAction):
                 self.result = True
                 return self.result
             # filter taste warm
-            if (
-                filter_name == "taste_warm"
-                and value_name in list(TasteWarm)
-                and target.taste_warm == value_name
-            ):
+            if filter_name == "taste_warm" and target.taste_warm == value_name:
                 self.result = True
                 return self.result
             # filter taste cold
-            if (
-                filter_name == "taste_cold"
-                and value_name in list(TasteCold)
-                and target.taste_cold == value_name
-            ):
+            if filter_name == "taste_cold" and target.taste_cold == value_name:
                 self.result = True
                 return self.result
 

--- a/tuxemon/event/actions/get_player_monster.py
+++ b/tuxemon/event/actions/get_player_monster.py
@@ -6,12 +6,7 @@ import logging
 from dataclasses import dataclass
 from typing import Optional, final
 
-from tuxemon.db import (
-    Comparison,
-    EvolutionStage,
-    GenderType,
-    StatType,
-)
+from tuxemon.db import Comparison, EvolutionStage, GenderType, StatType
 from tuxemon.event.eventaction import EventAction
 from tuxemon.menu.interface import MenuItem
 from tuxemon.monster import Monster

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from tuxemon.db import ElementType, Modifier
     from tuxemon.element import Element
     from tuxemon.monster import Monster
+    from tuxemon.taste import Taste
     from tuxemon.technique.technique import Technique
 
 logger = logging.getLogger(__name__)
@@ -27,29 +28,6 @@ range_map: dict[str, tuple[str, str]] = {
     "ranged": ("ranged", "dodge"),
     "reach": ("ranged", "armour"),
     "reliable": ("level", "resist"),
-}
-
-taste_maps: dict[str, dict[tuple[str, str], float]] = {
-    "armour": {
-        ("cold", "soft"): pre.TASTE_RANGE[0],
-        ("warm", "hearty"): pre.TASTE_RANGE[1],
-    },
-    "speed": {
-        ("cold", "mild"): pre.TASTE_RANGE[0],
-        ("warm", "peppy"): pre.TASTE_RANGE[1],
-    },
-    "melee": {
-        ("cold", "sweet"): pre.TASTE_RANGE[0],
-        ("warm", "salty"): pre.TASTE_RANGE[1],
-    },
-    "ranged": {
-        ("cold", "flakey"): pre.TASTE_RANGE[0],
-        ("warm", "zesty"): pre.TASTE_RANGE[1],
-    },
-    "dodge": {
-        ("cold", "dry"): pre.TASTE_RANGE[0],
-        ("warm", "refined"): pre.TASTE_RANGE[1],
-    },
 }
 
 
@@ -435,20 +413,34 @@ def simple_lifeleech(user: Monster, target: Monster, divisor: int) -> int:
     return heal
 
 
-def update_stat(mon: Monster, stat_name: str) -> int:
+def update_stat(
+    stat_name: str,
+    stat_value: int,
+    taste_warm: Optional[Taste],
+    taste_cold: Optional[Taste],
+) -> int:
     """
     It returns a bonus / malus of the stat based on additional parameters.
     """
-    stat = getattr(mon, stat_name)
-    bonus = 0
-    malus = 0
-    for (taste_type, value), multiplier in taste_maps[stat_name].items():
-        if getattr(mon, f"taste_{taste_type}") == value:
-            if taste_type == "cold":
-                malus = stat * multiplier
-            else:
-                bonus = stat * multiplier
-    return int(bonus + malus)
+    modified_stat = float(stat_value)
+
+    if taste_cold:
+        for modifier in taste_cold.modifiers:
+            if stat_name in modifier.values:
+                logger.debug(
+                    f"Applying modifier: {modifier.multiplier} for {stat_name}"
+                )
+                modified_stat *= modifier.multiplier
+
+    if taste_warm:
+        for modifier in taste_warm.modifiers:
+            if stat_name in modifier.values:
+                logger.debug(
+                    f"Applying modifier: {modifier.multiplier} for {stat_name}"
+                )
+                modified_stat *= modifier.multiplier
+
+    return int(modified_stat)
 
 
 def today_ordinal() -> int:

--- a/tuxemon/item/effects/capture_combined.py
+++ b/tuxemon/item/effects/capture_combined.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Union
 
 from tuxemon import formula, prepare
 from tuxemon.db import CategoryCondition as Category
-from tuxemon.db import GenderType, SeenStatus, TasteWarm
+from tuxemon.db import GenderType, SeenStatus
 from tuxemon.item.itemeffect import ItemEffect, ItemEffectResult
 
 if TYPE_CHECKING:
@@ -94,7 +94,7 @@ class CaptureCombinedEffect(ItemEffect):
                 item, target
             )
         else:  # Flavored-based tuxeball
-            target.taste_warm = TasteWarm(self.label)
+            target.taste_warm = self.label
 
         return tuxeball_modifier
 

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -25,8 +25,6 @@ from tuxemon.db import (
     PlagueType,
     ResponseCondition,
     StatType,
-    TasteCold,
-    TasteWarm,
     db,
 )
 from tuxemon.element import Element
@@ -34,6 +32,7 @@ from tuxemon.evolution import Evolution
 from tuxemon.locale import T
 from tuxemon.shape import Shape
 from tuxemon.sprite import Sprite
+from tuxemon.taste import Taste
 from tuxemon.technique.technique import Technique, decode_moves, encode_moves
 
 if TYPE_CHECKING:
@@ -142,8 +141,8 @@ class Monster:
 
         self.status: list[Condition] = []
         self.plague: dict[str, PlagueType] = {}
-        self.taste_cold = TasteCold.tasteless
-        self.taste_warm = TasteWarm.tasteless
+        self.taste_cold: str = "tasteless"
+        self.taste_warm: str = "tasteless"
 
         self.max_moves = prepare.MAX_MOVES
         self.txmn_id = 0
@@ -396,11 +395,23 @@ class Monster:
         """
         Apply updates to the monster's stats.
         """
-        self.armour += formula.update_stat(self, "armour")
-        self.dodge += formula.update_stat(self, "dodge")
-        self.melee += formula.update_stat(self, "melee")
-        self.ranged += formula.update_stat(self, "ranged")
-        self.speed += formula.update_stat(self, "speed")
+        taste_cold = Taste.get_taste(self.taste_cold)
+        taste_warm = Taste.get_taste(self.taste_warm)
+        self.armour = formula.update_stat(
+            "armour", self.armour, taste_cold, taste_warm
+        )
+        self.dodge = formula.update_stat(
+            "dodge", self.dodge, taste_cold, taste_warm
+        )
+        self.melee = formula.update_stat(
+            "melee", self.melee, taste_cold, taste_warm
+        )
+        self.ranged = formula.update_stat(
+            "ranged", self.ranged, taste_cold, taste_warm
+        )
+        self.speed = formula.update_stat(
+            "speed", self.speed, taste_cold, taste_warm
+        )
 
     def set_stats(self) -> None:
         """
@@ -413,28 +424,48 @@ class Monster:
         self.calculate_base_stats()
         self.apply_stat_updates()
 
-    def set_taste_cold(self, taste_cold: TasteCold) -> TasteCold:
-        """
-        It returns the cold taste.
-        """
-        if taste_cold.tasteless:
-            self.taste_cold = random.choice(
-                [t for t in TasteCold if t != TasteCold.tasteless]
-            )
+    def set_taste_cold(self, taste_slug: str = "tasteless") -> str:
+        """Sets the cold taste of the monster."""
+
+        if taste_slug == "tasteless":
+            cold_tastes = [
+                taste.slug
+                for taste in Taste.get_all_tastes().values()
+                if taste.taste_type == "cold" and taste.slug != "tasteless"
+            ]
+            if cold_tastes:
+                self.taste_cold = random.choice(cold_tastes)
+            else:
+                self.taste_cold = taste_slug
         else:
-            self.taste_cold = taste_cold
+            taste = Taste.get_taste(taste_slug)
+            if taste is None:
+                self.taste_cold = taste_slug
+            else:
+                self.taste_cold = taste.slug
+
         return self.taste_cold
 
-    def set_taste_warm(self, taste_warm: TasteWarm) -> TasteWarm:
-        """
-        It returns the warm taste.
-        """
-        if taste_warm.tasteless:
-            self.taste_warm = random.choice(
-                [t for t in TasteWarm if t != TasteWarm.tasteless]
-            )
+    def set_taste_warm(self, taste_slug: str = "tasteless") -> str:
+        """Sets the warm taste of the monster."""
+
+        if taste_slug == "tasteless":
+            warm_tastes = [
+                taste.slug
+                for taste in Taste.get_all_tastes().values()
+                if taste.taste_type == "warm" and taste.slug != "tasteless"
+            ]
+            if warm_tastes:
+                self.taste_warm = random.choice(warm_tastes)
+            else:
+                self.taste_warm = taste_slug
         else:
-            self.taste_warm = taste_warm
+            taste = Taste.get_taste(taste_slug)
+            if taste is None:
+                self.taste_warm = taste_slug
+            else:
+                self.taste_warm = taste.slug
+
         return self.taste_warm
 
     def set_capture(self, amount: int) -> int:

--- a/tuxemon/prepare.py
+++ b/tuxemon/prepare.py
@@ -252,8 +252,6 @@ COEFF_EXP: int = 3
 # weight and height (min and max) = -/+ 10%
 WEIGHT_RANGE: tuple[float, float] = (-0.1, 0.1)
 HEIGHT_RANGE: tuple[float, float] = (-0.1, 0.1)
-# tastes (malus and bonus)
-TASTE_RANGE: tuple[float, float] = (-0.1, 0.1)
 
 # Capture
 TOTAL_SHAKES: int = 4

--- a/tuxemon/taste.py
+++ b/tuxemon/taste.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from typing import Optional
+
+from tuxemon.db import Modifier, db
+from tuxemon.locale import T
+
+logger = logging.getLogger(__name__)
+
+
+class Taste:
+    """A taste can be warm or cold and it modifiers the monster's stats."""
+
+    _tastes: dict[str, Taste] = {}
+
+    def __init__(self, slug: Optional[str] = None) -> None:
+        self.name: str = ""
+        self.taste_type: str = ""
+        self.modifiers: Sequence[Modifier] = []
+
+        if slug:
+            self.load(slug)
+
+    def load(self, slug: str) -> None:
+        """Loads a taste."""
+
+        if slug in Taste._tastes:
+            cached_taste = Taste._tastes[slug]
+            self.slug = slug
+            self.name = cached_taste.name
+            self.modifiers = cached_taste.modifiers
+            self.taste_type = cached_taste.taste_type
+            return
+
+        try:
+            results = db.lookup(slug, table="taste")
+        except KeyError:
+            raise RuntimeError(f"Taste {slug} not found")
+
+        self.slug = slug
+        self.name = T.translate(self.slug)
+        self.modifiers = results.modifiers
+        self.taste_type = results.taste_type
+
+        Taste._tastes[slug] = self
+
+    @classmethod
+    def get_taste(cls, slug: str) -> Optional[Taste]:
+        """Retrieves a Taste object by its slug.
+
+        Parameters:
+            slug: The unique identifier for the taste.
+
+        Returns:
+            The Taste object if found, otherwise None.
+        """
+        return cls._tastes.get(slug)
+
+    @classmethod
+    def load_all_tastes(cls) -> None:
+        """Loads all tastes from the database into the cache."""
+        try:
+            all_taste_slugs = list(db.database["taste"])
+            for slug in all_taste_slugs:
+                cls(slug)
+        except Exception as e:
+            logger.error(f"Failed to load all tastes: {e}")
+
+    @classmethod
+    def get_all_tastes(cls) -> dict[str, Taste]:
+        """Returns all loaded tastes.
+
+        Returns:
+            A dictionary of all loaded Taste objects.
+        """
+        if not cls._tastes:
+            cls.load_all_tastes()
+        return cls._tastes
+
+    @classmethod
+    def clear_cache(cls) -> None:
+        """Clears the taste cache."""
+        cls._tastes.clear()
+
+    def __repr__(self) -> str:
+        return f"Taste(slug={self.slug}, name={self.name}, modifier={self.modifiers}, type={self.taste_type})"


### PR DESCRIPTION
PR refactors the **Taste** feature into a JSON format, similar to how `Shape` and `Element` are structured. This change allows modders to easily add or remove tastes as needed, rather than relying on a hardcoded model that was specific to a single campaign. The previous approach, suggested by @Sanglorian, was too rigid and did not accommodate the diverse requirements of different campaigns. 

Here’s an example of the new JSON structure:
```json
{
  "slug": "flakey",
  "name": "taste_flakey",
  "taste_type": "cold",
  "modifiers": [
    {
      "attribute": "stat",
      "values": ["ranged"],
      "multiplier": 0.9
    }
  ]
}
```
This new format allows for multiple modifiers and provides a broader range for the multiplier, which now spans from 0 to 2. This change enables more intuitive adjustments, allowing for the complete reduction or doubling of specific stats. Additionally, I have updated a series of unit tests to ensure they align with these changes, and I have also modified a couple of methods to support the new structure.