### PR TITLE
class Shape and class Element

### DIFF
--- a/tuxemon/element.py
+++ b/tuxemon/element.py
@@ -15,6 +15,8 @@ logger = logging.getLogger(__name__)
 class Element:
     """An Element holds a list of types and multipliers."""
 
+    _elements: dict[str, Element] = {}
+
     def __init__(self, slug: Optional[str] = None) -> None:
         self.name: str = ""
         self.icon: str = ""
@@ -25,6 +27,15 @@ class Element:
 
     def load(self, slug: str) -> None:
         """Loads an element."""
+
+        if slug in Element._elements:
+            cached_element = Element._elements[slug]
+            self.slug = slug
+            self.name = cached_element.name
+            self.types = cached_element.types
+            self.icon = cached_element.icon
+            return
+
         try:
             results = db.lookup(slug, table="element")
         except KeyError:
@@ -34,6 +45,51 @@ class Element:
         self.name = T.translate(self.slug)
         self.types = results.types
         self.icon = results.icon
+
+        Element._elements[slug] = self
+
+    @classmethod
+    def get_element(cls, slug: str) -> Optional[Element]:
+        """
+        Retrieves a Element object by its slug.
+
+        Parameters:
+            slug: The unique identifier for the element.
+
+        Returns:
+            The Element object if found, otherwise None.
+        """
+        return cls._elements.get(slug)
+
+    @classmethod
+    def load_all_elements(cls) -> None:
+        """Loads all elements from the database into the cache."""
+        try:
+            all_element_slugs = list(db.database["element"])
+            for slug in all_element_slugs:
+                cls(slug)
+        except Exception as e:
+            logger.error(f"Failed to load all elements: {e}")
+
+    @classmethod
+    def get_all_elements(cls) -> dict[str, Element]:
+        """
+        Returns all loaded elements.
+
+        Returns:
+            A dictionary of all loaded Element objects.
+        """
+        if not cls._elements:
+            cls.load_all_elements()
+        return cls._elements
+
+    @classmethod
+    def clear_cache(cls) -> None:
+        """Clears the element cache."""
+        cls._elements.clear()
+
+    def __repr__(self) -> str:
+        return f"Element(slug={self.slug}, name={self.name}, types={self.types}, icon={self.icon})"
 
     def lookup_field(self, element: str, field: str) -> Optional[float]:
         """Looks up the element against for this element."""

--- a/tuxemon/shape.py
+++ b/tuxemon/shape.py
@@ -13,6 +13,8 @@ logger = logging.getLogger(__name__)
 class Shape:
     """A shape holds all the values (speed, ranged, etc.)."""
 
+    _shapes: dict[str, Shape] = {}
+
     def __init__(self, slug: Optional[str] = None) -> None:
         self.slug = slug
         self.armour: int = 1
@@ -28,10 +30,21 @@ class Shape:
     def load(self, slug: str) -> None:
         """Loads shape."""
 
+        if slug in Shape._shapes:
+            cached_shape = Shape._shapes[slug]
+            self.slug = slug
+            self.armour = cached_shape.armour
+            self.dodge = cached_shape.dodge
+            self.hp = cached_shape.hp
+            self.melee = cached_shape.melee
+            self.ranged = cached_shape.ranged
+            self.speed = cached_shape.speed
+            return
+
         try:
             results = db.lookup(slug, table="shape")
         except KeyError:
-            raise RuntimeError(f"Shape {self.slug} not found")
+            raise RuntimeError(f"Shape {slug} not found")
 
         self.armour = results.armour
         self.dodge = results.dodge
@@ -39,3 +52,51 @@ class Shape:
         self.melee = results.melee
         self.ranged = results.ranged
         self.speed = results.speed
+
+        Shape._shapes[slug] = self
+
+    @classmethod
+    def get_shape(cls, slug: str) -> Optional[Shape]:
+        """
+        Retrieves a Shape object by its slug.
+
+        Parameters:
+            slug: The unique identifier for the shape.
+
+        Returns:
+            The Shape object if found, otherwise None.
+        """
+        return cls._shapes.get(slug)
+
+    @classmethod
+    def load_all_shapes(cls) -> None:
+        """Loads all shapes from the database into the cache."""
+        try:
+            all_shape_slugs = list(db.database["shape"])
+            for slug in all_shape_slugs:
+                cls(slug)
+        except Exception as e:
+            logger.error(f"Failed to load all shapes: {e}")
+
+    @classmethod
+    def get_all_shapes(cls) -> dict[str, Shape]:
+        """
+        Returns all loaded shapes.
+
+        Returns:
+            A dictionary of all loaded Shape objects.
+        """
+        if not cls._shapes:
+            cls.load_all_shapes()
+        return cls._shapes
+
+    @classmethod
+    def clear_cache(cls) -> None:
+        """Clears the shape cache."""
+        cls._shapes.clear()
+
+    def __repr__(self) -> str:
+        return (
+            f"Shape(slug={self.slug}, armour={self.armour}, dodge={self.dodge}, "
+            f"hp={self.hp}, melee={self.melee}, ranged={self.ranged}, speed={self.speed})"
+        )


### PR DESCRIPTION
PR introduces a modified version of the `Shape` and `Element` class with caching functionality to enhance performance by reducing repeated database lookups for the same shape or element
- added a `_shapes` / `_elements`class variable to cache instances of `Shape` / `Element` that have already been loaded, preventing unnecessary database queries
- updated the `load` method to first check if the shape /element is cached. If it is, it uses the cached values instead of querying the database again
- implemented class methods like `get_shape` / `get_element`, `load_all_shapes` / `load_all_elements`, `get_all_shapes` / `get_all_elements`, and `clear_cache` to manage the cached shapes / elements effectively
- the `__repr__` method gives a clear string representation of the `Shape` / `Element` instance