### PR TITLE
New Linting Workflow and Tox Command for Flake8

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,29 @@
+name: Lint
+
+on:
+  workflow_dispatch: # Allows manual triggering of the workflow
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Lint with flake8
+        run: |
+          # Uncomment the following line to stop the build on errors
+          # flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3
+envlist = py3, fmt, style, lint
 
 [testenv]
 usedevelop = True
@@ -31,3 +31,9 @@ commands =
     autoflake -r -i --imports=tuxemon,pygame --ignore-init-module-imports --check-diff --quiet tuxemon/
     isort --check --diff --quiet tuxemon tests
     black --check --diff --quiet tuxemon tests
+
+[testenv:lint]
+deps =
+    flake8
+commands =
+    flake8 tuxemon tests


### PR DESCRIPTION
PR creates a new workflow specifically for linting. This new workflow can be triggered manually whenever we want to check our code for linting issues without affecting the main build process.

Additionally, I've integrated the linting step into our `tox.ini` file. This means that you can now run the lint checks as part of your local development process by simply using the `tox -elint` command.