### PR TITLE
Version Class and Comparison Logic with Unit Tests

### DIFF
--- a/tests/tuxemon/test_version.py
+++ b/tests/tuxemon/test_version.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import unittest
+
+from tuxemon.version import Version, VersionComparator
+
+
+class TestVersion(unittest.TestCase):
+
+    def test_initialization(self):
+        version = Version(1, 2, 3)
+        self.assertEqual(version.major, 1)
+        self.assertEqual(version.minor, 2)
+        self.assertEqual(version.patch, 3)
+        self.assertEqual(version.pre_release, "")
+        self.assertEqual(version.build_metadata, "")
+
+    def test_string_representation(self):
+        version = Version(1, 2, 3, "alpha", "001")
+        self.assertEqual(str(version), "1.2.3-alpha+001")
+
+    def test_from_string(self):
+        version = Version.from_string("1.2.3-alpha+001")
+        self.assertEqual(version.major, 1)
+        self.assertEqual(version.minor, 2)
+        self.assertEqual(version.patch, 3)
+        self.assertEqual(version.pre_release, "alpha")
+        self.assertEqual(version.build_metadata, "001")
+
+    def test_from_string_invalid(self):
+        with self.assertRaises(ValueError):
+            Version.from_string("invalid.version.string")
+
+    def test_equality(self):
+        version1 = Version(1, 2, 3)
+        version2 = Version(1, 2, 3)
+        version3 = Version(1, 2, 4)
+        self.assertTrue(version1 == version2)
+        self.assertFalse(version1 == version3)
+
+    def test_inequality(self):
+        version1 = Version(1, 2, 3)
+        version2 = Version(1, 2, 4)
+        self.assertTrue(version1 != version2)
+
+    def test_less_than(self):
+        version1 = Version(1, 2, 3)
+        version2 = Version(1, 2, 4)
+        self.assertTrue(version1 < version2)
+
+    def test_less_than_equal(self):
+        version1 = Version(1, 2, 3)
+        version2 = Version(1, 2, 3)
+        version3 = Version(1, 2, 4)
+        self.assertTrue(version1 <= version2)
+        self.assertTrue(version1 <= version3)
+
+    def test_greater_than(self):
+        version1 = Version(1, 2, 4)
+        version2 = Version(1, 2, 3)
+        self.assertTrue(version1 > version2)
+
+    def test_greater_than_equal(self):
+        version1 = Version(1, 2, 3)
+        version2 = Version(1, 2, 3)
+        version3 = Version(1, 2, 2)
+        self.assertTrue(version1 >= version2)
+        self.assertTrue(version1 >= version3)
+
+    def test_validate_version(self):
+        Version.validate_version("1.2.3")
+        Version.validate_version("1.2.3-alpha")
+        Version.validate_version("1.2.3-alpha+001")
+        Version.validate_version("1.2.3+001")
+
+        with self.assertRaises(ValueError):
+            Version.validate_version("1.2")
+        with self.assertRaises(ValueError):
+            Version.validate_version("1.2.3.4")
+        with self.assertRaises(ValueError):
+            Version.validate_version("invalid.version")
+
+
+class TestVersionComparator(unittest.TestCase):
+
+    def test_compare_equal(self):
+        version1 = Version(1, 2, 3)
+        version2 = Version(1, 2, 3)
+        self.assertEqual(VersionComparator.compare(version1, version2), 0)
+
+    def test_compare_greater(self):
+        version1 = Version(1, 2, 4)
+        version2 = Version(1, 2, 3)
+        self.assertEqual(VersionComparator.compare(version1, version2), 1)
+
+    def test_compare_less(self):
+        version1 = Version(1, 2, 3)
+        version2 = Version(1, 2, 4)
+        self.assertEqual(VersionComparator.compare(version1, version2), -1)
+
+    def test_compare_major_difference(self):
+        version1 = Version(2, 0, 0)
+        version2 = Version(1, 9, 9)
+        self.assertEqual(VersionComparator.compare(version1, version2), 1)
+
+        version1 = Version(1, 0, 0)
+        version2 = Version(2, 0, 0)
+        self.assertEqual(VersionComparator.compare(version1, version2), -1)
+
+    def test_compare_minor_difference(self):
+        version1 = Version(1, 1, 0)
+        version2 = Version(1, 2, 0)
+        self.assertEqual(VersionComparator.compare(version1, version2), -1)
+
+        version1 = Version(1, 2, 0)
+        version2 = Version(1, 1, 0)
+        self.assertEqual(VersionComparator.compare(version1, version2), 1)
+
+    def test_compare_patch_difference(self):
+        version1 = Version(1, 2, 3)
+        version2 = Version(1, 2, 4)
+        self.assertEqual(VersionComparator.compare(version1, version2), -1)
+
+        version1 = Version(1, 2, 4)
+        version2 = Version(1, 2, 3)
+        self.assertEqual(VersionComparator.compare(version1, version2), 1)

--- a/tuxemon/version.py
+++ b/tuxemon/version.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import re
+
+__version__ = "0.4.35"
+
+
+class Version:
+    """Represents the version of a plugin, following semantic versioning."""
+
+    def __init__(
+        self,
+        major: int,
+        minor: int,
+        patch: int,
+        pre_release: str = "",
+        build_metadata: str = "",
+    ):
+        self.major = major
+        self.minor = minor
+        self.patch = patch
+        self.pre_release = pre_release
+        self.build_metadata = build_metadata
+
+    def __str__(self) -> str:
+        """Returns the string representation of the version."""
+        version_str = f"{self.major}.{self.minor}.{self.patch}"
+        if self.pre_release:
+            version_str += f"-{self.pre_release}"
+        if self.build_metadata:
+            version_str += f"+{self.build_metadata}"
+        return version_str
+
+    @classmethod
+    def from_string(cls, version_str: str) -> Version:
+        """Creates a Version from a string, supporting pre-release and build metadata."""
+        Version.validate_version(version_str)
+
+        try:
+            main_part, *rest = version_str.split("-")
+            major, minor, patch = map(int, main_part.split("."))
+            pre_release = ""
+            build_metadata = ""
+
+            if rest:
+                pre_release = rest[0]
+                if "+" in pre_release:
+                    pre_release, build_metadata = pre_release.split("+", 1)
+
+            return cls(major, minor, patch, pre_release, build_metadata)
+        except ValueError:
+            raise ValueError(
+                f"Invalid version string: {version_str}. Expected format: MAJOR.MINOR.PATCH[-PRERELEASE][+BUILD]"
+            )
+
+    def __eq__(self, other: object) -> bool:
+        """Checks if two Version instances are equal."""
+        if not isinstance(other, Version):
+            return NotImplemented
+        return (
+            self.major == other.major
+            and self.minor == other.minor
+            and self.patch == other.patch
+            and self.pre_release == other.pre_release
+            and self.build_metadata == other.build_metadata
+        )
+
+    def __lt__(self, other: Version) -> bool:
+        """Compares two Version instances for less than."""
+        if self.major != other.major:
+            return self.major < other.major
+        if self.minor != other.minor:
+            return self.minor < other.minor
+        if self.patch != other.patch:
+            return self.patch < other.patch
+        return self.pre_release < other.pre_release
+
+    def __gt__(self, other: "Version") -> bool:
+        """Compares two Version instances for greater than."""
+        return not (self < other or self == other)
+
+    def __ge__(self, other: "Version") -> bool:
+        """Compares two Version instances for greater than or equal to."""
+        return self > other or self == other
+
+    @staticmethod
+    def validate_version(version_str: str) -> None:
+        """Validates the version string format."""
+        if not re.match(
+            r"^\d+\.\d+\.\d+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$",
+            version_str,
+        ):
+            raise ValueError(
+                f"Invalid version format: {version_str}. Expected format: MAJOR.MINOR.PATCH[-PRERELEASE][+BUILD]"
+            )
+
+
+class VersionComparator:
+    @staticmethod
+    def compare(version1: Version, version2: Version) -> int:
+        """
+        Compares two Version objects.
+
+        Returns:
+            -1 if version1 < version2
+             0 if version1 == version2
+             1 if version1 > version2
+        """
+        if version1.major != version2.major:
+            return version1.major - version2.major
+        if version1.minor != version2.minor:
+            return version1.minor - version2.minor
+        return version1.patch - version2.patch


### PR DESCRIPTION
PR introduces a new `Version` class that, allows us to manage and compare version numbers. This class includes methods for creating version instances from strings, converting them back to string format, and comparing different versions. I've implemented a `VersionComparator` class that provides a way to compare two `Version` objects. This will help us determine the order of versions, which is essential for version management. To ensure everything works as expected, I've also added a comprehensive suite of unit tests.

remember to add in setup_cx_freeze:
```
from tuxemon.version import Version, __version__

version = Version.from_string(__version__) if __version__ else Version.from_string(config["version"])

version=str(version), (version.__str__)
```