### PR TITLE
Move today_ordinal() method

### DIFF
--- a/mods/tuxemon/maps/spyder_candy_town.tmx
+++ b/mods/tuxemon/maps/spyder_candy_town.tmx
@@ -354,9 +354,8 @@
   <object id="222" name="Talk Eliane 1" type="event" x="96" y="16" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_candy_eliane1"/>
-    <property name="act2" value="set_variable elianeflower:today"/>
-    <property name="act3" value="set_random_variable elianeoutput,cureall:restoration:potion:tea"/>
-    <property name="act4" value="random_integer luckgiveegg,1,10"/>
+    <property name="act2" value="set_random_variable elianeoutput,cureall:restoration:potion:tea"/>
+    <property name="act3" value="random_integer luckgiveegg,1,10"/>
     <property name="behav1" value="talk spyder_candy_eliane"/>
     <property name="cond1" value="is once 1,elianeflower"/>
    </properties>

--- a/tests/tuxemon/test_monster.py
+++ b/tests/tuxemon/test_monster.py
@@ -3,12 +3,13 @@
 import unittest
 from unittest.mock import MagicMock
 
-from tuxemon import formula, prepare
+from tuxemon import prepare
 from tuxemon.db import Modifier, ShapeModel, TechniqueModel, db
 from tuxemon.monster import Monster
 from tuxemon.prepare import MAX_LEVEL
 from tuxemon.taste import Taste
 from tuxemon.technique.technique import Technique
+from tuxemon.time_handler import today_ordinal
 
 
 class MonsterTestBase(unittest.TestCase):
@@ -38,11 +39,11 @@ class SetCapture(MonsterTestBase):
     def setUp(self):
         self.mon = Monster()
         self.mon.name = "agnite"
-        self.mon.set_capture(formula.today_ordinal())
+        self.mon.set_capture(today_ordinal())
 
     def test_set_capture_zero(self):
         self.mon.set_capture(0)
-        self.assertEqual(self.mon.capture, formula.today_ordinal())
+        self.assertEqual(self.mon.capture, today_ordinal())
 
     def test_set_capture_amount(self):
         self.mon.set_capture(5)

--- a/tuxemon/event/actions/add_monster.py
+++ b/tuxemon/event/actions/add_monster.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional, final
 
-from tuxemon import formula
 from tuxemon.db import SeenStatus, db
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.monster import Monster
+from tuxemon.time_handler import today_ordinal
 
 
 @final
@@ -62,7 +62,7 @@ class AddMonsterAction(EventAction):
         monster.load_from_db(monster_slug)
         monster.set_level(self.monster_level)
         monster.set_moves(self.monster_level)
-        monster.set_capture(formula.today_ordinal())
+        monster.set_capture(today_ordinal())
         monster.current_hp = monster.hp
 
         if self.exp is not None:

--- a/tuxemon/event/actions/random_battle.py
+++ b/tuxemon/event/actions/random_battle.py
@@ -7,7 +7,7 @@ import random
 from dataclasses import dataclass
 from typing import final
 
-from tuxemon import formula, prepare
+from tuxemon import prepare
 from tuxemon.combat import check_battle_legal
 from tuxemon.db import MonsterModel, NpcModel, db
 from tuxemon.event.eventaction import EventAction
@@ -15,6 +15,7 @@ from tuxemon.monster import Monster
 from tuxemon.npc import NPC
 from tuxemon.states.combat.combat import CombatState
 from tuxemon.states.world.worldstate import WorldState
+from tuxemon.time_handler import today_ordinal
 
 logger = logging.getLogger(__name__)
 
@@ -75,7 +76,7 @@ class RandomBattleAction(EventAction):
             current_monster.load_from_db(monster.slug)
             current_monster.set_level(level)
             current_monster.set_moves(level)
-            current_monster.set_capture(formula.today_ordinal())
+            current_monster.set_capture(today_ordinal())
             current_monster.current_hp = current_monster.hp
             current_monster.money_modifier = level
             current_monster.experience_modifier = level

--- a/tuxemon/event/actions/set_random_variable.py
+++ b/tuxemon/event/actions/set_random_variable.py
@@ -6,7 +6,6 @@ import random
 from dataclasses import dataclass
 from typing import final
 
-from tuxemon import formula
 from tuxemon.event.eventaction import EventAction
 
 
@@ -44,10 +43,6 @@ class SetRandomVariableAction(EventAction):
             value = random.choice(values)
         else:
             value = self.var_value
-
-        # replaces today value with ordinal
-        if value == "today":
-            value = str(formula.today_ordinal())
 
         # Append the game_variables dictionary with the key: value pair
         player.game_variables[self.var_key] = value

--- a/tuxemon/event/actions/set_variable.py
+++ b/tuxemon/event/actions/set_variable.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import final
 
-from tuxemon import formula
 from tuxemon.event.eventaction import EventAction
 
 
@@ -23,8 +22,6 @@ class SetVariableAction(EventAction):
     Script parameters:
         variable: Name of the variable.
         value: Value of the variable
-            (if value "today" = today's date)
-
     """
 
     name = "set_variable"
@@ -38,8 +35,5 @@ class SetVariableAction(EventAction):
         var_key = str(var_list[0])
         var_value = str(var_list[1])
 
-        # replaces today value with ordinal
-        if var_value == "today":
-            var_value = str(formula.today_ordinal())
         # Append the game_variables dictionary with the key: value pair
         player.game_variables[var_key] = var_value

--- a/tuxemon/event/actions/spawn_monster.py
+++ b/tuxemon/event/actions/spawn_monster.py
@@ -15,6 +15,7 @@ from tuxemon.event.eventaction import EventAction
 from tuxemon.locale import T
 from tuxemon.monster import Monster
 from tuxemon.states.dialog import DialogState
+from tuxemon.time_handler import today_ordinal
 from tuxemon.tools import open_dialog
 
 logger = logging.getLogger(__name__)
@@ -93,7 +94,7 @@ class SpawnMonsterAction(EventAction):
         child.load_from_db(seed_slug)
         child.set_level(level)
         child.set_moves(level)
-        child.set_capture(formula.today_ordinal())
+        child.set_capture(today_ordinal())
         child.name = name
         child.current_hp = child.hp
 

--- a/tuxemon/event/actions/trading.py
+++ b/tuxemon/event/actions/trading.py
@@ -7,11 +7,11 @@ import uuid
 from dataclasses import dataclass
 from typing import final
 
-from tuxemon import formula
 from tuxemon.db import SeenStatus, db
 from tuxemon.event import get_monster_by_iid
 from tuxemon.event.eventaction import EventAction
 from tuxemon.monster import Monster
+from tuxemon.time_handler import today_ordinal
 
 logger = logging.getLogger(__name__)
 
@@ -71,7 +71,7 @@ def _create_traded_monster(removed: Monster, added: str) -> Monster:
     new.load_from_db(added)
     new.set_level(removed.level)
     new.set_moves(removed.level)
-    new.set_capture(formula.today_ordinal())
+    new.set_capture(today_ordinal())
     new.current_hp = new.hp
     new.traded = True
     return new

--- a/tuxemon/event/conditions/once.py
+++ b/tuxemon/event/conditions/once.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from tuxemon import formula
 from tuxemon.event import MapCondition
 from tuxemon.event.eventcondition import EventCondition
 from tuxemon.session import Session
+from tuxemon.time_handler import today_ordinal
 
 
 @dataclass
@@ -32,10 +32,16 @@ class OnceCondition(EventCondition):
         timeframe = int(condition.parameters[0])
         variable = condition.parameters[1]
         player = session.player
-        if variable in player.game_variables:
-            today = int(player.game_variables[variable])
-            if today + timeframe <= formula.today_ordinal():
-                return True
-            else:
-                return False
-        return True
+
+        if variable not in player.game_variables:
+            player.game_variables[variable] = today_ordinal()
+            return True
+
+        last_occurrence_day = int(player.game_variables[variable])
+        current_day = today_ordinal()
+
+        if current_day - last_occurrence_day > timeframe:
+            player.game_variables[variable] = current_day
+            return True
+
+        return False

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-import datetime as dt
 import logging
 import math
 import random
@@ -441,13 +440,6 @@ def update_stat(
                 modified_stat *= modifier.multiplier
 
     return int(modified_stat)
-
-
-def today_ordinal() -> int:
-    """
-    It gives today's proleptic Gregorian ordinal.
-    """
-    return dt.date.today().toordinal()
 
 
 def set_weight(kg: float) -> float:

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -33,6 +33,7 @@ from tuxemon.shape import Shape
 from tuxemon.sprite import Sprite
 from tuxemon.taste import Taste
 from tuxemon.technique.technique import Technique, decode_moves, encode_moves
+from tuxemon.time_handler import today_ordinal
 
 if TYPE_CHECKING:
     import pygame
@@ -473,7 +474,7 @@ class Monster:
         """
         It returns the capture date.
         """
-        self.capture = formula.today_ordinal() if amount == 0 else amount
+        self.capture = today_ordinal() if amount == 0 else amount
         return self.capture
 
     def set_char_weight(self, value: float) -> float:

--- a/tuxemon/states/character/__init__.py
+++ b/tuxemon/states/character/__init__.py
@@ -16,6 +16,7 @@ from tuxemon.menu.menu import PygameMenuState
 from tuxemon.npc import NPC
 from tuxemon.platform.const import buttons
 from tuxemon.platform.events import PlayerInput
+from tuxemon.time_handler import today_ordinal
 
 MenuGameObj = Callable[[], object]
 lookup_cache: dict[str, MonsterModel] = {}
@@ -80,7 +81,7 @@ class CharacterState(PygameMenuState):
         msg_seen = T.format("tuxepedia_data_seen", _msg_seen)
         msg_caught = T.format("tuxepedia_data_caught", _msg_caught)
 
-        today = formula.today_ordinal()
+        today = today_ordinal()
         date = self.char.game_variables.get("date_start_game", today)
         date_begin = today - int(date)
         msg_begin = (

--- a/tuxemon/states/monster_info/__init__.py
+++ b/tuxemon/states/monster_info/__init__.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-import uuid
 from typing import Any, Optional
 
 import pygame_menu
@@ -16,6 +15,7 @@ from tuxemon.monster import Monster
 from tuxemon.platform.const import buttons
 from tuxemon.platform.events import PlayerInput
 from tuxemon.session import local_session
+from tuxemon.time_handler import today_ordinal
 
 lookup_cache: dict[str, MonsterModel] = {}
 
@@ -167,7 +167,7 @@ class MonsterInfoState(PygameMenuState):
         )
         lab9.translate(fix_measure(width, 0.50), fix_measure(height, 0.45))
         # capture
-        doc = formula.today_ordinal() - monster.capture
+        doc = today_ordinal() - monster.capture
         if doc >= 1:
             ref = (
                 T.format("tuxepedia_trade", {"doc": doc})

--- a/tuxemon/states/start/__init__.py
+++ b/tuxemon/states/start/__init__.py
@@ -20,6 +20,7 @@ from tuxemon.platform.events import PlayerInput
 from tuxemon.save import get_index_of_latest_save
 from tuxemon.session import local_session
 from tuxemon.state import State
+from tuxemon.time_handler import today_ordinal
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +59,7 @@ class StartState(PygameMenuState):
             map_path = prepare.fetch("maps", destination)
             self.client.push_state("WorldState", map_name=map_path)
             game_var = local_session.player.game_variables
-            game_var["date_start_game"] = formula.today_ordinal()
+            game_var["date_start_game"] = today_ordinal()
             self.client.pop_state(self)
 
         def change_state(

--- a/tuxemon/time_handler.py
+++ b/tuxemon/time_handler.py
@@ -13,6 +13,13 @@ def get_current_time() -> datetime:
     return dt.datetime.now()
 
 
+def today_ordinal() -> int:
+    """
+    It gives today's proleptic Gregorian ordinal.
+    """
+    return dt.date.today().toordinal()
+
+
 def calculate_day_night_cycle(time: datetime) -> str:
     """Calculates the current day/night cycle based on the time provided.
 


### PR DESCRIPTION
PR moves 'today_ordinal' from `formula.py` file to `time_handler.py`. This helps us keep all the time-related functions in one place. It also creates a new variable that we can use to make things happen only once a day, which is really useful for certain tasks. Updates `once` event condition and removes the hardcoded `today` from the variables.

