### PR TITLE
terrains + weathers

### DIFF
--- a/mods/tuxemon/db/monster/babysnitch.json
+++ b/mods/tuxemon/db/monster/babysnitch.json
@@ -43,7 +43,7 @@
             "evo_stage": "stage1"
         }
     ],
-    "terrains": ["boreal/snow", "mountains", "underground"],
+    "terrains": ["boreal_snow", "mountains", "underground"],
     "tags": ["bite", "claws", "fury", "ground"],
     "shape": "hunter",
     "stage": "basic",

--- a/mods/tuxemon/db/monster/baddrscratch.json
+++ b/mods/tuxemon/db/monster/baddrscratch.json
@@ -38,7 +38,7 @@
             "evo_stage": "basic"
         }
     ],
-    "terrains": ["boreal/snow", "mountains", "underground"],
+    "terrains": ["boreal_snow", "mountains", "underground"],
     "tags": ["bite", "claws", "fury", "ground", "darkness"],
     "shape": "hunter",
     "stage": "stage1",

--- a/mods/tuxemon/db/monster/caper.json
+++ b/mods/tuxemon/db/monster/caper.json
@@ -55,7 +55,7 @@
             "evo_stage": "stage1"
         }
     ],
-    "terrains": ["boreal/snow", "grassland", "mountains"],
+    "terrains": ["boreal_snow", "grassland", "mountains"],
     "tags": ["ice"],
     "shape": "landrace",
     "stage": "basic",

--- a/mods/tuxemon/db/monster/chillimp.json
+++ b/mods/tuxemon/db/monster/chillimp.json
@@ -47,7 +47,7 @@
             "evo_stage": "stage1"
         }
     ],
-    "terrains": ["boreal/snow", "mountains"],
+    "terrains": ["boreal_snow", "mountains"],
     "tags": ["ice", "fists"],
     "shape": "brute",
     "stage": "basic",

--- a/mods/tuxemon/db/monster/cohldrabi.json
+++ b/mods/tuxemon/db/monster/cohldrabi.json
@@ -59,7 +59,7 @@
             "evo_stage": "stage2"
         }
     ],
-    "terrains": ["boreal/snow", "grassland", "woodland"],
+    "terrains": ["boreal_snow", "grassland", "woodland"],
     "tags": ["plant", "ice"],
     "shape": "sprite",
     "stage": "basic",

--- a/mods/tuxemon/db/monster/crankus.json
+++ b/mods/tuxemon/db/monster/crankus.json
@@ -50,7 +50,7 @@
             "evo_stage": "basic"
         }
     ],
-    "terrains": ["boreal/snow", "grassland", "mountains"],
+    "terrains": ["boreal_snow", "grassland", "mountains"],
     "tags": ["ice", "fury", "megafauna"],
     "shape": "landrace",
     "stage": "stage1",

--- a/mods/tuxemon/db/monster/eaglace.json
+++ b/mods/tuxemon/db/monster/eaglace.json
@@ -62,7 +62,7 @@
             "evo_stage": "stage1"
         }
     ],
-    "terrains": ["boreal/snow", "grassland", "mountains"],
+    "terrains": ["boreal_snow", "grassland", "mountains"],
     "tags": ["gemstone", "ice", "bird", "weather"],
     "shape": "flier",
     "stage": "stage2",

--- a/mods/tuxemon/db/monster/eskipup.json
+++ b/mods/tuxemon/db/monster/eskipup.json
@@ -35,7 +35,7 @@
             "evo_stage": "stage1"
         }
     ],
-    "terrains": ["boreal/snow"],
+    "terrains": ["boreal_snow"],
     "tags": ["ice", "bite"],
     "shape": "hunter",
     "stage": "basic",

--- a/mods/tuxemon/db/monster/frostuce.json
+++ b/mods/tuxemon/db/monster/frostuce.json
@@ -54,7 +54,7 @@
             "evo_stage": "stage1"
         }
     ],
-    "terrains": ["boreal/snow"],
+    "terrains": ["boreal_snow"],
     "tags": ["plant", "ice"],
     "shape": "humanoid",
     "stage": "stage2",

--- a/mods/tuxemon/db/monster/heronquak.json
+++ b/mods/tuxemon/db/monster/heronquak.json
@@ -63,7 +63,7 @@
             "evo_stage": "stage2"
         }
     ],
-    "terrains": ["boreal/snow", "grassland", "mountains"],
+    "terrains": ["boreal_snow", "grassland", "mountains"],
     "tags": ["gemstone", "ice", "bird"],
     "shape": "flier",
     "stage": "stage1",

--- a/mods/tuxemon/db/monster/houndice.json
+++ b/mods/tuxemon/db/monster/houndice.json
@@ -30,7 +30,7 @@
             "evo_stage": "basic"
         }
     ],
-    "terrains": ["boreal/snow"],
+    "terrains": ["boreal_snow"],
     "tags": ["ice", "bite"],
     "shape": "hunter",
     "stage": "stage1",

--- a/mods/tuxemon/db/monster/jeluna.json
+++ b/mods/tuxemon/db/monster/jeluna.json
@@ -41,7 +41,7 @@
     ],
     "evolutions": [],
     "history": [],
-    "terrains": ["boreal/snow", "extraterrestrial", "ruins", "sea"],
+    "terrains": ["boreal_snow", "extraterrestrial", "ruins", "sea"],
     "tags": ["celestial", "light", "darkness"],
     "shape": "blob",
     "stage": "standalone",

--- a/mods/tuxemon/db/monster/lettice.json
+++ b/mods/tuxemon/db/monster/lettice.json
@@ -59,7 +59,7 @@
             "evo_stage": "stage2"
         }
     ],
-    "terrains": ["mountains", "boreal/snow", "grassland", "woodland"],
+    "terrains": ["mountains", "boreal_snow", "grassland", "woodland"],
     "tags": ["plant", "ice"],
     "shape": "humanoid",
     "stage": "stage1",

--- a/mods/tuxemon/db/monster/snowrilla.json
+++ b/mods/tuxemon/db/monster/snowrilla.json
@@ -42,7 +42,7 @@
             "evo_stage": "basic"
         }
     ],
-    "terrains": ["boreal/snow", "mountains"],
+    "terrains": ["boreal_snow", "mountains"],
     "tags": ["ice", "fists"],
     "shape": "brute",
     "stage": "stage1",

--- a/mods/tuxemon/db/monster/tux.json
+++ b/mods/tuxemon/db/monster/tux.json
@@ -53,7 +53,7 @@
     ],
     "evolutions": [],
     "history": [],
-    "terrains": ["boreal/snow", "coastal"],
+    "terrains": ["boreal_snow", "coastal"],
     "tags": ["water", "ice", "leadership", "rock"],
     "shape": "flier",
     "stage": "standalone",

--- a/mods/tuxemon/db/monster/tweesher.json
+++ b/mods/tuxemon/db/monster/tweesher.json
@@ -63,7 +63,7 @@
             "evo_stage": "stage2"
         }
     ],
-    "terrains": ["boreal/snow", "grassland", "mountains"],
+    "terrains": ["boreal_snow", "grassland", "mountains"],
     "tags": ["gemstone", "ice", "bird"],
     "shape": "flier",
     "stage": "basic",

--- a/mods/tuxemon/db/monster/wendigger.json
+++ b/mods/tuxemon/db/monster/wendigger.json
@@ -50,7 +50,7 @@
             "evo_stage": "stage1"
         }
     ],
-    "terrains": ["boreal/snow", "underground", "woodland"],
+    "terrains": ["boreal_snow", "underground", "woodland"],
     "tags": ["plant", "ground", "bite", "ice", "darkness", "ghost"],
     "shape": "brute",
     "stage": "stage2",

--- a/mods/tuxemon/db/monster/wolffsky.json
+++ b/mods/tuxemon/db/monster/wolffsky.json
@@ -53,7 +53,7 @@
     ],
     "evolutions": [],
     "history": [],
-    "terrains": ["boreal/snow", "woodland"],
+    "terrains": ["boreal_snow", "woodland"],
     "tags": ["bite", "ice", "darkness"],
     "shape": "hunter",
     "stage": "standalone",

--- a/mods/tuxemon/db/terrain/terrains.json
+++ b/mods/tuxemon/db/terrain/terrains.json
@@ -1,53 +1,308 @@
 [
   {
-    "slug": "underground"
+    "slug": "underground",
+    "name": "terrain_underground",
+    "element_modifier": {
+      "earth": 1,
+      "fire": 1,
+      "frost": 1,
+      "heroic": 1,
+      "lightning": 1,
+      "cosmic": 1,
+      "normal": 1,
+      "shadow": 1,
+      "sky": 1,
+      "venom": 1,
+      "water": 1,
+      "wood": 1
+    }
   },
   {
-    "slug": "swamp"
+    "slug": "swamp",
+    "name": "terrain_swamp",
+    "element_modifier": {
+      "earth": 1,
+      "fire": 1,
+      "frost": 1,
+      "heroic": 1,
+      "lightning": 1,
+      "cosmic": 1,
+      "normal": 1,
+      "shadow": 1,
+      "sky": 1,
+      "venom": 1,
+      "water": 1,
+      "wood": 1
+    }
   },
   {
-    "slug": "sea"
+    "slug": "sea",
+    "name": "terrain_sea",
+    "element_modifier": {
+      "earth": 1,
+      "fire": 1,
+      "frost": 1,
+      "heroic": 1,
+      "lightning": 1,
+      "cosmic": 1,
+      "normal": 1,
+      "shadow": 1,
+      "sky": 1,
+      "venom": 1,
+      "water": 1,
+      "wood": 1
+    }
   },
   {
-    "slug": "ruins"
+    "slug": "ruins",
+    "name": "terrain_ruins",
+    "element_modifier": {
+      "earth": 1,
+      "fire": 1,
+      "frost": 1,
+      "heroic": 1,
+      "lightning": 1,
+      "cosmic": 1,
+      "normal": 1,
+      "shadow": 1,
+      "sky": 1,
+      "venom": 1,
+      "water": 1,
+      "wood": 1
+    }
   },
   {
-    "slug": "mountains"
+    "slug": "mountains",
+    "name": "terrain_mountains",
+    "element_modifier": {
+      "earth": 1,
+      "fire": 1,
+      "frost": 1,
+      "heroic": 1,
+      "lightning": 1,
+      "cosmic": 1,
+      "normal": 1,
+      "shadow": 1,
+      "sky": 1,
+      "venom": 1,
+      "water": 1,
+      "wood": 1
+    }
   },
   {
-    "slug": "jungle"
+    "slug": "jungle",
+    "name": "terrain_jungle",
+    "element_modifier": {
+      "earth": 1,
+      "fire": 1,
+      "frost": 1,
+      "heroic": 1,
+      "lightning": 1,
+      "cosmic": 1,
+      "normal": 1,
+      "shadow": 1,
+      "sky": 1,
+      "venom": 1,
+      "water": 1,
+      "wood": 1
+    }
   },
   {
-    "slug": "grassland"
+    "slug": "grassland",
+    "name": "terrain_grassland",
+    "element_modifier": {
+      "earth": 1,
+      "fire": 1,
+      "frost": 1,
+      "heroic": 1,
+      "lightning": 1,
+      "cosmic": 1,
+      "normal": 1,
+      "shadow": 1,
+      "sky": 1,
+      "venom": 1,
+      "water": 1,
+      "wood": 1
+    }
   },
   {
-    "slug": "freshwater"
+    "slug": "freshwater",
+    "name": "terrain_freshwater",
+    "element_modifier": {
+      "earth": 1,
+      "fire": 1,
+      "frost": 1,
+      "heroic": 1,
+      "lightning": 1,
+      "cosmic": 1,
+      "normal": 1,
+      "shadow": 1,
+      "sky": 1,
+      "venom": 1,
+      "water": 1,
+      "wood": 1
+    }
   },
   {
-    "slug": "extraterrestrial"
+    "slug": "extraterrestrial",
+    "name": "terrain_extraterrestrial",
+    "element_modifier": {
+      "earth": 1,
+      "fire": 1,
+      "frost": 1,
+      "heroic": 1,
+      "lightning": 1,
+      "cosmic": 1,
+      "normal": 1,
+      "shadow": 1,
+      "sky": 1,
+      "venom": 1,
+      "water": 1,
+      "wood": 1
+    }
   },
   {
-    "slug": "extraplanar"
+    "slug": "extraplanar",
+    "name": "terrain_extraplanar",
+    "element_modifier": {
+      "earth": 1,
+      "fire": 1,
+      "frost": 1,
+      "heroic": 1,
+      "lightning": 1,
+      "cosmic": 1,
+      "normal": 1,
+      "shadow": 1,
+      "sky": 1,
+      "venom": 1,
+      "water": 1,
+      "wood": 1
+    }
   },
   {
-    "slug": "desert"
+    "slug": "desert",
+    "name": "terrain_desert",
+    "element_modifier": {
+      "earth": 1,
+      "fire": 1,
+      "frost": 1,
+      "heroic": 1,
+      "lightning": 1,
+      "cosmic": 1,
+      "normal": 1,
+      "shadow": 1,
+      "sky": 1,
+      "venom": 1,
+      "water": 1,
+      "wood": 1
+    }
   },
   {
-    "slug": "coastal"
+    "slug": "coastal",
+    "name": "terrain_coastal",
+    "element_modifier": {
+      "earth": 1,
+      "fire": 1,
+      "frost": 1,
+      "heroic": 1,
+      "lightning": 1,
+      "cosmic": 1,
+      "normal": 1,
+      "shadow": 1,
+      "sky": 1,
+      "venom": 1,
+      "water": 1,
+      "wood": 1
+    }
   },
   {
-    "slug": "boreal_snow"
+    "slug": "boreal_snow",
+    "name": "terrain_boreal_snow",
+    "element_modifier": {
+      "earth": 1,
+      "fire": 1,
+      "frost": 1,
+      "heroic": 1,
+      "lightning": 1,
+      "cosmic": 1,
+      "normal": 1,
+      "shadow": 1,
+      "sky": 1,
+      "venom": 1,
+      "water": 1,
+      "wood": 1
+    }
   },
   {
-    "slug": "any"
+    "slug": "any",
+    "name": "terrain_any",
+    "element_modifier": {
+      "earth": 1,
+      "fire": 1,
+      "frost": 1,
+      "heroic": 1,
+      "lightning": 1,
+      "cosmic": 1,
+      "normal": 1,
+      "shadow": 1,
+      "sky": 1,
+      "venom": 1,
+      "water": 1,
+      "wood": 1
+    }
   },
   {
-    "slug": "urban"
+    "slug": "urban",
+    "name": "terrain_urban",
+    "element_modifier": {
+      "earth": 1,
+      "fire": 1,
+      "frost": 1,
+      "heroic": 1,
+      "lightning": 1,
+      "cosmic": 1,
+      "normal": 1,
+      "shadow": 1,
+      "sky": 1,
+      "venom": 1,
+      "water": 1,
+      "wood": 1
+    }
   },
   {
-    "slug": "woodland"
+    "slug": "woodland",
+    "name": "terrain_woodland",
+    "element_modifier": {
+      "earth": 1,
+      "fire": 1,
+      "frost": 1,
+      "heroic": 1,
+      "lightning": 1,
+      "cosmic": 1,
+      "normal": 1,
+      "shadow": 1,
+      "sky": 1,
+      "venom": 1,
+      "water": 1,
+      "wood": 1
+    }
   },
   {
-    "slug": "other"
+    "slug": "other",
+    "name": "terrain_other",
+    "element_modifier": {
+      "earth": 1,
+      "fire": 1,
+      "frost": 1,
+      "heroic": 1,
+      "lightning": 1,
+      "cosmic": 1,
+      "normal": 1,
+      "shadow": 1,
+      "sky": 1,
+      "venom": 1,
+      "water": 1,
+      "wood": 1
+    }
   }
 ]

--- a/mods/tuxemon/db/weather/weathers.json
+++ b/mods/tuxemon/db/weather/weathers.json
@@ -1,32 +1,182 @@
 [
-  {
-    "slug": "misty"
-  },
-  {
-    "slug": "windy"
-  },
-  {
-    "slug": "freezing"
-  },
-  {
-    "slug": "hot"
-  },
-  {
-    "slug": "cloudy"
-  },
-  {
-    "slug": "foggy"
-  },
-  {
-    "slug": "thunderstorm"
-  },
-  {
-    "slug": "snow"
-  },
-  {
-    "slug": "rain"
-  },
-  {
-    "slug": "sunny"
-  }
-]
+    {
+      "slug": "misty",
+      "name": "weather_misty",
+      "element_modifier": {
+        "earth": 1,
+        "fire": 1,
+        "frost": 1,
+        "heroic": 1,
+        "lightning": 1,
+        "cosmic": 1,
+        "normal": 1,
+        "shadow": 1,
+        "sky": 1,
+        "venom": 1,
+        "water": 1,
+        "wood": 1
+      }
+    },
+    {
+      "slug": "windy",
+      "name": "weather_windy",
+      "element_modifier": {
+        "earth": 1,
+        "fire": 1,
+        "frost": 1,
+        "heroic": 1,
+        "lightning": 1,
+        "cosmic": 1,
+        "normal": 1,
+        "shadow": 1,
+        "sky": 1,
+        "venom": 1,
+        "water": 1,
+        "wood": 1
+      }
+    },
+    {
+      "slug": "freezing",
+      "name": "weather_freezing",
+      "element_modifier": {
+        "earth": 1,
+        "fire": 1,
+        "frost": 1,
+        "heroic": 1,
+        "lightning": 1,
+        "cosmic": 1,
+        "normal": 1,
+        "shadow": 1,
+        "sky": 1,
+        "venom": 1,
+        "water": 1,
+        "wood": 1
+      }
+    },
+    {
+      "slug": "hot",
+      "name": "weather_hot",
+      "element_modifier": {
+        "earth": 1,
+        "fire": 1,
+        "frost": 1,
+        "heroic": 1,
+        "lightning": 1,
+        "cosmic": 1,
+        "normal": 1,
+        "shadow": 1,
+        "sky": 1,
+        "venom": 1,
+        "water": 1,
+        "wood": 1
+      }
+    },
+    {
+      "slug": "cloudy",
+      "name": "weather_cloudy",
+      "element_modifier": {
+        "earth": 1,
+        "fire": 1,
+        "frost": 1,
+        "heroic": 1,
+        "lightning": 1,
+        "cosmic": 1,
+        "normal": 1,
+        "shadow": 1,
+        "sky": 1,
+        "venom": 1,
+        "water": 1,
+        "wood": 1
+      }
+    },
+    {
+      "slug": "foggy",
+      "name": "weather_foggy",
+      "element_modifier": {
+        "earth": 1,
+        "fire": 1,
+        "frost": 1,
+        "heroic": 1,
+        "lightning": 1,
+        "cosmic": 1,
+        "normal": 1,
+        "shadow": 1,
+        "sky": 1,
+        "venom": 1,
+        "water": 1,
+        "wood": 1
+      }
+    },
+    {
+      "slug": "thunderstorm",
+      "name": "weather_thunderstorm",
+      "element_modifier": {
+        "earth": 1,
+        "fire": 1,
+        "frost": 1,
+        "heroic": 1,
+        "lightning": 1,
+        "cosmic": 1,
+        "normal": 1,
+        "shadow": 1,
+        "sky": 1,
+        "venom": 1,
+        "water": 1,
+        "wood": 1
+      }
+    },
+    {
+      "slug": "snow",
+      "name": "weather_snow",
+      "element_modifier": {
+        "earth": 1,
+        "fire": 1,
+        "frost": 1,
+        "heroic": 1,
+        "lightning": 1,
+        "cosmic": 1,
+        "normal": 1,
+        "shadow": 1,
+        "sky": 1,
+        "venom": 1,
+        "water": 1,
+        "wood": 1
+      }
+    },
+    {
+      "slug": "rain",
+      "name": "weather_rain",
+      "element_modifier": {
+        "earth": 1,
+        "fire": 1,
+        "frost": 1,
+        "heroic": 1,
+        "lightning": 1,
+        "cosmic": 1,
+        "normal": 1,
+        "shadow": 1,
+        "sky": 1,
+        "venom": 1,
+        "water": 1,
+        "wood": 1
+      }
+    },
+    {
+      "slug": "sunny",
+      "name": "weather_sunny",
+      "element_modifier": {
+        "earth": 1,
+        "fire": 1,
+        "frost": 1,
+        "heroic": 1,
+        "lightning": 1,
+        "cosmic": 1,
+        "normal": 1,
+        "shadow": 1,
+        "sky": 1,
+        "venom": 1,
+        "water": 1,
+        "wood": 1
+      }
+    }
+  ]

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -6710,6 +6710,91 @@ msgstr "Refined"
 msgid "taste_dry"
 msgstr "Dry"
 
+# Terrains
+
+msgid "terrain_freshwater"
+msgstr "Freshwater"
+
+msgid "terrain_grassland"
+msgstr "Grassland"
+
+msgid "terrain_jungle"
+msgstr "Jungle"
+
+msgid "terrain_mountains"
+msgstr "Mountains"
+
+msgid "terrain_ruins"
+msgstr "Ruins"
+
+msgid "terrain_sea"
+msgstr "Sea"
+
+msgid "terrain_swamp"
+msgstr "Swamp"
+
+msgid "terrain_underground"
+msgstr "Underground"
+
+msgid "terrain_extraterrestrial"
+msgstr "Extraterrestrial"
+
+msgid "terrain_extraplanar"
+msgstr "Extraplanar"
+
+msgid "terrain_desert"
+msgstr "Desert"
+
+msgid "terrain_coastal"
+msgstr "Coastal"
+
+msgid "terrain_any"
+msgstr "Any"
+
+msgid "terrain_boreal_snow"
+msgstr "Boreal / Snow"
+
+msgid "terrain_urban"
+msgstr "Urban"
+
+msgid "terrain_woodland"
+msgstr "Woodland"
+
+msgid "terrain_other"
+msgstr "Other"
+
+# Weathers
+
+msgid "weather_misty"
+msgstr "Misty"
+
+msgid "weather_windy"
+msgstr "Windy"
+
+msgid "weather_freezing"
+msgstr "Freezing"
+
+msgid "weather_hot"
+msgstr "Hot"
+
+msgid "weather_cloudy"
+msgstr "Cloudy"
+
+msgid "weather_foggy"
+msgstr "Foggy"
+
+msgid "weather_thunderstorm"
+msgstr "Thunderstorm"
+
+msgid "weather_snow"
+msgstr "Snow"
+
+msgid "weather_rain"
+msgstr "Rain"
+
+msgid "weather_sunny"
+msgstr "Sunny"
+
 # STAT TYPES
 
 msgid "armour"

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -691,6 +691,16 @@ class MonsterModel(BaseModel, validate_assignment=True):
             return v
         raise ValueError(f"the shape {v} doesn't exist in the db")
 
+    @field_validator("terrains")
+    def terrain_exists(cls: MonsterModel, v: Sequence[str]) -> Sequence[str]:
+        if v:
+            for terrain in v:
+                if not has.db_entry("terrain", terrain):
+                    raise ValueError(
+                        f"the terrain '{terrain}' doesn't exist in the db"
+                    )
+        return v
+
 
 class StatModel(BaseModel):
     value: float = Field(
@@ -1449,10 +1459,31 @@ class AnimationModel(BaseModel):
 
 class TerrainModel(BaseModel):
     slug: str = Field(..., description="Slug of the terrain")
+    name: str = Field(..., description="Name of the terrain condition")
+    element_modifier: dict[str, float] = Field(
+        ..., description="Modifiers for elemental techniques in this terrain"
+    )
+
+    @field_validator("name")
+    def translation_exists_item(cls: TerrainModel, v: str) -> str:
+        if has.translation(v):
+            return v
+        raise ValueError(f"no translation exists with msgid: {v}")
 
 
 class WeatherModel(BaseModel):
     slug: str = Field(..., description="Slug of the weather")
+    name: str = Field(..., description="Name of the weather condition")
+    element_modifier: dict[str, float] = Field(
+        ...,
+        description="Modifiers for elemental techniques during this weather",
+    )
+
+    @field_validator("name")
+    def translation_exists_item(cls: WeatherModel, v: str) -> str:
+        if has.translation(v):
+            return v
+        raise ValueError(f"no translation exists with msgid: {v}")
 
 
 TableName = Literal[

--- a/tuxemon/terrain.py
+++ b/tuxemon/terrain.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from tuxemon.db import db
+
+logger = logging.getLogger(__name__)
+
+
+class Terrain:
+    """A terrain class (mountain, underground, etc)."""
+
+    _terrains: dict[str, Terrain] = {}
+
+    def __init__(self, slug: Optional[str] = None) -> None:
+        self.slug = slug
+        self.element_modifier: dict[str, float] = {}
+
+        if self.slug:
+            self.load(self.slug)
+
+    def load(self, slug: str) -> None:
+        """Loads terrain."""
+
+        if slug in Terrain._terrains:
+            cached_terrain = Terrain._terrains[slug]
+            self.slug = slug
+            self.element_modifier = cached_terrain.element_modifier
+            return
+
+        try:
+            results = db.lookup(slug, table="terrain")
+        except KeyError:
+            raise RuntimeError(f"Terrain {slug} not found")
+
+        self.element_modifier = results.element_modifier
+
+        Terrain._terrains[slug] = self
+
+    @classmethod
+    def get_terrain(cls, slug: str) -> Optional[Terrain]:
+        """
+        Retrieves a Terrain object by its slug.
+
+        Parameters:
+            slug: The unique identifier for the terrain.
+
+        Returns:
+            The Terrain object if found, otherwise None.
+        """
+        return cls._terrains.get(slug)
+
+    @classmethod
+    def load_all_terrains(cls) -> None:
+        """Loads all terrains from the database into the cache."""
+        try:
+            all_terrain_slugs = list(db.database["terrain"])
+            for slug in all_terrain_slugs:
+                cls(slug)
+        except Exception as e:
+            logger.error(f"Failed to load all terrains: {e}")
+
+    @classmethod
+    def get_all_terrains(cls) -> dict[str, Terrain]:
+        """
+        Returns all loaded terrains.
+
+        Returns:
+            A dictionary of all loaded Terrain objects.
+        """
+        if not cls._terrains:
+            cls.load_all_terrains()
+        return cls._terrains
+
+    @classmethod
+    def clear_cache(cls) -> None:
+        """Clears the terrain cache."""
+        cls._terrains.clear()
+
+    def __repr__(self) -> str:
+        return f"Terrain(slug={self.slug}, element_modifier={self.element_modifier})"

--- a/tuxemon/weather.py
+++ b/tuxemon/weather.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from tuxemon.db import db
+
+logger = logging.getLogger(__name__)
+
+
+class Weather:
+    """A weather class (sunny, freezing, etc.)."""
+
+    _weathers: dict[str, Weather] = {}
+
+    def __init__(self, slug: Optional[str] = None) -> None:
+        self.slug = slug
+        self.element_modifier: dict[str, float] = {}
+
+        if self.slug:
+            self.load(self.slug)
+
+    def load(self, slug: str) -> None:
+        """Loads weather."""
+
+        if slug in Weather._weathers:
+            cached_weather = Weather._weathers[slug]
+            self.slug = slug
+            self.element_modifier = cached_weather.element_modifier
+            return
+
+        try:
+            results = db.lookup(slug, table="weather")
+        except KeyError:
+            raise RuntimeError(f"Weather {slug} not found")
+
+        self.element_modifier = results.element_modifier
+
+        Weather._weathers[slug] = self
+
+    @classmethod
+    def get_weather(cls, slug: str) -> Optional[Weather]:
+        """
+        Retrieves a Weather object by its slug.
+
+        Parameters:
+            slug: The unique identifier for the weather.
+
+        Returns:
+            The Weather object if found, otherwise None.
+        """
+        return cls._weathers.get(slug)
+
+    @classmethod
+    def load_all_weathers(cls) -> None:
+        """Loads all weathers from the database into the cache."""
+        try:
+            all_weather_slugs = list(db.database["weather"])
+            for slug in all_weather_slugs:
+                cls(slug)
+        except Exception as e:
+            logger.error(f"Failed to load all weathers: {e}")
+
+    @classmethod
+    def get_all_weathers(cls) -> dict[str, Weather]:
+        """
+        Returns all loaded weathers.
+
+        Returns:
+            A dictionary of all loaded Weather objects.
+        """
+        if not cls._weathers:
+            cls.load_all_weathers()
+        return cls._weathers
+
+    @classmethod
+    def clear_cache(cls) -> None:
+        """Clears the weather cache."""
+        cls._weathers.clear()
+
+    def __repr__(self) -> str:
+        return f"Weather(slug={self.slug}, element_modifier={self.element_modifier})"


### PR DESCRIPTION
follows #2655

PR adds terrains and weather types, like the ones mentioned on Tuxepedia. It also includes codes for translating their names and some extra settings for each one. The default value is still 1, but it doesn't include any new calculations or formulas yet, because that needs to be discussed first. It checks the terrains field in the `MonsterModel` , renames `boreal/snow` into `boreal_snow` and creates the respective classes.