### PR TITLE
MoneyController + fix modify_money + transfer_money

### DIFF
--- a/tests/tuxemon/test_money.py
+++ b/tests/tuxemon/test_money.py
@@ -1,11 +1,18 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
-import unittest
+from unittest import TestCase
+from unittest.mock import MagicMock
 
-from tuxemon.money import BillEntry, MoneyManager, decode_money, encode_money
+from tuxemon.money import (
+    BillEntry,
+    MoneyController,
+    MoneyManager,
+    decode_money,
+    encode_money,
+)
 
 
-class TestMoneyManager(unittest.TestCase):
+class TestMoneyManager(TestCase):
 
     def test_init(self):
         money_manager = MoneyManager()
@@ -35,29 +42,31 @@ class TestMoneyManager(unittest.TestCase):
         money_manager.add_money(100)
         self.assertEqual(money_manager.get_money(), 100)
 
-    def test_transfer_npc_money(self):
-        class NPC:
-            def __init__(self):
-                self.money_manager = MoneyManager()
+    def test_transfer_money_to(self):
+        npc1 = MagicMock()
+        npc1.money_controller = MoneyController(npc1)
+        npc1.money_controller.money_manager = MoneyManager()
+        npc2 = MagicMock()
+        npc2.money_controller = MoneyController(npc2)
+        npc2.money_controller.money_manager = MoneyManager()
 
-        money_manager = MoneyManager()
-        money_manager.add_money(100)
-        npc = NPC()
-        money_manager.transfer_npc_money(50, npc)
-        self.assertEqual(money_manager.money, 50)
-        self.assertEqual(npc.money_manager.money, 50)
+        npc1.money_controller.money_manager.add_money(100)
+        npc1.money_controller.transfer_money_to(50, npc2)
+        self.assertEqual(npc1.money_controller.money_manager.money, 50)
+        self.assertEqual(npc2.money_controller.money_manager.money, 50)
 
-    def test_transfer_npc_bank(self):
-        class NPC:
-            def __init__(self):
-                self.money_manager = MoneyManager()
+    def test_transfer_bank_to(self):
+        npc1 = MagicMock()
+        npc1.money_controller = MoneyController(npc1)
+        npc1.money_controller.money_manager = MoneyManager()
+        npc2 = MagicMock()
+        npc2.money_controller = MoneyController(npc2)
+        npc2.money_controller.money_manager = MoneyManager()
 
-        money_manager = MoneyManager()
-        money_manager.deposit_to_bank(100)
-        npc = NPC()
-        money_manager.transfer_npc_bank(50, npc)
-        self.assertEqual(money_manager.bank_account, 50)
-        self.assertEqual(npc.money_manager.bank_account, 50)
+        npc1.money_controller.money_manager.deposit_to_bank(100)
+        npc1.money_controller.transfer_bank_to(50, npc2)
+        self.assertEqual(npc1.money_controller.money_manager.bank_account, 50)
+        self.assertEqual(npc2.money_controller.money_manager.bank_account, 50)
 
     def test_deposit_to_bank(self):
         money_manager = MoneyManager()

--- a/tuxemon/event/actions/modify_bill.py
+++ b/tuxemon/event/actions/modify_bill.py
@@ -49,6 +49,7 @@ class ModifyBillAction(EventAction):
             return
 
         player = self.session.player
+        money_manager = character.money_controller.money_manager
         if self.amount is None:
             if self.variable:
                 _amount = player.game_variables.get(self.variable, 0)
@@ -56,7 +57,7 @@ class ModifyBillAction(EventAction):
                     amount = int(_amount)
                 elif isinstance(_amount, float):
                     _value = float(_amount)
-                    _wallet = character.money_manager.get_bill(self.bill_slug)
+                    _wallet = money_manager.get_bill(self.bill_slug)
                     amount = int(_wallet.amount * _value)
                 else:
                     raise ValueError("It must be float or int")
@@ -68,11 +69,11 @@ class ModifyBillAction(EventAction):
         if not T.has_translation("en_US", self.bill_slug):
             logger.error(f"Please add {self.bill_slug} to the en_US base.po")
 
-        bill_amount = character.money_manager.get_bill(self.bill_slug).amount
+        bill_amount = money_manager.get_bill(self.bill_slug).amount
         if bill_amount <= 0:
             logger.error(f"Bill '{self.bill_slug}' doesn't exist")
             return
         if amount >= 0:
-            character.money_manager.add_bill(self.bill_slug, amount)
+            money_manager.add_bill(self.bill_slug, amount)
         else:
-            character.money_manager.remove_bill(self.bill_slug, amount)
+            money_manager.remove_bill(self.bill_slug, amount)

--- a/tuxemon/event/actions/modify_money.py
+++ b/tuxemon/event/actions/modify_money.py
@@ -46,6 +46,7 @@ class ModifyMoneyAction(EventAction):
             return
 
         player = self.session.player
+        money_manager = character.money_controller.money_manager
         if self.amount is None:
             if self.variable:
                 _amount = player.game_variables.get(self.variable, 0)
@@ -53,7 +54,7 @@ class ModifyMoneyAction(EventAction):
                     amount = int(_amount)
                 elif isinstance(_amount, float):
                     _value = float(_amount)
-                    _wallet = player.money_manager.get_money()
+                    _wallet = money_manager.get_money()
                     amount = int(_wallet * _value)
                 else:
                     raise ValueError("It must be float or int")
@@ -62,5 +63,5 @@ class ModifyMoneyAction(EventAction):
         else:
             amount = self.amount
 
-        player.money_manager.add_money(amount)
+        money_manager.add_money(amount)
         logger.info(f"{character.name}'s money changed by {amount}")

--- a/tuxemon/event/actions/set_bill.py
+++ b/tuxemon/event/actions/set_bill.py
@@ -49,5 +49,6 @@ class SetBillAction(EventAction):
         if amount < 0:
             raise AttributeError(f"{amount} must be >= 0")
         else:
-            character.money_manager.add_entry(self.bill_slug, amount)
+            money_manager = character.money_controller.money_manager
+            money_manager.add_entry(self.bill_slug, amount)
             logger.info(f"{character.name}'s have {amount}")

--- a/tuxemon/event/actions/set_money.py
+++ b/tuxemon/event/actions/set_money.py
@@ -43,5 +43,6 @@ class SetMoneyAction(EventAction):
         if amount < 0:
             raise AttributeError(f"{amount} must be >= 0")
         else:
-            character.money_manager.add_money(amount)
+            money_manager = character.money_controller.money_manager
+            money_manager.add_money(amount)
             logger.info(f"{character.name}'s have {amount}")

--- a/tuxemon/event/actions/transfer_money.py
+++ b/tuxemon/event/actions/transfer_money.py
@@ -45,14 +45,16 @@ class TransferMoneyAction(EventAction):
             logger.error(f"Character not found in map: {_char}")
             return
 
+        money_manager = character1.money_controller.money_manager
+
         if self.amount < 0:
             raise AttributeError(f"Value {self.amount} must be >= 0")
-        if self.amount > character1.money_manager.get_money():
+        if self.amount > money_manager.get_money():
             raise AttributeError(
                 f"{self.slug1}'s wallet doesn't have {self.amount}"
             )
 
-        character1.money_manager.transfer_npc_bank(self.amount, character2)
+        character1.money_controller.transfer_money_to(self.amount, character2)
         logger.info(
             f"{character1.name} transfer {self.amount} to {character2.name}"
         )

--- a/tuxemon/event/conditions/bill_is.py
+++ b/tuxemon/event/conditions/bill_is.py
@@ -53,7 +53,8 @@ class BillIsCondition(EventCondition):
         else:
             amount = int(_amount)
 
-        bill_amount = character.money_manager.get_bill(_bill).amount
+        money_manager = character.money_controller.money_manager
+        bill_amount = money_manager.get_bill(_bill).amount
         if bill_amount == 0:
             return False
         else:

--- a/tuxemon/event/conditions/money_is.py
+++ b/tuxemon/event/conditions/money_is.py
@@ -52,5 +52,6 @@ class MoneyIsCondition(EventCondition):
         else:
             amount = int(_amount)
 
-        money_amount = character.money_manager.get_money()
+        money_manager = character.money_controller.money_manager
+        money_amount = money_manager.get_money()
         return compare(operator, money_amount, amount)

--- a/tuxemon/locale.py
+++ b/tuxemon/locale.py
@@ -380,7 +380,7 @@ def replace_text(session: Session, text: str) -> str:
         "${{name}}": player.name,
         "${{NAME}}": player.name.upper(),
         "${{currency}}": "$",
-        "${{money}}": str(player.money_manager.get_money()),
+        "${{money}}": str(player.money_controller.money_manager.get_money()),
         "${{tuxepedia_seen}}": str(player.tuxepedia.get_seen_count()),
         "${{tuxepedia_caught}}": str(player.tuxepedia.get_caught_count()),
         "${{map_name}}": client.map_name,

--- a/tuxemon/menu/quantity.py
+++ b/tuxemon/menu/quantity.py
@@ -94,8 +94,8 @@ class QuantityMenu(Menu[None]):
         yield MenuItem(image, label, None, None)
 
     def show_money(self) -> Generator[MenuItem[None], None, None]:
-        money = local_session.player.money_manager.get_money()
-        label = f"{T.translate('wallet')}: {money}"
+        money_manager = local_session.player.money_controller.money_manager
+        label = f"{T.translate('wallet')}: {money_manager.get_money()}"
         image_money = self.shadow_text(label)
         yield MenuItem(image_money, label, None, None)
 

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -19,7 +19,7 @@ from tuxemon.map import dirs2, dirs3, get_direction, proj
 from tuxemon.map_view import SpriteRenderer
 from tuxemon.math import Vector2
 from tuxemon.mission import MissionManager
-from tuxemon.money import MoneyManager, decode_money, encode_money
+from tuxemon.money import MoneyController
 from tuxemon.monster import Monster, decode_monsters, encode_monsters
 from tuxemon.prepare import CONFIG
 from tuxemon.session import Session
@@ -98,7 +98,7 @@ class NPC(Entity[NPCState]):
         # Tracks Tuxepedia (monster seen or caught)
         self.tuxepedia = Tuxepedia()
         self.contacts: dict[str, str] = {}
-        self.money_manager = MoneyManager()
+        self.money_controller = MoneyController(self)
         # list of ways player can interact with the Npc
         self.interactions: Sequence[str] = []
         # menu labels (world menu)
@@ -168,7 +168,7 @@ class NPC(Entity[NPCState]):
             "battles": encode_battle(self.battles),
             "tuxepedia": encode_tuxepedia(self.tuxepedia),
             "contacts": self.contacts,
-            "money": encode_money(self.money_manager),
+            "money": dict(),
             "items": encode_items(self.items),
             "template": self.template.model_dump(),
             "missions": self.mission_manager.encode_missions(),
@@ -182,6 +182,7 @@ class NPC(Entity[NPCState]):
 
         self.monster_boxes.save(state)
         self.item_boxes.save(state)
+        state["money"] = self.money_controller.save()
 
         return state
 
@@ -198,7 +199,6 @@ class NPC(Entity[NPCState]):
         self.game_variables = save_data["game_variables"]
         self.tuxepedia = decode_tuxepedia(save_data["tuxepedia"])
         self.contacts = save_data["contacts"]
-        self.money_manager = decode_money(save_data["money"])
         self.battles = []
         for battle in decode_battle(save_data.get("battles")):
             self.battles.append(battle)
@@ -211,6 +211,7 @@ class NPC(Entity[NPCState]):
         self.mission_manager.load_missions(save_data.get("missions"))
         self.name = save_data["player_name"]
         self.steps = save_data["player_steps"]
+        self.money_controller.load(save_data)
         self.monster_boxes.load(save_data)
         self.item_boxes.load(save_data)
 

--- a/tuxemon/states/character/__init__.py
+++ b/tuxemon/states/character/__init__.py
@@ -135,7 +135,7 @@ class CharacterState(PygameMenuState):
         )
         lab1.translate(fix_measure(width, 0.45), fix_measure(height, 0.15))
         # money
-        money = self.char.money_manager.get_money()
+        money = self.char.money_controller.money_manager.get_money()
         lab2: Any = menu.add.label(
             title=f"{T.translate('wallet')}: {money}",
             label_id="money",

--- a/tuxemon/states/items/shop_menu.py
+++ b/tuxemon/states/items/shop_menu.py
@@ -64,6 +64,8 @@ class ShopMenuState(Menu[Item]):
         self.seller = seller
         self.buyer_purge = buyer_purge
         self.economy = economy
+        self.buyer_manager = self.buyer.money_controller.money_manager
+        self.seller_manager = self.seller.money_controller.money_manager
 
     def calc_internal_rect(self) -> pygame.rect.Rect:
         # area in the screen where the item list is
@@ -125,7 +127,7 @@ class ShopMenuState(Menu[Item]):
                 self.qty = self.buyer.game_variables[key]
 
                 fg = None
-                self.wallet = self.buyer.money_manager.get_money()
+                self.wallet = self.buyer_manager.get_money()
                 self.price = self.economy.lookup_item_price(itm.slug)
                 if self.price > self.wallet:
                     fg = self.unavailable_color_shop
@@ -209,7 +211,7 @@ class ShopMenuState(Menu[Item]):
                 key = f"{self.economy.model.slug}:{itm.slug}"
                 self.qty = self.buyer.game_variables[key]
                 fg = None
-                self.wallet = self.buyer.money_manager.get_money()
+                self.wallet = self.buyer_manager.get_money()
                 self.price = self.economy.lookup_item_price(itm.slug)
                 if self.price > self.wallet:
                     fg = self.unavailable_color_shop
@@ -298,14 +300,14 @@ class ShopBuyMenuState(ShopMenuState):
                 new_buy.quantity = quantity
                 self.buyer.add_item(new_buy)
             amount = quantity * price
-            self.buyer.money_manager.remove_money(amount)
+            self.buyer_manager.remove_money(amount)
 
             self.reload_items()
             if item not in self.seller.items:
                 # We're pointing at a new item
                 self.on_menu_selection_change()
 
-        money = self.buyer.money_manager.get_money()
+        money = self.buyer_manager.get_money()
         qty_can_afford = int(money / price)
         inventory = self.buyer.game_variables[label]
         _inventory = 99999 if inventory == INFINITE_ITEMS else inventory
@@ -349,7 +351,7 @@ class ShopSellMenuState(ShopMenuState):
                 itm.quantity = diff
 
             amount = quantity * cost
-            self.seller.money_manager.add_money(amount)
+            self.seller_manager.add_money(amount)
 
             self.reload_items()
             if item not in self.seller.items:

--- a/tuxemon/states/phone/phone_banking.py
+++ b/tuxemon/states/phone/phone_banking.py
@@ -29,8 +29,9 @@ class NuPhoneBanking(PygameMenuState):
         self,
         menu: pygame_menu.Menu,
     ) -> None:
-        bank_account = self.player.money_manager.get_bank_balance()
-        wallet_player = self.player.money_manager.get_money()
+        money_manager = self.player.money_controller.money_manager
+        bank_account = money_manager.get_bank_balance()
+        wallet_player = money_manager.get_money()
 
         _wallet = f"{T.translate('wallet')}: {wallet_player}"
         menu.add.label(
@@ -45,7 +46,7 @@ class NuPhoneBanking(PygameMenuState):
             font_size=self.font_size_small,
         )
 
-        for key, entry in self.player.money_manager.bills.items():
+        for key, entry in money_manager.bills.items():
             if entry.amount > 0:
                 _cathedral = f"{T.translate(key)}: {entry.amount}"
                 menu.add.label(
@@ -99,7 +100,7 @@ class NuPhoneBanking(PygameMenuState):
 
         def bill(op: str) -> None:
             var_menu = []
-            for key, entry in self.player.money_manager.bills.items():
+            for key, entry in money_manager.bills.items():
                 _key = T.translate(key)
                 if entry.amount > 0:
                     _param = (_key, _key, partial(bill_manager, op, key))
@@ -114,24 +115,24 @@ class NuPhoneBanking(PygameMenuState):
         def deposit(amount: int) -> None:
             self.client.pop_state()
             self.client.pop_state()
-            self.player.money_manager.deposit_to_bank(amount)
-            self.player.money_manager.remove_money(amount)
+            money_manager.deposit_to_bank(amount)
+            money_manager.remove_money(amount)
 
         def withdraw(amount: int) -> None:
             self.client.pop_state()
             self.client.pop_state()
-            self.player.money_manager.withdraw_from_bank(amount)
-            self.player.money_manager.add_money(amount)
+            money_manager.withdraw_from_bank(amount)
+            money_manager.add_money(amount)
 
         def pay(amount: int, bill_name: str) -> None:
             self.client.pop_state()
             self.client.pop_state()
-            self.player.money_manager.pay_bill_with_money(bill_name, amount)
+            money_manager.pay_bill_with_money(bill_name, amount)
 
         def e_pay(amount: int, bill_name: str) -> None:
             self.client.pop_state()
             self.client.pop_state()
-            self.player.money_manager.pay_bill_with_deposit(bill_name, amount)
+            money_manager.pay_bill_with_deposit(bill_name, amount)
 
         if wallet_player > 0:
             menu.add.vertical_margin(25)
@@ -154,7 +155,7 @@ class NuPhoneBanking(PygameMenuState):
 
         _payment = False
         _e_payment = False
-        for key, entry in self.player.money_manager.bills.items():
+        for key, entry in money_manager.bills.items():
             if entry.amount > 0 and wallet_player > 0:
                 _payment = True
             if entry.amount > 0 and bank_account > 0:

--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -247,8 +247,6 @@ class WorldState(state.State):
         self.camera_manager.update()
 
         logger.debug("*** Game Loop Started ***")
-        logger.debug("Player Variables:" + str(self.player.game_variables))
-        logger.debug("Money:" + str(self.player.money_manager.get_money()))
 
     def draw(self, surface: pygame.surface.Surface) -> None:
         """


### PR DESCRIPTION
PR creates the MoneyController class. It encapsulates the MoneyManager and its related logic and it provides methods for getting and setting the money state, separating money management from the NPC class's core logic. This makes the NPC class less cluttered and allows for easier modification of money-related behavior. It fixes a bug in `modify_money` (still hardcoded on the self.player instead of the character) as well as `transfer_money` (it was wrongly transfer the money to bank instead  to PC)