### PR TITLE
Expanding Shop Features: Reselling

### DIFF
--- a/mods/tuxemon/db/economy/cotton_scoop.json
+++ b/mods/tuxemon/db/economy/cotton_scoop.json
@@ -1,5 +1,7 @@
 {
   "slug": "cotton_scoop",
+  "resale_multiplier": 0.5,
+  "background": "gfx/ui/item/item_menu_bg.png",
   "monsters": [],
   "items": [
     {

--- a/mods/tuxemon/db/economy/leather_scoop.json
+++ b/mods/tuxemon/db/economy/leather_scoop.json
@@ -1,5 +1,7 @@
 {
   "slug": "leather_scoop",
+  "resale_multiplier": 0.5,
+  "background": "gfx/ui/item/item_menu_bg.png",
   "monsters": [],
   "items": [
     {

--- a/mods/tuxemon/db/economy/spyder_scoops.json
+++ b/mods/tuxemon/db/economy/spyder_scoops.json
@@ -1,6 +1,8 @@
 [
   {
     "slug": "spyder_paper_mart",
+    "resale_multiplier": 0.5,
+    "background": "gfx/ui/item/item_menu_bg.png",
     "monsters": [],
     "items": [
       {
@@ -22,6 +24,8 @@
   },
   {
     "slug": "spyder_cotton_scoop",
+    "resale_multiplier": 0.5,
+    "background": "gfx/ui/item/item_menu_bg.png",
     "monsters": [],
     "items": [
       {
@@ -43,6 +47,8 @@
   },
   {
     "slug": "spyder_cotton_tech",
+    "resale_multiplier": 0.5,
+    "background": "gfx/ui/item/item_menu_bg.png",
     "monsters": [],
     "items": [
       {
@@ -76,6 +82,8 @@
   },
   {
     "slug": "spyder_leather_scoop",
+    "resale_multiplier": 0.5,
+    "background": "gfx/ui/item/item_menu_bg.png",
     "monsters": [],
     "items": [
       {
@@ -107,6 +115,8 @@
   },
   {
     "slug": "spyder_flower_scoop",
+    "resale_multiplier": 0.5,
+    "background": "gfx/ui/item/item_menu_bg.png",
     "monsters": [],
     "items": [
       {
@@ -143,6 +153,8 @@
   },
   {
     "slug": "spyder_timber_scoop",
+    "resale_multiplier": 0.5,
+    "background": "gfx/ui/item/item_menu_bg.png",
     "monsters": [],
     "items": [
       {
@@ -199,6 +211,8 @@
   },
   {
     "slug": "spyder_candy_scoop",
+    "resale_multiplier": 0.5,
+    "background": "gfx/ui/item/item_menu_bg.png",
     "monsters": [],
     "items": [
       {
@@ -250,6 +264,8 @@
   },
   {
     "slug": "spyder_candy_tech",
+    "resale_multiplier": 0.5,
+    "background": "gfx/ui/item/item_menu_bg.png",
     "monsters": [],
     "items": [
       {

--- a/mods/tuxemon/db/economy/tuxe_mart_taba.json
+++ b/mods/tuxemon/db/economy/tuxe_mart_taba.json
@@ -1,5 +1,7 @@
 {
   "slug": "tuxe_mart_taba",
+  "resale_multiplier": 0.5,
+  "background": "gfx/ui/item/item_menu_bg.png",
   "monsters": [],
   "items": [
     {

--- a/mods/tuxemon/db/item/ancient_tea.json
+++ b/mods/tuxemon/db/item/ancient_tea.json
@@ -15,7 +15,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/boost_armour.json
+++ b/mods/tuxemon/db/item/boost_armour.json
@@ -15,7 +15,9 @@
     "MainCombatMenuState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/boost_dodge.json
+++ b/mods/tuxemon/db/item/boost_dodge.json
@@ -15,7 +15,9 @@
     "MainCombatMenuState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/boost_melee.json
+++ b/mods/tuxemon/db/item/boost_melee.json
@@ -15,7 +15,9 @@
     "MainCombatMenuState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/boost_ranged.json
+++ b/mods/tuxemon/db/item/boost_ranged.json
@@ -15,7 +15,9 @@
     "MainCombatMenuState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/boost_speed.json
+++ b/mods/tuxemon/db/item/boost_speed.json
@@ -15,7 +15,9 @@
     "MainCombatMenuState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/cureall.json
+++ b/mods/tuxemon/db/item/cureall.json
@@ -30,7 +30,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/fire_berry.json
+++ b/mods/tuxemon/db/item/fire_berry.json
@@ -21,7 +21,9 @@
     "MainCombatMenuState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/flintstone.json
+++ b/mods/tuxemon/db/item/flintstone.json
@@ -25,7 +25,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "show_dialog_on_success": false
+    "show_dialog_on_success": false,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/imperial_potion.json
+++ b/mods/tuxemon/db/item/imperial_potion.json
@@ -27,7 +27,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/imperial_tea.json
+++ b/mods/tuxemon/db/item/imperial_tea.json
@@ -15,7 +15,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/lima_pie.json
+++ b/mods/tuxemon/db/item/lima_pie.json
@@ -25,7 +25,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "show_dialog_on_success": false
+    "show_dialog_on_success": false,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/lucky_bamboo.json
+++ b/mods/tuxemon/db/item/lucky_bamboo.json
@@ -25,7 +25,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "show_dialog_on_success": false
+    "show_dialog_on_success": false,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/mega_potion.json
+++ b/mods/tuxemon/db/item/mega_potion.json
@@ -27,7 +27,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/metal_cherry.json
+++ b/mods/tuxemon/db/item/metal_cherry.json
@@ -21,7 +21,9 @@
     "MainCombatMenuState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/miaow_milk.json
+++ b/mods/tuxemon/db/item/miaow_milk.json
@@ -25,7 +25,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "show_dialog_on_success": false
+    "show_dialog_on_success": false,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/mm_earth.json
+++ b/mods/tuxemon/db/item/mm_earth.json
@@ -21,7 +21,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/mm_fire.json
+++ b/mods/tuxemon/db/item/mm_fire.json
@@ -21,7 +21,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/mm_metal.json
+++ b/mods/tuxemon/db/item/mm_metal.json
@@ -21,7 +21,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/mm_water.json
+++ b/mods/tuxemon/db/item/mm_water.json
@@ -21,7 +21,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/mm_wood.json
+++ b/mods/tuxemon/db/item/mm_wood.json
@@ -21,7 +21,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/mystery_tea.json
+++ b/mods/tuxemon/db/item/mystery_tea.json
@@ -15,7 +15,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/ox_stick.json
+++ b/mods/tuxemon/db/item/ox_stick.json
@@ -25,7 +25,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "show_dialog_on_success": false
+    "show_dialog_on_success": false,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/peace_lily.json
+++ b/mods/tuxemon/db/item/peace_lily.json
@@ -25,7 +25,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "show_dialog_on_success": false
+    "show_dialog_on_success": false,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/potion.json
+++ b/mods/tuxemon/db/item/potion.json
@@ -27,7 +27,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/pyramidion.json
+++ b/mods/tuxemon/db/item/pyramidion.json
@@ -25,7 +25,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "show_dialog_on_success": false
+    "show_dialog_on_success": false,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/raise_armour.json
+++ b/mods/tuxemon/db/item/raise_armour.json
@@ -15,7 +15,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/raise_dodge.json
+++ b/mods/tuxemon/db/item/raise_dodge.json
@@ -15,7 +15,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/raise_hp.json
+++ b/mods/tuxemon/db/item/raise_hp.json
@@ -15,7 +15,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/raise_melee.json
+++ b/mods/tuxemon/db/item/raise_melee.json
@@ -15,7 +15,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/raise_ranged.json
+++ b/mods/tuxemon/db/item/raise_ranged.json
@@ -15,7 +15,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/raise_speed.json
+++ b/mods/tuxemon/db/item/raise_speed.json
@@ -15,7 +15,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/restoration.json
+++ b/mods/tuxemon/db/item/restoration.json
@@ -30,7 +30,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/revive.json
+++ b/mods/tuxemon/db/item/revive.json
@@ -30,7 +30,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/sea_girdle.json
+++ b/mods/tuxemon/db/item/sea_girdle.json
@@ -25,7 +25,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "show_dialog_on_success": false
+    "show_dialog_on_success": false,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/stovepipe.json
+++ b/mods/tuxemon/db/item/stovepipe.json
@@ -25,7 +25,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "show_dialog_on_success": false
+    "show_dialog_on_success": false,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/sweet_sand.json
+++ b/mods/tuxemon/db/item/sweet_sand.json
@@ -25,7 +25,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "show_dialog_on_success": false
+    "show_dialog_on_success": false,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/tea.json
+++ b/mods/tuxemon/db/item/tea.json
@@ -15,7 +15,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tectonic_drill.json
+++ b/mods/tuxemon/db/item/tectonic_drill.json
@@ -25,7 +25,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "show_dialog_on_success": false
+    "show_dialog_on_success": false,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/thunderstone.json
+++ b/mods/tuxemon/db/item/thunderstone.json
@@ -25,7 +25,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "show_dialog_on_success": false
+    "show_dialog_on_success": false,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/tm_all_in.json
+++ b/mods/tuxemon/db/item/tm_all_in.json
@@ -21,7 +21,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tm_avalanche.json
+++ b/mods/tuxemon/db/item/tm_avalanche.json
@@ -26,7 +26,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tm_blade.json
+++ b/mods/tuxemon/db/item/tm_blade.json
@@ -21,7 +21,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tm_blossom.json
+++ b/mods/tuxemon/db/item/tm_blossom.json
@@ -26,7 +26,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tm_cavity.json
+++ b/mods/tuxemon/db/item/tm_cavity.json
@@ -21,7 +21,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tm_earth.json
+++ b/mods/tuxemon/db/item/tm_earth.json
@@ -16,7 +16,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tm_fire.json
+++ b/mods/tuxemon/db/item/tm_fire.json
@@ -16,7 +16,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tm_frostbite.json
+++ b/mods/tuxemon/db/item/tm_frostbite.json
@@ -21,7 +21,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tm_metal.json
+++ b/mods/tuxemon/db/item/tm_metal.json
@@ -16,7 +16,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tm_panjandrum.json
+++ b/mods/tuxemon/db/item/tm_panjandrum.json
@@ -21,7 +21,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tm_scope.json
+++ b/mods/tuxemon/db/item/tm_scope.json
@@ -21,7 +21,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tm_shadow_boxing.json
+++ b/mods/tuxemon/db/item/tm_shadow_boxing.json
@@ -21,7 +21,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tm_supernova.json
+++ b/mods/tuxemon/db/item/tm_supernova.json
@@ -21,7 +21,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tm_surf.json
+++ b/mods/tuxemon/db/item/tm_surf.json
@@ -31,7 +31,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tm_vorpal.json
+++ b/mods/tuxemon/db/item/tm_vorpal.json
@@ -21,7 +21,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tm_water.json
+++ b/mods/tuxemon/db/item/tm_water.json
@@ -16,7 +16,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tm_wood.json
+++ b/mods/tuxemon/db/item/tm_wood.json
@@ -16,7 +16,9 @@
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/tuxeball.json
+++ b/mods/tuxemon/db/item/tuxeball.json
@@ -26,7 +26,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "throwable": true
+    "throwable": true,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/tuxeball_candy.json
+++ b/mods/tuxemon/db/item/tuxeball_candy.json
@@ -26,7 +26,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "throwable": true
+    "throwable": true,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/tuxeball_crusher.json
+++ b/mods/tuxemon/db/item/tuxeball_crusher.json
@@ -26,7 +26,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "throwable": true
+    "throwable": true,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/tuxeball_diurnal.json
+++ b/mods/tuxemon/db/item/tuxeball_diurnal.json
@@ -27,7 +27,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "throwable": true
+    "throwable": true,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/tuxeball_earth.json
+++ b/mods/tuxemon/db/item/tuxeball_earth.json
@@ -27,7 +27,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "throwable": true
+    "throwable": true,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/tuxeball_female.json
+++ b/mods/tuxemon/db/item/tuxeball_female.json
@@ -27,7 +27,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "throwable": true
+    "throwable": true,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/tuxeball_fire.json
+++ b/mods/tuxemon/db/item/tuxeball_fire.json
@@ -27,7 +27,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "throwable": true
+    "throwable": true,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/tuxeball_gambler.json
+++ b/mods/tuxemon/db/item/tuxeball_gambler.json
@@ -27,7 +27,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "throwable": true
+    "throwable": true,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/tuxeball_grand.json
+++ b/mods/tuxemon/db/item/tuxeball_grand.json
@@ -26,7 +26,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "throwable": true
+    "throwable": true,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/tuxeball_hardened.json
+++ b/mods/tuxemon/db/item/tuxeball_hardened.json
@@ -26,7 +26,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "throwable": true
+    "throwable": true,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/tuxeball_hearty.json
+++ b/mods/tuxemon/db/item/tuxeball_hearty.json
@@ -27,7 +27,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "throwable": true
+    "throwable": true,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/tuxeball_lavish.json
+++ b/mods/tuxemon/db/item/tuxeball_lavish.json
@@ -26,7 +26,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "throwable": true
+    "throwable": true,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/tuxeball_majestic.json
+++ b/mods/tuxemon/db/item/tuxeball_majestic.json
@@ -26,7 +26,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "throwable": true
+    "throwable": true,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/tuxeball_male.json
+++ b/mods/tuxemon/db/item/tuxeball_male.json
@@ -27,7 +27,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "throwable": true
+    "throwable": true,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/tuxeball_metal.json
+++ b/mods/tuxemon/db/item/tuxeball_metal.json
@@ -27,7 +27,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "throwable": true
+    "throwable": true,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/tuxeball_neuter.json
+++ b/mods/tuxemon/db/item/tuxeball_neuter.json
@@ -27,7 +27,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "throwable": true
+    "throwable": true,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/tuxeball_noble.json
+++ b/mods/tuxemon/db/item/tuxeball_noble.json
@@ -26,7 +26,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "throwable": true
+    "throwable": true,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/tuxeball_nocturnal.json
+++ b/mods/tuxemon/db/item/tuxeball_nocturnal.json
@@ -27,7 +27,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "throwable": true
+    "throwable": true,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/tuxeball_omni.json
+++ b/mods/tuxemon/db/item/tuxeball_omni.json
@@ -27,7 +27,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "throwable": true
+    "throwable": true,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/tuxeball_peppy.json
+++ b/mods/tuxemon/db/item/tuxeball_peppy.json
@@ -27,7 +27,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "throwable": true
+    "throwable": true,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/tuxeball_refined.json
+++ b/mods/tuxemon/db/item/tuxeball_refined.json
@@ -27,7 +27,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "throwable": true
+    "throwable": true,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/tuxeball_salty.json
+++ b/mods/tuxemon/db/item/tuxeball_salty.json
@@ -27,7 +27,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "throwable": true
+    "throwable": true,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/tuxeball_water.json
+++ b/mods/tuxemon/db/item/tuxeball_water.json
@@ -27,7 +27,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "throwable": true
+    "throwable": true,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/tuxeball_wood.json
+++ b/mods/tuxemon/db/item/tuxeball_wood.json
@@ -27,7 +27,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "throwable": true
+    "throwable": true,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/tuxeball_xero.json
+++ b/mods/tuxemon/db/item/tuxeball_xero.json
@@ -27,7 +27,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "throwable": true
+    "throwable": true,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/mods/tuxemon/db/item/tuxeball_zesty.json
+++ b/mods/tuxemon/db/item/tuxeball_zesty.json
@@ -27,7 +27,8 @@
   ],
   "modifiers": [],
   "behaviors": {
-    "throwable": true
+    "throwable": true,
+    "resellable": true
   },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",

--- a/tests/tuxemon/test_economy.py
+++ b/tests/tuxemon/test_economy.py
@@ -15,6 +15,8 @@ class GetDefaultPriceAndCost(EconomyTestBase):
         self.economy = Economy()
         self.economy.model = EconomyModel(
             slug="test_economy",
+            background="gfx/ui/item/item_menu_bg.png",
+            resale_multiplier=0.5,
             items=[
                 EconomyItemModel(
                     name="potion",

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -55,7 +55,7 @@ class Item:
         self.use_success = ""
         self.use_failure = ""
         self.usable_in: Sequence[State] = []
-        self.cost: Optional[int] = None
+        self.cost: int = 0
 
         self.effect_manager = EffectManager(ItemEffect, paths.ITEM_EFFECT_PATH)
         self.condition_manager = ConditionManager(

--- a/tuxemon/menu/menu.py
+++ b/tuxemon/menu/menu.py
@@ -641,6 +641,10 @@ class Menu(Generic[T], state.State):
         image = graphics.load_and_scale(self.cursor_filename)
         self.arrow = MenuCursor(image)
 
+    def update_background(self, new_filename: str) -> None:
+        self.background_filename = new_filename
+        self.load_graphics()
+
     def show_cursor(self) -> None:
         """Show the cursor that indicates the selected object."""
         if self.arrow not in self.menu_sprites:

--- a/tuxemon/prepare.py
+++ b/tuxemon/prepare.py
@@ -182,7 +182,6 @@ BG_PARTY: str = "gfx/ui/background/player_info2.png"
 BG_ITEMS: str = ITEM_MENU
 BG_ITEMS_BACKPACK: str = "gfx/ui/item/backpack.png"
 BG_MOVES: str = ITEM_MENU
-BG_SHOP: str = ITEM_MENU
 BG_MONSTERS: str = "gfx/ui/monster/monster_menu_bg.png"
 
 # Native resolution is similar to the old gameboy resolution. This is


### PR DESCRIPTION
Previously, you could only resell items that the shop was already selling. For instance, if the shop sold potions, you could only resell potions. Now, with this change, you can resell items like Tuxeballs or potions, even if the shop doesn’t sell them.

Here's how it works:
- A new parameter, `resale_multiplier`, has been added to the economy system. This is a float value that defines the percentage of the original price at which an item can be resold. By default, this is set to 0.5 (50%) across all JSON files in the economy folder. For example, if a Tuxeball costs 100, you can resell it for 50.
- You can now change the shop's background by specifying a new path in the JSON files.
- A new flag, `resellable`, has been introduced for items. This is set to `false` by default, allowing modders to decide whether certain items can be resold or not. For example, some items can only be bought but not resold.

This is just the beginning, other improvements will follow.