### PR TITLE
fix various

### DIFF
--- a/mods/tuxemon/db/encounter/spyder_route7.json
+++ b/mods/tuxemon/db/encounter/spyder_route7.json
@@ -9,10 +9,10 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "exp_req_mod": 3,
       "level_range": [
-        35,
-        40
+        15,
+        20
       ]
     },
     {
@@ -23,10 +23,10 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "exp_req_mod": 3,
       "level_range": [
-        35,
-        40
+        15,
+        20
       ]
     },
     {
@@ -37,10 +37,10 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "exp_req_mod": 3,
       "level_range": [
-        35,
-        40
+        15,
+        20
       ]
     },
     {
@@ -51,10 +51,10 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "exp_req_mod": 3,
       "level_range": [
-        35,
-        40
+        15,
+        20
       ]
     },
     {
@@ -65,10 +65,10 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "exp_req_mod": 3,
       "level_range": [
-        35,
-        40
+        15,
+        20
       ]
     },
     {
@@ -79,10 +79,10 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "exp_req_mod": 3,
       "level_range": [
-        35,
-        40
+        15,
+        20
       ]
     }
   ]

--- a/mods/tuxemon/db/npc/spyder_boulder.json
+++ b/mods/tuxemon/db/npc/spyder_boulder.json
@@ -1,10 +1,8 @@
 {
   "slug": "spyder_boulder",
-  "template": 
-    {
-      "sprite_name": "boulder",
-      "combat_front": "noclass",
-      "slug": "interactive_obj"
-    }
-
+  "template": {
+    "sprite_name": "boulder",
+    "combat_front": "noclass",
+    "slug": "interactive_obj"
+  }
 }

--- a/mods/tuxemon/db/npc/spyder_candy_town_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_candy_town_npcs.json
@@ -1,172 +1,138 @@
 [
   {
     "slug": "spyder_candy_henrik",
-    "template": 
-      {
-        "sprite_name": "knight_red",
-        "combat_front": "enforcer_rookie",
-        "slug": "enforcer_rookie"
-      }
-  
+    "template": {
+      "sprite_name": "knight_red",
+      "combat_front": "enforcer_rookie",
+      "slug": "enforcer_rookie"
+    }
   },
   {
     "slug": "spyder_candy_eliane",
-    "template": 
-      {
-        "sprite_name": "florist_fiery",
-        "combat_front": "florist",
-        "slug": "florist"
-      }
-  
+    "template": {
+      "sprite_name": "florist_fiery",
+      "combat_front": "florist",
+      "slug": "florist"
+    }
   },
   {
     "slug": "spyder_candycafe_nora",
-    "template": 
-      {
-        "sprite_name": "barmaid_red",
-        "combat_front": "barmaid",
-        "slug": "barmaid"
-      }
-  
+    "template": {
+      "sprite_name": "barmaid_red",
+      "combat_front": "barmaid",
+      "slug": "barmaid"
+    }
   },
   {
     "slug": "spyder_candyhouse2_indiana",
-    "template": 
-      {
-        "sprite_name": "professor_green",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor_green",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "spyder_candyhouse2_barney",
-    "template": 
-      {
-        "sprite_name": "riverboatcaptain",
-        "combat_front": "enforcer_rookie",
-        "slug": "riverboatcaptain"
-      }
-  
+    "template": {
+      "sprite_name": "riverboatcaptain",
+      "combat_front": "enforcer_rookie",
+      "slug": "riverboatcaptain"
+    }
   },
   {
     "slug": "spyder_candyhouse3_joanie",
-    "template": 
-      {
-        "sprite_name": "catgirl",
-        "combat_front": "catgirl",
-        "slug": "catgirl"
-      }
-  
+    "template": {
+      "sprite_name": "catgirl",
+      "combat_front": "catgirl",
+      "slug": "catgirl"
+    }
   },
   {
     "slug": "spyder_candyhouse1_tillie",
-    "template": 
-      {
-        "sprite_name": "picnicker",
-        "combat_front": "picnicker",
-        "slug": "picnicker"
-      }
-  
+    "template": {
+      "sprite_name": "picnicker",
+      "combat_front": "picnicker",
+      "slug": "picnicker"
+    }
   },
   {
     "slug": "spyder_candyhouse1_sawyer",
-    "template": 
-      {
-        "sprite_name": "maniac_yellow",
-        "combat_front": "adventurer",
-        "slug": "maniac"
-      }
-  
+    "template": {
+      "sprite_name": "maniac_yellow",
+      "combat_front": "adventurer",
+      "slug": "maniac"
+    }
   },
   {
-    "slug": "spyder_candyscoop_clint",
-    "template": 
-      {
-        "sprite_name": "shopkeeper",
-        "combat_front": "adventurer",
-        "slug": "shopkeeper"
-      }
-  
+    "slug": "spyder_shopassistant",
+    "template": {
+      "sprite_name": "shopkeeper",
+      "combat_front": "adventurer",
+      "slug": "shopkeeper"
+    }
   },
   {
     "slug": "spyder_candyinn_cott",
-    "template": 
-      {
-        "sprite_name": "shopkeeper",
-        "combat_front": "adventurer",
-        "slug": "shopkeeper"
-      }
-  
+    "template": {
+      "sprite_name": "shopkeeper",
+      "combat_front": "adventurer",
+      "slug": "shopkeeper"
+    }
   },
   {
     "slug": "spyder_candyinn_lyle",
-    "template": 
-      {
-        "sprite_name": "riverboatcaptain",
-        "combat_front": "pirate",
-        "slug": "pirate"
-      }
-  
+    "template": {
+      "sprite_name": "riverboatcaptain",
+      "combat_front": "pirate",
+      "slug": "pirate"
+    }
   },
   {
     "slug": "spyder_candyinn_bob",
-    "template": 
-      {
-        "sprite_name": "maniac_rose",
-        "combat_front": "adventurer",
-        "slug": "maniac"
-      }
-  
+    "template": {
+      "sprite_name": "maniac_rose",
+      "combat_front": "adventurer",
+      "slug": "maniac"
+    }
   },
   {
     "slug": "spyder_candyinn_prof",
-    "template": 
-      {
-        "sprite_name": "professor_lapi",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor_lapi",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "spyder_candyinn_jess",
-    "template": 
-      {
-        "sprite_name": "goth",
-        "combat_front": "adventurer",
-        "slug": "goth"
-      }
-  
+    "template": {
+      "sprite_name": "goth",
+      "combat_front": "adventurer",
+      "slug": "goth"
+    }
   },
   {
     "slug": "spyder_candyinn_james",
-    "template": 
-      {
-        "sprite_name": "beachcomber_fiery",
-        "combat_front": "yellowbelt",
-        "slug": "yellowbelt"
-      }
-  
+    "template": {
+      "sprite_name": "beachcomber_fiery",
+      "combat_front": "yellowbelt",
+      "slug": "yellowbelt"
+    }
   },
   {
     "slug": "spyder_candyport_monk",
-    "template": 
-      {
-        "sprite_name": "monk_blue",
-        "combat_front": "monk",
-        "slug": "monk"
-      }
-  
+    "template": {
+      "sprite_name": "monk_blue",
+      "combat_front": "monk",
+      "slug": "monk"
+    }
   },
   {
     "slug": "spyder_candyinn_monk",
-    "template": 
-      {
-        "sprite_name": "monk_green",
-        "combat_front": "monk",
-        "slug": "monk"
-      }
-  
+    "template": {
+      "sprite_name": "monk_green",
+      "combat_front": "monk",
+      "slug": "monk"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_citypark_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_citypark_npcs.json
@@ -1,142 +1,114 @@
 [
   {
     "slug": "spyder_citypark_bobette",
-    "template": 
-      {
-        "sprite_name": "catgirl_green",
-        "combat_front": "catgirl",
-        "slug": "catgirl"
-      }
-  
+    "template": {
+      "sprite_name": "catgirl_green",
+      "combat_front": "catgirl",
+      "slug": "catgirl"
+    }
   },
   {
     "slug": "spyder_citypark_edith",
-    "template": 
-      {
-        "sprite_name": "picnicker",
-        "combat_front": "picnicker",
-        "slug": "picnicker"
-      }
-  
+    "template": {
+      "sprite_name": "picnicker",
+      "combat_front": "picnicker",
+      "slug": "picnicker"
+    }
   },
   {
     "slug": "spyder_citypark_florist",
-    "template": 
-      {
-        "sprite_name": "florist_fiery",
-        "combat_front": "florist",
-        "slug": "florist"
-      }
-  
+    "template": {
+      "sprite_name": "florist_fiery",
+      "combat_front": "florist",
+      "slug": "florist"
+    }
   },
   {
     "slug": "spyder_citypark_frances",
-    "template": 
-      {
-        "sprite_name": "florist_black",
-        "combat_front": "florist",
-        "slug": "florist"
-      }
-  
+    "template": {
+      "sprite_name": "florist_black",
+      "combat_front": "florist",
+      "slug": "florist"
+    }
   },
   {
     "slug": "spyder_citypark_magdalene",
-    "template": 
-      {
-        "sprite_name": "granny",
-        "combat_front": "adventurer",
-        "slug": "granny"
-      }
-  
+    "template": {
+      "sprite_name": "granny",
+      "combat_front": "adventurer",
+      "slug": "granny"
+    }
   },
   {
     "slug": "spyder_citypark_prue",
-    "template": 
-      {
-        "sprite_name": "florist_rose",
-        "combat_front": "florist",
-        "slug": "florist"
-      }
-  
+    "template": {
+      "sprite_name": "florist_rose",
+      "combat_front": "florist",
+      "slug": "florist"
+    }
   },
   {
     "slug": "spyder_citypark_mack",
-    "template": 
-      {
-        "sprite_name": "maniac_green",
-        "combat_front": "adventurer",
-        "slug": "maniac"
-      }
-  
+    "template": {
+      "sprite_name": "maniac_green",
+      "combat_front": "adventurer",
+      "slug": "maniac"
+    }
   },
   {
     "slug": "spyder_citypark_nurse",
-    "template": 
-      {
-        "sprite_name": "nurse_red",
-        "combat_front": "nurse",
-        "slug": "nurse"
-      }
-  
+    "template": {
+      "sprite_name": "nurse_red",
+      "combat_front": "nurse",
+      "slug": "nurse"
+    }
   },
   {
     "slug": "spyder_citypark_cd1",
-    "template": 
-      {
-        "sprite_name": "box",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "box",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_citypark_cd2",
-    "template": 
-      {
-        "sprite_name": "box",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "box",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_citypark_restoration",
-    "template": 
-      {
-        "sprite_name": "box",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "box",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_citypark_potion1",
-    "template": 
-      {
-        "sprite_name": "box",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "box",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_citypark_potion2",
-    "template": 
-      {
-        "sprite_name": "box",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "box",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_citypark_house_maniac",
-    "template": 
-      {
-        "sprite_name": "maniac_green",
-        "combat_front": "adventurer",
-        "slug": "maniac"
-      }
-  
+    "template": {
+      "sprite_name": "maniac_green",
+      "combat_front": "adventurer",
+      "slug": "maniac"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_cotton_town_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_cotton_town_npcs.json
@@ -1,301 +1,234 @@
 [
   {
     "slug": "spyder_cottontown_barmaid",
-    "template": 
-      {
-        "sprite_name": "barmaid",
-        "combat_front": "barmaid",
-        "slug": "barmaid"
-      }
-  
+    "template": {
+      "sprite_name": "barmaid",
+      "combat_front": "barmaid",
+      "slug": "barmaid"
+    }
   },
   {
     "slug": "spyder_cottontown_monk",
-    "template": 
-      {
-        "sprite_name": "monk",
-        "combat_front": "monk",
-        "slug": "monk"
-      }
-  
+    "template": {
+      "sprite_name": "monk",
+      "combat_front": "monk",
+      "slug": "monk"
+    }
   },
   {
     "slug": "spyder_cottontown_hacker",
-    "template": 
-      {
-        "sprite_name": "magician",
-        "combat_front": "magician",
-        "slug": "magician"
-      }
-  
+    "template": {
+      "sprite_name": "magician",
+      "combat_front": "magician",
+      "slug": "magician"
+    }
   },
   {
     "slug": "spyder_cottonhouse1_rodger",
-    "template": 
-      {
-        "sprite_name": "firefighter",
-        "combat_front": "firefighter",
-        "slug": "firefighter"
-      }
-  
+    "template": {
+      "sprite_name": "firefighter",
+      "combat_front": "firefighter",
+      "slug": "firefighter"
+    }
   },
   {
     "slug": "spyder_cottonhouse1_lila",
-    "template": 
-      {
-        "sprite_name": "homemaker_blonde",
-        "combat_front": "adventurer",
-        "slug": "homemaker"
-      }
-  
+    "template": {
+      "sprite_name": "homemaker_blonde",
+      "combat_front": "adventurer",
+      "slug": "homemaker"
+    }
   },
   {
     "slug": "spyder_cottoncafe_juliana",
-    "template": 
-      {
-        "sprite_name": "homemaker",
-        "combat_front": "adventurer",
-        "slug": "homemaker"
-      }
-  
+    "template": {
+      "sprite_name": "homemaker",
+      "combat_front": "adventurer",
+      "slug": "homemaker"
+    }
   },
   {
     "slug": "spyder_cottoncafe_cayden",
-    "template": 
-      {
-        "sprite_name": "goth",
-        "combat_front": "goth",
-        "slug": "goth"
-      }
-  
+    "template": {
+      "sprite_name": "goth",
+      "combat_front": "goth",
+      "slug": "goth"
+    }
   },
   {
     "slug": "spyder_cottoncafe_wilford",
-    "template": 
-      {
-        "sprite_name": "shopassistant",
-        "combat_front": "shopassistant",
-        "slug": "shopassistant"
-      }
-  
+    "template": {
+      "sprite_name": "shopassistant",
+      "combat_front": "shopassistant",
+      "slug": "shopassistant"
+    }
   },
   {
     "slug": "spyder_cottoncafe_hillary",
-    "template": 
-      {
-        "sprite_name": "florist_blue",
-        "combat_front": "florist",
-        "slug": "florist"
-      }
-  
+    "template": {
+      "sprite_name": "florist_blue",
+      "combat_front": "florist",
+      "slug": "florist"
+    }
   },
   {
     "slug": "spyder_cottoncafe_lotus",
-    "template": 
-      {
-        "sprite_name": "granny_lapi",
-        "combat_front": "adventurer",
-        "slug": "granny"
-      }
-  
+    "template": {
+      "sprite_name": "granny_lapi",
+      "combat_front": "adventurer",
+      "slug": "granny"
+    }
   },
   {
     "slug": "spyder_cottonartshop_phoenix",
-    "template": 
-      {
-        "sprite_name": "goth",
-        "combat_front": "adventurer",
-        "slug": "goth"
-      }
-  
+    "template": {
+      "sprite_name": "goth",
+      "combat_front": "adventurer",
+      "slug": "goth"
+    }
   },
   {
     "slug": "spyder_cottonartshop_philis",
-    "template": 
-      {
-        "sprite_name": "granny_green",
-        "combat_front": "adventurer",
-        "slug": "granny"
-      }
-  
+    "template": {
+      "sprite_name": "granny_green",
+      "combat_front": "adventurer",
+      "slug": "granny"
+    }
   },
   {
     "slug": "spyder_cottonhouse2_sidney",
-    "template": 
-      {
-        "sprite_name": "catgirl_fiery",
-        "combat_front": "catgirl",
-        "slug": "catgirl"
-      }
-  
+    "template": {
+      "sprite_name": "catgirl_fiery",
+      "combat_front": "catgirl",
+      "slug": "catgirl"
+    }
   },
   {
     "slug": "spyder_cottonartshop_luvinia",
-    "template": 
-      {
-        "sprite_name": "florist",
-        "combat_front": "florist",
-        "slug": "florist"
-      }
-  
+    "template": {
+      "sprite_name": "florist",
+      "combat_front": "florist",
+      "slug": "florist"
+    }
   },
   {
     "slug": "spyder_cottonhouse2_neva",
-    "template": 
-      {
-        "sprite_name": "picnicker",
-        "combat_front": "picnicker",
-        "slug": "picnicker"
-      }
-  
+    "template": {
+      "sprite_name": "picnicker",
+      "combat_front": "picnicker",
+      "slug": "picnicker"
+    }
   },
   {
     "slug": "spyder_cottonhouse2_davis",
-    "template": 
-      {
-        "sprite_name": "shopkeeper_blonde",
-        "combat_front": "adventurer",
-        "slug": "shopkeeper"
-      }
-  
+    "template": {
+      "sprite_name": "shopkeeper_blonde",
+      "combat_front": "adventurer",
+      "slug": "shopkeeper"
+    }
   },
   {
     "slug": "spyder_cottonartshop_carter",
-    "template": 
-      {
-        "sprite_name": "shopkeeper_brown",
-        "combat_front": "adventurer",
-        "slug": "shopkeeper"
-      }
-  
+    "template": {
+      "sprite_name": "shopkeeper_brown",
+      "combat_front": "adventurer",
+      "slug": "shopkeeper"
+    }
   },
   {
     "slug": "spyder_cottoncenter_ada",
-    "template": 
-      {
-        "sprite_name": "nurse_green",
-        "combat_front": "nurse",
-        "slug": "nurse"
-      }
-  
+    "template": {
+      "sprite_name": "nurse_green",
+      "combat_front": "nurse",
+      "slug": "nurse"
+    }
   },
   {
-    "slug": "spyder_cottonscoop_joe",
-    "template": 
-      {
-        "sprite_name": "shopkeeper",
-        "combat_front": "adventurer",
-        "slug": "shopkeeper"
-      }
-  
-  },
-  {
-    "slug": "spyder_shopassistant",
-    "template": 
-      {
-        "sprite_name": "shopassistant",
-        "combat_front": "shopassistant",
-        "slug": "shopassistant"
-      }
-  
+    "slug": "spyder_shopkeeper",
+    "template": {
+      "sprite_name": "shopkeeper",
+      "combat_front": "adventurer",
+      "slug": "shopkeeper"
+    }
   },
   {
     "slug": "spyder_cottontunnel_box1",
-    "template": 
-      {
-        "sprite_name": "box",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "box",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_cottontunnel_box2",
-    "template": 
-      {
-        "sprite_name": "box",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "box",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_cottontunnel_box3",
-    "template": 
-      {
-        "sprite_name": "box",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "box",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_cottontunnel_box4",
-    "template": 
-      {
-        "sprite_name": "box",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "box",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_cottontunnel_box5",
-    "template": 
-      {
-        "sprite_name": "box",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "box",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_cottontunnel_box6",
-    "template": 
-      {
-        "sprite_name": "box",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "box",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_cottontunnel_professor",
-    "template": 
-      {
-        "sprite_name": "professor_fiery",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor_fiery",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "spyder_cottontunnel_shopassistant",
-    "template": 
-      {
-        "sprite_name": "shopassistant_black",
-        "combat_front": "shopassistant",
-        "slug": "shopassistant"
-      }
-  
+    "template": {
+      "sprite_name": "shopassistant_black",
+      "combat_front": "shopassistant",
+      "slug": "shopassistant"
+    }
   },
   {
     "slug": "spyder_cottontunnel_carlos",
-    "template": 
-      {
-        "sprite_name": "dragonrider_black",
-        "combat_front": "dragonrider",
-        "slug": "dragonrider"
-      }
-  
+    "template": {
+      "sprite_name": "dragonrider_black",
+      "combat_front": "dragonrider",
+      "slug": "dragonrider"
+    }
   },
   {
     "slug": "spyder_confusedperson",
-    "template": 
-      {
-        "sprite_name": "childactor_fiery",
-        "combat_front": "tennisplayer_fiery",
-        "slug": "childactor"
-      }
+    "template": {
+      "sprite_name": "childactor_fiery",
+      "combat_front": "tennisplayer_fiery",
+      "slug": "childactor"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_crystal_town_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_crystal_town_npcs.json
@@ -1,82 +1,66 @@
 [
   {
     "slug": "spyder_crystal_magician_fiery",
-    "template": 
-      {
-        "sprite_name": "magician_fiery",
-        "combat_front": "magician",
-        "slug": "magician"
-      }
-  
+    "template": {
+      "sprite_name": "magician_fiery",
+      "combat_front": "magician",
+      "slug": "magician"
+    }
   },
   {
     "slug": "spyder_crystal_homemaker",
-    "template": 
-      {
-        "sprite_name": "homemaker_fiery",
-        "combat_front": "heroine",
-        "slug": "homemaker"
-      }
-  
+    "template": {
+      "sprite_name": "homemaker_fiery",
+      "combat_front": "heroine",
+      "slug": "homemaker"
+    }
   },
   {
     "slug": "spyder_crystal_barmaid",
-    "template": 
-      {
-        "sprite_name": "barmaid_red",
-        "combat_front": "barmaid",
-        "slug": "barmaid"
-      }
-  
+    "template": {
+      "sprite_name": "barmaid_red",
+      "combat_front": "barmaid",
+      "slug": "barmaid"
+    }
   },
   {
     "slug": "spyder_crystal_granny",
-    "template": 
-      {
-        "sprite_name": "granny",
-        "combat_front": "adventurer",
-        "slug": "granny"
-      }
-  
+    "template": {
+      "sprite_name": "granny",
+      "combat_front": "adventurer",
+      "slug": "granny"
+    }
   },
   {
     "slug": "spyder_crystal_maniac_green",
-    "template": 
-      {
-        "sprite_name": "maniac_green",
-        "combat_front": "adventurer",
-        "slug": "maniac"
-      }
-  
+    "template": {
+      "sprite_name": "maniac_green",
+      "combat_front": "adventurer",
+      "slug": "maniac"
+    }
   },
   {
     "slug": "spyder_crystal_monk_orange",
-    "template": 
-      {
-        "sprite_name": "monk_orange",
-        "combat_front": "monk",
-        "slug": "monk"
-      }
-  
+    "template": {
+      "sprite_name": "monk_orange",
+      "combat_front": "monk",
+      "slug": "monk"
+    }
   },
   {
     "slug": "spyder_crystal_tennisplayer",
-    "template": 
-      {
-        "sprite_name": "tennisplayer",
-        "combat_front": "tennisplayer",
-        "slug": "tennisplayer"
-      }
-  
+    "template": {
+      "sprite_name": "tennisplayer",
+      "combat_front": "tennisplayer",
+      "slug": "tennisplayer"
+    }
   },
   {
     "slug": "spyder_crystal_shopkeeper",
-    "template": 
-      {
-        "sprite_name": "shopassistant_black",
-        "combat_front": "shopassistant",
-        "slug": "shopassistant"
-      }
-  
+    "template": {
+      "sprite_name": "shopassistant_black",
+      "combat_front": "shopassistant",
+      "slug": "shopassistant"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_datacenter_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_datacenter_npcs.json
@@ -1,132 +1,106 @@
 [
   {
     "slug": "spyder_datacenter_fermi",
-    "template": 
-      {
-        "sprite_name": "scientist_black",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
+    "template": {
+      "sprite_name": "scientist_black",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
   },
   {
     "slug": "spyder_datacenter_onnes",
-    "template": 
-      {
-        "sprite_name": "scientist_fiery",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
+    "template": {
+      "sprite_name": "scientist_fiery",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
   },
   {
     "slug": "spyder_datacenter_bayliss",
-    "template": 
-      {
-        "sprite_name": "scientist_brown",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
+    "template": {
+      "sprite_name": "scientist_brown",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
   },
   {
     "slug": "spyder_datacenter_chomsky",
-    "template": 
-      {
-        "sprite_name": "scientist_fiery",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
+    "template": {
+      "sprite_name": "scientist_fiery",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
   },
   {
     "slug": "spyder_datacenter_lagrange",
-    "template": 
-      {
-        "sprite_name": "scientist",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
+    "template": {
+      "sprite_name": "scientist",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
   },
   {
     "slug": "spyder_box_goldpass",
-    "template": 
-      {
-        "sprite_name": "box",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "box",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_datacenter_s1",
-    "template": 
-      {
-        "sprite_name": "screen_small",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "screen_small",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_datacenter_s2",
-    "template": 
-      {
-        "sprite_name": "screen_small",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "screen_small",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_datacenter_s3",
-    "template": 
-      {
-        "sprite_name": "screen_small",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "screen_small",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_datacenter_s4",
-    "template": 
-      {
-        "sprite_name": "screen_small",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "screen_small",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_datacenter_s5",
-    "template": 
-      {
-        "sprite_name": "screen_small",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "screen_small",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_datacenter_s6",
-    "template": 
-      {
-        "sprite_name": "screen_small",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "screen_small",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_datacenter_s7",
-    "template": 
-      {
-        "sprite_name": "screen_small",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "screen_small",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_dryadsgrove_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_dryadsgrove_npcs.json
@@ -1,82 +1,66 @@
 [
   {
     "slug": "spyder_dryadsgrove_aquemini",
-    "template": 
-      {
-        "sprite_name": "woodnymph",
-        "combat_front": "waternymph",
-        "slug": "waternymph"
-      }
-  
+    "template": {
+      "sprite_name": "woodnymph",
+      "combat_front": "waternymph",
+      "slug": "waternymph"
+    }
   },
   {
     "slug": "spyder_dryadsgrove_ferris",
-    "template": 
-      {
-        "sprite_name": "woodnymph",
-        "combat_front": "metalnymph",
-        "slug": "metalnymph"
-      }
-  
+    "template": {
+      "sprite_name": "woodnymph",
+      "combat_front": "metalnymph",
+      "slug": "metalnymph"
+    }
   },
   {
     "slug": "spyder_dryadsgrove_ignatia",
-    "template": 
-      {
-        "sprite_name": "firenymph",
-        "combat_front": "firenymph",
-        "slug": "firenymph"
-      }
-  
+    "template": {
+      "sprite_name": "firenymph",
+      "combat_front": "firenymph",
+      "slug": "firenymph"
+    }
   },
   {
     "slug": "spyder_dryadsgrove_petra",
-    "template": 
-      {
-        "sprite_name": "woodnymph",
-        "combat_front": "earthnymph",
-        "slug": "earthnymph"
-      }
-  
+    "template": {
+      "sprite_name": "woodnymph",
+      "combat_front": "earthnymph",
+      "slug": "earthnymph"
+    }
   },
   {
     "slug": "spyder_dryadsgrove_sylvia",
-    "template": 
-      {
-        "sprite_name": "woodnymph",
-        "combat_front": "woodnymph",
-        "slug": "woodnymph"
-      }
-  
+    "template": {
+      "sprite_name": "woodnymph",
+      "combat_front": "woodnymph",
+      "slug": "woodnymph"
+    }
   },
   {
     "slug": "spyder_volcoli",
-    "template": 
-      {
-        "sprite_name": "volcoli",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "volcoli",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_dryadsgrove_boy",
-    "template": 
-      {
-        "sprite_name": "childactor_black",
-        "combat_front": "yellowbelt",
-        "slug": "childactor"
-      }
-  
+    "template": {
+      "sprite_name": "childactor_black",
+      "combat_front": "yellowbelt",
+      "slug": "childactor"
+    }
   },
   {
     "slug": "spyder_dryadsgrove_dad",
-    "template": 
-      {
-        "sprite_name": "beachcomber_gray",
-        "combat_front": "yellowbelt",
-        "slug": "beachcomber"
-      }
-  
+    "template": {
+      "sprite_name": "beachcomber_gray",
+      "combat_front": "yellowbelt",
+      "slug": "beachcomber"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_flower_city_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_flower_city_npcs.json
@@ -104,7 +104,7 @@
     }
   },
   {
-    "slug": "spyder_flowerscoop_jarod",
+    "slug": "spyder_shopassistant",
     "template": {
       "sprite_name": "shopkeeper",
       "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/spyder_greenwash_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_greenwash_npcs.json
@@ -1,201 +1,162 @@
 [
   {
     "slug": "spyder_greenwash_aissa",
-    "template": 
-      {
-        "sprite_name": "nurse_red",
-        "combat_front": "nurse",
-        "slug": "nurse"
-      }
-  
+    "template": {
+      "sprite_name": "nurse_red",
+      "combat_front": "nurse",
+      "slug": "nurse"
+    }
   },
   {
     "slug": "spyder_greenwash_alex",
-    "template": 
-      {
-        "sprite_name": "florist_rose",
-        "combat_front": "florist",
-        "slug": "florist"
-      }
-  
+    "template": {
+      "sprite_name": "florist_rose",
+      "combat_front": "florist",
+      "slug": "florist"
+    }
   },
   {
     "slug": "spyder_greenwash_broer",
-    "template": 
-      {
-        "sprite_name": "nurse_lapi",
-        "combat_front": "nurse",
-        "slug": "nurse"
-      }
-  
+    "template": {
+      "sprite_name": "nurse_lapi",
+      "combat_front": "nurse",
+      "slug": "nurse"
+    }
   },
   {
     "slug": "spyder_greenwash_chip",
-    "template": 
-      {
-        "sprite_name": "scientist_fiery",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
+    "template": {
+      "sprite_name": "scientist_fiery",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
   },
   {
     "slug": "spyder_greenwash_clarence",
-    "template": 
-      {
-        "sprite_name": "scientist_brown",
-        "combat_front": "aviator",
-        "slug": "aviator"
-      }
-  
+    "template": {
+      "sprite_name": "scientist_brown",
+      "combat_front": "aviator",
+      "slug": "aviator"
+    }
   },
   {
     "slug": "spyder_greenwash_dempsey",
-    "template": 
-      {
-        "sprite_name": "rogue_copper",
-        "combat_front": "rogue",
-        "slug": "rogue"
-      }
-  
+    "template": {
+      "sprite_name": "rogue_copper",
+      "combat_front": "rogue",
+      "slug": "rogue"
+    }
   },
   {
     "slug": "spyder_greenwash_dippel",
-    "template": 
-      {
-        "sprite_name": "scientist_fiery",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
+    "template": {
+      "sprite_name": "scientist_fiery",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
   },
   {
     "slug": "spyder_greenwash_gluck",
-    "template": 
-      {
-        "sprite_name": "florist_fiery",
-        "combat_front": "florist",
-        "slug": "florist"
-      }
-  
+    "template": {
+      "sprite_name": "florist_fiery",
+      "combat_front": "florist",
+      "slug": "florist"
+    }
   },
   {
     "slug": "spyder_greenwash_gregor",
-    "template": 
-      {
-        "sprite_name": "scientist_brown",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
+    "template": {
+      "sprite_name": "scientist_brown",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
   },
   {
     "slug": "spyder_greenwash_guard",
-    "template": 
-      {
-        "sprite_name": "soldier",
-        "combat_front": "soldier",
-        "slug": "soldier"
-      }
-  
+    "template": {
+      "sprite_name": "soldier",
+      "combat_front": "soldier",
+      "slug": "soldier"
+    }
   },
   {
     "slug": "spyder_greenwash_heidenstam",
-    "template": 
-      {
-        "sprite_name": "postboy_red",
-        "combat_front": "cooldude",
-        "slug": "postboy"
-      }
-  
+    "template": {
+      "sprite_name": "postboy_red",
+      "combat_front": "cooldude",
+      "slug": "postboy"
+    }
   },
   {
     "slug": "spyder_greenwash_hunt",
-    "template": 
-      {
-        "sprite_name": "scientist_black",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
+    "template": {
+      "sprite_name": "scientist_black",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
   },
   {
     "slug": "spyder_greenwash_lewie",
-    "template": 
-      {
-        "sprite_name": "firefighter",
-        "combat_front": "firefighter",
-        "slug": "firefighter"
-      }
-  
+    "template": {
+      "sprite_name": "firefighter",
+      "combat_front": "firefighter",
+      "slug": "firefighter"
+    }
   },
   {
     "slug": "spyder_greenwash_lewis",
-    "template": 
-      {
-        "sprite_name": "firefighter",
-        "combat_front": "firefighter",
-        "slug": "firefighter"
-      }
-  
+    "template": {
+      "sprite_name": "firefighter",
+      "combat_front": "firefighter",
+      "slug": "firefighter"
+    }
   },
   {
     "slug": "spyder_greenwash_looten",
-    "template": 
-      {
-        "sprite_name": "goth",
-        "combat_front": "goth",
-        "slug": "goth"
-      }
-  
+    "template": {
+      "sprite_name": "goth",
+      "combat_front": "goth",
+      "slug": "goth"
+    }
   },
   {
     "slug": "spyder_greenwash_louis",
-    "template": 
-      {
-        "sprite_name": "scientist",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
+    "template": {
+      "sprite_name": "scientist",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
   },
   {
     "slug": "spyder_greenwash_moreau",
-    "template": 
-      {
-        "sprite_name": "scientist_black",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
+    "template": {
+      "sprite_name": "scientist_black",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
   },
   {
     "slug": "spyder_greenwash_morehouse",
-    "template": 
-      {
-        "sprite_name": "scientist",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
-  },{
+    "template": {
+      "sprite_name": "scientist",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
+  },
+  {
     "slug": "spyder_greenwash_norton",
-    "template": 
-      {
-        "sprite_name": "firefighter",
-        "combat_front": "firefighter",
-        "slug": "firefighter"
-      }
-  
+    "template": {
+      "sprite_name": "firefighter",
+      "combat_front": "firefighter",
+      "slug": "firefighter"
+    }
   },
   {
     "slug": "spyder_greenwash_selby",
-    "template": 
-      {
-        "sprite_name": "scientist_fiery",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
+    "template": {
+      "sprite_name": "scientist_fiery",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_hospital_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_hospital_npcs.json
@@ -1,182 +1,146 @@
 [
   {
     "slug": "spyder_hospital1_aurora",
-    "template": 
-      {
-        "sprite_name": "spyderboss_blonde",
-        "combat_front": "spyder_boss",
-        "slug": "spyder_boss"
-      }
-  
+    "template": {
+      "sprite_name": "spyderboss_blonde",
+      "combat_front": "spyder_boss",
+      "slug": "spyder_boss"
+    }
   },
   {
     "slug": "spyder_hospital1_pem",
-    "template": 
-      {
-        "sprite_name": "spyderrookie",
-        "combat_front": "spyder_rookie",
-        "slug": "spyder_rookie"
-      }
-  
+    "template": {
+      "sprite_name": "spyderrookie",
+      "combat_front": "spyder_rookie",
+      "slug": "spyder_rookie"
+    }
   },
   {
     "slug": "spyder_hospital1_luzia",
-    "template": 
-      {
-        "sprite_name": "spyderboss_fiery",
-        "combat_front": "spyder_boss",
-        "slug": "spyder_boss"
-      }
-  
+    "template": {
+      "sprite_name": "spyderboss_fiery",
+      "combat_front": "spyder_boss",
+      "slug": "spyder_boss"
+    }
   },
   {
     "slug": "spyder_hospital1_liane",
-    "template": 
-      {
-        "sprite_name": "spyderboss_green",
-        "combat_front": "spyder_boss",
-        "slug": "spyder_boss"
-      }
-  
+    "template": {
+      "sprite_name": "spyderboss_green",
+      "combat_front": "spyder_boss",
+      "slug": "spyder_boss"
+    }
   },
   {
     "slug": "spyder_hospital1_fring",
-    "template": 
-      {
-        "sprite_name": "spyderrookie",
-        "combat_front": "spyder_rookie",
-        "slug": "spyder_rookie"
-      }
-  
+    "template": {
+      "sprite_name": "spyderrookie",
+      "combat_front": "spyder_rookie",
+      "slug": "spyder_rookie"
+    }
   },
   {
     "slug": "spyder_hospital1_felu",
-    "template": 
-      {
-        "sprite_name": "spyderrookie",
-        "combat_front": "spyder_rookie",
-        "slug": "spyder_rookie"
-      }
-  
+    "template": {
+      "sprite_name": "spyderrookie",
+      "combat_front": "spyder_rookie",
+      "slug": "spyder_rookie"
+    }
   },
   {
     "slug": "spyder_hospital1_eleni",
-    "template": 
-      {
-        "sprite_name": "spyderboss_lapi",
-        "combat_front": "spyder_boss",
-        "slug": "spyder_boss"
-      }
-  
+    "template": {
+      "sprite_name": "spyderboss_lapi",
+      "combat_front": "spyder_boss",
+      "slug": "spyder_boss"
+    }
   },
   {
     "slug": "spyder_hospital1_rakez",
-    "template": 
-      {
-        "sprite_name": "spyderrookie",
-        "combat_front": "spyder_rookie",
-        "slug": "spyder_rookie"
-      }
-  
+    "template": {
+      "sprite_name": "spyderrookie",
+      "combat_front": "spyder_rookie",
+      "slug": "spyder_rookie"
+    }
   },
   {
     "slug": "spyder_hospital1_rea",
-    "template": 
-      {
-        "sprite_name": "spyderboss",
-        "combat_front": "spyder_boss",
-        "slug": "spyder_boss"
-      }
-  
+    "template": {
+      "sprite_name": "spyderboss",
+      "combat_front": "spyder_boss",
+      "slug": "spyder_boss"
+    }
   },
   {
     "slug": "spyder_hospital1_zekar",
-    "template": 
-      {
-        "sprite_name": "spyderrookie",
-        "combat_front": "spyder_rookie",
-        "slug": "spyder_rookie"
-      }
-  
+    "template": {
+      "sprite_name": "spyderrookie",
+      "combat_front": "spyder_rookie",
+      "slug": "spyder_rookie"
+    }
   },
   {
     "slug": "spyder_hospital1_walt",
-    "template": 
-      {
-        "sprite_name": "spyderrookie",
-        "combat_front": "spyder_rookie",
-        "slug": "spyder_rookie"
-      }
-  
+    "template": {
+      "sprite_name": "spyderrookie",
+      "combat_front": "spyder_rookie",
+      "slug": "spyder_rookie"
+    }
   },
   {
     "slug": "spyder_hospital1_rhizome",
-    "template": 
-      {
-        "sprite_name": "professor_brown",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor_brown",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "spyder_hospital1_smith",
-    "template": 
-      {
-        "sprite_name": "scientist_brown",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
+    "template": {
+      "sprite_name": "scientist_brown",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
   },
   {
     "slug": "spyder_hospital1_lesley",
-    "template": 
-      {
-        "sprite_name": "scientist_black",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
+    "template": {
+      "sprite_name": "scientist_black",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
   },
   {
     "slug": "spyder_hospital1_trafford",
-    "template": 
-      {
-        "sprite_name": "scientist_fiery",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
+    "template": {
+      "sprite_name": "scientist_fiery",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
   },
   {
     "slug": "spyder_hospital1_marylyn",
-    "template": 
-      {
-        "sprite_name": "nurse_green",
-        "combat_front": "nurse",
-        "slug": "nurse"
-      }
-  
+    "template": {
+      "sprite_name": "nurse_green",
+      "combat_front": "nurse",
+      "slug": "nurse"
+    }
   },
   {
     "slug": "spyder_hospital1_melanie",
-    "template": 
-      {
-        "sprite_name": "nurse_blonde",
-        "combat_front": "nurse",
-        "slug": "nurse"
-      }
-  
+    "template": {
+      "sprite_name": "nurse_blonde",
+      "combat_front": "nurse",
+      "slug": "nurse"
+    }
   },
   {
     "slug": "spyder_hospital1_audie",
-    "template": 
-      {
-        "sprite_name": "nurse_blue",
-        "combat_front": "nurse",
-        "slug": "nurse"
-      }
-  
+    "template": {
+      "sprite_name": "nurse_blue",
+      "combat_front": "nurse",
+      "slug": "nurse"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_leather_town_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_leather_town_npcs.json
@@ -208,7 +208,7 @@
     }
   },
   {
-    "slug": "spyder_leatherscoop_blake",
+    "slug": "spyder_shopassistant",
     "template": {
       "sprite_name": "shopkeeper",
       "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/spyder_lion_mountain_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_lion_mountain_npcs.json
@@ -1,142 +1,114 @@
 [
   {
     "slug": "spyder_lionmountain_jacques",
-    "template": 
-      {
-        "sprite_name": "miner_blue",
-        "combat_front": "miner",
-        "slug": "miner"
-      }
-  
+    "template": {
+      "sprite_name": "miner_blue",
+      "combat_front": "miner",
+      "slug": "miner"
+    }
   },
   {
     "slug": "spyder_lionmountain_adam",
-    "template": 
-      {
-        "sprite_name": "miner_green",
-        "combat_front": "miner",
-        "slug": "miner"
-      }
-  
+    "template": {
+      "sprite_name": "miner_green",
+      "combat_front": "miner",
+      "slug": "miner"
+    }
   },
   {
     "slug": "spyder_lionmountain_arlene",
-    "template": 
-      {
-        "sprite_name": "miner_red",
-        "combat_front": "miner",
-        "slug": "miner"
-      }
-  
+    "template": {
+      "sprite_name": "miner_red",
+      "combat_front": "miner",
+      "slug": "miner"
+    }
   },
   {
     "slug": "spyder_lionmountain_david",
-    "template": 
-      {
-        "sprite_name": "miner_yellow",
-        "combat_front": "miner",
-        "slug": "miner"
-      }
-  
+    "template": {
+      "sprite_name": "miner_yellow",
+      "combat_front": "miner",
+      "slug": "miner"
+    }
   },
   {
     "slug": "spyder_lionmountain_alexander",
-    "template": 
-      {
-        "sprite_name": "miner",
-        "combat_front": "miner",
-        "slug": "miner"
-      }
-  
+    "template": {
+      "sprite_name": "miner",
+      "combat_front": "miner",
+      "slug": "miner"
+    }
   },
   {
     "slug": "spyder_lionmountain_chhurim",
-    "template": 
-      {
-        "sprite_name": "miner_blue",
-        "combat_front": "miner",
-        "slug": "miner"
-      }
-  
+    "template": {
+      "sprite_name": "miner_blue",
+      "combat_front": "miner",
+      "slug": "miner"
+    }
   },
   {
     "slug": "spyder_lionmountain_emilio",
-    "template": 
-      {
-        "sprite_name": "miner_green",
-        "combat_front": "miner",
-        "slug": "miner"
-      }
-  
+    "template": {
+      "sprite_name": "miner_green",
+      "combat_front": "miner",
+      "slug": "miner"
+    }
   },
   {
     "slug": "spyder_lionmountain_tom",
-    "template": 
-      {
-        "sprite_name": "miner_red",
-        "combat_front": "miner",
-        "slug": "miner"
-      }
-  
+    "template": {
+      "sprite_name": "miner_red",
+      "combat_front": "miner",
+      "slug": "miner"
+    }
   },
   {
     "slug": "spyder_lionmountain_conrad",
-    "template": 
-      {
-        "sprite_name": "miner_yellow",
-        "combat_front": "miner",
-        "slug": "miner"
-      }
-  
+    "template": {
+      "sprite_name": "miner_yellow",
+      "combat_front": "miner",
+      "slug": "miner"
+    }
   },
   {
     "slug": "spyder_lionmountain_kurt",
-    "template": 
-      {
-        "sprite_name": "miner",
-        "combat_front": "miner",
-        "slug": "miner"
-      }
-  
+    "template": {
+      "sprite_name": "miner",
+      "combat_front": "miner",
+      "slug": "miner"
+    }
   },
   {
     "slug": "spyder_lionmountain_scientist",
-    "template": 
-      {
-        "sprite_name": "scientist_fiery",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
+    "template": {
+      "sprite_name": "scientist_fiery",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
   },
   {
     "slug": "spyder_lionmountain_enforcer",
-    "template": 
-      {
-        "sprite_name": "knight_green",
-        "combat_front": "enforcer_agent",
-        "slug": "enforcer_agent"
-      }
-  
+    "template": {
+      "sprite_name": "knight_green",
+      "combat_front": "enforcer_agent",
+      "slug": "enforcer_agent"
+    }
   },
   {
     "slug": "spyder_lionmountain_nurse",
-    "template": 
-      {
-        "sprite_name": "nurse",
-        "combat_front": "nurse",
-        "slug": "nurse"
-      }
-  
+    "template": {
+      "sprite_name": "nurse",
+      "combat_front": "nurse",
+      "slug": "nurse"
+    }
   },
   {
     "slug": "spyder_lionmountain_snarlon",
-    "template": 
-      {
-        "sprite_name": "landrace",
-        "combat_front": "sludgehog",
-        "slug": "noclass"
-      }
-  
+    "template": {
+      "sprite_name": "landrace",
+      "combat_front": "sludgehog",
+      "slug": "noclass"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_log.json
+++ b/mods/tuxemon/db/npc/spyder_log.json
@@ -1,10 +1,8 @@
 {
   "slug": "spyder_log",
-  "template": 
-    {
-      "sprite_name": "log",
-      "combat_front": "noclass",
-      "slug": "interactive_obj"
-    }
-
+  "template": {
+    "sprite_name": "log",
+    "combat_front": "noclass",
+    "slug": "interactive_obj"
+  }
 }

--- a/mods/tuxemon/db/npc/spyder_omnichannel_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_omnichannel_npcs.json
@@ -1,172 +1,138 @@
 [
   {
     "slug": "spyder_omnichannel_beaverbrook",
-    "template": 
-      {
-        "sprite_name": "ceo",
-        "combat_front": "ceo",
-        "slug": "ceo"
-      }
-  
+    "template": {
+      "sprite_name": "ceo",
+      "combat_front": "ceo",
+      "slug": "ceo"
+    }
   },
   {
     "slug": "spyder_omnichannel_schwartz",
-    "template": 
-      {
-        "sprite_name": "rogue",
-        "combat_front": "rogue",
-        "slug": "rogue"
-      }
-  
+    "template": {
+      "sprite_name": "rogue",
+      "combat_front": "rogue",
+      "slug": "rogue"
+    }
   },
   {
     "slug": "spyder_omnichannel_strauss",
-    "template": 
-      {
-        "sprite_name": "warrior",
-        "combat_front": "warrior",
-        "slug": "warrior"
-      }
-  
+    "template": {
+      "sprite_name": "warrior",
+      "combat_front": "warrior",
+      "slug": "warrior"
+    }
   },
   {
     "slug": "spyder_omnichannel_william",
-    "template": 
-      {
-        "sprite_name": "beachcomber_black",
-        "combat_front": "yellowbelt",
-        "slug": "yellowbelt"
-      }
-  
+    "template": {
+      "sprite_name": "beachcomber_black",
+      "combat_front": "yellowbelt",
+      "slug": "yellowbelt"
+    }
   },
   {
     "slug": "spyder_omnichannel_tohei",
-    "template": 
-      {
-        "sprite_name": "spyderrookie",
-        "combat_front": "spyder_rookie",
-        "slug": "spyder_rookie"
-      }
-  
+    "template": {
+      "sprite_name": "spyderrookie",
+      "combat_front": "spyder_rookie",
+      "slug": "spyder_rookie"
+    }
   },
   {
     "slug": "spyder_omnichannel_worm",
-    "template": 
-      {
-        "sprite_name": "37707_female",
-        "combat_front": "ceo",
-        "slug": "ceo"
-      }
-  
+    "template": {
+      "sprite_name": "37707_female",
+      "combat_front": "ceo",
+      "slug": "ceo"
+    }
   },
   {
     "slug": "spyder_omnichannel_enforcer",
-    "template": 
-      {
-        "sprite_name": "knight",
-        "combat_front": "enforcer_rookie",
-        "slug": "enforcer_rookie"
-      }
-  
+    "template": {
+      "sprite_name": "knight",
+      "combat_front": "enforcer_rookie",
+      "slug": "enforcer_rookie"
+    }
   },
   {
     "slug": "spyder_omnichannel_thedukeofdeadair",
-    "template": 
-      {
-        "sprite_name": "rogue_red",
-        "combat_front": "rogue",
-        "slug": "rogue"
-      }
-  
+    "template": {
+      "sprite_name": "rogue_red",
+      "combat_front": "rogue",
+      "slug": "rogue"
+    }
   },
   {
     "slug": "spyder_omnichannel_dempsey",
-    "template": 
-      {
-        "sprite_name": "spyderboss",
-        "combat_front": "spyder_boss",
-        "slug": "spyder_boss"
-      }
-  
+    "template": {
+      "sprite_name": "spyderboss",
+      "combat_front": "spyder_boss",
+      "slug": "spyder_boss"
+    }
   },
   {
     "slug": "spyder_omnichannel_crane",
-    "template": 
-      {
-        "sprite_name": "spyderrookie",
-        "combat_front": "spyder_rookie",
-        "slug": "spyder_rookie"
-      }
-  
+    "template": {
+      "sprite_name": "spyderrookie",
+      "combat_front": "spyder_rookie",
+      "slug": "spyder_rookie"
+    }
   },
   {
     "slug": "spyder_omnichannel_carnegie",
-    "template": 
-      {
-        "sprite_name": "cooldude",
-        "combat_front": "cooldude",
-        "slug": "cooldude"
-      }
-  
+    "template": {
+      "sprite_name": "cooldude",
+      "combat_front": "cooldude",
+      "slug": "cooldude"
+    }
   },
   {
     "slug": "spyder_omnichannel_byrne",
-    "template": 
-      {
-        "sprite_name": "professor_green",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor_green",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "spyder_omnichannel_bettger",
-    "template": 
-      {
-        "sprite_name": "rogue_copper",
-        "combat_front": "rogue",
-        "slug": "rogue"
-      }
-  
+    "template": {
+      "sprite_name": "rogue_copper",
+      "combat_front": "rogue",
+      "slug": "rogue"
+    }
   },
   {
     "slug": "spyder_omnichannel_talbot",
-    "template": 
-      {
-        "sprite_name": "spyderrookie",
-        "combat_front": "spyder_rookie",
-        "slug": "spyder_rookie"
-      }
-  
+    "template": {
+      "sprite_name": "spyderrookie",
+      "combat_front": "spyder_rookie",
+      "slug": "spyder_rookie"
+    }
   },
   {
     "slug": "spyder_omnichannel_gore",
-    "template": 
-      {
-        "sprite_name": "spyderrookie",
-        "combat_front": "spyder_rookie",
-        "slug": "spyder_rookie"
-      }
-  
+    "template": {
+      "sprite_name": "spyderrookie",
+      "combat_front": "spyder_rookie",
+      "slug": "spyder_rookie"
+    }
   },
   {
     "slug": "spyder_omnichannel_danita",
-    "template": 
-      {
-        "sprite_name": "nurse",
-        "combat_front": "nurse",
-        "slug": "nurse"
-      }
-  
+    "template": {
+      "sprite_name": "nurse",
+      "combat_front": "nurse",
+      "slug": "nurse"
+    }
   },
   {
     "slug": "spyder_omnichannel_ethan",
-    "template": 
-      {
-        "sprite_name": "maniac_yellow",
-        "combat_front": "adventurer",
-        "slug": "maniac"
-      }
-  
+    "template": {
+      "sprite_name": "maniac_yellow",
+      "combat_front": "adventurer",
+      "slug": "maniac"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_paintings.json
+++ b/mods/tuxemon/db/npc/spyder_paintings.json
@@ -1,52 +1,42 @@
 [
   {
     "slug": "p_one",
-    "template": 
-      {
-        "sprite_name": "p_one",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "p_one",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "p_two",
-    "template": 
-      {
-        "sprite_name": "p_two",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "p_two",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "p_three",
-    "template": 
-      {
-        "sprite_name": "p_three",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "p_three",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "p_four",
-    "template": 
-      {
-        "sprite_name": "p_four",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "p_four",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "p_five",
-    "template": 
-      {
-        "sprite_name": "p_five",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "p_five",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_paper_town_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_paper_town_npcs.json
@@ -1,112 +1,90 @@
 [
   {
     "slug": "spyder_grannypiper",
-    "template": 
-      {
-        "sprite_name": "granny_yellow",
-        "combat_front": "adventurer",
-        "slug": "granny"
-      }
-  
+    "template": {
+      "sprite_name": "granny_yellow",
+      "combat_front": "adventurer",
+      "slug": "granny"
+    }
   },
   {
     "slug": "spyder_conileaffrolicking",
-    "template": 
-      {
-        "sprite_name": "conileaf",
-        "combat_front": "adventurer",
-        "slug": "noclass"
-      }
-  
+    "template": {
+      "sprite_name": "conileaf",
+      "combat_front": "adventurer",
+      "slug": "noclass"
+    }
   },
   {
     "slug": "spyder_rockittenfrolicking",
-    "template": 
-      {
-        "sprite_name": "rockitten",
-        "combat_front": "adventurer",
-        "slug": "noclass"
-      }
-  
+    "template": {
+      "sprite_name": "rockitten",
+      "combat_front": "adventurer",
+      "slug": "noclass"
+    }
   },
   {
     "slug": "spyder_papermart_harith",
-    "template": 
-      {
-        "sprite_name": "beachcomber_copper",
-        "combat_front": "adventurer",
-        "slug": "beachcomber"
-      }
-  
+    "template": {
+      "sprite_name": "beachcomber_copper",
+      "combat_front": "adventurer",
+      "slug": "beachcomber"
+    }
   },
   {
     "slug": "spyder_papermart_miles",
-    "template": 
-      {
-        "sprite_name": "tennisplayer_green",
-        "combat_front": "tennisplayer",
-        "slug": "tennisplayer"
-      }
-  
+    "template": {
+      "sprite_name": "tennisplayer_green",
+      "combat_front": "tennisplayer",
+      "slug": "tennisplayer"
+    }
   },
   {
     "slug": "spyder_papermart_shirley",
-    "template": 
-      {
-        "sprite_name": "picnicker",
-        "combat_front": "picnicker",
-        "slug": "picnicker"
-      }
-  
+    "template": {
+      "sprite_name": "picnicker",
+      "combat_front": "picnicker",
+      "slug": "picnicker"
+    }
   },
   {
     "slug": "spyder_papermart_rafael",
-    "template": 
-      {
-        "sprite_name": "tennisplayer_lapi",
-        "combat_front": "tennisplayer",
-        "slug": "tennisplayer"
-      }
-  
+    "template": {
+      "sprite_name": "tennisplayer_lapi",
+      "combat_front": "tennisplayer",
+      "slug": "tennisplayer"
+    }
   },
   {
     "slug": "spyder_papertown_mom",
-    "template": 
-      {
-        "sprite_name": "homemaker",
-        "combat_front": "adventurer",
-        "slug": "homemaker"
-      }
-  
+    "template": {
+      "sprite_name": "homemaker",
+      "combat_front": "adventurer",
+      "slug": "homemaker"
+    }
   },
   {
     "slug": "spyder_papertown_silver",
-    "template": 
-      {
-        "sprite_name": "florist",
-        "combat_front": "florist",
-        "slug": "florist"
-      }
-  
+    "template": {
+      "sprite_name": "florist",
+      "combat_front": "florist",
+      "slug": "florist"
+    }
   },
   {
     "slug": "spyder_papermanor_princeton",
-    "template": 
-      {
-        "sprite_name": "maniac_yellow",
-        "combat_front": "adventurer",
-        "slug": "maniac"
-      }
-  
+    "template": {
+      "sprite_name": "maniac_yellow",
+      "combat_front": "adventurer",
+      "slug": "maniac"
+    }
   },
   {
-    "slug": "spyder_paperscoop_santino",
-    "template": 
-      {
-        "sprite_name": "shopkeeper",
-        "combat_front": "adventurer",
-        "slug": "shopkeeper"
-      }
-  
+    "slug": "spyder_shopassistant",
+    "template": {
+      "sprite_name": "shopkeeper",
+      "combat_front": "adventurer",
+      "slug": "shopkeeper"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_park_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_park_npcs.json
@@ -1,72 +1,58 @@
 [
   {
     "slug": "spyder_park_reception",
-    "template": 
-      {
-        "sprite_name": "magician_grey",
-        "combat_front": "magician",
-        "slug": "magician"
-      }
-  
+    "template": {
+      "sprite_name": "magician_grey",
+      "combat_front": "magician",
+      "slug": "magician"
+    }
   },
   {
     "slug": "spyder_park_florist",
-    "template": 
-      {
-        "sprite_name": "florist_fiery",
-        "combat_front": "florist",
-        "slug": "florist"
-      }
-  
+    "template": {
+      "sprite_name": "florist_fiery",
+      "combat_front": "florist",
+      "slug": "florist"
+    }
   },
   {
     "slug": "spyder_park_guardian",
-    "template": 
-      {
-        "sprite_name": "magician_fiery",
-        "combat_front": "magician",
-        "slug": "magician"
-      }
-  
+    "template": {
+      "sprite_name": "magician_fiery",
+      "combat_front": "magician",
+      "slug": "magician"
+    }
   },
   {
     "slug": "spyder_park_soldier",
-    "template": 
-      {
-        "sprite_name": "soldier",
-        "combat_front": "soldier",
-        "slug": "soldier"
-      }
-  
+    "template": {
+      "sprite_name": "soldier",
+      "combat_front": "soldier",
+      "slug": "soldier"
+    }
   },
   {
     "slug": "spyder_park_scientist",
-    "template": 
-      {
-        "sprite_name": "scientist",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
+    "template": {
+      "sprite_name": "scientist",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
   },
   {
     "slug": "spyder_park_professor",
-    "template": 
-      {
-        "sprite_name": "professor_brown",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor_brown",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "spyder_park_tennisplayer",
-    "template": 
-      {
-        "sprite_name": "tennisplayer",
-        "combat_front": "tennisplayer",
-        "slug": "tennisplayer"
-      }
-  
+    "template": {
+      "sprite_name": "tennisplayer",
+      "combat_front": "tennisplayer",
+      "slug": "tennisplayer"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_route1_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_route1_npcs.json
@@ -1,12 +1,10 @@
 [
   {
     "slug": "spyder_route1_bjorn",
-    "template": 
-      {
-        "sprite_name": "beachcomber",
-        "combat_front": "adventurer",
-        "slug": "beachcomber"
-      }
-  
+    "template": {
+      "sprite_name": "beachcomber",
+      "combat_front": "adventurer",
+      "slug": "beachcomber"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_route2_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_route2_npcs.json
@@ -1,32 +1,26 @@
 [
   {
     "slug": "spyder_route2_marion",
-    "template": 
-      {
-        "sprite_name": "picnicker",
-        "combat_front": "picnicker",
-        "slug": "picnicker"
-      }
-  
+    "template": {
+      "sprite_name": "picnicker",
+      "combat_front": "picnicker",
+      "slug": "picnicker"
+    }
   },
   {
     "slug": "spyder_route2_graf",
-    "template": 
-      {
-        "sprite_name": "tennisplayer_green",
-        "combat_front": "tennisplayer",
-        "slug": "tennisplayer"
-      }
-  
+    "template": {
+      "sprite_name": "tennisplayer_green",
+      "combat_front": "tennisplayer",
+      "slug": "tennisplayer"
+    }
   },
   {
     "slug": "spyder_route2_roddick",
-    "template": 
-      {
-        "sprite_name": "tennisplayer_fiery",
-        "combat_front": "tennisplayer",
-        "slug": "tennisplayer"
-      }
-  
+    "template": {
+      "sprite_name": "tennisplayer_fiery",
+      "combat_front": "tennisplayer",
+      "slug": "tennisplayer"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_route3_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_route3_npcs.json
@@ -1,138 +1,114 @@
 [
   {
     "slug": "spyder_route3_qqq",
-    "template": 
-      {
-        "sprite_name": "spyderrookie",
-        "combat_front": "spyder_rookie",
-        "slug": "spyder_rookie"
-      }
-  
+    "template": {
+      "sprite_name": "spyderrookie",
+      "combat_front": "spyder_rookie",
+      "slug": "spyder_rookie"
+    }
   },
   {
     "slug": "spyder_route3_zoolander",
-    "template": 
-      {
-        "sprite_name": "overseer",
-        "combat_front": "overseer",
-        "slug": "overseer"
-      }
-  
+    "template": {
+      "sprite_name": "overseer",
+      "combat_front": "overseer",
+      "slug": "overseer"
+    }
   },
   {
     "slug": "spyder_route3_weaver",
-    "template": 
-      {
-        "sprite_name": "knight",
-        "combat_front": "knight",
-        "slug": "knight"
-      }
-  
+    "template": {
+      "sprite_name": "knight",
+      "combat_front": "knight",
+      "slug": "knight"
+    }
   },
   {
     "slug": "spyder_route3_wanda",
-    "template": 
-      {
-        "sprite_name": "fisher",
-        "combat_front": "fisher",
-        "slug": "fisher"
-      }
-  
+    "template": {
+      "sprite_name": "fisher",
+      "combat_front": "fisher",
+      "slug": "fisher"
+    }
   },
   {
     "slug": "spyder_route3_twig",
-    "template": 
-      {
-        "sprite_name": "miner_yellow",
-        "combat_front": "miner",
-        "slug": "miner"
-      }
-  
+    "template": {
+      "sprite_name": "miner_yellow",
+      "combat_front": "miner",
+      "slug": "miner"
+    }
   },
   {
     "slug": "spyder_route3_surat",
-    "template": 
-      {
-        "sprite_name": "miner_red",
-        "combat_front": "miner",
-        "slug": "miner"
-      }
-  
+    "template": {
+      "sprite_name": "miner_red",
+      "combat_front": "miner",
+      "slug": "miner"
+    }
   },
   {
     "slug": "spyder_route3_roxby",
-    "template": 
-      {
-        "sprite_name": "miner_green",
-        "combat_front": "miner",
-        "slug": "miner"
-      }
-  
+    "template": {
+      "sprite_name": "miner_green",
+      "combat_front": "miner",
+      "slug": "miner"
+    }
   },
   {
     "slug": "spyder_route3_novak",
-    "template": 
-      {
-        "sprite_name": "tennisplayer",
-        "combat_front": "tennisplayer",
-        "slug": "tennisplayer"
-      }
-  
+    "template": {
+      "sprite_name": "tennisplayer",
+      "combat_front": "tennisplayer",
+      "slug": "tennisplayer"
+    }
   },
   {
     "slug": "spyder_route3_curie",
-    "template": 
-      {
-        "sprite_name": "scientist",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
+    "template": {
+      "sprite_name": "scientist",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
   },
   {
     "slug": "spyder_route3_connor",
-    "template": 
-      {
-        "sprite_name": "tennisplayer",
-        "combat_front": "tennisplayer",
-        "slug": "tennisplayer"
-      }
-  
+    "template": {
+      "sprite_name": "tennisplayer",
+      "combat_front": "tennisplayer",
+      "slug": "tennisplayer"
+    }
   },
   {
     "slug": "spyder_route3_ryland",
-    "template": 
-      {
-        "sprite_name": "spyderrookie",
-        "combat_front": "spyder_rookie",
-        "slug": "spyder_rookie"
-      }  
+    "template": {
+      "sprite_name": "spyderrookie",
+      "combat_front": "spyder_rookie",
+      "slug": "spyder_rookie"
+    }
   },
   {
     "slug": "spyder_route3_miner1",
-    "template":
-      {
-        "sprite_name": "miner_blue",
-        "combat_front": "miner",
-        "slug": "miner"
-      }
+    "template": {
+      "sprite_name": "miner_blue",
+      "combat_front": "miner",
+      "slug": "miner"
+    }
   },
   {
     "slug": "spyder_route3_miner2",
-    "template":
-      {
-        "sprite_name": "miner_red",
-        "combat_front": "miner",
-        "slug": "miner"
-      }
+    "template": {
+      "sprite_name": "miner_red",
+      "combat_front": "miner",
+      "slug": "miner"
+    }
   },
   {
     "slug": "spyder_route3_miner3",
-    "template":
-      {
-        "sprite_name": "miner_yellow",
-        "combat_front": "miner",
-        "slug": "miner"
-      }
+    "template": {
+      "sprite_name": "miner_yellow",
+      "combat_front": "miner",
+      "slug": "miner"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_route4_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_route4_npcs.json
@@ -1,92 +1,74 @@
 [
   {
     "slug": "spyder_route4_beck",
-    "template": 
-      {
-        "sprite_name": "tennisplayer",
-        "combat_front": "yellowbelt",
-        "slug": "yellowbelt"
-      }
-  
+    "template": {
+      "sprite_name": "tennisplayer",
+      "combat_front": "yellowbelt",
+      "slug": "yellowbelt"
+    }
   },
   {
     "slug": "spyder_route4_marshall",
-    "template": 
-      {
-        "sprite_name": "soldier",
-        "combat_front": "soldier",
-        "slug": "soldier"
-      }
-  
+    "template": {
+      "sprite_name": "soldier",
+      "combat_front": "soldier",
+      "slug": "soldier"
+    }
   },
   {
     "slug": "spyder_route4_rincewind",
-    "template": 
-      {
-        "sprite_name": "beachcomber_blue",
-        "combat_front": "yellowbelt",
-        "slug": "yellowbelt"
-      }
-  
+    "template": {
+      "sprite_name": "beachcomber_blue",
+      "combat_front": "yellowbelt",
+      "slug": "yellowbelt"
+    }
   },
   {
     "slug": "spyder_route4_roger",
-    "template": 
-      {
-        "sprite_name": "soldier",
-        "combat_front": "soldier",
-        "slug": "soldier"
-      }
-  
+    "template": {
+      "sprite_name": "soldier",
+      "combat_front": "soldier",
+      "slug": "soldier"
+    }
   },
   {
     "slug": "spyder_route4_wulf",
-    "template": 
-      {
-        "sprite_name": "maniac",
-        "combat_front": "alchemist",
-        "slug": "alchemist"
-      }
-  
+    "template": {
+      "sprite_name": "maniac",
+      "combat_front": "alchemist",
+      "slug": "alchemist"
+    }
   },
   {
     "slug": "spyder_route4_rosamund",
-    "template": 
-      {
-        "sprite_name": "picnicker",
-        "combat_front": "picnicker",
-        "slug": "picnicker"
-      }
-  
+    "template": {
+      "sprite_name": "picnicker",
+      "combat_front": "picnicker",
+      "slug": "picnicker"
+    }
   },
   {
     "slug": "spyder_route4_super",
-    "template": 
-      {
-        "sprite_name": "box",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "box",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_route4_boost",
-    "template": 
-      {
-        "sprite_name": "box",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "box",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_route4_nurse",
-    "template": 
-      {
-        "sprite_name": "nurse_green",
-        "combat_front": "nurse",
-        "slug": "nurse"
-      }
-  
+    "template": {
+      "sprite_name": "nurse_green",
+      "combat_front": "nurse",
+      "slug": "nurse"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_route5_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_route5_npcs.json
@@ -1,82 +1,66 @@
 [
   {
     "slug": "spyder_route5_cleo",
-    "template": 
-      {
-        "sprite_name": "catgirl_blonde",
-        "combat_front": "catgirl",
-        "slug": "catgirl"
-      }
-  
+    "template": {
+      "sprite_name": "catgirl_blonde",
+      "combat_front": "catgirl",
+      "slug": "catgirl"
+    }
   },
   {
     "slug": "spyder_route5_edith",
-    "template": 
-      {
-        "sprite_name": "picnicker",
-        "combat_front": "picnicker",
-        "slug": "picnicker"
-      }
-  
+    "template": {
+      "sprite_name": "picnicker",
+      "combat_front": "picnicker",
+      "slug": "picnicker"
+    }
   },
   {
     "slug": "spyder_route5_hunter",
-    "template": 
-      {
-        "sprite_name": "soldier",
-        "combat_front": "soldier",
-        "slug": "soldier"
-      }
-  
+    "template": {
+      "sprite_name": "soldier",
+      "combat_front": "soldier",
+      "slug": "soldier"
+    }
   },
   {
     "slug": "spyder_route5_goliath",
-    "template": 
-      {
-        "sprite_name": "spyderrookie",
-        "combat_front": "spyder_rookie",
-        "slug": "spyder_rookie"
-      }
-  
+    "template": {
+      "sprite_name": "spyderrookie",
+      "combat_front": "spyder_rookie",
+      "slug": "spyder_rookie"
+    }
   },
   {
     "slug": "spyder_route5_sara",
-    "template": 
-      {
-        "sprite_name": "picnicker",
-        "combat_front": "picnicker",
-        "slug": "picnicker"
-      }
-  
+    "template": {
+      "sprite_name": "picnicker",
+      "combat_front": "picnicker",
+      "slug": "picnicker"
+    }
   },
   {
     "slug": "spyder_route5_tryphaena",
-    "template": 
-      {
-        "sprite_name": "florist_blue",
-        "combat_front": "florist",
-        "slug": "florist"
-      }
-  
+    "template": {
+      "sprite_name": "florist_blue",
+      "combat_front": "florist",
+      "slug": "florist"
+    }
   },
   {
     "slug": "spyder_route5_lexia",
-    "template": 
-      {
-        "sprite_name": "granny_lapi",
-        "combat_front": "adventurer",
-        "slug": "granny"
-      }
-  
+    "template": {
+      "sprite_name": "granny_lapi",
+      "combat_front": "adventurer",
+      "slug": "granny"
+    }
   },
   {
     "slug": "spyder_route5_nurse",
-    "template": 
-      {
-        "sprite_name": "nurse_blue",
-        "combat_front": "nurse",
-        "slug": "nurse"
-      }
-  
+    "template": {
+      "sprite_name": "nurse_blue",
+      "combat_front": "nurse",
+      "slug": "nurse"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_route6_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_route6_npcs.json
@@ -1,92 +1,74 @@
 [
   {
     "slug": "spyder_route6_frances",
-    "template": 
-      {
-        "sprite_name": "florist_brown",
-        "combat_front": "florist",
-        "slug": "florist"
-      }
-  
+    "template": {
+      "sprite_name": "florist_brown",
+      "combat_front": "florist",
+      "slug": "florist"
+    }
   },
   {
     "slug": "spyder_route6_orion",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "spyder_route6_ping",
-    "template": 
-      {
-        "sprite_name": "picnicker",
-        "combat_front": "picnicker",
-        "slug": "picnicker"
-      }
-  
+    "template": {
+      "sprite_name": "picnicker",
+      "combat_front": "picnicker",
+      "slug": "picnicker"
+    }
   },
   {
     "slug": "spyder_route6_rigel",
-    "template": 
-      {
-        "sprite_name": "scientist_fiery",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
+    "template": {
+      "sprite_name": "scientist_fiery",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
   },
   {
     "slug": "spyder_route6_richard",
-    "template": 
-      {
-        "sprite_name": "magician_grey",
-        "combat_front": "magician",
-        "slug": "magician"
-      }
-  
+    "template": {
+      "sprite_name": "magician_grey",
+      "combat_front": "magician",
+      "slug": "magician"
+    }
   },
   {
     "slug": "spyder_route6_blair",
-    "template": 
-      {
-        "sprite_name": "miner_yellow",
-        "combat_front": "miner",
-        "slug": "miner"
-      }
-  
+    "template": {
+      "sprite_name": "miner_yellow",
+      "combat_front": "miner",
+      "slug": "miner"
+    }
   },
   {
     "slug": "spyder_route6_gunner",
-    "template": 
-      {
-        "sprite_name": "knight",
-        "combat_front": "enforcer_rookie",
-        "slug": "enforcer_rookie"
-      }
-  
+    "template": {
+      "sprite_name": "knight",
+      "combat_front": "enforcer_rookie",
+      "slug": "enforcer_rookie"
+    }
   },
   {
     "slug": "spyder_route6_mungo",
-    "template": 
-      {
-        "sprite_name": "scientist_brown",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
+    "template": {
+      "sprite_name": "scientist_brown",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
   },
   {
     "slug": "spyder_route6_maxwell",
-    "template": 
-      {
-        "sprite_name": "professor_blue",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor_blue",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_route7_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_route7_npcs.json
@@ -1,142 +1,114 @@
 [
   {
     "slug": "spyder_route7_arnold",
-    "template": 
-      {
-        "sprite_name": "scientist",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
+    "template": {
+      "sprite_name": "scientist",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
   },
   {
     "slug": "spyder_route7_sylvester",
-    "template": 
-      {
-        "sprite_name": "beachcomber_copper",
-        "combat_front": "beachgoer",
-        "slug": "beachgoer"
-      }
-  
+    "template": {
+      "sprite_name": "beachcomber_copper",
+      "combat_front": "beachgoer",
+      "slug": "beachgoer"
+    }
   },
   {
     "slug": "spyder_route7_fritz",
-    "template": 
-      {
-        "sprite_name": "maniac_violet",
-        "combat_front": "adventurer",
-        "slug": "maniac"
-      }
-  
+    "template": {
+      "sprite_name": "maniac_violet",
+      "combat_front": "adventurer",
+      "slug": "maniac"
+    }
   },
   {
     "slug": "spyder_route7_statius",
-    "template": 
-      {
-        "sprite_name": "monk_black",
-        "combat_front": "monk",
-        "slug": "monk"
-      }
-  
+    "template": {
+      "sprite_name": "monk_black",
+      "combat_front": "monk",
+      "slug": "monk"
+    }
   },
   {
     "slug": "spyder_route7_jacopo",
-    "template": 
-      {
-        "sprite_name": "magician_blonde",
-        "combat_front": "magician",
-        "slug": "magician"
-      }
-  
+    "template": {
+      "sprite_name": "magician_blonde",
+      "combat_front": "magician",
+      "slug": "magician"
+    }
   },
   {
     "slug": "spyder_route7_pia",
-    "template": 
-      {
-        "sprite_name": "florist_fiery",
-        "combat_front": "florist",
-        "slug": "florist"
-      }
-  
+    "template": {
+      "sprite_name": "florist_fiery",
+      "combat_front": "florist",
+      "slug": "florist"
+    }
   },
   {
     "slug": "spyder_route7_penitent",
-    "template": 
-      {
-        "sprite_name": "boss_orange",
-        "combat_front": "baller",
-        "slug": "baller"
-      }
-  
+    "template": {
+      "sprite_name": "boss_orange",
+      "combat_front": "baller",
+      "slug": "baller"
+    }
   },
   {
     "slug": "spyder_route7_nino",
-    "template": 
-      {
-        "sprite_name": "professor_lapi",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor_lapi",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "spyder_route7_hugh",
-    "template": 
-      {
-        "sprite_name": "cooldude_black",
-        "combat_front": "rocker",
-        "slug": "rocker"
-      }
-  
+    "template": {
+      "sprite_name": "cooldude_black",
+      "combat_front": "rocker",
+      "slug": "rocker"
+    }
   },
   {
     "slug": "spyder_route7_arnaut",
-    "template": 
-      {
-        "sprite_name": "rogue_copper",
-        "combat_front": "winger",
-        "slug": "winger"
-      }
-  
+    "template": {
+      "sprite_name": "rogue_copper",
+      "combat_front": "winger",
+      "slug": "winger"
+    }
   },
   {
     "slug": "spyder_route7_conrad",
-    "template": 
-      {
-        "sprite_name": "picnicker",
-        "combat_front": "picnicker",
-        "slug": "picnicker"
-      }
-  
+    "template": {
+      "sprite_name": "picnicker",
+      "combat_front": "picnicker",
+      "slug": "picnicker"
+    }
   },
   {
     "slug": "spyder_route7_manfred",
-    "template": 
-      {
-        "sprite_name": "postboy_green",
-        "combat_front": "cooldude",
-        "slug": "postboy"
-      }
-  
+    "template": {
+      "sprite_name": "postboy_green",
+      "combat_front": "cooldude",
+      "slug": "postboy"
+    }
   },
   {
     "slug": "spyder_route7_sordello",
-    "template": 
-      {
-        "sprite_name": "tennisplayer_green",
-        "combat_front": "coach",
-        "slug": "coach"
-      }
-  
+    "template": {
+      "sprite_name": "tennisplayer_green",
+      "combat_front": "coach",
+      "slug": "coach"
+    }
   },
   {
     "slug": "spyder_route7_nurse",
-    "template": 
-      {
-        "sprite_name": "nurse_lapi",
-        "combat_front": "nurse",
-        "slug": "nurse"
-      }
-  
+    "template": {
+      "sprite_name": "nurse_lapi",
+      "combat_front": "nurse",
+      "slug": "nurse"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_routea_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_routea_npcs.json
@@ -1,162 +1,122 @@
 [
   {
     "slug": "spyder_routea_connie",
-    "template": 
-      {
-        "sprite_name": "beachcomber_copper",
-        "combat_front": "beachgoer",
-        "slug": "beachgoer"
-      }
-  
+    "template": {
+      "sprite_name": "beachcomber_copper",
+      "combat_front": "beachgoer",
+      "slug": "beachgoer"
+    }
   },
   {
     "slug": "spyder_routea_dagger",
-    "template": 
-      {
-        "sprite_name": "boss_orange",
-        "combat_front": "rocker",
-        "slug": "rocker"
-      }
-  
+    "template": {
+      "sprite_name": "boss_orange",
+      "combat_front": "rocker",
+      "slug": "rocker"
+    }
   },
   {
     "slug": "spyder_routea_doris",
-    "template": 
-      {
-        "sprite_name": "florist_blue",
-        "combat_front": "florist",
-        "slug": "florist"
-      }
-  
+    "template": {
+      "sprite_name": "florist_blue",
+      "combat_front": "florist",
+      "slug": "florist"
+    }
   },
   {
     "slug": "spyder_routea_joe",
-    "template": 
-      {
-        "sprite_name": "beachcomber_fiery",
-        "combat_front": "yellowbelt",
-        "slug": "yellowbelt"
-      }
-  
+    "template": {
+      "sprite_name": "beachcomber_fiery",
+      "combat_front": "yellowbelt",
+      "slug": "yellowbelt"
+    }
   },
   {
     "slug": "spyder_routea_koan",
-    "template": 
-      {
-        "sprite_name": "boss_red",
-        "combat_front": "rocker",
-        "slug": "rocker"
-      }
-  
+    "template": {
+      "sprite_name": "boss_red",
+      "combat_front": "rocker",
+      "slug": "rocker"
+    }
   },
   {
     "slug": "spyder_routea_lexi",
-    "template": 
-      {
-        "sprite_name": "catgirl_violet",
-        "combat_front": "catgirl",
-        "slug": "catgirl"
-      }
-  
+    "template": {
+      "sprite_name": "catgirl_violet",
+      "combat_front": "catgirl",
+      "slug": "catgirl"
+    }
   },
   {
     "slug": "spyder_routea_lotu",
-    "template": 
-      {
-        "sprite_name": "monk_red",
-        "combat_front": "monk",
-        "slug": "monk"
-      }
-  
+    "template": {
+      "sprite_name": "monk_red",
+      "combat_front": "monk",
+      "slug": "monk"
+    }
   },
   {
     "slug": "spyder_routea_rosy",
-    "template": 
-      {
-        "sprite_name": "picnicker",
-        "combat_front": "picnicker",
-        "slug": "picnicker"
-      }
-  
+    "template": {
+      "sprite_name": "picnicker",
+      "combat_front": "picnicker",
+      "slug": "picnicker"
+    }
   },
   {
     "slug": "spyder_routea_vince",
-    "template": 
-      {
-        "sprite_name": "goth",
-        "combat_front": "goth",
-        "slug": "goth"
-      }
-  
+    "template": {
+      "sprite_name": "goth",
+      "combat_front": "goth",
+      "slug": "goth"
+    }
   },
   {
     "slug": "spyder_routea_jarod",
-    "template": 
-      {
-        "sprite_name": "firefighter",
-        "combat_front": "firefighter",
-        "slug": "firefighter"
-      }
-  
+    "template": {
+      "sprite_name": "firefighter",
+      "combat_front": "firefighter",
+      "slug": "firefighter"
+    }
   },
   {
     "slug": "spyder_routea_john",
-    "template": 
-      {
-        "sprite_name": "maniac_green",
-        "combat_front": "adventurer",
-        "slug": "maniac"
-      }
-  
-  },
-  {
-    "slug": "spyder_routea_little",
-    "template": 
-      {
-        "sprite_name": "knight_red",
-        "combat_front": "knight",
-        "slug": "knight"
-      }
-  
+    "template": {
+      "sprite_name": "maniac_green",
+      "combat_front": "adventurer",
+      "slug": "maniac"
+    }
   },
   {
     "slug": "spyder_routea_super",
-    "template": 
-      {
-        "sprite_name": "box",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "box",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_routea_cureall",
-    "template": 
-      {
-        "sprite_name": "box",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "box",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_routea_tea",
-    "template": 
-      {
-        "sprite_name": "box",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "box",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_routea_nurse",
-    "template": 
-      {
-        "sprite_name": "nurse_blonde",
-        "combat_front": "nurse",
-        "slug": "nurse"
-      }
-  
+    "template": {
+      "sprite_name": "nurse_blonde",
+      "combat_front": "nurse",
+      "slug": "nurse"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_routeb_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_routeb_npcs.json
@@ -1,52 +1,42 @@
 [
   {
     "slug": "spyder_routeb_electra",
-    "template": 
-      {
-        "sprite_name": "knight_green",
-        "combat_front": "enforcer_agent",
-        "slug": "enforcer_agent"
-      }
-  
+    "template": {
+      "sprite_name": "knight_green",
+      "combat_front": "enforcer_agent",
+      "slug": "enforcer_agent"
+    }
   },
   {
     "slug": "spyder_routeb_cytherea",
-    "template": 
-      {
-        "sprite_name": "knight",
-        "combat_front": "enforcer_rookie",
-        "slug": "enforcer_rookie"
-      }
-  
+    "template": {
+      "sprite_name": "knight",
+      "combat_front": "enforcer_rookie",
+      "slug": "enforcer_rookie"
+    }
   },
   {
     "slug": "spyder_routeb_nephthys",
-    "template": 
-      {
-        "sprite_name": "knight_red",
-        "combat_front": "enforcer_agent",
-        "slug": "enforcer_agent"
-      }
-  
+    "template": {
+      "sprite_name": "knight_red",
+      "combat_front": "enforcer_agent",
+      "slug": "enforcer_agent"
+    }
   },
   {
     "slug": "spyder_routeb_sedna",
-    "template": 
-      {
-        "sprite_name": "knight_red",
-        "combat_front": "enforcer_rookie",
-        "slug": "enforcer_rookie"
-      }
-  
+    "template": {
+      "sprite_name": "knight_red",
+      "combat_front": "enforcer_rookie",
+      "slug": "enforcer_rookie"
+    }
   },
   {
     "slug": "spyder_routeb_calypso",
-    "template": 
-      {
-        "sprite_name": "knight_yellow",
-        "combat_front": "enforcer_boss",
-        "slug": "enforcer_boss"
-      }
-  
+    "template": {
+      "sprite_name": "knight_yellow",
+      "combat_front": "enforcer_boss",
+      "slug": "enforcer_boss"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_routee_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_routee_npcs.json
@@ -1,22 +1,18 @@
 [
   {
     "slug": "spyder_routee_calliope",
-    "template": 
-      {
-        "sprite_name": "knight_red",
-        "combat_front": "enforcer_agent",
-        "slug": "enforcer_agent"
-      }
-  
+    "template": {
+      "sprite_name": "knight_red",
+      "combat_front": "enforcer_agent",
+      "slug": "enforcer_agent"
+    }
   },
   {
     "slug": "spyder_routee_aiolos",
-    "template": 
-      {
-        "sprite_name": "knight_green",
-        "combat_front": "enforcer_rookie",
-        "slug": "enforcer_rookie"
-      }
-  
+    "template": {
+      "sprite_name": "knight_green",
+      "combat_front": "enforcer_rookie",
+      "slug": "enforcer_rookie"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_scoop_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_scoop_npcs.json
@@ -1,202 +1,162 @@
 [
   {
     "slug": "spyder_scoop_alyssa",
-    "template": 
-      {
-        "sprite_name": "nurse_blonde",
-        "combat_front": "nurse",
-        "slug": "nurse"
-      }
-  
+    "template": {
+      "sprite_name": "nurse_blonde",
+      "combat_front": "nurse",
+      "slug": "nurse"
+    }
   },
   {
     "slug": "spyder_scoop_paine",
-    "template": 
-      {
-        "sprite_name": "nurse_green",
-        "combat_front": "nurse",
-        "slug": "nurse"
-      }
-  
+    "template": {
+      "sprite_name": "nurse_green",
+      "combat_front": "nurse",
+      "slug": "nurse"
+    }
   },
   {
     "slug": "spyder_scoop_orba",
-    "template": 
-      {
-        "sprite_name": "spyderrookie",
-        "combat_front": "spyder_rookie",
-        "slug": "spyder_rookie"
-      }
-  
+    "template": {
+      "sprite_name": "spyderrookie",
+      "combat_front": "spyder_rookie",
+      "slug": "spyder_rookie"
+    }
   },
   {
     "slug": "spyder_scoop_rubid",
-    "template": 
-      {
-        "sprite_name": "scientist",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
+    "template": {
+      "sprite_name": "scientist",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
   },
   {
     "slug": "spyder_scoop_weaver",
-    "template": 
-      {
-        "sprite_name": "spyderrookie",
-        "combat_front": "spyder_rookie",
-        "slug": "spyder_rookie"
-      }
-  
+    "template": {
+      "sprite_name": "spyderrookie",
+      "combat_front": "spyder_rookie",
+      "slug": "spyder_rookie"
+    }
   },
   {
     "slug": "spyder_scoop_turner",
-    "template": 
-      {
-        "sprite_name": "knight",
-        "combat_front": "enforcer_rookie",
-        "slug": "enforcer_rookie"
-      }
-  
+    "template": {
+      "sprite_name": "knight",
+      "combat_front": "enforcer_rookie",
+      "slug": "enforcer_rookie"
+    }
   },
   {
     "slug": "spyder_scoop_taggart",
-    "template": 
-      {
-        "sprite_name": "nurse_red",
-        "combat_front": "nurse",
-        "slug": "nurse"
-      }
-  
+    "template": {
+      "sprite_name": "nurse_red",
+      "combat_front": "nurse",
+      "slug": "nurse"
+    }
   },
   {
     "slug": "spyder_scoop_arachne",
-    "template": 
-      {
-        "sprite_name": "spyderboss_blonde",
-        "combat_front": "spyder_boss",
-        "slug": "spyder_boss"
-      }
-  
+    "template": {
+      "sprite_name": "spyderboss_blonde",
+      "combat_front": "spyder_boss",
+      "slug": "spyder_boss"
+    }
   },
   {
     "slug": "spyder_scoop_berys",
-    "template": 
-      {
-        "sprite_name": "professor_black",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor_black",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "spyder_scoop_cochinia",
-    "template": 
-      {
-        "sprite_name": "varmint",
-        "combat_front": "cochini",
-        "slug": "noclass"
-      }
-  
+    "template": {
+      "sprite_name": "varmint",
+      "combat_front": "cochini",
+      "slug": "noclass"
+    }
   },
   {
     "slug": "spyder_scoop_cochinib",
-    "template": 
-      {
-        "sprite_name": "varmint",
-        "combat_front": "cochini",
-        "slug": "noclass"
-      }
-  
+    "template": {
+      "sprite_name": "varmint",
+      "combat_front": "cochini",
+      "slug": "noclass"
+    }
   },
   {
     "slug": "spyder_scoop_cochinic",
-    "template": 
-      {
-        "sprite_name": "varmint",
-        "combat_front": "cochini",
-        "slug": "noclass"
-      }
-  
+    "template": {
+      "sprite_name": "varmint",
+      "combat_front": "cochini",
+      "slug": "noclass"
+    }
   },
   {
     "slug": "spyder_scoop_donald",
-    "template": 
-      {
-        "sprite_name": "cooldude_fiery",
-        "combat_front": "cooldude",
-        "slug": "cooldude"
-      }
-  
+    "template": {
+      "sprite_name": "cooldude_fiery",
+      "combat_front": "cooldude",
+      "slug": "cooldude"
+    }
   },
   {
     "slug": "spyder_scoop_landrace",
-    "template": 
-      {
-        "sprite_name": "landrace",
-        "combat_front": "sludgehog",
-        "slug": "noclass"
-      }
-  
+    "template": {
+      "sprite_name": "landrace",
+      "combat_front": "sludgehog",
+      "slug": "noclass"
+    }
   },
   {
     "slug": "spyder_scoop_lanth",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "spyder_scoop_lapinoua",
-    "template": 
-      {
-        "sprite_name": "varmint",
-        "combat_front": "lapinou",
-        "slug": "noclass"
-      }
-  
+    "template": {
+      "sprite_name": "varmint",
+      "combat_front": "lapinou",
+      "slug": "noclass"
+    }
   },
   {
     "slug": "spyder_scoop_lapinoub",
-    "template": 
-      {
-        "sprite_name": "varmint",
-        "combat_front": "lapinou",
-        "slug": "noclass"
-      }
-  
+    "template": {
+      "sprite_name": "varmint",
+      "combat_front": "lapinou",
+      "slug": "noclass"
+    }
   },
   {
     "slug": "spyder_scoop_lapinouc",
-    "template": 
-      {
-        "sprite_name": "varmint",
-        "combat_front": "lapinou",
-        "slug": "noclass"
-      }
-  
+    "template": {
+      "sprite_name": "varmint",
+      "combat_front": "lapinou",
+      "slug": "noclass"
+    }
   },
   {
     "slug": "spyder_scoop_nash",
-    "template": 
-      {
-        "sprite_name": "scientist_fiery",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
+    "template": {
+      "sprite_name": "scientist_fiery",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
   },
   {
     "slug": "spyder_scoop_reese",
-    "template": 
-      {
-        "sprite_name": "scientist_brown",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
+    "template": {
+      "sprite_name": "scientist_brown",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_screen.json
+++ b/mods/tuxemon/db/npc/spyder_screen.json
@@ -1,10 +1,8 @@
 {
   "slug": "spyder_screen",
-  "template": 
-    {
-      "sprite_name": "screen",
-      "combat_front": "noclass",
-      "slug": "interactive_obj"
-    }
-
+  "template": {
+    "sprite_name": "screen",
+    "combat_front": "noclass",
+    "slug": "interactive_obj"
+  }
 }

--- a/mods/tuxemon/db/npc/spyder_searoutec_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_searoutec_npcs.json
@@ -1,142 +1,114 @@
 [
   {
     "slug": "spyder_searoutec_alpha",
-    "template": 
-      {
-        "sprite_name": "swimmer_red",
-        "combat_front": "swimmer",
-        "slug": "swimmer"
-      }
-  
+    "template": {
+      "sprite_name": "swimmer_red",
+      "combat_front": "swimmer",
+      "slug": "swimmer"
+    }
   },
   {
     "slug": "spyder_searoutec_river",
-    "template": 
-      {
-        "sprite_name": "swimmer_orange",
-        "combat_front": "swimmer",
-        "slug": "swimmer"
-      }
-  
+    "template": {
+      "sprite_name": "swimmer_orange",
+      "combat_front": "swimmer",
+      "slug": "swimmer"
+    }
   },
   {
     "slug": "spyder_searoutec_nigel",
-    "template": 
-      {
-        "sprite_name": "dragonrider_blue",
-        "combat_front": "dragonrider",
-        "slug": "dragonrider"
-      }
-  
+    "template": {
+      "sprite_name": "dragonrider_blue",
+      "combat_front": "dragonrider",
+      "slug": "dragonrider"
+    }
   },
   {
     "slug": "spyder_searoutec_more",
-    "template": 
-      {
-        "sprite_name": "swimmer_green",
-        "combat_front": "swimmer",
-        "slug": "swimmer"
-      }
-  
+    "template": {
+      "sprite_name": "swimmer_green",
+      "combat_front": "swimmer",
+      "slug": "swimmer"
+    }
   },
   {
     "slug": "spyder_searoutec_rutherford",
-    "template": 
-      {
-        "sprite_name": "scientist",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
+    "template": {
+      "sprite_name": "scientist",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
   },
   {
     "slug": "spyder_searoutec_sandy",
-    "template": 
-      {
-        "sprite_name": "fisher",
-        "combat_front": "fisher",
-        "slug": "fisher"
-      }
-  
+    "template": {
+      "sprite_name": "fisher",
+      "combat_front": "fisher",
+      "slug": "fisher"
+    }
   },
   {
     "slug": "spyder_searoutec_maurice",
-    "template": 
-      {
-        "sprite_name": "fisher_fiery",
-        "combat_front": "fisher",
-        "slug": "fisher"
-      }
-  
+    "template": {
+      "sprite_name": "fisher_fiery",
+      "combat_front": "fisher",
+      "slug": "fisher"
+    }
   },
   {
     "slug": "spyder_searoutec_leek",
-    "template": 
-      {
-        "sprite_name": "swimmer",
-        "combat_front": "swimmer",
-        "slug": "swimmer"
-      }
-  
+    "template": {
+      "sprite_name": "swimmer",
+      "combat_front": "swimmer",
+      "slug": "swimmer"
+    }
   },
   {
     "slug": "spyder_searoutec_wade",
-    "template": 
-      {
-        "sprite_name": "swimmer_blue",
-        "combat_front": "swimmer",
-        "slug": "swimmer"
-      }
-  
+    "template": {
+      "sprite_name": "swimmer_blue",
+      "combat_front": "swimmer",
+      "slug": "swimmer"
+    }
   },
   {
     "slug": "spyder_searoutec_stafford",
-    "template": 
-      {
-        "sprite_name": "beachcomber_copper",
-        "combat_front": "yellowbelt",
-        "slug": "beachcomber"
-      }
-  
+    "template": {
+      "sprite_name": "beachcomber_copper",
+      "combat_front": "yellowbelt",
+      "slug": "beachcomber"
+    }
   },
   {
     "slug": "spyder_searoutec_gil",
-    "template": 
-      {
-        "sprite_name": "swimmer_blue",
-        "combat_front": "swimmer",
-        "slug": "swimmer"
-      }
-  
+    "template": {
+      "sprite_name": "swimmer_blue",
+      "combat_front": "swimmer",
+      "slug": "swimmer"
+    }
   },
   {
     "slug": "spyder_searoutec_carstair",
-    "template": 
-      {
-        "sprite_name": "beachcomber_blue",
-        "combat_front": "yellowbelt",
-        "slug": "beachcomber"
-      }
-  
+    "template": {
+      "sprite_name": "beachcomber_blue",
+      "combat_front": "yellowbelt",
+      "slug": "beachcomber"
+    }
   },
   {
     "slug": "spyder_searoutec_beech",
-    "template": 
-      {
-        "sprite_name": "swimmer_red",
-        "combat_front": "swimmer",
-        "slug": "swimmer"
-      }
-  
+    "template": {
+      "sprite_name": "swimmer_red",
+      "combat_front": "swimmer",
+      "slug": "swimmer"
+    }
   },
   {
     "slug": "spyder_searoutec_beta",
-    "template": 
-      {
-        "sprite_name": "swimmer_orange",
-        "combat_front": "swimmer",
-        "slug": "swimmer"
-      }
-  
+    "template": {
+      "sprite_name": "swimmer_orange",
+      "combat_front": "swimmer",
+      "slug": "swimmer"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_statues.json
+++ b/mods/tuxemon/db/npc/spyder_statues.json
@@ -1,52 +1,42 @@
 [
   {
     "slug": "spyder_statue_blue",
-    "template": 
-      {
-        "sprite_name": "statue_blue",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "statue_blue",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_statue_red",
-    "template": 
-      {
-        "sprite_name": "statue_red",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "statue_red",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_statue_orange",
-    "template": 
-      {
-        "sprite_name": "statue_orange",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "statue_orange",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_statue_grey",
-    "template": 
-      {
-        "sprite_name": "statue_grey",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "statue_grey",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_statue_green",
-    "template": 
-      {
-        "sprite_name": "statue_green",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "statue_green",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_timber_town_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_timber_town_npcs.json
@@ -1,52 +1,42 @@
 [
   {
     "slug": "spyder_timberhouse_zed",
-    "template": 
-      {
-        "sprite_name": "firefighter",
-        "combat_front": "firefighter",
-        "slug": "firefighter"
-      }
-  
+    "template": {
+      "sprite_name": "firefighter",
+      "combat_front": "firefighter",
+      "slug": "firefighter"
+    }
   },
   {
     "slug": "spyder_timbercafe_grady",
-    "template": 
-      {
-        "sprite_name": "magician",
-        "combat_front": "magician",
-        "slug": "magician"
-      }
-  
+    "template": {
+      "sprite_name": "magician",
+      "combat_front": "magician",
+      "slug": "magician"
+    }
   },
   {
-    "slug": "spyder_timberscoop_leandro",
-    "template": 
-      {
-        "sprite_name": "shopkeeper",
-        "combat_front": "adventurer",
-        "slug": "shopkeeper"
-      }
-  
+    "slug": "spyder_shopassistant",
+    "template": {
+      "sprite_name": "shopkeeper",
+      "combat_front": "adventurer",
+      "slug": "shopkeeper"
+    }
   },
   {
     "slug": "spyder_outsidewalled_rogue",
-    "template": 
-      {
-        "sprite_name": "rogue_green",
-        "combat_front": "rogue",
-        "slug": "rogue"
-      }
-  
+    "template": {
+      "sprite_name": "rogue_green",
+      "combat_front": "rogue",
+      "slug": "rogue"
+    }
   },
   {
     "slug": "spyder_outsidewalled_midas",
-    "template": 
-      {
-        "sprite_name": "picnicker",
-        "combat_front": "picnicker",
-        "slug": "picnicker"
-      }
-  
+    "template": {
+      "sprite_name": "picnicker",
+      "combat_front": "picnicker",
+      "slug": "picnicker"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_tunnelb_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_tunnelb_npcs.json
@@ -1,92 +1,74 @@
 [
   {
     "slug": "spyder_tunnelb_beryll",
-    "template": 
-      {
-        "sprite_name": "scientist",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
+    "template": {
+      "sprite_name": "scientist",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
   },
   {
     "slug": "spyder_tunnelb_greta",
-    "template": 
-      {
-        "sprite_name": "picnicker",
-        "combat_front": "picnicker",
-        "slug": "picnicker"
-      }
-  
+    "template": {
+      "sprite_name": "picnicker",
+      "combat_front": "picnicker",
+      "slug": "picnicker"
+    }
   },
   {
     "slug": "spyder_tunnelb_iris",
-    "template": 
-      {
-        "sprite_name": "florist_brown",
-        "combat_front": "florist",
-        "slug": "florist"
-      }
-  
+    "template": {
+      "sprite_name": "florist_brown",
+      "combat_front": "florist",
+      "slug": "florist"
+    }
   },
   {
     "slug": "spyder_tunnelb_meitner",
-    "template": 
-      {
-        "sprite_name": "scientist_fiery",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
+    "template": {
+      "sprite_name": "scientist_fiery",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
   },
   {
     "slug": "spyder_tunnelb_lute",
-    "template": 
-      {
-        "sprite_name": "scientist_black",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
+    "template": {
+      "sprite_name": "scientist_black",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
   },
   {
     "slug": "spyder_tunnelb_tommy",
-    "template": 
-      {
-        "sprite_name": "beachcomber_gray",
-        "combat_front": "yellowbelt",
-        "slug": "yellowbelt"
-      }
-  
+    "template": {
+      "sprite_name": "beachcomber_gray",
+      "combat_front": "yellowbelt",
+      "slug": "yellowbelt"
+    }
   },
   {
     "slug": "spyder_tunnelb_rhincus",
-    "template": 
-      {
-        "sprite_name": "box",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "box",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_tunnelb_shammer",
-    "template": 
-      {
-        "sprite_name": "box",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "box",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_tunnelb_nurse",
-    "template": 
-      {
-        "sprite_name": "nurse_red",
-        "combat_front": "nurse",
-        "slug": "nurse"
-      }
-  
+    "template": {
+      "sprite_name": "nurse_red",
+      "combat_front": "nurse",
+      "slug": "nurse"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_tuxeballs.json
+++ b/mods/tuxemon/db/npc/spyder_tuxeballs.json
@@ -1,52 +1,42 @@
 [
   {
     "slug": "spyder_tuxeball_green",
-    "template": 
-      {
-        "sprite_name": "tuxeball_green",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "tuxeball_green",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_tuxeball_red",
-    "template": 
-      {
-        "sprite_name": "tuxeball_red",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "tuxeball_red",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_tuxeball_violet",
-    "template": 
-      {
-        "sprite_name": "tuxeball_violet",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "tuxeball_violet",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_tuxeball_yellow",
-    "template": 
-      {
-        "sprite_name": "tuxeball_yellow",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "tuxeball_yellow",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   },
   {
     "slug": "spyder_tuxeball",
-    "template": 
-      {
-        "sprite_name": "tuxeball",
-        "combat_front": "noclass",
-        "slug": "interactive_obj"
-      }
-  
+    "template": {
+      "sprite_name": "tuxeball",
+      "combat_front": "noclass",
+      "slug": "interactive_obj"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_unique_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_unique_npcs.json
@@ -1,52 +1,58 @@
 [
   {
-   "slug": "spyder_dante",
-   "template": 
-    {
-     "sprite_name": "shopassistant",
-     "combat_front": "adventurer",
-     "slug": "shopassistant"
+    "slug": "spyder_dante",
+    "template": {
+      "sprite_name": "shopassistant",
+      "combat_front": "adventurer",
+      "slug": "shopassistant"
     }
- 
   },
   {
-   "slug": "spyder_shady",
-   "template": 
-    {
-     "sprite_name": "cooldude_blue",
-     "combat_front": "cooldude",
-     "slug": "cooldude"
+    "slug": "spyder_shady",
+    "template": {
+      "sprite_name": "cooldude_blue",
+      "combat_front": "cooldude",
+      "slug": "cooldude"
     }
- 
   },
   {
-   "slug": "spyder_captain",
-   "template": 
-    {
-     "sprite_name": "riverboatcaptain",
-     "combat_front": "enforcer_rookie",
-     "slug": "riverboatcaptain"
+    "slug": "spyder_captain",
+    "template": {
+      "sprite_name": "riverboatcaptain",
+      "combat_front": "enforcer_rookie",
+      "slug": "riverboatcaptain"
     }
- 
   },
   {
-   "slug": "spyder_billie",
-   "template": 
-    {
-     "sprite_name": "fashionista",
-     "combat_front": "fashionista",
-     "slug": "fashionista"
+    "slug": "spyder_billie",
+    "template": {
+      "sprite_name": "fashionista",
+      "combat_front": "fashionista",
+      "slug": "fashionista"
     }
- 
   },
   {
-   "slug": "spyder_cathedral_nurse",
-   "template": 
-    {
+    "slug": "spyder_cathedral_nurse",
+    "template": {
       "sprite_name": "nurse",
       "combat_front": "nurse",
       "slug": "nurse"
     }
- 
+  },
+  {
+    "slug": "spyder_shopkeeper",
+    "template": {
+      "sprite_name": "shopassistant",
+      "combat_front": "shopassistant",
+      "slug": "shopassistant"
+    }
+  },
+  {
+    "slug": "spyder_shopassistant",
+    "template": {
+      "sprite_name": "shopassistant",
+      "combat_front": "shopassistant",
+      "slug": "shopassistant"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_walled_garden_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_walled_garden_npcs.json
@@ -1,132 +1,106 @@
 [
   {
     "slug": "spyder_walled_crassus",
-    "template": 
-      {
-        "sprite_name": "ceo",
-        "combat_front": "ceo",
-        "slug": "ceo"
-      }
-  
+    "template": {
+      "sprite_name": "ceo",
+      "combat_front": "ceo",
+      "slug": "ceo"
+    }
   },
   {
     "slug": "spyder_walled_alexander",
-    "template": 
-      {
-        "sprite_name": "ceo",
-        "combat_front": "ceo",
-        "slug": "ceo"
-      }
-  
+    "template": {
+      "sprite_name": "ceo",
+      "combat_front": "ceo",
+      "slug": "ceo"
+    }
   },
   {
     "slug": "spyder_walled_rufus",
-    "template": 
-      {
-        "sprite_name": "cooldude",
-        "combat_front": "cooldude",
-        "slug": "cooldude"
-      }
-  
+    "template": {
+      "sprite_name": "cooldude",
+      "combat_front": "cooldude",
+      "slug": "cooldude"
+    }
   },
   {
     "slug": "spyder_walled_vanderbilt",
-    "template": 
-      {
-        "sprite_name": "ceo",
-        "combat_front": "ceo",
-        "slug": "ceo"
-      }
-  
+    "template": {
+      "sprite_name": "ceo",
+      "combat_front": "ceo",
+      "slug": "ceo"
+    }
   },
   {
     "slug": "spyder_walled_astor",
-    "template": 
-      {
-        "sprite_name": "cooldude",
-        "combat_front": "cooldude",
-        "slug": "cooldude"
-      }
-  
+    "template": {
+      "sprite_name": "cooldude",
+      "combat_front": "cooldude",
+      "slug": "cooldude"
+    }
   },
   {
     "slug": "spyder_walled_ford",
-    "template": 
-      {
-        "sprite_name": "picnicker",
-        "combat_front": "picnicker",
-        "slug": "picnicker"
-      }
-  
+    "template": {
+      "sprite_name": "picnicker",
+      "combat_front": "picnicker",
+      "slug": "picnicker"
+    }
   },
   {
     "slug": "spyder_walled_girard",
-    "template": 
-      {
-        "sprite_name": "ceo",
-        "combat_front": "ceo",
-        "slug": "ceo"
-      }
-  
+    "template": {
+      "sprite_name": "ceo",
+      "combat_front": "ceo",
+      "slug": "ceo"
+    }
   },
   {
     "slug": "spyder_walled_augustus",
-    "template": 
-      {
-        "sprite_name": "ceo",
-        "combat_front": "ceo",
-        "slug": "ceo"
-      }
-  
+    "template": {
+      "sprite_name": "ceo",
+      "combat_front": "ceo",
+      "slug": "ceo"
+    }
   },
   {
     "slug": "spyder_walled_fugger",
-    "template": 
-      {
-        "sprite_name": "ceo",
-        "combat_front": "ceo",
-        "slug": "ceo"
-      }
-  
+    "template": {
+      "sprite_name": "ceo",
+      "combat_front": "ceo",
+      "slug": "ceo"
+    }
   },
   {
     "slug": "spyder_walled_carnegie",
-    "template": 
-      {
-        "sprite_name": "ceo",
-        "combat_front": "ceo",
-        "slug": "ceo"
-      }
-  
+    "template": {
+      "sprite_name": "ceo",
+      "combat_front": "ceo",
+      "slug": "ceo"
+    }
   },
   {
     "slug": "spyder_walled_osman",
-    "template": 
-      {
-        "sprite_name": "cooldude",
-        "combat_front": "cooldude",
-        "slug": "cooldude"
-      }
-  
+    "template": {
+      "sprite_name": "cooldude",
+      "combat_front": "cooldude",
+      "slug": "cooldude"
+    }
   },
   {
     "slug": "spyder_walled_musa",
-    "template": 
-      {
-        "sprite_name": "ceo",
-        "combat_front": "ceo",
-        "slug": "ceo"
-      }
-  
+    "template": {
+      "sprite_name": "ceo",
+      "combat_front": "ceo",
+      "slug": "ceo"
+    }
   },
   {
     "slug": "spyder_walled_midas",
-    "template": 
-      {
-        "sprite_name": "picnicker",
-        "combat_front": "picnicker",
-        "slug": "picnicker"
-      }
-  
+    "template": {
+      "sprite_name": "picnicker",
+      "combat_front": "picnicker",
+      "slug": "picnicker"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/spyder_wayfarer_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_wayfarer_npcs.json
@@ -1,142 +1,114 @@
 [
   {
     "slug": "spyder_wayfarer1_bismuth",
-    "template": 
-      {
-        "sprite_name": "scientist_black",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
+    "template": {
+      "sprite_name": "scientist_black",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
   },
   {
     "slug": "spyder_wayfarer1_victor",
-    "template": 
-      {
-        "sprite_name": "knight",
-        "combat_front": "enforcer_rookie",
-        "slug": "enforcer_rookie"
-      }
-  
+    "template": {
+      "sprite_name": "knight",
+      "combat_front": "enforcer_rookie",
+      "slug": "enforcer_rookie"
+    }
   },
   {
     "slug": "spyder_wayfarer1_ratcher",
-    "template": 
-      {
-        "sprite_name": "nurse",
-        "combat_front": "nurse",
-        "slug": "nurse"
-      }
-  
+    "template": {
+      "sprite_name": "nurse",
+      "combat_front": "nurse",
+      "slug": "nurse"
+    }
   },
   {
     "slug": "spyder_wayfarer1_nightshade",
-    "template": 
-      {
-        "sprite_name": "nurse_blue",
-        "combat_front": "nurse",
-        "slug": "nurse"
-      }
-  
+    "template": {
+      "sprite_name": "nurse_blue",
+      "combat_front": "nurse",
+      "slug": "nurse"
+    }
   },
   {
     "slug": "spyder_wayfarer1_morton",
-    "template": 
-      {
-        "sprite_name": "beachcomber_fiery",
-        "combat_front": "yellowbelt",
-        "slug": "yellowbelt"
-      }
-  
+    "template": {
+      "sprite_name": "beachcomber_fiery",
+      "combat_front": "yellowbelt",
+      "slug": "yellowbelt"
+    }
   },
   {
     "slug": "spyder_wayfarer1_jessie",
-    "template": 
-      {
-        "sprite_name": "nurse_red",
-        "combat_front": "nurse",
-        "slug": "nurse"
-      }
-  
+    "template": {
+      "sprite_name": "nurse_red",
+      "combat_front": "nurse",
+      "slug": "nurse"
+    }
   },
   {
     "slug": "spyder_wayfarer1_morningstar",
-    "template": 
-      {
-        "sprite_name": "nurse_lapi",
-        "combat_front": "nurse",
-        "slug": "nurse"
-      }
-  
+    "template": {
+      "sprite_name": "nurse_lapi",
+      "combat_front": "nurse",
+      "slug": "nurse"
+    }
   },
   {
     "slug": "spyder_wayfarer1_james",
-    "template": 
-      {
-        "sprite_name": "scientist",
-        "combat_front": "scientist",
-        "slug": "scientist"
-      }
-  
+    "template": {
+      "sprite_name": "scientist",
+      "combat_front": "scientist",
+      "slug": "scientist"
+    }
   },
   {
     "slug": "spyder_wayfarer1_bravo",
-    "template": 
-      {
-        "sprite_name": "knight",
-        "combat_front": "enforcer_agent",
-        "slug": "enforcer_agent"
-      }
-  
+    "template": {
+      "sprite_name": "knight",
+      "combat_front": "enforcer_agent",
+      "slug": "enforcer_agent"
+    }
   },
   {
     "slug": "spyder_wayfarer2_gae",
-    "template": 
-      {
-        "sprite_name": "granny",
-        "combat_front": "adventurer",
-        "slug": "granny"
-      }
-  
+    "template": {
+      "sprite_name": "granny",
+      "combat_front": "adventurer",
+      "slug": "granny"
+    }
   },
   {
     "slug": "spyder_wayfarer1_addy",
-    "template": 
-      {
-        "sprite_name": "nurse_green",
-        "combat_front": "nurse",
-        "slug": "nurse"
-      }
-  
+    "template": {
+      "sprite_name": "nurse_green",
+      "combat_front": "nurse",
+      "slug": "nurse"
+    }
   },
   {
     "slug": "spyder_wayfarer1_wes",
-    "template": 
-      {
-        "sprite_name": "maniac_violet",
-        "combat_front": "adventurer",
-        "slug": "maniac"
-      }
-  
+    "template": {
+      "sprite_name": "maniac_violet",
+      "combat_front": "adventurer",
+      "slug": "maniac"
+    }
   },
   {
     "slug": "spyder_wayfarer2_kim",
-    "template": 
-      {
-        "sprite_name": "maniac",
-        "combat_front": "adventurer",
-        "slug": "maniac"
-      }
-  
+    "template": {
+      "sprite_name": "maniac",
+      "combat_front": "adventurer",
+      "slug": "maniac"
+    }
   },
   {
     "slug": "spyder_wayfarer1_norm",
-    "template": 
-      {
-        "sprite_name": "shopkeeper_brown",
-        "combat_front": "adventurer",
-        "slug": "shopkeeper"
-      }
-  
+    "template": {
+      "sprite_name": "shopkeeper_brown",
+      "combat_front": "adventurer",
+      "slug": "shopkeeper"
+    }
   }
 ]

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -9707,48 +9707,67 @@ msgstr "Vince"
 
 msgid "spyder_routea_rosy1"
 msgstr "I came here to play with my Shammer, but he's just lazing around in the sun."
+
 msgid "spyder_routea_rosy2"
 msgstr "That perked him up, thank you!"
+
 msgid "spyder_routea_lotu1"
 msgstr "You younglings, always in such a rush to experience the world."
+
 msgid "spyder_routea_lotu2"
 msgstr "Leave time to stop and smell the flowers every once in a while."
+
 msgid "spyder_routea_connie1"
 msgstr "A morning run's just the thing to clear the head."
+
 msgid "spyder_routea_connie2"
 msgstr "A tuxemon battle, that's the tonic!"
+
 msgid "spyder_routea_lexi1"
 msgstr "There's some great tuxemon on this route!"
+
 msgid "spyder_routea_lexi2"
 msgstr "I simply love bugs, don't you?"
+
 msgid "spyder_routea_joe1"
 msgstr "I got my report card from school yesterday."
+
 msgid "spyder_routea_joe2"
 msgstr "'Needs improvement.'' Where have I heard that before?"
+
 msgid "spyder_routea_koan1"
 msgstr "Flower City is cold but I like where I'm living."
+
 msgid "spyder_routea_koan2"
 msgstr "What can I possibly say?"
+
 msgid "spyder_routea_dagger1"
 msgstr "Someone said you were asking after me."
+
 msgid "spyder_routea_dagger2"
 msgstr "No one said you were asking after me. I'm just a blaggard."
+
 msgid "spyder_routea_doris1"
 msgstr "I love the color of the leaves this time of year."
+
 msgid "spyder_routea_doris2"
 msgstr "Thank you. It's always a pleasure to battle someone new."
+
 msgid "spyder_routea_vince1"
 msgstr "I love to just sit by myself in the park and read."
+
 msgid "spyder_routea_vince2"
 msgstr "... Just me, alone in nature."
+
 msgid "spyder_routea_vince3"
 msgstr "... Gee, you really can't take a hint can you kid?"
+
 msgid "spyder_routea_vince4"
 msgstr "Oh golly, my spine is broken! On my book, I mean."
+
 msgid "spyder_routea_maniac"
 msgstr "It's funny\n I come to the park to get away from people\n but I always end up running into someone I know!"
-msgid "spyder_routea_little1"
-msgstr "The access is blocked. A landslide damaged the route."
+
 msgid "spyder_routea_firefighter"
 msgstr "It's so quiet here.\n It's a nice break from the noise of the city."
 
@@ -12065,8 +12084,6 @@ msgid "spyder_wayfarer2_kim"
 msgstr "Kim"
 msgid "spyder_routea_john"
 msgstr "John"
-msgid "spyder_routea_little"
-msgstr "Little"
 msgid "spyder_candyhouse1_sawyer"
 msgstr "Sawyer"
 msgid "spyder_leathermuseum_giles"
@@ -12097,18 +12114,6 @@ msgid "spyder_cottoncenter_ada"
 msgstr "Ada"
 msgid "spyder_cottoncenter_ada1"
 msgstr "The computer system is experiencing technical difficulties.\n Withdrawing and depositing monsters and items is currently unavailable.\n Thank you for your patience."
-msgid "spyder_candyscoop_clint"
-msgstr "Clint"
-msgid "spyder_cottonscoop_joe"
-msgstr "Joe"
-msgid "spyder_flowerscoop_jarod"
-msgstr "Jarod"
-msgid "spyder_paperscoop_santino"
-msgstr "Santino"
-msgid "spyder_timberscoop_leandro"
-msgstr "Leandro"
-msgid "spyder_leatherscoop_blake"
-msgstr "Blake"
 
 msgid "spyder_riverboatcaptain"
 msgstr "Riverboat Captain"

--- a/mods/tuxemon/maps/route1.tmx
+++ b/mods/tuxemon/maps/route1.tmx
@@ -188,8 +188,16 @@
     <property name="act21" value="create_npc bob,32,26,stand"/>
     <property name="act22" value="create_npc marissa,33,26,stand"/>
     <property name="act23" value="create_npc tuxemart_keeper,34,26,stand"/>
-    <property name="cond1" value="not variable_set letusthrough:no"/>
-    <property name="cond2" value="not variable_set letusthrough:almost"/>
+    <property name="cond10" value="not variable_set letusthrough:no"/>
+    <property name="cond11" value="not variable_set letusthrough:almost"/>
+    <property name="cond12" value="not char_exists liela"/>
+    <property name="cond13" value="not char_exists bob"/>
+    <property name="cond14" value="not char_exists marissa"/>
+    <property name="cond15" value="not char_exists tuxemart_keeper"/>
+    <property name="cond16" value="not char_exists omnigrunt"/>
+    <property name="cond17" value="not char_exists omnigrunt2"/>
+    <property name="cond18" value="not char_exists omnigrunt3"/>
+    <property name="cond19" value="not char_exists omnigrunt4"/>
    </properties>
   </object>
   <object id="112" name="they're angry" type="event" x="592" y="336" width="16" height="32">
@@ -473,7 +481,10 @@
     <property name="act10" value="wait 2.2"/>
     <property name="act20" value="char_move omnigrunt4, up 1"/>
     <property name="act30" value="char_face omnigrunt4,down"/>
+    <property name="act40" value="remove_npc omnigrunt4"/>
+    <property name="act50" value="set_variable replaceomnigrunt4:yes"/>
     <property name="cond1" value="is variable_set threemusketeers:yay"/>
+    <property name="cond2" value="not variable_set replaceomnigrunt4:yes"/>
    </properties>
   </object>
   <object id="128" name="kyle sucks" type="event" x="400" y="352" width="16" height="16">
@@ -640,6 +651,7 @@
     <property name="act1" value="create_npc omnigrunt4,34,26,stand"/>
     <property name="act2" value="char_face omnigrunt4,down"/>
     <property name="cond1" value="not char_exists omnigrunt4"/>
+    <property name="cond2" value="is variable_set replaceomnigrunt4:yes"/>
    </properties>
   </object>
   <object id="142" name="hey!" type="event" x="384" y="480" width="16" height="160">

--- a/mods/tuxemon/maps/spyder_candy_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_candy_scoop.tmx
@@ -52,10 +52,10 @@
   </object>
   <object id="20" name="Create Shopkeeper" type="event" x="16" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc spyder_candyscoop_clint,1,6"/>
-    <property name="act2" value="char_face spyder_candyscoop_clint,right"/>
-    <property name="act3" value="set_economy spyder_candyscoop_clint,spyder_candy_scoop"/>
-    <property name="cond1" value="not char_exists spyder_candyscoop_clint"/>
+    <property name="act1" value="create_npc spyder_shopassistant,1,6"/>
+    <property name="act2" value="char_face spyder_shopassistant,right"/>
+    <property name="act3" value="set_economy spyder_shopassistant,spyder_candy_scoop"/>
+    <property name="cond1" value="not char_exists spyder_shopassistant"/>
    </properties>
   </object>
   <object id="28" name="Route Music" type="event" x="0" y="0" width="16" height="16">
@@ -66,18 +66,18 @@
   </object>
   <object id="29" name="Open Shop" type="event" x="32" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="char_face spyder_candyscoop_clint,right"/>
+    <property name="act1" value="char_face spyder_shopassistant,right"/>
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
-    <property name="act3" value="open_shop spyder_candyscoop_clint"/>
+    <property name="act3" value="open_shop spyder_shopassistant"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="30" name="Open Shop" type="event" x="16" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="char_face spyder_candyscoop_clint,down"/>
+    <property name="act1" value="char_face spyder_shopassistant,down"/>
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
-    <property name="act3" value="open_shop spyder_candyscoop_clint"/>
+    <property name="act3" value="open_shop spyder_shopassistant"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_cotton_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_scoop.tmx
@@ -52,10 +52,10 @@
   </object>
   <object id="20" name="Create Shopkeeper" type="event" x="16" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc spyder_cottonscoop_joe,1,6"/>
-    <property name="act2" value="char_face spyder_cottonscoop_joe,right"/>
-    <property name="act3" value="set_economy spyder_cottonscoop_joe,spyder_cotton_scoop"/>
-    <property name="cond1" value="not char_exists spyder_cottonscoop_joe"/>
+    <property name="act1" value="create_npc spyder_shopkeeper,1,6"/>
+    <property name="act2" value="char_face spyder_shopkeeper,right"/>
+    <property name="act3" value="set_economy spyder_shopkeeper,spyder_cotton_scoop"/>
+    <property name="cond1" value="not char_exists spyder_shopkeeper"/>
    </properties>
   </object>
   <object id="21" name="Create Assistant" type="event" x="112" y="128" width="16" height="16">
@@ -74,7 +74,7 @@
   <object id="23" name="Devices, no explain" type="event" x="96" y="96" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_cottonscoop_devicenoexplan"/>
-    <property name="act2" value="pathfind spyder_cottonscoop_joe,1,6"/>
+    <property name="act2" value="pathfind spyder_shopkeeper,1,6"/>
     <property name="act3" value="set_variable heardcapture:null"/>
     <property name="cond1" value="is variable_set heardcapture:yes"/>
    </properties>
@@ -84,7 +84,7 @@
     <property name="act1" value="char_stop player"/>
     <property name="act11" value="lock_controls"/>
     <property name="act12" value="translated_dialog spyder_cottonscoop_deviceexplan"/>
-    <property name="act20" value="pathfind spyder_cottonscoop_joe,1,6"/>
+    <property name="act20" value="pathfind spyder_shopkeeper,1,6"/>
     <property name="act21" value="pathfind spyder_shopassistant,6,9"/>
     <property name="act22" value="translated_dialog spyder_cottonscoop_deviceexplan2"/>
     <property name="act30" value="set_variable heardcapture:null"/>
@@ -96,8 +96,8 @@
    <properties>
     <property name="act10" value="char_stop player"/>
     <property name="act11" value="lock_controls"/>
-    <property name="act20" value="pathfind spyder_cottonscoop_joe,5,9"/>
-    <property name="act21" value="char_face spyder_cottonscoop_joe,down"/>
+    <property name="act20" value="pathfind spyder_shopkeeper,5,9"/>
+    <property name="act21" value="char_face spyder_shopkeeper,down"/>
     <property name="act22" value="translated_dialog spyder_cottonscoop_deviceoffer"/>
     <property name="act23" value="translated_dialog_choice yes:no,heardcapture"/>
     <property name="act30" value="add_item tuxeball"/>
@@ -119,18 +119,18 @@
   </object>
   <object id="30" name="Open Shop" type="event" x="32" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="char_face spyder_cottonscoop_joe,right"/>
+    <property name="act1" value="char_face spyder_shopkeeper,right"/>
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
-    <property name="act3" value="open_shop spyder_cottonscoop_joe"/>
+    <property name="act3" value="open_shop spyder_shopkeeper"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="31" name="Open Shop" type="event" x="16" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="char_face spyder_cottonscoop_joe,down"/>
+    <property name="act1" value="char_face spyder_shopkeeper,down"/>
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
-    <property name="act3" value="open_shop spyder_cottonscoop_joe"/>
+    <property name="act3" value="open_shop spyder_shopkeeper"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_flower_scoop.yaml
+++ b/mods/tuxemon/maps/spyder_flower_scoop.yaml
@@ -19,17 +19,17 @@ events:
     type: "event"
   Create Shopkeeper:
     actions:
-    - create_npc spyder_flowerscoop_jarod,1,6
-    - char_face spyder_flowerscoop_jarod,right
-    - set_economy spyder_flowerscoop_jarod,spyder_flower_scoop
+    - create_npc spyder_shopassistant,1,6
+    - char_face spyder_shopassistant,right
+    - set_economy spyder_shopassistant,spyder_flower_scoop
     conditions:
-    - not char_exists spyder_flowerscoop_jarod
+    - not char_exists spyder_shopassistant
     type: "event"
   Open Shop 1:
     actions:
-    - char_face spyder_flowerscoop_jarod,right
+    - char_face spyder_shopassistant,right
     - translated_dialog spyder_scoop_welcome
-    - open_shop spyder_flowerscoop_jarod
+    - open_shop spyder_shopassistant
     conditions:
     - is char_facing_tile player
     - is button_pressed K_RETURN
@@ -38,9 +38,9 @@ events:
     type: "event"
   Open Shop 2:
     actions:
-    - char_face spyder_flowerscoop_jarod,down
+    - char_face spyder_shopassistant,down
     - translated_dialog spyder_scoop_welcome
-    - open_shop spyder_flowerscoop_jarod
+    - open_shop spyder_shopassistant
     conditions:
     - is char_facing_tile player
     - is button_pressed K_RETURN
@@ -93,16 +93,16 @@ events:
     - set_layer
     - unlock_controls
     - camera_position
-    - pathfind spyder_flowerscoop_jarod,1,6
-    - char_face spyder_flowerscoop_jarod,right
+    - pathfind spyder_shopassistant,1,6
+    - char_face spyder_shopassistant,right
     conditions:
     - is variable_set ocaptain:yes
     type: "event"
   Trigger Flashback:
     actions:
     - lock_controls
-    - pathfind spyder_flowerscoop_jarod,3,8
-    - char_face spyder_flowerscoop_jarod,right
+    - pathfind spyder_shopassistant,3,8
+    - char_face spyder_shopassistant,right
     - translated_dialog spyder_drinking_trigger
     - translated_dialog_choice no:yes,ocaptain
     - unlock_controls

--- a/mods/tuxemon/maps/spyder_leather_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_leather_scoop.tmx
@@ -60,28 +60,28 @@
   </object>
   <object id="19" name="Open Shop" type="event" x="32" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="char_face spyder_leatherscoop_blake,right"/>
+    <property name="act1" value="char_face spyder_shopassistant,right"/>
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
-    <property name="act3" value="open_shop spyder_leatherscoop_blake"/>
+    <property name="act3" value="open_shop spyder_shopassistant"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="20" name="Open Shop" type="event" x="16" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="char_face spyder_leatherscoop_blake,down"/>
+    <property name="act1" value="char_face spyder_shopassistant,down"/>
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
-    <property name="act3" value="open_shop spyder_leatherscoop_blake"/>
+    <property name="act3" value="open_shop spyder_shopassistant"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="21" name="Create Shopkeeper" type="event" x="16" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc spyder_leatherscoop_blake,1,6"/>
-    <property name="act2" value="char_face spyder_leatherscoop_blake,right"/>
-    <property name="act3" value="set_economy spyder_leatherscoop_blake,spyder_leather_scoop"/>
-    <property name="cond1" value="not char_exists spyder_leatherscoop_blake"/>
+    <property name="act1" value="create_npc spyder_shopassistant,1,6"/>
+    <property name="act2" value="char_face spyder_shopassistant,right"/>
+    <property name="act3" value="set_economy spyder_shopassistant,spyder_leather_scoop"/>
+    <property name="cond1" value="not char_exists spyder_shopassistant"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_paper_mart.yaml
+++ b/mods/tuxemon/maps/spyder_paper_mart.yaml
@@ -9,8 +9,8 @@ events:
     actions:
     - change_bg
     - lock_controls
-    - create_npc spyder_paperscoop_santino,7,6
-    - char_face spyder_paperscoop_santino,left
+    - create_npc spyder_shopassistant,7,6
+    - char_face spyder_shopassistant,left
     - create_npc spyder_dante,7,7
     - char_face spyder_dante,left
     - create_npc spyder_papermart_miles,4,7
@@ -103,11 +103,11 @@ events:
     - wait 0.5
     - char_face spyder_dante,up
     - wait 0.5
-    - char_face spyder_paperscoop_santino,down
+    - char_face spyder_shopassistant,down
     - wait 0.5
-    - pathfind spyder_paperscoop_santino,6,6
+    - pathfind spyder_shopassistant,6,6
     - wait 0.5
-    - char_face spyder_paperscoop_santino,down
+    - char_face spyder_shopassistant,down
     - wait 0.5
     - char_face spyder_dante,left
     - wait 0.5
@@ -117,7 +117,7 @@ events:
     - char_face spyder_dante,down
     - pathfind player,6,10
     - transition_teleport spyder_bedroom.tmx,3,4,0.3
-    - remove_npc spyder_paperscoop_santino
+    - remove_npc spyder_shopassistant
     - remove_npc spyder_dante
     - set_variable intro_scoop:done
     - unlock_controls

--- a/mods/tuxemon/maps/spyder_paper_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_paper_scoop.tmx
@@ -58,9 +58,9 @@
   </object>
   <object id="60" name="Create Shopkeeper" type="event" x="0" y="64" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc spyder_paperscoop_santino,0,4"/>
-    <property name="act2" value="char_face spyder_paperscoop_santino,up"/>
-    <property name="cond1" value="not char_exists spyder_paperscoop_santino"/>
+    <property name="act1" value="create_npc spyder_shopassistant,0,4"/>
+    <property name="act2" value="char_face spyder_shopassistant,up"/>
+    <property name="cond1" value="not char_exists spyder_shopassistant"/>
    </properties>
   </object>
   <object id="61" name="Create Dante" type="event" x="176" y="96" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_route7.tmx
+++ b/mods/tuxemon/maps/spyder_route7.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="272">
+<map version="1.10" tiledversion="1.11.1-99-gec89c545" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="272">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="map_type" value="route"/>
@@ -17,7 +17,7 @@
  </layer>
  <layer id="2" name="Tile Layer 2" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eAHVlb2OFDEQhIcVxGSQ8hLLny5DIuRtnCCiAUEGTzMJIocInmYSIrq4/Xbr+vyzc4g/S3Vtu6u7y23vXLkzTWUjnk1Xx9Z4+C/uTdOj3TQ9DjwJfIi18ND21tAmLAnsY93/NuS9O2B363osXGJb9v1BD7qyfRo6ib3akdN+y18OPVcv5waIbdmRvpe/oI+aPX3L4E5G+j6GPnJs7d85+pTz4vYpMzFY6XsVbr9XX38Pfbyjz8HTXO9JA93Yy93TX2r0+ndiX87Ihf0a+r4dcPf+ac6ebAmNAsPfPtpdNzz0OZ8zEqezzhHQA/mw5fCusWtoE3o5pD9/U9BH3hyv/L3ewiceS96jjdojffJnfcvh7ZOXeljlP0dfyf2K9VGb5mfq0z3m++vdI/rQ37JLaKgBjUvoEzh3zcqvcRG2VFDrk/L72+Qs2fJ7vKxw+ou+Wo7cJ8/BedzW9KknvfFJ5wzO8wZJ8QL9EF9DPcLiq9WfgwQ4Yz5X7pXWftY16hMrXy1+DT1CbeAb6eMc5GBds8rFUH9ao6h3ATTQC7f4RvqWOJ/AYF2z9KvWK++vevsTkXcNzJE8g/zkVLzQyu3753ybcz31i/4uMRekraWPfsiW4AHfr83FG/U8a9Na/VIv/JzSJtT4Xhtei+vx4txUHzVL5BCUS5jDkQFXFl6L67Hi3ESf7pOxRA5BuYTRgCc7B7kHcc59s3rPGbX7LZETSCtz7Bp+0NMmn3iKaw35MjIX/xLcDHHz3ho8MIe/hxEPv9ucD1/urdbeX631rYAvm3PlNdy8zxq/W3zYoy/qrwmxPO5dxJvVWz/yd39WX4neZEgfezV98vsoodnBWehFtvjdtjjocKvarNG3hAbg2jT3Oj7PNVk7hzk+LPvocKuarKUvfyv8jeptLrs6qJUttd22OOhw6/ry22QtTks7vylxasN1Mb+pPtftc9VFa7a8iZo27S27629iq7593FsPquN6fS69/iZG3yv1MA/66nmZZ67W+Xxaw69Z76nifa3vlXroEMeHfNI4yk1e6cnYD3qMX3W9jvdWb9V/b6z53Xlcb561ab1leG7O7Fa5fK0ea3hcby6ux2+Zn1Mnc17HxptATdN+8D+lFtPby7Wdq1pC5nB+ceFgvzy4vqd4/FttL1Y+Rqn0RXutUXtzv3Pvf9fHnf8tW+vf3u5X838NPwCXAiT8
+   eAHVlb2OFDEQhIcVxGSQ8hLLny5DIuRtnCCiAUEGTzMJIocInmYSIrq4/Xbr+vyzc4g/S3Vtu6u7y23vXLkzTWUjnk1Xx9Z4+C/uTdOj3TQ9DjwJfIi18ND21tAmLAnsY93/NuS9O2B363osXGJb9v1BD7qyfRo6ib3akdN+y18OPVcv5waIbdmRvpe/oI+aPX3L4E5G+j6GPnJs7d85+pTz4vYpMzFY6XsVbr9XX38Pfbyjz8HTXO9JA93Yy93TX2r0+ndiX87Ihf0a+r4dcPf+ac6ebAmNAsPfPtpdNzz0OZ8zEqezzhHQA/mw5fCusWtoE3o5pD9/U9BH3hyv/L3ewiceS96jjdojffJnfcvh7ZOXeljlP0dfyf2K9VGb5mfq0z3m++vdI/rQ37JLaKgBjUvoEzh3zcqvcRG2VFDrk/L72+Qs2fJ7vKxw+ou+Wo7cJ8/BedzW9KknvfFJ5wzO8wZJ8QL9EF9DPcLiq9WfgwQ4Yz5X7pXWftY16hMrXy1+DT1CbeAb6eMc5GBds8rFUH9ao6h3ATTQC7f4RvqWOJ/AYF2z9KvWK++vevsTkXcNzJE8g/zkVLzQyu3753ybcz31i/4uMRekraWPfsiW4AHfr83FG/U8a9Na/VIv/JzSJtT4Xhtei+vx4txUHzVL5BCUS5jDkQFXFl6L67Hi3ESf7pOxRA5BuYTRgCc7B7kHcc59s3rPGbX7LZETSCtz7Bp+0NMmn3iKaw35MjIX/xLcDHHz3ho8MIe/hxEPv9ucD1/urdbeX631rYAvm3PlNdy8zxq/W3zYoy/qrwmxPO5dxJvVWz/yd39WX4neZEgfezV98vsoodnBWehFtvjdtjjocKvarNG3hAbg2jT3Oj7PNVk7hzk+LPvocKuarKUvfyv8jeptLrs6qJUttd22OOhw6/ry22QtTks7vylxasN1Mb+pPtftc9VFa7a8iZo27S27629iq7593FsPquN6fS69/iZG3yv1MA/66nmZZ67W+Xxaw69Z76nifa3vlXroEMeHfNI4yk1e6cnYD3qMX3W9jvdWb9V/b6z53Xlcb561ab1leG7O7Fa5fK0ea3hcby6ux2+Zn1Mnc17HxptATdN+8D+lFtPby7Wdq1pC5nB+ceFgvzy4vqd4/FttL1Y+Rqn0RXutUXtzv3Pvf9XHXf9tW+vfvvL+/qW9HzEpJ1I=
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="40" height="40">
@@ -31,7 +31,7 @@
   </data>
  </layer>
  <objectgroup color="#ff0000" id="3" name="Collisions">
-  <object id="3" type="collision" x="48" y="608" width="592" height="32"/>
+  <object id="3" type="collision" x="16" y="608" width="624" height="32"/>
   <object id="153" type="collision" x="464" y="496" width="80" height="64"/>
   <object id="155" type="collision" x="560" y="512" width="80" height="96"/>
   <object id="156" type="collision" x="416" y="480" width="48" height="96"/>
@@ -77,14 +77,6 @@
    <properties>
     <property name="act1" value="play_music music_chibi_ninja"/>
     <property name="cond1" value="not music_playing music_chibi_ninja"/>
-   </properties>
-  </object>
-  <object id="5" name="Teleport Route" type="event" x="16" y="624" width="16" height="16">
-   <properties>
-    <property name="act1" value="transition_teleport spyder_routea.tmx,1,0,0.3"/>
-    <property name="act2" value="char_face player,down"/>
-    <property name="cond1" value="is char_at player"/>
-    <property name="cond2" value="is char_facing player,down"/>
    </properties>
   </object>
   <object id="7" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
@@ -220,14 +212,6 @@
     <property name="cond2" value="is char_moved player"/>
    </properties>
   </object>
-  <object id="231" name="Teleport Route" type="event" x="32" y="624" width="16" height="16">
-   <properties>
-    <property name="act1" value="transition_teleport spyder_routea.tmx,2,0,0.3"/>
-    <property name="act2" value="char_face player,up"/>
-    <property name="cond1" value="is char_at player"/>
-    <property name="cond2" value="is char_facing player,up"/>
-   </properties>
-  </object>
   <object id="233" name="Teleport Crystal 2" type="event" x="576" y="0" width="16" height="16">
    <properties>
     <property name="act1" value="transition_teleport spyder_crystal_town.tmx,36,24,0.3"/>
@@ -248,9 +232,9 @@
     <property name="act10" value="pathfind_to_player spyder_route7_arnaut"/>
     <property name="act11" value="translated_dialog spyder_route7_arnaut1"/>
     <property name="act12" value="unlock_controls"/>
-    <property name="act13" value="add_monster fluttaflap,40,spyder_route7_arnaut,5,10"/>
-    <property name="act14" value="add_monster metesaur,30,spyder_route7_arnaut,5,10"/>
-    <property name="act15" value="add_monster heronquak,30,spyder_route7_arnaut,5,10"/>
+    <property name="act13" value="add_monster fluttaflap,20,spyder_route7_arnaut,5,10"/>
+    <property name="act14" value="add_monster metesaur,10,spyder_route7_arnaut,5,10"/>
+    <property name="act15" value="add_monster heronquak,10,spyder_route7_arnaut,5,10"/>
     <property name="act16" value="start_battle player,spyder_route7_arnaut"/>
     <property name="act17" value="translated_dialog spyder_route7_arnaut2"/>
     <property name="act18" value="set_variable route7arnaut:yes"/>
@@ -307,9 +291,9 @@
     <property name="act10" value="pathfind_to_player spyder_route7_nino"/>
     <property name="act11" value="translated_dialog spyder_route7_nino1"/>
     <property name="act12" value="unlock_controls"/>
-    <property name="act13" value="add_monster vividactil,40,spyder_route7_nino,5,10"/>
-    <property name="act14" value="add_monster fluttaflap,40,spyder_route7_nino,5,10"/>
-    <property name="act15" value="add_monster statursus,40,spyder_route7_nino,5,10"/>
+    <property name="act13" value="add_monster vividactil,20,spyder_route7_nino,5,10"/>
+    <property name="act14" value="add_monster fluttaflap,20,spyder_route7_nino,5,10"/>
+    <property name="act15" value="add_monster statursus,20,spyder_route7_nino,5,10"/>
     <property name="act16" value="start_battle player,spyder_route7_nino"/>
     <property name="act17" value="translated_dialog spyder_route7_nino2"/>
     <property name="act18" value="set_variable route7nino:yes"/>
@@ -330,11 +314,11 @@
     <property name="act10" value="pathfind_to_player spyder_route7_sordello"/>
     <property name="act11" value="translated_dialog spyder_route7_sordello1"/>
     <property name="act12" value="unlock_controls"/>
-    <property name="act13" value="add_monster fuzzlet,30,spyder_route7_sordello,5,10"/>
-    <property name="act14" value="add_monster ziggurat,30,spyder_route7_sordello,5,10"/>
-    <property name="act15" value="add_monster woodoor,30,spyder_route7_sordello,5,10"/>
-    <property name="act16" value="add_monster potturmeist,30,spyder_route7_sordello,5,10"/>
-    <property name="act17" value="add_monster squink,30,spyder_route7_sordello,5,10"/>
+    <property name="act13" value="add_monster fuzzlet,10,spyder_route7_sordello,5,10"/>
+    <property name="act14" value="add_monster ziggurat,10,spyder_route7_sordello,5,10"/>
+    <property name="act15" value="add_monster woodoor,10,spyder_route7_sordello,5,10"/>
+    <property name="act16" value="add_monster potturmeist,10,spyder_route7_sordello,5,10"/>
+    <property name="act17" value="add_monster squink,10,spyder_route7_sordello,5,10"/>
     <property name="act18" value="start_battle player,spyder_route7_sordello"/>
     <property name="act19" value="translated_dialog spyder_route7_sordello2"/>
     <property name="act20" value="set_variable route7sordello:yes"/>
@@ -355,10 +339,10 @@
     <property name="act10" value="pathfind_to_player spyder_route7_statius"/>
     <property name="act11" value="translated_dialog spyder_route7_statius1"/>
     <property name="act12" value="unlock_controls"/>
-    <property name="act13" value="add_monster aardart,30,spyder_route7_statius,5,10"/>
-    <property name="act14" value="add_monster pairagrim,30,spyder_route7_statius,5,10"/>
-    <property name="act15" value="add_monster bolt,30,spyder_route7_statius,5,10"/>
-    <property name="act16" value="add_monster fribbit,30,spyder_route7_statius,5,10"/>
+    <property name="act13" value="add_monster aardart,10,spyder_route7_statius,5,10"/>
+    <property name="act14" value="add_monster pairagrim,10,spyder_route7_statius,5,10"/>
+    <property name="act15" value="add_monster bolt,10,spyder_route7_statius,5,10"/>
+    <property name="act16" value="add_monster fribbit,10,spyder_route7_statius,5,10"/>
     <property name="act17" value="start_battle player,spyder_route7_statius"/>
     <property name="act18" value="translated_dialog spyder_route7_statius2"/>
     <property name="act19" value="set_variable route7statius:yes"/>
@@ -379,10 +363,10 @@
     <property name="act10" value="pathfind_to_player spyder_route7_jacopo"/>
     <property name="act11" value="translated_dialog spyder_route7_jacopo1"/>
     <property name="act12" value="unlock_controls"/>
-    <property name="act13" value="add_monster shelagu,30,spyder_route7_jacopo,5,10"/>
-    <property name="act14" value="add_monster vivisource,30,spyder_route7_jacopo,5,10"/>
-    <property name="act15" value="add_monster statursus,30,spyder_route7_jacopo,5,10"/>
-    <property name="act16" value="add_monster statursus,35,spyder_route7_jacopo,5,10"/>
+    <property name="act13" value="add_monster shelagu,10,spyder_route7_jacopo,5,10"/>
+    <property name="act14" value="add_monster vivisource,10,spyder_route7_jacopo,5,10"/>
+    <property name="act15" value="add_monster statursus,10,spyder_route7_jacopo,5,10"/>
+    <property name="act16" value="add_monster statursus,15,spyder_route7_jacopo,5,10"/>
     <property name="act17" value="start_battle player,spyder_route7_jacopo"/>
     <property name="act18" value="translated_dialog spyder_route7_jacopo2"/>
     <property name="act19" value="set_variable route7jacopo:yes"/>
@@ -403,9 +387,9 @@
     <property name="act10" value="pathfind_to_player spyder_route7_pia"/>
     <property name="act11" value="translated_dialog spyder_route7_pia1"/>
     <property name="act12" value="unlock_controls"/>
-    <property name="act13" value="add_monster anoleaf,35,spyder_route7_pia,5,10"/>
-    <property name="act14" value="add_monster gectile,40,spyder_route7_pia,5,10"/>
-    <property name="act15" value="add_monster velocitile,45,spyder_route7_pia,5,10"/>
+    <property name="act13" value="add_monster anoleaf,15,spyder_route7_pia,5,10"/>
+    <property name="act14" value="add_monster gectile,20,spyder_route7_pia,5,10"/>
+    <property name="act15" value="add_monster velocitile,25,spyder_route7_pia,5,10"/>
     <property name="act16" value="start_battle player,spyder_route7_pia"/>
     <property name="act17" value="translated_dialog spyder_route7_pia2"/>
     <property name="act18" value="set_variable route7pia:yes"/>
@@ -425,9 +409,9 @@
     <property name="act10" value="pathfind_to_player spyder_route7_penitent"/>
     <property name="act11" value="translated_dialog spyder_route7_penitent1"/>
     <property name="act12" value="unlock_controls"/>
-    <property name="act13" value="add_monster rhinocarpe,40,spyder_route7_penitent,5,10"/>
-    <property name="act14" value="add_monster bursa,30,spyder_route7_penitent,5,10"/>
-    <property name="act15" value="add_monster dandicub,30,spyder_route7_penitent,5,10"/>
+    <property name="act13" value="add_monster rhinocarpe,20,spyder_route7_penitent,5,10"/>
+    <property name="act14" value="add_monster bursa,10,spyder_route7_penitent,5,10"/>
+    <property name="act15" value="add_monster dandicub,10,spyder_route7_penitent,5,10"/>
     <property name="act16" value="start_battle player,spyder_route7_penitent"/>
     <property name="act17" value="translated_dialog spyder_route7_penitent2"/>
     <property name="act18" value="set_variable route7penitent:yes"/>
@@ -447,8 +431,8 @@
     <property name="act10" value="pathfind_to_player spyder_route7_hugh"/>
     <property name="act11" value="translated_dialog spyder_route7_hugh1"/>
     <property name="act12" value="unlock_controls"/>
-    <property name="act13" value="add_monster qetzlrokilus,40,spyder_route7_hugh,5,10"/>
-    <property name="act14" value="add_monster velocitile,40,spyder_route7_hugh,5,10"/>
+    <property name="act13" value="add_monster qetzlrokilus,20,spyder_route7_hugh,5,10"/>
+    <property name="act14" value="add_monster velocitile,20,spyder_route7_hugh,5,10"/>
     <property name="act15" value="start_battle player,spyder_route7_hugh"/>
     <property name="act16" value="translated_dialog spyder_route7_hugh2"/>
     <property name="act17" value="set_variable route7hugh:yes"/>
@@ -468,9 +452,9 @@
     <property name="act10" value="pathfind_to_player spyder_route7_manfred"/>
     <property name="act11" value="translated_dialog spyder_route7_manfred1"/>
     <property name="act12" value="unlock_controls"/>
-    <property name="act13" value="add_monster chenipode,30,spyder_route7_manfred,5,10"/>
-    <property name="act14" value="add_monster chenipode,30,spyder_route7_manfred,5,10"/>
-    <property name="act15" value="add_monster exapode,40,spyder_route7_manfred,5,10"/>
+    <property name="act13" value="add_monster chenipode,10,spyder_route7_manfred,5,10"/>
+    <property name="act14" value="add_monster chenipode,10,spyder_route7_manfred,5,10"/>
+    <property name="act15" value="add_monster exapode,20,spyder_route7_manfred,5,10"/>
     <property name="act16" value="start_battle player,spyder_route7_manfred"/>
     <property name="act17" value="translated_dialog spyder_route7_manfred2"/>
     <property name="act18" value="set_variable route7manfred:yes"/>
@@ -491,9 +475,9 @@
     <property name="act10" value="pathfind_to_player spyder_route7_conrad"/>
     <property name="act11" value="translated_dialog spyder_route7_conrad1"/>
     <property name="act12" value="unlock_controls"/>
-    <property name="act13" value="add_monster tux,40,spyder_route7_conrad,5,10"/>
-    <property name="act14" value="add_monster snowrilla,40,spyder_route7_conrad,5,10"/>
-    <property name="act15" value="add_monster chillimp,30,spyder_route7_conrad,5,10"/>
+    <property name="act13" value="add_monster tux,20,spyder_route7_conrad,5,10"/>
+    <property name="act14" value="add_monster snowrilla,20,spyder_route7_conrad,5,10"/>
+    <property name="act15" value="add_monster chillimp,10,spyder_route7_conrad,5,10"/>
     <property name="act16" value="start_battle player,spyder_route7_conrad"/>
     <property name="act17" value="translated_dialog spyder_route7_conrad2"/>
     <property name="act18" value="set_variable route7conrad:yes"/>

--- a/mods/tuxemon/maps/spyder_routea.tmx
+++ b/mods/tuxemon/maps/spyder_routea.tmx
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="130">
+<map version="1.10" tiledversion="1.11.1-99-gec89c545" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="20" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="130">
  <properties>
   <property name="edges" value="clamped"/>
+  <property name="map_type" value="route"/>
   <property name="north" value="route7"/>
   <property name="scenario" value="spyder"/>
   <property name="slug" value="routea"/>
   <property name="south" value="flower_city"/>
-  <property name="map_type" value="route"/>
  </properties>
  <tileset firstgid="1" source="../gfx/tilesets/core_city_and_country.tsx"/>
  <tileset firstgid="1441" source="../gfx/tilesets/core_outdoor.tsx"/>
@@ -17,12 +17,12 @@
  </layer>
  <layer id="2" name="Layer 2" width="20" height="40">
   <data encoding="base64" compression="zlib">
-   eAHdVrtOW0EQvSCEkE0f0vMDIHrskk+IcR8QHxEFJVACogHyD6FCQOckbRIFRUrSBVr4BhDnyHvsw2QvXitUjHTuzt2ZObszO/exMFkNZMH0weSYyqJxuJ6j2YLvNtAAmgGzuKd0MG4m/VUa+5Z/rx9hPwZy6y5Z7AuEtoC5AryEzyi+Zfi0CtFOfG8aVeXw/T1XPvaXcn6KfMmR43uNGq8VYj2dB4bK9+T6Dmy7hdiDn/rFOVw/hc9ZQGuqqtpAnD8v4PsLn8uANXCtA3H+Cn56jnxPrvOc9GzOTFRVDrJrBG22fifNfj30bNIvJ7L/xtp/AIrvifoGuCisr6/bn314lf0xPkWQT+trLo6yl/J9Rt2+AKNEvPSL+SqW+zsC14cCPsX8D9/8rLMM9ZL9vcVeVwvRhZ/EuZnvNXK9GTNfcuXeB+QrkR/BST1Ezrg/uf6EcgAcAvT/lcDvGuPEQb+63tH+5NuD7yeAvXGXwO8a+bxfRvHJrprkxgusIxH3Cs4/l2/k+4rAb4bvIkqj6sLbHJ/WC2G1tz1YWBdK5FNufevw6mfiZ0MP1Zt65PPcPC/W4NbOhefDs6GoPtQjH+ck3meK4f4l++n5k43zdXzKQfkrxvnEK9tjfDoT53uP/Fg79rTOlOu+A3LvavWzfMXFkfze0z1sxntdfZ7LV77kYd+KF2qtyCfHxyDZvY61ZOZfx6dY1dH7SM8K+6kzjfdkQhfjKD7xxnE3fRPjvPPxHzq+k/V/zTj+f0d7vPd3dVyL9/qniHrO1+fuAU8S2vE=
+   eAHdls1OVEEQhRtjDIHZo3teQOLemSWPwDh7Z8JDEBLRpRg2Ku8gK6PsRtkC0ZAgO2WLzwDhnEyfzKHSd25PYkJiJXW7bnf1113VdX9Suj95/SClN9Al6HLQDu7nlU+YcwBdK8x9Zn0rAD+u1Cfwa+M9h0+3UnuZt7WUkqvv73/lPcUZKOZ/ES8ZJd5L5HhYqaN8HmiS78nttxjbrdR38FO9OMPtL/D5GrT7MKUeNPYfVvB+w+dP0CFYI2jsv4TfRn4WfE9u85z0bC4upFRSjasFtpi/z8uTfOjZpF9JNP4La1807G8TLArz6+tOeu9eNT6LpxnkaX31xVbjtbzvyNsRtE3EpZ+fgdvc30ew9it4vp4z3G7jrXacMrWd4bbztrHXF5U6gJ8k8q4Q69854yWr9D7g/mrkR3BSDZEZ9yfXMxjvoR+g9D/Pyu8a54lBv6ba0f7kO4bvNyhr4yYrv2vkeb208TSunJTan1hHIvY6zr8Ub+QdY+KJ6alAuVVeeFviab0wrfF2jBHmhRJ5im0yOr36mfjZ0EP5ph15HpvHxRxc27nwfHg2FOWHduSxT+J1pjncv2QvP38aY38TTzEofs1xnrgam8XTmThvB/Exd6xpnSnXfQUtvatVz/IViy35XtNjbMZrXXVeile+5LBuxYXZKPIp8ThJ457HRpj5N/E0V3n0OtKzwnrqP8J7MusAbRtP3Nju5m9i7HdeHzmP72T/v+b/dxyP9/6ujmvxXv8U0S75et8tAGLYwA==
   </data>
  </layer>
  <layer id="3" name="Layer 3" width="20" height="40">
   <data encoding="base64" compression="zlib">
-   eAFjYKAtEAcaL4GGJSmw0h6o1wENO5Jh3kFWiKZ0IJWBhjPJMA+mpR/ImICGJ8IkyaC3A/XsQMM7gfxdZJgF0nIfiB+g4YdA/iMgJgewMzIwcAAxJzA8uYAYzAbyuYCYEmAINMsIGkeUmDNU9DqwMDA4AjG1QAbQrEwKzQPFLQiEAuMhDIjDgThiBMUJxPej5GgIjIbAaAiMhsBoCIyGALVDAAClCBdk
+   eAHtkcENgkAQRYdEo9KAWAY2IBQB2AFQDVCNSjOolfCQ2xwZPDE/eZudw/+b/SPyX52JjxQXw5M3vIkiNeSVeCtFbchr8LaKzpD3wPtUvJj7hZkDvrfiw/yFJToEIkc47UVC+N2ZQ7AoJusKW1GyE0lhLVVk1ca8abeTMvaQQwH3De1k/r2f3oA34A14A96AN7B2AyO5Vhae
   </data>
  </layer>
  <layer id="4" name="Above Player" width="20" height="40">
@@ -436,22 +436,6 @@
     <property name="cond2" value="not variable_set vincesecond:yes"/>
    </properties>
   </object>
-  <object id="97" name="Teleport Route7" type="event" x="16" y="0" width="16" height="16">
-   <properties>
-    <property name="act1" value="transition_teleport spyder_route7.tmx,1,39,0.3"/>
-    <property name="act2" value="char_face player,up"/>
-    <property name="cond1" value="is char_at player"/>
-    <property name="cond2" value="is char_facing player,up"/>
-   </properties>
-  </object>
-  <object id="98" name="Teleport Route7" type="event" x="32" y="0" width="16" height="16">
-   <properties>
-    <property name="act1" value="transition_teleport spyder_route7.tmx,1,39,0.3"/>
-    <property name="act2" value="char_face player,up"/>
-    <property name="cond1" value="is char_at player"/>
-    <property name="cond2" value="is char_facing player,up"/>
-   </properties>
-  </object>
   <object id="109" name="Teleport to Top" type="event" x="80" y="96" width="16" height="16">
    <properties>
     <property name="act1" value="transition_teleport spyder_mansion_top.tmx,7,18,0.3"/>
@@ -466,18 +450,6 @@
     <property name="act2" value="char_face player,up"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,up"/>
-   </properties>
-  </object>
-  <object id="111" name="Create Guard" type="event" x="32" y="32" width="16" height="16">
-   <properties>
-    <property name="act1" value="create_npc spyder_routea_little,2,2"/>
-    <property name="cond1" value="not char_exists spyder_routea_little"/>
-   </properties>
-  </object>
-  <object id="112" name="Talk Guard" type="event" x="0" y="48" width="16" height="16">
-   <properties>
-    <property name="act1" value="translated_dialog spyder_routea_little1"/>
-    <property name="behav1" value="talk spyder_routea_little"/>
    </properties>
   </object>
   <object id="113" name="Create Super Potion" type="event" x="160" y="96" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_timber_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_timber_scoop.tmx
@@ -52,10 +52,10 @@
   </object>
   <object id="20" name="Create Shopkeeper" type="event" x="16" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc spyder_timberscoop_leandro,1,6"/>
-    <property name="act2" value="char_face spyder_timberscoop_leandro,right"/>
-    <property name="act3" value="set_economy spyder_timberscoop_leandro,spyder_timber_scoop"/>
-    <property name="cond1" value="not char_exists spyder_timberscoop_leandro"/>
+    <property name="act1" value="create_npc spyder_shopassistant,1,6"/>
+    <property name="act2" value="char_face spyder_shopassistant,right"/>
+    <property name="act3" value="set_economy spyder_shopassistant,spyder_timber_scoop"/>
+    <property name="cond1" value="not char_exists spyder_shopassistant"/>
    </properties>
   </object>
   <object id="28" name="Route Music" type="event" x="0" y="0" width="16" height="16">
@@ -66,18 +66,18 @@
   </object>
   <object id="29" name="Open Shop" type="event" x="32" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="char_face spyder_timberscoop_leandro,right"/>
+    <property name="act1" value="char_face spyder_shopassistant,right"/>
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
-    <property name="act3" value="open_shop spyder_timberscoop_leandro"/>
+    <property name="act3" value="open_shop spyder_shopassistant"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>
   </object>
   <object id="30" name="Open Shop" type="event" x="16" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="char_face spyder_timberscoop_leandro,down"/>
+    <property name="act1" value="char_face spyder_shopassistant,down"/>
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
-    <property name="act3" value="open_shop spyder_timberscoop_leandro"/>
+    <property name="act3" value="open_shop spyder_shopassistant"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>

--- a/mods/tuxemon/maps/taba_town.tmx
+++ b/mods/tuxemon/maps/taba_town.tmx
@@ -711,6 +711,8 @@
     <property name="act3" value="create_npc rock,38,38,stand"/>
     <property name="cond1" value="is variable_set go_get_tuxemon:yes"/>
     <property name="cond2" value="not variable_set havetuxemon:yes"/>
+    <property name="cond3" value="not char_exists postboy"/>
+    <property name="cond4" value="not char_exists rock"/>
    </properties>
   </object>
   <object id="148" name="myrock" type="event" x="592" y="624" width="16" height="16">
@@ -779,7 +781,6 @@
     <property name="act1" value="remove_npc postboy"/>
     <property name="act2" value="remove_npc rock"/>
     <property name="cond1" value="is variable_set havetuxemon:yes"/>
-    <property name="cond2" value="is char_exists postboy"/>
    </properties>
   </object>
   <object id="157" name="propeller cat" type="event" x="64" y="64" width="16" height="64">

--- a/tuxemon/camera.py
+++ b/tuxemon/camera.py
@@ -54,9 +54,10 @@ class CameraManager:
         Parameters:
             camera: The camera instance to be added.
         """
-        self.cameras.append(camera)
-        if self.active_camera is None:
-            self.set_active_camera(camera)
+        if camera not in self.cameras:
+            self.cameras.append(camera)
+            if self.active_camera is None:
+                self.set_active_camera(camera)
 
     def set_active_camera(self, camera: Camera) -> None:
         """
@@ -310,15 +311,13 @@ class Camera:
         Applies the shake effect to the camera's position if the shake duration is active.
         """
         if self.shake_duration > 0:
-            original_position = Vector2(self.position.x, self.position.y)
-            self.position.x += random.uniform(
+            jitter_x = random.uniform(
                 -self.shake_intensity, self.shake_intensity
             )
-            self.position.y += random.uniform(
+            jitter_y = random.uniform(
                 -self.shake_intensity, self.shake_intensity
             )
-
+            self.position += Vector2(jitter_x, jitter_y)
             self.shake_duration -= 1 / self.FRAME_RATE
-            if self.shake_duration <= 0:
-                self.shake_duration = 0
-                self.position = original_position
+        else:
+            self.shake_duration = 0.0

--- a/tuxemon/event/actions/modify_bill.py
+++ b/tuxemon/event/actions/modify_bill.py
@@ -32,7 +32,6 @@ class ModifyBillAction(EventAction):
 
     eg. "modify_bill player,bill_slug,-50"
     eg. "modify_bill player,bill_slug,,name_variable"
-
     """
 
     name = "modify_bill"
@@ -69,10 +68,6 @@ class ModifyBillAction(EventAction):
         if not T.has_translation("en_US", self.bill_slug):
             logger.error(f"Please add {self.bill_slug} to the en_US base.po")
 
-        bill_amount = money_manager.get_bill(self.bill_slug).amount
-        if bill_amount <= 0:
-            logger.error(f"Bill '{self.bill_slug}' doesn't exist")
-            return
         if amount >= 0:
             money_manager.add_bill(self.bill_slug, amount)
         else:

--- a/tuxemon/event/actions/set_bill.py
+++ b/tuxemon/event/actions/set_bill.py
@@ -22,7 +22,7 @@ class SetBillAction(EventAction):
     Script usage:
         .. code-block::
 
-            set_money <slug>,<bill_slug>,[amount]
+            set_bill <slug>,<bill_slug>,[amount]
 
     Script parameters:
         character: Either "player" or character slug name (e.g. "npc_maple").

--- a/tuxemon/graphics.py
+++ b/tuxemon/graphics.py
@@ -295,29 +295,6 @@ def create_animation(
     return animation
 
 
-def scale_tile(
-    surface: pygame.surface.Surface,
-    tile_size: int,
-) -> pygame.surface.Surface:
-    """
-    Scales a map tile based on resolution.
-
-    Parameters:
-        surface: Surface to rescale.
-        tile_size: Desired size.
-
-    Returns:
-        The rescaled surface.
-
-    """
-    if type(surface) is pygame.Surface:
-        surface = pygame.transform.scale(surface, tile_size)
-    else:
-        surface.scale(tile_size)
-
-    return surface
-
-
 def scale_sprite(
     sprite: Sprite,
     ratio: float,

--- a/tuxemon/networking.py
+++ b/tuxemon/networking.py
@@ -16,7 +16,7 @@ from tuxemon.middleware import Controller, Multiplayer
 from tuxemon.npc import NPC
 from tuxemon.platform.const import buttons
 from tuxemon.session import local_session
-from tuxemon.states import world
+from tuxemon.states.world import worldstate as world
 
 logger = logging.getLogger(__name__)
 pp = pprint.PrettyPrinter(indent=4)

--- a/tuxemon/prepare.py
+++ b/tuxemon/prepare.py
@@ -462,20 +462,20 @@ def fetch(*args: str) -> str:
     for mod_name in CONFIG.mods:
         # when assets are in folder with the source
         path = os.path.join(paths.mods_folder, mod_name, relative_path)
-        logger.debug("searching asset: %s", path)
+        logger.debug(f"searching asset: {path}")
         if os.path.exists(path):
             return path
 
         # when assets are in a system path (like for os packages and android)
         for root_path in paths.system_installed_folders:
             path = os.path.join(root_path, "mods", mod_name, relative_path)
-            logger.debug("searching asset: %s", path)
+            logger.debug(f"searching asset: {path}")
             if os.path.exists(path):
                 return path
 
         # mods folder is in same folder as the launch script
         path = os.path.join(paths.BASEDIR, "mods", mod_name, relative_path)
-        logger.debug("searching asset: %s", path)
+        logger.debug(f"searching asset: {path}")
         if os.path.exists(path):
             return path
 

--- a/tuxemon/save.py
+++ b/tuxemon/save.py
@@ -179,7 +179,7 @@ def open_save_file(save_path: str) -> Optional[dict[str, Any]]:
                 package = json_load(save_path)
                 return package
         except ValueError as e:
-            logger.error("Cannot decode save: %s", save_path)
+            logger.error(f"Cannot decode save: {save_path}")
             return None
     except OSError as e:
         logger.info(e)
@@ -202,7 +202,7 @@ def save(save_data: SaveData, slot: int) -> None:
         "separators": (",", ": "),
     }
 
-    logger.info("Saving data to save file: %s", save_path)
+    logger.info(f"Saving data to save file: {save_path}")
     if config.compress_save is None and prepare.SAVE_METHOD == "CBOR":
         cbor.dump(save_data, save_path_tmp)
     else:

--- a/tuxemon/state.py
+++ b/tuxemon/state.py
@@ -491,7 +491,7 @@ class StateManager:
 
         """
         if state in self._resume_set:
-            logger.debug("removing %s from resume set", state.name)
+            logger.debug(f"removing {state.name} from resume set")
             self._resume_set.remove(state)
             state.resume()
 
@@ -520,7 +520,7 @@ class StateManager:
                 new state.
 
         """
-        logger.debug("queue state: %s", state_name)
+        logger.debug(f"queue state: {state_name}")
         self._state_queue.append((state_name, kwargs))
 
     def pop_state(self, state: Optional[State] = None) -> None:
@@ -540,7 +540,7 @@ class StateManager:
         if self._state_queue:
             state_name, kwargs = self._state_queue.pop(0)
             self.replace_state(state_name, **kwargs)
-            logger.debug("pop state, using queue instead: %s", state_name)
+            logger.debug(f"pop state, using queue instead: {state_name}")
             return
 
         # raise error if stack is empty
@@ -559,7 +559,7 @@ class StateManager:
             )
 
         if index == 0:
-            logger.debug("pop state: %s", state.name)
+            logger.debug(f"pop state: {state.name}")
             self._state_stack.pop(0)
             self._check_resume(state)
             state.pause()
@@ -569,7 +569,7 @@ class StateManager:
             if self.is_hook_registered("on_state_change"):
                 self.trigger_global_hook("on_state_change")
         else:
-            logger.debug("pop-remove state: %s", state.name)
+            logger.debug(f"pop-remove state: {state.name}")
             self._state_stack.remove(state)
 
     def remove_state(self, state: State) -> None:
@@ -589,10 +589,10 @@ class StateManager:
             raise RuntimeError
 
         if index == 0:
-            logger.debug("remove-pop state: %s", state.name)
+            logger.debug(f"remove-pop state: {state.name}")
             self.pop_state()
         else:
-            logger.debug("remove state: %s", state.name)
+            logger.debug(f"remove state: {state.name}")
             self._state_stack.remove(state)
             state.shutdown()
 
@@ -653,7 +653,7 @@ class StateManager:
             Instanced state.
 
         """
-        logger.debug("push state: %s", state_name)
+        logger.debug(f"push state: {state_name}")
         previous = self.current_state
         if previous is not None:
             self._check_resume(previous)
@@ -713,7 +713,7 @@ class StateManager:
             Instanced state.
 
         """
-        logger.debug("replace state: %s", state_name)
+        logger.debug(f"replace state: {state_name}")
         # raise error if stack is empty
         if not self._state_stack:
             raise RuntimeError(


### PR DESCRIPTION
PR fixes small things: 
- gets rid of a unused function
- removes a unnecessary space
- removes a unnecessary line in modify_bill
- beautified some files JSON
- corrects a naming mistake
- centralized spyder shop assistant and spyder shopkeeper without having 5 different NPC with the identical template
- removes the access to Route 7 from Side Route A and viceversa (it'll be accessed somewhere else)
- fixes some warning in Xero (see below)

Taba Town warning:
```
[2025-04-03 15:21:29,081] tuxemon.event.actions.create_npc - ERROR - 'postboy' already exists on the map. Skipping creation.
[2025-04-03 15:21:29,082] tuxemon.event.actions.create_npc - ERROR - 'rock' already exists on the map. Skipping creation.
```
Route1 warning:
```
[2025-04-03 15:45:46,148] tuxemon.event.actions.create_npc - ERROR - 'omnigrunt' already exists on the map. Skipping creation.
[2025-04-03 15:45:46,148] tuxemon.event.actions.create_npc - ERROR - 'omnigrunt2' already exists on the map. Skipping creation.
[2025-04-03 15:45:46,149] tuxemon.event.actions.create_npc - ERROR - 'omnigrunt3' already exists on the map. Skipping creation.
[2025-04-03 15:45:46,149] tuxemon.event.actions.create_npc - ERROR - 'omnigrunt4' already exists on the map. Skipping creation.
[2025-04-03 15:45:46,150] tuxemon.event.actions.create_npc - ERROR - 'liela' already exists on the map. Skipping creation.
[2025-04-03 15:45:46,150] tuxemon.event.actions.create_npc - ERROR - 'bob' already exists on the map. Skipping creation.
[2025-04-03 15:45:46,151] tuxemon.event.actions.create_npc - ERROR - 'marissa' already exists on the map. Skipping creation.
```
