### PR TITLE
Refactor Screen Transition into WorldTransition Class

### DIFF
--- a/docs/handcrafted/action_list.rst
+++ b/docs/handcrafted/action_list.rst
@@ -35,6 +35,8 @@
 .. autoscriptinfoclass:: tuxemon.event.actions.delayed_teleport.DelayedTeleportAction
 .. autoscriptinfoclass:: tuxemon.event.actions.dojo_method.DojoMethodAction
 .. autoscriptinfoclass:: tuxemon.event.actions.evolution.EvolutionAction
+.. autoscriptinfoclass:: tuxemon.event.actions.fade_in.FadeInAction
+.. autoscriptinfoclass:: tuxemon.event.actions.fade_out.FadeOutAction
 .. autoscriptinfoclass:: tuxemon.event.actions.fadeout_music.FadeoutMusicAction
 .. autoscriptinfoclass:: tuxemon.event.actions.format_variable.FormatVariableAction
 .. autoscriptinfoclass:: tuxemon.event.actions.get_monster_tech.GetMonsterTechAction

--- a/tests/tuxemon/test_world_transition.py
+++ b/tests/tuxemon/test_world_transition.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from tuxemon.states.world.world_transition import WorldTransition
+
+
+class TestTransition(TestCase):
+    def setUp(self):
+        self.mock_world = MagicMock()
+        self.mock_world.client.screen.get_size.return_value = (800, 600)
+        self.mock_world.player = MagicMock()
+
+        self.transition = WorldTransition(self.mock_world)
+
+    def test_transition_initialization(self):
+        self.assertIsNone(self.transition.transition_surface)
+        self.assertEqual(self.transition.transition_alpha, 0)
+        self.assertFalse(self.transition.in_transition)
+
+    def test_set_transition_surface_size(self):
+        color = (0, 0, 0, 255)
+        self.transition.set_transition_surface(color)
+
+        self.assertEqual(
+            self.transition.transition_surface.get_size(), (800, 600)
+        )
+
+    def test_draw_no_action(self):
+        mock_surface = MagicMock()
+
+        self.transition.set_transition_state(False)
+        self.transition.draw(mock_surface)
+
+        mock_surface.blit.assert_not_called()
+
+    def test_transition_state_changes(self):
+        self.transition.set_transition_state(True)
+        self.assertTrue(self.transition.in_transition)
+
+        self.transition.set_transition_state(False)
+        self.assertFalse(self.transition.in_transition)
+
+    def test_set_transition_surface(self):
+        mock_color = (255, 0, 0)
+        self.transition.set_transition_surface(mock_color)
+
+        self.assertIsNotNone(self.transition.transition_surface)
+        self.assertEqual(
+            self.transition.transition_surface.get_size(), (800, 600)
+        )
+        self.assertEqual(
+            self.transition.transition_surface.get_at((0, 0)), mock_color
+        )
+
+    def test_set_transition_state(self):
+        self.transition.set_transition_state(True)
+        self.assertTrue(self.transition.in_transition)
+
+        self.transition.set_transition_state(False)
+        self.assertFalse(self.transition.in_transition)
+
+    @patch("pygame.Surface")
+    def test_draw_with_transition(self, MockSurface):
+        mock_surface = MagicMock()
+        self.transition.set_transition_surface((0, 0, 0, 255))
+        self.transition.set_transition_state(True)
+
+        self.transition.transition_alpha = 100
+        self.transition.draw(mock_surface)
+
+        self.transition.transition_surface.set_alpha.assert_called_with(100)
+        mock_surface.blit.assert_called_with(
+            self.transition.transition_surface, (0, 0)
+        )
+
+    @patch("pygame.Surface")
+    def test_alpha_change_during_fade(self, MockSurface):
+        color = (0, 0, 0, 255)
+        self.transition.fade_out(1.0, color)
+
+        self.mock_world.animate.assert_called_with(
+            self.transition,
+            transition_alpha=255,
+            initial=0,
+            duration=1.0,
+            round_values=True,
+        )
+
+    @patch("pygame.Surface")
+    def test_fade_out(self, MockSurface):
+        mock_color = (0, 0, 0, 255)
+        self.transition.fade_out(1.0, mock_color)
+
+        self.mock_world.animate.assert_called_with(
+            self.transition,
+            transition_alpha=255,
+            initial=0,
+            duration=1.0,
+            round_values=True,
+        )
+        self.mock_world.stop_char.assert_called_with(self.mock_world.player)
+        self.mock_world.lock_controls.assert_called_with(
+            self.mock_world.player
+        )
+        self.assertTrue(self.transition.in_transition)
+
+    @patch("pygame.Surface")
+    def test_fade_in(self, MockSurface):
+        mock_color = (0, 0, 0, 255)
+        self.transition.fade_in(1.0, mock_color)
+
+        self.mock_world.animate.assert_called_with(
+            self.transition,
+            transition_alpha=0,
+            initial=255,
+            duration=1.0,
+            round_values=True,
+        )
+        self.mock_world.task.assert_called()
+        self.assertFalse(self.transition.in_transition)
+
+    @patch("pygame.Surface")
+    def test_fade_and_teleport(self, MockSurface):
+        mock_color = (0, 0, 0, 255)
+        mock_teleport = MagicMock()
+        self.transition.fade_and_teleport(1.0, mock_color, mock_teleport)
+
+        self.mock_world.animate.assert_called_with(
+            self.transition,
+            transition_alpha=255,
+            initial=0,
+            duration=1.0,
+            round_values=True,
+        )
+        self.mock_world.task.assert_called_with(mock_teleport, 1.0)
+
+        chained_task = self.mock_world.task.return_value.chain
+        chained_task.assert_called()
+
+    @patch("pygame.Surface")
+    def test_draw(self, MockSurface):
+        mock_surface = MagicMock()
+        self.transition.set_transition_surface((0, 0, 0, 255))
+        self.transition.set_transition_state(True)
+        self.transition.transition_alpha = 128
+
+        self.transition.draw(mock_surface)
+
+        self.transition.transition_surface.set_alpha.assert_called_with(128)
+        mock_surface.blit.assert_called_with(
+            self.transition.transition_surface, (0, 0)
+        )
+
+    def test_no_draw_when_not_in_transition(self):
+        mock_surface = MagicMock()
+        self.transition.set_transition_state(False)
+
+        self.transition.draw(mock_surface)
+
+        mock_surface.blit.assert_not_called()

--- a/tuxemon/event/actions/char_face.py
+++ b/tuxemon/event/actions/char_face.py
@@ -57,7 +57,7 @@ class CharFaceAction(EventAction):
         # we've reached the apex of the transition.
         if character.isplayer:
             world_state = self.session.client.get_state_by_name(WorldState)
-            if world_state.in_transition:
+            if world_state.transition_manager.in_transition:
                 world_state.teleporter.delayed_facing = direction
             else:
                 character.facing = direction

--- a/tuxemon/event/actions/fade_in.py
+++ b/tuxemon/event/actions/fade_in.py
@@ -13,24 +13,24 @@ from tuxemon.states.world.worldstate import WorldState
 
 @final
 @dataclass
-class ScreenTransitionAction(EventAction):
+class FadeInAction(EventAction):
     """
-    Initiate a screen transition.
+    Fade in.
 
     Script usage:
         .. code-block::
 
-            screen_transition [trans_time][,rgb]
+            fade_in [trans_time][,rgb]
 
     Script parameters:
         trans_time: Transition time in seconds - default 0.3
         rgb: color (eg red > 255,0,0 > 255:0:0) - default rgb(0,0,0)
 
-    eg: "screen_transition 3"
-    eg: "screen_transition 3,255:0:0:50" (red)
+    eg: "fade_in 3"
+    eg: "fade_in 3,255:0:0:50" (red)
     """
 
-    name = "screen_transition"
+    name = "fade_in"
     trans_time: Optional[float] = None
     rgb: Optional[str] = None
 
@@ -43,10 +43,5 @@ class ScreenTransitionAction(EventAction):
         rgb: ColorLike = BLACK_COLOR
         if self.rgb:
             rgb = string_to_colorlike(self.rgb)
-
-        def fade_in() -> None:
-            world.transition_manager.fade_in(_time, rgb)
-
-        world.transition_manager.fade_out(_time, rgb)
-        world.task(fade_in, _time)
+        world.transition_manager.fade_in(_time, rgb)
         self.stop()

--- a/tuxemon/event/actions/fade_out.py
+++ b/tuxemon/event/actions/fade_out.py
@@ -13,24 +13,24 @@ from tuxemon.states.world.worldstate import WorldState
 
 @final
 @dataclass
-class ScreenTransitionAction(EventAction):
+class FadeOutAction(EventAction):
     """
-    Initiate a screen transition.
+    Fade out.
 
     Script usage:
         .. code-block::
 
-            screen_transition [trans_time][,rgb]
+            fade_out [trans_time][,rgb]
 
     Script parameters:
         trans_time: Transition time in seconds - default 0.3
         rgb: color (eg red > 255,0,0 > 255:0:0) - default rgb(0,0,0)
 
-    eg: "screen_transition 3"
-    eg: "screen_transition 3,255:0:0:50" (red)
+    eg: "fade_out 3"
+    eg: "fade_out 3,255:0:0:50" (red)
     """
 
-    name = "screen_transition"
+    name = "fade_out"
     trans_time: Optional[float] = None
     rgb: Optional[str] = None
 
@@ -43,10 +43,5 @@ class ScreenTransitionAction(EventAction):
         rgb: ColorLike = BLACK_COLOR
         if self.rgb:
             rgb = string_to_colorlike(self.rgb)
-
-        def fade_in() -> None:
-            world.transition_manager.fade_in(_time, rgb)
-
         world.transition_manager.fade_out(_time, rgb)
-        world.task(fade_in, _time)
         self.stop()

--- a/tuxemon/event/actions/teleport.py
+++ b/tuxemon/event/actions/teleport.py
@@ -49,7 +49,7 @@ class TeleportAction(EventAction):
 
         # Check to see if we're also performing a transition. If we are, wait
         # to perform the teleport at the apex of the transition
-        if world.in_transition:
+        if world.transition_manager.in_transition:
             if not world.teleporter.delayed_teleport:
                 world.teleporter.delayed_char = char
                 world.teleporter.delayed_teleport = True

--- a/tuxemon/states/world/world_transition.py
+++ b/tuxemon/states/world/world_transition.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Optional
+
+import pygame
+
+from tuxemon.graphics import ColorLike
+
+if TYPE_CHECKING:
+    from tuxemon.states.world.worldstate import WorldState
+
+
+class WorldTransition:
+    def __init__(self, world: WorldState) -> None:
+        self.world = world
+        self.transition_alpha = 0
+        self.transition_surface: Optional[pygame.surface.Surface] = None
+        self.in_transition = False
+
+    def set_transition_surface(self, color: ColorLike) -> None:
+        self.transition_surface = pygame.Surface(
+            self.world.client.screen.get_size(), pygame.SRCALPHA
+        )
+        self.transition_surface.fill(color)
+
+    def set_transition_state(self, in_transition: bool) -> None:
+        """Update the transition state."""
+        self.in_transition = in_transition
+
+    def fade_out(self, duration: float, color: ColorLike) -> None:
+        self.set_transition_surface(color)
+        self.world.animate(
+            self,
+            transition_alpha=255,
+            initial=0,
+            duration=duration,
+            round_values=True,
+        )
+        self.world.stop_char(self.world.player)
+        self.world.lock_controls(self.world.player)
+        self.set_transition_state(True)
+
+    def fade_in(self, duration: float, color: ColorLike) -> None:
+        self.set_transition_surface(color)
+        self.world.animate(
+            self,
+            transition_alpha=0,
+            initial=255,
+            duration=duration,
+            round_values=True,
+        )
+        self.world.task(
+            lambda: self.world.unlock_controls(self.world.player),
+            max(duration, 0),
+        )
+
+        def cleanup() -> None:
+            self.set_transition_state(False)
+
+        self.world.task(cleanup, duration)
+
+    def fade_and_teleport(
+        self,
+        duration: float,
+        color: ColorLike,
+        teleport_function: Callable[[], None],
+    ) -> None:
+        def fade_in() -> None:
+            self.fade_in(duration, color)
+
+        self.world.lock_controls(self.world.player)
+        self.world.remove_animations_of(self.world)
+        self.world.remove_animations_of(self.set_transition_state)
+        self.world.stop_and_reset_char(self.world.player)
+
+        self.fade_out(duration, color)
+        task = self.world.task(teleport_function, duration)
+        task.chain(fade_in, duration + 0.5)
+
+    def draw(self, surface: pygame.surface.Surface) -> None:
+        if self.in_transition:
+            assert self.transition_surface
+            self.transition_surface.set_alpha(self.transition_alpha)
+            surface.blit(self.transition_surface, (0, 0))

--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -8,7 +8,6 @@ import os
 import uuid
 from collections import defaultdict
 from collections.abc import Mapping, MutableMapping, Sequence
-from functools import partial
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -26,7 +25,6 @@ from tuxemon.boundary import BoundaryChecker
 from tuxemon.camera import Camera, CameraManager, project
 from tuxemon.db import Direction
 from tuxemon.entity import Entity
-from tuxemon.graphics import ColorLike
 from tuxemon.map import RegionProperties, TuxemonMap, dirs2, proj
 from tuxemon.map_loader import TMXMapLoader, YAMLEventLoader
 from tuxemon.map_view import MapRenderer
@@ -37,6 +35,7 @@ from tuxemon.platform.events import PlayerInput
 from tuxemon.platform.tools import translate_input_event
 from tuxemon.session import local_session
 from tuxemon.states.world.world_menus import WorldMenuState
+from tuxemon.states.world.world_transition import WorldTransition
 from tuxemon.teleporter import Teleporter
 
 if TYPE_CHECKING:
@@ -99,14 +98,7 @@ class WorldState(state.State):
 
         self.current_map: TuxemonMap
 
-        ######################################################################
-        #                            Transitions                             #
-        ######################################################################
-
-        # default variables for transition
-        self.transition_alpha = 0
-        self.transition_surface: Optional[pygame.surface.Surface] = None
-        self.in_transition = False
+        self.transition_manager = WorldTransition(self)
 
         if local_session.player is None:
             new_player = Player(prepare.PLAYER_NPC, world=self)
@@ -130,42 +122,6 @@ class WorldState(state.State):
         """Called before another state gets focus"""
         self.lock_controls(self.player)
         self.stop_char(self.player)
-
-    def set_transition_surface(self, color: ColorLike) -> None:
-        self.transition_surface = pygame.Surface(
-            self.client.screen.get_size(), pygame.SRCALPHA
-        )
-        self.transition_surface.fill(color)
-
-    def set_transition_state(self, in_transition: bool) -> None:
-        """Update the transition state."""
-        self.in_transition = in_transition
-
-    def fade_out(self, duration: float, color: ColorLike) -> None:
-        self.set_transition_surface(color)
-        self.animate(
-            self,
-            transition_alpha=255,
-            initial=0,
-            duration=duration,
-            round_values=True,
-        )
-        self.stop_char(self.player)
-        self.lock_controls(self.player)
-
-    def fade_in(self, duration: float, color: ColorLike) -> None:
-        self.set_transition_surface(color)
-        self.animate(
-            self,
-            transition_alpha=0,
-            initial=255,
-            duration=duration,
-            round_values=True,
-        )
-        self.task(
-            partial(self.unlock_controls, self.player),
-            max(duration, 0),
-        )
 
     def broadcast_player_teleport_change(self) -> None:
         """Tell clients/host that player has moved after teleport."""
@@ -213,7 +169,7 @@ class WorldState(state.State):
         """
         self.screen = surface
         self.map_renderer.draw(surface, self.current_map)
-        self.fullscreen_animations(surface)
+        self.transition_manager.draw(surface)
 
     def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
         """
@@ -727,22 +683,6 @@ class WorldState(state.State):
         pygame.draw.line(surface, (255, 50, 50), (0, cy), (w, cy))
 
         surface.unlock()
-
-    ####################################################
-    #         Full Screen Animations Functions         #
-    ####################################################
-    def fullscreen_animations(self, surface: pygame.surface.Surface) -> None:
-        """
-        Handles fullscreen animations such as transitions, cutscenes, etc.
-
-        Parameters:
-            surface: Surface to draw onto.
-
-        """
-        if self.in_transition:
-            assert self.transition_surface
-            self.transition_surface.set_alpha(self.transition_alpha)
-            surface.blit(self.transition_surface, (0, 0))
 
     ####################################################
     #             Map Change/Load Functions            #


### PR DESCRIPTION
PR introduces an improvement to the transition logic by encapsulating it into a new `WorldTransition` class and groups all transition-related logic (fade in, fade out, and fade-and-teleport) into a single cohesive unit. Specifically:
- moves the following transition-related methods from `WorldState` to the new `WorldTransition` class: `set_transition_surface`, `set_transition_state`, `fade_out`, `fade_in` and drawing of the transition surface (`fullscreen_animations` logic)
- updates `ScreenTransitionAction` to use the new `WorldTransition` class, simplifying its implementation to perform fade-in and fade-out without teleportation
- updates `TransitionTeleportAction` to fully remove the dependency on `ScreenTransitionAction` and integrates its teleport logic into `fade_and_teleport`
- adds two new event actions: `FadeInAction` for performing a fade-in transition independently and `FadeOutAction` for performing a fade-out transition independently