### PR TITLE
Refactor Monster Class to Extract Sprite Handling Logic

### DIFF
--- a/tests/tuxemon/test_monster.py
+++ b/tests/tuxemon/test_monster.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+
+import pygame
 
 from tuxemon import prepare
 from tuxemon.db import (
@@ -11,7 +13,7 @@ from tuxemon.db import (
     TechniqueModel,
     db,
 )
-from tuxemon.monster import Monster
+from tuxemon.monster import Monster, MonsterSpriteHandler
 from tuxemon.prepare import MAX_LEVEL
 from tuxemon.taste import Taste
 from tuxemon.technique.technique import Technique
@@ -243,3 +245,137 @@ class Learn(MonsterTestBase):
         self.assertEqual(move.accuracy, 0.85)
         self.assertEqual(move.power, 1.5)
         self.assertEqual(move.potency, 0.0)
+
+
+class TestMonsterSpriteHandler(unittest.TestCase):
+    def setUp(self):
+        self.slug = "rockitten"
+        self.front_path = "gfx/sprites/battle/front"
+        self.back_path = "gfx/sprites/battle/back"
+        self.menu1_path = "gfx/sprites/battle/menu1"
+        self.menu2_path = "gfx/sprites/battle/menu2"
+        self.flairs = {}
+
+        self.handler = MonsterSpriteHandler(
+            slug=self.slug,
+            front_path=self.front_path,
+            back_path=self.back_path,
+            menu1_path=self.menu1_path,
+            menu2_path=self.menu2_path,
+            flairs=self.flairs,
+        )
+
+    @patch(
+        "tuxemon.tools.transform_resource_filename",
+        return_value="transformed/gfx/sprites/battle/sprite.png",
+    )
+    def test_get_sprite_path_valid(self, mock_transform):
+        sprite_path = self.handler.get_sprite_path("test_sprite")
+        self.assertEqual(
+            sprite_path, "transformed/gfx/sprites/battle/sprite.png"
+        )
+        mock_transform.assert_called_once_with("test_sprite.png")
+
+    @patch("tuxemon.graphics.load_sprite")
+    def test_load_sprite(self, mock_load_sprite):
+        mock_surface = MagicMock()
+        mock_surface.image = pygame.Surface((100, 100))
+        mock_load_sprite.return_value = mock_surface
+
+        sprite = self.handler.load_sprite(
+            "valid/gfx/sprites/battle/sprite.png"
+        )
+        self.assertIn(
+            "valid/gfx/sprites/battle/sprite.png", self.handler.sprite_cache
+        )
+        self.assertEqual(sprite, mock_surface.image)
+        mock_load_sprite.assert_called_once_with(
+            "valid/gfx/sprites/battle/sprite.png"
+        )
+
+    @patch("tuxemon.graphics.load_animated_sprite")
+    @patch("tuxemon.tools.transform_resource_filename")
+    def test_load_animated_sprite(
+        self, mock_transform_resource_filename, mock_load_animated_sprite
+    ):
+        mock_transform_resource_filename.side_effect = lambda path: path
+
+        mock_sprite = MagicMock()
+        mock_load_animated_sprite.return_value = mock_sprite
+
+        animated_sprite = self.handler.load_animated_sprite(
+            ["gfx/sprites/battle/frame1", "gfx/sprites/battle/frame2"], 0.25
+        )
+
+        self.assertEqual(animated_sprite, mock_sprite)
+        mock_transform_resource_filename.assert_any_call(
+            "gfx/sprites/battle/frame1.png"
+        )
+        mock_transform_resource_filename.assert_any_call(
+            "gfx/sprites/battle/frame2.png"
+        )
+        mock_load_animated_sprite.assert_called_once_with(
+            ["gfx/sprites/battle/frame1.png", "gfx/sprites/battle/frame2.png"],
+            0.25,
+            prepare.SCALE,
+        )
+
+    @patch("tuxemon.graphics.load_sprite")
+    def test_get_sprite_with_flairs(self, mock_load_sprite):
+        base_surface = pygame.Surface((100, 100))
+        flair_surface = pygame.Surface((50, 50), pygame.SRCALPHA)
+
+        mock_base = MagicMock()
+        mock_base.image = base_surface
+        mock_flair = MagicMock()
+        mock_flair.image = flair_surface
+
+        mock_load_sprite.side_effect = [mock_base, mock_flair]
+
+        sprite = self.handler.get_sprite("front")
+        self.assertEqual(sprite.image.get_size(), (100, 100))
+        mock_load_sprite.assert_any_call(self.front_path)
+
+    @patch("tuxemon.graphics.load_and_scale")
+    def test_load_sprites(self, mock_load_and_scale):
+        mock_surface = pygame.Surface((100, 100))
+        mock_load_and_scale.return_value = mock_surface
+
+        sprites = self.handler.load_sprites()
+        self.assertIn("front", sprites)
+        self.assertIn("back", sprites)
+        self.assertIn("menu01", sprites)
+        self.assertIn("menu02", sprites)
+        mock_load_and_scale.assert_any_call(self.front_path, prepare.SCALE)
+        mock_load_and_scale.assert_any_call(self.back_path, prepare.SCALE)
+        mock_load_and_scale.assert_any_call(self.menu1_path, prepare.SCALE)
+        mock_load_and_scale.assert_any_call(self.menu2_path, prepare.SCALE)
+
+        self.assertEqual(len(sprites), 4)
+        self.assertIn("front", sprites)
+        self.assertIn("back", sprites)
+        self.assertIn("menu01", sprites)
+        self.assertIn("menu02", sprites)
+
+    @patch("tuxemon.graphics.load_sprite")
+    def test_sprite_cache_usage(self, mock_load_sprite):
+        mock_surface = MagicMock()
+        mock_surface.image = pygame.Surface((100, 100))
+        mock_load_sprite.return_value = mock_surface
+
+        sprite1 = self.handler.load_sprite(self.front_path)
+        sprite2 = self.handler.load_sprite(self.front_path)
+
+        self.assertIs(sprite1, sprite2)
+        mock_load_sprite.assert_called_once_with(self.front_path)
+
+    @patch("tuxemon.graphics.load_sprite")
+    def test_empty_flairs(self, mock_load_sprite):
+        mock_surface = MagicMock()
+        mock_surface.image = pygame.Surface((100, 100))
+        mock_load_sprite.return_value = mock_surface
+
+        self.handler.flairs = {}
+        sprite = self.handler.get_sprite("front")
+        self.assertIsNotNone(sprite.image)
+        self.assertEqual(sprite.image.get_size(), (100, 100))

--- a/tuxemon/event/actions/translated_dialog.py
+++ b/tuxemon/event/actions/translated_dialog.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Any, Optional, Union, final
+from typing import Any, Optional, final
 
 from tuxemon.db import DialogueModel, db
 from tuxemon.event.eventaction import EventAction
@@ -45,7 +45,7 @@ class TranslatedDialogAction(EventAction):
 
     name = "translated_dialog"
     raw_parameters: str
-    avatar: Union[int, str, None] = None
+    avatar: Optional[str] = None
     position: Optional[str] = None
     style: Optional[str] = None
 

--- a/tuxemon/graphics.py
+++ b/tuxemon/graphics.py
@@ -184,6 +184,7 @@ def load_sprite(
 def load_animated_sprite(
     filenames: Iterable[str],
     delay: float,
+    scale: float = prepare.SCALE,
 ) -> Sprite:
     """
     Load a set of images and return an animated sprite.
@@ -197,16 +198,22 @@ def load_animated_sprite(
     Parameters:
         filenames: Filenames to load.
         delay: Frame interval; time between each frame.
+        scale: A scaling factor applied to the images during loading.
+            Defaults to the 'prepare.SCALE' constant.
 
     Returns:
         Loaded animated sprite.
-
     """
     anim = []
     for filename in filenames:
         if os.path.exists(filename):
-            image = load_and_scale(filename)
+            image = load_and_scale(filename, scale)
             anim.append((image, delay))
+        else:
+            logger.error(f"File not found: {filename}")
+
+    if not anim:
+        raise ValueError("Cannot create animated sprite: no valid frames.")
 
     tech = SurfaceAnimation(anim, True)
     tech.play()
@@ -442,7 +449,7 @@ def capture_screenshot(game: LocalPygameClient) -> pygame.surface.Surface:
     return screenshot
 
 
-def get_avatar(session: Session, avatar: Union[str, int]) -> Optional[Sprite]:
+def get_avatar(session: Session, avatar: str) -> Optional[Sprite]:
     """
     Retrieves the avatar sprite of a monster or NPC.
 
@@ -451,30 +458,36 @@ def get_avatar(session: Session, avatar: Union[str, int]) -> Optional[Sprite]:
         avatar: The identifier of the avatar to be used.
 
     Returns:
-        The surface of the monster or NPC avatar sprite, or None if not found.
-
+        The sprite for the monster or NPC avatar, or None if not found.
     """
-    if isinstance(avatar, int):
+    if avatar.isdigit():
         try:
-            return session.player.monsters[avatar].get_sprite("menu")
+            monster = session.player.monsters[int(avatar)]
+            return monster.get_sprite("menu")
         except IndexError:
             logger.debug(f"Invalid avatar monster slot: {avatar}")
             return None
 
-    if avatar in db.database["monster"]:
-        monster = db.lookup(avatar, table="monster")
-        if not monster.sprites:
-            logger.warning(f"Monster '{avatar}' has no sprites")
+    if avatar in db.database.get("monster", {}):
+        monster_data = db.lookup(avatar, table="monster")
+        if not monster_data.sprites:
+            logger.error(f"Monster '{avatar}' has no sprites")
             return None
-        menu_sprites = [
-            transform_resource_filename(f"{monster.sprites.menu1}.png"),
-            transform_resource_filename(f"{monster.sprites.menu2}.png"),
-        ]
-        return load_animated_sprite(menu_sprites, 0.25)
 
-    if avatar in db.database["npc"]:
-        npc = db.lookup(avatar, table="npc")
-        path = f"gfx/sprites/player/{npc.template.combat_front}.png"
+        # Replace MonsterSpriteHandler with direct logic
+        menu_sprites = [
+            transform_resource_filename(f"{monster_data.sprites.menu1}.png"),
+            transform_resource_filename(f"{monster_data.sprites.menu2}.png"),
+        ]
+        try:
+            return load_animated_sprite(menu_sprites, 0.25)
+        except ValueError as e:
+            logger.error(f"Failed to load animated sprite for '{avatar}': {e}")
+            return None
+
+    if avatar in db.database.get("npc", {}):
+        npc_data = db.lookup(avatar, table="npc")
+        path = f"gfx/sprites/player/{npc_data.template.combat_front}.png"
         sprite = load_sprite(path)
         scale_sprite(sprite, 0.5)
         return sprite

--- a/tuxemon/states/combat/combat_animations.py
+++ b/tuxemon/states/combat/combat_animations.py
@@ -186,9 +186,9 @@ class CombatAnimations(ABC, Menu[None]):
 
         # Load monster sprite and set final position
         monster_sprite = monster.get_sprite(
-            "back" if npc == self.players[0] else "front",
-            midbottom=feet,
+            "back" if npc == self.players[0] else "front"
         )
+        monster_sprite.rect.midbottom = feet
         self.sprites.add(monster_sprite)
         self._monster_sprite_map[monster] = monster_sprite
 
@@ -664,11 +664,9 @@ class CombatAnimations(ABC, Menu[None]):
             )
             self._monster_sprite_map[opponent] = enemy
         else:
-            enemy = opp_mon.get_sprite(
-                "front",
-                bottom=back_island.rect.bottom - scale(24),
-                centerx=back_island.rect.centerx,
-            )
+            enemy = opp_mon.get_sprite("front")
+            enemy.rect.bottom = back_island.rect.bottom - scale(24)
+            enemy.rect.centerx = back_island.rect.centerx
             self._monster_sprite_map[opp_mon] = enemy
             self.monsters_in_play[opponent].append(opp_mon)
             self.update_hud(opponent)

--- a/tuxemon/states/monster/__init__.py
+++ b/tuxemon/states/monster/__init__.py
@@ -6,14 +6,18 @@ from collections.abc import Generator
 from typing import Optional
 
 import pygame
+from pygame.font import Font
 from pygame.rect import Rect
+from pygame.surface import Surface
 
-from tuxemon import graphics, prepare, tools
+from tuxemon import prepare, tools
+from tuxemon.graphics import ColorLike, load_and_scale, load_image
 from tuxemon.locale import T
 from tuxemon.menu.interface import ExpBar, HpBar, MenuItem
 from tuxemon.menu.menu import Menu
 from tuxemon.monster import Monster
 from tuxemon.session import local_session
+from tuxemon.sprite import Sprite
 from tuxemon.ui.draw import GraphicBox
 from tuxemon.ui.text import TextArea, draw_text
 
@@ -37,49 +41,21 @@ class MonsterMenuState(Menu[Optional[Monster]]):
         self.text_area.rect = Rect(tools.scale_sequence((20, 80, 80, 100)))
         self.sprites.add(self.text_area, layer=100)
         self.held_item_display = HeldItemDisplay(self)
+        self.monster_sprite_displays: list[MonsterSpriteDisplay] = []
+        self.monster_sprite_display = MonsterSpriteDisplay(self)
+        self.monster_portrait_display = MonsterPortraitDisplay(self)
 
         # Set up the border images used for the monster slots
-        self.monster_slot_border = {}
-        self.monster_portrait = pygame.sprite.Sprite()
         self.hp_bar = HpBar()
         self.exp_bar = ExpBar()
-
-        # load and scale the monster slot borders
-        root = "gfx/ui/monster/"
-        border_types = ["empty", "filled", "active"]
-        for border_type in border_types:
-            filename = root + border_type + "_monster_slot_border.png"
-            border = graphics.load_and_scale(filename)
-
-            filename = root + border_type + "_monster_slot_bg.png"
-            background = graphics.load_image(filename)
-
-            window = GraphicBox(border, background, None)
-            self.monster_slot_border[border_type] = window
+        self.monster_info_renderer = MonsterInfoRenderer(
+            self.font, self.hp_bar, self.font_color
+        )
+        self.monster_slot_border = MonsterSlotBorder()
 
         # TODO: something better than this global, load_sprites stuff
         for monster in local_session.player.monsters:
             monster.load_sprites()
-
-    def animate_monster_down(self) -> None:
-        ani = self.animate(
-            self.monster_portrait.rect,
-            y=-tools.scale(5),
-            duration=1,
-            transition="in_out_quad",
-            relative=True,
-        )
-        ani.callback = self.animate_monster_up
-
-    def animate_monster_up(self) -> None:
-        ani = self.animate(
-            self.monster_portrait.rect,
-            y=tools.scale(5),
-            duration=1,
-            transition="in_out_quad",
-            relative=True,
-        )
-        ani.callback = self.animate_monster_down
 
     def calc_menu_items_rect(self) -> Rect:
         width, height = self.rect.size
@@ -94,20 +70,14 @@ class MonsterMenuState(Menu[Optional[Monster]]):
         # position the monster portrait
         try:
             monster = local_session.player.monsters[self.selected_index]
-            image = monster.sprites["front"]
+            self.monster_portrait_display.update(monster)
         except IndexError:
-            image = pygame.Surface((1, 1), pygame.SRCALPHA)
+            self.monster_portrait_display.update(None)
+
+        self.animations.empty()
+        self.monster_portrait_display.animate_down()
 
         # position and animate the monster portrait
-        width, height = prepare.SCREEN_SIZE
-        self.monster_portrait.rect = image.get_rect(
-            centerx=width // 4,
-            top=height // 12,
-        )
-        self.sprites.add(self.monster_portrait)
-        self.animations.empty()
-        self.animate_monster_down()
-
         width = prepare.SCREEN_SIZE[0] // 2
         height = prepare.SCREEN_SIZE[1] // int(
             local_session.player.party_limit * 1.5,
@@ -116,7 +86,7 @@ class MonsterMenuState(Menu[Optional[Monster]]):
         # make 6 slots
         for _ in range(local_session.player.party_limit):
             rect = Rect(0, 0, width, height)
-            surface = pygame.Surface(rect.size, pygame.SRCALPHA)
+            surface = Surface(rect.size, pygame.SRCALPHA)
             item = MenuItem(surface, None, None, None)
             yield item
 
@@ -130,13 +100,13 @@ class MonsterMenuState(Menu[Optional[Monster]]):
 
     def render_monster_slot(
         self,
-        surface: pygame.surface.Surface,
+        surface: Surface,
         rect: Rect,
         monster: Optional[Monster],
         in_focus: bool,
-    ) -> pygame.surface.Surface:
+    ) -> Surface:
         filled = monster is not None
-        border = self.determine_border(in_focus, filled)
+        border = self.monster_slot_border.get_border(in_focus, filled)
         border.draw(surface)
         if monster is not None:
             self.draw_monster_info(surface, monster, rect)
@@ -157,6 +127,7 @@ class MonsterMenuState(Menu[Optional[Monster]]):
 
     def refresh_menu_items(self) -> None:
         """Used to render slots after their 'focus' flags change."""
+        self.monster_sprite_displays = []
 
         for index, item in enumerate(self.menu_items):
             monster: Optional[Monster]
@@ -177,72 +148,35 @@ class MonsterMenuState(Menu[Optional[Monster]]):
                 item.game_object,
                 item.in_focus,
             )
+            if monster:
+                monster_sprite_display = MonsterSpriteDisplay(self)
+                monster_sprite_display.update(monster, item.rect)
+                self.monster_sprite_displays.append(monster_sprite_display)
 
     def draw_monster_info(
         self,
-        surface: pygame.surface.Surface,
+        surface: Surface,
         monster: Monster,
         rect: Rect,
     ) -> None:
-        # position and draw hp bar
-        hp_rect = rect.copy()
-        left = int(rect.width * 0.6)
-        right = rect.right - tools.scale(4)
-        hp_rect.width = right - left
-        hp_rect.left = left
-        hp_rect.height = tools.scale(8)
-        hp_rect.centery = rect.centery
-
-        # draw the hp bar
-        self.hp_bar.value = monster.current_hp / monster.hp
-        self.hp_bar.draw(surface, hp_rect)
-
-        # draw the name + gender
-        if monster.gender == "male":
-            icon = "♂"
-        elif monster.gender == "female":
-            icon = "♀"
-        else:
-            icon = ""
-        upper_label = f"{monster.name}{icon}"
-        text_rect = rect.inflate(-tools.scale(6), -tools.scale(6))
-        draw_text(surface, upper_label, text_rect, font=self.font)
-
-        # draw the level info
-        text_rect.top = rect.bottom - tools.scale(7)
-        bottom_label = f"  Lv {monster.level}"
-        draw_text(surface, bottom_label, text_rect, font=self.font)
-
-        # draw any status icons
-        # TODO: caching or something, idk
-        # TODO: not hardcode icon sizes
-        for index, status in enumerate(monster.status):
-            if status.icon:
-                image = graphics.load_and_scale(status.icon)
-                pos = (
-                    (rect.width * 0.45) + (index * tools.scale(6)),
-                    rect.y + tools.scale(4),
-                )
-                surface.blit(image, pos)
-
-    def determine_border(self, selected: bool, filled: bool) -> GraphicBox:
-        if selected:
-            return self.monster_slot_border["active"]
-        elif filled:
-            return self.monster_slot_border["filled"]
-        else:
-            return self.monster_slot_border["empty"]
+        self.monster_info_renderer.draw(surface, monster, rect)
 
     def on_menu_selection_change(self) -> None:
         try:
             monster = local_session.player.monsters[self.selected_index]
-            image = monster.sprites["front"]
+            self.monster_portrait_display.update(monster)
         except IndexError:
-            monster = None
-            image = pygame.Surface((1, 1), pygame.SRCALPHA)
+            self.monster_portrait_display.update(None)
         self.held_item_display.update(monster)
-        self.monster_portrait.image = image
         self.refresh_menu_items()
+
+    def remove_monster_sprite_display(self, monster: Monster) -> None:
+        for sprite_display in self.monster_sprite_displays:
+            if sprite_display.monster == monster:
+                if sprite_display.sprite:
+                    self.sprites.remove(sprite_display.sprite)
+                self.monster_sprite_displays.remove(sprite_display)
+                break
 
 
 class HeldItemDisplay:
@@ -279,3 +213,153 @@ class HeldItemDisplay:
         self.sprite.image = image
         width, height = prepare.SCREEN_SIZE
         self.sprite.rect.topleft = (width // 10, height // 2 + 50)
+
+
+class MonsterSpriteDisplay:
+    def __init__(self, menu_state: MonsterMenuState) -> None:
+        self.menu_state = menu_state
+        self.sprite: Optional[Sprite] = None
+        self.monster: Optional[Monster] = None
+
+    def update(self, monster: Optional[Monster], rect: Rect) -> None:
+        self.monster = monster
+        if monster:
+            if self.sprite is None:
+                self.sprite = monster.get_sprite("menu", 0.25, 2.5)
+                self.menu_state.sprites.add(self.sprite)
+            if self.sprite is not None:
+                self.sprite.rect.x = prepare.SCREEN_SIZE[0] - (
+                    self.sprite.rect.width
+                    + int(prepare.SCREEN_SIZE[0] * 0.005)
+                )
+                self.sprite.rect.y = rect.y + (self.sprite.rect.height)
+        else:
+            if self.sprite is not None:
+                self.menu_state.sprites.remove(self.sprite)
+                self.sprite = None
+
+
+class MonsterPortraitDisplay:
+    def __init__(self, menu_state: MonsterMenuState) -> None:
+        self.menu_state = menu_state
+        self.portrait = pygame.sprite.Sprite()
+        self.portrait.rect = Rect(0, 0, 0, 0)
+        self.menu_state.sprites.add(self.portrait)
+
+    def update(self, monster: Optional[Monster]) -> None:
+        image = None
+        if monster is not None:
+            try:
+                sprite = monster.get_sprite("front")
+                image = sprite.image
+            except AttributeError:
+                pass
+        image = image or Surface((1, 1), pygame.SRCALPHA)
+
+        self.portrait.image = image
+        width, height = prepare.SCREEN_SIZE
+        self.portrait.rect = image.get_rect(
+            centerx=width // 4,
+            top=height // 12,
+        )
+
+    def animate_down(self) -> None:
+        ani = self.menu_state.animate(
+            self.portrait.rect,
+            y=-tools.scale(5),
+            duration=1,
+            transition="in_out_quad",
+            relative=True,
+        )
+        ani.callback = self.animate_up
+
+    def animate_up(self) -> None:
+        ani = self.menu_state.animate(
+            self.portrait.rect,
+            y=tools.scale(5),
+            duration=1,
+            transition="in_out_quad",
+            relative=True,
+        )
+        ani.callback = self.animate_down
+
+
+class MonsterInfoRenderer:
+    def __init__(
+        self, font: Font, hp_bar: HpBar, font_color: ColorLike
+    ) -> None:
+        self.font = font
+        self.hp_bar = hp_bar
+        self.font_color = font_color
+
+    def draw_hp_bar(
+        self, surface: Surface, monster: Monster, rect: Rect
+    ) -> None:
+        hp_rect = rect.copy()
+        left = int(rect.width * 0.6)
+        right = rect.right - tools.scale(4)
+        hp_rect.width = right - left
+        hp_rect.left = left
+        hp_rect.height = tools.scale(8)
+        hp_rect.centery = rect.centery
+        self.hp_bar.value = monster.current_hp / monster.hp
+        self.hp_bar.draw(surface, hp_rect)
+
+    def draw_name_and_level(
+        self, surface: Surface, monster: Monster, rect: Rect
+    ) -> None:
+        if monster.gender == "male":
+            icon = "♂"
+        elif monster.gender == "female":
+            icon = "♀"
+        else:
+            icon = ""
+        upper_label = f"{monster.name}{icon}"
+        text_rect = rect.inflate(-tools.scale(6), -tools.scale(6))
+        draw_text(surface, upper_label, text_rect, font=self.font)
+        text_rect.top = rect.bottom - tools.scale(7)
+        bottom_label = f"  Lv {monster.level}"
+        draw_text(surface, bottom_label, text_rect, font=self.font)
+
+    def draw_status_icons(
+        self, surface: Surface, monster: Monster, rect: Rect
+    ) -> None:
+        for index, status in enumerate(monster.status):
+            if status.icon:
+                image = load_and_scale(status.icon)
+                pos = (
+                    (rect.width * 0.45) + (index * tools.scale(6)),
+                    rect.y + tools.scale(4),
+                )
+                surface.blit(image, pos)
+
+    def draw(self, surface: Surface, monster: Monster, rect: Rect) -> None:
+        self.draw_hp_bar(surface, monster, rect)
+        self.draw_name_and_level(surface, monster, rect)
+        self.draw_status_icons(surface, monster, rect)
+
+
+class MonsterSlotBorder:
+    def __init__(self, root: str = "gfx/ui/monster/"):
+        self.border_types = ["empty", "filled", "active"]
+        self.borders: dict[str, GraphicBox] = {}
+        self.load_borders(root)
+
+    def load_borders(self, root: str) -> None:
+        for border_type in self.border_types:
+            filename = root + border_type + "_monster_slot_border.png"
+            border = load_and_scale(filename)
+
+            filename = root + border_type + "_monster_slot_bg.png"
+            background = load_image(filename)
+
+            window = GraphicBox(border, background, None)
+            self.borders[border_type] = window
+
+    def get_border(self, selected: bool, filled: bool) -> GraphicBox:
+        if selected:
+            return self.borders["active"]
+        elif filled:
+            return self.borders["filled"]
+        else:
+            return self.borders["empty"]

--- a/tuxemon/states/monster_info/__init__.py
+++ b/tuxemon/states/monster_info/__init__.py
@@ -284,7 +284,7 @@ class MonsterInfoState(PygameMenuState):
         for elements in labels:
             f.pack(elements)
         # image
-        new_image = self._create_image(monster.front_battle_sprite)
+        new_image = self._create_image(monster.sprite_handler.front_path)
         new_image.scale(prepare.SCALE, prepare.SCALE)
         image_widget = menu.add.image(image_path=new_image.copy())
         image_widget.set_float(origin_position=True)

--- a/tuxemon/states/monster_moves/__init__.py
+++ b/tuxemon/states/monster_moves/__init__.py
@@ -83,7 +83,7 @@ class MonsterMovesState(PygameMenuState):
             ).translate(fix_measure(width, 0.50), fix_measure(height, _height))
 
         # image
-        new_image = self._create_image(monster.front_battle_sprite)
+        new_image = self._create_image(monster.sprite_handler.front_path)
         new_image.scale(prepare.SCALE, prepare.SCALE)
         image_widget = menu.add.image(image_path=new_image.copy())
         image_widget.set_float(origin_position=True)

--- a/tuxemon/states/pc_kennel/__init__.py
+++ b/tuxemon/states/pc_kennel/__init__.py
@@ -173,7 +173,7 @@ class MonsterTakeState(PygameMenuState):
         for monster in _sorted:
             label = T.translate(monster.name).upper()
             iid = monster.instance_id.hex
-            new_image = self._create_image(monster.front_battle_sprite)
+            new_image = self._create_image(monster.sprite_handler.front_path)
             new_image.scale(prepare.SCALE * 0.5, prepare.SCALE * 0.5)
             menu.add.banner(
                 new_image,

--- a/tuxemon/states/techniques/__init__.py
+++ b/tuxemon/states/techniques/__init__.py
@@ -121,7 +121,7 @@ class TechniqueMenuState(Menu[Technique]):
         # load the backpack icon
         self.backpack_center = self.rect.width * 0.16, self.rect.height * 0.45
         self.load_sprite(
-            self.mon.front_battle_sprite,
+            self.mon.sprite_handler.front_path,
             center=self.backpack_center,
             layer=100,
         )

--- a/tuxemon/states/world/world_menus.py
+++ b/tuxemon/states/world/world_menus.py
@@ -157,14 +157,13 @@ class WorldMenuState(PygameMenuState):
             player = local_session.player
             success = player.release_monster(monster)
 
-            # Close the dialog and confirmation menu, and inform the user
-            # their tuxemon has been released.
             if success:
                 self.client.pop_state()
                 self.client.pop_state()
                 params = {"name": monster.name.upper()}
                 msg = T.format("tuxemon_released", params)
                 open_dialog(local_session, [msg])
+                monster_menu.remove_monster_sprite_display(monster)
                 monster_menu.refresh_menu_items()
                 monster_menu.on_menu_selection_change()
             else:


### PR DESCRIPTION
PR extracts the sprite handling logic. Before methods like `load_sprite`, `get_sprite`, and others were tightly coupled within the `Monster` class. This refactor extracts those methods into their own `MonsterSpriteHandler` class. Extract from `MonsterMenuState` the monster sprite (the one who goes up and down) into a separate `MonsterPortraitDisplay` class. As shown in the video below, it adds the small menu sprites to the left of the bar, these menu sprites exist, but weren't used anywhere, at least now these can be shown. Same extraction for `MonsterInfoRenderer` and `MonsterSlotBorder`.

https://github.com/user-attachments/assets/957c5d20-7872-4320-902b-d61d1741211d