### PR TITLE
Update Damage Calculation Logic (range_map.yaml) + Capture Logic (config_capture.yaml)

### DIFF
--- a/mods/config_capture.yaml
+++ b/mods/config_capture.yaml
@@ -1,0 +1,28 @@
+# Configuration for creature capture mechanics.
+
+total_shakes: 4
+# Number of times the capture device shakes.
+
+shake_constant: 524325
+# Constant used in the shake check calculation.
+# This constant is a scaling factor that affects the overall
+# probability of a successful capture.
+
+shake_denominator: 8
+# Denominator in the shake check calculation.
+# This value scales the result of the shake check,
+# affecting the sensitivity of the capture rate.
+
+shake_divisor: 65536
+# Divisor used to calculate the final capture probability.
+# Represents the total possible outcomes,
+# allowing for fine-grained probability calculations.
+
+shake_hp_multiplier: 3
+# Multiplier applied to the target monster's maximum HP in the catch_check calculation.
+
+shake_current_hp_multiplier: 2
+# Multiplier applied to the target monster's current HP in the catch_check calculation.
+
+shake_hp_divisor: 3
+# Divisor applied to the HP-related component of the catch_check calculation.

--- a/mods/range_map.yaml
+++ b/mods/range_map.yaml
@@ -1,0 +1,41 @@
+# The range_map dictionary defines the relationships between technique ranges
+# and the corresponding user and target stats with associated weights.
+
+# Close combat techniques that rely on the user's melee stat and target's armour stat.
+melee:
+  - user_stat: melee
+    weight: 1.0  # User stat: melee with weight 1.0
+  - target_stat: armour
+    weight: 1.0  # Target stat: armour with weight 1.0
+
+# Techniques requiring a touch, relying on the user's melee skill
+# and target's dodge ability to determine effectiveness.
+touch:
+  - user_stat: melee
+    weight: 1.0  # User stat: melee with weight 1.0
+  - target_stat: dodge
+    weight: 1.0  # Target stat: dodge with weight 1.0
+
+# Long-range techniques that depend on the user's ranged accuracy
+# and the target's dodge ability to calculate success and damage.
+ranged:
+  - user_stat: ranged
+    weight: 1.0  # User stat: ranged with weight 1.0
+  - target_stat: dodge
+    weight: 1.0  # Target stat: dodge with weight 1.0
+
+# Techniques with extended reach, relying on the user's ranged stats
+# and the target's armour to assess damage.
+reach:
+  - user_stat: ranged
+    weight: 1.0  # User stat: ranged with weight 1.0
+  - target_stat: armour
+    weight: 1.0  # Target stat: armour with weight 1.0
+
+# Reliable techniques that utilize the user's level and apply resistance-based
+# reduction from the target to calculate damage. "Resist" is kept here as placeholder.
+reliable:
+  - user_stat: level
+    weight: 1.0  # User stat: level with weight 1.0
+  - target_stat: resist
+    weight: 1.0  # Target stat: resist with weight 1.0

--- a/tuxemon/prepare.py
+++ b/tuxemon/prepare.py
@@ -248,9 +248,6 @@ WEIGHT_RANGE: tuple[float, float] = (-0.1, 0.1)
 HEIGHT_RANGE: tuple[float, float] = (-0.1, 0.1)
 
 # Capture
-TOTAL_SHAKES: int = 4
-MAX_SHAKE_RATE: int = 65536
-SHAKE_CONSTANT: int = 524325
 # default modifiers
 STATUS_MODIFIER: float = 1.0
 TUXEBALL_MODIFIER: float = 1.0

--- a/tuxemon/technique/effects/run.py
+++ b/tuxemon/technique/effects/run.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional
 
 from tuxemon import formula
 from tuxemon.combat import set_var
@@ -12,6 +12,8 @@ from tuxemon.technique.techeffect import TechEffect, TechEffectResult
 
 if TYPE_CHECKING:
     from tuxemon.monster import Monster
+    from tuxemon.npc import NPC
+    from tuxemon.states.combat.combat import CombatState
     from tuxemon.technique.technique import Technique
 
 
@@ -35,43 +37,14 @@ class RunEffect(TechEffect):
 
         game_variables = player.game_variables
         attempts = game_variables.get("run_attempts", 0)
-        escape_method = game_variables.get("method_escape", "default")
-        escape_ai_method = game_variables.get("method_escape_ai", "default")
 
-        # Check if the user is in the player party or NPC party
-        if user in combat.monsters_in_play_right:
-            escape_method = escape_method
-        elif user in combat.monsters_in_play_left:
-            escape_method = escape_ai_method
-        else:
-            return TechEffectResult(
-                name=tech.name,
-                success=True,
-                damage=0,
-                element_multiplier=0.0,
-                should_tackle=False,
-                extras=[],
-            )
+        method = self._determine_escape_method(user, combat, game_variables)
+        if not method:
+            return self._default_result(tech)
 
-        # Attempt to escape
-        if formula.attempt_escape(
-            escape_method,
-            user,
-            target,
-            attempts,
-        ):
-            game_variables["run_attempts"] = 0
+        if formula.attempt_escape(method, user, target, attempts):
+            self._trigger_escape(combat, player, game_variables, extra)
             ran = True
-
-        # Trigger the run effect
-        if ran:
-            combat._run = True
-            extra = [T.translate("combat_player_run")]
-            set_var(self.session, "battle_last_result", self.name)
-            for remove in combat.players:
-                combat.clean_combat()
-                del combat.monsters_in_play[remove]
-                combat.players.remove(remove)
         else:
             game_variables["run_attempts"] = attempts + 1
 
@@ -82,4 +55,60 @@ class RunEffect(TechEffect):
             element_multiplier=0.0,
             should_tackle=False,
             extras=extra,
+        )
+
+    def _determine_escape_method(
+        self,
+        user: Monster,
+        combat: CombatState,
+        game_variables: dict[str, Any],
+    ) -> Optional[str]:
+        """
+        Determine the appropriate escape method based on combat state.
+        """
+        escape_method = str(game_variables.get("method_escape", "default"))
+        escape_ai_method = str(
+            game_variables.get("method_escape_ai", "default")
+        )
+
+        if user in combat.monsters_in_play_right:
+            return escape_method
+        elif user in combat.monsters_in_play_left:
+            return escape_ai_method
+        else:
+            return None
+
+    def _trigger_escape(
+        self,
+        combat: CombatState,
+        player: NPC,
+        game_variables: dict[str, Any],
+        extra: list[str],
+    ) -> None:
+        """
+        Handle the escape trigger and clean up the combat state.
+        """
+        combat._run = True
+        extra.append(T.translate("combat_player_run"))
+        game_variables["run_attempts"] = 0
+        set_var(self.session, "battle_last_result", self.name)
+
+        # Clean up combat for all players
+        players_to_remove = list(combat.players)
+        for player in players_to_remove:
+            combat.clean_combat()
+            del combat.monsters_in_play[player]
+            combat.players.remove(player)
+
+    def _default_result(self, tech: Technique) -> TechEffectResult:
+        """
+        Return the default result for the RunEffect.
+        """
+        return TechEffectResult(
+            name=tech.name,
+            success=True,
+            damage=0,
+            element_multiplier=0.0,
+            should_tackle=False,
+            extras=[],
         )


### PR DESCRIPTION
PR refactors the `simple_damage_calculate` function. The original code relied on a static dictionary (`range_map`) with hardcoded mappings between technique ranges and corresponding stats. This approach worked but lacked flexibility for future changes or expansions.

The new version introduces a `Loader` class to dynamically load these mappings from an external YAML file (`range_map.yaml`). This change provides the following benefits:
- we can now update mappings without touching the code - just edit the YAML file
- the updated logic accounts for weighted contributions from user and target stats, offering greater precision in damage calculations
- division by zero is explicitly prevented by ensuring target resistance values are always at least 1
- detailed debug logs have been added to trace calculation steps

external file also for `config_capture.yaml` and simplified `attempt_escape` too (avoid overhead)