### PR TITLE
Enabling Cross-Mod Dependencies

### DIFF
--- a/mods/db_config.json
+++ b/mods/db_config.json
@@ -1,35 +1,64 @@
 {
-    "active_mods": [
-      "tuxemon"
-    ],
-    "mod_versions": {
-      "tuxemon": "1.0.0"
-    },
-    "mod_activation": {
-      "tuxemon": true
-    },
-    "mod_tables": {
-      "tuxemon": [
-        "item",
-        "monster",
-        "npc",
-        "status",
-        "technique",
-        "encounter",
-        "dialogue",
-        "environment",
-        "sounds",
-        "music",
-        "animation",
-        "economy",
-        "element",
-        "taste",
-        "shape",
-        "template",
-        "mission",
-        "terrain",
-        "weather"
-      ]
-    },
-    "mod_table_exclusions": {}
-  }
+  "model_map": {
+    "economy": "tuxemon.db.EconomyModel",
+    "element": "tuxemon.db.ElementModel",
+    "taste": "tuxemon.db.TasteModel",
+    "shape": "tuxemon.db.ShapeModel",
+    "template": "tuxemon.db.TemplateModel",
+    "mission": "tuxemon.db.MissionModel",
+    "encounter": "tuxemon.db.EncounterModel",
+    "dialogue": "tuxemon.db.DialogueModel",
+    "environment": "tuxemon.db.EnvironmentModel",
+    "item": "tuxemon.db.ItemModel",
+    "monster": "tuxemon.db.MonsterModel",
+    "music": "tuxemon.db.MusicModel",
+    "animation": "tuxemon.db.AnimationModel",
+    "npc": "tuxemon.db.NpcModel",
+    "sounds": "tuxemon.db.SoundModel",
+    "status": "tuxemon.db.StatusModel",
+    "technique": "tuxemon.db.TechniqueModel",
+    "terrain": "tuxemon.db.TerrainModel",
+    "weather": "tuxemon.db.WeatherModel"
+  },
+  "mod_base_path": "mods",
+  "mod_db_subfolder": "db",
+  "file_extensions": [
+    ".json",
+    ".yaml"
+  ],
+  "default_lookup_table": "monster",
+  "active_mods": [
+    "tuxemon"
+  ],
+  "mod_versions": {
+    "tuxemon": "1.0.0"
+  },
+  "mod_activation": {
+    "tuxemon": true
+  },
+  "mod_tables": {
+    "tuxemon": [
+      "item",
+      "monster",
+      "npc",
+      "status",
+      "technique",
+      "encounter",
+      "dialogue",
+      "environment",
+      "sounds",
+      "music",
+      "animation",
+      "economy",
+      "element",
+      "taste",
+      "shape",
+      "template",
+      "mission",
+      "terrain",
+      "weather"
+    ]
+  },
+  "mod_table_exclusions": {},
+  "mod_dependencies": {}
+}


### PR DESCRIPTION
PR introduces an enhancement to the database configuration system: `mod_dependencies`. This addition aims to improve modularity and resource sharing between mods while eliminating unnecessary data duplication. Key points:
- mods can now declare dependencies on other mods. When a mod is loaded, its dependencies are automatically resolved and their corresponding data tables are made available to ensure integration
- by leveraging dependencies, mods can reuse tables from other mods without duplicating data
- a new `mod_dependencies` property has been added to the `DatabaseConfig` class. It allows mods to list other mods they depend on. Dependencies are resolved recursively, ensuring that all required tables are preloaded before the mod itself is loaded
- "mods", "db", ".json", ".yaml": these hardcoded strings have been moved into `DatabaseConfig` dataclass and it includes "monster" default table
- the `model_map` will be loaded from the  configuration file and this involve specifying the table names and corresponding model classes in the configuration (temporary, the idea is to create a system like PluginDiscovery, maybe even involved it into the ModData loader, but it requires more testing and attempts)
- `reload` method is improved by clearing both `preloaded` and `database` data, integrating mod path handling for data loading, adding logging for traceability, error handling to capture and report issues, and simplifying the workflow by focusing on table-specific reloading

```
{
    "active_mods": ["mod_a", "mod_b"],
    "mod_versions": {
        "mod_a": "1.0.0",
        "mod_b": "1.0.0"
    },
    "mod_activation": {
        "mod_a": true,
        "mod_b": true
    },
    "mod_tables": {
        "mod_a": ["npc", "monster"],
        "mod_b": ["npc"]
    },
    "mod_dependencies": {
        "mod_b": ["mod_a"]  <--- mod_b will get monster from mod_a
    }
}
```