### PR TITLE
Add Callback Support and Dialog Speed to Menu

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -796,6 +796,9 @@ msgstr "{name} cannot be used on any of your Tuxemon right now."
 msgid "technique_description"
 msgstr "ID.{id} ({types}) - Accuracy {acc}%, Potency {pot}%, Power {pow}/3, Recharge {rec} turns"
 
+msgid "technique_combat"
+msgstr "{name} ({types})\n Power {pow}/{max_pow}\n Accuracy {acc}%\n Recharge {rec} turns"
+
 msgid "technique_id_types_recharge"
 msgstr "ID.{id} ({types}) - Recharge {rec} turns"
 

--- a/tuxemon/menu/menu.py
+++ b/tuxemon/menu/menu.py
@@ -337,6 +337,12 @@ class Menu(Generic[T], state.State):
         # holds sprites representing menu items
         self.create_new_menu_items_group()
 
+        # callbacks
+        self.on_close_callback: Optional[Callable[[], None]] = None
+        self.on_menu_selection_change_callback: Optional[
+            Callable[[], None]
+        ] = None
+
         self.font_filename = prepare.fetch("font", self.font_filename)
         self.set_font()  # load default font
         self.load_graphics()  # load default graphics
@@ -405,6 +411,7 @@ class Menu(Generic[T], state.State):
         text_area: TextArea,
         text: str,
         callback: Optional[Callable[[], None]] = None,
+        dialog_speed: str = "slow",
     ) -> None:
         """
         Set and animate a text area.
@@ -413,10 +420,10 @@ class Menu(Generic[T], state.State):
             text_area: Text area to animate.
             text: Text to display.
             callback: Function called when alert is complete.
-
+            dialog_speed: Speed of blitting chars to the dialog box.
         """
         text_area.text = text
-        if CONFIG.dialog_speed == "max":
+        if CONFIG.dialog_speed == "max" or dialog_speed == "max":
             # exhaust the iterator to immediately blit every char to the dialog
             # box
             for _ in text_area:
@@ -430,6 +437,7 @@ class Menu(Generic[T], state.State):
         self,
         message: str,
         callback: Optional[Callable[[], None]] = None,
+        dialog_speed: str = "slow",
     ) -> None:
         """
         Write a message to the first available text area.
@@ -441,7 +449,7 @@ class Menu(Generic[T], state.State):
         Parameters:
             message: Message to write.
             callback: Function called when alert is complete.
-
+            dialog_speed: Speed of blitting chars to the dialog box.
         """
 
         def find_textarea() -> TextArea:
@@ -453,7 +461,7 @@ class Menu(Generic[T], state.State):
                 message,
             )
 
-        self.animate_text(find_textarea(), message, callback)
+        self.animate_text(find_textarea(), message, callback, dialog_speed)
 
     def initialize_items(self) -> Optional[Iterable[MenuItem[T]]]:
         """
@@ -962,6 +970,7 @@ class Menu(Generic[T], state.State):
         if self.state in ["normal", "opening"]:
             self.state = "closing"
             ani = self.animate_close()
+            self.on_close()
             if ani:
                 ani.callback = self.client.pop_state
             else:
@@ -1042,6 +1051,11 @@ class Menu(Generic[T], state.State):
     def on_open(self) -> None:
         """Hook is called after opening animation has finished."""
 
+    def on_close(self) -> None:
+        """Hook is called after opening animation has finished."""
+        if self.on_close_callback:
+            self.on_close_callback()
+
     def on_menu_selection(self, selected_item: MenuItem[T]) -> None:
         """
         Hook for things to happen when player selects a menu option.
@@ -1068,6 +1082,8 @@ class Menu(Generic[T], state.State):
         Override in subclass.
 
         """
+        if self.on_menu_selection_change_callback:
+            self.on_menu_selection_change_callback()
 
     def animate_open(self) -> Optional[Animation]:
         """


### PR DESCRIPTION
fixes #1805

PR adds callback support to the `Menu` class by introducing attributes in its `__init__` method for managing events like `on_menu_selection_change` and `on_close`. This makes the `Menu` class more flexible and allows custom functions to be hooked into these events without overriding the methods directly.

Additionally, the `alert` method has been enhanced with a new parameter for dialog speed. This allows control over how quickly characters are blitted, including the option to display the entire message immediately.

Now you’ll be able to check out the details of the move right in the combat menu, instead of just seeing "What will Puparmor do?"

https://github.com/user-attachments/assets/c9f7ed4d-0884-4c9d-9eab-211c2f6a411e