### PR TITLE
fix class Pathfinder + remove duplicate method

### DIFF
--- a/tests/tuxemon/test_pathfinder.py
+++ b/tests/tuxemon/test_pathfinder.py
@@ -29,16 +29,18 @@ class TestPathfinder(unittest.TestCase):
         node1 = MagicMock(spec=PathfindNode)
         node1.get_value.return_value = start
         node1.get_parent.return_value = None
+        node1.reconstruct_path.return_value = [start]
 
         node2 = MagicMock(spec=PathfindNode)
         node2.get_value.return_value = dest
         node2.get_parent.return_value = node1
+        node2.reconstruct_path.return_value = [start, dest]
 
         self.pathfinder.pathfind_r = MagicMock(return_value=node2)
 
         path = self.pathfinder.pathfind(start, dest)
 
-        self.assertEqual(path, [(1, 1)])
+        self.assertEqual(path, [start, dest])
 
     def test_pathfind_failure(self):
         start = (0, 0)

--- a/tests/tuxemon/test_pathfindnode.py
+++ b/tests/tuxemon/test_pathfindnode.py
@@ -57,3 +57,65 @@ class TestPathfindNode(unittest.TestCase):
         for _ in range(1000):
             parent = PathfindNode((1, 1), parent)
         self.assertEqual(parent.get_depth(), 1000)
+
+    def test_circular_reference(self):
+        node = PathfindNode((1, 2))
+        with self.assertRaises(ValueError):
+            node.set_parent(node)
+
+    def test_reconstruct_path(self):
+        root = PathfindNode((0, 0))
+        child = PathfindNode((1, 1), root)
+        grandchild = PathfindNode((2, 2), child)
+
+        self.assertEqual(grandchild.reconstruct_path(), [(2, 2), (1, 1)])
+
+    def test_reconstruct_path_single_node(self):
+        node = PathfindNode((0, 0))
+        self.assertEqual(node.reconstruct_path(), [])
+
+    def test_invalid_parent_assignment(self):
+        node = PathfindNode((1, 2))
+        with self.assertRaises(ValueError):
+            node.set_parent(None)
+        # Parent cannot be the node itself
+        with self.assertRaises(ValueError):
+            node.set_parent(node)
+
+    def test_boundary_values(self):
+        # Max value for a 32-bit integer
+        max_int = (2147483647, 2147483647)
+        node = PathfindNode(max_int)
+        self.assertEqual(node.get_value(), max_int)
+        # Min value for a 32-bit integer
+        min_int = (-2147483648, -2147483648)
+        node = PathfindNode(min_int)
+        self.assertEqual(node.get_value(), min_int)
+
+    def test_depth_update(self):
+        root = PathfindNode((0, 0))
+        child = PathfindNode((1, 1), root)
+        self.assertEqual(child.get_depth(), 1)
+
+        grandchild = PathfindNode((2, 2), child)
+        self.assertEqual(grandchild.get_depth(), 2)
+
+        grandchild.set_parent(root)
+        self.assertEqual(grandchild.get_depth(), 1)
+
+    def test_multi_level_string_representation(self):
+        parent = PathfindNode((0, 0))
+        child = PathfindNode((1, 1), parent)
+        grandchild = PathfindNode((2, 2), child)
+
+        self.assertIn("(0, 0)", str(grandchild))
+        self.assertIn("(1, 1)", str(grandchild))
+        self.assertIn("(2, 2)", str(grandchild))
+
+    def test_large_hierarchy_performance(self):
+        root = PathfindNode((0, 0))
+        current = root
+        # Create a deep hierarchy
+        for i in range(10000):
+            current = PathfindNode((i + 1, i + 1), current)
+        self.assertEqual(len(current.reconstruct_path()), 10000)

--- a/tuxemon/entity.py
+++ b/tuxemon/entity.py
@@ -93,30 +93,23 @@ class Entity(Generic[SaveDict]):
 
         Parameters:
             pos: Position to be added.
-
         """
         coords = (int(pos[0]), int(pos[1]))
         region = self.world.collision_map.get(coords)
 
-        # Handle player vs non-player entities
-        if self.isplayer and region:
-            prop = RegionProperties(
-                region.enter_from or [],  # Use empty list if not present
-                region.exit_from or [],
-                region.endure or [],
-                self,
-                region.key,
-            )
-        else:
-            prop = RegionProperties(
-                enter_from=[],
-                exit_from=[],
-                endure=[],
-                entity=self,
-                key=None,
-            )
+        enter_from = region.enter_from if self.isplayer and region else []
+        exit_from = region.exit_from if self.isplayer and region else []
+        endure = region.endure if self.isplayer and region else []
+        key = region.key if self.isplayer and region else None
 
-        # Update collision map
+        prop = RegionProperties(
+            enter_from=enter_from,
+            exit_from=exit_from,
+            endure=endure,
+            entity=self,
+            key=key,
+        )
+
         self.world.collision_map[coords] = prop
 
     def remove_collision(self) -> None:
@@ -127,8 +120,7 @@ class Entity(Generic[SaveDict]):
         if not region:
             return  # Nothing to remove
 
-        if region.enter_from or region.exit_from or region.endure:
-            # Update properties
+        if any([region.enter_from, region.exit_from, region.endure]):
             prop = RegionProperties(
                 region.enter_from,
                 region.exit_from,

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -256,19 +256,6 @@ class NPC(Entity[NPCState]):
         except (KeyError, TypeError):
             pass
 
-    def stop_moving(self) -> None:
-        """
-        Completely stop all movement.
-
-        Be careful, if stopped while in the path, it might not be tile-aligned.
-
-        May continue if move_direction is set.
-
-        """
-        self.velocity3.x = 0
-        self.velocity3.y = 0
-        self.velocity3.z = 0
-
     def cancel_path(self) -> None:
         """
         Stop following a path.


### PR DESCRIPTION
PR:
- introduced iteration through `dirs2` for direction mapping in pathfinding without additional hardcoding
- removed the `stop_moving` method from `NPC`, consolidating its functionality in the `Entity` base class
- enhanced `PathfindNode` functionality: refined `reconstruct_path` for clear, consistent path construction and improved validation and logging in `set_parent`
- simplified and optimized logic in the `Pathfinder` class: replaced manual list reversal with `reconstruct_path` and eliminated redundant checks in `pathfind`
- updated test cases to verify `PathfindNode` behavior