### PR TITLE
Add Magnitude + Normalize Property and Unit Tests (math.py)

### DIFF
--- a/tests/tuxemon/test_math.py
+++ b/tests/tuxemon/test_math.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import unittest
+
+from tuxemon.math import Vector2, Vector3
+
+
+class TestVector3(unittest.TestCase):
+    def test_initialization(self):
+        v1 = Vector3()
+        self.assertEqual(tuple(v1), (0, 0, 0))
+
+        v2 = Vector3(1, 2, 3)
+        self.assertEqual(tuple(v2), (1, 2, 3))
+
+        v3 = Vector3([4, 5, 6])
+        self.assertEqual(tuple(v3), (4, 5, 6))
+
+    def test_addition(self):
+        v1 = Vector3(1, 2, 3)
+        v2 = Vector3(4, 5, 6)
+        result = v1 + v2
+        self.assertEqual(tuple(result), (5, 7, 9))
+
+    def test_scalar_multiplication(self):
+        v1 = Vector3(1, 2, 3)
+        result = v1 * 2
+        self.assertEqual(tuple(result), (2, 4, 6))
+
+        result = 2 * v1
+        self.assertEqual(tuple(result), (2, 4, 6))
+
+    def test_iteration(self):
+        v1 = Vector3(1, 2, 3)
+        values = list(iter(v1))
+        self.assertEqual(values, [1, 2, 3])
+
+    def test_equality(self):
+        v1 = Vector3(1, 2, 3)
+        v2 = Vector3(1, 2, 3)
+        v3 = Vector3(4, 5, 6)
+        self.assertTrue(v1 == v2)
+        self.assertFalse(v1 == v3)
+
+    def test_getitem(self):
+        v1 = Vector3(1, 2, 3)
+        self.assertEqual(v1[0], 1)
+        self.assertEqual(v1[1], 2)
+        self.assertEqual(v1[2], 3)
+        self.assertEqual(v1[0:2], (1, 2))
+
+    def test_vector3_magnitude(self):
+        v3 = Vector3(1, 2, 2)
+        self.assertAlmostEqual(v3.magnitude, 3.0, places=2)
+
+        v3_zero = Vector3(0, 0, 0)
+        self.assertAlmostEqual(v3_zero.magnitude, 0.0, places=2)
+
+        v3_large = Vector3(10, 10, 10)
+        self.assertAlmostEqual(v3_large.magnitude, 17.32, places=2)
+
+    def test_vector3_normalized(self):
+        v3 = Vector3(1, 2, 2)
+        normalized_v3 = v3.normalized
+        self.assertAlmostEqual(normalized_v3.magnitude, 1.0, places=2)
+        self.assertAlmostEqual(normalized_v3[0], 0.33, places=2)
+        self.assertAlmostEqual(normalized_v3[1], 0.67, places=2)
+        self.assertAlmostEqual(normalized_v3[2], 0.67, places=2)
+
+        v3_zero = Vector3(0, 0, 0)
+        normalized_v3_zero = v3_zero.normalized
+        self.assertEqual(normalized_v3_zero.magnitude, 0.0)
+
+
+class TestVector2(unittest.TestCase):
+    def test_initialization(self):
+        v1 = Vector2()
+        self.assertEqual(tuple(v1), (0, 0))
+
+        v2 = Vector2(1, 2)
+        self.assertEqual(tuple(v2), (1, 2))
+
+        v3 = Vector2([4, 5])
+        self.assertEqual(tuple(v3), (4, 5))
+
+    def test_addition(self):
+        v1 = Vector2(1, 2)
+        v2 = Vector2(3, 4)
+        result = v1 + v2
+        self.assertEqual(tuple(result), (4, 6))
+
+    def test_scalar_multiplication(self):
+        v1 = Vector2(1, 2)
+        result = v1 * 2
+        self.assertEqual(tuple(result), (2, 4))
+
+        result = 2 * v1
+        self.assertEqual(tuple(result), (2, 4))
+
+    def test_iteration(self):
+        v1 = Vector2(1, 2)
+        values = list(iter(v1))
+        self.assertEqual(values, [1, 2])
+
+    def test_equality(self):
+        v1 = Vector2(1, 2)
+        v2 = Vector2(1, 2)
+        v3 = Vector2(3, 4)
+        self.assertTrue(v1 == v2)
+        self.assertFalse(v1 == v3)
+
+    def test_getitem(self):
+        v1 = Vector2(1, 2)
+        self.assertEqual(v1[0], 1)
+        self.assertEqual(v1[1], 2)
+        self.assertEqual(v1[0:2], (1, 2))
+
+    def test_vector2_magnitude(self):
+        v2 = Vector2(3, 4)
+        self.assertAlmostEqual(v2.magnitude, 5.0, places=2)
+
+        v2_zero = Vector2(0, 0)
+        self.assertAlmostEqual(v2_zero.magnitude, 0.0, places=2)
+
+        v2_diagonal = Vector2(1, 1)
+        self.assertAlmostEqual(v2_diagonal.magnitude, 1.41, places=2)
+
+    def test_vector2_normalized(self):
+        v2 = Vector2(3, 4)
+        normalized_v2 = v2.normalized
+        self.assertAlmostEqual(normalized_v2.magnitude, 1.0, places=2)
+        self.assertAlmostEqual(normalized_v2[0], 0.6, places=2)
+        self.assertAlmostEqual(normalized_v2[1], 0.8, places=2)
+
+        v2_zero = Vector2(0, 0)
+        normalized_v2_zero = v2_zero.normalized
+        self.assertEqual(normalized_v2_zero.magnitude, 0.0)

--- a/tuxemon/math.py
+++ b/tuxemon/math.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Generator, Sequence
+from math import sqrt
 from typing import TypeVar, Union, overload
 
 SelfType = TypeVar("SelfType", bound="Vector")
@@ -24,11 +25,27 @@ class Vector(ABC, Sequence[float]):
     def __str__(self) -> str:
         return f"{type(self)}{tuple(self)}"
 
+    @property
+    def magnitude(self) -> float:
+        return sqrt(sum(component**2 for component in self))
+
+    @property
+    def normalized(self: SelfType) -> SelfType:
+        """
+        Returns the normalized vector (unit vector).
+        """
+        if self.magnitude == 0:
+            return type(self)([0] * len(self))
+        return self * (1 / self.magnitude)
+
+    @property
+    def as_tuple(self) -> tuple[float, ...]:
+        return tuple(self)
+
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Sequence) or len(self) != len(other):
             return NotImplemented
-
-        return tuple(self) == tuple(other)
+        return self.as_tuple == tuple(other)
 
     def __len__(self) -> int:
         return len(tuple(iter(self)))


### PR DESCRIPTION
PR introduces the following updates to `math.py`:
- implemented a `magnitude` property for vectors (it'll used in #2706)
- implemented a `normalize` property for vectors (it'll used in #2706)
- simplified the `__eq__` method by introducing an `as_tuple` property