### PR TITLE
Add CameraMoveAction (smooth camera transitions)

### DIFF
--- a/docs/handcrafted/action_list.rst
+++ b/docs/handcrafted/action_list.rst
@@ -8,6 +8,7 @@
 .. autoscriptinfoclass:: tuxemon.event.actions.call_event.CallEventAction
 .. autoscriptinfoclass:: tuxemon.event.actions.camera_follow.CameraFollowAction
 .. autoscriptinfoclass:: tuxemon.event.actions.camera_mode.CameraModeAction
+.. autoscriptinfoclass:: tuxemon.event.actions.camera_move.CameraMoveAction
 .. autoscriptinfoclass:: tuxemon.event.actions.camera_position.CameraPositionAction
 .. autoscriptinfoclass:: tuxemon.event.actions.camera_shake.CameraShakeAction
 .. autoscriptinfoclass:: tuxemon.event.actions.change_bg.ChangeBgAction

--- a/tests/tuxemon/test_camera.py
+++ b/tests/tuxemon/test_camera.py
@@ -54,13 +54,13 @@ class TestCamera(unittest.TestCase):
         self.assertEqual(self.camera.get_entity_center(), Vector2(88, 88))
 
     def test_update_follow(self):
-        self.camera.update()
+        self.camera.update(0.1)
         self.assertEqual(self.camera.position, Vector2(88, 88))
 
     def test_update_unfollow(self):
-        self.camera.update()
+        self.camera.update(0.1)
         self.camera.unfollow()
-        self.camera.update()
+        self.camera.update(0.1)
         self.assertEqual(self.camera.position, Vector2(88, 88))
         self.camera.move(dx=10)
         self.assertNotEqual(self.camera.position, Vector2(88, 88))
@@ -144,7 +144,7 @@ class TestCameraManager(unittest.TestCase):
 
     def test_update(self):
         self.manager.add_camera(self.camera1)
-        self.manager.update()
+        self.manager.update(0.1)
         self.camera1.update.assert_called_once()
 
     def test_handle_input(self):

--- a/tuxemon/camera.py
+++ b/tuxemon/camera.py
@@ -76,7 +76,7 @@ class CameraManager:
         else:
             raise ValueError("Camera not managed by this CameraManager.")
 
-    def update(self) -> None:
+    def update(self, delta_time: float) -> None:
         """
         Updates the active camera, if one is set.
 
@@ -84,7 +84,7 @@ class CameraManager:
         state is updated.
         """
         if self.active_camera:
-            self.active_camera.update()
+            self.active_camera.update(delta_time)
 
     def handle_input(self, event: PlayerInput) -> Optional[PlayerInput]:
         """
@@ -157,6 +157,7 @@ class Camera:
     """
 
     FRAME_RATE: int = 60
+    TRANSITION_SPEED: float = 5.0
 
     def __init__(self, entity: Entity[Any], boundary: BoundaryChecker):
         """
@@ -174,8 +175,58 @@ class Camera:
         self.follows_entity = True
         self.free_roaming_enabled = False
         self.boundary = boundary
+
         self.shake_intensity = 0.0
         self.shake_duration = 0.0
+
+        self.smooth_transition_speed = self.TRANSITION_SPEED
+        self.is_moving_smoothly = False
+        self.pending_follow = False
+
+    @staticmethod
+    def get_distance(pos1: Vector2, pos2: Vector2) -> float:
+        """Calculate the Euclidean distance between two positions."""
+        return float(((pos2.x - pos1.x) ** 2 + (pos2.y - pos1.y) ** 2) ** 0.5)
+
+    def move_smoothly_to(
+        self, target_x: float, target_y: float, duration: float
+    ) -> None:
+        """Start a smooth movement toward the target position over the given duration."""
+        self.target_position = self.get_center(Vector2(target_x, target_y))
+        self.smooth_transition_speed = (
+            self.get_distance(self.position, self.target_position) / duration
+        )
+        self.is_moving_smoothly = True
+
+    def update_smooth_transition(self, delta_time: float) -> None:
+        """Smoothly move the camera toward the target position."""
+        dx = self.target_position.x - self.position.x
+        dy = self.target_position.y - self.position.y
+
+        distance_to_target = (dx**2 + dy**2) ** 0.5
+        step = self.smooth_transition_speed * delta_time
+
+        if step >= distance_to_target:
+            self.position = self.target_position
+            self.is_moving_smoothly = False
+            if self.pending_follow:
+                self.follow()
+                self.pending_follow = False
+        else:
+            self.position.x += step * (dx / distance_to_target)
+            self.position.y += step * (dy / distance_to_target)
+
+    def smooth_reset_to_entity_center(self, duration: float) -> None:
+        """
+        Smoothly moves the camera to the center of the entity's tile over the given duration.
+
+        Parameters:
+            duration: The time (in seconds) it should take to move to the entity's center.
+        """
+        target_position = self.get_entity_center()
+        tile = unproject(target_position)
+        self.move_smoothly_to(tile[0], tile[1], duration)
+        self.pending_follow = True
 
     def follow(self) -> None:
         """
@@ -215,10 +266,12 @@ class Camera:
             Vector2(self.entity.position3.x, self.entity.position3.y)
         )
 
-    def update(self) -> None:
+    def update(self, delta_time: float) -> None:
         """
         Updates the camera's position if it's set to follow the entity.
         """
+        if self.is_moving_smoothly:
+            self.update_smooth_transition(delta_time)
         if self.follows_entity:
             self.position = self.get_entity_center()
         self.handle_shake()

--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -199,7 +199,7 @@ class WorldState(state.State):
         super().update(time_delta)
         self.update_npcs(time_delta)
         self.map_renderer.update(time_delta)
-        self.camera_manager.update()
+        self.camera_manager.update(time_delta)
 
         logger.debug("*** Game Loop Started ***")
 


### PR DESCRIPTION
PR introduces the `CameraMoveAction`, which allows the camera to smoothly move to specified coordinates or reset to the entity's center and improves `CameraPositionAction`

```
    <property name="act1" value="camera_move 2.0,32,6"/>
    <property name="act2" value="wait 2"/> 
    <-- important to set wait equal to the camera_move time, if not the dialog will appear while moving -->
    <property name="act3" value="translated_dialog spyder_papertown_sunnyside"/>
    <property name="act4" value="camera_move 2.0"/>
```

https://github.com/user-attachments/assets/ad6cd020-69b1-4488-a71c-03be9b4789c2