### PR TITLE
Improve InputMenu Structure

### DIFF
--- a/mods/tuxemon/l18n/de_DE/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/de_DE/LC_MESSAGES/base.po
@@ -608,9 +608,6 @@ msgid "menu_alphabet"
 msgstr ""
 "AÄBCDEFGHIJKLMNOÖPQRS\\0TUÜVWXYZaäbcdefghijklmnoöpqrsßtuüvwxyz1234567890.-!"
 
-msgid "menu_alphabet_n_columns"
-msgstr "15"
-
 # Monster Menu notifications
 msgid "monster_menu_info"
 msgstr "Info"

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -3061,9 +3061,6 @@ msgstr "From ${{map_name}} to ${{east}}"
 msgid "menu_alphabet"
 msgstr "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890.-!"
 
-msgid "menu_alphabet_n_columns"
-msgstr "13"
-
 msgid "dont_care"
 msgstr "DON'T CARE"
 

--- a/mods/tuxemon/l18n/eo/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/eo/LC_MESSAGES/base.po
@@ -240,9 +240,6 @@ msgstr "Run"
 msgid "menu_alphabet"
 msgstr "ABCĈDEFGĜHĤIJĴKLMNOPRSŜTUŬVZabcĉdefgĝhĥijĵklmnoprsŝtuŭvz1234567890.-!\0"
 
-msgid "menu_alphabet_n_columns"
-msgstr "14"
-
 # Monster Menu notifications
 msgid "monster_menu_info"
 msgstr "Informoj"

--- a/mods/tuxemon/l18n/es_ES/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/es_ES/LC_MESSAGES/base.po
@@ -568,9 +568,6 @@ msgstr "Punta de Ala"
 msgid "menu_alphabet"
 msgstr "ABCDEFGHIJKLMNÑOPQRSTUVWXYZ\0abcdefghijklmnñopqrstuvwxyz\01234567890.-¡!"
 
-msgid "menu_alphabet_n_columns"
-msgstr "14"
-
 msgid "menu_char_variants"
 msgstr "AÁ\n"
 "EÉ\n"

--- a/mods/tuxemon/l18n/es_MX/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/es_MX/LC_MESSAGES/base.po
@@ -1795,9 +1795,6 @@ msgstr "Red"
 msgid "wing_tip"
 msgstr "Punta del Ala"
 
-msgid "menu_alphabet_n_columns"
-msgstr "13"
-
 msgid "quicklyknight2"
 msgstr "Dos personas controlan Omnichannel. La junta directiva es una broma."
 

--- a/mods/tuxemon/l18n/fi/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/fi/LC_MESSAGES/base.po
@@ -137,9 +137,6 @@ msgstr "Junttaa"
 msgid "refresh"
 msgstr "Virkistä"
 
-msgid "menu_alphabet_n_columns"
-msgstr "13"
-
 msgid "venomous_tentacle"
 msgstr "Myrkkylonkero"
 

--- a/mods/tuxemon/l18n/fr_FR/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/fr_FR/LC_MESSAGES/base.po
@@ -1966,9 +1966,6 @@ msgstr "Supernova"
 msgid "take_cover"
 msgstr "À Couvert"
 
-msgid "menu_alphabet_n_columns"
-msgstr "13"
-
 msgid "kindling_flame"
 msgstr "Flamme Étincelante"
 

--- a/mods/tuxemon/l18n/it_IT/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/it_IT/LC_MESSAGES/base.po
@@ -1787,9 +1787,6 @@ msgid "menu_alphabet"
 msgstr ""
 "AÀBCDEÈÉFGHIÌJKLMNOÒPQRSTUÙVWXYZaàbcdeèéfghiìjklmnoòpqrstuùvwxyz1234567890.-!"
 
-msgid "menu_alphabet_n_columns"
-msgstr "14"
-
 msgid "professorexists1"
 msgstr "Grazie Ben."
 

--- a/mods/tuxemon/l18n/pl/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/pl/LC_MESSAGES/base.po
@@ -1504,9 +1504,6 @@ msgstr "Może robią park wodny!"
 msgid "hmmm3"
 msgstr "Jaki to ma sens? Trasa i tak jest prawie cała w trawie."
 
-msgid "menu_alphabet_n_columns"
-msgstr "13"
-
 ## MENU TRANSLATIONS ##
 msgid "menu_alphabet"
 msgstr ""

--- a/mods/tuxemon/l18n/pt_BR/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/pt_BR/LC_MESSAGES/base.po
@@ -857,9 +857,6 @@ msgstr "Ponta da Asa"
 msgid "menu_alphabet"
 msgstr "AÁÀÂÃBCÇDEÉÈÊFGHIÍÌJKLMNOÓÒÔÕPQRSTUÚÙVWXYZaáàâãbcçdeéèêẽfghiíìjklmnoóòôõpqrstuúùvwxyz1234567890.-!"
 
-msgid "menu_alphabet_n_columns"
-msgstr "14"
-
 # Monster Menu notifications
 msgid "monster_menu_info"
 msgstr "Informações"

--- a/mods/tuxemon/l18n/zh_CN/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/zh_CN/LC_MESSAGES/base.po
@@ -587,9 +587,6 @@ msgstr "翅膀攻击"
 msgid "menu_alphabet"
 msgstr "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890.-!"
 
-msgid "menu_alphabet_n_columns"
-msgstr "13"
-
 # Monster Menu notifications
 msgid "monster_menu_info"
 msgstr "信息"

--- a/tuxemon/menu/input.py
+++ b/tuxemon/menu/input.py
@@ -63,7 +63,6 @@ class InputMenu(Menu[InputMenuObj]):
         self.is_first_input = True
         self.input_string = initial
         self.chars = T.translate("menu_alphabet").replace(r"\0", "\0")
-        self.n_columns = int(T.translate("menu_alphabet_n_columns"))
         self.char_variants = {
             s[0]: s[1:] for s in T.translate("menu_char_variants").split("\n")
         }
@@ -93,6 +92,17 @@ class InputMenu(Menu[InputMenuObj]):
         self.random = random
         assert self.callback
 
+        # Character counter
+        self.char_counter = TextArea(self.font, self.font_color, (96, 96, 96))
+        self.char_counter.animated = False
+        self.update_char_counter()
+
+        self.char_counter.rect.topleft = (
+            self.text_area.rect.right + (self.rect.width * 0.25),
+            self.text_area.rect.top,
+        )
+        self.sprites.add(self.char_counter)
+
     def calc_internal_rect(self) -> Rect:
         w = self.rect.width - self.rect.width * 0.95
         h = self.rect.height - self.rect.height * 0.5
@@ -103,26 +113,16 @@ class InputMenu(Menu[InputMenuObj]):
     def initialize_items(
         self,
     ) -> Generator[MenuItem[InputMenuObj], None, None]:
-        self.menu_items.columns = self.n_columns
+        self.menu_items.columns = max(
+            1, self.rect.width // int(self.rect.width * 0.075)
+        )
 
         # add the keys
         for char in self.chars:
             if char == "\0":
-                empty = MenuItem(
-                    self.shadow_text(" "),
-                    None,
-                    None,
-                    InputMenuObj(self.empty),
-                )
-                empty.enabled = False
-                yield empty
+                yield self._create_empty_item()
             else:
-                yield MenuItem(
-                    self.shadow_text(char),
-                    None,
-                    None,
-                    InputMenuObj(partial(self.add_input_char, char), char),
-                )
+                yield self._create_char_item(char)
 
         # backspace key
         yield MenuItem(
@@ -151,43 +151,15 @@ class InputMenu(Menu[InputMenuObj]):
 
     def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
         if event.button in (buttons.A, intentions.SELECT):
-            menu_item = self.get_selected_item()
-            if menu_item is None:
-                return None
-
-            if event.triggered:
-                if self.leaving_char_variant_dialog:
-                    self.leaving_char_variant_dialog = False
-                else:
-                    menu_item.game_object()
-
-            # Wait roughly 1 sec before showing the char variants menu
-            elif event.held and event.hold_time > self.client.fps:
-                base_char = menu_item.game_object.char
-                if base_char:
-                    variants = self.char_variants.get(base_char, "")
-                    all_variants = base_char + variants
-                    choices = [
-                        (c, c, partial(self.add_input_char_and_pop, c))
-                        for c in all_variants
-                    ]
-                    self.client.push_state(ChoiceState(menu=choices))
+            self._handle_select_event(event)
             return None
-
-        maybe_event = super().process_event(event)
-
-        if maybe_event and maybe_event.pressed:
-            if maybe_event.button == events.BACKSPACE:
-                self.backspace()
-                return None
-
-            if maybe_event.button == events.UNICODE:
-                char = maybe_event.value
-                if char == " " or char in self.all_chars:
-                    self.add_input_char(char)
-                return None
-
-        return maybe_event
+        if event.pressed and event.button == events.BACKSPACE:
+            self._handle_backspace_event()
+            return None
+        if event.pressed and event.button == events.UNICODE:
+            self._handle_unicode_event(event.value)
+            return None
+        return super().process_event(event)
 
     def empty(self) -> None:
         pass
@@ -195,6 +167,7 @@ class InputMenu(Menu[InputMenuObj]):
     def backspace(self) -> None:
         self.input_string = self.input_string[:-1]
         self.update_text_area()
+        self.update_char_counter()
 
     def add_input_char_and_pop(self, char: str) -> None:
         self.leaving_char_variant_dialog = True
@@ -202,19 +175,22 @@ class InputMenu(Menu[InputMenuObj]):
         self.client.pop_state()
 
     def add_input_char(self, char: str) -> None:
-        if (
-            self.char_limit is None
-            or len(self.input_string) <= self.char_limit
-        ):
+        if self.char_limit is None or len(self.input_string) < self.char_limit:
             # removes A at the end of the name
             self.input_string += char if not self.is_first_input else ""
             self.is_first_input = False
             self.update_text_area()
+            self.update_char_counter()
         else:
             self.text_area.text = T.translate("alert_text")
+            self.update_char_counter()
 
     def update_text_area(self) -> None:
         self.text_area.text = self.input_string
+
+    def update_char_counter(self) -> None:
+        remaining = max(0, self.char_limit - len(self.input_string))
+        self.char_counter.text = f"{remaining}"
 
     def confirm(self) -> None:
         """
@@ -225,7 +201,8 @@ class InputMenu(Menu[InputMenuObj]):
         """
         if not self.text_area.text:
             return
-        assert self.callback
+        if self.callback is None:
+            raise ValueError("Callback function not provided!")
         self.callback(self.input_string)
         self.client.pop_state(self)
 
@@ -247,3 +224,48 @@ class InputMenu(Menu[InputMenuObj]):
             default_names = T.translate("random_names")
         self.input_string = rd.choice(default_names.split("\n"))
         self.update_text_area()
+
+    def _create_empty_item(self) -> MenuItem[InputMenuObj]:
+        empty = MenuItem(
+            self.shadow_text(" "),
+            None,
+            None,
+            InputMenuObj(self.empty),
+        )
+        empty.enabled = False
+        return empty
+
+    def _create_char_item(self, char: str) -> MenuItem[InputMenuObj]:
+        return MenuItem(
+            self.shadow_text(char),
+            None,
+            None,
+            InputMenuObj(partial(self.add_input_char, char), char),
+        )
+
+    def _handle_select_event(self, event: PlayerInput) -> None:
+        menu_item = self.get_selected_item()
+        if menu_item is None:
+            return
+        if event.triggered:
+            if self.leaving_char_variant_dialog:
+                self.leaving_char_variant_dialog = False
+            else:
+                menu_item.game_object()
+        elif event.held and event.hold_time > self.client.fps:
+            base_char = menu_item.game_object.char
+            if base_char:
+                variants = self.char_variants.get(base_char, "")
+                all_variants = base_char + variants
+                choices = [
+                    (c, c, partial(self.add_input_char_and_pop, c))
+                    for c in all_variants
+                ]
+                self.client.push_state(ChoiceState(menu=choices))
+
+    def _handle_backspace_event(self) -> None:
+        self.backspace()
+
+    def _handle_unicode_event(self, char: str) -> None:
+        if char == " " or char in self.all_chars:
+            self.add_input_char(char)


### PR DESCRIPTION
PR refactors the `InputMenu` class by breaking down complex operations into smaller, private helper methods.
- added helper methods like `_create_empty_item`, `_create_char_item`, `_handle_select_event`, `_handle_backspace_event`, and `_handle_unicode_event`
- refactored sections of the `initialize_items` and `process_event` methods to rely on these helpers
- displayed a small counter of remaining characters
- number of columns calculated by using the width

This is not an overhaul, but a cleanup. Added the counter, see video below:

https://github.com/user-attachments/assets/af6b9d5d-219b-4a59-904e-745b3cf74924