### PR TITLE
small fixes

### DIFF
--- a/tuxemon/config.py
+++ b/tuxemon/config.py
@@ -10,6 +10,7 @@ from typing import Any, Optional
 import pygame
 
 from tuxemon.animation import Animation
+from tuxemon.constants import paths
 from tuxemon.platform.const import buttons, events
 
 Animation.default_transition = "out_quint"
@@ -41,6 +42,7 @@ class TuxemonConfig:
 
         # not configurable from the file yet
         self.mods = ["tuxemon"]
+        assert all(mod in paths.mods_subfolders for mod in self.mods)
 
     def save_config(self) -> None:
         assert self.config_path

--- a/tuxemon/constants/paths.py
+++ b/tuxemon/constants/paths.py
@@ -35,6 +35,14 @@ logger.debug(f"basedir: {BASEDIR}")
 mods_folder = os.path.normpath(os.path.join(LIBDIR, "..", "mods"))
 logger.debug(f"mods: {mods_folder}")
 
+# mods subfolders
+mods_subfolders = [
+    f
+    for f in os.listdir(mods_folder)
+    if os.path.isdir(os.path.join(mods_folder, f))
+]
+logger.debug(f"Mods subfolders: {mods_subfolders}")
+
 # action/condition plugins (eventually move out of lib folder)
 CONDITIONS_PATH = os.path.normpath(os.path.join(LIBDIR, "event/conditions"))
 ACTIONS_PATH = os.path.normpath(os.path.join(LIBDIR, "event/actions"))

--- a/tuxemon/event/actions/load_game.py
+++ b/tuxemon/event/actions/load_game.py
@@ -65,11 +65,7 @@ class LoadGameAction(EventAction):
             map_path = prepare.fetch(
                 "maps", save_data["npc_state"]["current_map"]
             )
-            client.push_state(
-                WorldState(
-                    map_name=map_path,
-                )
-            )
+            client.push_state("WorldState", map_name=map_path)
 
             # TODO: Get player from whatever place and use self.client in
             # order to build a Session

--- a/tuxemon/event/actions/random_battle.py
+++ b/tuxemon/event/actions/random_battle.py
@@ -92,12 +92,11 @@ class RandomBattleAction(EventAction):
 
         logger.info(f"Starting battle with '{npc.name}'!")
         self.session.client.push_state(
-            CombatState(
-                players=(player, npc),
-                combat_type="trainer",
-                graphics=env.battle_graphics,
-                battle_mode="single",
-            )
+            "CombatState",
+            players=(player, npc),
+            combat_type="trainer",
+            graphics=env.battle_graphics,
+            battle_mode="single",
         )
 
         self.session.client.event_engine.execute_action(

--- a/tuxemon/event/actions/start_battle.py
+++ b/tuxemon/event/actions/start_battle.py
@@ -74,12 +74,11 @@ class StartBattleAction(EventAction):
             f"Starting battle between {fighters[0].name} and {fighters[1].name}!"
         )
         self.session.client.push_state(
-            CombatState(
-                players=(fighters[0], fighters[1]),
-                combat_type="trainer",
-                graphics=env.battle_graphics,
-                battle_mode="single",
-            )
+            "CombatState",
+            players=(fighters[0], fighters[1]),
+            combat_type="trainer",
+            graphics=env.battle_graphics,
+            battle_mode="single",
         )
 
         filename = env.battle_music if not self.music else self.music

--- a/tuxemon/event/actions/start_double_battle.py
+++ b/tuxemon/event/actions/start_double_battle.py
@@ -82,12 +82,11 @@ class StartDoubleBattleAction(EventAction):
             f"Starting double battle between {fighters[0].name} and {fighters[1].name}!"
         )
         self.session.client.push_state(
-            CombatState(
-                players=(fighters[0], fighters[1]),
-                combat_type="trainer",
-                graphics=env.battle_graphics,
-                battle_mode="double",
-            )
+            "CombatState",
+            players=(fighters[0], fighters[1]),
+            combat_type="trainer",
+            graphics=env.battle_graphics,
+            battle_mode="double",
         )
         # music
         filename = env.battle_music if not self.music else self.music

--- a/tuxemon/event/actions/wild_encounter.py
+++ b/tuxemon/event/actions/wild_encounter.py
@@ -14,7 +14,6 @@ from tuxemon.graphics import ColorLike, string_to_colorlike
 from tuxemon.item.item import Item
 from tuxemon.npc import NPC
 from tuxemon.states.combat.combat import CombatState
-from tuxemon.states.transition.flash import FlashTransition
 from tuxemon.states.world.worldstate import WorldState
 
 logger = logging.getLogger(__name__)
@@ -106,7 +105,7 @@ class WildEncounterAction(EventAction):
         rgb: ColorLike = prepare.WHITE_COLOR
         if self.rgb:
             rgb = string_to_colorlike(self.rgb)
-        self.session.client.push_state(FlashTransition(color=rgb))
+        self.session.client.push_state("FlashTransition", color=rgb)
 
         self.session.client.event_engine.execute_action(
             "play_music", [environment.battle_music], True

--- a/tuxemon/menu/input.py
+++ b/tuxemon/menu/input.py
@@ -98,7 +98,7 @@ class InputMenu(Menu[InputMenuObj]):
         self.update_char_counter()
 
         self.char_counter.rect.topleft = (
-            self.text_area.rect.right + (self.rect.width * 0.25),
+            int(self.text_area.rect.right + (self.rect.width * 0.25)),
             self.text_area.rect.top,
         )
         self.sprites.add(self.char_counter)

--- a/tuxemon/states/dialog/__init__.py
+++ b/tuxemon/states/dialog/__init__.py
@@ -49,8 +49,10 @@ class DialogState(PopUpMenu[None]):
             "font_color": self.font_color,
             "font_shadow": self.font_shadow_color,
             "border": self.borders_filename,
+            "alignment": "left",
+            "v_alignment": "top",
         }
-        box_style = box_style or {}
+
         final_box_style = default_box_style.copy()
         final_box_style.update(box_style)
 

--- a/tuxemon/states/start/__init__.py
+++ b/tuxemon/states/start/__init__.py
@@ -12,7 +12,7 @@ import pygame
 import pygame_menu
 from pygame_menu import locals
 
-from tuxemon import formula, prepare
+from tuxemon import prepare
 from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.platform.const import buttons

--- a/tuxemon/tools.py
+++ b/tuxemon/tools.py
@@ -204,16 +204,13 @@ def open_dialog(
         The pushed dialog state.
 
     """
-    from tuxemon.states.dialog import DialogState
-
     rect = calc_dialog_rect(session.client.screen.get_rect(), position)
     return session.client.push_state(
-        DialogState(
-            text=text,
-            avatar=avatar,
-            rect=rect,
-            box_style=box_style,
-        )
+        "DialogState",
+        text=text,
+        avatar=avatar,
+        rect=rect,
+        box_style=box_style,
     )
 
 
@@ -233,13 +230,10 @@ def open_choice_dialog(
         The pushed dialog choice state.
 
     """
-    from tuxemon.states.choice.choice_state import ChoiceState
-
     return session.client.push_state(
-        ChoiceState(
-            menu=menu,
-            escape_key_exits=escape_key_exits,
-        )
+        "ChoiceState",
+        menu=menu,
+        escape_key_exits=escape_key_exits,
     )
 
 


### PR DESCRIPTION
PR addresses the following issues:
* a missing type hint in `menu.py`, which incorrectly flagged a tuple as [float, int] instead of [int, int]
* added `mod_subfolders` in `paths.py` for getting a list of all the mods we have in the mods folder
* removed unused imports from `StartState`
* added check in `TuxemonConfig` for `self.mods`
* forgotten parameters in the class `DialogState`, which caused an error during saving, resulting in the following error messages: 
```
[2025-04-07 13:48:20,555] tuxemon.event.eventaction - ERROR - Error executing action: 'alignment'
[2025-04-07 13:48:20,555] tuxemon.event.eventengine - ERROR - Error executing action 'save_game': 'alignment'
```