### PR TITLE
fix professor lab + fix crash bug combat

### DIFF
--- a/mods/tuxemon/maps/professor_lab.tmx
+++ b/mods/tuxemon/maps/professor_lab.tmx
@@ -3,9 +3,9 @@
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
+  <property name="map_type" value="notype"/>
   <property name="scenario" value="xero"/>
   <property name="slug" value="professor_lab"/>
-  <property name="map_type" value="notype"/>
  </properties>
  <tileset firstgid="1" source="../gfx/tilesets/core_indoor_floors.tsx"/>
  <tileset firstgid="3865" source="../gfx/tilesets/core_indoor_walls.tsx"/>
@@ -335,7 +335,7 @@
     <property name="cond3" value="not variable_set endbattleprof:yes"/>
    </properties>
   </object>
-  <object id="116" name="first battle lost" type="event" x="144" y="0" width="16" height="16">
+  <object id="116" name="first battle lost or draw" type="event" x="144" y="0" width="16" height="16">
    <properties>
     <property name="act2" value="modify_money player,120"/>
     <property name="act3" value="set_variable firstbattledone:yes"/>
@@ -343,7 +343,7 @@
     <property name="act5" value="set_variable ohnotyou:itsme"/>
     <property name="act6" value="set_variable endbattleprof:yes"/>
     <property name="cond1" value="is variable_set finishedbattle:yes"/>
-    <property name="cond2" value="is variable_set battle_last_result:lost"/>
+    <property name="cond2" value="not variable_set battle_last_result:won"/>
     <property name="cond3" value="not variable_set endbattleprof:yes"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_paper_town.tmx
+++ b/mods/tuxemon/maps/spyder_paper_town.tmx
@@ -329,7 +329,7 @@
     <property name="act50" value="set_monster_health"/>
     <property name="act60" value="set_monster_status"/>
     <property name="act70" value="set_variable firstfightend:no"/>
-    <property name="cond1" value="is variable_set battle_last_result:lost"/>
+    <property name="cond1" value="not variable_set battle_last_result:won"/>
     <property name="cond2" value="is variable_set firstfightend:yes"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/taba_ba_br_1.tmx
+++ b/mods/tuxemon/maps/taba_ba_br_1.tmx
@@ -199,7 +199,7 @@
     <property name="act21" value="teleport_faint"/>
     <property name="act30" value="set_variable redo:please"/>
     <property name="act40" value="unlock_controls"/>
-    <property name="cond1" value="is variable_set battle_last_result:lost"/>
+    <property name="cond1" value="not variable_set battle_last_result:won"/>
     <property name="cond2" value="is variable_set battle_last_trainer:acolyte"/>
     <property name="cond4" value="not variable_set redo:please"/>
     <property name="cond5" value="is variable_set battledone:yes"/>

--- a/mods/tuxemon/maps/taba_ba_br_2.tmx
+++ b/mods/tuxemon/maps/taba_ba_br_2.tmx
@@ -132,7 +132,7 @@
     <property name="act4" value="set_variable acolyte2battledone:yes"/>
     <property name="act5" value="teleport_faint"/>
     <property name="cond1" value="is variable_set talkedonce:yes"/>
-    <property name="cond2" value="is variable_set battle_last_result:lost"/>
+    <property name="cond2" value="not variable_set battle_last_result:won"/>
     <property name="cond3" value="not variable_set acolyte2battledone:yes"/>
    </properties>
   </object>

--- a/tuxemon/states/monster/__init__.py
+++ b/tuxemon/states/monster/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Generator
 from typing import Optional
 
-import pygame
+from pygame import SRCALPHA
 from pygame.font import Font
 from pygame.rect import Rect
 from pygame.surface import Surface
@@ -86,7 +86,7 @@ class MonsterMenuState(Menu[Optional[Monster]]):
         # make 6 slots
         for _ in range(local_session.player.party_limit):
             rect = Rect(0, 0, width, height)
-            surface = Surface(rect.size, pygame.SRCALPHA)
+            surface = Surface(rect.size, SRCALPHA)
             item = MenuItem(surface, None, None, None)
             yield item
 
@@ -121,7 +121,6 @@ class MonsterMenuState(Menu[Optional[Monster]]):
 
         Parameters:
             monster: The monster corresponding to the menu item, if any.
-
         """
         return monster is not None
 
@@ -242,7 +241,7 @@ class MonsterSpriteDisplay:
 class MonsterPortraitDisplay:
     def __init__(self, menu_state: MonsterMenuState) -> None:
         self.menu_state = menu_state
-        self.portrait = pygame.sprite.Sprite()
+        self.portrait = Sprite()
         self.portrait.rect = Rect(0, 0, 0, 0)
         self.menu_state.sprites.add(self.portrait)
 
@@ -254,7 +253,7 @@ class MonsterPortraitDisplay:
                 image = sprite.image
             except AttributeError:
                 pass
-        image = image or Surface((1, 1), pygame.SRCALPHA)
+        image = image or Surface((1, 1), SRCALPHA)
 
         self.portrait.image = image
         width, height = prepare.SCREEN_SIZE


### PR DESCRIPTION
PR fixes bug occurring after tying with the professor in a fight. The issue was caused by incomplete variable checking, which didn't account for the scenario where the player draws against the professor. I've reviewed all the maps and discovered some additional potential issues resulting from the lack of a drawing output. Everything has been fixed.

before
```
<property name="cond2" value="is variable_set battle_last_result:won"/>
and
<property name="cond2" value="is variable_set battle_last_result:lost"/>
```
after
```
<property name="cond2" value="is variable_set battle_last_result:won"/>
and
<property name="cond2" value="not variable_set battle_last_result:won"/>
```


and the line in MonsterMenuState fixes this crash
```
Traceback (most recent call last):
  File "/home/giorgio/Tuxemon/run_tuxemon.py", line 49, in <module>
    main.main(load_slot=args.slot)
  File "/home/giorgio/Tuxemon/tuxemon/main.py", line 50, in main
    client.main()
  File "/home/giorgio/Tuxemon/tuxemon/client.py", line 282, in main
    draw(screen)
  File "/home/giorgio/Tuxemon/tuxemon/client.py", line 382, in draw
    state.draw(surface)
  File "/home/giorgio/Tuxemon/tuxemon/menu/menu.py", line 706, in draw
    self.sprites.draw(surface)
  File "/home/giorgio/venv/lib/python3.12/site-packages/pygame/sprite.py", line 873, in draw
    newrect = surface_blit(spr.image, spr.rect)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument 1 must be pygame.surface.Surface, not None
```