### PR TITLE
fix various + fix flickering NPC walking

### DIFF
--- a/tests/tuxemon/test_map_view.py
+++ b/tests/tuxemon/test_map_view.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 import pygame
+from pygame.surface import Surface
 
 from tuxemon import prepare
 from tuxemon.db import EntityFacing
@@ -33,7 +34,7 @@ class TestSpriteRenderer(TestCase):
 
     @patch("tuxemon.graphics.load_and_scale")
     def test_load_sprites_npc(self, mock_load_and_scale):
-        mock_surface = MagicMock(spec=pygame.Surface)
+        mock_surface = MagicMock(spec=Surface)
         mock_surface.get_size.return_value = (32, 32)
         mock_load_and_scale.return_value = mock_surface
         self.sprite_controller.load_sprites(self.npc.template)
@@ -49,7 +50,7 @@ class TestSpriteRenderer(TestCase):
         self.npc_template = MagicMock()
         self.npc_template.sprite_name = "screen"
         self.npc_template.slug = "interactive_obj"
-        mock_surface = MagicMock(spec=pygame.Surface)
+        mock_surface = MagicMock(spec=Surface)
         mock_surface.get_size.return_value = (32, 32)
         mock_load_and_scale.return_value = mock_surface
         self.sprite_controller.load_sprites(self.npc.template)
@@ -62,7 +63,7 @@ class TestSpriteRenderer(TestCase):
 
     @patch("tuxemon.graphics.load_and_scale")
     def test_load_walking_animations(self, mock_load_and_scale):
-        mock_surface = MagicMock(spec=pygame.Surface)
+        mock_surface = MagicMock(spec=Surface)
         mock_load_and_scale.return_value = mock_surface
         self.sprite_renderer._load_walking_animations(self.npc.template)
 
@@ -85,7 +86,7 @@ class TestSpriteRenderer(TestCase):
 
     def test_get_frame_standing(self):
         self.npc.moving = False
-        self.mock_standing_surface = pygame.Surface((80, 160))
+        self.mock_standing_surface = Surface((80, 160))
         self.sprite_renderer.standing[EntityFacing.front] = (
             self.mock_standing_surface
         )
@@ -97,7 +98,7 @@ class TestSpriteRenderer(TestCase):
     @patch("tuxemon.surfanim.SurfaceAnimation.get_current_frame")
     def test_get_frame_walking(self, mock_get_current_frame):
         self.npc.moving = True
-        mock_surface = MagicMock(spec=pygame.Surface)
+        mock_surface = MagicMock(spec=Surface)
         mock_get_current_frame.return_value = mock_surface
         frame = self.sprite_renderer.get_frame("front_walk", self.npc)
         self.assertEqual(frame, mock_surface)
@@ -108,7 +109,7 @@ class TestSpriteRenderer(TestCase):
 
     @patch("tuxemon.graphics.load_and_scale")
     def adventurer_loading_paths(self, mock_load_and_scale):
-        mock_load_and_scale.return_value = pygame.Surface((1, 1))
+        mock_load_and_scale.return_value = Surface((1, 1))
         self.sprite_controller.load_sprites(self.npc.template)
         expected_paths = [
             os.path.join("sprites", "adventurer_front.png"),

--- a/tests/tuxemon/test_world_transition.py
+++ b/tests/tuxemon/test_world_transition.py
@@ -64,16 +64,16 @@ class TestTransition(TestCase):
     @patch("pygame.Surface")
     def test_draw_with_transition(self, MockSurface):
         mock_surface = MagicMock()
+        mock_transition_surface = MockSurface.return_value
         self.transition.set_transition_surface((0, 0, 0, 255))
         self.transition.set_transition_state(True)
 
+        self.transition.transition_surface = MockSurface()
         self.transition.transition_alpha = 100
         self.transition.draw(mock_surface)
 
-        self.transition.transition_surface.set_alpha.assert_called_with(100)
-        mock_surface.blit.assert_called_with(
-            self.transition.transition_surface, (0, 0)
-        )
+        mock_transition_surface.set_alpha.assert_called_with(100)
+        mock_surface.blit.assert_called_with(mock_transition_surface, (0, 0))
 
     @patch("pygame.Surface")
     def test_alpha_change_during_fade(self, MockSurface):
@@ -142,16 +142,17 @@ class TestTransition(TestCase):
     @patch("pygame.Surface")
     def test_draw(self, MockSurface):
         mock_surface = MagicMock()
+        mock_transition_surface = MockSurface.return_value
         self.transition.set_transition_surface((0, 0, 0, 255))
         self.transition.set_transition_state(True)
+
+        self.transition.transition_surface = MockSurface()
         self.transition.transition_alpha = 128
 
         self.transition.draw(mock_surface)
 
-        self.transition.transition_surface.set_alpha.assert_called_with(128)
-        mock_surface.blit.assert_called_with(
-            self.transition.transition_surface, (0, 0)
-        )
+        mock_transition_surface.set_alpha.assert_called_with(128)
+        mock_surface.blit.assert_called_with(mock_transition_surface, (0, 0))
 
     def test_no_draw_when_not_in_transition(self):
         mock_surface = MagicMock()

--- a/tuxemon/animation.py
+++ b/tuxemon/animation.py
@@ -486,7 +486,7 @@ class Animation(pygame.sprite.Sprite):
 
         """
         if self._round_values:
-            value = int(round(value, 0))
+            value = round(value)
 
         attr = getattr(target, name)
         if callable(attr):

--- a/tuxemon/event/actions/teleport_faint.py
+++ b/tuxemon/event/actions/teleport_faint.py
@@ -24,7 +24,7 @@ class TeleportFaintAction(EventAction):
     Script usage:
         .. code-block::
 
-            teleport_faint [character][,trans_time][,rgb]
+            teleport_faint <character>[,trans_time][,rgb]
 
     Script parameters:
         character: Either "player" or npc slug name (e.g. "npc_maple").
@@ -36,7 +36,7 @@ class TeleportFaintAction(EventAction):
     """
 
     name = "teleport_faint"
-    character: Optional[str] = None
+    character: str
     trans_time: Optional[float] = None
     rgb: Optional[str] = None
 

--- a/tuxemon/map_view.py
+++ b/tuxemon/map_view.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Optional
 
 import pygame
+from pygame.rect import Rect
+from pygame.surface import Surface
 
 from tuxemon import prepare
 from tuxemon.db import EntityFacing
@@ -25,10 +27,6 @@ if TYPE_CHECKING:
     from tuxemon.npc import NPC
     from tuxemon.states.world.worldstate import WorldState
 
-SpriteMap = Union[
-    dict[str, SurfaceAnimation], dict[str, pygame.surface.Surface]
-]
-
 
 @dataclass
 class AnimationInfo:
@@ -39,19 +37,16 @@ class AnimationInfo:
 
 @dataclass
 class WorldSurfaces:
-    surface: pygame.surface.Surface
+    surface: Surface
     position3: Vector2
     layer: int
 
 
-sprite_cache: dict[str, pygame.surface.Surface] = {}
-standing_sprite_cache: dict[
-    str, dict[EntityFacing, pygame.surface.Surface]
-] = {}
-walking_sprite_cache: dict[str, SurfaceAnimation] = {}
+sprite_cache: dict[str, Surface] = {}
+standing_sprite_cache: dict[str, dict[EntityFacing, Surface]] = {}
 
 
-def load_and_scale_with_cache(file_path: str) -> pygame.surface.Surface:
+def load_and_scale_with_cache(file_path: str) -> Surface:
     """
     Load and scale an image, using a cache to avoid redundant file operations.
     """
@@ -68,40 +63,27 @@ def load_walking_animations_with_cache(
     template: NpcTemplateModel, facing: EntityFacing, frame_duration: float
 ) -> SurfaceAnimation:
     """
-    Load walking animations with caching to avoid redundant frame processing.
+    Load walking animations without caching.
     """
-    cache_key = f"{template.sprite_name}_{facing.value}_walk"
-    if cache_key not in walking_sprite_cache:
-        logger.info(f"Creating new walking animation for: {cache_key}")
-        images: list[str] = [
-            f"sprites/{template.sprite_name}_{facing.value}_walk.{str(0).zfill(3)}.png",
-            f"sprites/{template.sprite_name}_{facing.value}.png",
-            f"sprites/{template.sprite_name}_{facing.value}_walk.{str(1).zfill(3)}.png",
-            f"sprites/{template.sprite_name}_{facing.value}.png",
-        ]
-        frames: list[tuple[pygame.surface.Surface, float]] = [
-            (load_and_scale_with_cache(image), frame_duration)
-            for image in images
-        ]
-        walking_sprite_cache[cache_key] = SurfaceAnimation(frames, loop=True)
-    else:
-        logger.info(f"Using cached walking animation for: {cache_key}")
-    return walking_sprite_cache[cache_key]
+    logger.info(
+        f"Loading new walking animation for: {template.sprite_name}, {facing.value}"
+    )
+    images: list[str] = [
+        f"sprites/{template.sprite_name}_{facing.value}_walk.{str(0).zfill(3)}.png",
+        f"sprites/{template.sprite_name}_{facing.value}.png",
+        f"sprites/{template.sprite_name}_{facing.value}_walk.{str(1).zfill(3)}.png",
+        f"sprites/{template.sprite_name}_{facing.value}.png",
+    ]
+    frames: list[tuple[Surface, float]] = [
+        (load_and_scale_with_cache(image), frame_duration) for image in images
+    ]
+    return SurfaceAnimation(frames, loop=True)
 
 
 def clear_standing_cache(cache_key: str) -> None:
     """Clears a specific item from the standing cache."""
     if cache_key in standing_sprite_cache:
         del standing_sprite_cache[cache_key]
-        logger.info(f"Cleared cache for: {cache_key}")
-    else:
-        logger.info(f"No cache found for: {cache_key}")
-
-
-def clear_walking_cache(cache_key: str) -> None:
-    """Clears a specific item from the walking cache."""
-    if cache_key in walking_sprite_cache:
-        del walking_sprite_cache[cache_key]
         logger.info(f"Cleared cache for: {cache_key}")
     else:
         logger.info(f"No cache found for: {cache_key}")
@@ -130,7 +112,7 @@ class SpriteController:
         )
         self.sprite_renderer.play()
 
-    def get_frame(self, ani: str) -> pygame.surface.Surface:
+    def get_frame(self, ani: str) -> Surface:
         """Get the current frame of the sprite animation."""
         return self.sprite_renderer.get_frame(ani, self.npc)
 
@@ -171,14 +153,12 @@ class SpriteRenderer:
 
     def __init__(self) -> None:
         """Initialize the SpriteRenderer."""
-        self.standing: dict[
-            Union[EntityFacing, str], pygame.surface.Surface
-        ] = {}
+        self.standing: dict[EntityFacing, Surface] = {}
         self.sprite: dict[str, SurfaceAnimation] = {}
         self.surface_animations = SurfaceAnimationCollection()
         self.player_width = 0
         self.player_height = 0
-        self.rect = pygame.rect.Rect(0, 0, 0, 0)
+        self.rect = Rect(0, 0, 0, 0)
         self.frame_duration = self._calculate_frame_duration()
 
     def load_sprites(
@@ -222,7 +202,7 @@ class SpriteRenderer:
         self.player_width, self.player_height = self.standing[
             EntityFacing.front
         ].get_size()
-        self.rect = pygame.rect.Rect(
+        self.rect = Rect(
             (
                 tile_pos[0],
                 tile_pos[1],
@@ -252,16 +232,23 @@ class SpriteRenderer:
         """Update the sprite animation."""
         self.surface_animations.update(time_delta)
 
-    def get_frame(self, ani: str, npc: NPC) -> pygame.surface.Surface:
+    def get_frame(self, ani: str, npc: NPC) -> Surface:
         """Get the current frame of the sprite animation."""
-        frame_dict: SpriteMap = self.sprite if npc.moving else self.standing
-        if ani in frame_dict:
-            frame = frame_dict[ani]
-            if isinstance(frame, SurfaceAnimation):
-                frame.rate = npc.moverate / prepare.CONFIG.player_walkrate
-                return frame.get_current_frame()
-            return frame
-        raise ValueError(f"Animation '{ani}' not found.")
+        if npc.moving:
+            frame_dict = self.sprite
+            if ani in frame_dict:
+                frame = frame_dict[ani]
+                if isinstance(frame, SurfaceAnimation):
+                    frame.rate = npc.moverate / prepare.CONFIG.player_walkrate
+                    return frame.get_current_frame()
+                else:
+                    raise ValueError(
+                        f"Expected SurfaceAnimation, got {type(frame)}"
+                    )
+            raise ValueError(f"Animation '{ani}' not found.")
+        else:
+            facing = EntityFacing(ani)
+            return self.standing[facing]
 
     def play(self) -> None:
         """Play the sprite animation."""
@@ -276,22 +263,20 @@ class MapRenderer:
     """Renders the game map, NPCs, and animations."""
 
     def __init__(
-        self, world_state: WorldState, screen: pygame.Surface, camera: Camera
+        self, world_state: WorldState, screen: Surface, camera: Camera
     ):
         """Initializes the MapRenderer."""
         self.world_state = world_state
         self.screen = screen
         self.camera = camera
-        self.layer = pygame.Surface(self.screen.get_size(), pygame.SRCALPHA)
+        self.layer = Surface(self.screen.get_size(), pygame.SRCALPHA)
         self.layer_color: ColorLike = prepare.TRANSPARENT_COLOR
-        self.bubble: dict[NPC, pygame.surface.Surface] = {}
+        self.bubble: dict[NPC, Surface] = {}
         self.cinema_x_ratio: Optional[float] = None
         self.cinema_y_ratio: Optional[float] = None
         self.map_animations: dict[str, AnimationInfo] = {}
 
-    def draw(
-        self, surface: pygame.surface.Surface, current_map: TuxemonMap
-    ) -> None:
+    def draw(self, surface: Surface, current_map: TuxemonMap) -> None:
         """Draws the map, sprites, and animations onto the given surface."""
         self._prepare_map_rendering(current_map)
         screen_surfaces = self._get_and_position_surfaces(
@@ -318,7 +303,7 @@ class MapRenderer:
 
     def _get_and_position_surfaces(
         self, sprite_layer: int
-    ) -> list[tuple[pygame.surface.Surface, pygame.rect.Rect, int]]:
+    ) -> list[tuple[Surface, Rect, int]]:
         """Retrieves and positions surfaces for rendering."""
         npc_surfaces = self._get_npc_surfaces(sprite_layer)
         map_animations = self._get_map_animations()
@@ -329,21 +314,19 @@ class MapRenderer:
 
     def _draw_map_and_sprites(
         self,
-        surface: pygame.surface.Surface,
-        screen_surfaces: list[
-            tuple[pygame.surface.Surface, pygame.rect.Rect, int]
-        ],
+        surface: Surface,
+        screen_surfaces: list[tuple[Surface, Rect, int]],
         current_map: TuxemonMap,
     ) -> None:
         """Draws the map and sprites onto the surface."""
         assert current_map.renderer
         current_map.renderer.draw(surface, surface.get_rect(), screen_surfaces)
 
-    def _apply_effects(self, surface: pygame.surface.Surface) -> None:
+    def _apply_effects(self, surface: Surface) -> None:
         """Applies visual effects to the surface."""
         self._set_layer(surface)
 
-    def _apply_cinema_bars(self, surface: pygame.surface.Surface) -> None:
+    def _apply_cinema_bars(self, surface: Surface) -> None:
         """Applies cinema bars (letterboxing) to the surface."""
         if self.cinema_x_ratio is not None:
             self._apply_horizontal_bars(self.cinema_x_ratio, surface)
@@ -371,7 +354,7 @@ class MapRenderer:
 
     def _position_surfaces(
         self, surfaces: list[WorldSurfaces]
-    ) -> list[tuple[pygame.surface.Surface, pygame.rect.Rect, int]]:
+    ) -> list[tuple[Surface, Rect, int]]:
         """Positions surfaces on the screen."""
         screen_surfaces = []
         for frame in surfaces:
@@ -379,7 +362,7 @@ class MapRenderer:
             position = frame.position3
             layer = frame.layer
             screen_position = self.world_state.get_pos_from_tilepos(position)
-            rect = pygame.rect.Rect(screen_position, surface.get_size())
+            rect = Rect(screen_position, surface.get_size())
             if surface.get_height() > prepare.TILE_SIZE[1]:
                 rect.y -= surface.get_height() // 2
             screen_surfaces.append((surface, rect, layer))
@@ -387,9 +370,7 @@ class MapRenderer:
 
     def _set_bubble(
         self,
-        screen_surfaces: list[
-            tuple[pygame.surface.Surface, pygame.rect.Rect, int]
-        ],
+        screen_surfaces: list[tuple[Surface, Rect, int]],
     ) -> None:
         """Adds speech bubbles to the screen surfaces."""
         if self.bubble:
@@ -408,7 +389,7 @@ class MapRenderer:
                 )
                 screen_surfaces.append((surface, bubble_rect, 100))
 
-    def _set_layer(self, surface: pygame.surface.Surface) -> None:
+    def _set_layer(self, surface: Surface) -> None:
         """Applies the layer effect to the surface."""
         self.layer.fill(self.layer_color)
         surface.blit(self.layer, (0, 0))
@@ -421,14 +402,14 @@ class MapRenderer:
         frame = sprite_renderer.get_frame(state, npc)
         return [WorldSurfaces(frame, proj(npc.position3), layer)]
 
-    def debug_drawing(self, surface: pygame.surface.Surface) -> None:
+    def debug_drawing(self, surface: Surface) -> None:
         """Draws debug information on the surface."""
         self.world_state.debug_drawing(surface)
 
     def _apply_vertical_bars(
         self,
         aspect_ratio: float,
-        screen: pygame.surface.Surface,
+        screen: Surface,
     ) -> None:
         """Applies vertical cinema bars."""
         screen_aspect_ratio = prepare.SCREEN_SIZE[0] / prepare.SCREEN_SIZE[1]
@@ -438,7 +419,7 @@ class MapRenderer:
                 * (1 - screen_aspect_ratio / aspect_ratio)
                 / 2
             )
-            bar = pygame.Surface((prepare.SCREEN_SIZE[0], bar_height))
+            bar = Surface((prepare.SCREEN_SIZE[0], bar_height))
             bar.fill(prepare.BLACK_COLOR)
             screen.blit(bar, (0, 0))
             screen.blit(bar, (0, prepare.SCREEN_SIZE[1] - bar_height))
@@ -446,7 +427,7 @@ class MapRenderer:
     def _apply_horizontal_bars(
         self,
         aspect_ratio: float,
-        screen: pygame.surface.Surface,
+        screen: Surface,
     ) -> None:
         """Applies horizontal cinema bars."""
         screen_aspect_ratio = prepare.SCREEN_SIZE[1] / prepare.SCREEN_SIZE[0]
@@ -456,7 +437,7 @@ class MapRenderer:
                 * (1 - screen_aspect_ratio / aspect_ratio)
                 / 2
             )
-            bar = pygame.Surface((bar_width, prepare.SCREEN_SIZE[1]))
+            bar = Surface((bar_width, prepare.SCREEN_SIZE[1]))
             bar.fill(prepare.BLACK_COLOR)
             screen.blit(bar, (0, 0))
             screen.blit(bar, (prepare.SCREEN_SIZE[0] - bar_width, 0))

--- a/tuxemon/sprite.py
+++ b/tuxemon/sprite.py
@@ -204,11 +204,12 @@ class Sprite(DirtySprite):
         """
         Update the image of the sprite.
         """
-        image: Optional[Surface]
+        image: Optional[Surface] = None
         if self._original_image is not None and self._needs_rescale:
             w = self.rect.width if self._width is None else self._width
             h = self.rect.height if self._height is None else self._height
-            image = scale(self._original_image, (w, h))
+            if (w, h) != self._original_image.get_size():
+                image = scale(self._original_image, (w, h))
             center = self.rect.center
             self.rect.size = w, h
             self.rect.center = center
@@ -216,7 +217,11 @@ class Sprite(DirtySprite):
             image = self._original_image
 
         if image is not None and self._rotation:
-            image = rotozoom(image, self._rotation, 1)
+            image = (
+                rotozoom(image, self._rotation, 1)
+                if self._rotation != 0
+                else image
+            )
             rect = image.get_rect(center=self.rect.center)
             self.rect.size = rect.size
             self.rect.center = rect.center
@@ -242,7 +247,7 @@ class Sprite(DirtySprite):
         Parameters:
             width: The new width of the sprite.
         """
-        width = int(round(width, 0))
+        width = round(width)
         if not width == self._width:
             self._width = width
             self._needs_rescale = True
@@ -266,7 +271,7 @@ class Sprite(DirtySprite):
         Parameters:
             height: The new height of the sprite.
         """
-        height = int(round(height, 0))
+        height = round(height)
         if not height == self._height:
             self._height = height
             self._needs_rescale = True
@@ -290,7 +295,7 @@ class Sprite(DirtySprite):
         Parameters:
             value: The new rotation of the sprite.
         """
-        value = int(round(value, 0)) % 360
+        value = round(value) % 360
         if not value == self._rotation:
             self._rotation = value
             self._needs_update = True
@@ -312,8 +317,7 @@ class Sprite(DirtySprite):
             x: The new x-coordinate of the sprite.
             y: The new y-coordinate of the sprite.
         """
-        self.rect.x = x
-        self.rect.y = y
+        self.rect.topleft = (x, y)
 
     def get_position(self) -> tuple[int, int]:
         """
@@ -333,14 +337,9 @@ class Sprite(DirtySprite):
         """
         return self.visible
 
-    def toggle_visible(sprite: Sprite) -> None:
-        """
-        Toggles the visibility of a sprite.
-
-        Parameters:
-            sprite: The sprite to toggle visibility for.
-        """
-        sprite.visible = not sprite.visible
+    def toggle_visible(self) -> None:
+        """Toggles the visibility of a sprite."""
+        self.visible = not self.visible
 
 
 class CaptureDeviceSprite(Sprite):

--- a/tuxemon/states/minigame/__init__.py
+++ b/tuxemon/states/minigame/__init__.py
@@ -63,11 +63,11 @@ class MinigameState(PygameMenuState):
         )
         new_image.scale(prepare.SCALE, prepare.SCALE)
         menu.add.image(image_path=new_image.copy())
+
         choice = random.sample(data, 5)
-        pos = random.choice(range(len(choice)))
         if tuxemon not in choice:
-            choice.pop()
-            choice.insert(pos, tuxemon)
+            pos = random.randint(0, len(choice) - 1)
+            choice[pos] = tuxemon
 
         def checking(mon: MonsterModel) -> None:
             if mon.slug == self.tuxemon.slug:

--- a/tuxemon/states/world/world_transition.py
+++ b/tuxemon/states/world/world_transition.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Optional
 
 import pygame
+from pygame.surface import Surface
 
 from tuxemon.graphics import ColorLike
 
@@ -17,11 +18,11 @@ class WorldTransition:
     def __init__(self, world: WorldState) -> None:
         self.world = world
         self.transition_alpha = 0
-        self.transition_surface: Optional[pygame.surface.Surface] = None
+        self.transition_surface: Optional[Surface] = None
         self.in_transition = False
 
     def set_transition_surface(self, color: ColorLike) -> None:
-        self.transition_surface = pygame.Surface(
+        self.transition_surface = Surface(
             self.world.client.screen.get_size(), pygame.SRCALPHA
         )
         self.transition_surface.fill(color)
@@ -80,7 +81,7 @@ class WorldTransition:
         task = self.world.task(teleport_function, duration)
         task.chain(fade_in, duration + 0.5)
 
-    def draw(self, surface: pygame.surface.Surface) -> None:
+    def draw(self, surface: Surface) -> None:
         if self.in_transition:
             assert self.transition_surface
             self.transition_surface.set_alpha(self.transition_alpha)

--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -18,6 +18,7 @@ from typing import (
 
 import pygame
 from pygame.rect import Rect
+from pygame.surface import Surface
 
 from tuxemon import networking, prepare, state
 from tuxemon.boundary import BoundaryChecker
@@ -88,7 +89,7 @@ class WorldState(state.State):
         self.npcs: list[NPC] = []
         self.npcs_off_map: list[NPC] = []
         self.wants_to_move_char: dict[str, Direction] = {}
-        self.allow_char_movement: list[str] = []
+        self.allow_char_movement: set[str] = set()
 
         ######################################################################
         #                              Map                                   #
@@ -157,7 +158,7 @@ class WorldState(state.State):
 
         logger.debug("*** Game Loop Started ***")
 
-    def draw(self, surface: pygame.surface.Surface) -> None:
+    def draw(self, surface: Surface) -> None:
         """
         Draw the game world to the screen.
 
@@ -541,7 +542,7 @@ class WorldState(state.State):
         then the character will start moving after this is called.
 
         """
-        self.allow_char_movement.append(char.slug)
+        self.allow_char_movement.add(char.slug)
         if char.slug in self.wants_to_move_char.keys():
             _dir = self.wants_to_move_char.get(char.slug, Direction.down)
             self.move_char(char, _dir)
@@ -641,7 +642,7 @@ class WorldState(state.State):
 
         return Rect(x, y, tw, th)
 
-    def _npc_to_pgrect(self, npc: NPC) -> pygame.rect.Rect:
+    def _npc_to_pgrect(self, npc: NPC) -> Rect:
         """Returns a Rect (in screen-coords) version of an NPC's bounding box."""
         pos = self.get_pos_from_tilepos(proj(npc.position3))
         return Rect(pos, self.tile_size)
@@ -649,7 +650,7 @@ class WorldState(state.State):
     ####################################################
     #                Debug Drawing                     #
     ####################################################
-    def debug_drawing(self, surface: pygame.surface.Surface) -> None:
+    def debug_drawing(self, surface: Surface) -> None:
         from pygame.gfxdraw import box
 
         surface.lock()


### PR DESCRIPTION
PR fixes:
- changes `allow_char_movement` in WorldState from `list[str]` to `set[str]`, because of inconsistencies during the teleport;
- removes unnecessary rounding and conversions like `width = int(round(width, 0))` -> `width = round(width)`
- instead of defining `toggle_visible(sprite: Sprite)`, make it a method inside `Sprite`
- uses `self.rect.topleft = (x, y)` to avoid modifying `x` and `y` separately
- returns `self.rect.topleft` directly, which is already a tuple, instead of returning a new one
- checks if scaling is necessary, this prevents unnecessary scaling
- `rotozoom(image, self._rotation, 1)` is always applied if `_rotation` is set., instead, **only rotate if `_rotation` is non-zero**, this avoids unnecessary transformations
- typehints
- mostly `pygame.surface.Surface` or `pygame.rect.Rect`