### PR TITLE
Enhancing AI Decision-Making (Combat)

### DIFF
--- a/mods/ai_items.yaml
+++ b/mods/ai_items.yaml
@@ -1,0 +1,29 @@
+# General Rules for Item Evaluation
+items:
+  item_slug:
+    # The upper threshold for the item's use.
+    # The item will not be used if the current health is ABOVE this percentage of max HP.
+    # Optional: Can be omitted if no upper limit is needed.
+    hp_below: 0.3
+    
+    # The lower threshold for the item's use.
+    # The item will not be used if the current health is BELOW this percentage of max HP.
+    # Optional: Can be omitted if no lower limit is needed.
+    hp_above: 0.8
+
+    # A specific health range (inclusive of the lower bound and exclusive of the upper bound).
+    # The item will only be used if the current health is WITHIN this range.
+    # Optional: Can be omitted if no range restriction is needed.
+    hp_range: [0.3, 0.8]
+
+    # A list of status effects required for the item to be used (e.g., "poisoned", "stunned").
+    # If omitted, status effects will not be a consideration for item usage.
+    # Optional: Can be left out entirely.
+    status_effects: ["poisoned"]
+
+    # A list of specific monster slugs for which the item is applicable.
+    # If omitted, the item will not be restricted to any particular monsters.
+    # Optional: Can be left out entirely.
+    monster_slugs: ["monster_slug"]
+  potion:
+    hp_range: [0.3, 0.8]

--- a/mods/ai_opponent.yaml
+++ b/mods/ai_opponent.yaml
@@ -1,0 +1,47 @@
+# Rules for AI Decision Making
+rules:
+  default:
+    # Weight assigned to health in scoring an opponent.
+    # Opponents with higher remaining HP score higher relative to their max HP.
+    health_weight: 1.0
+
+    # Weight assigned to armour in scoring.
+    # Opponents with higher armour are evaluated as tougher targets.
+    armour_weight: 1.0
+
+    # Weight assigned to dodge (evasion capability) in scoring.
+    # Opponents with higher dodge may be harder to hit, increasing their priority.
+    dodge_weight: 1.0
+
+    # Weight assigned to melee attack capability.
+    # Opponents with stronger melee attacks may be evaluated as dangerous targets.
+    melee_weight: 1.0
+
+    # Weight assigned to ranged attack capability.
+    # Opponents with stronger ranged attacks may be evaluated as dangerous at a distance.
+    ranged_weight: 1.0
+
+    # Weight assigned to speed in scoring.
+    # Faster opponents may pose a higher threat as they act earlier in combat rounds.
+    speed_weight: 1.0
+
+    # Weight assigned to status effects in scoring.
+    # Opponents with harmful status effects like "poisoned" or "stunned" receive higher scores.
+    status_effects_weight: 1.0
+
+    # List of predefined multipliers for status effects.
+    # These values specify how much each status effect increases an opponent's priority.
+    status_effects:
+      poisoned: 1.0  # Opponent is poisoned; slightly increases their evaluation score.
+
+    # The threshold for level difference consideration.
+    # If the level difference (positive or negative) exceeds this value, it's factored into the score.
+    level_difference_threshold: 5
+
+    # Weight for level differences in evaluations.
+    # Larger differences are scaled based on this weight.
+    level_difference_weight: 0.3
+  # The unique identifier (slug) of the NPC character the player is battling against.
+  # This helps associate specific configurations or strategies with this NPC character.
+  character_slug:
+    health_weight: 1.0

--- a/mods/ai_techniques.yaml
+++ b/mods/ai_techniques.yaml
@@ -1,0 +1,29 @@
+techniques:
+  slug: # Can be a monster_slug (wild battle) or trainer_slug (trainer battle).
+    melee_bonus: 1.0  # Optional: Bonus multiplier applied to melee techniques.
+    touch_bonus: 1.0  # Optional: Bonus multiplier applied to touch-based techniques.
+    special_bonus: 1.0  # Optional: Bonus multiplier applied to special techniques.
+    ranged_bonus: 1.0  # Optional: Bonus multiplier applied to ranged techniques.
+    reach_bonus: 1.0  # Optional: Bonus multiplier applied to techniques with extended reach.
+    reliable_bonus: 1.0  # Optional: Bonus multiplier applied to techniques deemed reliable.
+
+    # Optional: Weight assigned to the base power of a technique. Higher values indicate prioritization of power.
+    power_weight: 1.0
+
+    # Optional: Weight assigned to the accuracy of a technique. Higher values indicate prioritization of precision.
+    accuracy_weight: 1.0
+
+    # Optional: Weight assigned to elemental effectiveness. Higher values indicate prioritization of exploiting elemental advantages.
+    elemental_multiplier_weight: 1.0
+
+    # Optional: Scaling for elemental effectiveness based on opponent's health condition.
+    elemental_health_scaling: 1.0  # Higher values increase effectiveness against opponents with high health.
+    elemental_health_threshold: 1.0  # Threshold for scaling; effectiveness applies if opponent's health is above this percentage.
+
+    # Optional: Threshold and weight for rewarding healing techniques based on the target's health.
+    health_priority_threshold: 0.5  # Techniques are rewarded if the target's health is below this percentage.
+    healing_weight: 1.5  # Determines the significance of healing effectiveness.
+
+    # Optional: Threshold and weight for penalizing healing techniques if the target's health is near full.
+    healing_penalty_threshold: 0.9  # Techniques are penalized if the target's health is above this percentage.
+    healing_penalty_weight: 0.5  # Determines the significance of the penalty applied.

--- a/mods/ai_trainers.yaml
+++ b/mods/ai_trainers.yaml
@@ -1,0 +1,20 @@
+trainers:
+  character_slug:  # Trainer slug representing a specific AI-controlled entity in the game.
+    monster_slug:  # Monster slug representing a specific monster associated with the trainer.
+      techniques:  # List of techniques the monster can use, along with their conditions.
+        - technique: "technique1_slug"  # Technique slug that the monster can perform.
+          condition:  # Conditions under which this technique can be used.
+            turn: 1  # Use this technique on turn 1. If omitted, the technique is not restricted to specific turns.
+            hp_below: 0.2  # Trigger this technique if the monster's HP falls below 20%. Optional condition.
+            hp_above: 0.5  # Trigger this technique if the monster's HP exceeds 50%. Optional condition.
+            always: true  # This condition overrides all other conditions and ensures the technique can always be used.
+            status_effects: ["poisoned"]  # Use this technique if the monster has the "poisoned" status effect. Optional.
+            opponent_types: ["fire"]  # Trigger this technique if the opponent's type is "fire". Optional condition.
+            opponent_slugs: ["opponent_slug"]  # Use this technique if the opponent's slug is "opponent_slug". Optional condition.
+            opponent_status: ["poisoned"]  # Use this technique if the the opponent has the "poisoned" status effect. Optional.
+            hp_range: [[0.8,1.0]]  # Execute the technique if the monster's HP is between 80% and 100%. Optional condition.
+
+        - technique: "technique2_slug"  # Another technique the monster can perform.
+          condition:  # Conditions for this technique.
+            always: true  # This technique will always be available for use, regardless of other conditions.
+

--- a/tests/tuxemon/test_ai.py
+++ b/tests/tuxemon/test_ai.py
@@ -4,6 +4,9 @@ import unittest
 from unittest.mock import MagicMock
 
 from tuxemon.ai import (
+    AIConfigLoader,
+    AIItems,
+    ItemEntry,
     OpponentEvaluator,
     TrainerAIDecisionStrategy,
     WildAIDecisionStrategy,
@@ -12,8 +15,7 @@ from tuxemon.ai import (
 
 class TestRecharging(unittest.TestCase):
     def test_recharging(self):
-        mock_technique = MagicMock()
-        mock_technique.next_use = 0
+        mock_technique = MagicMock(next_use=0)
         global recharging
         recharging = MagicMock(side_effect=lambda move: move.next_use == 0)
         self.assertTrue(
@@ -21,8 +23,7 @@ class TestRecharging(unittest.TestCase):
         )
 
     def test_not_recharging(self):
-        mock_technique = MagicMock()
-        mock_technique.next_use = 1
+        mock_technique = MagicMock(next_use=1)
         global recharging
         recharging = MagicMock(side_effect=lambda move: move.next_use == 0)
         self.assertFalse(
@@ -32,77 +33,104 @@ class TestRecharging(unittest.TestCase):
 
 
 class TestOpponentEvaluator(unittest.TestCase):
+    def setUp(self):
+        self.mock_combat = MagicMock()
+        self.mock_user = MagicMock(
+            slug="rockitten", current_hp=50, hp=100, level=10
+        )
+
     def test_evaluate(self):
-        mock_opponent = MagicMock()
-        mock_opponent.current_hp = 50
-        mock_opponent.hp = 100
-        evaluator = OpponentEvaluator(opponents=[mock_opponent])
+        mock_opponent = MagicMock(current_hp=50, hp=100, level=10)
+
+        evaluator = OpponentEvaluator(
+            combat=self.mock_combat,
+            user=self.mock_user,
+            opponents=[mock_opponent],
+        )
+        evaluator.evaluate = MagicMock(
+            side_effect=lambda opponent: opponent.current_hp / opponent.hp
+        )
+
         score = evaluator.evaluate(mock_opponent)
         self.assertEqual(score, 0.5)
 
     def test_get_best_target(self):
-        mock_opponent_1 = MagicMock()
-        mock_opponent_1.current_hp = 20
-        mock_opponent_1.hp = 100
-        mock_opponent_2 = MagicMock()
-        mock_opponent_2.current_hp = 80
-        mock_opponent_2.hp = 100
-        opponents = [mock_opponent_1, mock_opponent_2]
-        evaluator = OpponentEvaluator(opponents=opponents)
+        mock_opponent_1 = MagicMock(current_hp=20, hp=100, level=10)
+        mock_opponent_2 = MagicMock(current_hp=80, hp=100, level=10)
+
+        evaluator = OpponentEvaluator(
+            combat=self.mock_combat,
+            user=self.mock_user,
+            opponents=[mock_opponent_1, mock_opponent_2],
+        )
+        evaluator.evaluate = MagicMock(
+            side_effect=lambda opponent: opponent.current_hp / opponent.hp
+        )
+
         best_target = evaluator.get_best_target()
         self.assertEqual(best_target, mock_opponent_2)
 
 
 class TestTrainerAIDecisionStrategy(unittest.TestCase):
+    def setUp(self):
+        self.mock_ai = MagicMock()
+        self.mock_ai.character.items = []
+        self.mock_evaluator = MagicMock()
+        self.mock_tracker = MagicMock()
+
     def test_make_decision_use_potion(self):
-        mock_ai = MagicMock()
-        mock_ai.character.items = [MagicMock(category="potion")]
-        mock_ai.need_potion.return_value = True
+        mock_item = MagicMock(slug="potion")
+        self.mock_ai.character.items = [mock_item]
+        AIConfigLoader.get_ai_items = MagicMock(
+            return_value=AIItems(
+                items={"potion": ItemEntry(hp_range=(0.2, 0.8))}
+            )
+        )
+        self.mock_ai.monster.current_hp = 40
+        self.mock_ai.monster.hp = 100
 
-        mock_evaluator = MagicMock()
-        mock_tracker = MagicMock()
+        strategy = TrainerAIDecisionStrategy(
+            self.mock_evaluator, self.mock_tracker
+        )
+        strategy.make_decision(self.mock_ai)
 
-        strategy = TrainerAIDecisionStrategy(mock_evaluator, mock_tracker)
-        strategy.make_decision(mock_ai)
-
-        mock_ai.action_item.assert_called_once_with(mock_ai.character.items[0])
-        mock_evaluator.get_best_target.assert_not_called()
-        mock_tracker.get_valid_moves.assert_not_called()
+        self.mock_ai.action_item.assert_called_once_with(mock_item)
 
     def test_make_decision_select_move(self):
-        mock_ai = MagicMock()
-        mock_ai.character.items = []
-        mock_ai.need_potion.return_value = False
-
-        mock_evaluator = MagicMock()
-        mock_evaluator.get_best_target.return_value = MagicMock()
-
-        mock_tracker = MagicMock()
-        mock_tracker.get_valid_moves.return_value = [
+        self.mock_tracker.get_valid_moves.return_value = [
             (MagicMock(), MagicMock())
         ]
+        self.mock_evaluator.get_best_target.return_value = MagicMock()
 
-        strategy = TrainerAIDecisionStrategy(mock_evaluator, mock_tracker)
-        strategy.make_decision(mock_ai)
+        self.mock_tracker.evaluate_technique.return_value = 10.0
 
-        mock_ai.action_item.assert_not_called()
-        mock_tracker.get_valid_moves.assert_called_once_with(mock_ai.opponents)
-        mock_ai.action_tech.assert_called_once()
+        strategy = TrainerAIDecisionStrategy(
+            self.mock_evaluator, self.mock_tracker
+        )
+        strategy.make_decision(self.mock_ai)
+
+        self.mock_tracker.get_valid_moves.assert_called_once_with(
+            self.mock_ai.opponents
+        )
+        self.mock_ai.action_tech.assert_called_once()
 
 
 class TestWildAIDecisionStrategy(unittest.TestCase):
+    def setUp(self):
+        self.mock_ai = MagicMock()
+        self.mock_evaluator = MagicMock()
+        self.mock_tracker = MagicMock()
+
     def test_make_decision(self):
-        mock_ai = MagicMock()
-
-        mock_evaluator = MagicMock()
-        mock_evaluator.get_best_target.return_value = MagicMock()
-
-        mock_tracker = MagicMock()
-        mock_tracker.get_valid_moves.return_value = [
+        self.mock_tracker.get_valid_moves.return_value = [
             (MagicMock(), MagicMock())
         ]
+        self.mock_tracker.evaluate_technique.return_value = 5.0
+        self.mock_evaluator.get_best_target.return_value = MagicMock()
 
-        strategy = WildAIDecisionStrategy(mock_evaluator, mock_tracker)
-        strategy.make_decision(mock_ai)
+        strategy = WildAIDecisionStrategy(
+            self.mock_evaluator, self.mock_tracker
+        )
+        strategy.make_decision(self.mock_ai)
 
-        mock_ai.action_tech.assert_called_once()
+        self.mock_ai.action_tech.assert_called_once()

--- a/tuxemon/ai.py
+++ b/tuxemon/ai.py
@@ -2,12 +2,18 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+import logging
 import random
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Optional
 
-from tuxemon.combat import pre_checking, recharging
-from tuxemon.db import ItemCategory
+import yaml
+
+from tuxemon import prepare
+from tuxemon.combat import has_status, pre_checking, recharging
+from tuxemon.constants import paths
+from tuxemon.formula import simple_damage_multiplier
 from tuxemon.technique.technique import Technique
 
 if TYPE_CHECKING:
@@ -15,6 +21,184 @@ if TYPE_CHECKING:
     from tuxemon.monster import Monster
     from tuxemon.npc import NPC
     from tuxemon.states.combat.combat import CombatState
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ItemEntry:
+    hp_below: Optional[float] = None
+    hp_above: Optional[float] = None
+    hp_range: Optional[tuple[float, float]] = None
+    status_effects: Optional[list[str]] = None
+    monster_slugs: Optional[list[str]] = None
+
+
+@dataclass
+class AIItems:
+    items: dict[str, ItemEntry]
+
+
+@dataclass
+class UserMonsterEntry:
+    health_weight: Optional[float] = None
+    armour_weight: Optional[float] = None
+    dodge_weight: Optional[float] = None
+    melee_weight: Optional[float] = None
+    ranged_weight: Optional[float] = None
+    speed_weight: Optional[float] = None
+    status_effects_weight: Optional[float] = None
+    status_effects: Optional[dict[str, float]] = None
+    level_difference_threshold: Optional[float] = None
+    level_difference_weight: Optional[float] = None
+
+
+@dataclass
+class AIOpponent:  # most of the time the player
+    rules: dict[str, UserMonsterEntry]
+
+
+@dataclass
+class TechniqueCondition:
+    turn: Optional[int] = None
+    hp_below: Optional[float] = None
+    hp_above: Optional[float] = None
+    priority: Optional[int] = None
+    always: Optional[bool] = False
+    status_effects: Optional[list[str]] = None
+    opponent_types: Optional[list[str]] = None
+    opponent_slugs: Optional[list[str]] = None
+    opponent_status: Optional[list[str]] = None
+    hp_range: Optional[tuple[float, float]] = None
+
+
+@dataclass
+class MonsterTechnique:
+    technique: str
+    condition: Optional[TechniqueCondition]
+
+
+@dataclass
+class MonsterEntry:
+    techniques: list[MonsterTechnique]
+
+
+@dataclass
+class AITrainers:
+    trainers: dict[str, dict[str, MonsterEntry]]
+
+
+@dataclass
+class SingleTechnique:
+    melee_bonus: Optional[float] = None
+    touch_bonus: Optional[float] = None
+    special_bonus: Optional[float] = None
+    ranged_bonus: Optional[float] = None
+    reach_bonus: Optional[float] = None
+    reliable_bonus: Optional[float] = None
+    power_weight: Optional[float] = None
+    accuracy_weight: Optional[float] = None
+    elemental_multiplier_weight: Optional[float] = None
+    elemental_health_scaling: Optional[float] = None
+    elemental_health_threshold: Optional[float] = None
+    health_priority_threshold: Optional[float] = None
+    healing_weight: Optional[float] = None
+    healing_penalty_threshold: Optional[float] = None
+    healing_penalty_weight: Optional[float] = None
+
+
+@dataclass
+class AITechniques:
+    techniques: dict[str, SingleTechnique]
+
+
+def load_yaml(filepath: str) -> Any:
+    try:
+        with open(filepath) as file:
+            return yaml.safe_load(file)
+    except FileNotFoundError:
+        logger.error(f"Config file not found: {filepath}")
+        raise
+    except yaml.YAMLError as exc:
+        logger.error(f"Error parsing YAML file: {exc}")
+        raise exc
+
+
+class AIConfigLoader:
+    _ai_techniques: Optional[AITechniques] = None
+    _ai_items: Optional[AIItems] = None
+    _ai_opponent: Optional[AIOpponent] = None
+    _ai_character: Optional[AITrainers] = None
+
+    @classmethod
+    def get_ai_opponent(cls, filename: str) -> AIOpponent:
+        yaml_path = f"{paths.mods_folder}/{filename}"
+        if cls._ai_opponent is None:
+            raw_map = load_yaml(yaml_path)
+
+            rules = {
+                slug: UserMonsterEntry(**rules)
+                for slug, rules in raw_map["rules"].items()
+            }
+
+            if "default" not in rules:
+                raise ValueError(f"'default' is missing")
+
+            cls._ai_opponent = AIOpponent(rules=rules)
+        return cls._ai_opponent
+
+    @classmethod
+    def get_ai_items(cls, filename: str) -> AIItems:
+        yaml_path = f"{paths.mods_folder}/{filename}"
+        if cls._ai_items is None:
+            raw_map = load_yaml(yaml_path)
+            cls._ai_items = AIItems(**raw_map)
+        return cls._ai_items
+
+    @classmethod
+    def get_ai_character(cls, filename: str) -> AITrainers:
+        yaml_path = f"{paths.mods_folder}/{filename}"
+        if cls._ai_character is None:
+            raw_map = load_yaml(yaml_path)
+
+            trainers = {
+                character_slug: {
+                    monster_slug: MonsterEntry(
+                        techniques=[
+                            MonsterTechnique(
+                                technique=tech_data["technique"],
+                                condition=(
+                                    TechniqueCondition(
+                                        **tech_data["condition"]
+                                    )
+                                    if "condition" in tech_data
+                                    else None
+                                ),
+                            )
+                            for tech_data in monster_data["techniques"]
+                        ]
+                    )
+                    for monster_slug, monster_data in monsters.items()
+                }
+                for character_slug, monsters in raw_map["trainers"].items()
+            }
+
+            cls._ai_character = AITrainers(trainers=trainers)
+        return cls._ai_character
+
+    @classmethod
+    def get_ai_techniques(cls, filename: str) -> AITechniques:
+        yaml_path = f"{paths.mods_folder}/{filename}"
+        if cls._ai_techniques is None:
+            raw_map = load_yaml(yaml_path)
+
+            techniques = {
+                key: SingleTechnique(**value)
+                for key, value in raw_map["techniques"].items()
+            }
+
+            cls._ai_techniques = AITechniques(techniques=techniques)
+        return cls._ai_techniques
 
 
 class TechniqueTracker:
@@ -33,22 +217,51 @@ class TechniqueTracker:
             if mov.validate_monster(opponent)
         ]
 
+    def evaluate_technique(
+        self,
+        user: Monster,
+        technique: Technique,
+        opponent: Monster,
+        config: SingleTechnique,
+    ) -> float:
+        """
+        Evaluate the effectiveness of a technique against a specific opponent.
+        """
+        return technique_score(user, technique, opponent, config)
+
 
 class OpponentEvaluator:
-    def __init__(self, opponents: list[Monster]):
+    def __init__(
+        self, combat: CombatState, user: Monster, opponents: list[Monster]
+    ):
+        self.combat = combat
+        self.user = user
         self.opponents = opponents
+        self.ai_opponent = AIConfigLoader.get_ai_opponent("ai_opponent.yaml")
 
     def evaluate(self, opponent: Monster) -> float:
         """
         Scores opponents based on their current health, status effects, and power level.
         Higher scores indicate better targets.
         """
-        score = opponent.current_hp / opponent.hp
-        return score
+        if not self.combat.is_trainer_battle or not self.combat.is_double:
+            return 1.0
+
+        assert self.user.owner
+        config = self.ai_opponent.rules.get(
+            self.user.owner.slug, self.ai_opponent.rules.get("default")
+        )
+
+        if config is None:
+            return 1.0
+
+        return calculate_score(config, self.user, opponent)
 
     def get_best_target(self) -> Monster:
         """Returns the opponent with the highest evaluation score."""
-        return max(self.opponents, key=self.evaluate)
+        best_target = max(self.opponents, key=self.evaluate)
+        logger.debug(f"Best target selected: {best_target.slug}")
+        return best_target
 
 
 class AIDecisionStrategy(ABC):
@@ -57,6 +270,9 @@ class AIDecisionStrategy(ABC):
     ):
         self.evaluator = evaluator
         self.tracker = tracker
+        self.ai_trainers = AIConfigLoader.get_ai_character("ai_trainers.yaml")
+        self.ai_items = AIConfigLoader.get_ai_items("ai_items.yaml")
+        self.ai_techs = AIConfigLoader.get_ai_techniques("ai_techniques.yaml")
 
     @abstractmethod
     def make_decision(self, ai: AI) -> None:
@@ -68,20 +284,75 @@ class AIDecisionStrategy(ABC):
     ) -> tuple[Technique, Monster]:
         pass
 
+    def check_ai_techs(self, user: Monster) -> Optional[SingleTechnique]:
+        _config = self.ai_techs
+        if user.wild:
+            config = _config.techniques.get(user.slug)
+        else:
+            assert user.owner
+            config = _config.techniques.get(user.owner.slug)
+        return config
+
 
 class TrainerAIDecisionStrategy(AIDecisionStrategy):
     def make_decision(self, ai: AI) -> None:
         """Trainer battle decision-making"""
-        if len(ai.character.items) > 0:
-            for itm in ai.character.items:
-                if itm.category == ItemCategory.potion:
-                    if ai.need_potion():
-                        ai.action_item(itm)
-                        return
+        character_slug = ai.character.slug
+        config = self.ai_trainers.trainers.get(character_slug)
 
-        target = self.evaluator.get_best_target()
-        technique, target = self.select_move(ai, target)
-        ai.action_tech(technique, target)
+        if len(ai.character.items) > 0:
+            for item in ai.character.items:
+                if self.need_healing(ai, item):
+                    ai.action_item(item)
+                    return
+
+        if config is None:
+            self.default_decision(ai)
+            return
+
+        monster_config = config.get(ai.monster.slug)
+
+        if monster_config is None:
+            self.default_decision(ai)
+            return
+
+        if self.handle_monster_config(ai, monster_config):
+            return
+
+        valid_actions = self.tracker.get_valid_moves(ai.opponents)
+        random_action = random.choice(valid_actions)
+        ai.action_tech(random_action[0], random_action[1])
+
+    def handle_monster_config(
+        self, ai: AI, monster_config: MonsterEntry
+    ) -> bool:
+        """Handle decision-making logic for a specific monster configuration."""
+        for technique_entry in monster_config.techniques:
+            technique = technique_entry.technique
+            condition = technique_entry.condition
+
+            if condition is not None and not check_tech_conditions(
+                condition, ai
+            ):
+                continue
+
+            valid_actions = self.tracker.get_valid_moves(ai.opponents)
+            for valid_technique, opponent in valid_actions:
+                if valid_technique.slug == technique:
+                    ai.action_tech(valid_technique, opponent)
+                    return True
+
+        return False
+
+    def need_healing(self, ai: AI, item: Item) -> bool:
+        """
+        Determines if a healing item is needed based on the AI's monster's current state.
+        """
+        item_entry = self.ai_items.items.get(item.slug)
+        if not item_entry:
+            return False
+
+        return check_item_conditions(item_entry, ai)
 
     def select_move(
         self, ai: AI, target: Monster
@@ -94,7 +365,30 @@ class TrainerAIDecisionStrategy(AIDecisionStrategy):
             skip.load("skip")
             return skip, target
 
-        return random.choice(valid_actions)
+        config = self.check_ai_techs(ai.monster)
+        if config is None:
+            return random.choice(valid_actions)
+
+        best_action = None
+        highest_score = 0.0
+
+        for technique, opponent in valid_actions:
+            score = self.tracker.evaluate_technique(
+                ai.monster, technique, opponent, config
+            )
+            logger.debug(
+                f"Score: {score}, Technique: {technique.slug}, Opponent: {opponent.slug}"
+            )
+            if score > highest_score:
+                highest_score = score
+                best_action = (technique, opponent)
+
+        return best_action or random.choice(valid_actions)
+
+    def default_decision(self, ai: AI) -> None:
+        target = self.evaluator.get_best_target()
+        technique, target = self.select_move(ai, target)
+        ai.action_tech(technique, target)
 
 
 class WildAIDecisionStrategy(AIDecisionStrategy):
@@ -115,7 +409,22 @@ class WildAIDecisionStrategy(AIDecisionStrategy):
             skip.load("skip")
             return skip, target
 
-        return random.choice(valid_actions)
+        config = self.check_ai_techs(ai.monster)
+        if config is None:
+            return random.choice(valid_actions)
+
+        best_action = None
+        highest_score = 0.0
+
+        for technique, opponent in valid_actions:
+            score = self.tracker.evaluate_technique(
+                ai.monster, technique, opponent, config
+            )
+            if score > highest_score:
+                highest_score = score
+                best_action = (technique, opponent)
+
+        return best_action or random.choice(valid_actions)
 
 
 class AI:
@@ -131,7 +440,9 @@ class AI:
             else combat.monsters_in_play[combat.players[0]]
         )
 
-        self.evaluator = OpponentEvaluator(self.opponents)
+        self.evaluator = OpponentEvaluator(
+            self.combat, self.monster, self.opponents
+        )
         self.tracker = TechniqueTracker(self.monster.moves)
 
         self.decision_strategy = (
@@ -154,15 +465,6 @@ class AI:
         """
         return self.evaluator.get_best_target()
 
-    def need_potion(self) -> bool:
-        """
-        It checks if the current_hp are less than the 15%.
-        """
-        return (
-            self.monster.current_hp > 1
-            and self.monster.current_hp <= round(self.monster.hp * 0.15)
-        )
-
     def action_tech(self, technique: Technique, target: Monster) -> None:
         """
         Send action tech.
@@ -176,3 +478,221 @@ class AI:
         Send action item.
         """
         self.combat.enqueue_action(self.character, item, self.monster)
+
+
+def check_item_conditions(item_entry: ItemEntry, ai: AI) -> bool:
+    """
+    Check if all conditions for a technique are met.
+    """
+    hp_ratio = ai.monster.current_hp / ai.monster.hp
+
+    if item_entry.hp_below and hp_ratio >= item_entry.hp_below:
+        return False
+
+    if item_entry.hp_above and hp_ratio <= item_entry.hp_above:
+        return False
+
+    if item_entry.hp_range and not (
+        item_entry.hp_range[0] <= hp_ratio < item_entry.hp_range[1]
+    ):
+        return False
+
+    if item_entry.status_effects and not any(
+        has_status(ai.monster, status) for status in item_entry.status_effects
+    ):
+        return False
+
+    if (
+        item_entry.monster_slugs
+        and ai.monster.slug not in item_entry.monster_slugs
+    ):
+        return False
+
+    return True
+
+
+def check_tech_conditions(condition: TechniqueCondition, ai: AI) -> bool:
+    """
+    Check if all conditions for a technique are met.
+    """
+    current_turn = ai.combat._turn
+    monster_health = ai.monster.current_hp / ai.monster.hp
+
+    if condition.always:
+        return True
+
+    if condition.turn is not None and current_turn != condition.turn:
+        return False
+
+    if condition.hp_below is not None and monster_health >= condition.hp_below:
+        return False
+
+    if condition.hp_above is not None and monster_health <= condition.hp_above:
+        return False
+
+    if condition.hp_range and not (
+        condition.hp_range[0] <= monster_health <= condition.hp_range[1]
+    ):
+        return False
+
+    if condition.status_effects:
+        return any(
+            has_status(ai.monster, status)
+            for status in condition.status_effects
+        )
+
+    if condition.opponent_status:
+        if not ai.combat.is_double:
+            return any(
+                has_status(ai.opponents[0], opponent_status)
+                for opponent_status in condition.opponent_status
+            )
+
+    if condition.opponent_types:
+        if not ai.combat.is_double:
+            return any(
+                ai.opponents[0].has_type(opponent_type)
+                for opponent_type in condition.opponent_types
+            )
+
+    if condition.opponent_slugs:
+        if not ai.combat.is_double:
+            return ai.opponents[0].slug in condition.opponent_slugs
+
+    return True
+
+
+def calculate_score(
+    config: UserMonsterEntry, user: Monster, opponent: Monster
+) -> float:
+    """Calculate score."""
+    health_score = 0.0
+    armour_score = 0.0
+    dodge_score = 0.0
+    melee_score = 0.0
+    ranged_score = 0.0
+    speed_score = 0.0
+    status_effect_score = 0.0
+    level_difference_score = 0.0
+
+    monster_health = opponent.current_hp / opponent.hp
+
+    if config.health_weight:
+        health_score = monster_health * config.health_weight
+    if config.armour_weight:
+        armour_score = opponent.armour * config.armour_weight
+    if config.dodge_weight:
+        dodge_score = opponent.dodge * config.dodge_weight
+    if config.melee_weight:
+        melee_score = opponent.melee * config.melee_weight
+    if config.ranged_weight:
+        ranged_score = opponent.ranged * config.ranged_weight
+    if config.speed_weight:
+        speed_score = opponent.speed * config.speed_weight
+
+    if config.status_effects and config.status_effects_weight:
+        for status in opponent.status:
+            if status.slug in config.status_effects:
+                status_effect_score += (
+                    config.status_effects.get(status.slug, 1.0)
+                    * config.status_effects_weight
+                )
+
+    if config.level_difference_threshold and config.level_difference_weight:
+        level_difference = opponent.level - user.level
+        if abs(level_difference) >= config.level_difference_threshold:
+            level_difference_score = (
+                level_difference * config.level_difference_weight
+            )
+
+    total_score = (
+        health_score
+        + armour_score
+        + dodge_score
+        + melee_score
+        + ranged_score
+        + speed_score
+        + status_effect_score
+        + level_difference_score
+    )
+    logger.debug(f"Health score: {health_score}")
+    logger.debug(f"Armour score: {armour_score}")
+    logger.debug(f"Dodge score: {dodge_score}")
+    logger.debug(f"Melee score: {melee_score}")
+    logger.debug(f"Ranged score: {ranged_score}")
+    logger.debug(f"Speed score: {speed_score}")
+    logger.debug(f"Status effect score: {status_effect_score}")
+    logger.debug(f"Level difference score: {level_difference_score}")
+    logger.debug(f"Final total score: {total_score}")
+    return total_score
+
+
+def technique_score(
+    user: Monster,
+    technique: Technique,
+    opponent: Monster,
+    config: SingleTechnique,
+) -> float:
+    """Technique score."""
+    effectiveness_score = 0.0
+    type_bonus = 0.0
+    power_score = 0.0
+    accuracy_score = 0.0
+    healing_score = 0.0
+
+    if config.elemental_multiplier_weight:
+        effectiveness_score = (
+            simple_damage_multiplier(technique.types, opponent.types)
+            * config.elemental_multiplier_weight
+        )
+
+    elemental_health = config.elemental_health_threshold
+    elemental_scaling = config.elemental_health_scaling
+    if elemental_health and elemental_scaling:
+        if opponent.current_hp > opponent.hp * elemental_health:
+            effectiveness_score *= elemental_scaling
+
+    type_bonus += getattr(config, f"{technique.range}_bonus", 0.0)
+
+    if config.power_weight:
+        normalized_power = technique.power / prepare.POWER_RANGE[1]
+        power_score = normalized_power * config.power_weight
+
+    if config.accuracy_weight:
+        accuracy_score = technique.accuracy * config.accuracy_weight
+
+    health_priority = config.health_priority_threshold
+    healing_penalty = config.healing_penalty_threshold
+    healing_weight = config.healing_weight
+    healing_penalty_weight = config.healing_penalty_weight
+    if health_priority:
+        if technique.healing_power > 0.0 or technique.power == 0.0:
+            user_health_ratio = user.current_hp / user.hp
+            if user_health_ratio < health_priority and healing_weight:
+                # Reward healing when health is below the priority threshold
+                healing_score = technique.healing_power * healing_weight
+
+    if healing_penalty:
+        if technique.healing_power > 0.0 or technique.power == 0.0:
+            user_health_ratio = user.current_hp / user.hp
+            if user_health_ratio > healing_penalty and healing_penalty_weight:
+                # Penalize healing when health is above the penalty threshold
+                healing_score = (
+                    -technique.healing_power * healing_penalty_weight
+                )
+
+    total_score = (
+        effectiveness_score
+        + type_bonus
+        + power_score
+        + accuracy_score
+        + healing_score
+    )
+    logger.debug(f"Elemental effectiveness score: {effectiveness_score}")
+    logger.debug(f"Type bonus for range '{technique.range}': {type_bonus}")
+    logger.debug(f"Power score (normalized): {power_score}")
+    logger.debug(f"Accuracy score: {accuracy_score}")
+    logger.debug(f"Healing score: {healing_score}")
+    logger.debug(f"Final technique score: {total_score}")
+
+    return total_score


### PR DESCRIPTION
PR adds several improvements to AI decision-making processes (fixes #8 )
- introduced `AIConfigLoader` to load and cache configurations for techniques and items using YAML files
- `ai_opponent.yaml` file is primarily used for double combat scenarios. It evaluates the monsters in the player's party and determines the optimal target for the AI opponent (AI vs Human), based on the parameters defined within the file. It allows the possibility to specify the character's slug (opponent) against which the player is fighting.
- `ai_items.yaml` file enables modders to configure the use of specific items for NPC trainers. The functionality depends on whether the trainers possess items in their inventory. Currently, the only available item is the potion
- `ai_trainers.yaml` file empowers modders to create tailored strategies for specific NPC trainers by defining unique slugs. It also offers flexibility in customizing techniques, enabling modders to expand or limit the set of techniques available to individual characters
- `ai_techniques.yaml` file empowers modders to fine-tune the decision-making process for monsters, whether they are AI opponent trainers or wild monsters. By leveraging a range of customizable parameters, this file allows modders to define how techniques are selected, ensuring that monsters can make more strategic choices based on specific conditions or priorities

No changes, it'll keep picking up the technique randomly.
For now, the file is located in the mod folder, but it’ll be moved into each mod’s subfolder, so each scenario will use different rules.