### PR TITLE
Refactoring Defaults for Effect Result Dataclasses

### DIFF
--- a/tests/tuxemon/test_core_processor.py
+++ b/tests/tuxemon/test_core_processor.py
@@ -48,20 +48,10 @@ class TestEffectProcessor(unittest.TestCase):
             extras=["Critical"],
         )
 
-        meta_result = TechEffectResult(
-            name=self.technique.name,
-            success=False,
-            damage=0,
-            element_multiplier=0.0,
-            should_tackle=False,
-            extras=[],
-        )
-
         final_result = self.processor.process_tech(
             source=self.technique,
             user=self.user,
             target=self.target,
-            meta_result=meta_result,
         )
 
         self.assertTrue(final_result.success)
@@ -77,12 +67,8 @@ class TestEffectProcessor(unittest.TestCase):
             extras=["Heal Boost"],
         )
 
-        meta_result = ItemEffectResult(
-            name=self.item.name, success=False, num_shakes=0, extras=[]
-        )
-
         final_result = self.processor.process_item(
-            source=self.item, target=self.target, meta_result=meta_result
+            source=self.item, target=self.target
         )
 
         self.assertTrue(final_result.success)
@@ -98,16 +84,9 @@ class TestEffectProcessor(unittest.TestCase):
             extras=["Duration Boost"],
         )
 
-        meta_result = StatusEffectResult(
-            name=self.status.name,
-            success=False,
-            statuses=[],
-            techniques=[],
-            extras=[],
-        )
-
         final_result = self.processor.process_status(
-            source=self.status, target=self.target, meta_result=meta_result
+            source=self.status,
+            target=self.target,
         )
 
         self.assertTrue(final_result.success)

--- a/tuxemon/core/core_effect.py
+++ b/tuxemon/core/core_effect.py
@@ -17,27 +17,27 @@ if TYPE_CHECKING:
 
 @dataclass
 class EffectResult:
-    name: str
-    success: bool
-    extras: list[str]
+    name: str = ""
+    success: bool = False
+    extras: list[str] = field(default_factory=list)
 
 
 @dataclass
 class TechEffectResult(EffectResult):
-    damage: int
-    element_multiplier: float
-    should_tackle: bool
+    damage: int = 0
+    element_multiplier: float = 0.0
+    should_tackle: bool = False
 
 
 @dataclass
 class ItemEffectResult(EffectResult):
-    num_shakes: int
+    num_shakes: int = 0
 
 
 @dataclass
 class StatusEffectResult(EffectResult):
-    statuses: list[Status]
-    techniques: list[Technique]
+    statuses: list[Status] = field(default_factory=list)
+    techniques: list[Technique] = field(default_factory=list)
 
 
 @dataclass
@@ -60,14 +60,7 @@ class TechEffect(Effect):
     def apply(
         self, tech: Technique, user: Monster, target: Monster
     ) -> TechEffectResult:
-        return TechEffectResult(
-            name=tech.name,
-            success=True,
-            extras=[],
-            damage=0,
-            element_multiplier=0.0,
-            should_tackle=False,
-        )
+        return TechEffectResult(name=tech.name)
 
 
 @dataclass
@@ -75,21 +68,10 @@ class ItemEffect(Effect):
     def apply(
         self, item: Item, target: Union[Monster, None]
     ) -> ItemEffectResult:
-        return ItemEffectResult(
-            name=item.name,
-            success=True,
-            extras=[],
-            num_shakes=0,
-        )
+        return ItemEffectResult(name=item.name)
 
 
 @dataclass
 class StatusEffect(Effect):
     def apply(self, status: Status, target: Monster) -> StatusEffectResult:
-        return StatusEffectResult(
-            name=status.name,
-            success=True,
-            extras=[],
-            statuses=[],
-            techniques=[],
-        )
+        return StatusEffectResult(name=status.name)

--- a/tuxemon/core/core_processor.py
+++ b/tuxemon/core/core_processor.py
@@ -39,8 +39,8 @@ class EffectProcessor:
         source: Technique,
         user: Monster,
         target: Monster,
-        meta_result: TechEffectResult,
     ) -> TechEffectResult:
+        meta_result = TechEffectResult(name=source.name)
         for effect in self.effects:
             if isinstance(effect, TechEffect):
                 result = effect.apply(source, user, target)
@@ -51,8 +51,8 @@ class EffectProcessor:
         self,
         source: Item,
         target: Optional[Monster],
-        meta_result: ItemEffectResult,
     ) -> ItemEffectResult:
+        meta_result = ItemEffectResult(name=source.name)
         for effect in self.effects:
             if isinstance(effect, ItemEffect):
                 result = effect.apply(source, target)
@@ -60,8 +60,11 @@ class EffectProcessor:
         return meta_result
 
     def process_status(
-        self, source: Status, target: Monster, meta_result: StatusEffectResult
+        self,
+        source: Status,
+        target: Monster,
     ) -> StatusEffectResult:
+        meta_result = StatusEffectResult(name=source.name)
         for effect in self.effects:
             if isinstance(effect, StatusEffect):
                 result = effect.apply(source, target)

--- a/tuxemon/core/effects/appear.py
+++ b/tuxemon/core/effects/appear.py
@@ -45,8 +45,5 @@ class AppearEffect(TechEffect):
         return TechEffectResult(
             name=tech.name,
             success=not target_is_disappeared,
-            damage=0,
-            element_multiplier=0.0,
             should_tackle=not target_is_disappeared,
-            extras=[],
         )

--- a/tuxemon/core/effects/buff.py
+++ b/tuxemon/core/effects/buff.py
@@ -46,6 +46,4 @@ class BuffEffect(ItemEffect):
         target.speed += value if self.statistic == StatType.speed else 0
         target.ranged += value if self.statistic == StatType.ranged else 0
 
-        return ItemEffectResult(
-            name=item.name, success=True, num_shakes=0, extras=[]
-        )
+        return ItemEffectResult(name=item.name, success=True)

--- a/tuxemon/core/effects/burnt.py
+++ b/tuxemon/core/effects/burnt.py
@@ -41,10 +41,4 @@ class BurntEffect(StatusEffect):
                 status.use_failure = T.format("combat_state_immune", params)
                 target.status = []
 
-        return StatusEffectResult(
-            name=status.name,
-            success=burnt,
-            statuses=[],
-            techniques=[],
-            extras=[],
-        )
+        return StatusEffectResult(name=status.name, success=burnt)

--- a/tuxemon/core/effects/capture.py
+++ b/tuxemon/core/effects/capture.py
@@ -44,15 +44,13 @@ class CaptureEffect(ItemEffect):
 
         if not capture:
             self._handle_capture_failure(item, target)
-            return ItemEffectResult(
-                name=item.name, success=False, num_shakes=shakes, extras=[]
-            )
+            return ItemEffectResult(name=item.name, num_shakes=shakes)
 
         # Apply capture effects
         self._apply_capture_effects(item, target)
 
         return ItemEffectResult(
-            name=item.name, success=True, num_shakes=shakes, extras=[]
+            name=item.name, success=True, num_shakes=shakes
         )
 
     def _calculate_status_modifier(self, target: Monster) -> float:

--- a/tuxemon/core/effects/capture_combined.py
+++ b/tuxemon/core/effects/capture_combined.py
@@ -47,15 +47,13 @@ class CaptureCombinedEffect(ItemEffect):
         capture, shakes = formula.capture(shake_check)
 
         if not capture:
-            return ItemEffectResult(
-                name=item.name, success=False, num_shakes=shakes, extras=[]
-            )
+            return ItemEffectResult(name=item.name, num_shakes=shakes)
 
         # Apply capture effects
         self._apply_capture_effects(item, target)
 
         return ItemEffectResult(
-            name=item.name, success=True, num_shakes=shakes, extras=[]
+            name=item.name, success=True, num_shakes=shakes
         )
 
     def _calculate_status_modifier(self, target: Monster) -> float:

--- a/tuxemon/core/effects/change_stat.py
+++ b/tuxemon/core/effects/change_stat.py
@@ -41,6 +41,4 @@ class ChangeStatEffect(ItemEffect):
         client = self.session.client.event_engine
         params = [self.name, self.statistic, self.percentage]
         client.execute_action("modify_monster_stats", params, True)
-        return ItemEffectResult(
-            name=item.name, success=True, num_shakes=0, extras=[]
-        )
+        return ItemEffectResult(name=item.name, success=True)

--- a/tuxemon/core/effects/chargedup.py
+++ b/tuxemon/core/effects/chargedup.py
@@ -34,9 +34,5 @@ class ChargedUpEffect(StatusEffect):
                 cond.link = target
                 _statuses = [cond]
         return StatusEffectResult(
-            name=status.name,
-            success=True,
-            statuses=_statuses,
-            techniques=[],
-            extras=[],
+            name=status.name, success=True, statuses=_statuses
         )

--- a/tuxemon/core/effects/charging.py
+++ b/tuxemon/core/effects/charging.py
@@ -42,9 +42,5 @@ class ChargingEffect(StatusEffect):
                 cond.link = target
                 _statuses = [cond]
         return StatusEffectResult(
-            name=status.name,
-            success=True,
-            statuses=_statuses,
-            techniques=[],
-            extras=[],
+            name=status.name, success=True, statuses=_statuses
         )

--- a/tuxemon/core/effects/confused.py
+++ b/tuxemon/core/effects/confused.py
@@ -69,7 +69,6 @@ class ConfusedEffect(StatusEffect):
         return StatusEffectResult(
             name=status.name,
             success=True,
-            statuses=[],
             techniques=tech,
             extras=extra,
         )

--- a/tuxemon/core/effects/cooldown.py
+++ b/tuxemon/core/effects/cooldown.py
@@ -49,14 +49,7 @@ class CoolDownEffect(TechEffect):
         assert combat
         tech.hit = tech.accuracy >= combat._random_tech_hit.get(user, 0.0)
         if not tech.hit:
-            return TechEffectResult(
-                name=tech.name,
-                success=False,
-                damage=0,
-                element_multiplier=0.0,
-                should_tackle=False,
-                extras=[],
-            )
+            return TechEffectResult(name=tech.name)
 
         objectives = self.objectives.split(":")
         monsters = get_target_monsters(objectives, tech, user, target)
@@ -79,14 +72,7 @@ class CoolDownEffect(TechEffect):
         if self.next_use > 0:
             tech.next_use -= 1
 
-        return TechEffectResult(
-            name=tech.name,
-            success=True,
-            damage=0,
-            element_multiplier=0.0,
-            should_tackle=False,
-            extras=[],
-        )
+        return TechEffectResult(name=tech.name, success=True)
 
 
 def _is_next_use_valid(next_use: int) -> bool:

--- a/tuxemon/core/effects/damage.py
+++ b/tuxemon/core/effects/damage.py
@@ -53,5 +53,4 @@ class DamageEffect(TechEffect):
             element_multiplier=mult,
             should_tackle=bool(damage),
             success=bool(damage),
-            extras=[],
         )

--- a/tuxemon/core/effects/diehard.py
+++ b/tuxemon/core/effects/diehard.py
@@ -42,10 +42,4 @@ class DieHardEffect(StatusEffect):
                 target.status.clear()
                 extra = [T.format("combat_state_diehard_end", params)]
 
-        return StatusEffectResult(
-            name=status.name,
-            success=True,
-            statuses=[],
-            techniques=[],
-            extras=extra,
-        )
+        return StatusEffectResult(name=status.name, success=True, extras=extra)

--- a/tuxemon/core/effects/disappear.py
+++ b/tuxemon/core/effects/disappear.py
@@ -44,11 +44,4 @@ class DisappearEffect(TechEffect):
             land_action = EnqueuedAction(user, land_technique, target)
             combat._action_queue.add_pending(land_action, combat._turn)
 
-        return TechEffectResult(
-            name=tech.name,
-            success=user.out_of_range,
-            damage=0,
-            element_multiplier=0.0,
-            should_tackle=False,
-            extras=[],
-        )
+        return TechEffectResult(name=tech.name, success=user.out_of_range)

--- a/tuxemon/core/effects/elemental_shield.py
+++ b/tuxemon/core/effects/elemental_shield.py
@@ -54,10 +54,4 @@ class ElementalShieldBackEffect(StatusEffect):
                 damage = target.hp // self.divisor
                 attacker.current_hp = max(0, attacker.current_hp - damage)
                 done = True
-        return StatusEffectResult(
-            name=status.name,
-            success=done,
-            statuses=[],
-            techniques=[],
-            extras=[],
-        )
+        return StatusEffectResult(name=status.name, success=done)

--- a/tuxemon/core/effects/empty.py
+++ b/tuxemon/core/effects/empty.py
@@ -28,11 +28,4 @@ class EmptyEffect(TechEffect):
         combat = tech.combat_state
         assert combat
         tech.hit = tech.accuracy >= combat._random_tech_hit.get(user, 0.0)
-        return TechEffectResult(
-            name=tech.name,
-            success=tech.hit,
-            damage=0,
-            element_multiplier=0.0,
-            should_tackle=False,
-            extras=[],
-        )
+        return TechEffectResult(name=tech.name, success=tech.hit)

--- a/tuxemon/core/effects/enraged.py
+++ b/tuxemon/core/effects/enraged.py
@@ -24,10 +24,4 @@ class EnragedEffect(StatusEffect):
     def apply(self, status: Status, target: Monster) -> StatusEffectResult:
         if status.phase == "perform_action_tech":
             target.status.clear()
-        return StatusEffectResult(
-            name=status.name,
-            success=True,
-            statuses=[],
-            techniques=[],
-            extras=[],
-        )
+        return StatusEffectResult(name=status.name, success=True)

--- a/tuxemon/core/effects/evolve.py
+++ b/tuxemon/core/effects/evolve.py
@@ -24,9 +24,7 @@ class EvolveEffect(ItemEffect):
     ) -> ItemEffectResult:
         assert target and target.owner
         if not target.evolutions:
-            return ItemEffectResult(
-                name=item.name, success=False, num_shakes=0, extras=[]
-            )
+            return ItemEffectResult(name=item.name)
         choices = [d for d in target.evolutions if d.item == item.slug]
         if len(choices) == 1:
             evolution = choices[0].monster_slug
@@ -42,6 +40,4 @@ class EvolveEffect(ItemEffect):
             original=target.slug,
             evolved=new_monster.slug,
         )
-        return ItemEffectResult(
-            name=item.name, success=True, num_shakes=0, extras=[]
-        )
+        return ItemEffectResult(name=item.name, success=True)

--- a/tuxemon/core/effects/exhausted.py
+++ b/tuxemon/core/effects/exhausted.py
@@ -34,9 +34,5 @@ class ExhaustedEffect(StatusEffect):
                 cond.link = target
                 _statuses = [cond]
         return StatusEffectResult(
-            name=status.name,
-            success=True,
-            statuses=_statuses,
-            techniques=[],
-            extras=[],
+            name=status.name, success=True, statuses=_statuses
         )

--- a/tuxemon/core/effects/feedback.py
+++ b/tuxemon/core/effects/feedback.py
@@ -53,10 +53,4 @@ class FeedBackEffect(StatusEffect):
                 damage = target.hp // self.divisor
                 attacker.current_hp = max(0, attacker.current_hp - damage)
                 done = True
-        return StatusEffectResult(
-            name=status.name,
-            success=done,
-            statuses=[],
-            techniques=[],
-            extras=[],
-        )
+        return StatusEffectResult(name=status.name, success=done)

--- a/tuxemon/core/effects/festering.py
+++ b/tuxemon/core/effects/festering.py
@@ -21,10 +21,4 @@ class FesteringEffect(StatusEffect):
     name = "festering"
 
     def apply(self, status: Status, target: Monster) -> StatusEffectResult:
-        return StatusEffectResult(
-            name=status.name,
-            success=True,
-            statuses=[],
-            techniques=[],
-            extras=[],
-        )
+        return StatusEffectResult(name=status.name, success=True)

--- a/tuxemon/core/effects/fishing.py
+++ b/tuxemon/core/effects/fishing.py
@@ -50,12 +50,8 @@ class FishingEffect(ItemEffect):
             mon_slug = random.choice(monster_lists[item.slug])
             level = random.randint(self.lower_bound, self.upper_bound)
             self._trigger_fishing_encounter(mon_slug, level)
-            return ItemEffectResult(
-                name=item.name, success=True, num_shakes=0, extras=[]
-            )
-        return ItemEffectResult(
-            name=item.name, success=False, num_shakes=0, extras=[]
-        )
+            return ItemEffectResult(name=item.name, success=True)
+        return ItemEffectResult(name=item.name)
 
     def _trigger_fishing_encounter(self, mon_slug: str, level: int) -> None:
         """Trigger a fishing encounter"""

--- a/tuxemon/core/effects/flinching.py
+++ b/tuxemon/core/effects/flinching.py
@@ -39,9 +39,5 @@ class FlinchingEffect(StatusEffect):
             tech = [skip]
             user.status.clear()
         return StatusEffectResult(
-            name=status.name,
-            success=True,
-            statuses=[],
-            techniques=tech,
-            extras=[],
+            name=status.name, success=True, techniques=tech
         )

--- a/tuxemon/core/effects/foresight.py
+++ b/tuxemon/core/effects/foresight.py
@@ -52,11 +52,4 @@ class ForesightEffect(TechEffect):
         action = EnqueuedAction(user, set_technique, target)
         combat._action_queue.add_pending(action, next_turn)
 
-        return TechEffectResult(
-            name=tech.name,
-            success=True,
-            damage=0,
-            element_multiplier=0.0,
-            should_tackle=False,
-            extras=[],
-        )
+        return TechEffectResult(name=tech.name, success=True)

--- a/tuxemon/core/effects/forfeit.py
+++ b/tuxemon/core/effects/forfeit.py
@@ -41,14 +41,7 @@ class ForfeitEffect(TechEffect):
         for mon in player.monsters:
             mon.faint()
 
-        return TechEffectResult(
-            name=tech.name,
-            success=True,
-            damage=0,
-            element_multiplier=0.0,
-            should_tackle=False,
-            extras=extra,
-        )
+        return TechEffectResult(name=tech.name, success=True, extras=extra)
 
     def _clean_combat_state(self, combat: CombatState) -> None:
         """

--- a/tuxemon/core/effects/gain_xp.py
+++ b/tuxemon/core/effects/gain_xp.py
@@ -34,6 +34,4 @@ class GainXpEffect(ItemEffect):
         client = self.session.client.event_engine
         _params = [self.name, self.amount]
         client.execute_action("give_experience", _params, True)
-        return ItemEffectResult(
-            name=item.name, success=True, num_shakes=0, extras=[]
-        )
+        return ItemEffectResult(name=item.name, success=True)

--- a/tuxemon/core/effects/give.py
+++ b/tuxemon/core/effects/give.py
@@ -57,11 +57,4 @@ class GiveEffect(TechEffect):
                     monster.apply_status(status)
                 combat.reset_status_icons()
 
-        return TechEffectResult(
-            name=tech.name,
-            success=bool(monsters),
-            damage=0,
-            element_multiplier=0.0,
-            should_tackle=False,
-            extras=[],
-        )
+        return TechEffectResult(name=tech.name, success=bool(monsters))

--- a/tuxemon/core/effects/grabbed.py
+++ b/tuxemon/core/effects/grabbed.py
@@ -40,10 +40,4 @@ class GrabbedEffect(StatusEffect):
             for move in moves:
                 move.potency = move.default_potency / self.divisor
                 move.power = move.default_power / self.divisor
-        return StatusEffectResult(
-            name=status.name,
-            success=done,
-            statuses=[],
-            techniques=[],
-            extras=[],
-        )
+        return StatusEffectResult(name=status.name, success=done)

--- a/tuxemon/core/effects/harpooned.py
+++ b/tuxemon/core/effects/harpooned.py
@@ -32,10 +32,4 @@ class HarpoonedEffect(StatusEffect):
             target.current_hp = max(0, target.current_hp - damage)
             if fainted(target):
                 target.faint()
-        return StatusEffectResult(
-            name=status.name,
-            success=True,
-            statuses=[],
-            techniques=[],
-            extras=[],
-        )
+        return StatusEffectResult(name=status.name, success=True)

--- a/tuxemon/core/effects/heal.py
+++ b/tuxemon/core/effects/heal.py
@@ -44,8 +44,6 @@ class HealEffect(ItemEffect):
         if has_status(target, "festering") and item.category == category:
             return ItemEffectResult(
                 name=item.name,
-                success=False,
-                num_shakes=0,
                 extras=[T.translate("combat_state_festering_item")],
             )
 
@@ -59,6 +57,4 @@ class HealEffect(ItemEffect):
             )
         target.current_hp = min(target.hp, target.current_hp + healing_amount)
 
-        return ItemEffectResult(
-            name=item.name, success=True, num_shakes=0, extras=[]
-        )
+        return ItemEffectResult(name=item.name, success=True)

--- a/tuxemon/core/effects/healing.py
+++ b/tuxemon/core/effects/healing.py
@@ -48,11 +48,4 @@ class HealingEffect(TechEffect):
                     done = True
                 elif monster.current_hp == monster.hp:
                     extra = ["combat_full_health"]
-        return TechEffectResult(
-            name=tech.name,
-            success=done,
-            damage=0,
-            element_multiplier=0.0,
-            should_tackle=False,
-            extras=extra,
-        )
+        return TechEffectResult(name=tech.name, success=done, extras=extra)

--- a/tuxemon/core/effects/learn_mm.py
+++ b/tuxemon/core/effects/learn_mm.py
@@ -50,13 +50,9 @@ class LearnMmEffect(ItemEffect):
                 "add_tech", [self.name, tech_slug], True
             )
 
-            return ItemEffectResult(
-                name=item.name, success=True, num_shakes=0, extras=[]
-            )
+            return ItemEffectResult(name=item.name, success=True)
 
-        return ItemEffectResult(
-            name=item.name, success=False, num_shakes=0, extras=[]
-        )
+        return ItemEffectResult(name=item.name)
 
 
 def _lookup_techniques(element: str) -> None:

--- a/tuxemon/core/effects/learn_tm.py
+++ b/tuxemon/core/effects/learn_tm.py
@@ -41,10 +41,6 @@ class LearnTmEffect(ItemEffect):
                 "add_tech", [self.name, self.technique], True
             )
 
-            return ItemEffectResult(
-                name=item.name, success=True, num_shakes=0, extras=[]
-            )
+            return ItemEffectResult(name=item.name, success=True)
 
-        return ItemEffectResult(
-            name=item.name, success=False, num_shakes=0, extras=[]
-        )
+        return ItemEffectResult(name=item.name)

--- a/tuxemon/core/effects/life_share.py
+++ b/tuxemon/core/effects/life_share.py
@@ -53,14 +53,7 @@ class LifeShareEffect(TechEffect):
                 else:
                     simple_average(source, dest)
                 done = True
-        return TechEffectResult(
-            name=tech.name,
-            success=done,
-            damage=0,
-            element_multiplier=0.0,
-            should_tackle=False,
-            extras=[],
-        )
+        return TechEffectResult(name=tech.name, success=done)
 
 
 def weighted_average(source: Monster, dest: Monster) -> None:

--- a/tuxemon/core/effects/life_swap.py
+++ b/tuxemon/core/effects/life_swap.py
@@ -40,11 +40,4 @@ class LifeSwapEffect(TechEffect):
                 user.current_hp = min(user.hp, hp_target)
                 target.current_hp = min(target.hp, hp_user)
                 done = True
-        return TechEffectResult(
-            name=tech.name,
-            success=done,
-            damage=0,
-            element_multiplier=0.0,
-            should_tackle=False,
-            extras=[],
-        )
+        return TechEffectResult(name=tech.name, success=done)

--- a/tuxemon/core/effects/lifegift.py
+++ b/tuxemon/core/effects/lifegift.py
@@ -41,10 +41,4 @@ class LifeGiftEffect(StatusEffect):
         if fainted(user):
             target.status.clear()
 
-        return StatusEffectResult(
-            name=status.name,
-            success=lifegift,
-            statuses=[],
-            techniques=[],
-            extras=[],
-        )
+        return StatusEffectResult(name=status.name, success=lifegift)

--- a/tuxemon/core/effects/lifeleech.py
+++ b/tuxemon/core/effects/lifeleech.py
@@ -41,10 +41,4 @@ class LifeLeechEffect(StatusEffect):
         if fainted(user):
             target.status.clear()
 
-        return StatusEffectResult(
-            name=status.name,
-            success=lifeleech,
-            statuses=[],
-            techniques=[],
-            extras=[],
-        )
+        return StatusEffectResult(name=status.name, success=lifeleech)

--- a/tuxemon/core/effects/lockdown.py
+++ b/tuxemon/core/effects/lockdown.py
@@ -26,10 +26,4 @@ class LockdownEffect(StatusEffect):
         if status.phase == "enqueue_item":
             params = {"target": target.name.upper()}
             extra = [T.format("combat_state_lockdown_item", params)]
-        return StatusEffectResult(
-            name=status.name,
-            success=True,
-            statuses=[],
-            techniques=[],
-            extras=extra,
-        )
+        return StatusEffectResult(name=status.name, success=True, extras=extra)

--- a/tuxemon/core/effects/mirror.py
+++ b/tuxemon/core/effects/mirror.py
@@ -78,11 +78,4 @@ class MirrorEffect(TechEffect):
             combat._monster_sprite_map[user] = back_target
             combat.sprites.remove(user_sprite)
 
-        return TechEffectResult(
-            name=tech.name,
-            success=True,
-            damage=0,
-            element_multiplier=0.0,
-            should_tackle=False,
-            extras=[],
-        )
+        return TechEffectResult(name=tech.name, success=True)

--- a/tuxemon/core/effects/money.py
+++ b/tuxemon/core/effects/money.py
@@ -48,8 +48,6 @@ class MoneyEffect(TechEffect):
         return TechEffectResult(
             name=tech.name,
             success=tech.hit,
-            damage=0,
-            element_multiplier=0.0,
             should_tackle=tech.hit,
             extras=extra,
         )

--- a/tuxemon/core/effects/move_type.py
+++ b/tuxemon/core/effects/move_type.py
@@ -50,11 +50,4 @@ class MoveTypeEffect(TechEffect):
                 f"{self.direction} must be 'own_monster' or 'enemy_monster'"
             )
 
-        return TechEffectResult(
-            name=tech.name,
-            success=True,
-            damage=0,
-            element_multiplier=0.0,
-            should_tackle=False,
-            extras=[],
-        )
+        return TechEffectResult(name=tech.name, success=True)

--- a/tuxemon/core/effects/multiattack.py
+++ b/tuxemon/core/effects/multiattack.py
@@ -53,10 +53,5 @@ class MultiAttackEffect(TechEffect):
             combat.enqueue_action(user, tech, target)
 
         return TechEffectResult(
-            name=tech.name,
-            damage=0,
-            element_multiplier=0.0,
-            should_tackle=done,
-            success=done,
-            extras=[],
+            name=tech.name, should_tackle=done, success=done
         )

--- a/tuxemon/core/effects/noddingoff.py
+++ b/tuxemon/core/effects/noddingoff.py
@@ -48,7 +48,6 @@ class NoddingOffEffect(StatusEffect):
         return StatusEffectResult(
             name=status.name,
             success=True,
-            statuses=[],
             techniques=tech,
             extras=extra,
         )

--- a/tuxemon/core/effects/park.py
+++ b/tuxemon/core/effects/park.py
@@ -47,6 +47,4 @@ class ParkEffect(ItemEffect):
         else:
             raise ValueError(f"Must be capture, doll or food")
 
-        return ItemEffectResult(
-            name=item.name, success=True, num_shakes=0, extras=[]
-        )
+        return ItemEffectResult(name=item.name, success=True)

--- a/tuxemon/core/effects/photogenesis.py
+++ b/tuxemon/core/effects/photogenesis.py
@@ -71,11 +71,4 @@ class PhotogenesisEffect(TechEffect):
                     done = True
                 elif user.current_hp == user.hp:
                     extra = ["combat_full_health"]
-        return TechEffectResult(
-            name=tech.name,
-            success=done,
-            damage=0,
-            element_multiplier=0.0,
-            should_tackle=False,
-            extras=extra,
-        )
+        return TechEffectResult(name=tech.name, success=done, extras=extra)

--- a/tuxemon/core/effects/plague.py
+++ b/tuxemon/core/effects/plague.py
@@ -56,11 +56,4 @@ class PlagueEffect(TechEffect):
             )
         ]
 
-        return TechEffectResult(
-            name=tech.name,
-            success=success,
-            damage=0,
-            element_multiplier=0.0,
-            should_tackle=False,
-            extras=extra,
-        )
+        return TechEffectResult(name=tech.name, success=success, extras=extra)

--- a/tuxemon/core/effects/poisoned.py
+++ b/tuxemon/core/effects/poisoned.py
@@ -41,10 +41,4 @@ class PoisonedEffect(StatusEffect):
                 status.use_failure = T.format("combat_state_immune", params)
                 target.status = []
 
-        return StatusEffectResult(
-            name=status.name,
-            success=poisoned,
-            statuses=[],
-            techniques=[],
-            extras=[],
-        )
+        return StatusEffectResult(name=status.name, success=poisoned)

--- a/tuxemon/core/effects/prickly.py
+++ b/tuxemon/core/effects/prickly.py
@@ -53,10 +53,4 @@ class PricklyBackEffect(StatusEffect):
                 damage = target.hp // self.divisor
                 attacker.current_hp = max(0, attacker.current_hp - damage)
                 done = True
-        return StatusEffectResult(
-            name=status.name,
-            success=done,
-            statuses=[],
-            techniques=[],
-            extras=[],
-        )
+        return StatusEffectResult(name=status.name, success=done)

--- a/tuxemon/core/effects/prop_damage.py
+++ b/tuxemon/core/effects/prop_damage.py
@@ -62,8 +62,6 @@ class PropDamageEffect(TechEffect):
         return TechEffectResult(
             name=tech.name,
             damage=damage,
-            element_multiplier=0.0,
             should_tackle=tech.hit,
             success=tech.hit,
-            extras=[],
         )

--- a/tuxemon/core/effects/prop_healing.py
+++ b/tuxemon/core/effects/prop_healing.py
@@ -57,11 +57,4 @@ class PropHealingEffect(TechEffect):
                     monster.hp, monster.current_hp + amount
                 )
 
-        return TechEffectResult(
-            name=tech.name,
-            damage=0,
-            element_multiplier=0.0,
-            should_tackle=False,
-            success=tech.hit,
-            extras=[],
-        )
+        return TechEffectResult(name=tech.name, success=tech.hit)

--- a/tuxemon/core/effects/recover.py
+++ b/tuxemon/core/effects/recover.py
@@ -46,9 +46,5 @@ class RecoverEffect(StatusEffect):
             extra = [T.format("combat_state_recover_failure", params)]
 
         return StatusEffectResult(
-            name=status.name,
-            success=healing,
-            statuses=[],
-            techniques=[],
-            extras=extra,
+            name=status.name, success=healing, extras=extra
         )

--- a/tuxemon/core/effects/remove.py
+++ b/tuxemon/core/effects/remove.py
@@ -54,11 +54,4 @@ class RemoveEffect(TechEffect):
                     if has_status(monster, self.status):
                         monster.status.clear()
 
-        return TechEffectResult(
-            name=tech.name,
-            success=bool(monsters),
-            damage=0,
-            element_multiplier=0.0,
-            should_tackle=False,
-            extras=[],
-        )
+        return TechEffectResult(name=tech.name, success=bool(monsters))

--- a/tuxemon/core/effects/remove_entity.py
+++ b/tuxemon/core/effects/remove_entity.py
@@ -41,6 +41,4 @@ class RemoveEntityEffect(ItemEffect):
                     player.game_variables[npc.slug] = self.name
                     remove = True
 
-        return ItemEffectResult(
-            name=item.name, success=remove, num_shakes=0, extras=[]
-        )
+        return ItemEffectResult(name=item.name, success=remove)

--- a/tuxemon/core/effects/restore.py
+++ b/tuxemon/core/effects/restore.py
@@ -57,6 +57,4 @@ class RestoreEffect(ItemEffect):
         else:
             target.status.clear()
 
-        return ItemEffectResult(
-            name=item.name, success=True, num_shakes=0, extras=[]
-        )
+        return ItemEffectResult(name=item.name, success=True)

--- a/tuxemon/core/effects/retaliate.py
+++ b/tuxemon/core/effects/retaliate.py
@@ -57,10 +57,4 @@ class RetaliateEffect(StatusEffect):
             ):
                 attacker.current_hp = max(0, attacker.current_hp - dam)
                 done = True
-        return StatusEffectResult(
-            name=status.name,
-            success=done,
-            statuses=[],
-            techniques=[],
-            extras=[],
-        )
+        return StatusEffectResult(name=status.name, success=done)

--- a/tuxemon/core/effects/revenge.py
+++ b/tuxemon/core/effects/revenge.py
@@ -57,10 +57,4 @@ class RevengeEffect(StatusEffect):
                 attacker.current_hp = max(0, attacker.current_hp - dam)
                 target.current_hp = min(target.hp, target.current_hp + dam)
                 done = True
-        return StatusEffectResult(
-            name=status.name,
-            success=done,
-            statuses=[],
-            techniques=[],
-            extras=[],
-        )
+        return StatusEffectResult(name=status.name, success=done)

--- a/tuxemon/core/effects/reverse.py
+++ b/tuxemon/core/effects/reverse.py
@@ -39,25 +39,11 @@ class ReverseEffect(TechEffect):
         tech.hit = tech.accuracy >= combat._random_tech_hit.get(user, 0.0)
 
         if not tech.hit:
-            return TechEffectResult(
-                name=tech.name,
-                success=tech.hit,
-                damage=0,
-                element_multiplier=0.0,
-                should_tackle=False,
-                extras=[],
-            )
+            return TechEffectResult(name=tech.name, success=tech.hit)
 
         objectives = self.objectives.split(":")
         monsters = get_target_monsters(objectives, tech, user, target)
         for monster in monsters:
             monster.reset_types()
 
-        return TechEffectResult(
-            name=tech.name,
-            success=True,
-            damage=0,
-            element_multiplier=0.0,
-            should_tackle=False,
-            extras=[],
-        )
+        return TechEffectResult(name=tech.name, success=True)

--- a/tuxemon/core/effects/run.py
+++ b/tuxemon/core/effects/run.py
@@ -48,14 +48,7 @@ class RunEffect(TechEffect):
         else:
             game_variables["run_attempts"] = attempts + 1
 
-        return TechEffectResult(
-            name=tech.name,
-            success=ran,
-            damage=0,
-            element_multiplier=0.0,
-            should_tackle=False,
-            extras=extra,
-        )
+        return TechEffectResult(name=tech.name, success=ran, extras=extra)
 
     def _determine_escape_method(
         self,
@@ -104,11 +97,4 @@ class RunEffect(TechEffect):
         """
         Return the default result for the RunEffect.
         """
-        return TechEffectResult(
-            name=tech.name,
-            success=True,
-            damage=0,
-            element_multiplier=0.0,
-            should_tackle=False,
-            extras=[],
-        )
+        return TechEffectResult(name=tech.name, success=True)

--- a/tuxemon/core/effects/sacrifice.py
+++ b/tuxemon/core/effects/sacrifice.py
@@ -52,8 +52,6 @@ class SacrificeEffect(TechEffect):
         return TechEffectResult(
             name=tech.name,
             damage=damage,
-            element_multiplier=0.0,
             should_tackle=tech.hit,
             success=tech.hit,
-            extras=[],
         )

--- a/tuxemon/core/effects/scope.py
+++ b/tuxemon/core/effects/scope.py
@@ -33,11 +33,4 @@ class ScopeEffect(TechEffect):
             "SD": target.speed,
         }
         extra = [T.format("combat_scope", params)]
-        return TechEffectResult(
-            name=tech.name,
-            success=True,
-            damage=0,
-            element_multiplier=0.0,
-            should_tackle=False,
-            extras=extra,
-        )
+        return TechEffectResult(name=tech.name, success=True, extras=extra)

--- a/tuxemon/core/effects/sniping.py
+++ b/tuxemon/core/effects/sniping.py
@@ -24,10 +24,4 @@ class SnipingEffect(StatusEffect):
     def apply(self, status: Status, target: Monster) -> StatusEffectResult:
         if status.phase == "perform_action_tech":
             target.status.clear()
-        return StatusEffectResult(
-            name=status.name,
-            success=True,
-            statuses=[],
-            techniques=[],
-            extras=[],
-        )
+        return StatusEffectResult(name=status.name, success=True)

--- a/tuxemon/core/effects/splash.py
+++ b/tuxemon/core/effects/splash.py
@@ -49,5 +49,4 @@ class SplashEffect(TechEffect):
             damage=damage,
             should_tackle=bool(damage),
             element_multiplier=mult,
-            extras=[],
         )

--- a/tuxemon/core/effects/statchange.py
+++ b/tuxemon/core/effects/statchange.py
@@ -72,10 +72,4 @@ class StatChangeEffect(StatusEffect):
                 if newstatvalue <= 0:
                     newstatvalue = 1
                 setattr(target, slugdata, newstatvalue)
-        return StatusEffectResult(
-            name=status.name,
-            success=bool(newstatvalue),
-            statuses=[],
-            techniques=[],
-            extras=[],
-        )
+        return StatusEffectResult(name=status.name, success=bool(newstatvalue))

--- a/tuxemon/core/effects/step_damage.py
+++ b/tuxemon/core/effects/step_damage.py
@@ -64,8 +64,6 @@ class StepDamageEffect(TechEffect):
         return TechEffectResult(
             name=tech.name,
             damage=damage,
-            element_multiplier=0.0,
             should_tackle=tech.hit,
             success=tech.hit,
-            extras=[],
         )

--- a/tuxemon/core/effects/step_healing.py
+++ b/tuxemon/core/effects/step_healing.py
@@ -62,11 +62,4 @@ class StepHealingEffect(TechEffect):
                     done = True
                 elif monster.current_hp == monster.hp:
                     extra = ["combat_full_health"]
-        return TechEffectResult(
-            name=tech.name,
-            success=done,
-            damage=0,
-            element_multiplier=0.0,
-            should_tackle=False,
-            extras=extra,
-        )
+        return TechEffectResult(name=tech.name, success=done, extras=extra)

--- a/tuxemon/core/effects/stuck.py
+++ b/tuxemon/core/effects/stuck.py
@@ -40,10 +40,4 @@ class StuckEffect(StatusEffect):
             for move in moves:
                 move.potency = move.default_potency / self.divisor
                 move.power = move.default_power / self.divisor
-        return StatusEffectResult(
-            name=status.name,
-            success=done,
-            statuses=[],
-            techniques=[],
-            extras=[],
-        )
+        return StatusEffectResult(name=status.name, success=done)

--- a/tuxemon/core/effects/swap.py
+++ b/tuxemon/core/effects/swap.py
@@ -51,11 +51,4 @@ class SwapEffect(TechEffect):
         # give a slight delay
         combat_state.task(partial(swap_add, user), 0.75)
 
-        return TechEffectResult(
-            name=tech.name,
-            success=True,
-            damage=0,
-            element_multiplier=0.0,
-            should_tackle=False,
-            extras=[],
-        )
+        return TechEffectResult(name=tech.name, success=True)

--- a/tuxemon/core/effects/switch.py
+++ b/tuxemon/core/effects/switch.py
@@ -47,14 +47,7 @@ class SwitchEffect(TechEffect):
         tech.hit = tech.accuracy >= combat._random_tech_hit.get(user, 0.0)
 
         if not tech.hit:
-            return TechEffectResult(
-                name=tech.name,
-                success=tech.hit,
-                damage=0,
-                element_multiplier=0.0,
-                should_tackle=False,
-                extras=[],
-            )
+            return TechEffectResult(name=tech.name, success=tech.hit)
 
         objectives = self.objectives.split(":")
         monsters = get_target_monsters(objectives, tech, user, target)
@@ -73,14 +66,7 @@ class SwitchEffect(TechEffect):
                 messages.append(get_extra_message(monster, new_type))
 
         extra = ["\n".join(messages)]
-        return TechEffectResult(
-            name=tech.name,
-            success=tech.hit,
-            damage=0,
-            element_multiplier=0.0,
-            should_tackle=False,
-            extras=extra,
-        )
+        return TechEffectResult(name=tech.name, success=tech.hit, extras=extra)
 
 
 def get_extra_message(monster: Monster, new_type: Element) -> str:

--- a/tuxemon/core/effects/switch_type.py
+++ b/tuxemon/core/effects/switch_type.py
@@ -44,6 +44,4 @@ class SwitchTypeEffect(ItemEffect):
             else:
                 random_target_element = random.choice(elements)
                 target.types = [Element(random_target_element)]
-        return ItemEffectResult(
-            name=item.name, success=target is not None, num_shakes=0, extras=[]
-        )
+        return ItemEffectResult(name=item.name, success=target is not None)

--- a/tuxemon/core/effects/tired.py
+++ b/tuxemon/core/effects/tired.py
@@ -28,10 +28,4 @@ class TiredEffect(StatusEffect):
             params = {"target": target.name.upper()}
             extra = [T.format("combat_state_tired_end", params)]
             target.status.clear()
-        return StatusEffectResult(
-            name=status.name,
-            success=True,
-            statuses=[],
-            techniques=[],
-            extras=extra,
-        )
+        return StatusEffectResult(name=status.name, success=True, extras=extra)

--- a/tuxemon/core/effects/transfer.py
+++ b/tuxemon/core/effects/transfer.py
@@ -47,11 +47,4 @@ class TransferEffect(TechEffect):
                 dest.status = source.status
                 source.status = []
                 done = True
-        return TechEffectResult(
-            name=tech.name,
-            success=done,
-            damage=0,
-            element_multiplier=0.0,
-            should_tackle=False,
-            extras=[],
-        )
+        return TechEffectResult(name=tech.name, success=done)

--- a/tuxemon/core/effects/wasting.py
+++ b/tuxemon/core/effects/wasting.py
@@ -33,10 +33,4 @@ class WastingEffect(StatusEffect):
             damage = (target.hp // self.divisor) * status.nr_turn
             target.current_hp = max(0, target.current_hp - damage)
             done = True
-        return StatusEffectResult(
-            name=status.name,
-            success=done,
-            statuses=[],
-            techniques=[],
-            extras=[],
-        )
+        return StatusEffectResult(name=status.name, success=done)

--- a/tuxemon/core/effects/wild.py
+++ b/tuxemon/core/effects/wild.py
@@ -44,9 +44,5 @@ class WildEffect(StatusEffect):
                 damage = user.hp // self.divisor
                 user.current_hp = max(0, user.current_hp - damage)
         return StatusEffectResult(
-            name=status.name,
-            success=True,
-            statuses=[],
-            techniques=tech,
-            extras=[],
+            name=status.name, success=True, techniques=tech
         )

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -121,15 +121,7 @@ class Item:
         """
         Applies the item's effects using EffectProcessor and returns the results.
         """
-        meta_result = ItemEffectResult(
-            name=self.name,
-            success=False,
-            num_shakes=0,
-            extras=[],
-        )
-        result = self.effect_handler.process_item(
-            source=self, target=target, meta_result=meta_result
-        )
+        result = self.effect_handler.process_item(source=self, target=target)
 
         # If this is a consumable item, remove it from the player's inventory.
         if (

--- a/tuxemon/status/status.py
+++ b/tuxemon/status/status.py
@@ -157,15 +157,9 @@ class Status:
         """
         Applies the status's effects using EffectProcessor and returns the results.
         """
-        meta_result = StatusEffectResult(
-            name=self.name,
-            success=False,
-            statuses=[],
-            techniques=[],
-            extras=[],
-        )
         result = self.effect_handler.process_status(
-            source=self, target=target, meta_result=meta_result
+            source=self,
+            target=target,
         )
 
         return result

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -155,16 +155,10 @@ class Technique:
         """
         Applies the technique's effects using EffectProcessor and returns the results.
         """
-        meta_result = TechEffectResult(
-            name=self.name,
-            success=False,
-            damage=0,
-            element_multiplier=0.0,
-            should_tackle=False,
-            extras=[],
-        )
         result = self.effect_handler.process_tech(
-            source=self, user=user, target=target, meta_result=meta_result
+            source=self,
+            user=user,
+            target=target,
         )
         self.next_use = self.recharge_length
         return result


### PR DESCRIPTION
PR sets default values for the dataclasses `TechEffectResult`, `StatusEffectResult`, and `ItemEffectResult`. It then removes all the default values from their subclasses, as these defaults are now handled in the main class definitions. This change helps to simplify and clean up the codebase.