### PR TITLE
Update Method `number_or_variable`

### DIFF
--- a/tuxemon/event/actions/variable_math.py
+++ b/tuxemon/event/actions/variable_math.py
@@ -48,9 +48,9 @@ class VariableMathAction(EventAction):
         # Read the parameters
         var = self.var1
         result = var if self.result is None else self.result
-        operand1 = number_or_variable(self.session, var)
+        operand1 = number_or_variable(player.game_variables, var)
         operation = self.operation
-        operand2 = number_or_variable(self.session, self.var2)
+        operand2 = number_or_variable(player.game_variables, self.var2)
 
         # Perform the operation on the variable
         if operation in ops_dict:

--- a/tuxemon/event/conditions/variable_is.py
+++ b/tuxemon/event/conditions/variable_is.py
@@ -33,7 +33,8 @@ class VariableIsCondition(EventCondition):
 
     def test(self, session: Session, condition: MapCondition) -> bool:
         # Read the parameters
-        operand1 = number_or_variable(session, condition.parameters[0])
+        variables = session.player.game_variables
+        operand1 = number_or_variable(variables, condition.parameters[0])
         operation = condition.parameters[1]
-        operand2 = number_or_variable(session, condition.parameters[2])
+        operand2 = number_or_variable(variables, condition.parameters[2])
         return compare(operation, operand1, operand2)

--- a/tuxemon/tools.py
+++ b/tuxemon/tools.py
@@ -239,39 +239,39 @@ def vector2_to_tile_pos(vector: Vector2) -> tuple[int, int]:
     return (int(vector[0]), int(vector[1]))
 
 
-def number_or_variable(
-    session: Session,
-    value: str,
-) -> float:
+def number_or_variable(variables: dict[str, Any], value: str) -> float:
     """
-    Returns a numeric game variable by its name.
+    Converts a string to a numeric value or retrieves a numeric variable by
+    name.
 
-    If ``value`` is already a number, convert from string to float and
-    return that.
+    This function attempts to convert the input string `value` into a float.
+    If that fails, it then tries to retrieve a variable by its name from the
+    `variables` dictionary and convert its value to a float.
 
     Parameters:
-        session: Session object, that contains the requested variable.
-        value: Name of the requested variable or string with numerical value.
+        variables: A dictionary containing variable names and their
+            corresponding values.
+        value: Either a string containing a numeric value or the name of a
+            variable.
 
     Returns:
-        Numerical value contained in the string or in the variable referenced
-        by that name.
+        The numeric value obtained by converting the string or retrieving
+        the variable.
 
     Raises:
-        ValueError: If ``value`` is not a number but no numeric variable with
-        that name can be retrieved.
-
+        ValueError: If `value` is neither a valid numeric string nor a valid
+        variable name, or the retrieved variable value cannot be converted to
+        a float.
     """
-    player = session.player
-    if value.isdigit():
+    try:
         return float(value)
-    elif value.replace(".", "", 1).isdigit():
-        return float(value)
-    else:
+    except ValueError:
         try:
-            return float(player.game_variables[value])
+            return float(variables[value])
         except (KeyError, ValueError, TypeError):
-            raise ValueError(f"invalid number or game variable {value}")
+            raise ValueError(
+                f"Unable to retrieve numeric variable or convert value '{value}'."
+            )
 
 
 # TODO: stability/testing


### PR DESCRIPTION
PR updates the `number_or_variable` function.
- the old version required passing an entire `Session` object to access `game_variables`
- the old implementation manually checked if a string was numeric using `isdigit()` and `replace()`, which failed for cases like negative numbers
- by handling conversions with `try`/`except`, the new implementation eliminates redundant checks
- the error message has been updated for clarity. Instead of `"invalid number or game variable"`, the new message specifies `"Unable to retrieve numeric variable or convert value '<value>'"` to help with debugging
- unittest has been updated to align with the new logic