### PR TITLE
Add Missing Attributes and Beautify Encounters JSON Files

### DIFF
--- a/mods/tuxemon/db/encounter/37707_town.json
+++ b/mods/tuxemon/db/encounter/37707_town.json
@@ -1,41 +1,49 @@
 {
-    "slug": "37707_town",
-    "monsters": [
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          1,
-          10
-        ],
-        "monster": "fruitera"
-      },
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          1,
-          10
-        ],
-        "monster": "dollfin"
-      },
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          1,
-          10
-        ],
-        "monster": "legko"
-      },
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          1,
-          10
-        ],
-        "monster": "rockitten"
-      }
-    ]
-  }
+  "slug": "37707_town",
+  "monsters": [
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        1,
+        10
+      ],
+      "monster": "fruitera"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        1,
+        10
+      ],
+      "monster": "dollfin"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        1,
+        10
+      ],
+      "monster": "legko"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        1,
+        10
+      ],
+      "monster": "rockitten"
+    }
+  ]
+}

--- a/mods/tuxemon/db/encounter/37707_town_missing.json
+++ b/mods/tuxemon/db/encounter/37707_town_missing.json
@@ -1,39 +1,47 @@
 {
-    "slug": "37707_town_missing",
-    "monsters": [
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          1,
-          999
-        ],
-        "monster": "f7u1t3ra"
-      },
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          1
-        ],
-        "monster": "d0llf1n"
-      },
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          666
-        ],
-        "monster": "l3gk0"
-      },
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          13,
-          37
-        ],
-        "monster": "r0ck1tt3n"
-      }
-    ]
-  }
+  "slug": "37707_town_missing",
+  "monsters": [
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        1,
+        999
+      ],
+      "monster": "f7u1t3ra"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        1
+      ],
+      "monster": "d0llf1n"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        666
+      ],
+      "monster": "l3gk0"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        13,
+        37
+      ],
+      "monster": "r0ck1tt3n"
+    }
+  ]
+}

--- a/mods/tuxemon/db/encounter/default_encounter.json
+++ b/mods/tuxemon/db/encounter/default_encounter.json
@@ -1,95 +1,115 @@
 {
-   "slug": "default_encounter",
-   "monsters": [
-     {
-       "encounter_rate": 0.5,
-       "exp_req_mod": 1,
-       "level_range": [
-         2,
-         4
-       ],
-       "monster": "eyenemy"
-     },
-     {
-       "encounter_rate": 0.5,
-       "exp_req_mod": 1,
-       "level_range": [
-         2,
-         4
-       ],
-       "monster": "dandicub"
-     },
-     {
-       "encounter_rate": 0.5,
-       "exp_req_mod": 1,
-       "level_range": [
-         2,
-         4
-       ],
-       "monster": "cardiling"
-     },
-     {
-       "encounter_rate": 0.5,
-       "exp_req_mod": 1,
-       "level_range": [
-         2,
-         4
-       ],
-       "monster": "budaye"
-     },
-     {
-       "encounter_rate": 0.5,
-       "exp_req_mod": 1,
-       "level_range": [
-         2,
-         4
-       ],
-       "monster": "cataspike"
-     },
-     {
-       "encounter_rate": 0.5,
-       "exp_req_mod": 1,
-       "level_range": [
-         3,
-         6
-       ],
-       "monster": "elofly"
-     },
-     {
-       "encounter_rate": 0.5,
-       "exp_req_mod": 1,
-       "level_range": [
-         3,
-         6
-       ],
-       "monster": "aardorn"
-     },
-     {
-       "encounter_rate": 0.5,
-       "exp_req_mod": 1,
-       "level_range": [
-         3,
-         6
-       ],
-       "monster": "nut"
-     },
-     {
-       "encounter_rate": 0.5,
-       "exp_req_mod": 1,
-       "level_range": [
-         3,
-         6
-       ],
-       "monster": "grimachin"
-     },
-     {
-       "encounter_rate": 0.5,
-       "exp_req_mod": 1,
-       "level_range": [
-         3,
-         6
-       ],
-       "monster": "spighter"
-     }
-   ]
- }
+  "slug": "default_encounter",
+  "monsters": [
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        2,
+        4
+      ],
+      "monster": "eyenemy"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        2,
+        4
+      ],
+      "monster": "dandicub"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        2,
+        4
+      ],
+      "monster": "cardiling"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        2,
+        4
+      ],
+      "monster": "budaye"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        2,
+        4
+      ],
+      "monster": "cataspike"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        3,
+        6
+      ],
+      "monster": "elofly"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        3,
+        6
+      ],
+      "monster": "aardorn"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        3,
+        6
+      ],
+      "monster": "nut"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        3,
+        6
+      ],
+      "monster": "grimachin"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        3,
+        6
+      ],
+      "monster": "spighter"
+    }
+  ]
+}

--- a/mods/tuxemon/db/encounter/new_txmn.json
+++ b/mods/tuxemon/db/encounter/new_txmn.json
@@ -1,50 +1,60 @@
 {
-    "slug": "new_txmn",
-    "monsters": [
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          2,
-          4
-        ],
-        "monster": "chloragon"
-      },
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          2,
-          4
-        ],
-        "monster": "chillimp"
-      },
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          3,
-          6
-        ],
-        "monster": "coproblight"
-      },
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          3,
-          6
-        ],
-        "monster": "pilthropus"
-      },
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          3,
-          6
-        ],
-        "monster": "teddisun"
-      }
-    ]
-  }
+  "slug": "new_txmn",
+  "monsters": [
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        2,
+        4
+      ],
+      "monster": "chloragon"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        2,
+        4
+      ],
+      "monster": "chillimp"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        3,
+        6
+      ],
+      "monster": "coproblight"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        3,
+        6
+      ],
+      "monster": "pilthropus"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        3,
+        6
+      ],
+      "monster": "teddisun"
+    }
+  ]
+}

--- a/mods/tuxemon/db/encounter/propellercat.json
+++ b/mods/tuxemon/db/encounter/propellercat.json
@@ -1,14 +1,16 @@
 {
-   "slug": "propellercat",
-   "monsters": [
-     {
-       "monster": "propellercat",
-       "encounter_rate": 1,
-       "exp_req_mod": 1,
-       "level_range": [
-         2,
-         64
-       ]
-     }
-   ]
- }
+  "slug": "propellercat",
+  "monsters": [
+    {
+      "monster": "propellercat",
+      "encounter_rate": 1,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        2,
+        64
+      ]
+    }
+  ]
+}

--- a/mods/tuxemon/db/encounter/rare_txmn.json
+++ b/mods/tuxemon/db/encounter/rare_txmn.json
@@ -1,185 +1,225 @@
 {
-    "slug": "rare_txmn",
-    "monsters": [
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          18,
-          35
-        ],
-        "monster": "legko"
-      },
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          36,
-          50
-        ],
-        "monster": "moloch"
-      },
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          18,
-          35
-        ],
-        "monster": "heronquak"
-      },
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          36,
-          50
-        ],
-        "monster": "eaglace"
-      },
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          18,
-          35
-        ],
-        "monster": "sapragon"
-      },
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          36,
-          50
-        ],
-        "monster": "dragarbor"
-      },
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          18,
-          35
-        ],
-        "monster": "gectile"
-      },
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          36,
-          50
-        ],
-        "monster": "velocitile"
-      },
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          18,
-          35
-        ],
-        "monster": "allagon"
-      },
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          10,
-          30
-        ],
-        "monster": "aardart"
-      },
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          18,
-          35
-        ],
-        "monster": "agnidon"
-      },
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          36,
-          50
-        ],
-        "monster": "agnigon"
-      },
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          18,
-          35
-        ],
-        "monster": "cardiwing"
-      },
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          36,
-          50
-        ],
-        "monster": "cardinale"
-      },
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          10,
-          30
-        ],
-        "monster": "corvix"
-      },
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          18,
-          35
-        ],
-        "monster": "dracune"
-      },
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          36,
-          50
-        ],
-        "monster": "fluttaflap"
-      },
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          10,
-          30
-        ],
-        "monster": "noctalo"
-      },
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          10,
-          30
-        ],
-        "monster": "possessun"
-      },
-      {
-        "encounter_rate": 0.5,
-        "exp_req_mod": 1,
-        "level_range": [
-          10,
-          30
-        ],
-        "monster": "sharpfin"
-      }
-    ]
-  }
+  "slug": "rare_txmn",
+  "monsters": [
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        18,
+        35
+      ],
+      "monster": "legko"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        36,
+        50
+      ],
+      "monster": "moloch"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        18,
+        35
+      ],
+      "monster": "heronquak"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        36,
+        50
+      ],
+      "monster": "eaglace"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        18,
+        35
+      ],
+      "monster": "sapragon"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        36,
+        50
+      ],
+      "monster": "dragarbor"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        18,
+        35
+      ],
+      "monster": "gectile"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        36,
+        50
+      ],
+      "monster": "velocitile"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        18,
+        35
+      ],
+      "monster": "allagon"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        10,
+        30
+      ],
+      "monster": "aardart"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        18,
+        35
+      ],
+      "monster": "agnidon"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        36,
+        50
+      ],
+      "monster": "agnigon"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        18,
+        35
+      ],
+      "monster": "cardiwing"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        36,
+        50
+      ],
+      "monster": "cardinale"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        10,
+        30
+      ],
+      "monster": "corvix"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        18,
+        35
+      ],
+      "monster": "dracune"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        36,
+        50
+      ],
+      "monster": "fluttaflap"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        10,
+        30
+      ],
+      "monster": "noctalo"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        10,
+        30
+      ],
+      "monster": "possessun"
+    },
+    {
+      "encounter_rate": 0.5,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 1,
+      "level_range": [
+        10,
+        30
+      ],
+      "monster": "sharpfin"
+    }
+  ]
+}

--- a/mods/tuxemon/db/encounter/spyder_citypark.json
+++ b/mods/tuxemon/db/encounter/spyder_citypark.json
@@ -9,7 +9,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         5,
         8
@@ -23,7 +24,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         8,
         11
@@ -37,7 +39,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         6,
         9
@@ -51,7 +54,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         5,
         8
@@ -65,7 +69,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         8,
         12
@@ -79,7 +84,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         8,
         12
@@ -93,7 +99,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         8,
         12
@@ -107,7 +114,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         9,
         14

--- a/mods/tuxemon/db/encounter/spyder_cotton_tunnel.json
+++ b/mods/tuxemon/db/encounter/spyder_cotton_tunnel.json
@@ -9,7 +9,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         35,
         40
@@ -23,7 +24,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         30,
         35
@@ -37,7 +39,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         25,
         35
@@ -51,7 +54,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         30,
         35

--- a/mods/tuxemon/db/encounter/spyder_datacenter.json
+++ b/mods/tuxemon/db/encounter/spyder_datacenter.json
@@ -9,7 +9,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         45,
         50
@@ -23,7 +24,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         45,
         50
@@ -37,7 +39,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         40,
         45

--- a/mods/tuxemon/db/encounter/spyder_dragonscave.json
+++ b/mods/tuxemon/db/encounter/spyder_dragonscave.json
@@ -9,7 +9,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         25,
         28
@@ -23,7 +24,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         20,
         25
@@ -37,7 +39,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         25,
         28
@@ -51,7 +54,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         20,
         25
@@ -65,7 +69,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         28,
         30
@@ -79,7 +84,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         25,
         28
@@ -93,7 +99,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         28,
         30
@@ -107,7 +114,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         25,
         28

--- a/mods/tuxemon/db/encounter/spyder_dryadsgrove.json
+++ b/mods/tuxemon/db/encounter/spyder_dryadsgrove.json
@@ -9,7 +9,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         25,
         28
@@ -23,7 +24,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         20,
         25
@@ -37,7 +39,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         25,
         28
@@ -51,7 +54,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         25,
         28
@@ -65,7 +69,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         28,
         30
@@ -79,7 +84,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         25,
         28

--- a/mods/tuxemon/db/encounter/spyder_greenwash.json
+++ b/mods/tuxemon/db/encounter/spyder_greenwash.json
@@ -9,7 +9,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         15,
         25
@@ -23,7 +24,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         15,
         25
@@ -37,7 +39,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         15,
         25
@@ -51,7 +54,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         20,
         25
@@ -65,7 +69,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         20,
         25

--- a/mods/tuxemon/db/encounter/spyder_lion_mountain.json
+++ b/mods/tuxemon/db/encounter/spyder_lion_mountain.json
@@ -9,7 +9,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         55,
         65
@@ -23,7 +24,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         65,
         75
@@ -37,7 +39,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         55,
         65
@@ -51,7 +54,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         65,
         75
@@ -65,7 +69,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         55,
         65
@@ -79,7 +84,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         65,
         75
@@ -93,7 +99,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         55,
         65
@@ -107,7 +114,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         65,
         75

--- a/mods/tuxemon/db/encounter/spyder_mansion.json
+++ b/mods/tuxemon/db/encounter/spyder_mansion.json
@@ -9,7 +9,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         13,
         16
@@ -23,7 +24,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         13,
         16
@@ -37,7 +39,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         14,
         17
@@ -51,7 +54,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         13,
         16
@@ -65,7 +69,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         14,
         18
@@ -79,7 +84,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         14,
         18
@@ -93,7 +99,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         14,
         18
@@ -107,7 +114,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         14,
         18

--- a/mods/tuxemon/db/encounter/spyder_omnichannel.json
+++ b/mods/tuxemon/db/encounter/spyder_omnichannel.json
@@ -4,7 +4,9 @@
     {
       "monster": "dark_robo",
       "encounter_rate": 0.5,
-      "exp_req_mod": 1,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         30,
         31
@@ -13,7 +15,9 @@
     {
       "monster": "xeon_2",
       "encounter_rate": 0.5,
-      "exp_req_mod": 1,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         30,
         31

--- a/mods/tuxemon/db/encounter/spyder_park.json
+++ b/mods/tuxemon/db/encounter/spyder_park.json
@@ -5,6 +5,9 @@
       {
         "monster": "pairagrim",
         "encounter_rate": 3.5,
+        "variables": [],
+        "held_items": [],
+        "exp_req_mod": 3,
         "level_range": [
           5,
           6

--- a/mods/tuxemon/db/encounter/spyder_route1.json
+++ b/mods/tuxemon/db/encounter/spyder_route1.json
@@ -9,7 +9,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         2,
         4
@@ -23,7 +24,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         2,
         4
@@ -37,7 +39,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         2,
         4
@@ -51,7 +54,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         3,
         5
@@ -65,7 +69,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         3,
         5
@@ -79,7 +84,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         3,
         5

--- a/mods/tuxemon/db/encounter/spyder_route2.json
+++ b/mods/tuxemon/db/encounter/spyder_route2.json
@@ -9,7 +9,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         3,
         6
@@ -23,7 +24,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         3,
         6
@@ -37,7 +39,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         3,
         6
@@ -51,7 +54,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         4,
         7
@@ -65,7 +69,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         3,
         6
@@ -79,7 +84,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         3,
         6
@@ -93,7 +99,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         4,
         8
@@ -107,7 +114,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         4,
         8
@@ -121,7 +129,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         5,
         8
@@ -135,7 +144,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         4,
         8

--- a/mods/tuxemon/db/encounter/spyder_route3.json
+++ b/mods/tuxemon/db/encounter/spyder_route3.json
@@ -9,7 +9,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         7,
         10
@@ -23,7 +24,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         7,
         10
@@ -37,7 +39,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         8,
         11
@@ -51,7 +54,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         7,
         10
@@ -65,7 +69,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         9,
         12
@@ -79,7 +84,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         9,
         12
@@ -93,7 +99,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         9,
         12
@@ -107,7 +114,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         9,
         12

--- a/mods/tuxemon/db/encounter/spyder_route4.json
+++ b/mods/tuxemon/db/encounter/spyder_route4.json
@@ -9,7 +9,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         11,
         14
@@ -23,7 +24,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         12,
         15
@@ -37,7 +39,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         11,
         14
@@ -51,7 +54,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         11,
         14
@@ -65,7 +69,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         13,
         16
@@ -79,7 +84,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         13,
         16
@@ -93,7 +99,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         13,
         16
@@ -107,7 +114,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         13,
         16

--- a/mods/tuxemon/db/encounter/spyder_route5.json
+++ b/mods/tuxemon/db/encounter/spyder_route5.json
@@ -9,7 +9,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         19,
         23
@@ -23,7 +24,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         16,
         20
@@ -37,7 +39,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         18,
         22
@@ -51,7 +54,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         18,
         22
@@ -65,7 +69,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         22,
         26

--- a/mods/tuxemon/db/encounter/spyder_route6.json
+++ b/mods/tuxemon/db/encounter/spyder_route6.json
@@ -9,7 +9,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         19,
         20
@@ -23,7 +24,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         21,
         23
@@ -37,7 +39,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         19,
         22
@@ -51,7 +54,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         20,
         24
@@ -65,7 +69,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         22,
         24
@@ -79,7 +84,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         20,
         24

--- a/mods/tuxemon/db/encounter/spyder_route7.json
+++ b/mods/tuxemon/db/encounter/spyder_route7.json
@@ -9,6 +9,7 @@
           "daytime": "true"
         }
       ],
+      "held_items": [],
       "exp_req_mod": 3,
       "level_range": [
         15,
@@ -23,6 +24,7 @@
           "daytime": "true"
         }
       ],
+      "held_items": [],
       "exp_req_mod": 3,
       "level_range": [
         15,
@@ -37,6 +39,7 @@
           "daytime": "true"
         }
       ],
+      "held_items": [],
       "exp_req_mod": 3,
       "level_range": [
         15,
@@ -51,6 +54,7 @@
           "daytime": "false"
         }
       ],
+      "held_items": [],
       "exp_req_mod": 3,
       "level_range": [
         15,
@@ -65,6 +69,7 @@
           "daytime": "false"
         }
       ],
+      "held_items": [],
       "exp_req_mod": 3,
       "level_range": [
         15,
@@ -79,6 +84,7 @@
           "daytime": "false"
         }
       ],
+      "held_items": [],
       "exp_req_mod": 3,
       "level_range": [
         15,

--- a/mods/tuxemon/db/encounter/spyder_routea.json
+++ b/mods/tuxemon/db/encounter/spyder_routea.json
@@ -9,7 +9,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         12,
         15
@@ -23,7 +24,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         12,
         15
@@ -37,7 +39,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         12,
         15
@@ -51,7 +54,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         14,
         18
@@ -65,7 +69,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         14,
         18
@@ -79,7 +84,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         14,
         18

--- a/mods/tuxemon/db/encounter/spyder_routeb.json
+++ b/mods/tuxemon/db/encounter/spyder_routeb.json
@@ -9,7 +9,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         25,
         28
@@ -23,7 +24,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         20,
         25
@@ -37,7 +39,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         25,
         28
@@ -51,7 +54,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         20,
         25
@@ -65,7 +69,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         26,
         30
@@ -79,7 +84,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         26,
         30
@@ -93,7 +99,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         26,
         30
@@ -107,7 +114,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         26,
         30

--- a/mods/tuxemon/db/encounter/spyder_routec.json
+++ b/mods/tuxemon/db/encounter/spyder_routec.json
@@ -9,7 +9,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         22,
         26
@@ -23,7 +24,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         22,
         26
@@ -37,7 +39,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         22,
         26
@@ -51,7 +54,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         22,
         26
@@ -65,7 +69,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         22,
         26
@@ -79,7 +84,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         22,
         26
@@ -93,7 +99,8 @@
           "daytime": "true"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         22,
         26
@@ -107,7 +114,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         25,
         29
@@ -121,7 +129,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         25,
         29
@@ -135,7 +144,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         25,
         29
@@ -149,7 +159,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         25,
         29
@@ -163,7 +174,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         25,
         29
@@ -177,7 +189,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         25,
         29
@@ -191,7 +204,8 @@
           "daytime": "false"
         }
       ],
-      "exp_req_mod": 1,
+      "held_items": [],
+      "exp_req_mod": 3,
       "level_range": [
         25,
         29

--- a/mods/tuxemon/db/encounter/taba_ba_passageway_1.json
+++ b/mods/tuxemon/db/encounter/taba_ba_passageway_1.json
@@ -4,6 +4,8 @@
     {
       "monster": "chloragon",
       "encounter_rate": 3.5,
+      "variables": [],
+      "held_items": [],
       "exp_req_mod": 15,
       "level_range": [
         2,
@@ -13,6 +15,8 @@
     {
       "monster": "aardorn",
       "encounter_rate": 3.5,
+      "variables": [],
+      "held_items": [],
       "exp_req_mod": 15,
       "level_range": [
         3,
@@ -22,6 +26,9 @@
     {
       "monster": "nut",
       "encounter_rate": 0.2,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 15,
       "level_range": [
         4,
         7

--- a/mods/tuxemon/db/encounter/taba_ba_passageway_2.json
+++ b/mods/tuxemon/db/encounter/taba_ba_passageway_2.json
@@ -3,7 +3,10 @@
   "monsters": [
     {
       "monster": "mystikapi",
-      "encounter_rate": 3.0,
+      "encounter_rate": 3,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 15,
       "level_range": [
         4,
         6
@@ -11,7 +14,10 @@
     },
     {
       "monster": "aardorn",
-      "encounter_rate": 3.0,
+      "encounter_rate": 3,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 15,
       "level_range": [
         4,
         6
@@ -20,6 +26,9 @@
     {
       "monster": "nut",
       "encounter_rate": 1.6,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 15,
       "level_range": [
         5,
         8

--- a/mods/tuxemon/db/encounter/taba_ba_passageway_3.json
+++ b/mods/tuxemon/db/encounter/taba_ba_passageway_3.json
@@ -3,7 +3,10 @@
   "monsters": [
     {
       "monster": "lambert",
-      "encounter_rate": 3.0,
+      "encounter_rate": 3,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 15,
       "level_range": [
         5,
         7
@@ -11,7 +14,10 @@
     },
     {
       "monster": "katapill",
-      "encounter_rate": 3.0,
+      "encounter_rate": 3,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 15,
       "level_range": [
         5,
         7
@@ -20,6 +26,9 @@
     {
       "monster": "nut",
       "encounter_rate": 0.8,
+      "variables": [],
+      "held_items": [],
+      "exp_req_mod": 15,
       "level_range": [
         6,
         8

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -1059,10 +1059,10 @@ class StatusModel(BaseModel):
 class PartyMemberModel(BaseModel):
     slug: str = Field(..., description="Slug of the monster")
     level: int = Field(..., description="Level of the monster", gt=0)
-    money_mod: int = Field(
+    money_mod: float = Field(
         ..., description="Modifier for money this monster gives", gt=0
     )
-    exp_req_mod: int = Field(
+    exp_req_mod: float = Field(
         ..., description="Experience required modifier", gt=0
     )
     gender: GenderType = Field(..., description="Gender of the monster")
@@ -1274,7 +1274,7 @@ class EncounterItemModel(BaseModel):
         ..., description="Probability of encountering this monster."
     )
     held_items: Sequence[str] = Field(
-        [], description="A list of items that will be held."
+        ..., description="A list of items that will be held."
     )
     level_range: Sequence[int] = Field(
         ...,
@@ -1282,14 +1282,13 @@ class EncounterItemModel(BaseModel):
         max_length=2,
     )
     variables: Sequence[dict[str, str]] = Field(
-        [],
+        ...,
         description="List of variables that affect the encounter.",
-        min_length=1,
     )
-    exp_req_mod: int = Field(
-        1,
+    exp_req_mod: float = Field(
+        ...,
         description="Modifier for the experience points required to defeat this wild monster.",
-        gt=0,
+        gt=0.0,
     )
 
     @field_validator("monster")

--- a/tuxemon/event/actions/add_monster.py
+++ b/tuxemon/event/actions/add_monster.py
@@ -38,8 +38,8 @@ class AddMonsterAction(EventAction):
     monster_slug: str
     monster_level: int
     npc_slug: Optional[str] = None
-    exp: Optional[int] = None
-    money: Optional[int] = None
+    exp: Optional[float] = None
+    money: Optional[float] = None
 
     def start(self) -> None:
         player = self.session.player

--- a/tuxemon/event/actions/random_monster.py
+++ b/tuxemon/event/actions/random_monster.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import random as rd
 from dataclasses import dataclass
-from typing import Union, final
+from typing import Optional, final
 
 from tuxemon.db import EvolutionStage, MonsterModel, db
 from tuxemon.event.eventaction import EventAction
@@ -36,11 +36,11 @@ class RandomMonsterAction(EventAction):
 
     name = "random_monster"
     monster_level: int
-    trainer_slug: Union[str, None] = None
-    exp: Union[int, None] = None
-    money: Union[int, None] = None
-    shape: Union[str, None] = None
-    evo: Union[str, None] = None
+    trainer_slug: Optional[str] = None
+    exp: Optional[float] = None
+    money: Optional[float] = None
+    shape: Optional[str] = None
+    evo: Optional[str] = None
 
     def start(self) -> None:
         if not lookup_cache:

--- a/tuxemon/event/actions/wild_encounter.py
+++ b/tuxemon/event/actions/wild_encounter.py
@@ -45,8 +45,8 @@ class WildEncounterAction(EventAction):
     name = "wild_encounter"
     monster_slug: str
     monster_level: int
-    exp: Optional[int] = None
-    money: Optional[int] = None
+    exp: Optional[float] = None
+    money: Optional[float] = None
     env: Optional[str] = None
     rgb: Optional[str] = None
     held_item: Optional[str] = None

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -128,8 +128,8 @@ class Monster:
         self.possible_genders: list[GenderType] = []
         self.held_item = MonsterItemHandler()
 
-        self.money_modifier = 0
-        self.experience_modifier = 1
+        self.money_modifier: float = 0.0
+        self.experience_modifier: float = 1.0
         self.total_experience = 0
 
         self.types: list[Element] = []


### PR DESCRIPTION
PR updates the JSON files by adding all the missing attributes, such as `held_items`, `variables`, and `exp_req_mod`, to all the tables. It also beautifies the ones that were not yet beautified.

It changes the data types of `experience_modifier` and `money_modifier` from `int` to `float`, addressing a limitation of integers that prevents representing values between 0 and 1. Using floats enables more precise adjustments, such as halving values, without being constrained by whole numbers or zero.