### PR TITLE
Fix: Preventing Tuxeball Usage on Trainer's Monsters During Battles

### DIFF
--- a/tuxemon/states/combat/combat_menus_park.py
+++ b/tuxemon/states/combat/combat_menus_park.py
@@ -98,7 +98,7 @@ class MainParkMenuState(PopUpMenu[MenuGameObj]):
 
         def choose_item() -> None:
             menu = self.client.push_state(ItemMenuState())
-            menu.is_valid_entry = validate  # type: ignore[assignment]
+            menu.is_valid_entry = validate  # type: ignore[method-assign]
             menu.on_menu_selection = choose_target  # type: ignore[method-assign]
 
         def validate(item: Optional[Item]) -> bool:

--- a/tuxemon/states/items/item_menu.py
+++ b/tuxemon/states/items/item_menu.py
@@ -246,9 +246,10 @@ class ItemMenuState(Menu[Item]):
         page_items = self.inventory[start_index:end_index]
 
         for obj in sort_inventory(page_items):
+            enable = self.is_valid_entry(obj)
             label = f"{obj.name} x {obj.quantity}"
             image = self.shadow_text(label, bg=prepare.DIMGRAY_COLOR)
-            yield MenuItem(image, obj.name, obj.description, obj)
+            yield MenuItem(image, obj.name, obj.description, obj, enable)
 
     def get_inventory(self, state: str) -> list[Item]:
         """Get player inventory items based on the current state."""
@@ -271,6 +272,9 @@ class ItemMenuState(Menu[Item]):
         if selected_item:
             self.animate_item_selection(selected_item.game_object)
             self.show_item_description(selected_item.game_object)
+
+    def is_valid_entry(self, item: Optional[Item]) -> bool:
+        return item is not None
 
     def animate_item_selection(self, item: Item) -> None:
         """Animate the selected item being pulled from the bag."""
@@ -299,9 +303,10 @@ class ItemMenuState(Menu[Item]):
         )
 
         for obj in sort_inventory(page_items):
+            enable = self.is_valid_entry(obj)
             label = f"{obj.name} x {obj.quantity}"
             image = self.shadow_text(label, bg=prepare.DIMGRAY_COLOR)
-            self.add(MenuItem(image, obj.name, obj.description, obj))
+            self.add(MenuItem(image, obj.name, obj.description, obj, enable))
 
         if self.menu_items:
             self.selected_index = min(

--- a/tuxemon/states/monster_item/__init__.py
+++ b/tuxemon/states/monster_item/__init__.py
@@ -38,7 +38,7 @@ class MonsterItemState(PygameMenuState):
 
         def add_item() -> None:
             menu = self.client.push_state(ItemMenuState())
-            menu.is_valid_entry = validate  # type: ignore[assignment]
+            menu.is_valid_entry = validate  # type: ignore[method-assign]
             menu.on_menu_selection = choose_target  # type: ignore[method-assign]
 
         def validate(item: Optional[Item]) -> bool:


### PR DESCRIPTION
PR resolves the bug where players could attempt to use a tuxeball on a trainer's monster. The issue stemmed from the absence of the `is_valid_entry` method. With the fix in place, the tuxeball can no longer be selected as an item during trainer battles, preventing the popup from appearing and solving the bug.