### PR TITLE
Fix Angle Calculation in `angle_of_points` Function & Angle Handling in `orientation_by_angle` Function

### DIFF
--- a/tuxemon/map.py
+++ b/tuxemon/map.py
@@ -353,10 +353,10 @@ def angle_of_points(
 
     Returns:
         Angle between the two points.
-
     """
-    ang = atan2(-(point1[1] - point0[1]), point1[0] - point1[0])
-    ang %= 2 * pi
+    ang = atan2(-(point1[1] - point0[1]), point1[0] - point0[0])
+    if ang < 0:
+        ang += 2 * pi
     return ang
 
 
@@ -388,14 +388,13 @@ def orientation_by_angle(angle: float) -> Orientation:
 
     Returns:
         Whether the orientation is horizontal or vertical.
-
     """
-    if angle == 3 / 2 * pi:
-        return Orientation.vertical
-    elif angle == 0.0:
+    if angle in {0.0, 2 * pi}:
         return Orientation.horizontal
+    elif angle in {pi / 2, 3 * pi / 2}:
+        return Orientation.vertical
     else:
-        raise Exception("A collision line must be aligned to an axis")
+        raise ValueError("A collision line must be aligned to an axis")
 
 
 def extract_region_properties(


### PR DESCRIPTION
PR fixes the angle calculation in the `angle_of_points` function by addressing two key issues:
- corrected the X-coordinate difference in `atan2` from `point1[0] - point1[0]` (always zero) to `point1[0] - point0[0]`, ensuring valid angle computations
- added a check to handle negative angles. If the computed angle is less than zero, `2 * pi` is added to bring the result into the range `[0, 2π]`

The function now works as intended and properly calculates the angle between two points in various scenarios.
The negation of the Y-coordinate difference (`-(point1[1] - point0[1])`) has been retained.

PR improves the `orientation_by_angle` function with two key updates:
- added support for more angle cases: horizontal orientation now covers both `0.0` and `2 * pi`, as they are equivalent angles and vertical orientation now includes `pi / 2` and `3 * pi / 2`
- replaced the generic `Exception` with a more specific `ValueError`