### PR TITLE
Enhanced `extract_region_properties`

### DIFF
--- a/tests/tuxemon/test_region_properties.py
+++ b/tests/tuxemon/test_region_properties.py
@@ -112,3 +112,75 @@ class TestExtractRegionProperties(unittest.TestCase):
         properties = {"enter_from": "", "exit_from": ""}
         with self.assertRaises(ValueError):
             extract_region_properties(properties)
+
+    def test_missing_enter_exit_from(self):
+        properties = {"endure": "left"}
+        expected = RegionProperties(
+            enter_from=[],
+            exit_from=[],
+            endure=[Direction.left],
+            entity=None,
+            key=None,
+        )
+        self.assertEqual(extract_region_properties(properties), expected)
+
+    def test_invalid_slide_label(self):
+        properties = {"enter_from": "slide"}
+        with self.assertRaises(ValueError):
+            extract_region_properties(properties)
+
+    def test_mixed_valid_invalid_keys(self):
+        properties = {
+            "enter_from": "up, left",
+            "invalid_key": "value",
+            "key": "door",
+        }
+        expected = RegionProperties(
+            enter_from=[Direction.left, Direction.up],
+            exit_from=[],
+            endure=[],
+            entity=None,
+            key="door",
+        )
+        self.assertEqual(extract_region_properties(properties), expected)
+
+    def test_empty_endure(self):
+        properties = {"endure": ""}
+        with self.assertRaises(ValueError):
+            extract_region_properties(properties)
+
+    def test_circular_logic(self):
+        properties = {"exit_from": "left, right"}
+        expected = RegionProperties(
+            enter_from=[Direction.up, Direction.down],
+            exit_from=[Direction.left, Direction.right],
+            endure=[],
+            entity=None,
+            key=None,
+        )
+        self.assertEqual(extract_region_properties(properties), expected)
+
+    def test_all_keys_missing(self):
+        properties = {"unknown_key": "value"}
+        self.assertIsNone(extract_region_properties(properties))
+
+    def test_case_insensitive_keys(self):
+        properties = {"Enter_from": "up, left"}
+        expected = RegionProperties(
+            enter_from=[Direction.left, Direction.up],
+            exit_from=[],
+            endure=[],
+            entity=None,
+            key=None,
+        )
+        self.assertEqual(extract_region_properties(properties), expected)
+
+    def test_all_directions_empty_key(self):
+        properties = {"enter_from": "up, down, left, right", "key": ""}
+        with self.assertRaises(ValueError):
+            extract_region_properties(properties)
+
+    def test_invalid_characters_in_directions(self):
+        properties = {"enter_from": "up, @, left"}
+        with self.assertRaises(ValueError):
+            extract_region_properties(properties)


### PR DESCRIPTION
PR makes the `extract_region_properties` function. Here's what's new:
- added checks to handle empty input dictionaries (`if not properties`) and ensure invalid or irrelevant keys don't cause unintended behavior
- keys are now processed case-insensitively (`key.lower()`), so mixed-case inputs like `"Enter_from"` are properly recognized
- any empty string values (`""`) raise a `ValueError`, preventing silent failures in cases like `"enter_from": ""`
- the calculation of `enter_from` when `exit_from` is present ensures directions are consistently sorted
- for the `"slide"` key, all movement properties (`enter_from`, `exit_from`, `endure`) are set to include every possible direction, maintaining predictable behavior
- `movement_properties` is renamed to `movements` for brevity
- when invalid keys or directions are provided, the function raises meaningful `ValueError` messages