### PR TITLE
Refactoring `get_explicit_tile_exits`

### DIFF
--- a/tests/tuxemon/test_action_queue.py
+++ b/tests/tuxemon/test_action_queue.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import random
 import unittest
 from unittest.mock import MagicMock, call
 
@@ -367,6 +368,7 @@ class TestSpeedTestFunction(unittest.TestCase):
             )
 
     def test_fast_vs_normal_technique(self):
+        random.seed(69)
         self.tech.is_fast = True
         results1_fast = [
             speed_monster(self.monster1, self.tech) for _ in range(1000)

--- a/tuxemon/event/actions/char_wander.py
+++ b/tuxemon/event/actions/char_wander.py
@@ -82,7 +82,7 @@ class CharWanderAction(EventAction):
 
             # Choose a random direction that is free and walk toward it
             origin = (character.tile_pos[0], character.tile_pos[1])
-            exits = world.pathfinder.get_exits(origin)
+            exits = world.pathfinder.get_exits(origin, character.facing)
             if exits:
                 path = random.choice(exits)
                 if not output or path in output:

--- a/tuxemon/map.py
+++ b/tuxemon/map.py
@@ -527,6 +527,52 @@ def direction_to_list(direction: Optional[str]) -> list[Direction]:
     )
 
 
+def get_explicit_tile_exits(
+    position: tuple[int, int],
+    tile: RegionProperties,
+    facing: Direction,
+    skip_nodes: Optional[set[tuple[int, int]]] = None,
+) -> list[tuple[float, ...]]:
+    """
+    Check for exits from tile which are defined in the map.
+
+    This will return exits which were defined by the map creator.
+
+    Checks "endure" and "exits" properties of the tile.
+
+    Parameters:
+        position: Original position.
+        tile: Region properties of the tile.
+        facing: Character facing.
+        skip_nodes: Set of nodes to skip.
+    """
+    skip_nodes = skip_nodes or set()
+    exits: list[tuple[float, ...]] = []
+
+    try:
+        # Check if the player's current position has any exit limitations.
+        if tile.endure:
+            direction = (
+                facing
+                if len(tile.endure) > 1 or not tile.endure
+                else tile.endure[0]
+            )
+            exit_position = tuple(dirs2[direction] + position)
+            if exit_position not in skip_nodes:
+                exits.append(exit_position)
+
+        # Check if the tile explicitly defines exits.
+        if tile.exit_from:
+            exits.extend(
+                tuple(dirs2[direction] + position)
+                for direction in tile.exit_from
+                if tuple(dirs2[direction] + position) not in skip_nodes
+            )
+    except (KeyError, TypeError):
+        return []
+    return exits
+
+
 class TuxemonMap:
     """
     Contains collisions geometry and events loaded from a file.

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -251,7 +251,7 @@ class NPC(Entity[NPCState]):
 
         """
         self.pathfinding = destination
-        path = self.world.pathfind(self.tile_pos, destination)
+        path = self.world.pathfind(self.tile_pos, destination, self.facing)
         if path:
             self.path = list(path)
             self.next_waypoint()

--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -25,7 +25,7 @@ from tuxemon.boundary import BoundaryChecker
 from tuxemon.camera import Camera, CameraManager, project
 from tuxemon.db import Direction
 from tuxemon.entity import Entity
-from tuxemon.map import RegionProperties, TuxemonMap, dirs2, proj
+from tuxemon.map import RegionProperties, TuxemonMap, proj
 from tuxemon.map_view import MapRenderer
 from tuxemon.math import Vector2
 from tuxemon.movement import Pathfinder
@@ -474,57 +474,9 @@ class WorldState(state.State):
                 return RegionProperties([], [], [], entity_or_label, None)
 
     def pathfind(
-        self,
-        start: tuple[int, int],
-        dest: tuple[int, int],
+        self, start: tuple[int, int], dest: tuple[int, int], facing: Direction
     ) -> Optional[Sequence[tuple[int, int]]]:
-        return self.pathfinder.pathfind(start, dest)
-
-    def get_explicit_tile_exits(
-        self,
-        position: tuple[int, int],
-        tile: RegionProperties,
-        skip_nodes: Optional[set[tuple[int, int]]] = None,
-    ) -> list[tuple[float, ...]]:
-        """
-        Check for exits from tile which are defined in the map.
-
-        This will return exits which were defined by the map creator.
-
-        Checks "endure" and "exits" properties of the tile.
-
-        Parameters:
-            position: Original position.
-            tile: Region properties of the tile.
-            skip_nodes: Set of nodes to skip.
-
-        """
-        skip_nodes = skip_nodes or set()
-        exits: list[tuple[float, ...]] = []
-
-        try:
-            # Check if the player's current position has any exit limitations.
-            if tile.endure:
-                direction = (
-                    self.player.facing
-                    if len(tile.endure) > 1 or not tile.endure
-                    else tile.endure[0]
-                )
-                exit_position = tuple(dirs2[direction] + position)
-                if exit_position not in skip_nodes:
-                    exits.append(exit_position)
-
-            # Check if the tile explicitly defines exits.
-            if tile.exit_from:
-                exits.extend(
-                    tuple(dirs2[direction] + position)
-                    for direction in tile.exit_from
-                    if tuple(dirs2[direction] + position) not in skip_nodes
-                )
-        except (KeyError, TypeError):
-            return []
-
-        return exits
+        return self.pathfinder.pathfind(start, dest, facing)
 
     ####################################################
     #              Character Movement                  #


### PR DESCRIPTION
PR introduces a change where the `get_explicit_tile_exits` method has been moved out of the `WorldState` class and implemented as an independent method, with the `facing` parameter explicitly passed to eliminate dependency on `self.player.facing`.

Additionally, the PR updates the `get_exits`, `pathfind_r`, and `pathfind` methods by injecting the `facing` parameter into each, improving their modularity, flexibility, and independence from the `WorldState` class.