### PR TITLE
Refactoring Capture Effects with YAML-Based Configuration

### DIFF
--- a/mods/capture_devices.yaml
+++ b/mods/capture_devices.yaml
@@ -1,0 +1,199 @@
+# The base multiplier applied to status effects during calculations.
+status_modifier: 1.0
+
+# The base multiplier applied to capture device effects during calculations.
+capdev_modifier: 1.0
+
+items:
+  # Example capture device configuration with custom modifiers.
+  example:
+    # Multiplier applied specifically to this capture device during calculations.
+    specific_capdev_modifier: 1.0
+
+    # Multiplier applied when the target has a "positive" status (e.g., diehard).
+    # This value boosts the capture rate for targets with beneficial or advantageous statuses.
+    positive_modifier: 1.0
+
+    # Multiplier applied when the target has a "negative" status (e.g., poisoned).
+    # This value reflects an increased capture rate for targets with detrimental statuses.
+    negative_modifier: 1.2
+
+    # Specific multipliers for named statuses. Overrides the general `positive_modifier` or
+    # `negative_modifier` when the target is affected by a specific status.
+    specific_status_modifiers:
+      # Custom multiplier for a named status like "poisoned."
+      name_status: 0.8
+
+    # Specific multipliers for named elements or types. Overrides the general modifiers if the
+    # target belongs to a specific element/type (e.g., "fire" or "ice").
+    specific_element_modifiers:
+      # Custom multiplier for a named element like "fire."
+      name_element: 1.0
+
+    # Multiplier applied for unspecified elements or types.
+    # This value acts as a malus, reducing effectiveness for elements not explicitly defined.
+    fallback_element_malus: 1.0
+
+    # Specific multipliers for named genders. Overrides general modifiers when the target's
+    # gender matches a specific value (e.g., "male" or "female").
+    specific_gender_modifiers:
+      # Custom multiplier for a named gender like "male."
+      name_gender: 1.0
+
+    # Multiplier applied for unspecified genders.
+    # Acts as a malus, reducing effectiveness for genders not explicitly defined.
+    fallback_gender_malus: 1.0
+
+    # Modifiers for specific variables take precedence over general modifiers when the 
+    # target variable matches any explicitly defined entry in the game configuration.
+    specific_variables_modifiers:
+      - key: daytime
+        value: false
+
+    # Default modifiers applied to variables not covered by `specific_variables_modifiers`.
+    # The `fallback_variables_bonus` enhances effectiveness for these unspecified variables, 
+    # while the `fallback_variables_malus` applies a penalty, reducing their impact.
+    fallback_variables_bonus: 1.5
+    fallback_variables_malus: 0.2
+
+    # Bounds for random multiplier calculations. These values are used in conjunction with
+    # `random.uniform(random_bounds[0], random_bounds[1])` to generate a random multiplier
+    # within the specified range. Useful for introducing variability in specific capture devices.
+    random_bounds: [0.0, 2.0]  # [lower_bound, upper_bound] for the random multiplier
+
+    # Indicates if the capture device is reusable (false means consumable)
+    capdev_persistent_on_failure: False
+    capdev_persistent_on_success: False
+
+    # `target_attribute`: Specifies the attribute of the monster to be modified
+    # during the capture process (e.g., level, health).
+    # `operation`: Defines the type of modification to perform on the attribute.
+    # Supported operations include:
+    # - `increment`: Adds the specified value to the current attribute.
+    # - `decrement`: Subtracts the specified value from the current attribute.
+    # - `set`: Replaces the current attribute value with the specified value.
+    # - `multiply`: Multiplies the current attribute value by the specified value.
+    # - `divide`: Divides the current attribute value by the specified value.
+    # `value`: Represents the numerical value used in the specified operation.
+    capdev_effects:
+      - target_attribute: level
+        operation: increment
+        value: 1
+
+  # Default configuration for a capture device with no custom status-specific modifiers.
+  tuxeball:
+    specific_capdev_modifier: 1.0
+
+  tuxeball_crusher:
+    specific_capdev_modifier: null
+
+  tuxeball_ancient:
+    specific_capdev_modifier: 99.0
+
+  tuxeball_noble:
+    specific_capdev_modifier: 1.25
+
+  tuxeball_lavish:
+    specific_capdev_modifier: 1.5
+
+  tuxeball_grand:
+    specific_capdev_modifier: 1.75
+
+  tuxeball_majestic:
+    specific_capdev_modifier: 2.0
+
+  tuxeball_earth:
+    specific_element_modifiers:
+      earth: 1.5
+    fallback_element_malus: 0.2
+
+  tuxeball_fire:
+    specific_element_modifiers:
+      fire: 1.5
+    fallback_element_malus: 0.2
+
+  tuxeball_metal:
+    specific_element_modifiers:
+      metal: 1.5
+    fallback_element_malus: 0.2
+
+  tuxeball_water:
+    specific_element_modifiers:
+      water: 1.5
+    fallback_element_malus: 0.2
+
+  tuxeball_wood:
+    specific_element_modifiers:
+      wood: 1.5
+    fallback_element_malus: 0.2
+
+  tuxeball_male:
+    specific_gender_modifiers:
+      male: 1.5
+    fallback_gender_malus: 0.2
+
+  tuxeball_female:
+    specific_gender_modifiers:
+      female: 1.5
+    fallback_gender_malus: 0.2
+
+  tuxeball_neuter:
+    specific_gender_modifiers:
+      neuter: 1.5
+    fallback_gender_malus: 0.2
+
+  tuxeball_gambler:
+    random_bounds: [0.0, 2.0]
+
+  tuxeball_candy:
+    capdev_effects:
+      - target_attribute: level
+        operation: increment
+        value: 1
+
+  tuxeball_hearty:
+    capdev_effects:
+      - target_attribute: taste_warm
+        operation: set
+        value: hearty
+
+  tuxeball_peppy:
+    capdev_effects:
+      - target_attribute: taste_warm
+        operation: set
+        value: peppy
+
+  tuxeball_refined:
+    capdev_effects:
+      - target_attribute: taste_warm
+        operation: set
+        value: refined
+
+  tuxeball_salty:
+    capdev_effects:
+      - target_attribute: taste_warm
+        operation: set
+        value: salty
+
+  tuxeball_zesty:
+    capdev_effects:
+      - target_attribute: taste_warm
+        operation: set
+        value: zesty
+
+  tuxeball_hardened:
+    capdev_persistent_on_failure: True
+
+  tuxeball_diurnal:
+    specific_variables_modifiers:
+      - key: daytime
+        value: "true"
+    fallback_variables_bonus: 1.5
+    fallback_variables_malus: 0.2
+
+  tuxeball_nocturnal:
+    specific_variables_modifiers:
+      - key: daytime
+        value: "false"
+    fallback_variables_bonus: 1.5
+    fallback_variables_malus: 0.2

--- a/mods/tuxemon/db/item/tuxeball_diurnal.json
+++ b/mods/tuxemon/db/item/tuxeball_diurnal.json
@@ -12,8 +12,7 @@
   ],
   "effects": [
     {
-      "type": "capture_combined",
-      "parameters": ["variable","daytime:true","0.2","1.5"]
+      "type": "capture"
     }
   ],
   "animation": "capture_1",

--- a/mods/tuxemon/db/item/tuxeball_earth.json
+++ b/mods/tuxemon/db/item/tuxeball_earth.json
@@ -12,8 +12,7 @@
   ],
   "effects": [
     {
-      "type": "capture_combined",
-      "parameters": ["element","earth","0.2","1.5"]
+      "type": "capture"
     }
   ],
   "animation": "capture_1",

--- a/mods/tuxemon/db/item/tuxeball_female.json
+++ b/mods/tuxemon/db/item/tuxeball_female.json
@@ -12,8 +12,7 @@
   ],
   "effects": [
     {
-      "type": "capture_combined",
-      "parameters": ["gender","female","0.2","1.5"]
+      "type": "capture"
     }
   ],
   "animation": "capture_1",

--- a/mods/tuxemon/db/item/tuxeball_fire.json
+++ b/mods/tuxemon/db/item/tuxeball_fire.json
@@ -12,8 +12,7 @@
   ],
   "effects": [
     {
-      "type": "capture_combined",
-      "parameters": ["element","fire","0.2","1.5"]
+      "type": "capture"
     }
   ],
   "animation": "capture_1",

--- a/mods/tuxemon/db/item/tuxeball_gambler.json
+++ b/mods/tuxemon/db/item/tuxeball_gambler.json
@@ -12,8 +12,7 @@
   ],
   "effects": [
     {
-      "type": "capture_combined",
-      "parameters": ["gambler","gambler","0.0","2.0"]
+      "type": "capture"
     }
   ],
   "animation": "capture_1",

--- a/mods/tuxemon/db/item/tuxeball_hearty.json
+++ b/mods/tuxemon/db/item/tuxeball_hearty.json
@@ -12,8 +12,7 @@
   ],
   "effects": [
     {
-      "type": "capture_combined",
-      "parameters": ["taste_warm","hearty","1","1"]
+      "type": "capture"
     }
   ],
   "animation": "capture_1",

--- a/mods/tuxemon/db/item/tuxeball_male.json
+++ b/mods/tuxemon/db/item/tuxeball_male.json
@@ -12,8 +12,7 @@
   ],
   "effects": [
     {
-      "type": "capture_combined",
-      "parameters": ["gender","male","0.2","1.5"]
+      "type": "capture"
     }
   ],
   "animation": "capture_1",

--- a/mods/tuxemon/db/item/tuxeball_metal.json
+++ b/mods/tuxemon/db/item/tuxeball_metal.json
@@ -12,8 +12,7 @@
   ],
   "effects": [
     {
-      "type": "capture_combined",
-      "parameters": ["element","metal","0.2","1.5"]
+      "type": "capture"
     }
   ],
   "animation": "capture_1",

--- a/mods/tuxemon/db/item/tuxeball_neuter.json
+++ b/mods/tuxemon/db/item/tuxeball_neuter.json
@@ -12,8 +12,7 @@
   ],
   "effects": [
     {
-      "type": "capture_combined",
-      "parameters": ["gender","neuter","0.2","1.5"]
+      "type": "capture"
     }
   ],
   "animation": "capture_1",

--- a/mods/tuxemon/db/item/tuxeball_nocturnal.json
+++ b/mods/tuxemon/db/item/tuxeball_nocturnal.json
@@ -12,8 +12,7 @@
   ],
   "effects": [
     {
-      "type": "capture_combined",
-      "parameters": ["variable","daytime:false","0.2","1.5"]
+      "type": "capture"
     }
   ],
   "animation": "capture_1",

--- a/mods/tuxemon/db/item/tuxeball_peppy.json
+++ b/mods/tuxemon/db/item/tuxeball_peppy.json
@@ -12,8 +12,7 @@
   ],
   "effects": [
     {
-      "type": "capture_combined",
-      "parameters": ["taste_warm","peppy","1","1"]
+      "type": "capture"
     }
   ],
   "animation": "capture_1",

--- a/mods/tuxemon/db/item/tuxeball_refined.json
+++ b/mods/tuxemon/db/item/tuxeball_refined.json
@@ -12,8 +12,7 @@
   ],
   "effects": [
     {
-      "type": "capture_combined",
-      "parameters": ["taste_warm","refined","1","1"]
+      "type": "capture"
     }
   ],
   "animation": "capture_1",

--- a/mods/tuxemon/db/item/tuxeball_salty.json
+++ b/mods/tuxemon/db/item/tuxeball_salty.json
@@ -12,8 +12,7 @@
   ],
   "effects": [
     {
-      "type": "capture_combined",
-      "parameters": ["taste_warm","salty","1","1"]
+      "type": "capture"
     }
   ],
   "animation": "capture_1",

--- a/mods/tuxemon/db/item/tuxeball_water.json
+++ b/mods/tuxemon/db/item/tuxeball_water.json
@@ -12,8 +12,7 @@
   ],
   "effects": [
     {
-      "type": "capture_combined",
-      "parameters": ["element","water","0.2","1.5"]
+      "type": "capture"
     }
   ],
   "animation": "capture_1",

--- a/mods/tuxemon/db/item/tuxeball_wood.json
+++ b/mods/tuxemon/db/item/tuxeball_wood.json
@@ -12,8 +12,7 @@
   ],
   "effects": [
     {
-      "type": "capture_combined",
-      "parameters": ["element","wood","0.2","1.5"]
+      "type": "capture"
     }
   ],
   "animation": "capture_1",

--- a/mods/tuxemon/db/item/tuxeball_zesty.json
+++ b/mods/tuxemon/db/item/tuxeball_zesty.json
@@ -12,8 +12,7 @@
   ],
   "effects": [
     {
-      "type": "capture_combined",
-      "parameters": ["taste_warm","zesty","1","1"]
+      "type": "capture"
     }
   ],
   "animation": "capture_1",

--- a/tests/tuxemon/test_capture.py
+++ b/tests/tuxemon/test_capture.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import random
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tuxemon.formula import (
+    CaptureDeviceConfig,
+    CaptureDevicesConfig,
+    Loader,
+    calculate_capdev_modifier,
+    calculate_status_modifier,
+    capture,
+    config_capdev,
+    shake_check,
+)
+from tuxemon.monster import Monster
+
+
+class TestShakeCheck(unittest.TestCase):
+
+    @patch("random.uniform")
+    def test_shake_check_basic(self, mock_uniform):
+        target = MagicMock(spec=Monster)
+        target.hp = 100
+        target.current_hp = 50
+        target.catch_rate = 100
+        target.lower_catch_resistance = 0.9
+        target.upper_catch_resistance = 1.1
+        mock_uniform.return_value = 1.0
+        status_modifier = 1.0
+        tuxeball_modifier = 1.0
+        result = shake_check(target, status_modifier, tuxeball_modifier)
+        self.assertIsInstance(result, float)
+        self.assertGreater(result, 0)
+
+    @patch("random.uniform")
+    def test_shake_check_different_values(self, mock_uniform):
+        mock_uniform.return_value = 0.5
+        target = MagicMock(spec=Monster)
+        target.hp = 150
+        target.current_hp = 25
+        target.catch_rate = 200
+        target.lower_catch_resistance = 0.8
+        target.upper_catch_resistance = 1.2
+        status_modifier = 1.5
+        tuxeball_modifier = 2.0
+        result = shake_check(target, status_modifier, tuxeball_modifier)
+        self.assertIsInstance(result, float)
+
+    @patch("random.uniform")
+    def test_shake_check_edge_cases(self, mock_uniform):
+        mock_uniform.return_value = 1.0
+        target = MagicMock(spec=Monster)
+        target.hp = 100
+        target.current_hp = 50
+        target.catch_rate = 100
+        target.lower_catch_resistance = 0.9
+        target.upper_catch_resistance = 1.1
+        status_modifier = 1.0
+        tuxeball_modifier = 1.0
+        result = shake_check(target, status_modifier, tuxeball_modifier)
+        self.assertIsInstance(result, float)
+
+        target2 = MagicMock(spec=Monster)
+        target2.hp = 1000
+        target2.current_hp = 1
+        target2.catch_rate = 255
+        target2.lower_catch_resistance = 1.0
+        target2.upper_catch_resistance = 1.0
+        result = shake_check(target2, status_modifier, tuxeball_modifier)
+        self.assertIsInstance(result, float)
+
+    @patch("random.uniform")
+    def test_shake_check_zero_hp(self, mock_uniform):
+        mock_uniform.return_value = 1.0
+        target = MagicMock(spec=Monster)
+        target.hp = 100
+        target.current_hp = 0
+        target.catch_rate = 100
+        target.lower_catch_resistance = 1.0
+        target.upper_catch_resistance = 1.0
+        status_modifier = 1.0
+        tuxeball_modifier = 1.0
+        result = shake_check(target, status_modifier, tuxeball_modifier)
+        self.assertIsInstance(result, float)
+
+
+class TestCapture(unittest.TestCase):
+    def setUp(self):
+        config_capture = Loader.get_config_capture("config_capture.yaml")
+        self.max_shake_rate = config_capture.shake_divisor
+        self.total_shake = config_capture.total_shakes
+
+    @patch("random.randint")
+    def test_capture_success(self, mock_randint):
+        mock_randint.return_value = self.max_shake_rate // 2
+        shake_check = self.max_shake_rate
+        captured, shakes = capture(shake_check)
+        self.assertTrue(captured)
+        self.assertEqual(shakes, self.total_shake)
+
+    @patch("random.randint")
+    def test_capture_failure_first_shake(self, mock_randint):
+        mock_randint.return_value = self.max_shake_rate
+        shake_check = 0
+        captured, shakes = capture(shake_check)
+        self.assertFalse(captured)
+        self.assertEqual(shakes, 1)
+
+    @patch("random.randint")
+    def test_capture_failure_middle_shake(self, mock_randint):
+        mock_randint.side_effect = [
+            self.max_shake_rate // 4,
+            self.max_shake_rate // 4,
+            self.max_shake_rate,
+        ]
+        shake_check = self.max_shake_rate // 4
+        captured, shakes = capture(shake_check)
+        self.assertFalse(captured)
+        self.assertEqual(shakes, 3)
+
+    @patch("random.randint")
+    def test_capture_failure_last_shake(self, mock_randint):
+        mock_randint.side_effect = [
+            self.max_shake_rate // 4,
+            self.max_shake_rate // 4,
+            self.max_shake_rate // 4,
+            self.max_shake_rate,
+        ]
+        shake_check = self.max_shake_rate // 4
+        captured, shakes = capture(shake_check)
+        self.assertFalse(captured)
+        self.assertEqual(shakes, self.total_shake)
+
+    @patch("random.randint")
+    def test_capture_edge_case_shake_check_zero(self, mock_randint):
+        mock_randint.return_value = self.max_shake_rate // 2
+        shake_check = 0
+        captured, shakes = capture(shake_check)
+        self.assertFalse(captured)
+        self.assertEqual(shakes, 1)
+
+    @patch("random.randint")
+    def test_capture_edge_case_shake_check_max(self, mock_randint):
+        mock_randint.return_value = self.max_shake_rate // 2
+        shake_check = self.max_shake_rate
+        captured, shakes = capture(shake_check)
+        self.assertTrue(captured)
+        self.assertEqual(shakes, self.total_shake)
+
+
+class TestCalculateStatusModifier(unittest.TestCase):
+    def setUp(self):
+        self.item = MagicMock(slug="example")
+        self.target = MagicMock()
+
+    def test_no_config_or_status(self):
+        self.target.status = None
+        result = calculate_status_modifier(self.item, self.target)
+        self.assertEqual(result, 1.0)
+
+    def test_no_target_status(self):
+        self.target.status = None
+        result = calculate_status_modifier(self.item, self.target)
+        self.assertEqual(result, 1.0)
+
+    def test_negative_category_modifier_applied(self):
+        self.target.status = [MagicMock(slug="unknown", category="negative")]
+        result = calculate_status_modifier(self.item, self.target)
+        self.assertEqual(result, 1.2)
+
+    def test_positive_category_modifier_applied(self):
+        self.target.status = [MagicMock(slug="unknown", category="positive")]
+        result = calculate_status_modifier(self.item, self.target)
+        self.assertEqual(result, 1.0)
+
+    def test_multiple_status_modifiers(self):
+        self.target.status = [
+            MagicMock(slug="unknown", category="negative"),
+            MagicMock(slug="name_status", category="positive"),
+        ]
+        result = calculate_status_modifier(self.item, self.target)
+        expected = 0.8 * 1.2
+        self.assertEqual(result, expected)

--- a/tests/tuxemon/test_formula.py
+++ b/tests/tuxemon/test_formula.py
@@ -2,21 +2,18 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import math
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from tuxemon import prepare
 from tuxemon.db import Modifier
 from tuxemon.element import Element
 from tuxemon.formula import (
-    Loader,
     average_damage,
     calculate_time_based_multiplier,
-    capture,
     cumulative_damage,
     first_applicable_damage,
     set_height,
     set_weight,
-    shake_check,
     simple_damage_calculate,
     simple_damage_multiplier,
     simple_heal,
@@ -228,139 +225,6 @@ class TestSimpleDamageMultiplier(unittest.TestCase):
             [attack_type], [target_type], additional_factors
         )
         self.assertEqual(round(multiplier, 1), 2.4)
-
-
-class TestShakeCheck(unittest.TestCase):
-
-    @patch("random.uniform")
-    def test_shake_check_basic(self, mock_uniform):
-        target = MagicMock(spec=Monster)
-        target.hp = 100
-        target.current_hp = 50
-        target.catch_rate = 100
-        target.lower_catch_resistance = 0.9
-        target.upper_catch_resistance = 1.1
-        mock_uniform.return_value = 1.0
-        status_modifier = 1.0
-        tuxeball_modifier = 1.0
-        result = shake_check(target, status_modifier, tuxeball_modifier)
-        self.assertIsInstance(result, float)
-        self.assertGreater(result, 0)
-
-    @patch("random.uniform")
-    def test_shake_check_different_values(self, mock_uniform):
-        mock_uniform.return_value = 0.5
-        target = MagicMock(spec=Monster)
-        target.hp = 150
-        target.current_hp = 25
-        target.catch_rate = 200
-        target.lower_catch_resistance = 0.8
-        target.upper_catch_resistance = 1.2
-        status_modifier = 1.5
-        tuxeball_modifier = 2.0
-        result = shake_check(target, status_modifier, tuxeball_modifier)
-        self.assertIsInstance(result, float)
-
-    @patch("random.uniform")
-    def test_shake_check_edge_cases(self, mock_uniform):
-        mock_uniform.return_value = 1.0
-        target = MagicMock(spec=Monster)
-        target.hp = 100
-        target.current_hp = 50
-        target.catch_rate = 100
-        target.lower_catch_resistance = 0.9
-        target.upper_catch_resistance = 1.1
-        status_modifier = 1.0
-        tuxeball_modifier = 1.0
-        result = shake_check(target, status_modifier, tuxeball_modifier)
-        self.assertIsInstance(result, float)
-
-        target2 = MagicMock(spec=Monster)
-        target2.hp = 1000
-        target2.current_hp = 1
-        target2.catch_rate = 255
-        target2.lower_catch_resistance = 1.0
-        target2.upper_catch_resistance = 1.0
-        result = shake_check(target2, status_modifier, tuxeball_modifier)
-        self.assertIsInstance(result, float)
-
-    @patch("random.uniform")
-    def test_shake_check_zero_hp(self, mock_uniform):
-        mock_uniform.return_value = 1.0
-        target = MagicMock(spec=Monster)
-        target.hp = 100
-        target.current_hp = 0
-        target.catch_rate = 100
-        target.lower_catch_resistance = 1.0
-        target.upper_catch_resistance = 1.0
-        status_modifier = 1.0
-        tuxeball_modifier = 1.0
-        result = shake_check(target, status_modifier, tuxeball_modifier)
-        self.assertIsInstance(result, float)
-
-
-class TestCapture(unittest.TestCase):
-    def setUp(self):
-        config_capture = Loader.get_config_capture("config_capture.yaml")
-        self.max_shake_rate = config_capture.shake_divisor
-        self.total_shake = config_capture.total_shakes
-
-    @patch("random.randint")
-    def test_capture_success(self, mock_randint):
-        mock_randint.return_value = self.max_shake_rate // 2
-        shake_check = self.max_shake_rate
-        captured, shakes = capture(shake_check)
-        self.assertTrue(captured)
-        self.assertEqual(shakes, self.total_shake)
-
-    @patch("random.randint")
-    def test_capture_failure_first_shake(self, mock_randint):
-        mock_randint.return_value = self.max_shake_rate
-        shake_check = 0
-        captured, shakes = capture(shake_check)
-        self.assertFalse(captured)
-        self.assertEqual(shakes, 1)
-
-    @patch("random.randint")
-    def test_capture_failure_middle_shake(self, mock_randint):
-        mock_randint.side_effect = [
-            self.max_shake_rate // 4,
-            self.max_shake_rate // 4,
-            self.max_shake_rate,
-        ]
-        shake_check = self.max_shake_rate // 4
-        captured, shakes = capture(shake_check)
-        self.assertFalse(captured)
-        self.assertEqual(shakes, 3)
-
-    @patch("random.randint")
-    def test_capture_failure_last_shake(self, mock_randint):
-        mock_randint.side_effect = [
-            self.max_shake_rate // 4,
-            self.max_shake_rate // 4,
-            self.max_shake_rate // 4,
-            self.max_shake_rate,
-        ]
-        shake_check = self.max_shake_rate // 4
-        captured, shakes = capture(shake_check)
-        self.assertFalse(captured)
-        self.assertEqual(shakes, self.total_shake)
-
-    @patch("random.randint")
-    def test_capture_edge_case_shake_check_zero(self, mock_randint):
-        mock_randint.return_value = self.max_shake_rate // 2
-        shake_check = 0
-        captured, shakes = capture(shake_check)
-        self.assertFalse(captured)
-        self.assertEqual(shakes, 1)
-
-    @patch("random.randint")
-    def test_capture_edge_case_shake_check_max(self, mock_randint):
-        mock_randint.return_value = self.max_shake_rate // 2
-        shake_check = self.max_shake_rate
-        captured, shakes = capture(shake_check)
-        self.assertTrue(captured)
-        self.assertEqual(shakes, self.total_shake)
 
 
 class TestDamageCalculations(unittest.TestCase):

--- a/tuxemon/core/effects/capture_combined.py
+++ b/tuxemon/core/effects/capture_combined.py
@@ -3,14 +3,12 @@
 from __future__ import annotations
 
 import logging
-import random
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Union
 
-from tuxemon import formula, prepare
+from tuxemon import formula
 from tuxemon.core.core_effect import ItemEffect, ItemEffectResult
-from tuxemon.db import CategoryStatus as Category
-from tuxemon.db import GenderType, SeenStatus
+from tuxemon.db import SeenStatus
 
 if TYPE_CHECKING:
     from tuxemon.item.item import Item
@@ -35,7 +33,7 @@ class CaptureCombinedEffect(ItemEffect):
         assert target
 
         # Calculate status modifier
-        status_modifier = self._calculate_status_modifier(target)
+        status_modifier = formula.calculate_status_modifier(item, target)
 
         # Calculate tuxeball modifier
         tuxeball_modifier = self._calculate_tuxeball_modifier(item, target)
@@ -56,16 +54,6 @@ class CaptureCombinedEffect(ItemEffect):
             name=item.name, success=True, num_shakes=shakes
         )
 
-    def _calculate_status_modifier(self, target: Monster) -> float:
-        status_modifier = prepare.STATUS_MODIFIER
-        if target.status and target.status[0].category:
-            status_modifier = (
-                prepare.STATUS_NEGATIVE
-                if target.status[0].category == Category.negative
-                else prepare.STATUS_POSITIVE
-            )
-        return status_modifier
-
     def _calculate_tuxeball_modifier(
         self, item: Item, target: Monster
     ) -> float:
@@ -73,99 +61,32 @@ class CaptureCombinedEffect(ItemEffect):
         Calculate the status effectiveness modifier based on the opponent's
         status.
         """
-        tuxeball_modifier = prepare.TUXEBALL_MODIFIER
-
-        if self.category == "element":
-            tuxeball_modifier = self._calculate_element_tuxeball_modifier(
-                target
-            )
-        elif self.category == "gender":
-            tuxeball_modifier = self._calculate_gender_tuxeball_modifier(
-                target
-            )
-        elif self.category == "variable":
-            tuxeball_modifier = self._calculate_variable_tuxeball_modifier()
-        elif self.category == "gambler":
-            tuxeball_modifier = self._calculate_gambler_tuxeball_modifier()
-        elif self.category == "monster":
-            tuxeball_modifier = self._calculate_monster_tuxeball_modifier(
-                item, target
-            )
-        else:  # Flavored-based tuxeball
-            target.taste_warm = self.label
-
-        return tuxeball_modifier
-
-    def _calculate_element_tuxeball_modifier(self, opponent: Monster) -> float:
-        """
-        Calculate the tuxeball effectiveness modifier based on the item's
-        element and the opponent's type.
-        """
-        if opponent.types[0].slug != self.label:
-            return self.lower_bound
-        return self.upper_bound
-
-    def _calculate_gender_tuxeball_modifier(self, opponent: Monster) -> float:
-        """
-        Calculate the tuxeball effectiveness modifier based on the item's
-        gender and the opponent's gender.
-        """
-        if opponent.gender != GenderType(self.label):
-            return self.lower_bound
-        return self.upper_bound
-
-    def _calculate_variable_tuxeball_modifier(self) -> float:
-        """
-        Calculate the tuxeball effectiveness modifier based on the item's
-        variable and the game variables.
-        """
-        key, value = self.label.split(":")
-        if (
-            key in self.session.player.game_variables
-            and self.session.player.game_variables[key] == value
-        ):
-            return self.upper_bound
-        return self.lower_bound
-
-    def _calculate_gambler_tuxeball_modifier(self) -> float:
-        """
-        Calculate the tuxeball effectiveness modifier based on the item's
-        gambler category.
-        """
-        return random.uniform(self.lower_bound, self.upper_bound)
-
-    def _calculate_monster_tuxeball_modifier(
-        self, item: Item, target: Monster
-    ) -> float:
-        """
-        Calculate the tuxeball effectiveness modifier based on the item's
-        monster category.
-        """
+        capdev_modifier = formula.config_capdev.capdev_modifier
         assert item.combat_state
         our_monster = item.combat_state.monsters_in_play[self.session.player]
 
         if not our_monster:
-            return prepare.TUXEBALL_MODIFIER
+            return capdev_modifier
 
         monster = our_monster[0]
 
         if not monster.types or not monster.types:
-            return prepare.TUXEBALL_MODIFIER
+            return capdev_modifier
 
         if self.label == "xero":
             return (
                 self.upper_bound
-                if monster.types[0].slug != target.types[0].slug
+                if monster.types != target.types
                 else self.lower_bound
             )
         elif self.label == "omni":
             return (
                 self.lower_bound
-                if monster.types[0].slug != target.types[0].slug
+                if monster.types != target.types
                 else self.upper_bound
             )
         else:
-            return prepare.TUXEBALL_MODIFIER
+            return capdev_modifier
 
     def _apply_capture_effects(self, item: Item, target: Monster) -> None:
         assert item.combat_state

--- a/tuxemon/prepare.py
+++ b/tuxemon/prepare.py
@@ -246,17 +246,6 @@ COEFF_EXP: int = 3
 WEIGHT_RANGE: tuple[float, float] = (-0.1, 0.1)
 HEIGHT_RANGE: tuple[float, float] = (-0.1, 0.1)
 
-# Capture
-# default modifiers
-STATUS_MODIFIER: float = 1.0
-TUXEBALL_MODIFIER: float = 1.0
-# standard modifiers if target has status:
-# if the status is positive
-# equal to status_modifier, but it can be changed
-STATUS_POSITIVE: float = 1.0
-# if the status is negative
-STATUS_NEGATIVE: float = 1.2
-
 # Camera
 CAMERA_SHAKE_RANGE: tuple[float, float] = (0.0, 3.0)
 


### PR DESCRIPTION
PR refactors hardcoded values related to capture effects (items) into a dedicated YAML file. Specifically, the status modifiers and the tuxeball modifier have been migrated to the YAML configuration. Each value within the YAML file is accompanied by detailed comments to clearly explain its purpose and functionality. Additionally, support for defining specific multipliers for individual statuses has been introduced, laying the groundwork for potential expansion of existing or future capture devices.