### PR TITLE
Event Actions with `npc_slug` Implementation

### DIFF
--- a/mods/tuxemon/maps/cotton_daycare.tmx
+++ b/mods/tuxemon/maps/cotton_daycare.tmx
@@ -86,8 +86,8 @@
    <properties>
     <property name="act10" value="translated_dialog cotton_breeder2a_1"/>
     <property name="act15" value="breeding female"/>
-    <property name="act16" value="create_kennel cotton_breeder"/>
-    <property name="act17" value="set_kennel_visible daycare,false"/>
+    <property name="act16" value="create_kennel player,cotton_breeder"/>
+    <property name="act17" value="set_kennel_visible player,daycare,false"/>
     <property name="act18" value="store_monster breeding_mother,cotton_breeder"/>
     <property name="act20" value="translated_dialog cotton_breeder2a_2"/>
     <property name="act30" value="breeding male"/>

--- a/mods/tuxemon/maps/spyder.yaml
+++ b/mods/tuxemon/maps/spyder.yaml
@@ -345,20 +345,20 @@ events:
     type: "event"
   Create Quarantine Kennel:
     actions:
-    - create_kennel quarantine
+    - create_kennel player,quarantine
     conditions:
     - not kennel player,quarantine,exist
     type: "event"
   Hide Quarantine Kennel:
     actions:
-    - set_kennel_visible quarantine,false
+    - set_kennel_visible player,quarantine,false
     conditions:
     - not variable_set hospitalcure:yes
     - is kennel player,quarantine,visible
     type: "event"
   Show Quarantine Kennel:
     actions:
-    - set_kennel_visible quarantine,true
+    - set_kennel_visible player,quarantine,true
     conditions:
     - is variable_set hospitalcure:yes
     - is kennel player,quarantine,hidden

--- a/mods/tuxemon/maps/spyder_candy_cafe.yaml
+++ b/mods/tuxemon/maps/spyder_candy_cafe.yaml
@@ -70,7 +70,7 @@ events:
     type: "event"
   Quarantine:
     actions:
-    - quarantine spyderbite,in
+    - quarantine player,spyderbite,in
     - char_face player,right
     - char_stop player
     - lock_controls

--- a/mods/tuxemon/maps/spyder_candy_hospital1.tmx
+++ b/mods/tuxemon/maps/spyder_candy_hospital1.tmx
@@ -304,7 +304,7 @@
     <property name="act1" value="translated_dialog spyder_hospital1_scientist1"/>
     <property name="act2" value="translated_dialog spyder_hospital1_scientist2"/>
     <property name="act3" value="set_variable quarantine_garvan:yes"/>
-    <property name="act4" value="quarantine spyderbite,out,1"/>
+    <property name="act4" value="quarantine player,spyderbite,out,1"/>
     <property name="behav1" value="talk spyder_hospital1_smith"/>
     <property name="cond1" value="not variable_set quarantine_garvan:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_candy_hospital2.tmx
+++ b/mods/tuxemon/maps/spyder_candy_hospital2.tmx
@@ -245,7 +245,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_hospital2_scientist2"/>
     <property name="act2" value="set_variable quarantine_qua2:yes"/>
-    <property name="act3" value="quarantine spyderbite,out,1"/>
+    <property name="act3" value="quarantine player,spyderbite,out,1"/>
     <property name="behav1" value="talk spyder_hospital1_trafford"/>
     <property name="cond1" value="not variable_set quarantine_qua2:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_candy_town.tmx
+++ b/mods/tuxemon/maps/spyder_candy_town.tmx
@@ -226,7 +226,7 @@
     <property name="act15" value="wait 1"/>
     <property name="act20" value="translated_dialog spyder_enforcer_candy4"/>
     <property name="act25" value="wait 1"/>
-    <property name="act30" value="quarantine spyderbite,in"/>
+    <property name="act30" value="quarantine player,spyderbite,in"/>
     <property name="act40" value="set_variable party_sick:yes"/>
     <property name="act45" value="pathfind spyder_candy_henrik,35,10"/>
     <property name="act50" value="set_variable confiscation_done:yes"/>
@@ -459,7 +459,7 @@
     <property name="act15" value="wait 1"/>
     <property name="act20" value="translated_dialog spyder_enforcer_candy4"/>
     <property name="act25" value="wait 1"/>
-    <property name="act30" value="quarantine spyderbite,in"/>
+    <property name="act30" value="quarantine player,spyderbite,in"/>
     <property name="act40" value="set_variable party_sick:yes"/>
     <property name="act45" value="pathfind spyder_candy_henrik,21,5"/>
     <property name="act50" value="set_variable confiscation_done:yes"/>

--- a/mods/tuxemon/maps/spyder_paper_daycare.yaml
+++ b/mods/tuxemon/maps/spyder_paper_daycare.yaml
@@ -100,8 +100,8 @@ events:
   Give Monster Yes:
     actions:
     - get_player_monster daycare_choice
-    - create_kennel daycare
-    - set_kennel_visible daycare,false
+    - create_kennel player,daycare
+    - set_kennel_visible player,daycare,false
     - store_monster daycare_choice,daycare
     - set_variable stored:stored
     - info daycare_choice,name

--- a/tuxemon/event/actions/create_kennel.py
+++ b/tuxemon/event/actions/create_kennel.py
@@ -2,10 +2,14 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import final
 
+from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
+
+logger = logging.getLogger(__name__)
 
 
 @final
@@ -22,17 +26,22 @@ class CreateKennelAction(EventAction):
     Script usage:
         .. code-block::
 
-            create_kennel <kennel>
+            create_kennel <character>,<kennel>
 
     Script parameters:
+        character: Either "player" or npc slug name (e.g. "npc_maple").
         kennel: Name of the kennel.
-
     """
 
     name = "create_kennel"
+    npc_slug: str
     kennel: str
 
     def start(self) -> None:
-        player = self.session.player
-        if not player.monster_boxes.has_box(self.kennel, "monster"):
-            player.monster_boxes.create_box(self.kennel, "monster")
+        character = get_npc(self.session, self.npc_slug)
+        if character is None:
+            logger.error(f"{self.npc_slug} not found")
+            return
+
+        if not character.monster_boxes.has_box(self.kennel, "monster"):
+            character.monster_boxes.create_box(self.kennel, "monster")

--- a/tuxemon/event/actions/set_kennel_visible.py
+++ b/tuxemon/event/actions/set_kennel_visible.py
@@ -2,12 +2,16 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import final
 
+from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.prepare import KENNEL
 from tuxemon.states.pc_kennel import HIDDEN_LIST
+
+logger = logging.getLogger(__name__)
 
 
 @final
@@ -17,28 +21,34 @@ class SetKennelVisibleAction(EventAction):
     Set the kennel visible or hidden.
 
     From hidden to visible:
-    set_kennel_visible name_kennel,true
+    set_kennel_visible player,name_kennel,true
 
     From visible to hidden:
-    set_kennel_visible name_kennel,false
+    set_kennel_visible player,name_kennel,false
 
     Script usage:
         .. code-block::
 
-            set_kennel_visible <kennel>,<visible>
+            set_kennel_visible <character>,<kennel>,<visible>
 
     Script parameters:
+        character: Either "player" or npc slug name (e.g. "npc_maple").
         kennel: Name of the kennel.
         visible: true/false.
 
     """
 
     name = "set_kennel_visible"
+    npc_slug: str
     kennel: str
     visible: str
 
     def start(self) -> None:
-        player = self.session.player
+        character = get_npc(self.session, self.npc_slug)
+        if character is None:
+            logger.error(f"{self.npc_slug} not found")
+            return
+
         kennel = self.kennel
         visible = self.visible
 
@@ -47,7 +57,7 @@ class SetKennelVisibleAction(EventAction):
                 f"{kennel} cannot be made invisible.",
             )
         else:
-            if player.monster_boxes.has_box(kennel, "monster"):
+            if character.monster_boxes.has_box(kennel, "monster"):
                 if visible == "true":
                     if kennel in HIDDEN_LIST:
                         HIDDEN_LIST.remove(kennel)


### PR DESCRIPTION
PR updates a series of event actions by implementing the `npc_slug`. As a result, `self.session.player` is no longer used to access certain services, such as the player's monster. Wherever possible, the character is now retrieved using `get_npc()`. While there are still some instances of `self.session.player` being used, primarily to access `game_variables`, these will be addressed in a separate fix.