### PR TITLE
Introducing PlayTileAnimationAction

### DIFF
--- a/docs/handcrafted/action_list.rst
+++ b/docs/handcrafted/action_list.rst
@@ -65,6 +65,7 @@
 .. autoscriptinfoclass:: tuxemon.event.actions.play_map_animation.PlayMapAnimationAction
 .. autoscriptinfoclass:: tuxemon.event.actions.play_music.PlayMusicAction
 .. autoscriptinfoclass:: tuxemon.event.actions.play_sound.PlaySoundAction
+.. autoscriptinfoclass:: tuxemon.event.actions.play_tile_animation.PlayTileAnimationAction
 .. autoscriptinfoclass:: tuxemon.event.actions.print.PrintAction
 .. autoscriptinfoclass:: tuxemon.event.actions.quarantine.QuarantineAction
 .. autoscriptinfoclass:: tuxemon.event.actions.quit.QuitAction

--- a/mods/tuxemon/maps/spyder_route3.tmx
+++ b/mods/tuxemon/maps/spyder_route3.tmx
@@ -180,7 +180,7 @@
     <property name="act30" value="pathfind spyder_route3_ryland,9,8"/>
     <property name="act40" value="pathfind spyder_route3_zoolander,7,8"/>
     <property name="act50" value="translated_dialog spyder_route3_drag1"/>
-    <property name="act60" value="play_map_animation dragonbirth,0.1,noloop,6,8"/>
+    <property name="act60" value="play_tile_animation 6,8,dragonbirth,0.1,noloop"/>
     <property name="act61" value="wait 5.0"/>
     <property name="act73" value="translated_dialog spyder_route3_drag2"/>
     <property name="act74" value="pathfind spyder_route3_ryland,17,10"/>

--- a/tuxemon/animation_entity.py
+++ b/tuxemon/animation_entity.py
@@ -10,6 +10,7 @@ from pygame.surface import Surface
 from tuxemon import prepare
 from tuxemon.db import db
 from tuxemon.graphics import create_animation, load_frames_files
+from tuxemon.map_view import AnimationInfo
 
 logger = logging.getLogger(__name__)
 
@@ -44,3 +45,50 @@ class AnimationEntity:
         self.directory = prepare.fetch("animations", self.file)
         self.frames = load_frames_files(self.directory, self.slug)
         self.play = create_animation(self.frames, self.duration, self.loop)
+
+
+def setup_and_play_animation(
+    animation_name: str,
+    duration: float,
+    loop: str,
+    position: tuple[int, int],
+    animations: dict[str, AnimationInfo],
+    layer: int,
+) -> None:
+    """
+    Sets up and plays a map animation with configurable layering.
+
+    Parameters:
+        animation_name: The name of the animation to play.
+        duration: Duration (in seconds) for each frame of the animation.
+        loop: Indicates whether the animation should loop. Must be "loop"
+            or "noloop".
+        position: The (x, y) coordinates where the animation should be
+            displayed.
+        animations: A dictionary of existing animations, storing their
+            states and properties.
+        layer: The rendering layer for the animation, affecting its visual
+            depth.
+
+    Raises:
+        ValueError: If `loop` is not "loop" or "noloop".
+    """
+    if loop == "loop":
+        loop_mode = True
+    elif loop == "noloop":
+        loop_mode = False
+    else:
+        raise ValueError(f"{loop} value must be 'loop' or 'noloop'")
+
+    _animation = AnimationEntity(animation_name, duration, loop_mode)
+
+    if animation_name in animations:
+        logger.debug(f"{animation_name} loaded")
+        animations[animation_name].position = position
+        animations[animation_name].animation.play()
+    else:
+        logger.debug(f"{animation_name} not loaded, loading")
+        animations[animation_name] = AnimationInfo(
+            _animation.play, position, layer
+        )
+        _animation.play.play()

--- a/tuxemon/event/actions/play_tile_animation.py
+++ b/tuxemon/event/actions/play_tile_animation.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from typing import final
 
 from tuxemon.animation_entity import setup_and_play_animation
-from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.states.world.worldstate import WorldState
 
@@ -16,41 +15,36 @@ logger = logging.getLogger(__name__)
 
 @final
 @dataclass
-class PlayMapAnimationAction(EventAction):
+class PlayTileAnimationAction(EventAction):
     """
-    Trigger a map animation at a specified position based on the character's
-    coordinates within the world map
+    Trigger a map animation at a specified tile position on the world map.
 
     Script usage:
         .. code-block::
 
-            play_map_animation <animation_name>,<duration>,<loop>,<character>
+            play_tile_animation <tile_pos_x>,<tile_pos_y>,<animation_name>,<duration>,<loop>
 
     Script parameters:
+        tile_pos_x, tile_pos_y: Coordinates (x, y) specifying the tile position
+            where the animation will be drawn on the map.
         animation_name: The name of the animation stored in the
             resources/animations/tileset directory. For example, an animation
             named "grass" will load frames named "grass_xx.png".
         frame_duration: Duration (in seconds) for each frame of the animation.
         loop_mode: Indicates whether the animation should loop. Options: "loop"
             or "noloop".
-        character: Either "player" or character slug name (e.g. "npc_maple").
     """
 
-    name = "play_map_animation"
+    name = "play_tile_animation"
+    tile_pos_x: int
+    tile_pos_y: int
     animation_name: str
     duration: float
     loop: str
-    character: str
 
     def start(self) -> None:
-        character = get_npc(self.session, self.character)
-
-        if character is None:
-            logger.error(f"Character '{self.character}' not found")
-            return
-
         world_state = self.session.client.get_state_by_name(WorldState)
-        position = character.tile_pos
+        position = (self.tile_pos_x, self.tile_pos_y)
         animations = world_state.map_renderer.map_animations
 
         setup_and_play_animation(


### PR DESCRIPTION
PR adds a new event action called `PlayTileAnimationAction`. The goal is to create a clear distinction between animations tied to tiles (`PlayTileAnimationAction`) and those tied to characters (`PlayMapAnimationAction`). By splitting these functionalities into separate actions, it avoids overcomplicating the original `PlayMapAnimationAction` while making the system cleaner and easier to manage.

To further improve code reuse and reduce duplication, a helper method `setup_and_play_animation` has been introduced. This method centralizes the logic for setting up and playing animations, allowing both `PlayTileAnimationAction` and `PlayMapAnimationAction` to leverage the same functionality.