### PR TITLE
Refactoring MapRenderer: Debug, Utilities, and Testing `get_pos_from_tilepos`

### DIFF
--- a/tests/tuxemon/test_map.py
+++ b/tests/tuxemon/test_map.py
@@ -4,6 +4,7 @@ import unittest
 from math import pi
 from unittest.mock import MagicMock
 
+from tuxemon import prepare
 from tuxemon.compat import Rect
 from tuxemon.db import Direction, Orientation
 from tuxemon.map import (
@@ -15,6 +16,7 @@ from tuxemon.map import (
     get_coords_ext,
     get_direction,
     get_explicit_tile_exits,
+    get_pos_from_tilepos,
     orientation_by_angle,
     pairs,
     point_to_grid,
@@ -23,6 +25,7 @@ from tuxemon.map import (
     snap_rect,
     tiles_inside_rect,
 )
+from tuxemon.math import Vector2
 
 
 class TestSnapInterval(unittest.TestCase):
@@ -725,3 +728,82 @@ class TestGetExplicitTileExits(unittest.TestCase):
 
         exits = get_explicit_tile_exits(position, tile, facing, skip_nodes)
         self.assertEqual(exits, [])
+
+
+class TestGetPosFromTilePos(unittest.TestCase):
+    def test_get_pos_from_tilepos(self):
+        mock_map = MagicMock()
+        mock_map.renderer.get_center_offset.return_value = (50, 75)
+
+        tile_position = Vector2(3, 4)
+
+        expected_px = 3 * prepare.TILE_SIZE[0]
+        expected_py = 4 * prepare.TILE_SIZE[1]
+        expected_x = expected_px + 50
+        expected_y = expected_py + 75
+        expected_result = (expected_x, expected_y)
+
+        result = get_pos_from_tilepos(mock_map, tile_position)
+        self.assertEqual(result, expected_result)
+
+    def test_different_tile_size(self):
+        mock_map = MagicMock()
+        mock_map.renderer.get_center_offset.return_value = (50, 75)
+
+        tile_position = Vector2(2, 3)
+
+        expected_px = 2 * prepare.TILE_SIZE[0]
+        expected_py = 3 * prepare.TILE_SIZE[1]
+        expected_result = (expected_px + 50, expected_py + 75)
+
+        result = get_pos_from_tilepos(mock_map, tile_position)
+        self.assertEqual(result, expected_result)
+
+    def test_tile_position_origin(self):
+        mock_map = MagicMock()
+        mock_map.renderer.get_center_offset.return_value = (50, 75)
+
+        tile_position = Vector2(0, 0)
+
+        expected_result = (50, 75)
+        result = get_pos_from_tilepos(mock_map, tile_position)
+        self.assertEqual(result, expected_result)
+
+    def test_negative_tile_position(self):
+        mock_map = MagicMock()
+        mock_map.renderer.get_center_offset.return_value = (50, 75)
+
+        tile_position = Vector2(-1, -2)
+
+        expected_px = -1 * prepare.TILE_SIZE[0]
+        expected_py = -2 * prepare.TILE_SIZE[1]
+        expected_result = (expected_px + 50, expected_py + 75)
+
+        result = get_pos_from_tilepos(mock_map, tile_position)
+        self.assertEqual(result, expected_result)
+
+    def test_large_tile_position(self):
+        mock_map = MagicMock()
+        mock_map.renderer.get_center_offset.return_value = (50, 75)
+
+        tile_position = Vector2(1000, 2000)
+
+        expected_px = 1000 * prepare.TILE_SIZE[0]
+        expected_py = 2000 * prepare.TILE_SIZE[1]
+        expected_result = (expected_px + 50, expected_py + 75)
+
+        result = get_pos_from_tilepos(mock_map, tile_position)
+        self.assertEqual(result, expected_result)
+
+    def test_zero_center_offset(self):
+        mock_map = MagicMock()
+        mock_map.renderer.get_center_offset.return_value = (0, 0)
+
+        tile_position = Vector2(5, 7)
+
+        expected_px = 5 * prepare.TILE_SIZE[0]
+        expected_py = 7 * prepare.TILE_SIZE[1]
+        expected_result = (expected_px, expected_py)
+
+        result = get_pos_from_tilepos(mock_map, tile_position)
+        self.assertEqual(result, expected_result)

--- a/tuxemon/graphics.py
+++ b/tuxemon/graphics.py
@@ -470,3 +470,39 @@ def string_to_colorlike(color: str) -> ColorLike:
         else (int(part[0]), int(part[1]), int(part[2]))
     )
     return rgb
+
+
+def apply_cinema_bars(
+    aspect_ratio: float,
+    screen: Surface,
+    orientation: str,
+    screen_size: tuple[int, int],
+    black_color: tuple[int, int, int],
+) -> None:
+    """
+    Applies cinema bars (letterboxing) to the screen in either horizontal or vertical orientation.
+    """
+    if orientation == "horizontal":
+        screen_aspect_ratio = screen_size[1] / screen_size[0]
+        if screen_aspect_ratio < aspect_ratio:
+            bar_width = int(
+                screen_size[0] * (1 - screen_aspect_ratio / aspect_ratio) / 2
+            )
+            bar = Surface((bar_width, screen_size[1]))
+            bar.fill(black_color)
+            screen.blit(bar, (0, 0))
+            screen.blit(bar, (screen_size[0] - bar_width, 0))
+    elif orientation == "vertical":
+        screen_aspect_ratio = screen_size[0] / screen_size[1]
+        if screen_aspect_ratio < aspect_ratio:
+            bar_height = int(
+                screen_size[1] * (1 - screen_aspect_ratio / aspect_ratio) / 2
+            )
+            bar = Surface((screen_size[0], bar_height))
+            bar.fill(black_color)
+            screen.blit(bar, (0, 0))
+            screen.blit(bar, (0, screen_size[1] - bar_height))
+    else:
+        raise ValueError(
+            f"Invalid orientation: '{orientation}'. Must be 'horizontal' or 'vertical'."
+        )

--- a/tuxemon/map.py
+++ b/tuxemon/map.py
@@ -13,6 +13,7 @@ from pytmx import pytmx
 from pytmx.pytmx import TiledMap
 
 from tuxemon import prepare
+from tuxemon.camera import project
 from tuxemon.compat.rect import ReadOnlyRect
 from tuxemon.db import Direction, Orientation
 from tuxemon.event import EventObject
@@ -71,7 +72,6 @@ def translate_short_path(
 
     Yields:
         Positions in the path.
-
     """
     position_vec = Vector2(*position)
     for char in path.lower():
@@ -206,7 +206,6 @@ def get_direction(
 
     Returns:
         Direction.
-
     """
     y_offset = base[1] - target[1]
     x_offset = base[0] - target[0]
@@ -228,7 +227,6 @@ def pairs(direction: Direction) -> Direction:
 
     Returns:
         Complimentary direction.
-
     """
     opposites = {
         Direction.up: Direction.down,
@@ -253,7 +251,6 @@ def proj(point: Vector3) -> Vector2:
 
     Returns:
         2d projection vector.
-
     """
     return Vector2(point.x, point.y)
 
@@ -273,7 +270,6 @@ def tiles_inside_rect(
 
     Yields:
         Tile positions inside the rect.
-
     """
     # scan order is left->right, top->bottom
     for y, x in product(
@@ -305,7 +301,6 @@ def snap_outer_point(
 
     Returns:
         Snapped point.
-
     """
     return (
         snap_interval(point[0], grid_size[0]),
@@ -326,7 +321,6 @@ def snap_point(
 
     Returns:
         Snapped point.
-
     """
     return (
         round_to_divisible(point[0], grid_size[0]),
@@ -347,7 +341,6 @@ def point_to_grid(
 
     Returns:
         Snapped point.
-
     """
     point = snap_point(point, grid_size)
     return point[0] // grid_size[0], point[1] // grid_size[1]
@@ -386,7 +379,6 @@ def snap_rect(
 
     Returns:
         Snapped rect.
-
     """
     left, top = snap_point(rect.topleft, grid_size)
     right, bottom = snap_point(rect.bottomright, grid_size)
@@ -536,7 +528,6 @@ def direction_to_list(direction: Optional[str]) -> list[Direction]:
 
     Returns:
         List with Direction/s
-
     """
     if direction is None:
         return []
@@ -594,6 +585,33 @@ def get_explicit_tile_exits(
     return exits
 
 
+def get_pos_from_tilepos(
+    current_map: TuxemonMap, tile_position: Vector2
+) -> tuple[int, int]:
+    """
+    Returns the map pixel coordinates based on the tile position.
+
+    This method calculates the pixel coordinates on the map corresponding
+    to the specified tile position, accounting for the map's center offset.
+    Use this method for drawing elements on the screen.
+
+    Parameters:
+        current_map: The map object (`TuxemonMap`) containing the renderer
+            and relevant positional data.
+        tile_position: A [x, y] tile position represented as a `Vector2`.
+
+    Returns:
+        A tuple representing the pixel coordinates (x, y) to draw at the
+        given tile position, adjusted for the map's center offset.
+    """
+    assert current_map.renderer
+    cx, cy = current_map.renderer.get_center_offset()
+    px, py = project(tile_position)
+    x = px + cx
+    y = py + cy
+    return x, y
+
+
 class TuxemonMap:
     """
     Contains collisions geometry and events loaded from a file.
@@ -637,7 +655,6 @@ class TuxemonMap:
             tiled_map: Original tiled map.
             maps: Dictionary of map properties.
             filename: Path of the map.
-
         """
         self.collision_map = collision_map
         self.surface_map = surface_map
@@ -683,7 +700,6 @@ class TuxemonMap:
 
         Returns:
             Renderer for the map.
-
         """
         visual_data = pyscroll.data.TiledMapData(self.data)
         # Behaviour at the edges.


### PR DESCRIPTION
PR refactors and enhances the codebase by relocating the `debug_drawing` functionality from the `WorldState` class into a dedicated `DebugRenderer` class, improving modularity and separation of concerns. The `DebugRenderer` class is responsible for rendering debug information, and it has been integrated into the `MapRenderer` class to streamline debug-related operations.

Additionally, the `_set_bubble` method has been updated to inject `layer` and `offset` parameters, replacing hardcoded magic numbers for improved clarity and maintainability. The PR also introduces a new utility method, `apply_cinema_bars`, which has been placed in `graphics.py` to keep the `MapRenderer` class uncluttered.

Furthermore, the `get_pos_from_tilepos` method has been extracted as a standalone utility function to enhance reusability, and a comprehensive unit test suite has been set up to ensure its robustness across various scenarios.