### PR TITLE
Centralizing Character (NPC) in Menu States and Updating Connected Methods

### DIFF
--- a/tuxemon/event/actions/breeding.py
+++ b/tuxemon/event/actions/breeding.py
@@ -25,7 +25,6 @@ class BreedingAction(EventAction):
 
     Script parameters:
         gender: Gender (male or female).
-
     """
 
     name = "breeding"
@@ -49,7 +48,9 @@ class BreedingAction(EventAction):
 
     def start(self) -> None:
         # pull up the monster menu so we know which one we are saving
-        menu = self.session.client.push_state(MonsterMenuState())
+        menu = self.session.client.push_state(
+            MonsterMenuState(self.session.player)
+        )
         menu.is_valid_entry = self.validate  # type: ignore[assignment]
         menu.on_menu_selection = self.set_var  # type: ignore[assignment]
 

--- a/tuxemon/event/actions/get_monster_tech.py
+++ b/tuxemon/event/actions/get_monster_tech.py
@@ -48,7 +48,6 @@ class GetMonsterTechAction(EventAction):
     eg. "get_monster_tech name_variable,monster_id"
     eg. "get_monster_tech name_variable,monster_id,element,water"
     eg, "get_monster_tech name_variable,monster_id,power,less_than,1.6"
-
     """
 
     name = "get_monster_tech"
@@ -129,7 +128,7 @@ class GetMonsterTechAction(EventAction):
         for mon in monsters:
             # pull up the monster menu so we know which one we are saving
             menu = self.session.client.push_state(
-                TechniqueMenuState(monster=mon)
+                TechniqueMenuState(character=self.session.player, monster=mon)
             )
             menu.is_valid_entry = self.validate  # type: ignore[assignment]
             menu.on_menu_selection = self.set_var  # type: ignore[assignment]

--- a/tuxemon/event/actions/get_party_monsters.py
+++ b/tuxemon/event/actions/get_party_monsters.py
@@ -22,7 +22,6 @@ class GetPartyMonsterAction(EventAction):
 
     Script parameters:
         npc_slug: npc slug name (e.g. "npc_maple") - default "player"
-
     """
 
     name = "get_party_monster"

--- a/tuxemon/event/actions/get_player_monster.py
+++ b/tuxemon/event/actions/get_player_monster.py
@@ -54,7 +54,6 @@ class GetPlayerMonsterAction(EventAction):
         filter_name: the name of the first filter
         value_name: the actual value to filter
         extra: used to filter more
-
     """
 
     name = "get_player_monster"
@@ -149,7 +148,9 @@ class GetPlayerMonsterAction(EventAction):
         self.result = False
         self.choose = False
         # pull up the monster menu so we know which one we are saving
-        menu = self.session.client.push_state(MonsterMenuState())
+        menu = self.session.client.push_state(
+            MonsterMenuState(self.session.player)
+        )
         menu.is_valid_entry = self.validate  # type: ignore[assignment]
         menu.on_menu_selection = self.set_var  # type: ignore[assignment]
         # if without filters, no closing by clicking back

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -516,7 +516,7 @@ class CombatState(CombatAnimations):
                 return True
             return False
 
-        state = self.client.push_state(MonsterMenuState())
+        state = self.client.push_state(MonsterMenuState(player))
         # must use a partial because alert relies on a text box that may not
         # exist until after the state hs been startup
         state.task(partial(state.alert, T.translate("combat_replacement")), 0)

--- a/tuxemon/states/combat/combat_menus.py
+++ b/tuxemon/states/combat/combat_menus.py
@@ -148,7 +148,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                 return validate_monster(menu_item)
             return False
 
-        menu = self.client.push_state(MonsterMenuState())
+        menu = self.client.push_state(MonsterMenuState(self.character))
         menu.on_menu_selection = swap_it  # type: ignore[assignment]
         menu.is_valid_entry = validate  # type: ignore[assignment]
         menu.anchor("bottom", self.rect.top)
@@ -163,7 +163,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
 
         def choose_item() -> None:
             # open menu to choose item
-            menu = self.client.push_state(ItemMenuState())
+            menu = self.client.push_state(ItemMenuState(self.character))
 
             # set next menu after the selection is made
             menu.is_valid_entry = validate_item  # type: ignore[method-assign]
@@ -180,7 +180,9 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                     mon = MenuItem(surface, None, None, enemy)
                     enqueue_item(item, mon)
                 else:
-                    state = self.client.push_state(MonsterMenuState())
+                    state = self.client.push_state(
+                        MonsterMenuState(self.character)
+                    )
                     state.is_valid_entry = partial(validate, item)  # type: ignore[method-assign]
                     state.on_menu_selection = partial(enqueue_item, item)  # type: ignore[method-assign]
 

--- a/tuxemon/states/combat/combat_menus_park.py
+++ b/tuxemon/states/combat/combat_menus_park.py
@@ -97,7 +97,7 @@ class MainParkMenuState(PopUpMenu[MenuGameObj]):
             self.description = choice.description
 
         def choose_item() -> None:
-            menu = self.client.push_state(ItemMenuState())
+            menu = self.client.push_state(ItemMenuState(self.player))
             menu.is_valid_entry = validate  # type: ignore[method-assign]
             menu.on_menu_selection = choose_target  # type: ignore[method-assign]
 

--- a/tuxemon/states/items/item_menu.py
+++ b/tuxemon/states/items/item_menu.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator, Sequence
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import pygame
 
@@ -22,6 +22,9 @@ from tuxemon.sprite import Sprite
 from tuxemon.states.monster import MonsterMenuState
 from tuxemon.ui.paginator import Paginator
 from tuxemon.ui.text import TextArea
+
+if TYPE_CHECKING:
+    from tuxemon.npc import NPC
 
 
 def sort_inventory(
@@ -58,7 +61,8 @@ class ItemMenuState(Menu[Item]):
     background_filename = prepare.BG_ITEMS
     draw_borders = False
 
-    def __init__(self) -> None:
+    def __init__(self, character: NPC) -> None:
+        self.char = character
         super().__init__()
 
         # this sprite is used to display the item
@@ -117,9 +121,7 @@ class ItemMenuState(Menu[Item]):
         item = menu_item.game_object
 
         # Check if the item can be used on any monster
-        if not any(
-            item.validate_monster(m) for m in local_session.player.monsters
-        ):
+        if not any(item.validate_monster(m) for m in self.char.monsters):
             self.on_menu_selection_change()
             error_message = self.get_error_message(item)
             tools.open_dialog(local_session, [error_message])
@@ -186,7 +188,7 @@ class ItemMenuState(Menu[Item]):
 
         def use_item_with_monster(menu_item: MenuItem[Monster]) -> None:
             """Use the item with a monster."""
-            player = local_session.player
+            player = self.char
             monster = menu_item.game_object
             result = item.use(player, monster)
             self.client.remove_state_by_name("MonsterMenuState")
@@ -196,7 +198,7 @@ class ItemMenuState(Menu[Item]):
 
         def use_item_without_monster() -> None:
             """Use the item without a monster."""
-            player = local_session.player
+            player = self.char
             self.client.remove_state_by_name("ItemMenuState")
             self.client.remove_state_by_name("WorldMenuState")
             result = item.use(player, None)
@@ -206,7 +208,7 @@ class ItemMenuState(Menu[Item]):
             """Confirm the use of the item."""
             self.client.remove_state_by_name("ChoiceState")
             if item.behaviors.requires_monster_menu:
-                menu = self.client.push_state(MonsterMenuState())
+                menu = self.client.push_state(MonsterMenuState(self.char))
                 menu.is_valid_entry = item.validate_monster  # type: ignore[assignment]
                 menu.on_menu_selection = use_item_with_monster  # type: ignore[assignment]
             else:
@@ -256,15 +258,11 @@ class ItemMenuState(Menu[Item]):
         if state == "MainCombatMenuState":
             return [
                 item
-                for item in local_session.player.items
+                for item in self.char.items
                 if State[state] in item.usable_in
             ]
         else:
-            return [
-                item
-                for item in local_session.player.items
-                if item.behaviors.visible
-            ]
+            return [item for item in self.char.items if item.behaviors.visible]
 
     def on_menu_selection_change(self) -> None:
         """Called when menu selection changes."""

--- a/tuxemon/states/monster/__init__.py
+++ b/tuxemon/states/monster/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from pygame import SRCALPHA
 from pygame.font import Font
@@ -21,6 +21,9 @@ from tuxemon.sprite import Sprite
 from tuxemon.ui.draw import GraphicBox
 from tuxemon.ui.text import TextArea, draw_text
 
+if TYPE_CHECKING:
+    from tuxemon.npc import NPC
+
 
 class MonsterMenuState(Menu[Optional[Monster]]):
     """
@@ -33,7 +36,8 @@ class MonsterMenuState(Menu[Optional[Monster]]):
     background_filename = prepare.BG_MONSTERS
     draw_borders = False
 
-    def __init__(self) -> None:
+    def __init__(self, character: NPC) -> None:
+        self.char = character
         super().__init__()
 
         # make a text area to show messages
@@ -54,7 +58,7 @@ class MonsterMenuState(Menu[Optional[Monster]]):
         self.monster_slot_border = MonsterSlotBorder()
 
         # TODO: something better than this global, load_sprites stuff
-        for monster in local_session.player.monsters:
+        for monster in self.char.monsters:
             monster.load_sprites()
 
     def calc_menu_items_rect(self) -> Rect:
@@ -69,7 +73,7 @@ class MonsterMenuState(Menu[Optional[Monster]]):
     ) -> Generator[MenuItem[Optional[Monster]], None, None]:
         # position the monster portrait
         try:
-            monster = local_session.player.monsters[self.selected_index]
+            monster = self.char.monsters[self.selected_index]
             self.monster_portrait_display.update(monster)
         except IndexError:
             self.monster_portrait_display.update(None)
@@ -80,11 +84,11 @@ class MonsterMenuState(Menu[Optional[Monster]]):
         # position and animate the monster portrait
         width = prepare.SCREEN_SIZE[0] // 2
         height = prepare.SCREEN_SIZE[1] // int(
-            local_session.player.party_limit * 1.5,
+            self.char.party_limit * 1.5,
         )
 
         # make 6 slots
-        for _ in range(local_session.player.party_limit):
+        for _ in range(self.char.party_limit):
             rect = Rect(0, 0, width, height)
             surface = Surface(rect.size, SRCALPHA)
             item = MenuItem(surface, None, None, None)
@@ -131,7 +135,7 @@ class MonsterMenuState(Menu[Optional[Monster]]):
         for index, item in enumerate(self.menu_items):
             monster: Optional[Monster]
             try:
-                monster = local_session.player.monsters[index]
+                monster = self.char.monsters[index]
             except IndexError:
                 monster = None
             item.game_object = monster
@@ -162,7 +166,7 @@ class MonsterMenuState(Menu[Optional[Monster]]):
 
     def on_menu_selection_change(self) -> None:
         try:
-            monster = local_session.player.monsters[self.selected_index]
+            monster = self.char.monsters[self.selected_index]
             self.monster_portrait_display.update(monster)
         except IndexError:
             self.monster_portrait_display.update(None)

--- a/tuxemon/states/monster_item/__init__.py
+++ b/tuxemon/states/monster_item/__init__.py
@@ -36,7 +36,8 @@ class MonsterItemState(PygameMenuState):
     ) -> None:
 
         def add_item() -> None:
-            menu = self.client.push_state(ItemMenuState())
+            assert monster.owner
+            menu = self.client.push_state(ItemMenuState(monster.owner))
             menu.is_valid_entry = validate  # type: ignore[method-assign]
             menu.on_menu_selection = choose_target  # type: ignore[method-assign]
 

--- a/tuxemon/states/pc_kennel/__init__.py
+++ b/tuxemon/states/pc_kennel/__init__.py
@@ -401,7 +401,7 @@ class MonsterDropOff(MonsterMenuState):
     """Shows all Tuxemon in player's party, puts it into box if selected."""
 
     def __init__(self, box_name: str, character: NPC) -> None:
-        super().__init__()
+        super().__init__(character=character)
 
         self.box_name = box_name
         self.char = character

--- a/tuxemon/states/pc_locker/__init__.py
+++ b/tuxemon/states/pc_locker/__init__.py
@@ -376,7 +376,7 @@ class ItemDropOff(ItemMenuState):
     """Shows all items in player's bag, puts it into box if selected."""
 
     def __init__(self, box_name: str, character: NPC) -> None:
-        super().__init__()
+        super().__init__(character=character)
 
         self.box_name = box_name
         self.char = character

--- a/tuxemon/states/techniques/__init__.py
+++ b/tuxemon/states/techniques/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
+from typing import TYPE_CHECKING
 
 import pygame
 
@@ -17,6 +18,9 @@ from tuxemon.states.monster import MonsterMenuState
 from tuxemon.technique.technique import Technique
 from tuxemon.ui.text import TextArea
 
+if TYPE_CHECKING:
+    from tuxemon.npc import NPC
+
 
 class TechniqueMenuState(Menu[Technique]):
     """The technique menu allows you to view and use techniques of your party."""
@@ -24,8 +28,9 @@ class TechniqueMenuState(Menu[Technique]):
     background_filename = prepare.BG_MOVES
     draw_borders = False
 
-    def __init__(self, monster: Monster) -> None:
-        self.mon = monster
+    def __init__(self, character: NPC, monster: Monster) -> None:
+        self.char = character
+        self.monster = monster
 
         super().__init__()
 
@@ -61,13 +66,12 @@ class TechniqueMenuState(Menu[Technique]):
 
         Parameters:
             menu_technique: Selected menu technique.
-
         """
         tech = menu_technique.game_object
 
         if not any(
             menu_technique.game_object.validate_monster(m)
-            for m in local_session.player.monsters
+            for m in self.char.monsters
         ):
             msg = T.format("item_no_available_target", {"name": tech.name})
             tools.open_dialog(local_session, [msg])
@@ -83,7 +87,6 @@ class TechniqueMenuState(Menu[Technique]):
 
         Parameters:
             technique: Selected technique.
-
         """
 
         def use_technique(menu_technique: MenuItem[Monster]) -> None:
@@ -96,7 +99,7 @@ class TechniqueMenuState(Menu[Technique]):
         def confirm() -> None:
             self.client.pop_state()  # close the confirm dialog
 
-            menu = self.client.push_state(MonsterMenuState())
+            menu = self.client.push_state(MonsterMenuState(self.char))
             menu.is_valid_entry = technique.validate_monster  # type: ignore[assignment]
             menu.on_menu_selection = use_technique  # type: ignore[assignment]
 
@@ -121,13 +124,13 @@ class TechniqueMenuState(Menu[Technique]):
         # load the backpack icon
         self.backpack_center = self.rect.width * 0.16, self.rect.height * 0.45
         self.load_sprite(
-            self.mon.sprite_handler.front_path,
+            self.monster.sprite_handler.front_path,
             center=self.backpack_center,
             layer=100,
         )
 
         moveset: list[Technique] = []
-        moveset = self.mon.moves
+        moveset = self.monster.moves
         output = sorted(moveset, key=lambda x: x.tech_id)
 
         for tech in output:

--- a/tuxemon/states/world/world_menus.py
+++ b/tuxemon/states/world/world_menus.py
@@ -69,7 +69,12 @@ class WorldMenuState(PygameMenuState):
         if player.monsters and player.menu_monsters:
             menu.append(("menu_monster", self.open_monster_menu))
         if player.items and player.menu_bag:
-            menu.append(("menu_bag", change("ItemMenuState")))
+            menu.append(
+                (
+                    "menu_bag",
+                    partial(change("ItemMenuState"), character=player),
+                )
+            )
         if player.menu_player:
             CharacterState = change("CharacterState", kwargs=param)
             menu.append(("menu_player", CharacterState))
@@ -232,7 +237,9 @@ class WorldMenuState(PygameMenuState):
 
         # dict passed around to hold info between menus/callbacks
         context: dict[str, Any] = dict()
-        monster_menu = self.client.push_state(MonsterMenuState())
+        monster_menu = self.client.push_state(
+            MonsterMenuState(local_session.player)
+        )
         monster_menu.on_menu_selection = handle_selection  # type: ignore[assignment]
         monster_menu.on_menu_selection_change = monster_menu_hook  # type: ignore[method-assign]
 


### PR DESCRIPTION
PR introduces the `character` (NPC) parameter into `MonsterMenuState`, `ItemMenuState`, and `TechniqueMenuState`. The goal is to pass an essential parameter explicitly and phase out reliance on `local_session`. 

The `character` will become a central access point for key attributes such as `monster`, `tuxepedia`, and similar entities. This approach ensures cleaner, more modular code while maintaining separation of responsibilities. However, it’s important to note that, for now, the changes do not affect `local_session.player.game_variables`.

As part of this change, all connected methods across these menu states have been updated to align with the new implementation.