### PR TITLE
FlipAxes to Use Enum Instead of Literal

### DIFF
--- a/tests/tuxemon/test_evolution.py
+++ b/tests/tuxemon/test_evolution.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from tuxemon.db import (
     ElementModel,
@@ -13,12 +13,13 @@ from tuxemon.element import Element
 from tuxemon.monster import Monster
 from tuxemon.player import Player
 from tuxemon.session import local_session
+from tuxemon.surfanim import FlipAxes
 from tuxemon.technique.technique import Technique
 
 _ram = TechniqueModel(
     tech_id=69,
     accuracy=0.85,
-    flip_axes="",
+    flip_axes=FlipAxes.NONE,
     potency=0.0,
     power=1.5,
     range="melee",
@@ -45,7 +46,7 @@ _ram = TechniqueModel(
 _strike = TechniqueModel(
     tech_id=69,
     accuracy=0.85,
-    flip_axes="",
+    flip_axes=FlipAxes.NONE,
     potency=0.0,
     power=1.5,
     range="melee",

--- a/tests/tuxemon/test_monster.py
+++ b/tests/tuxemon/test_monster.py
@@ -15,6 +15,7 @@ from tuxemon.db import (
 )
 from tuxemon.monster import Monster, MonsterSpriteHandler
 from tuxemon.prepare import MAX_LEVEL
+from tuxemon.surfanim import FlipAxes
 from tuxemon.taste import Taste
 from tuxemon.technique.technique import Technique
 from tuxemon.time_handler import today_ordinal
@@ -203,7 +204,7 @@ class Learn(MonsterTestBase):
     _tech = TechniqueModel(
         tech_id=69,
         accuracy=0.85,
-        flip_axes="",
+        flip_axes=FlipAxes.NONE,
         potency=0.0,
         power=1.5,
         range="melee",

--- a/tests/tuxemon/test_monster_actions.py
+++ b/tests/tuxemon/test_monster_actions.py
@@ -16,6 +16,7 @@ from tuxemon.db import (
 )
 from tuxemon.player import Player
 from tuxemon.session import local_session
+from tuxemon.surfanim import FlipAxes
 from tuxemon.tuxepedia import Tuxepedia
 
 
@@ -81,7 +82,7 @@ class TestMonsterActions(unittest.TestCase):
     _faint = StatusModel(
         effects=[],
         modifiers=[],
-        flip_axes="",
+        flip_axes=FlipAxes.NONE,
         icon="gfx/ui/icons/status/icon_faint.png",
         sfx="sfx_faint",
         slug="faint",

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -26,6 +26,7 @@ from pydantic import (
 from tuxemon import prepare
 from tuxemon.constants.paths import mods_folder
 from tuxemon.locale import T
+from tuxemon.surfanim import FlipAxes
 
 logger = logging.getLogger(__name__)
 
@@ -260,8 +261,8 @@ class ItemModel(BaseModel):
     effects: Sequence[CommonEffect] = Field(
         ..., description="Effects this item will have"
     )
-    flip_axes: Literal["", "x", "y", "xy"] = Field(
-        "",
+    flip_axes: FlipAxes = Field(
+        FlipAxes.NONE,
         description="Axes along which item animation should be flipped",
     )
     animation: Optional[str] = Field(
@@ -819,7 +820,7 @@ class TechniqueModel(BaseModel):
     effects: Sequence[CommonEffect] = Field(
         ..., description="Effects this technique uses"
     )
-    flip_axes: Literal["", "x", "y", "xy"] = Field(
+    flip_axes: FlipAxes = Field(
         ...,
         description="Axes along which technique animation should be flipped",
     )
@@ -953,7 +954,7 @@ class StatusModel(BaseModel):
     effects: Sequence[CommonEffect] = Field(
         ..., description="Effects this status uses"
     )
-    flip_axes: Literal["", "x", "y", "xy"] = Field(
+    flip_axes: FlipAxes = Field(
         ...,
         description="Axes along which status animation should be flipped",
     )

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -17,6 +17,7 @@ from tuxemon.core.core_manager import ConditionManager, EffectManager
 from tuxemon.core.core_processor import ConditionProcessor, EffectProcessor
 from tuxemon.db import ItemCategory, State, db
 from tuxemon.locale import T
+from tuxemon.surfanim import FlipAxes
 
 if TYPE_CHECKING:
     from tuxemon.monster import Monster
@@ -43,7 +44,7 @@ class Item:
         self.instance_id = uuid.uuid4()
         self.quantity = 1
         self.animation: Optional[str] = None
-        self.flip_axes = ""
+        self.flip_axes = FlipAxes.NONE
         # The path to the sprite to load.
         self.sprite = ""
         self.category = ItemCategory.none

--- a/tuxemon/status/status.py
+++ b/tuxemon/status/status.py
@@ -19,6 +19,7 @@ from tuxemon.db import (
     db,
 )
 from tuxemon.locale import T
+from tuxemon.surfanim import FlipAxes
 
 if TYPE_CHECKING:
     from tuxemon.monster import Monster
@@ -50,7 +51,7 @@ class Status:
         self.category: Optional[CategoryStatus] = None
         self.combat_state: Optional[CombatState] = None
         self.description = ""
-        self.flip_axes = ""
+        self.flip_axes = FlipAxes.NONE
         self.gain_cond = ""
         self.icon = ""
         self.link: Optional[Monster] = None

--- a/tuxemon/surfanim.py
+++ b/tuxemon/surfanim.py
@@ -20,6 +20,13 @@ from pygame.rect import Rect
 from pygame.surface import Surface
 
 
+class FlipAxes(str, Enum):
+    NONE = ""
+    X = "x"
+    Y = "y"
+    XY = "xy"
+
+
 class State(Enum):
     PLAYING = "playing"
     PAUSED = "paused"
@@ -201,11 +208,11 @@ class SurfaceAnimation:
         """
         self._internal_clock += time_delta
 
-    def flip(self, flip_axes: str) -> None:
+    def flip(self, flip_axes: FlipAxes) -> None:
         """Flip all frames of an animation along the X-axis and/or Y-axis."""
         # Empty string - animation won't be flipped
-        flip_x = "x" in flip_axes
-        flip_y = "y" in flip_axes
+        flip_x = flip_axes in {FlipAxes.X, FlipAxes.XY}
+        flip_y = flip_axes in {FlipAxes.Y, FlipAxes.XY}
         self._frame_manager.flip_images(flip_x, flip_y)
 
     def _get_max_size(self) -> tuple[int, int]:

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -15,6 +15,7 @@ from tuxemon.core.core_processor import ConditionProcessor, EffectProcessor
 from tuxemon.db import Range, db
 from tuxemon.element import Element
 from tuxemon.locale import T
+from tuxemon.surfanim import FlipAxes
 
 if TYPE_CHECKING:
     from tuxemon.monster import Monster
@@ -44,7 +45,7 @@ class Technique:
         self.animation: Optional[str] = None
         self.combat_state: Optional[CombatState] = None
         self.description = ""
-        self.flip_axes = ""
+        self.flip_axes = FlipAxes.NONE
         self.hit = False
         self.is_fast = False
         self.randomly = True


### PR DESCRIPTION
PR updates the `FlipAxes` type definition by replacing the `Literal` approach with an `Enum`. 