### PR TITLE
Refactor `EventAction` Context Management with `ActionContextManager`

### DIFF
--- a/tests/tuxemon/test_event_action.py
+++ b/tests/tuxemon/test_event_action.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import unittest
+from unittest.mock import MagicMock
+
+from tuxemon.event.eventaction import ActionContextManager
+
+
+class TestActionContextManager(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mock_action = MagicMock()
+        self.mock_action.cancelled = False
+
+    def test_context_manager_enter(self):
+        with ActionContextManager(self.mock_action):
+            self.mock_action.start.assert_called_once()
+
+    def test_context_manager_exit(self):
+        with ActionContextManager(self.mock_action):
+            pass  # Enter and exit
+        self.mock_action.cleanup.assert_called_once()
+
+    def test_cancelled_action(self):
+        self.mock_action.cancelled = True
+        with ActionContextManager(self.mock_action):
+            self.mock_action.start.assert_not_called()
+        self.mock_action.cleanup.assert_not_called()
+
+    def test_exception_handling(self):
+        self.mock_action.cleanup = MagicMock(
+            side_effect=Exception("Cleanup error")
+        )
+        with self.assertRaises(Exception):
+            with ActionContextManager(self.mock_action):
+                pass


### PR DESCRIPTION
PR refactors the `EventAction` class by introducing the `ActionContextManager` to handle context management (`__enter__` and `__exit__`) separately. This change simplifies the `EventAction` class, making it more focused and adhering to the single responsibility principle.