### PR TITLE
Refactor `EventEngine`'s `update_running_events`

### DIFF
--- a/tuxemon/client.py
+++ b/tuxemon/client.py
@@ -125,7 +125,7 @@ class LocalPygameClient:
         self.events = map_data.events
         self.inits = list(map_data.inits)
         self.event_engine.reset()
-        self.event_engine.current_map = map_data
+        self.event_engine.set_current_map(map_data)
         self.maps = map_data.maps
 
         # Map properties


### PR DESCRIPTION
PR refactors the `update_running_events` method in `EventEngine`. The original implementation contained a deeply nested loop that was difficult to follow and maintain. This has now been simplified by extracting parts of the logic into two new helper methods: `process_running_event` and `handle_next_action`. Additionally, a new method, `set_current_map`, has been introduced to manage changes to the current map in a cleaner, centralized manner.

Key changes include:
- `process_running_event`: handles the lifecycle of an individual `RunningEvent`, managing current and next actions
- `handle_next_action`: handles fetching and starting the next action for an event
- `set_current_map`: this method ensures proper updates when switching to a new map and resets the necessary attributes accordingly