### PR TITLE
Refactor Drawing Logic and Add Unit Tests for New Drawer Classes

### DIFF
--- a/tests/tuxemon/test_state_draw.py
+++ b/tests/tuxemon/test_state_draw.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import unittest
+from unittest.mock import Mock, patch
+
+import pygame
+
+from tuxemon import prepare
+from tuxemon.state_draw import EventDebugDrawer, Renderer, StateDrawer
+
+
+class TestRenderer(unittest.TestCase):
+
+    def setUp(self):
+        self.screen = Mock()
+        self.state_drawer = Mock()
+        self.caption = "Test Caption"
+        self.renderer = Renderer(self.screen, self.state_drawer, self.caption)
+
+    def test_init(self):
+        self.assertEqual(self.renderer.screen, self.screen)
+        self.assertEqual(self.renderer.state_drawer, self.state_drawer)
+        self.assertEqual(self.renderer.caption, self.caption)
+        self.assertEqual(self.renderer.frames, 0)
+        self.assertEqual(self.renderer.fps_timer, 0.0)
+
+    @patch("pygame.image.save")
+    def test_draw_save_to_disk(self, mock_save):
+        frame_number = 1
+        save_to_disk = True
+        collision_map = False
+        debug_drawer = Mock()
+        partial_events = []
+        self.renderer.draw(
+            frame_number,
+            save_to_disk,
+            collision_map,
+            debug_drawer,
+            partial_events,
+        )
+        self.state_drawer.draw.assert_called_once()
+        mock_save.assert_called_once_with(self.screen, "snapshot00001.tga")
+
+    @patch("pygame.image.save")
+    def test_draw_dont_save_to_disk(self, mock_save):
+        frame_number = 1
+        save_to_disk = False
+        collision_map = False
+        debug_drawer = Mock()
+        partial_events = []
+        self.renderer.draw(
+            frame_number,
+            save_to_disk,
+            collision_map,
+            debug_drawer,
+            partial_events,
+        )
+        self.state_drawer.draw.assert_called_once()
+        mock_save.assert_not_called()
+
+    @patch("pygame.image.save")
+    def test_draw_collision_map(self, mock_save):
+        frame_number = 1
+        save_to_disk = False
+        collision_map = True
+        debug_drawer = Mock()
+        partial_events = []
+        self.renderer.draw(
+            frame_number,
+            save_to_disk,
+            collision_map,
+            debug_drawer,
+            partial_events,
+        )
+        self.state_drawer.draw.assert_called_once()
+        debug_drawer.draw_event_debug.assert_called_once_with(partial_events)
+
+    @patch("pygame.image.save")
+    def test_draw_no_collision_map(self, mock_save):
+        frame_number = 1
+        save_to_disk = False
+        collision_map = False
+        debug_drawer = Mock()
+        partial_events = []
+        self.renderer.draw(
+            frame_number,
+            save_to_disk,
+            collision_map,
+            debug_drawer,
+            partial_events,
+        )
+        self.state_drawer.draw.assert_called_once()
+        debug_drawer.draw_event_debug.assert_not_called()
+
+
+class TestStateDrawer(unittest.TestCase):
+    def test_init(self):
+        surface = Mock()
+        state_manager = Mock()
+        config = Mock()
+        state_drawer = StateDrawer(surface, state_manager, config)
+        self.assertEqual(state_drawer.surface, surface)
+        self.assertEqual(state_drawer.state_manager, state_manager)
+        self.assertEqual(state_drawer.config, config)
+
+    def test_draw(self):
+        surface = Mock()
+        state_manager = Mock()
+        config = Mock()
+        state_drawer = StateDrawer(surface, state_manager, config)
+        state1 = Mock()
+        state2 = Mock()
+        state_manager.active_states = [state1, state2]
+        state_drawer.draw()
+        state1.draw.assert_called_once_with(surface)
+        state2.draw.assert_called_once_with(surface)
+
+    def test_draw_with_transparency(self):
+        surface = Mock()
+        state_manager = Mock()
+        config = Mock()
+        state_drawer = StateDrawer(surface, state_manager, config)
+        state1 = Mock()
+        state1.transparent = False
+        state1.rect = Mock()
+        state1.rect.return_value = (0, 0, 100, 100)
+        state2 = Mock()
+        state_manager.active_states = [state1, state2]
+        state_drawer.draw()
+        state1.draw.assert_called_once_with(surface)
+        state2.draw.assert_called_once_with(surface)
+
+    def test_draw_with_full_screen(self):
+        surface = Mock()
+        state_manager = Mock()
+        config = Mock()
+        state_drawer = StateDrawer(surface, state_manager, config)
+        state1 = Mock()
+        state1.transparent = False
+        state1.rect = Mock()
+        state1.rect.return_value = (0, 0, 100, 100)
+        state1.force_draw = False
+        state2 = Mock()
+        state_manager.active_states = [state1, state2]
+        surface.get_rect.return_value = (0, 0, 100, 100)
+        state1.rect.return_value = (0, 0, 100, 100)
+        state_drawer.draw()
+        state1.draw.assert_called_once_with(surface)
+        state2.draw.assert_called_once_with(surface)
+
+
+class TestEventDebugDrawer(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        pygame.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        pygame.quit()
+
+    def test_init(self):
+        screen = Mock()
+        event_debug_drawer = EventDebugDrawer(screen)
+        self.assertEqual(event_debug_drawer.screen, screen)
+        self.assertEqual(event_debug_drawer.max_width, 1000)
+        self.assertEqual(event_debug_drawer.x_offset, 20)
+        self.assertEqual(event_debug_drawer.y_offset, 200)
+        self.assertEqual(event_debug_drawer.initial_x, 4)
+        self.assertEqual(event_debug_drawer.initial_y, 20)
+        self.assertEqual(event_debug_drawer.success_color, prepare.GREEN_COLOR)
+        self.assertEqual(event_debug_drawer.failure_color, prepare.RED_COLOR)
+
+    def test_draw_event_debug(self):
+        screen = Mock()
+        event_debug_drawer = EventDebugDrawer(screen)
+        event1 = [(True, Mock()), (False, Mock())]
+        event1[0][1].parameters = ["param1", "param2"]
+        event1[1][1].parameters = ["param3", "param4"]
+        event2 = [(True, Mock()), (False, Mock())]
+        event2[0][1].parameters = ["param5", "param6"]
+        event2[1][1].parameters = ["param7", "param8"]
+        event_debug_drawer.draw_event_debug([event1, event2])
+        self.assertTrue(screen.blit.called)
+
+    def test_render_text(self):
+        screen = Mock()
+        event_debug_drawer = EventDebugDrawer(screen)
+        text = "Test text"
+        color = (255, 0, 0)
+        position = (10, 20)
+        font_size = 15
+        event_debug_drawer.render_text(text, color, position, font_size)
+        self.assertTrue(screen.blit.called)

--- a/tuxemon/client.py
+++ b/tuxemon/client.py
@@ -10,11 +10,8 @@ from threading import Thread
 from typing import Any, Optional, TypeVar, Union, overload
 
 import pygame
-from pygame.font import Font, get_default_font
-from pygame.image import save as pg_save
 from pygame.surface import Surface
 
-from tuxemon import networking, prepare, rumble
 from tuxemon.audio import MusicPlayerState, SoundManager
 from tuxemon.cli.processor import CommandProcessor
 from tuxemon.config import TuxemonConfig
@@ -23,10 +20,13 @@ from tuxemon.event import EventObject
 from tuxemon.event.eventengine import EventEngine
 from tuxemon.map import TuxemonMap
 from tuxemon.map_loader import MapLoader
+from tuxemon.networking import NetworkManager
 from tuxemon.platform.events import PlayerInput
 from tuxemon.platform.input_manager import InputManager
+from tuxemon.rumble import RumbleManager
 from tuxemon.session import local_session
 from tuxemon.state import State, StateManager
+from tuxemon.state_draw import EventDebugDrawer, Renderer, StateDrawer
 from tuxemon.states.world.worldstate import WorldState
 
 StateType = TypeVar("StateType", bound=State)
@@ -72,8 +72,19 @@ class LocalPygameClient:
         self.frame_number = 0
         self.save_to_disk = False
 
+        # Initialize drawers
+        self.state_drawer = StateDrawer(
+            self.screen, self.state_manager, config
+        )
+        self.event_debug_drawer = EventDebugDrawer(self.screen)
+        self.renderer = Renderer(
+            self.screen,
+            self.state_drawer,
+            config.window_caption,
+        )
+
         # Set up our networking for multiplayer.
-        self.network_manager = networking.NetworkManager(self)
+        self.network_manager = NetworkManager(self)
         self.network_manager.initialize()
 
         self.map_loader = MapLoader()
@@ -102,7 +113,7 @@ class LocalPygameClient:
             thread.start()
 
         # Set up rumble support for gamepads
-        self.rumble_manager = rumble.RumbleManager()
+        self.rumble_manager = RumbleManager()
         self.rumble = self.rumble_manager.rumbler
 
         # TODO: phase these out
@@ -151,41 +162,6 @@ class LocalPygameClient:
         self.map_south = map_data.south_trans
         self.map_east = map_data.east_trans
         self.map_west = map_data.west_trans
-
-    def draw_event_debug(self) -> None:
-        """
-        Very simple overlay of event data.  Needs some love.
-
-        """
-        y = 20
-        x = 4
-
-        yy = y
-        xx = x
-
-        font = Font(get_default_font(), 15)
-        for event in self.event_engine.partial_events:
-            w = 0
-            for valid, item in event:
-                p = " ".join(item.parameters)
-                text = f"{item.operator} {item.type}: {p}"
-                if valid:
-                    color = prepare.GREEN_COLOR
-                else:
-                    color = prepare.RED_COLOR
-                image = font.render(text, True, color)
-                self.screen.blit(image, (xx, yy))
-                ww, hh = image.get_size()
-                yy += hh
-                w = max(w, ww)
-
-            xx += w + 20
-
-            if xx > 1000:
-                xx = x
-                y += 200
-
-            yy = y
 
     def process_events(
         self,
@@ -270,8 +246,6 @@ class LocalPygameClient:
         frame_length = 1.0 / self.fps
         time_since_draw = 0.0
         last_update = clock()
-        fps_timer = 0.0
-        frames = 0
 
         while not self.exit:
             clock_tick = clock() - last_update
@@ -280,13 +254,12 @@ class LocalPygameClient:
             update(clock_tick)
             if time_since_draw >= frame_length:
                 time_since_draw -= frame_length
-                draw(screen)
+                draw()
                 if self.input_manager.controller_overlay:
                     self.input_manager.controller_overlay.draw(screen)
                 flip()
-                frames += 1
-
-            fps_timer, frames = self.handle_fps(clock_tick, fps_timer, frames)
+            if self.config.show_fps:
+                self.renderer.update_fps(clock_tick)
             time.sleep(0.01)
 
     def update(self, time_delta: float) -> None:
@@ -351,80 +324,16 @@ class LocalPygameClient:
         if self.state_manager.current_state is None:
             self.exit = True
 
-    def draw(self, surface: Surface) -> None:
-        """
-        Draw all active states.
-
-        Parameters:
-            surface: Surface where the drawing takes place.
-
-        """
-        # TODO: refactor into Widget
-
-        # iterate through layers and determine optimal drawing strategy
-        # this is a big performance boost for states covering other states
-        # force_draw is used for transitions, mostly
-        to_draw = list()
-        full_screen = surface.get_rect()
-        for state in self.state_manager.active_states:
-            to_draw.append(state)
-
-            # if this state covers the screen
-            # break here so lower screens are not drawn
-            if (
-                not state.transparent
-                and state.rect == full_screen
-                and not state.force_draw
-            ):
-                break
-
-        # draw from bottom up for proper layering
-        for state in reversed(to_draw):
-            state.draw(surface)
-
-        if self.config.collision_map:
-            self.draw_event_debug()
-
-        if self.save_to_disk:
-            filename = "snapshot%05d.tga" % self.frame_number
-            self.frame_number += 1
-            pg_save(self.screen, filename)
-
-    def handle_fps(
-        self,
-        clock_tick: float,
-        fps_timer: float,
-        frames: int,
-    ) -> tuple[float, int]:
-        """
-        Compute and print the frames per second.
-
-        This function only prints FPS if that option has been set in the
-        config. It only prints the FPS if at least one second has elapsed
-        since the last time it printed them.
-
-        Parameters:
-            clock_tick: Seconds elapsed since the last ``update`` call.
-            fps_timer: Number of seconds elapsed since the last time the FPS
-                were printed.
-            frames: Number of frames printed since the last time the FPS were
-                printed.
-
-        Returns:
-            Updated values of ``fps_timer`` and ``frames``. They will be the
-            same as the values passed unless the FPS are printed, in which case
-            they are reset to 0.
-        """
-        if not self.show_fps:
-            return fps_timer, frames
-
-        fps_timer += clock_tick
-        if fps_timer >= 1:
-            with_fps = f"{self.caption} - {frames / fps_timer:.2f} FPS"
-            pygame.display.set_caption(with_fps)
-            return 0, 0
-
-        return fps_timer, frames
+    def draw(self) -> None:
+        """Centralized draw logic."""
+        self.renderer.draw(
+            frame_number=self.frame_number,
+            save_to_disk=self.save_to_disk,
+            collision_map=self.config.collision_map,
+            debug_drawer=self.event_debug_drawer,
+            partial_events=self.event_engine.partial_events,
+        )
+        self.frame_number += 1
 
     def add_clients_to_map(self, registry: Mapping[str, Any]) -> None:
         """

--- a/tuxemon/state_draw.py
+++ b/tuxemon/state_draw.py
@@ -1,0 +1,226 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+import pygame
+from pygame.font import Font, get_default_font
+from pygame.surface import Surface
+
+from tuxemon import prepare
+from tuxemon.graphics import ColorLike
+
+if TYPE_CHECKING:
+    from tuxemon.config import TuxemonConfig
+    from tuxemon.event import MapCondition
+    from tuxemon.state import State, StateManager
+
+
+class Renderer:
+    def __init__(
+        self,
+        screen: Surface,
+        state_drawer: StateDrawer,
+        caption: str,
+    ) -> None:
+        """
+        Initializes the Renderer class.
+
+        The Renderer handles all drawing and rendering-related operations,
+        including state rendering, optional debug overlays, and saving frames
+        to disk.
+
+        Parameters:
+            screen: The pygame screen surface where everything is drawn.
+            state_drawer: Handles rendering the current game state.
+            caption: The window title used for displaying FPS updates.
+        """
+        self.screen = screen
+        self.state_drawer = state_drawer
+        self.caption = caption
+        self.frames = 0
+        self.fps_timer = 0.0
+
+    def draw(
+        self,
+        frame_number: int,
+        save_to_disk: bool,
+        collision_map: bool,
+        debug_drawer: EventDebugDrawer,
+        partial_events: list[Sequence[tuple[bool, MapCondition]]],
+    ) -> None:
+        """
+        Renders the current frame and handles optional debug overlays and
+        frame saving.
+        This function manages the main rendering process, including drawing
+        game states, debug information, and saving frames to disk.
+
+        Parameters:
+            frame_number: The current frame number used for naming saved
+                snapshots.
+            save_to_disk: If True, saves the current frame to disk as an
+                image.
+            collision_map: If True, renders debug information for
+                collisions/events.
+            debug_drawer: Handles rendering debug overlays.
+            partial_events: A collection of partial events used for debugging
+                purposes.
+        """
+        # Draw the current game state
+        self.state_drawer.draw()
+
+        # Optional: Draw debug information if enabled
+        if collision_map:
+            debug_drawer.draw_event_debug(partial_events)
+
+        # Optional: Save to disk if enabled
+        if save_to_disk:
+            filename = f"snapshot{frame_number:05d}.tga"
+            pygame.image.save(self.screen, filename)
+
+    def update_fps(self, clock_tick: float) -> None:
+        """
+        Updates and displays the frames per second (FPS) on the window caption.
+
+        This function calculates FPS based on elapsed time and updates the
+        window caption to reflect the current FPS.
+
+        Parameters:
+            clock_tick: The time elapsed (in seconds) since the last update.
+        """
+        self.fps_timer += clock_tick
+        self.frames += 1
+        if self.fps_timer >= 1.0:
+            fps_display = (
+                f"{self.caption} - {self.frames / self.fps_timer:.2f} FPS"
+            )
+            pygame.display.set_caption(fps_display)
+            self.fps_timer = 0.0
+            self.frames = 0
+
+
+class StateDrawer:
+    def __init__(
+        self,
+        surface: Surface,
+        state_manager: StateManager,
+        config: TuxemonConfig,
+    ) -> None:
+        """
+        Initializes the StateDrawer.
+
+        Responsible for managing the drawing of active states onto the
+        given surface. This class iterates through the layers of active
+        states, ensuring optimal rendering strategies based on transparency
+        and layering requirements.
+
+        Parameters:
+            surface: The target surface where states will be drawn.
+            state_manager: Manages the list of active states to be drawn.
+            config: Configuration settings that may affect rendering
+                behavior.
+        """
+        self.surface = surface
+        self.state_manager = state_manager
+        self.config = config
+
+    def draw(self) -> None:
+        """Draw all active states to the surface."""
+        to_draw: list[State] = []
+        full_screen = self.surface.get_rect()
+
+        # Collect states to be drawn.
+        for state in self.state_manager.active_states:
+            to_draw.append(state)
+
+            if (
+                not state.transparent
+                and state.rect == full_screen
+                and not state.force_draw
+            ):
+                break
+
+        # Draw states from bottom to top for proper layering.
+        for state in reversed(to_draw):
+            state.draw(self.surface)
+
+
+class EventDebugDrawer:
+    def __init__(
+        self,
+        screen: Surface,
+        max_width: int = 1000,
+        x_offset: int = 20,
+        y_offset: int = 200,
+        initial_x: int = 4,
+        initial_y: int = 20,
+        success_color: ColorLike = prepare.GREEN_COLOR,
+        failure_color: ColorLike = prepare.RED_COLOR,
+    ) -> None:
+        """
+        Initializes the EventDebugDrawer.
+
+        Handles the drawing of event debug overlays on the provided screen.
+        This class is responsible for rendering event-related data for
+        debugging purposes using customizable font size, colors, and
+        positioning.
+
+        Parameters:
+            screen: The screen surface where the debug overlay will be drawn.
+            max_width: Maximum width allowed for rendering the overlay before
+                wrapping.
+            x_offset: Horizontal spacing between event sections.
+            y_offset: Vertical spacing between event lines.
+            initial_x: The starting x-coordinate for rendering the overlay.
+            initial_y: The starting y-coordinate for rendering the overlay.
+            valid_color: Color used to indicate valid conditions.
+            invalid_color: Color used to indicate invalid conditions.
+        """
+        self.screen = screen
+        self.max_width = max_width
+        self.x_offset = x_offset
+        self.y_offset = y_offset
+        self.initial_x = initial_x
+        self.initial_y = initial_y
+        self.success_color = success_color
+        self.failure_color = failure_color
+
+    def draw_event_debug(
+        self, partial_events: list[Sequence[tuple[bool, MapCondition]]]
+    ) -> None:
+        """Overlay event data on the screen."""
+        initial_x, initial_y = self.initial_x, self.initial_y
+        current_x, current_y = initial_x, initial_y
+
+        for event in partial_events:
+            max_width = 0
+            for valid, item in event:
+                parameters = " ".join(item.parameters)
+                text = f"{item.operator} {item.type}: {parameters}"
+                color = self.success_color if valid else self.failure_color
+                size = self.render_text(text, color, (current_x, current_y))
+
+                current_y += size[1]
+                max_width = max(max_width, size[0])
+
+            current_x += max_width + self.x_offset
+
+            if current_x > self.max_width:
+                current_x = initial_x
+                initial_y += self.y_offset
+
+            current_y = initial_y
+
+    def render_text(
+        self,
+        text: str,
+        color: ColorLike,
+        position: tuple[int, int],
+        font_size: int = 15,
+    ) -> tuple[int, int]:
+        font = Font(get_default_font(), font_size)
+        image = font.render(text, True, color)
+        self.screen.blit(image, position)
+        return image.get_size()


### PR DESCRIPTION
PR includes the following changes:
- Removed `draw_event_debug` and `draw` methods from `LocalPygameClient`
- Introduced two new classes:
  - `StateDrawer` for managing the rendering of active states onto the surface
  - `EventDebugDrawer` for handling the drawing of event debugging overlays
- Added initialization for `StateDrawer` and `EventDebugDrawer` in the `__init__` method of `LocalPygameClient`
- Replaced the original methods with a unified `draw()` method in `LocalPygameClient`, which:
  - Delegates state rendering to `StateDrawer`
  - Handles event debugging through `EventDebugDrawer`
  - Includes an option to save the current screen to disk
- Implemented unit tests for `Renderer`, `StateDrawer` and `EventDebugDrawer`
- Introduced a **`Renderer`** class, which centralizes and streamlines all rendering-related operations. This includes:
  - Delegating active state rendering to `StateDrawer`
  - Managing optional debugging overlays via `EventDebugDrawer`
  - Handling FPS updates and dynamic display of FPS information in the window's caption
  - Facilitating snapshot saving of the current screen to disk
- Consequently, `StateDrawer` and `EventDebugDrawer` integrate seamlessly as part of the `Renderer`