### PR TITLE
Improve Plugin Discovery and Filtering

### DIFF
--- a/tests/tuxemon/test_plugin.py
+++ b/tests/tuxemon/test_plugin.py
@@ -5,8 +5,10 @@ from collections.abc import Iterable
 from unittest.mock import MagicMock, patch
 
 from tuxemon.plugin import (
-    DefaultPluginLoader,
     FileSystemPluginDiscovery,
+    ImportLibPluginLoader,
+    PluginFilter,
+    PluginLoader,
     PluginManager,
     PluginObject,
     get_available_classes,
@@ -15,42 +17,47 @@ from tuxemon.plugin import (
 
 
 class TestPluginManager(unittest.TestCase):
+    def setUp(self):
+        self.discovery = FileSystemPluginDiscovery([])
+        self.loader = PluginLoader(ImportLibPluginLoader())
+        self.filter = PluginFilter()
+        self.manager = PluginManager(self.discovery, self.loader, self.filter)
+        self.interface = PluginObject
+
     def test_init(self):
-        discovery = FileSystemPluginDiscovery([])
-        loader = DefaultPluginLoader()
-        manager = PluginManager(discovery, loader)
-        self.assertEqual(manager.discovery.folders, [])
-        self.assertEqual(manager.modules, [])
+        self.assertEqual(self.manager.discovery.folders, [])
+        self.assertEqual(self.manager.modules, [])
 
     def test_set_plugin_places(self):
         plugin_folders = ["folder1", "folder2"]
         discovery = FileSystemPluginDiscovery(plugin_folders)
-        loader = DefaultPluginLoader()
-        manager = PluginManager(discovery, loader)
+        manager = PluginManager(discovery, self.loader, self.filter)
         self.assertEqual(manager.discovery.folders, plugin_folders)
 
     def test_collect_plugins(self):
         plugin_folders = ["folder1", "folder2"]
+
         discovery = FileSystemPluginDiscovery(plugin_folders)
-        loader = DefaultPluginLoader()
-        manager = PluginManager(discovery, loader)
+        discovery.discover_plugins = MagicMock(
+            return_value=["plugin1", "plugin2"]
+        )
+
+        manager = PluginManager(discovery, self.loader, self.filter)
         manager.collect_plugins()
 
+        discovery.discover_plugins.assert_called_once()
+
+        filtered_plugins = self.filter.filter_plugins(["plugin1", "plugin2"])
+
+        self.assertEqual(manager.modules, filtered_plugins)
+
     def test_get_all_plugins(self):
-        discovery = FileSystemPluginDiscovery([])
-        loader = DefaultPluginLoader()
-        manager = PluginManager(discovery, loader)
-        interface = PluginObject
-        plugins = manager.get_all_plugins(interface=interface)
+        plugins = self.manager.get_all_plugins(interface=self.interface)
         self.assertIsInstance(plugins, list)
 
     def test_get_classes_from_module(self):
-        discovery = FileSystemPluginDiscovery([])
-        loader = DefaultPluginLoader()
-        manager = PluginManager(discovery, loader)
         module = MagicMock()
-        interface = PluginObject
-        classes = manager._get_classes_from_module(module, interface)
+        classes = self.manager._get_classes_from_module(module, self.interface)
         self.assertIsInstance(classes, Iterable)
 
     def test_load_directory(self):
@@ -61,18 +68,92 @@ class TestPluginManager(unittest.TestCase):
     def test_get_available_classes(self):
         plugin_folder = "folder1"
         manager = load_directory(plugin_folder)
-        interface = PluginObject
-        classes = get_available_classes(manager, interface=interface)
+        classes = get_available_classes(manager, interface=self.interface)
         self.assertIsInstance(classes, list)
 
     def test_file_system_plugin_discovery(self):
-        discovery = FileSystemPluginDiscovery([])
-        self.assertEqual(discovery.folders, [])
-        self.assertEqual(discovery.file_extensions, (".py", ".pyc"))
+        self.assertEqual(self.discovery.folders, [])
+        self.assertEqual(self.discovery.file_extensions, (".py", ".pyc"))
 
     def test_default_plugin_loader(self):
-        loader = DefaultPluginLoader()
         module_name = "test_module"
         with patch("importlib.import_module") as mock_import_module:
-            loader.load_plugin(module_name)
+            self.loader.load_plugin(module_name)
             mock_import_module.assert_called_once_with(module_name)
+
+    def test_plugin_filter(self):
+        filter = PluginFilter(
+            exclude_classes=["ExcludedPlugin"],
+            include_patterns=["AllowedPattern"],
+        )
+
+        self.assertTrue(filter.is_excluded("ExcludedPlugin"))
+        self.assertFalse(filter.is_excluded("SomeOtherPlugin"))
+
+        class MockPlugin:
+            pass
+
+        self.assertFalse(filter.matches_patterns(MockPlugin))
+
+    def test_default_plugin_loader_import_failure(self):
+        module_name = "non_existent_module"
+        with patch(
+            "importlib.import_module",
+            side_effect=ImportError("Module not found"),
+        ):
+            with self.assertRaises(ImportError):
+                self.loader.load_plugin(module_name)
+
+    def test_collect_plugins_no_plugins_found(self):
+        discovery = FileSystemPluginDiscovery([])
+        discovery.discover_plugins = MagicMock(return_value=[])
+
+        manager = PluginManager(discovery, self.loader, self.filter)
+        manager.collect_plugins()
+
+        self.assertEqual(manager.modules, [])
+
+    def test_mock_discover_plugins(self):
+        discovery = FileSystemPluginDiscovery([])
+        discovery.discover_plugins = MagicMock(
+            return_value=["mock_plugin1", "mock_plugin2"]
+        )
+
+        self.assertEqual(
+            discovery.discover_plugins(), ["mock_plugin1", "mock_plugin2"]
+        )
+        discovery.discover_plugins.assert_called_once()
+
+    def test_mock_plugin_loader(self):
+        mock_module = MagicMock()
+
+        with patch(
+            "importlib.import_module", return_value=mock_module
+        ) as mock_import:
+            module = self.loader.load_plugin("mock_plugin")
+
+            self.assertEqual(module, mock_module)
+            mock_import.assert_called_once_with("mock_plugin")
+
+    def test_mock_plugin_manager(self):
+        discovery = MagicMock()
+        loader = MagicMock()
+        filter = PluginFilter()
+        manager = PluginManager(discovery, loader, filter)
+
+        discovery.discover_plugins.return_value = ["mock_plugin"]
+        loader.load_plugin.return_value = MagicMock()
+
+        manager.collect_plugins()
+        discovery.discover_plugins.assert_called_once()
+
+        filtered_plugins = self.filter.filter_plugins(["mock_plugin"])
+
+        self.assertEqual(manager.modules, filtered_plugins)
+        discovery.discover_plugins.assert_called_once()
+
+    def test_plugin_filter_exclusion(self):
+        filter = PluginFilter(exclude_classes=["ExcludedPlugin"])
+
+        self.assertTrue(filter.is_excluded("ExcludedPlugin"))
+        self.assertFalse(filter.is_excluded("AllowedPlugin"))

--- a/tuxemon/cli/processor.py
+++ b/tuxemon/cli/processor.py
@@ -13,8 +13,10 @@ from tuxemon.cli.context import InvokeContext
 from tuxemon.cli.exceptions import CommandNotFoundError, ParseError
 from tuxemon.cli.formatter import Formatter
 from tuxemon.plugin import (
-    DefaultPluginLoader,
     FileSystemPluginDiscovery,
+    ImportLibPluginLoader,
+    PluginFilter,
+    PluginLoader,
     PluginManager,
     get_available_classes,
 )
@@ -123,10 +125,11 @@ class CommandProcessor:
             folder: Folder to search.
         """
         discovery = FileSystemPluginDiscovery([folder])
-        loader = DefaultPluginLoader()
-        pm = PluginManager(discovery, loader)
-        pm.INCLUDE_PATTERNS = ["commands"]
-        pm.EXCLUDE_CLASSES = ["CLICommand"]
+        loader = PluginLoader(ImportLibPluginLoader())
+        filter = PluginFilter(
+            include_patterns=["commands"], exclude_classes=["CLICommand"]
+        )
+        pm = PluginManager(discovery, loader, filter)
         pm.collect_plugins()
         for cmd_class in get_available_classes(pm, interface=CLICommand):
             if cmd_class.usable_from_root:


### PR DESCRIPTION
PR introduces several improvements to the plugin discovery and filtering system:
- replaced string-based path manipulations with `Path` from `pathlib`
- extracted filtering logic into a separate class (`PluginFilter`) for better separation of concerns and reusability
- allowed configurable exclusion lists and pattern matching for filtering plugins
- made `folder_name` configurable instead of hardcoding `"tuxemon"`
- added try-except blocks around plugin loading to gracefully handle import errors
- used default arguments (`filter: Optional[PluginFilter] = None`) for better flexibility in `PluginManager`
- introduced `PluginLoadingStrategy`, allows multiple strategies for loading plugins, such as `ImportLibPluginLoader` and `ImportLibFileLoader`, improving flexibility
- refactored `PluginLoader`, now delegates the actual loading logic to a `PluginLoadingStrategy`
- enhanced `PluginFilter`, now includes methods like `is_valid_plugin`, `filter_plugins`, and `matches_patterns` for more precise control over plugin filtering
- `PluginManager` now applies filtering earlier in the discovery process, ensuring unnecessary modules aren’t processed further