### PR TITLE
Event Persistence and Refactor `CharMovedCondition`

### DIFF
--- a/tuxemon/client.py
+++ b/tuxemon/client.py
@@ -21,6 +21,7 @@ from tuxemon.config import TuxemonConfig
 from tuxemon.db import MapType
 from tuxemon.event import EventObject
 from tuxemon.event.eventengine import EventEngine
+from tuxemon.event.eventpersist import EventPersist
 from tuxemon.map import TuxemonMap
 from tuxemon.map_loader import MapLoader
 from tuxemon.platform.events import PlayerInput
@@ -84,7 +85,7 @@ class LocalPygameClient:
         # Set up our game's event engine which executes actions based on
         # conditions defined in map files.
         self.event_engine = EventEngine(local_session)
-        self.event_persist: dict[str, dict[str, Any]] = {}
+        self.event_persist = EventPersist()
 
         # Set up a variable that will keep track of currently playing music.
         self.current_music = MusicPlayerState()

--- a/tuxemon/event/eventcondition.py
+++ b/tuxemon/event/eventcondition.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, ClassVar
+from typing import ClassVar
 
 from tuxemon.event import MapCondition
 from tuxemon.session import Session
@@ -25,22 +25,6 @@ class EventCondition:
             Value of the condition.
         """
         return True
-
-    def get_persist(self, session: Session) -> dict[str, Any]:
-        """
-        Return dictionary for this event class's data.
-        This dictionary will track movement and be shared across all
-        conditions. It will be saved when the game is saved.
-
-        Returns:
-            Dictionary with the persisting information.
-        """
-        try:
-            return session.client.event_persist[self.name]
-        except KeyError:
-            persist: dict[str, Any] = {}
-            session.client.event_persist[self.name] = persist
-            return persist
 
     @property
     def done(self) -> bool:

--- a/tuxemon/event/eventpersist.py
+++ b/tuxemon/event/eventpersist.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class EventPersist:
+    """Handles event persistence data, ensuring proper state tracking."""
+
+    def __init__(self) -> None:
+        self.storage: dict[str, dict[str, Any]] = defaultdict(dict)
+
+    def update_event_data(self, event_name: str, key: str, value: Any) -> None:
+        self.storage[event_name][key] = value
+
+    def get_event_data(self, event_name: str) -> dict[str, Any]:
+        return self.storage[event_name]


### PR DESCRIPTION
PR introduces a new class, `EventPersist`, to handle event persistence more efficiently and ensure proper state tracking across game conditions. It also refactors `CharMovedCondition`.

Key:
- created `EventPersist` class, stores event-related data in a structured way and provides methods for updating and retrieving event persistence information
- integrated `EventPersist` in `LocalPygameClient`, initialized with `self.event_persist = EventPersist()` and ensures event conditions have consistent access to persistence handling

- refactored `CharMovedCondition`, extracted `generic_test` into a separate function for better readability and reuse, now uses `event_persist` to store movement state instead of direct dictionary manipulation and improved type hinting with `Optional[tuple[int, int]]` for clarity in tracking movement data