### PR TITLE
CLI: Improving Command Execution & Clean Exit

### DIFF
--- a/tuxemon/cli/commands/action.py
+++ b/tuxemon/cli/commands/action.py
@@ -52,7 +52,7 @@ class ActionParentCommand(CLICommand):
         Parameters:
             ctx: Contains references to parts of the game and CLI interface.
         """
-        actions = ctx.session.client.event_engine.get_actions()
+        actions = ctx.client.event_engine.get_actions()
         for action in actions:
             command = ActionCommand()
             command.name = action.name
@@ -61,9 +61,7 @@ class ActionParentCommand(CLICommand):
 
 
 class ActionCommand(CLICommand):
-    """
-    Subcommand used by ``action`` to invoke EventActions.
-    """
+    """Subcommand used by ``action`` to invoke EventActions."""
 
     usable_from_root = False
 
@@ -78,7 +76,7 @@ class ActionCommand(CLICommand):
         line = f"{self.name} {line}"
         name, args = parse_action_string(line)
         try:
-            ctx.session.client.event_engine.execute_action(name, args)
+            ctx.client.event_engine.execute_action(name, args)
         except Exception as e:
             print(f"Error executing action {e}", file=sys.stderr)
             traceback.print_exc()

--- a/tuxemon/cli/commands/help.py
+++ b/tuxemon/cli/commands/help.py
@@ -8,9 +8,7 @@ from tuxemon.cli.processor import MetaCommand
 
 
 class HelpCommand(CLICommand):
-    """
-    Command to get list available commands and display help for them.
-    """
+    """Command to get list available commands and display help for them."""
 
     name = "help"
     description = "Get help"

--- a/tuxemon/cli/commands/print.py
+++ b/tuxemon/cli/commands/print.py
@@ -7,9 +7,7 @@ from tuxemon.cli.context import InvokeContext
 
 
 class PrintCommand(CLICommand):
-    """
-    Print variables set by map event actions.
-    """
+    """Print variables set by map event actions."""
 
     name = "print"
     description = "Print values of variables set using map actions and events."
@@ -25,11 +23,6 @@ class PrintCommand(CLICommand):
         """
         variable = line.strip()
         if variable:
-            if variable in ctx.session.player.game_variables:
-                print(
-                    f"{variable}: {ctx.session.player.game_variables[variable]}"
-                )
-            else:
-                print(f"'{variable}' has not been set yet by map actions.")
+            ctx.client.event_engine.execute_action("print", [variable])
         else:
-            print(ctx.session.player.game_variables)
+            ctx.client.event_engine.execute_action("print", [])

--- a/tuxemon/cli/commands/quit.py
+++ b/tuxemon/cli/commands/quit.py
@@ -7,9 +7,7 @@ from tuxemon.cli.context import InvokeContext
 
 
 class QuitCommand(CLICommand):
-    """
-    Quit the game.
-    """
+    """Quit the game."""
 
     name = "quit"
     description = "Quit the game."
@@ -23,4 +21,4 @@ class QuitCommand(CLICommand):
             ctx: Contains references to parts of the game and CLI interface.
             line: Complete text as entered into the prompt.
         """
-        ctx.session.client.event_engine.execute_action("quit")
+        ctx.processor.quit()

--- a/tuxemon/cli/commands/random_encounter.py
+++ b/tuxemon/cli/commands/random_encounter.py
@@ -7,9 +7,7 @@ from tuxemon.cli.context import InvokeContext
 
 
 class RandomEncounterCommand(CLICommand):
-    """
-    Start random encounter using "default_encounter".
-    """
+    """Start random encounter using "default_encounter"."""
 
     name = "random_encounter"
     description = "Start random encounter using 'default_encounter'."
@@ -23,6 +21,6 @@ class RandomEncounterCommand(CLICommand):
             ctx: Contains references to parts of the game and CLI interface.
             line: Complete text as entered into the prompt.
         """
-        ctx.session.client.event_engine.execute_action(
+        ctx.client.event_engine.execute_action(
             "random_encounter", ["default_encounter", 100]
         )

--- a/tuxemon/cli/commands/shell.py
+++ b/tuxemon/cli/commands/shell.py
@@ -9,9 +9,7 @@ from tuxemon.cli.context import InvokeContext
 
 
 class ShellCommand(CLICommand):
-    """
-    Open python shell.
-    """
+    """Open python shell."""
 
     name = "shell"
     description = "Start interactive python shell."

--- a/tuxemon/cli/commands/test.py
+++ b/tuxemon/cli/commands/test.py
@@ -17,9 +17,7 @@ if TYPE_CHECKING:
 
 
 class TestConditionParentCommand(CLICommand):
-    """
-    Command that will test a condition.
-    """
+    """Command that will test a condition."""
 
     name = "test"
     description = "Evaluate condition and print the result."
@@ -42,7 +40,7 @@ class TestConditionParentCommand(CLICommand):
         Parameters:
             ctx: Contains references to parts of the game and CLI interface.
         """
-        conditions = ctx.session.client.event_engine.get_conditions()
+        conditions = ctx.client.event_engine.get_conditions()
         for condition in conditions:
             command = TestConditionCommand()
             command.name = condition.name
@@ -76,7 +74,7 @@ class TestConditionCommand(CLICommand):
         except ValueError:
             raise ParseError
         try:
-            result = ctx.session.client.event_engine.check_condition(cond)
+            result = ctx.client.event_engine.check_condition(cond)
             print(result)
         except Exception:
             traceback.print_exc()

--- a/tuxemon/cli/commands/trainer_battle.py
+++ b/tuxemon/cli/commands/trainer_battle.py
@@ -13,9 +13,7 @@ from tuxemon.cli.parser import parse
 
 
 class TrainerBattleCommand(CLICommand):
-    """
-    Command to start a trainer battle.
-    """
+    """Command to start a trainer battle."""
 
     name = "trainer_battle"
     description = "Start a trainer battle."
@@ -36,7 +34,7 @@ class TrainerBattleCommand(CLICommand):
         elif len(args) == 1:
             trainer = args[0]
             try:
-                action = ctx.session.client.event_engine.execute_action
+                action = ctx.client.event_engine.execute_action
                 action("create_npc", (trainer, 7, 6))
                 action("start_battle", (trainer,))
                 action("remove_npc", (trainer,))

--- a/tuxemon/cli/commands/whereami.py
+++ b/tuxemon/cli/commands/whereami.py
@@ -9,9 +9,7 @@ from tuxemon.cli.context import InvokeContext
 
 
 class WhereAmICommand(CLICommand):
-    """
-    Display player map name.
-    """
+    """Display player map name."""
 
     name = "whereami"
     description = "Print the filename of map where player is."
@@ -25,7 +23,7 @@ class WhereAmICommand(CLICommand):
             ctx: Contains references to parts of the game and CLI interface.
             line: Input text after the command name.
         """
-        current_map = ctx.session.client.event_engine.current_map
+        current_map = ctx.client.event_engine.current_map
         if current_map:
             name = current_map.data.filename
             print(name)

--- a/tuxemon/cli/context.py
+++ b/tuxemon/cli/context.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from tuxemon.cli.clicommand import CLICommand
     from tuxemon.cli.formatter import Formatter
     from tuxemon.cli.processor import CommandProcessor
-    from tuxemon.session import Session
+    from tuxemon.client import LocalPygameClient
 
 
 @dataclass
@@ -19,7 +19,7 @@ class InvokeContext:
     """
 
     processor: CommandProcessor
-    session: Session
+    client: LocalPygameClient
     root_command: CLICommand
     current_command: CLICommand
     formatter: Formatter

--- a/tuxemon/cli/processor.py
+++ b/tuxemon/cli/processor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import sys
 from collections.abc import Iterable, Sequence
+from typing import TYPE_CHECKING
 
 from prompt_toolkit import PromptSession
 
@@ -20,7 +21,9 @@ from tuxemon.plugin import (
     PluginManager,
     get_available_classes,
 )
-from tuxemon.session import Session
+
+if TYPE_CHECKING:
+    from tuxemon.client import LocalPygameClient
 
 
 class MetaCommand(CLICommand):
@@ -64,13 +67,13 @@ class CommandProcessor:
     A class to enable an interactive debug command line.
 
     Parameters:
-        session: Session which will be controlled by the debug prompt.
+        client: LocalPygameClient which will be controlled by the debug prompt.
         prompt: Default text to display before the input area, ie "> ".
     """
 
-    def __init__(self, session: Session, prompt: str = "> ") -> None:
+    def __init__(self, client: LocalPygameClient, prompt: str = "> ") -> None:
         self.prompt = prompt
-        self.session = session
+        self.client = client
         folder = os.path.join(os.path.dirname(__file__), "commands")
         # TODO: add folder(s) from mods
         commands = list(self.collect_commands(folder))
@@ -82,16 +85,16 @@ class CommandProcessor:
         """
         ctx = InvokeContext(
             processor=self,
-            session=self.session,
+            client=self.client,
             root_command=self.root_command,
             current_command=self.root_command,
             formatter=Formatter(),
         )
-        session: PromptSession[str] = PromptSession()
+        self.prompt_session: PromptSession[str] = PromptSession()
 
-        while True:
+        while self.client.is_running:
             try:
-                line = session.prompt(self.prompt)
+                line = self.prompt_session.prompt(self.prompt)
                 if line:
                     try:
                         command, tail = self.root_command.resolve(ctx, line)
@@ -112,8 +115,15 @@ class CommandProcessor:
             except KeyboardInterrupt:
                 print("Got KeyboardInterrupt")
                 print("Press CTRL-D to quit.")
+                break
 
-        self.session.client.quit()
+        self.quit()
+
+    def quit(self) -> None:
+        """
+        Gracefully shuts down the command processor and exits the client.
+        """
+        self.client.quit()
 
     def collect_commands(self, folder: str) -> Iterable[CLICommand]:
         """

--- a/tuxemon/client.py
+++ b/tuxemon/client.py
@@ -115,7 +115,7 @@ class LocalPygameClient:
             # behavior for the game.  at some point, a lock should be
             # implemented so that actions executed here have exclusive
             # control of the game loop and state.
-            self.cli = CommandProcessor(local_session)
+            self.cli = CommandProcessor(self)
             thread = Thread(target=self.cli.run)
             thread.daemon = True
             thread.start()
@@ -127,6 +127,10 @@ class LocalPygameClient:
         # TODO: phase these out
         self.key_events: Sequence[PlayerInput] = []
         self.event_data: dict[str, Any] = {}
+
+    @property
+    def is_running(self) -> bool:
+        return self.state == ClientState.RUNNING
 
     def on_state_change(self) -> None:
         logger.debug("resetting controls due to state change")


### PR DESCRIPTION
PR introduces a dedicated `quit` method, allowing the `'quit'` command to be executed directly without needing to pass through event actions. Additionally, it ensures the `print` command invokes event actions directly, bypassing the need to route through `session.player`.  

It also adds the `is_running` property to `LocalPygameClient`, making state checks cleaner without requiring direct comparisons to `ClientState`. Finally, the lingering `'> '` prompt will now properly disappear from the terminal after calling `'quit'`, ensuring a clean exit.

Furthermore, the `CommandProcessor` now directly receives the `client` instead of `local_session`. Previously, the only use of `session` was to access the player via the `print` command, while everything else client-related was already being accessed through `self.session.client`. This change simplifies direct interactions with the client. In the future, if the session is required again, `local_session` can easily be imported (or injected) when needed.