### PR TITLE
fix various

### DIFF
--- a/tests/tuxemon/test_animation.py
+++ b/tests/tuxemon/test_animation.py
@@ -1,108 +1,60 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import unittest
-from collections.abc import Callable
-from unittest.mock import Mock, call
+from unittest.mock import MagicMock
 
-from pygame.sprite import Group
-
-from tuxemon.animation import Task
-
-DEFAULT_INTERVAL = 1.0
+from tuxemon.animation import Animation, AnimationState
 
 
 class TestAnimation(unittest.TestCase):
     def setUp(self) -> None:
-        self.mock_callback = Mock(spec=Callable)
-        self.other_mock_callback = Mock(spec=Callable)
+        self.ani = Animation(x=100, y=100, duration=1000)
+        self.sprite = MagicMock()
 
-    def test_task_run_callback_after_interval(self):
-        task = Task(self.mock_callback, DEFAULT_INTERVAL)
+    def test_init(self):
+        self.assertEqual(self.ani.props, {"x": 100, "y": 100})
+        self.assertEqual(self.ani.delay, 0)
+        self.assertEqual(self.ani._duration, 1000)
+        self.assertEqual(self.ani._relative, False)
 
-        task.update(0.5)
-        self.mock_callback.assert_not_called()
+    def test_start(self):
+        self.ani.start(self.sprite)
+        self.assertEqual(self.ani._state, AnimationState.RUNNING)
+        self.assertEqual(self.ani._targets, (self.sprite,))
 
-        task.update(0.5)
-        self.mock_callback.assert_called()
+    def test_update(self):
+        self.ani.start(self.sprite)
+        self.ani.update(500)
+        self.assertEqual(self.ani._elapsed, 500)
 
-    def test_raise_value_error_when_times_is_0(self):
-        times = 0
-        with self.assertRaises(ValueError):
-            Task(self.mock_callback, DEFAULT_INTERVAL, times)
+    def test_finish(self):
+        self.ani.start(self.sprite)
+        self.ani.finish()
+        self.assertEqual(self.ani._state, AnimationState.FINISHED)
 
-    def test_raise_value_error_when_callback_is_not_callable(self):
-        with self.assertRaises(ValueError):
-            Task("not callable", DEFAULT_INTERVAL)
+    def test_abort(self):
+        self.ani.start(self.sprite)
+        self.ani.abort()
+        self.assertEqual(self.ani._state, AnimationState.FINISHED)
 
-    def test_task_run_callback_immediately_when_no_interval(self):
-        task = Task(self.mock_callback, 0)
+    def test_get_value(self):
+        self.sprite.x = 50
+        self.assertEqual(self.ani._get_value(self.sprite, "x"), 50)
 
-        task.update(0)
+    def test_set_value(self):
+        self.ani._set_value(self.sprite, "x", 100)
+        self.sprite.x.assert_called_once_with(100)
 
-        self.mock_callback.assert_called()
+    def test_callback(self):
+        callback = MagicMock()
+        self.ani.callback = callback
+        self.ani.start(MagicMock())
+        self.ani.finish()
+        callback.assert_called_once()
 
-    def test_task_run_callback_twice_when_times_is_2(self):
-        times = 2
-        task = Task(self.mock_callback, DEFAULT_INTERVAL, times)
-
-        task.update(DEFAULT_INTERVAL)
-        task.update(DEFAULT_INTERVAL)
-
-        self.mock_callback.assert_has_calls([call(), call()])
-
-    def test_raise_runtime_error_when_calling_update_after_task_finished(self):
-        task = Task(self.mock_callback, DEFAULT_INTERVAL)
-
-        task.update(DEFAULT_INTERVAL)
-        with self.assertRaises(RuntimeError):
-            task.update(DEFAULT_INTERVAL)
-
-    def test_add_chained_callback_to_group_when_original_task_finished(self):
-        task = Task(self.mock_callback, DEFAULT_INTERVAL)
-        task.chain(self.other_mock_callback, DEFAULT_INTERVAL)
-        task_group = Group()
-        task_group.add(task)
-
-        task_group.update(DEFAULT_INTERVAL)
-        self.mock_callback.assert_called()
-        self.other_mock_callback.assert_not_called()
-
-        task_group.update(DEFAULT_INTERVAL)
-        self.other_mock_callback.assert_called()
-
-    def test_is_finish_return_true_when_task_finished(self):
-        task = Task(self.mock_callback, DEFAULT_INTERVAL)
-
-        task.update(DEFAULT_INTERVAL)
-        self.assertTrue(task.is_finish())
-
-    def test_is_finish_return_false_when_task_in_progress(self):
-        task = Task(self.mock_callback, DEFAULT_INTERVAL)
-
-        task.update(0.5)
-        self.assertFalse(task.is_finish())
-
-    def test_reset_delay_when_new_delay_is_greater_than_interval(self):
-        task = Task(self.mock_callback, DEFAULT_INTERVAL)
-        greater_delay = DEFAULT_INTERVAL * 2
-
-        task.reset_delay(greater_delay)
-
-        self.assertEqual(greater_delay, task._interval)
-
-    def test_reset_delay_when_new_delay_is_greater_than_time_left(self):
-        task = Task(self.mock_callback, DEFAULT_INTERVAL)
-        same_delay = DEFAULT_INTERVAL
-        task.update(0.5)  # Time left is decreasing
-
-        task.reset_delay(same_delay)
-
-        self.assertEqual(same_delay, task._interval)
-
-    def test_dont_change_delay_when_new_delay_is_lower_than_time_left(self):
-        task = Task(self.mock_callback, DEFAULT_INTERVAL)
-        lower_delay = DEFAULT_INTERVAL / 2
-
-        task.reset_delay(lower_delay)
-
-        self.assertEqual(DEFAULT_INTERVAL, task._interval)
+    def test_update_callback(self):
+        update_callback = MagicMock()
+        self.ani.update_callback = update_callback
+        self.ani.start(MagicMock())
+        self.ani.update(1000)
+        self.assertGreater(update_callback.call_count, 0)

--- a/tests/tuxemon/test_task.py
+++ b/tests/tuxemon/test_task.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import unittest
+from collections.abc import Callable
+from unittest.mock import MagicMock, call
+
+from pygame.sprite import Group
+
+from tuxemon.animation import Task
+
+DEFAULT_INTERVAL = 1.0
+
+
+class TestTask(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mock_callback = MagicMock(spec=Callable)
+        self.other_mock_callback = MagicMock(spec=Callable)
+
+    def test_task_run_callback_after_interval(self):
+        task = Task(self.mock_callback, DEFAULT_INTERVAL)
+
+        task.update(0.5)
+        self.mock_callback.assert_not_called()
+
+        task.update(0.5)
+        self.mock_callback.assert_called()
+
+    def test_raise_value_error_when_times_is_0(self):
+        times = 0
+        with self.assertRaises(ValueError):
+            Task(self.mock_callback, DEFAULT_INTERVAL, times)
+
+    def test_raise_value_error_when_callback_is_not_callable(self):
+        with self.assertRaises(ValueError):
+            Task("not callable", DEFAULT_INTERVAL)
+
+    def test_task_run_callback_immediately_when_no_interval(self):
+        task = Task(self.mock_callback, 0)
+
+        task.update(0)
+
+        self.mock_callback.assert_called()
+
+    def test_task_run_callback_twice_when_times_is_2(self):
+        times = 2
+        task = Task(self.mock_callback, DEFAULT_INTERVAL, times)
+
+        task.update(DEFAULT_INTERVAL)
+        task.update(DEFAULT_INTERVAL)
+
+        self.mock_callback.assert_has_calls([call(), call()])
+
+    def test_raise_runtime_error_when_calling_update_after_task_finished(self):
+        task = Task(self.mock_callback, DEFAULT_INTERVAL)
+
+        task.update(DEFAULT_INTERVAL)
+        with self.assertRaises(RuntimeError):
+            task.update(DEFAULT_INTERVAL)
+
+    def test_add_chained_callback_to_group_when_original_task_finished(self):
+        task = Task(self.mock_callback, DEFAULT_INTERVAL)
+        task.chain(self.other_mock_callback, DEFAULT_INTERVAL)
+        task_group = Group()
+        task_group.add(task)
+
+        task_group.update(DEFAULT_INTERVAL)
+        self.mock_callback.assert_called()
+        self.other_mock_callback.assert_not_called()
+
+        task_group.update(DEFAULT_INTERVAL)
+        self.other_mock_callback.assert_called()
+
+    def test_is_finish_return_true_when_task_finished(self):
+        task = Task(self.mock_callback, DEFAULT_INTERVAL)
+
+        task.update(DEFAULT_INTERVAL)
+        self.assertTrue(task.is_finish())
+
+    def test_is_finish_return_false_when_task_in_progress(self):
+        task = Task(self.mock_callback, DEFAULT_INTERVAL)
+
+        task.update(0.5)
+        self.assertFalse(task.is_finish())
+
+    def test_reset_delay_when_new_delay_is_greater_than_interval(self):
+        task = Task(self.mock_callback, DEFAULT_INTERVAL)
+        greater_delay = DEFAULT_INTERVAL * 2
+
+        task.reset_delay(greater_delay)
+
+        self.assertEqual(greater_delay, task._interval)
+
+    def test_reset_delay_when_new_delay_is_greater_than_time_left(self):
+        task = Task(self.mock_callback, DEFAULT_INTERVAL)
+        same_delay = DEFAULT_INTERVAL
+        task.update(0.5)  # Time left is decreasing
+
+        task.reset_delay(same_delay)
+
+        self.assertEqual(same_delay, task._interval)
+
+    def test_dont_change_delay_when_new_delay_is_lower_than_time_left(self):
+        task = Task(self.mock_callback, DEFAULT_INTERVAL)
+        lower_delay = DEFAULT_INTERVAL / 2
+
+        task.reset_delay(lower_delay)
+
+        self.assertEqual(DEFAULT_INTERVAL, task._interval)

--- a/tests/tuxemon/test_world_transition.py
+++ b/tests/tuxemon/test_world_transition.py
@@ -91,7 +91,7 @@ class TestTransition(TestCase):
     @patch("pygame.Surface")
     def test_fade_out(self, MockSurface):
         mock_color = (0, 0, 0, 255)
-        self.transition.fade_out(1.0, mock_color)
+        self.transition.fade_out(1.0, mock_color, self.mock_world.player)
 
         self.mock_world.animate.assert_called_with(
             self.transition,
@@ -127,7 +127,9 @@ class TestTransition(TestCase):
     def test_fade_and_teleport(self, MockSurface):
         mock_color = (0, 0, 0, 255)
         mock_teleport = MagicMock()
-        self.transition.fade_and_teleport(1.0, mock_color, mock_teleport)
+        self.transition.fade_and_teleport(
+            1.0, mock_color, self.mock_world.player, mock_teleport
+        )
 
         self.mock_world.animate.assert_called_with(
             self.transition,

--- a/tuxemon/event/actions/transition_teleport.py
+++ b/tuxemon/event/actions/transition_teleport.py
@@ -60,6 +60,7 @@ class TransitionTeleportAction(EventAction):
         self.world.transition_manager.fade_and_teleport(
             _time,
             rgb,
+            self.world.player,
             lambda: self.world.teleporter.handle_delayed_teleport(
                 self.world.player
             ),

--- a/tuxemon/map_view.py
+++ b/tuxemon/map_view.py
@@ -327,7 +327,8 @@ class MapRenderer:
 
     def _apply_effects(self, surface: Surface) -> None:
         """Applies visual effects to the surface."""
-        self._set_layer(surface)
+        self.layer.fill(self.layer_color)
+        surface.blit(self.layer, (0, 0))
 
     def _apply_cinema_bars(self, surface: Surface) -> None:
         """Applies cinema bars (letterboxing) to the surface."""
@@ -386,26 +387,23 @@ class MapRenderer:
         The bubbles are layered according to the specified rendering layer,
         with options for vertical offset adjustment to fine-tune their placement.
         """
-        if self.bubble:
-            for npc, surface in self.bubble.items():
-                sprite_renderer = npc.sprite_controller.get_sprite_renderer()
-                center_x, center_y = get_pos_from_tilepos(
-                    current_map, Vector2(npc.tile_pos)
-                )
-                bubble_rect = surface.get_rect()
-                bubble_rect.centerx = sprite_renderer.rect.centerx
-                bubble_rect.bottom = sprite_renderer.rect.top
-                bubble_rect.x = center_x
-                bubble_rect.y = center_y - (
-                    surface.get_height()
-                    + int(sprite_renderer.rect.height / offset_divisor)
-                )
-                screen_surfaces.append((surface, bubble_rect, layer))
+        if not self.bubble:
+            return
 
-    def _set_layer(self, surface: Surface) -> None:
-        """Applies the layer effect to the surface."""
-        self.layer.fill(self.layer_color)
-        surface.blit(self.layer, (0, 0))
+        for npc, surface in self.bubble.items():
+            sprite_renderer = npc.sprite_controller.get_sprite_renderer()
+            center_x, center_y = get_pos_from_tilepos(
+                current_map, Vector2(npc.tile_pos)
+            )
+            bubble_rect = surface.get_rect()
+            bubble_rect.centerx = sprite_renderer.rect.centerx
+            bubble_rect.bottom = sprite_renderer.rect.top
+            bubble_rect.x = center_x
+            bubble_rect.y = center_y - (
+                surface.get_height()
+                + int(sprite_renderer.rect.height / offset_divisor)
+            )
+            screen_surfaces.append((surface, bubble_rect, layer))
 
     def _get_sprites(self, npc: NPC, layer: int) -> list[WorldSurfaces]:
         """Retrieves sprite surfaces for an NPC."""

--- a/tuxemon/menu/menu.py
+++ b/tuxemon/menu/menu.py
@@ -414,7 +414,6 @@ class Menu(Generic[T], State):
                 self.task(next_character, self.character_delay)
 
         self.character_delay = self.default_character_delay
-        self.remove_animations_of(next_character)
         next_character()
 
     def animate_text(

--- a/tuxemon/states/world/world_transition.py
+++ b/tuxemon/states/world/world_transition.py
@@ -11,6 +11,7 @@ from pygame.surface import Surface
 from tuxemon.graphics import ColorLike
 
 if TYPE_CHECKING:
+    from tuxemon.npc import NPC
     from tuxemon.states.world.worldstate import WorldState
 
 
@@ -22,16 +23,26 @@ class WorldTransition:
         self.in_transition = False
 
     def set_transition_surface(self, color: ColorLike) -> None:
-        self.transition_surface = Surface(
-            self.world.client.screen.get_size(), SRCALPHA
-        )
-        self.transition_surface.fill(color)
+        if (
+            self.transition_surface
+            and self.transition_surface.get_at((0, 0)) == color
+        ):
+            return
+
+        new_surface = Surface(self.world.client.screen.get_size(), SRCALPHA)
+        new_surface.fill(color)
+        self.transition_surface = new_surface
 
     def set_transition_state(self, in_transition: bool) -> None:
         """Update the transition state."""
         self.in_transition = in_transition
 
-    def fade_out(self, duration: float, color: ColorLike) -> None:
+    def fade_out(
+        self,
+        duration: float,
+        color: ColorLike,
+        character: Optional[NPC] = None,
+    ) -> None:
         self.set_transition_surface(color)
         self.world.animate(
             self,
@@ -40,11 +51,15 @@ class WorldTransition:
             duration=duration,
             round_values=True,
         )
-        self.world.movement.stop_char(self.world.player)
-        self.world.movement.lock_controls(self.world.player)
+        self.lock_character_controls(character)
         self.set_transition_state(True)
 
-    def fade_in(self, duration: float, color: ColorLike) -> None:
+    def fade_in(
+        self,
+        duration: float,
+        color: ColorLike,
+        character: Optional[NPC] = None,
+    ) -> None:
         self.set_transition_surface(color)
         self.world.animate(
             self,
@@ -53,10 +68,7 @@ class WorldTransition:
             duration=duration,
             round_values=True,
         )
-        self.world.task(
-            lambda: self.world.movement.unlock_controls(self.world.player),
-            max(duration, 0),
-        )
+        self.unlock_character_controls(character, duration)
 
         def cleanup() -> None:
             self.set_transition_state(False)
@@ -67,17 +79,18 @@ class WorldTransition:
         self,
         duration: float,
         color: ColorLike,
+        character: NPC,
         teleport_function: Callable[[], None],
     ) -> None:
         def fade_in() -> None:
-            self.fade_in(duration, color)
+            self.fade_in(duration, color, character)
 
-        self.world.movement.lock_controls(self.world.player)
+        self.world.movement.lock_controls(character)
         self.world.remove_animations_of(self.world)
-        self.world.remove_animations_of(self.set_transition_state)
-        self.world.movement.stop_and_reset_char(self.world.player)
+        self.world.stop_scheduled_callbacks()
+        self.world.movement.stop_and_reset_char(character)
 
-        self.fade_out(duration, color)
+        self.fade_out(duration, color, character)
         task = self.world.task(teleport_function, duration)
         task.chain(fade_in, duration + 0.5)
 
@@ -85,4 +98,19 @@ class WorldTransition:
         if self.in_transition:
             assert self.transition_surface
             self.transition_surface.set_alpha(self.transition_alpha)
-            surface.blit(self.transition_surface, (0, 0))
+            if self.transition_alpha > 0:
+                surface.blit(self.transition_surface, (0, 0))
+
+    def lock_character_controls(self, character: Optional[NPC]) -> None:
+        if character:
+            self.world.movement.stop_char(character)
+            self.world.movement.lock_controls(character)
+
+    def unlock_character_controls(
+        self, character: Optional[NPC], duration: float
+    ) -> None:
+        if character:
+            self.world.task(
+                lambda: self.world.movement.unlock_controls(character),
+                max(duration, 0),
+            )


### PR DESCRIPTION
PR fixes various issue (redundancy, etc):
- merged `_set_layer` in `_apply_effects` (map_view.py)
- added early return `if not self.bubble` to avoid triggering the mechanism for nothing
- added an optional `character: NPC` parameter to `fade_out`, `fade_in`, and `fade_and_teleport` methods, transition effects (movement locking, stopping, animations) now apply **to the provided character** instead of only the player, default behavior remains unchanged when no `character` is provided, ensuring backward compatibility and updated relevant imports to include `NPC`
- currently, each transition method (fade_out, fade_in, and fade_and_teleport) calls `set_transition_surface`(color), even if the surface remains unchanged, introduced a caching mechanism, this ensures that the transition surface is only updated when necessary, improving performance
- a couple of helper methods (reduce duplication)
- `surface.blit(self.transition_surface, (0, 0))`, but if `self.transition_alpha == 0`, this does nothing visually yet still executes, so added a guard clause before blitting
- removed `self.world.remove_animations_of(self.set_transition_state)`, unnecessary because it doesn't target a relevant object with animations (1), this was wild, because it kept removing nothing even after exiting the location with the NPC wandering (performance)
- removed `self.remove_animations_of(next_character)`, unnecessary because it doesn't target a relevant object with animations (1), same as above, constantly triggering even after the battle (appearing message)
- the `remove_animations_of` method has been refined, the type annotation now correctly specifies `Group[Animation]`, removing unnecessary references to `Task`, the filtering process has been optimized using set comprehensions for faster lookups, reducing iteration overhead and the docstring has been updated too
- removed some empty lines
- got rid of `ANIMATION_NOT_STARTED`, `ANIMATION_RUNNING`, `ANIMATION_DELAYED` and `ANIMATION_FINISHED` for `AnimationState(Enum)`, which makes animation states more readable, structured, and prevent accidental misuse... instead of using plain integers
- updated and simplified `_execute_callbacks`, since we're already using `defaultdict(list)`, the key will always exist, simplified to avoid unnecessary exception handling
- implemented `stop_scheduled_callbacks` in the `State` class to properly halt scheduled tasks, not sure how long this bug has been lurking, but while refactoring `char_wander` and `char_look` - both of which rely on scheduling - I discovered that tasks continued running even after changing locations, and this issue led to unnecessary resource consumption, but now the scheduling successfully stops as intended, preventing wasted performance
- added a unittest suite for `Animation`, renamed the tests appropriately to `Task`, and split them into two separate files to reflect the distinct classes

(1) used a logger.debug in `remove_animations_of` (state.py)

```
    logger.debug(f"Removing {len(to_remove)} animations for target: {target}")
    for ani in to_remove:
        logger.debug(f"Removing animation: {ani}")
```