### PR TITLE
fix various (crash left/right + crash running)

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -9655,6 +9655,15 @@ msgstr "I'm working, boss, I'm working! \n Oh, it's just you. You know, we throw
 msgid "spyder_papertown_danteworking"
 msgstr "Hah, I knew you were up to something!\n Well, looks like you've got yourself a little troublemaker now.\n Hope you're ready - once they find a home, they don't forget it!"
 
+msgid "spyder_papertown_dante1"
+msgstr "Look who decided to swing by again!\n What, did you miss me? You're looking sharper than last time - I swear, you're leveling up every time I see you."
+
+msgid "spyder_papertown_dante2"
+msgstr "Guess what? Granny Piper finally decided to go big - she opened a daycare!\n Gotta respect the hustle. Not everyone's cut out to train tuxemon; some folks just take care of them instead.\n Me? I stick to selling stuff and making sarcastic comments."
+
+msgid "spyder_papertown_dante3"
+msgstr "Wow. You really pulled it off.\n First the thieves, now this? I gotta say, I knew you had guts, but this... this is big.\n The city's gonna feel this one for a long time. Hope you're ready for whatever comes next.\n Speaking of disasters - my boss is breathing down my neck because the store's PC isn't working.\n Probably some network problem, but hey, I sell stuff, I don't fix tech.\n If you know anything about computers, please save me before I get blamed for breaking it."
+
 msgid "spyder_cotton_nurse1" 
 msgstr "Welcome to the Cathedral Centre! \n Do you want to heal your Tuxemon?"
 

--- a/mods/tuxemon/maps/spyder.yaml
+++ b/mods/tuxemon/maps/spyder.yaml
@@ -235,7 +235,7 @@ events:
     - is variable_set stage_of_day:night
     - not variable_set flashback:on
     - is location_inside
-    - not check_world layer,255:255:255:0
+    - is check_world layer
     type: "event"
   Day Cycle Outside:
     actions:

--- a/mods/tuxemon/maps/spyder_candy_cafe.yaml
+++ b/mods/tuxemon/maps/spyder_candy_cafe.yaml
@@ -151,6 +151,7 @@ events:
     type: "event"
   Default Template:
     actions:
+    - set_layer
     - set_template player,default
     conditions:
     - is char_sprite player,invisible

--- a/mods/tuxemon/maps/spyder_greenwash_level2.tmx
+++ b/mods/tuxemon/maps/spyder_greenwash_level2.tmx
@@ -393,10 +393,20 @@
     <property name="cond1" value="is variable_set dempsey_flashback:yes"/>
    </properties>
   </object>
-  <object id="136" name="Default" type="event" x="176" y="16" width="16" height="16">
+  <object id="136" name="Default Fossilator" type="event" x="176" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="set_template player,default"/>
+    <property name="act1" value="set_layer"/>
+    <property name="act2" value="set_template player,default"/>
     <property name="cond1" value="is char_sprite player,invisible"/>
+    <property name="cond2" value="is variable_set unveildefossilator:done"/>
+   </properties>
+  </object>
+  <object id="114" name="Default Dempsey" type="event" x="176" y="16" width="16" height="16">
+   <properties>
+    <property name="act1" value="set_layer"/>
+    <property name="act2" value="set_template player,default"/>
+    <property name="cond1" value="is char_sprite player,invisible"/>
+    <property name="cond2" value="is variable_set dempsey_flashback:done"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_greenwash_level3.yaml
+++ b/mods/tuxemon/maps/spyder_greenwash_level3.yaml
@@ -90,7 +90,6 @@ events:
     - set_variable incident_greenwash:done
     - unlock_controls
     - set_variable flashback:off
-    - set_layer
     - transition_teleport spyder_candy_cafe.tmx,4,7
     - char_face player,left
     conditions:
@@ -120,7 +119,7 @@ events:
     - remove_npc spyder_greenwash_chip
     - remove_npc spyder_greenwash_selby
     - set_variable unveildefossilator:done
-    - set_layer
+    - set_layer 0:0:0:255
     - unlock_controls
     - set_variable flashback:off
     - transition_teleport spyder_greenwash_level2.tmx,9,2
@@ -152,7 +151,7 @@ events:
     - pathfind spyder_greenwash_looten,2,4
     - remove_npc spyder_greenwash_looten
     - set_variable dempsey_flashback:done
-    - set_layer
+    - set_layer 0:0:0:255
     - unlock_controls
     - camera_position
     - set_variable flashback:off

--- a/mods/tuxemon/maps/spyder_nimrod_middle.tmx
+++ b/mods/tuxemon/maps/spyder_nimrod_middle.tmx
@@ -387,7 +387,8 @@
   </object>
   <object id="55" name="Default Template" type="event" x="208" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="set_template player,default"/>
+    <property name="act1" value="set_layer"/>
+    <property name="act2" value="set_template player,default"/>
     <property name="cond1" value="is char_sprite player,invisible"/>
     <property name="cond2" value="is variable_set zircon_argon:done"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_nimrod_room.yaml
+++ b/mods/tuxemon/maps/spyder_nimrod_room.yaml
@@ -71,7 +71,7 @@ events:
     - remove_npc spyder_nimrod_zircon
     - set_variable zircon_argon:done
     - set_variable flashback:off
-    - set_layer
+    - set_layer 0:0:0:255
     - unlock_controls
     - transition_teleport spyder_nimrod_middle.tmx,14,10
     conditions:
@@ -112,7 +112,7 @@ events:
     - remove_npc spyder_nimrod_thatcher
     - set_variable enforcers_response:done
     - set_variable flashback:off
-    - set_layer
+    - set_layer 0:0:0:255
     - unlock_controls
     - char_face player,right
     - transition_teleport spyder_wayfarer_inn1.tmx,9,6

--- a/mods/tuxemon/maps/spyder_paper_daycare.yaml
+++ b/mods/tuxemon/maps/spyder_paper_daycare.yaml
@@ -203,7 +203,7 @@ events:
     - char_face spyder_grannypiper,up
     - translated_dialog spyder_billie_flashback_end
     - set_variable billie_grandma:done
-    - set_layer
+    - set_layer 0:0:0:255
     - unlock_controls
     - set_variable flashback:off
     - transition_teleport spyder_paper_rival_downstairs.tmx,7,9

--- a/mods/tuxemon/maps/spyder_paper_rival_downstairs.yaml
+++ b/mods/tuxemon/maps/spyder_paper_rival_downstairs.yaml
@@ -108,6 +108,7 @@ events:
     type: "event"
   Default Template:
     actions:
+    - set_layer
     - set_template player,default
     conditions:
     - is char_sprite player,invisible

--- a/mods/tuxemon/maps/spyder_paper_scoop.yaml
+++ b/mods/tuxemon/maps/spyder_paper_scoop.yaml
@@ -50,6 +50,36 @@ events:
     - is variable_set intro_scoop:done
     - is party_size player,greater_than,0
     type: "event"
+  Talk Dante Player Returns:
+    actions:
+    - translated_dialog spyder_papertown_dante1
+    - set_variable spokendante:yes
+    behav:
+    - talk spyder_dante
+    conditions:
+    - is variable_set zoolanderdefeat:yes
+    - not variable_set spokendante:yes
+    type: "event"
+  Talk Dante Daycare:
+    actions:
+    - translated_dialog spyder_papertown_dante2
+    behav:
+    - talk spyder_dante
+    conditions:
+    - is variable_set zoolanderdefeat:yes
+    - not variable_set omnichannelradioannounce:yes
+    - is variable_set spokendante:yes
+    type: "event"
+  Talk Dante Omnichannel:
+    actions:
+    - translated_dialog spyder_papertown_dante3
+    behav:
+    - talk spyder_dante
+    conditions:
+    - is variable_set zoolanderdefeat:yes
+    - is variable_set omnichannelradioannounce:yes
+    - is variable_set spokendante:yes
+    type: "event"
   Potions:
     actions:
     - translated_dialog potions_in_shop

--- a/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
+++ b/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
@@ -430,7 +430,8 @@
   </object>
   <object id="91" name="Default Template" type="event" x="144" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="set_template player,default"/>
+    <property name="act1" value="set_layer"/>
+    <property name="act2" value="set_template player,default"/>
     <property name="cond1" value="is char_sprite player,invisible"/>
     <property name="cond2" value="is variable_set enforcers_response:done"/>
    </properties>

--- a/tests/tuxemon/test_actions.py
+++ b/tests/tuxemon/test_actions.py
@@ -7,7 +7,7 @@ from tuxemon import prepare
 from tuxemon.db import Direction
 from tuxemon.entity import Body, Mover
 from tuxemon.event.eventengine import EventEngine
-from tuxemon.math import Point3
+from tuxemon.math import Point3, Vector3
 from tuxemon.player import Player
 from tuxemon.session import local_session
 from tuxemon.tuxepedia import Tuxepedia
@@ -204,12 +204,6 @@ class TestCharacterActions(unittest.TestCase):
     def setUp(self):
         self.mock_screen = MagicMock()
         local_session.client = MagicMock()
-        local_session.client.config.player_walkrate = (
-            prepare.CONFIG.player_walkrate
-        )
-        local_session.client.config.player_runrate = (
-            prepare.CONFIG.player_runrate
-        )
         with patch.object(Player, "__init__", mockPlayer):
             self.action = EventEngine(local_session)
             local_session.player = Player()
@@ -230,11 +224,13 @@ class TestCharacterActions(unittest.TestCase):
 
     def test_char_walk(self):
         self.player.set_moverate(6.9)
+        self.player.body.velocity = Vector3(1, 0, 0)
         self.action.execute_action("char_walk", ["player"])
         self.assertEqual(self.player.moverate, prepare.CONFIG.player_walkrate)
 
     def test_char_run(self):
         self.player.set_moverate(6.9)
+        self.player.body.velocity = Vector3(1, 0, 0)
         self.action.execute_action("char_run", ["player"])
         self.assertEqual(self.player.moverate, prepare.CONFIG.player_runrate)
 

--- a/tests/tuxemon/test_sprite_renderer.py
+++ b/tests/tuxemon/test_sprite_renderer.py
@@ -8,8 +8,7 @@ import pygame
 from pygame.surface import Surface
 
 from tuxemon import prepare
-from tuxemon.db import EntityFacing
-from tuxemon.map_view import SpriteController
+from tuxemon.map_view import EntityFacing, SpriteController
 from tuxemon.npc import NPC
 from tuxemon.surfanim import SurfaceAnimation
 

--- a/tuxemon/animation.py
+++ b/tuxemon/animation.py
@@ -53,9 +53,9 @@ def remove_animations_of(
         group: A Pygame group containing `Animation` instances.
     """
     animations = {ani for ani in group if isinstance(ani, Animation)}
-    to_remove = {
-        ani for ani in animations if target in {i[0] for i in ani.targets}
-    }
+    to_remove = [
+        ani for ani in animations if target in [i[0] for i in ani.targets]
+    ]
     if not to_remove:
         logger.debug(f"No animations found for target: {target}")
     group.remove(*to_remove)

--- a/tuxemon/core/core_processor.py
+++ b/tuxemon/core/core_processor.py
@@ -43,6 +43,8 @@ class EffectProcessor:
         target: Monster,
     ) -> TechEffectResult:
         meta_result = TechEffectResult(name=source.name)
+        if not self.effects:
+            return meta_result
         for effect in self.effects:
             if isinstance(effect, TechEffect):
                 result = effect.apply(session, source, user, target)
@@ -56,6 +58,8 @@ class EffectProcessor:
         target: Optional[Monster],
     ) -> ItemEffectResult:
         meta_result = ItemEffectResult(name=source.name)
+        if not self.effects:
+            return meta_result
         for effect in self.effects:
             if isinstance(effect, ItemEffect):
                 result = effect.apply(session, source, target)
@@ -69,6 +73,8 @@ class EffectProcessor:
         target: Monster,
     ) -> StatusEffectResult:
         meta_result = StatusEffectResult(name=source.name)
+        if not self.effects:
+            return meta_result
         for effect in self.effects:
             if isinstance(effect, StatusEffect):
                 result = effect.apply(session, source, target)

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -133,13 +133,6 @@ class MissionStatus(str, Enum):
     removed = "removed"
 
 
-class EntityFacing(str, Enum):
-    front = "front"
-    back = "back"
-    left = "left"
-    right = "right"
-
-
 class MusicStatus(str, Enum):
     playing = "playing"
     paused = "paused"

--- a/tuxemon/entity.py
+++ b/tuxemon/entity.py
@@ -111,13 +111,15 @@ class Mover:
 
     def running(self) -> None:
         """Boosts moverate to running speed."""
-        self.moverate = CONFIG.player_runrate
-        self.state = EntityState.RUNNING
+        if self.body.velocity != Vector3(0, 0, 0):
+            self.moverate = CONFIG.player_runrate
+            self.state = EntityState.RUNNING
 
     def walking(self) -> None:
         """Resets moverate back to walking speed."""
-        self.moverate = CONFIG.player_walkrate
-        self.state = EntityState.WALKING
+        if self.body.velocity != Vector3(0, 0, 0):
+            self.moverate = CONFIG.player_walkrate
+            self.state = EntityState.WALKING
 
 
 class Entity(Generic[SaveDict]):

--- a/tuxemon/event/actions/set_layer.py
+++ b/tuxemon/event/actions/set_layer.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional, final
 
-from tuxemon import prepare
 from tuxemon.event.eventaction import EventAction
 from tuxemon.graphics import string_to_colorlike
 from tuxemon.session import Session
@@ -37,7 +36,6 @@ class SetLayerAction(EventAction):
     rgb: Optional[str] = None
 
     def start(self, session: Session) -> None:
-        transparent = prepare.TRANSPARENT_COLOR
-        rgb = string_to_colorlike(self.rgb) if self.rgb else transparent
+        rgb = string_to_colorlike(self.rgb) if self.rgb else None
         world = session.client.get_state_by_name(WorldState)
         world.map_renderer.layer_color = rgb

--- a/tuxemon/event/conditions/check_world.py
+++ b/tuxemon/event/conditions/check_world.py
@@ -17,7 +17,10 @@ logger = logging.getLogger(__name__)
 @dataclass
 class CheckWorldCondition(EventCondition):
     """
-    Check some world's parameter against a given value.
+    Evaluates specific world conditions against expected values.
+
+    This condition can check various parameters of the game world, such as
+    overlay colors (layer) and speech bubbles (bubble).
 
     Script usage:
         .. code-block::
@@ -25,14 +28,15 @@ class CheckWorldCondition(EventCondition):
             check_world <parameter>,<value>
 
     Script parameters:
-        parameter: Name of the parameter to check (eg. "layer", etc.).
-        value: Given value to check.
+        parameter: The name of the world attribute to check.
+        value: The expected value to compare against.
 
-    layer: color value which is used to overlay the world
-    bubble: speech bubble of an npc
+    Examples:
+        - "check_world layer"
+          Ensures the overlay color is empty.
 
-    eg. "check_world layer,255:255:255:0"
-
+        - "check_world bubble,npc_maple"
+          Checks if NPC "npc_maple" currently has a speech bubble.
     """
 
     name = "check_world"
@@ -41,9 +45,13 @@ class CheckWorldCondition(EventCondition):
         world = session.client.get_state_by_name(WorldState)
         params = condition.parameters
         if params[0] == "layer":
-            rgb = string_to_colorlike(params[1])
-            return world.map_renderer.layer_color == rgb
+            if len(params) > 1:
+                rgb = string_to_colorlike(params[1])
+                return world.map_renderer.layer_color == rgb
+            return True
         if params[0] == "bubble":
+            if len(params) < 2:
+                return False
             char = get_npc(session, params[1])
             if char is None:
                 logger.error(f"{params[1]} not found")


### PR DESCRIPTION
PR:
- added some lines for Dante in the Spyder campaign - he’ll say different things depending on where the protagonist is in the story, kind of like how the protagonist’s mom does
- added check if the color is different (map_view.py) -> improve performance
- moved the managers to class attributes, ensuring they are initialized only once per class rather than on every instance (Technique, Item and Status)
- fixed crash when the player clicks right or left on the loading screen while selecting a saved game (it happens in the input - where the player writes the name too)
- fixed crash caused by pressing the **RUN** button when the player is stationary, now, the system checks for actual velocity to confirm movement before activating the running state, preventing unintended behavior

```
    ani for ani in animations if target in {i[0] for i in ani.targets}
                                            ~^^^
TypeError: unhashable type: 'pygame.rect.Rect'
```
and the running one
```
  File "/usr/lib/python3.12/enum.py", line 757, in __call__
    return cls.__new__(cls, value)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/enum.py", line 1171, in __new__
    raise ve_exc
ValueError: 'front_walk' is not a valid EntityFacing
```
