### PR TITLE
Injecting `MapRenderer` Directly with Client & Centralizing Camera Updates

### DIFF
--- a/tuxemon/client.py
+++ b/tuxemon/client.py
@@ -15,6 +15,7 @@ from pygame.surface import Surface
 
 from tuxemon.audio import MusicPlayerState, SoundManager
 from tuxemon.boundary import BoundaryChecker
+from tuxemon.camera import CameraManager
 from tuxemon.cli.processor import CommandProcessor
 from tuxemon.config import TuxemonConfig
 from tuxemon.event.eventengine import EventEngine
@@ -105,6 +106,7 @@ class LocalPygameClient:
         self.map_loader = MapLoader()
         self.map_manager = MapManager()
         self.boundary = BoundaryChecker()
+        self.camera_manager = CameraManager()
 
         # Set up a variable that will keep track of currently playing music.
         self.current_music = MusicPlayerState()

--- a/tuxemon/event/actions/camera_follow.py
+++ b/tuxemon/event/actions/camera_follow.py
@@ -9,7 +9,6 @@ from typing import Optional, final
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.session import Session
-from tuxemon.states.world.worldstate import WorldState
 
 logger = logging.getLogger(__name__)
 
@@ -36,8 +35,7 @@ class CameraFollowAction(EventAction):
     def start(self, session: Session) -> None:
         self.npc_slug = self.npc_slug or "player"
         character = get_npc(session, self.npc_slug)
-        world = session.client.get_state_by_name(WorldState)
-        active_camera = world.camera_manager.get_active_camera()
+        active_camera = session.client.camera_manager.get_active_camera()
 
         if active_camera is None:
             logger.error("No active camera found.")

--- a/tuxemon/event/actions/camera_mode.py
+++ b/tuxemon/event/actions/camera_mode.py
@@ -9,7 +9,6 @@ from typing import final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.session import Session
-from tuxemon.states.world.worldstate import WorldState
 
 logger = logging.getLogger(__name__)
 
@@ -38,8 +37,7 @@ class CameraModeAction(EventAction):
     mode: str
 
     def start(self, session: Session) -> None:
-        world = session.client.get_state_by_name(WorldState)
-        camera = world.camera_manager.get_active_camera()
+        camera = session.client.camera_manager.get_active_camera()
         if camera is None:
             logger.error("No active camera found.")
             return

--- a/tuxemon/event/actions/camera_move.py
+++ b/tuxemon/event/actions/camera_move.py
@@ -9,7 +9,6 @@ from typing import Optional, final
 from tuxemon.camera import Camera
 from tuxemon.event.eventaction import EventAction
 from tuxemon.session import Session
-from tuxemon.states.world.worldstate import WorldState
 
 logger = logging.getLogger(__name__)
 
@@ -36,8 +35,7 @@ class CameraMoveAction(EventAction):
     y: Optional[int] = None
 
     def start(self, session: Session) -> None:
-        world = session.client.get_state_by_name(WorldState)
-        self.camera = world.camera_manager.get_active_camera()
+        self.camera = session.client.camera_manager.get_active_camera()
         if self.camera is None:
             logger.error("No active camera found.")
             return

--- a/tuxemon/event/actions/camera_position.py
+++ b/tuxemon/event/actions/camera_position.py
@@ -9,7 +9,6 @@ from typing import Optional, final
 from tuxemon.camera import Camera
 from tuxemon.event.eventaction import EventAction
 from tuxemon.session import Session
-from tuxemon.states.world.worldstate import WorldState
 
 logger = logging.getLogger(__name__)
 
@@ -35,8 +34,7 @@ class CameraPositionAction(EventAction):
     y: Optional[int] = None
 
     def start(self, session: Session) -> None:
-        world = session.client.get_state_by_name(WorldState)
-        camera = world.camera_manager.get_active_camera()
+        camera = session.client.camera_manager.get_active_camera()
         if camera is None:
             logger.error("No active camera found.")
             return

--- a/tuxemon/event/actions/camera_shake.py
+++ b/tuxemon/event/actions/camera_shake.py
@@ -9,7 +9,6 @@ from typing import final
 from tuxemon.event.eventaction import EventAction
 from tuxemon.prepare import CAMERA_SHAKE_RANGE
 from tuxemon.session import Session
-from tuxemon.states.world.worldstate import WorldState
 
 logger = logging.getLogger(__name__)
 
@@ -39,13 +38,12 @@ class CameraShakeAction(EventAction):
     duration: float
 
     def start(self, session: Session) -> None:
-        world = session.client.get_state_by_name(WorldState)
         lower, upper = CAMERA_SHAKE_RANGE
         if not lower <= self.intensity <= upper:
             logger.error(
                 f"{self.intensity} must be between {lower} and {upper}",
             )
-        camera = world.camera_manager.get_active_camera()
+        camera = session.client.camera_manager.get_active_camera()
         if camera is None:
             logger.error("No active camera found.")
             return

--- a/tuxemon/event/conditions/camera_position.py
+++ b/tuxemon/event/conditions/camera_position.py
@@ -9,7 +9,6 @@ from tuxemon.camera import unproject
 from tuxemon.event import MapCondition
 from tuxemon.event.eventcondition import EventCondition
 from tuxemon.session import Session
-from tuxemon.states.world.worldstate import WorldState
 from tuxemon.tools import compare
 
 logger = logging.getLogger(__name__)
@@ -36,8 +35,7 @@ class CameraPositionCondition(EventCondition):
         map_size = session.client.map_manager.map_size
         pos_x = int(condition.parameters[0])
         pos_y = int(condition.parameters[1])
-        world = session.client.get_state_by_name(WorldState)
-        camera = world.camera_manager.get_active_camera()
+        camera = session.client.camera_manager.get_active_camera()
         if camera is None:
             logger.error("No active camera found.")
             return False

--- a/tuxemon/map_view.py
+++ b/tuxemon/map_view.py
@@ -25,11 +25,10 @@ from tuxemon.surfanim import SurfaceAnimation, SurfaceAnimationCollection
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from tuxemon.camera import Camera
+    from tuxemon.client import LocalPygameClient
     from tuxemon.db import NpcTemplateModel
     from tuxemon.map import TuxemonMap
     from tuxemon.npc import NPC
-    from tuxemon.states.world.worldstate import WorldState
 
 
 class EntityFacing(str, Enum):
@@ -279,20 +278,19 @@ class SpriteRenderer:
 class MapRenderer:
     """Renders the game map, NPCs, and animations."""
 
-    def __init__(
-        self, world_state: WorldState, screen: Surface, camera: Camera
-    ):
+    def __init__(self, client: LocalPygameClient):
         """Initializes the MapRenderer."""
-        self.world_state = world_state
-        self.screen = screen
-        self.camera = camera
+        self.client = client
+        self.screen = client.screen
+        self.camera_manager = client.camera_manager
+        self.camera = self.camera_manager.get_active_camera()
         self.layer = Surface(self.screen.get_size(), pygame.SRCALPHA)
         self.layer_color: Optional[ColorLike] = None
         self.bubble: dict[NPC, Surface] = {}
         self.cinema_x_ratio: Optional[float] = None
         self.cinema_y_ratio: Optional[float] = None
         self.map_animations: dict[str, AnimationInfo] = {}
-        self.debug_renderer = DebugRenderer(world_state)
+        self.debug_renderer = DebugRenderer(client)
 
     def draw(self, surface: Surface, current_map: TuxemonMap) -> None:
         """Draws the map, sprites, and animations onto the given surface."""
@@ -307,6 +305,7 @@ class MapRenderer:
 
     def update(self, time_delta: float) -> None:
         """Update the map animations."""
+        self.camera_manager.update(time_delta)
         for anim_data in self.map_animations.values():
             anim_data.animation.update(time_delta)
 
@@ -314,7 +313,8 @@ class MapRenderer:
         """Prepares the map renderer for drawing."""
         if current_map.renderer is None:
             current_map.initialize_renderer()
-        camera_x, camera_y = self.camera.position
+        position = self.camera.position if self.camera else Vector2(0, 0)
+        camera_x, camera_y = position
         assert current_map.renderer
         current_map.renderer.center((camera_x, camera_y))
 
@@ -356,7 +356,7 @@ class MapRenderer:
         """Retrieves surfaces for NPCs."""
         return [
             surf
-            for npc in self.world_state.client.npc_manager.npcs.values()
+            for npc in self.client.npc_manager.npcs.values()
             for surf in self._get_sprites(npc, current_map)
         ]
 
@@ -433,12 +433,12 @@ class MapRenderer:
 class DebugRenderer:
     def __init__(
         self,
-        world_state: WorldState,
+        client: LocalPygameClient,
         event_color: ColorLike = (0, 255, 0, 128),
         collision_color: ColorLike = (255, 0, 0, 128),
         center_line_color: ColorLike = (255, 50, 50),
     ) -> None:
-        self.world_state = world_state
+        self.client = client
         self.event_color = event_color
         self.collision_color = collision_color
         self.center_line_color = center_line_color
@@ -453,7 +453,7 @@ class DebugRenderer:
 
     def _draw_events(self, current_map: TuxemonMap, surface: Surface) -> None:
         """Draws event-related debug information on the surface."""
-        for event in self.world_state.client.map_manager.events:
+        for event in self.client.map_manager.events:
             vector = Vector2(event.x, event.y)
             topleft = get_pos_from_tilepos(current_map, vector)
             size = project((event.w, event.h))
@@ -466,13 +466,13 @@ class DebugRenderer:
         # We need to iterate over all collidable objects. Start with walls/collision boxes.
         box_iter = map(
             lambda box: collision_box_to_pgrect(current_map, box),
-            self.world_state.client.map_manager.collision_map,
+            self.client.map_manager.collision_map,
         )
 
         # Next, deal with solid NPCs.
         npc_iter = map(
             lambda npc: npc_to_pgrect(current_map, npc),
-            self.world_state.client.npc_manager.npcs.values(),
+            self.client.npc_manager.npcs.values(),
         )
         for item in chain(box_iter, npc_iter):
             box(surface, item, self.collision_color)

--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -17,7 +17,7 @@ from typing import (
 from pygame.surface import Surface
 
 from tuxemon import networking, prepare
-from tuxemon.camera import Camera, CameraManager
+from tuxemon.camera import Camera
 from tuxemon.db import Direction
 from tuxemon.map import RegionProperties
 from tuxemon.map_view import MapRenderer
@@ -78,9 +78,8 @@ class WorldState(State):
             local_session.player = new_player
 
         self.camera = Camera(local_session.player, self.client.boundary)
-        self.map_renderer = MapRenderer(self, self.screen, self.camera)
-        self.camera_manager = CameraManager()
-        self.camera_manager.add_camera(self.camera)
+        self.client.camera_manager.add_camera(self.camera)
+        self.map_renderer = MapRenderer(self.client)
 
         if map_name:
             self.change_map(map_name)
@@ -132,7 +131,6 @@ class WorldState(State):
         self.client.npc_manager.update_npcs(time_delta, self.client)
         self.client.npc_manager.update_npcs_off_map(time_delta, self.client)
         self.map_renderer.update(time_delta)
-        self.camera_manager.update(time_delta)
 
         logger.debug("*** Game Loop Started ***")
 
@@ -202,7 +200,7 @@ class WorldState(State):
         # Handle directional movement
         if (direction := direction_map.get(event.button)) is not None:
             if not self.camera.follows_entity:
-                return self.camera_manager.handle_input(event)
+                return self.client.camera_manager.handle_input(event)
             if event.held:
                 self.movement.queue_movement(self.player.slug, direction)
                 if self.movement.is_movement_allowed(self.player):


### PR DESCRIPTION
PR relocates the initialization of `CameraManager()` from `WorldState()` to `LocalPygameClient()`, improving modularity. Additionally, `MapRenderer` is now injected directly with the client, removing dependencies on `WorldState`, `Surface`, and `Camera`, since all relevant values originate from the client itself. The camera update with the time delta is now consistently handled through `CameraManager` within `MapRenderer`, eliminating redundant updates.