### PR TITLE
Refactoring Player Creation:  `Player.create()` +  `Session` injected in WorldState

### DIFF
--- a/tuxemon/event/actions/load_game.py
+++ b/tuxemon/event/actions/load_game.py
@@ -66,7 +66,7 @@ class LoadGameAction(EventAction):
             map_path = prepare.fetch(
                 "maps", save_data["npc_state"]["current_map"]
             )
-            client.push_state("WorldState", map_name=map_path)
+            client.push_state("WorldState", session=session, map_name=map_path)
 
             # TODO: Get player from whatever place and use self.client in
             # order to build a Session

--- a/tuxemon/main.py
+++ b/tuxemon/main.py
@@ -96,7 +96,9 @@ def configure_game_states(
         if len(config.mods) == 1:
             destination = f"{prepare.STARTING_MAP}{config.mods[0]}.tmx"
             map_name = prepare.fetch("maps", destination)
-            client.push_state("WorldState", map_name=map_name)
+            client.push_state(
+                "WorldState", session=local_session, map_name=map_name
+            )
         else:
             client.push_state("ModsChoice", mods=config.mods)
 

--- a/tuxemon/player.py
+++ b/tuxemon/player.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
 from tuxemon.map import proj
 from tuxemon.npc import NPC
-from tuxemon.states.world.worldstate import WorldState
+from tuxemon.prepare import PLAYER_NPC
+
+if TYPE_CHECKING:
+    from tuxemon.session import Session
+    from tuxemon.states.world.worldstate import WorldState
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +27,15 @@ class Player(NPC):
     ) -> None:
         super().__init__(npc_slug, world=world)
         self.isplayer = True
+
+    @classmethod
+    def create(
+        cls, session: Session, world: WorldState, slug: str = PLAYER_NPC
+    ) -> Player:
+        """Creates a player instance only if one doesn't already exist."""
+        if session.player is None:
+            session.player = cls(slug, world)
+        return session.player
 
     def update(self, time_delta: float) -> None:
         """

--- a/tuxemon/states/start/__init__.py
+++ b/tuxemon/states/start/__init__.py
@@ -57,7 +57,9 @@ class StartState(PygameMenuState):
         def new_game() -> None:
             destination = f"{prepare.STARTING_MAP}{config.mods[0]}.tmx"
             map_path = prepare.fetch("maps", destination)
-            self.client.push_state("WorldState", map_name=map_path)
+            self.client.push_state(
+                "WorldState", session=local_session, map_name=map_path
+            )
             game_var = local_session.player.game_variables
             game_var["date_start_game"] = today_ordinal()
             self.client.pop_state(self)
@@ -148,7 +150,9 @@ class ModsChoice(PygameMenuState):
         def new_game(mod_name: str) -> None:
             destination = f"{prepare.STARTING_MAP}{mod_name}.tmx"
             map_path = prepare.fetch("maps", destination)
-            self.client.push_state("WorldState", map_name=map_path)
+            self.client.push_state(
+                "WorldState", session=local_session, map_name=map_path
+            )
             game_var = local_session.player.game_variables
             game_var["date_start_game"] = today_ordinal()
             self.client.pop_state(self)

--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -25,6 +25,7 @@ from tuxemon.movement import MovementManager, Pathfinder
 from tuxemon.platform.const import intentions
 from tuxemon.platform.events import PlayerInput
 from tuxemon.platform.tools import translate_input_event
+from tuxemon.player import Player
 from tuxemon.session import local_session
 from tuxemon.state import State
 from tuxemon.states.world.world_transition import WorldTransition
@@ -61,9 +62,6 @@ class WorldState(State):
 
     def __init__(self, map_name: str) -> None:
         super().__init__()
-
-        from tuxemon.player import Player
-
         self.movement = MovementManager(self.client)
         self.teleporter = Teleporter(self.client, self)
         self.pathfinder = Pathfinder(self.client, self)
@@ -73,11 +71,9 @@ class WorldState(State):
 
         self.transition_manager = WorldTransition(self)
 
-        if local_session.player is None:
-            new_player = Player(prepare.PLAYER_NPC, world=self)
-            local_session.player = new_player
+        self.player = Player.create(local_session, self)
 
-        self.camera = Camera(local_session.player, self.client.boundary)
+        self.camera = Camera(self.player, self.client.boundary)
         self.map_renderer = MapRenderer(self, self.screen, self.camera)
         self.camera_manager = CameraManager()
         self.camera_manager.add_camera(self.camera)
@@ -613,7 +609,7 @@ class WorldState(State):
                 if self.wants_duel:
                     if event_data["response"] == "Accept":
                         world = self.client.current_state
-                        pd = local_session.player.__dict__
+                        pd = self.player.__dict__
                         event_data = {
                             "type": "CLIENT_INTERACTION",
                             "interaction": "START_DUEL",

--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -26,7 +26,7 @@ from tuxemon.platform.const import intentions
 from tuxemon.platform.events import PlayerInput
 from tuxemon.platform.tools import translate_input_event
 from tuxemon.player import Player
-from tuxemon.session import local_session
+from tuxemon.session import Session
 from tuxemon.state import State
 from tuxemon.states.world.world_transition import WorldTransition
 from tuxemon.teleporter import Teleporter
@@ -60,8 +60,9 @@ CollisionMap = Mapping[
 class WorldState(State):
     """The state responsible for the world game play"""
 
-    def __init__(self, map_name: str) -> None:
+    def __init__(self, session: Session, map_name: str) -> None:
         super().__init__()
+        self.session = session
         self.movement = MovementManager(self.client)
         self.teleporter = Teleporter(self.client, self)
         self.pathfinder = Pathfinder(self.client, self)
@@ -71,9 +72,9 @@ class WorldState(State):
 
         self.transition_manager = WorldTransition(self)
 
-        self.player = Player.create(local_session, self)
+        self.player = Player.create(self.session, self)
 
-        self.camera = Camera(local_session.player, self.client.boundary)
+        self.camera = Camera(self.player, self.client.boundary)
         self.client.camera_manager.add_camera(self.camera)
         self.map_renderer = MapRenderer(self.client)
 
@@ -486,17 +487,7 @@ class WorldState(State):
     ####################################################
     def change_map(self, map_name: str) -> None:
         """
-        Changes the current map and updates the player state.
-
-        Parameters:
-            map_name: The name of the map to load.
-        """
-        self.load_and_update_map(map_name)
-        self.update_player_state()
-
-    def load_and_update_map(self, map_name: str) -> None:
-        """
-        Loads a new map and updates the game state accordingly.
+        Changes the current map and updates the game state accordingly.
 
         This method loads the map data, updates the game state, and notifies
         the client and boundary checker. The currently loaded map is updated
@@ -517,19 +508,6 @@ class WorldState(State):
         map_size = self.client.map_manager.map_size
         self.client.boundary.update_boundaries(map_size)
 
-    def update_player_state(self) -> None:
-        """
-        Updates the player's state after changing maps.
-
-        Parameters:
-            player: The player object to update.
-        """
-        player = local_session.player
-        player.world = self
-        self.movement.stop_char(player)
-        self.player = player
-        self.client.npc_manager.add_npc(player)
-
     @no_type_check  # only used by multiplayer which is disabled
     def check_interactable_space(self) -> bool:
         """
@@ -539,7 +517,6 @@ class WorldState(State):
 
         Returns:
             ``True`` if there is an Npc to interact with. ``False`` otherwise.
-
         """
         collision_dict = self.get_collision_map()
         player_tile_pos = self.player.tile_pos
@@ -587,7 +564,6 @@ class WorldState(State):
 
         :type event_data: Dictionary
         :type registry: Dictionary
-
         """
         target = registry[event_data["target"]]["sprite"]
         target_name = str(target.name)

--- a/tuxemon/teleporter.py
+++ b/tuxemon/teleporter.py
@@ -166,6 +166,7 @@ class Teleporter:
         logger.debug(f"Finalizing teleportation for {character.slug}...")
         self.world.movement.unlock_controls(character)
         logger.info(f"{character.slug} has completed teleportation.")
+        self.client.npc_manager.add_npc(character)
 
     def _switch_map_if_needed(self, map_name: str) -> None:
         if (


### PR DESCRIPTION
PR refactors player instantiation logic to improve code maintainability and centralization of player creation within the `Player` class. It injects  `Session` in  `WorldState`.

Below are the key changes:  
- introduced a class method `create()` inside `Player`, ensuring that player instantiation happens only once per session
- if a player instance doesn’t exist in the session, `create()` initializes and assigns it
- this removes redundant manual player creation logic from `WorldState`
- updates `change_map`, some operations where already handled in `Teleporter` as well as in the newly created classmethod