### PR TITLE
Improved CLI Argument Parsing and Code Readability in the `__main__` script

### DIFF
--- a/tuxemon/__main__.py
+++ b/tuxemon/__main__.py
@@ -1,37 +1,37 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
-"""Starts the main.main() function which, in turn, initializes
-pygame and starts the game, unless headless is specified.
-"""
+"""Launches the game or headless server based on command-line arguments."""
 
-import getopt
 import sys
+from argparse import ArgumentParser, Namespace
+
+from tuxemon.main import headless, main
 
 
-def main(args=None):
-    server = False
-    opts, args = getopt.getopt(sys.argv[1:], "hs", ["help", "server"])
-    for opt, arg in opts:
-        if opt == "-h":
-            print(sys.argv[0], "[--server]")
-            print("  -h              Display this help message.")
-            print("  -s, --headless  Start a headless server.")
-            sys.exit()
-        elif opt in ("-s", "--server"):
-            server = True
+def parse_args() -> Namespace:
+    """Parse command-line arguments."""
+    parser = ArgumentParser(description="Start the game or headless server.")
+    parser.add_argument(
+        "-s",
+        "--headless",
+        action="store_true",
+        help="Run in headless mode (no graphical interface).",
+    )
+    return parser.parse_args()
 
-    if server:
-        from tuxemon.main import headless
 
-        headless()
-
-    else:
-        from tuxemon.main import main
-
-        main()
-
-    sys.exit()
+def run() -> None:
+    """Run the game or headless server based on parsed arguments."""
+    try:
+        args = parse_args()
+        if args.headless:
+            headless()
+        else:
+            main()
+    except Exception as e:
+        print(f"An error occurred: {e}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":
-    main()
+    run()


### PR DESCRIPTION
PR improves the handling of command-line arguments and enhances code readability in the `__main__` script. 

Changes made:
- replaced `getopt` with `argparse` for better error handling and usability
- encapsulated argument parsing into a separate function (`parse_args()`) to keep things clean
- renamed the entry point function to `run()` to avoid confusion with `tuxemon.main.main()`
- improved command descriptions to make CLI usage clearer