### PR TITLE
Refactor File Path Handling: Replace `os.path` with `pathlib.Path`

### DIFF
--- a/scripts/test_actions.py
+++ b/scripts/test_actions.py
@@ -1,7 +1,6 @@
 """
 Script to validate map actions
 """
-from pathlib import Path
 from unittest.mock import MagicMock
 
 from tuxemon.constants import paths
@@ -21,9 +20,7 @@ loader = TMXMapLoader()
 loader.image_loader = MagicMock()
 
 for mod_name in CONFIG.mods:
-    for path in (
-        Path().joinpath(paths.mods_folder, mod_name, "maps").glob("*.tmx")
-    ):
+    for path in (paths.mods_folder / mod_name / "maps").glob("*.tmx"):
         txmn_map = loader.load(str(path))
         for event in txmn_map.events:
             for act in event.acts:

--- a/tests/tuxemon/test_core_manager.py
+++ b/tests/tuxemon/test_core_manager.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from tuxemon.core.core_manager import (
@@ -15,8 +16,8 @@ from tuxemon.plugin import PluginObject
 
 class TestCoreManager(unittest.TestCase):
     def setUp(self):
-        self.temp_dir = tempfile.TemporaryDirectory()
-        self.path = self.temp_dir.name
+        self.temp_dir = Path(tempfile.mkdtemp())
+        self.path = self.temp_dir / "tuxemon"
         self.category = "category"
         self.plugin_interface = MagicMock(spec=PluginObject)
         self.manager = CoreManager(
@@ -24,7 +25,10 @@ class TestCoreManager(unittest.TestCase):
         )
 
     def tearDown(self):
-        self.temp_dir.cleanup()
+        for item in self.temp_dir.iterdir():
+            if item.is_dir():
+                item.rmdir()
+        self.temp_dir.rmdir()
 
     @patch("tuxemon.plugin.load_plugins")
     def test_load_plugins(self, mock_load_plugins):
@@ -77,15 +81,18 @@ class TestCoreManager(unittest.TestCase):
 class TestEffectManager(unittest.TestCase):
     def setUp(self):
         self.effect_class = MagicMock(spec=PluginObject)
-        self.temp_dir = tempfile.TemporaryDirectory()
-        self.path = self.temp_dir.name
+        self.temp_dir = Path(tempfile.mkdtemp())
+        self.path = self.temp_dir / "tuxemon"
         self.category = "effects"
         self.manager = EffectManager(
             self.effect_class, self.path, self.category
         )
 
     def tearDown(self):
-        self.temp_dir.cleanup()
+        for item in self.temp_dir.iterdir():
+            if item.is_dir():
+                item.rmdir()
+        self.temp_dir.rmdir()
 
     def test_parse_effects(self):
         effect_instance = MagicMock(spec=PluginObject)
@@ -100,15 +107,18 @@ class TestEffectManager(unittest.TestCase):
 class TestConditionManager(unittest.TestCase):
     def setUp(self):
         self.condition_class = MagicMock(spec=PluginObject)
-        self.temp_dir = tempfile.TemporaryDirectory()
-        self.path = self.temp_dir.name
+        self.temp_dir = Path(tempfile.mkdtemp())
+        self.path = self.temp_dir / "tuxemon"
         self.category = "conditions"
         self.manager = ConditionManager(
             self.condition_class, self.path, self.category
         )
 
     def tearDown(self):
-        self.temp_dir.cleanup()
+        for item in self.temp_dir.iterdir():
+            if item.is_dir():
+                item.rmdir()
+        self.temp_dir.rmdir()
 
     def test_parse_conditions(self):
         condition_instance = MagicMock(spec=PluginObject)

--- a/tests/tuxemon/test_event_loader_map.py
+++ b/tests/tuxemon/test_event_loader_map.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
-import os
 import unittest
+from pathlib import Path
 
 from tuxemon.map_loader import YAMLEventLoader, parse_yaml
 
@@ -10,8 +10,8 @@ class TestYAMLEventLoader(unittest.TestCase):
 
     def setUp(self):
         self.loader = YAMLEventLoader()
-        self.valid_yaml_path = os.path.join(
-            "tests/tuxemon", "test_event_loader_map.yaml"
+        self.valid_yaml_path = (
+            Path("tests/tuxemon") / "test_event_loader_map.yaml"
         )
 
     def test_parse_yaml_success(self):

--- a/tests/tuxemon/test_folder_maps_yaml.py
+++ b/tests/tuxemon/test_folder_maps_yaml.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
-import os
 import unittest
 from collections.abc import Generator
+from pathlib import Path
 from typing import Any
 
 import yaml
@@ -33,9 +33,10 @@ def expand_expected_scenarios() -> None:
 
 
 def get_yaml_files(folder_path: str) -> Generator[str, Any, None]:
-    for file in os.listdir(folder_path):
-        if file.endswith(".yaml"):
-            yield os.path.join(folder_path, file)
+    folder = Path(folder_path)
+    for file in folder.iterdir():
+        if file.suffix == ".yaml" and file.is_file():
+            yield file.as_posix()
 
 
 def load_yaml_files(folder_path: str) -> dict[str, dict]:
@@ -62,7 +63,7 @@ class TestYAMLFiles(unittest.TestCase):
                 self.assertLessEqual(
                     len(event_name),
                     MAX_LENGTH_NAME,
-                    f"Event name {event_name} exceeds {MAX_LENGTH_NAME} characters: {os.path.basename(path)}",
+                    f"Event name {event_name} exceeds {MAX_LENGTH_NAME} characters: {Path(path).name}",
                 )
 
     def test_yaml_event_labels(self):
@@ -72,7 +73,7 @@ class TestYAMLFiles(unittest.TestCase):
                     self.assertIn(
                         name,
                         YAML_ATTR,
-                        f"Event name {name} isn't among {YAML_ATTR}: {os.path.basename(path)}",
+                        f"Event name {name} isn't among {YAML_ATTR}: {Path(path).name}",
                     )
 
     def test_yaml_event_type(self):
@@ -81,7 +82,7 @@ class TestYAMLFiles(unittest.TestCase):
                 self.assertIn(
                     event_data["type"],
                     YAML_TYPES,
-                    f"Event type {event_data['type']} isn't among {YAML_TYPES}: {os.path.basename(path)}",
+                    f"Event type {event_data['type']} isn't among {YAML_TYPES}: {Path(path).name}",
                 )
 
     def test_yaml_event_x_coordinate(self):
@@ -91,7 +92,7 @@ class TestYAMLFiles(unittest.TestCase):
                     self.assertIsInstance(
                         event_data["x"],
                         int,
-                        f"Value of 'x' should be an integer: {os.path.basename(path)}",
+                        f"Value of 'x' should be an integer: {Path(path).name}",
                     )
 
     def test_yaml_event_y_coordinate(self):
@@ -101,7 +102,7 @@ class TestYAMLFiles(unittest.TestCase):
                     self.assertIsInstance(
                         event_data["y"],
                         int,
-                        f"Value of 'y' should be an integer: {os.path.basename(path)}",
+                        f"Value of 'y' should be an integer: {Path(path).name}",
                     )
 
     def test_yaml_event_width(self):
@@ -111,7 +112,7 @@ class TestYAMLFiles(unittest.TestCase):
                     self.assertIsInstance(
                         event_data["width"],
                         int,
-                        f"Value of 'width' should be an integer: {os.path.basename(path)}",
+                        f"Value of 'width' should be an integer: {Path(path).name}",
                     )
 
     def test_yaml_event_height(self):
@@ -121,7 +122,7 @@ class TestYAMLFiles(unittest.TestCase):
                     self.assertIsInstance(
                         event_data["height"],
                         int,
-                        f"Value of 'height' should be an integer: {os.path.basename(path)}",
+                        f"Value of 'height' should be an integer: {Path(path).name}",
                     )
 
     def test_actions_structure(self):
@@ -132,7 +133,7 @@ class TestYAMLFiles(unittest.TestCase):
                         self.assertIsInstance(
                             action,
                             str,
-                            f"Action in event should be a string: {os.path.basename(path)}",
+                            f"Action in event should be a string: {Path(path).name}",
                         )
 
     def test_actions_teleport(self):
@@ -146,7 +147,7 @@ class TestYAMLFiles(unittest.TestCase):
                                 prepare.fetch(FOLDER, params[0])
                             except OSError:
                                 self.fail(
-                                    f"Map '{params[0]}' does not exist in object {action} at {os.path.basename(path)}"
+                                    f"Map '{params[0]}' does not exist in object {action} at {Path(path).name}"
                                 )
 
     def test_conditions_structure(self):
@@ -157,7 +158,7 @@ class TestYAMLFiles(unittest.TestCase):
                         self.assertIsInstance(
                             condition,
                             str,
-                            f"Condition in event should be a string: {os.path.basename(path)}",
+                            f"Condition in event should be a string: {Path(path).name}",
                         )
 
     def test_conditions_operator(self):
@@ -167,5 +168,5 @@ class TestYAMLFiles(unittest.TestCase):
                     for condition in event_data["conditions"]:
                         self.assertTrue(
                             condition.lower().startswith(("is ", "not ")),
-                            f"Condition '{condition}' should start with 'is' or 'not': {os.path.basename(path)}",
+                            f"Condition '{condition}' should start with 'is' or 'not': {Path(path).name}",
                         )

--- a/tests/tuxemon/test_fusion.py
+++ b/tests/tuxemon/test_fusion.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
-import os
 import unittest
+from pathlib import Path
 
 from PIL import Image
 
@@ -23,8 +23,9 @@ class TestFusion(unittest.TestCase):
         self.body.tertiary_colors = [(0, 255, 0)]  # Green
 
     def tearDown(self):
-        if os.path.exists(self.image_path):
-            os.remove(self.image_path)
+        image_path = Path(self.image_path)
+        if image_path.exists():
+            image_path.unlink()
 
     def test_replace_color(self):
         result_image = replace_color(self.image, (255, 0, 0), (0, 0, 255))

--- a/tests/tuxemon/test_jsons_monster.py
+++ b/tests/tuxemon/test_jsons_monster.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import json
-import os
 import unittest
+from pathlib import Path
 from typing import Any
 
 from tuxemon import prepare
@@ -13,11 +13,10 @@ MAX_TXMN_ID: int = 393
 
 def process_json_data(directory: str) -> list[dict[str, Any]]:
     data_list = []
-    directory = f"{prepare.fetch('db')}/{directory}/"
-    for filename in os.listdir(directory):
-        if filename.endswith(".json"):
-            filepath = os.path.join(directory, filename)
-            with open(filepath, "r") as f:
+    directory_path = Path(prepare.fetch("db")) / directory
+    for file in directory_path.iterdir():
+        if file.suffix == ".json" and file.is_file():
+            with file.open("r") as f:
                 data_list.append(json.load(f))
     return data_list
 

--- a/tests/tuxemon/test_jsons_technique.py
+++ b/tests/tuxemon/test_jsons_technique.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import json
-import os
 import unittest
+from pathlib import Path
 from typing import Any
 
 from tuxemon import prepare
@@ -17,11 +17,10 @@ SIMPLE_HEAL_EFFECT = ("healing", "photogenesis")
 
 def process_json_data(directory: str) -> list[dict[str, Any]]:
     data_list = []
-    directory = f"{prepare.fetch('db')}/{directory}/"
-    for filename in os.listdir(directory):
-        if filename.endswith(".json"):
-            filepath = os.path.join(directory, filename)
-            with open(filepath, "r") as f:
+    directory_path = Path(prepare.fetch("db")) / directory
+    for file in directory_path.iterdir():
+        if file.suffix == ".json" and file.is_file():
+            with file.open("r") as f:
                 data_list.append(json.load(f))
     return data_list
 

--- a/tests/tuxemon/test_paths.py
+++ b/tests/tuxemon/test_paths.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import unittest
+from pathlib import Path
+
+from tuxemon.constants.paths import (
+    ACTIONS_PATH,
+    BASEDIR,
+    CACHE_DIR,
+    CONDITIONS_PATH,
+    CORE_CONDITION_PATH,
+    CORE_EFFECT_PATH,
+    L18N_MO_FILES,
+    LIBDIR,
+    USER_CONFIG_PATH,
+    USER_GAME_DATA_DIR,
+    USER_GAME_SAVE_DIR,
+    mods_folder,
+)
+
+
+class TestCorePaths(unittest.TestCase):
+
+    def test_libdir(self):
+        self.assertTrue(LIBDIR.exists())
+
+    def test_basedir(self):
+        self.assertTrue(BASEDIR.exists())
+
+    def test_mods_folder(self):
+        folder = LIBDIR.parent / "mods"
+        self.assertTrue(folder.exists())
+        self.assertEqual(folder, mods_folder)
+
+    def test_event_paths(self):
+        self.assertTrue(CONDITIONS_PATH.exists())
+        self.assertTrue(ACTIONS_PATH.exists())
+
+    def test_core_paths(self):
+        self.assertTrue(CORE_EFFECT_PATH.exists())
+        self.assertTrue(CORE_CONDITION_PATH.exists())
+
+    def test_user_config_path(self):
+        self.assertTrue(USER_CONFIG_PATH.parent.exists())
+
+    def test_user_game_data_dir(self):
+        self.assertTrue(USER_GAME_DATA_DIR.exists())
+
+    def test_user_game_save_dir(self):
+        self.assertTrue(USER_GAME_SAVE_DIR.exists())
+
+    def test_cache_dir(self):
+        self.assertTrue(CACHE_DIR.exists())
+
+    def test_l18n_mo_files(self):
+        self.assertTrue(L18N_MO_FILES.exists())

--- a/tests/tuxemon/test_sprite_renderer.py
+++ b/tests/tuxemon/test_sprite_renderer.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
-import os
+from pathlib import Path
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
@@ -116,26 +116,26 @@ class TestSpriteRenderer(TestCase):
         mock_load_and_scale.return_value = Surface((1, 1))
         self.sprite_controller.load_sprites(self.npc.template)
         expected_paths = [
-            os.path.join("sprites", "adventurer_front.png"),
-            os.path.join("sprites", "adventurer_back.png"),
-            os.path.join("sprites", "adventurer_left.png"),
-            os.path.join("sprites", "adventurer_right.png"),
-            os.path.join("sprites", "adventurer_front_walk.000.png"),
-            os.path.join("sprites", "adventurer_front.png"),
-            os.path.join("sprites", "adventurer_front_walk.001.png"),
-            os.path.join("sprites", "adventurer_front.png"),
-            os.path.join("sprites", "adventurer_back_walk.000.png"),
-            os.path.join("sprites", "adventurer_back.png"),
-            os.path.join("sprites", "adventurer_back_walk.001.png"),
-            os.path.join("sprites", "adventurer_back.png"),
-            os.path.join("sprites", "adventurer_left_walk.000.png"),
-            os.path.join("sprites", "adventurer_left.png"),
-            os.path.join("sprites", "adventurer_left_walk.001.png"),
-            os.path.join("sprites", "adventurer_left.png"),
-            os.path.join("sprites", "adventurer_right_walk.000.png"),
-            os.path.join("sprites", "adventurer_right.png"),
-            os.path.join("sprites", "adventurer_right_walk.001.png"),
-            os.path.join("sprites", "adventurer_right.png"),
+            Path("sprites") / "adventurer_front.png",
+            Path("sprites") / "adventurer_back.png",
+            Path("sprites") / "adventurer_left.png",
+            Path("sprites") / "adventurer_right.png",
+            Path("sprites") / "adventurer_front_walk.000.png",
+            Path("sprites") / "adventurer_front.png",
+            Path("sprites") / "adventurer_front_walk.001.png",
+            Path("sprites") / "adventurer_front.png",
+            Path("sprites") / "adventurer_back_walk.000.png",
+            Path("sprites") / "adventurer_back.png",
+            Path("sprites") / "adventurer_back_walk.001.png",
+            Path("sprites") / "adventurer_back.png",
+            Path("sprites") / "adventurer_left_walk.000.png",
+            Path("sprites") / "adventurer_left.png",
+            Path("sprites") / "adventurer_left_walk.001.png",
+            Path("sprites") / "adventurer_left.png",
+            Path("sprites") / "adventurer_right_walk.000.png",
+            Path("sprites") / "adventurer_right.png",
+            Path("sprites") / "adventurer_right_walk.001.png",
+            Path("sprites") / "adventurer_right.png",
         ]
         actual_paths = [
             call[0][0] for call in mock_load_and_scale.call_args_list

--- a/tuxemon/ai.py
+++ b/tuxemon/ai.py
@@ -6,6 +6,7 @@ import logging
 import random
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
 import yaml
@@ -113,9 +114,9 @@ class AITechniques:
     techniques: dict[str, SingleTechnique]
 
 
-def load_yaml(filepath: str) -> Any:
+def load_yaml(filepath: Path) -> Any:
     try:
-        with open(filepath) as file:
+        with filepath.open() as file:
             return yaml.safe_load(file)
     except FileNotFoundError:
         logger.error(f"Config file not found: {filepath}")
@@ -133,7 +134,7 @@ class AIConfigLoader:
 
     @classmethod
     def get_ai_opponent(cls, filename: str) -> AIOpponent:
-        yaml_path = f"{paths.mods_folder}/{filename}"
+        yaml_path = paths.mods_folder / filename
         if cls._ai_opponent is None:
             raw_map = load_yaml(yaml_path)
 
@@ -150,7 +151,7 @@ class AIConfigLoader:
 
     @classmethod
     def get_ai_items(cls, filename: str) -> AIItems:
-        yaml_path = f"{paths.mods_folder}/{filename}"
+        yaml_path = paths.mods_folder / filename
         if cls._ai_items is None:
             raw_map = load_yaml(yaml_path)
             cls._ai_items = AIItems(**raw_map)
@@ -158,7 +159,7 @@ class AIConfigLoader:
 
     @classmethod
     def get_ai_character(cls, filename: str) -> AITrainers:
-        yaml_path = f"{paths.mods_folder}/{filename}"
+        yaml_path = paths.mods_folder / filename
         if cls._ai_character is None:
             raw_map = load_yaml(yaml_path)
 
@@ -189,7 +190,7 @@ class AIConfigLoader:
 
     @classmethod
     def get_ai_techniques(cls, filename: str) -> AITechniques:
-        yaml_path = f"{paths.mods_folder}/{filename}"
+        yaml_path = paths.mods_folder / filename
         if cls._ai_techniques is None:
             raw_map = load_yaml(yaml_path)
 

--- a/tuxemon/audio.py
+++ b/tuxemon/audio.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-import os.path
+from pathlib import Path
 from typing import Optional, Protocol
 
 import pygame
@@ -164,11 +164,13 @@ class SoundManager:
         filename = db.lookup_file("sounds", slug)
         filename = transform_resource_filename("sounds", filename)
 
-        if not os.path.exists(filename):
+        path = Path(filename)
+
+        if not path.exists():
             logger.error(f"audio file does not exist: {filename}")
             return None
 
-        return filename
+        return path.as_posix()
 
     def load_sound(
         self, slug: str, value: float = prepare.CONFIG.sound_volume

--- a/tuxemon/cli/processor.py
+++ b/tuxemon/cli/processor.py
@@ -2,9 +2,9 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-import os
 import sys
 from collections.abc import Iterable, Sequence
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from prompt_toolkit import PromptSession
@@ -74,9 +74,9 @@ class CommandProcessor:
     def __init__(self, client: LocalPygameClient, prompt: str = "> ") -> None:
         self.prompt = prompt
         self.client = client
-        folder = os.path.join(os.path.dirname(__file__), "commands")
+        folder = Path(__file__).parent / "commands"
         # TODO: add folder(s) from mods
-        commands = list(self.collect_commands(folder))
+        commands = list(self.collect_commands(folder.as_posix()))
         self.root_command = MetaCommand(commands)
 
     def run(self) -> None:

--- a/tuxemon/client.py
+++ b/tuxemon/client.py
@@ -6,7 +6,7 @@ import logging
 import time
 from collections.abc import Mapping, Sequence
 from enum import Enum
-from os.path import basename
+from pathlib import Path
 from threading import Thread
 from typing import Any, Optional, TypeVar, Union, overload
 
@@ -260,9 +260,7 @@ class LocalPygameClient:
         map_path = self.map_manager.get_map_filepath()
         if map_path is None:
             raise ValueError("Name of the map requested when no map is active")
-
-        # extract map name from path
-        return basename(map_path)
+        return Path(map_path).name
 
     """
     The following methods provide an interface to the state stack

--- a/tuxemon/constants/paths.py
+++ b/tuxemon/constants/paths.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import logging
-import os
 import sys
+from pathlib import Path
 
-from tuxemon import platform
+from tuxemon.platform import get_system_storage_dirs, get_user_storage_dir
 
 logger = logging.getLogger(__name__)
 
@@ -18,69 +18,60 @@ PLUGIN_INCLUDE_PATTERNS = [
 # --- Core Game Paths ---
 
 # LIBDIR is where the tuxemon lib is
-LIBDIR = os.path.normpath(
-    os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-)
+LIBDIR = Path(__file__).resolve().parent.parent
 logger.debug(f"libdir: {LIBDIR}")
 
 # BASEDIR is where tuxemon was launched from
-BASEDIR = os.path.normpath(sys.path[0])
+BASEDIR = Path(sys.path[0]).resolve()
 logger.debug(f"basedir: {BASEDIR}")
 
 # mods
-mods_folder = os.path.normpath(os.path.join(LIBDIR, "..", "mods"))
+mods_folder = (LIBDIR.parent / "mods").resolve()
 logger.debug(f"mods: {mods_folder}")
 
 # mods subfolders
-mods_subfolders = [
-    f
-    for f in os.listdir(mods_folder)
-    if os.path.isdir(os.path.join(mods_folder, f))
-]
+mods_subfolders = [f.name for f in mods_folder.iterdir() if f.is_dir()]
 logger.debug(f"Mods subfolders: {mods_subfolders}")
 
 # action/condition plugins (eventually move out of lib folder)
-CONDITIONS_PATH = os.path.normpath(os.path.join(LIBDIR, "event/conditions"))
-ACTIONS_PATH = os.path.normpath(os.path.join(LIBDIR, "event/actions"))
+CONDITIONS_PATH = LIBDIR / "event" / "conditions"
+ACTIONS_PATH = LIBDIR / "event" / "actions"
 
-CORE_EFFECT_PATH = os.path.normpath(os.path.join(LIBDIR, "core/effects"))
-CORE_CONDITION_PATH = os.path.normpath(os.path.join(LIBDIR, "core/conditions"))
+CORE_EFFECT_PATH = LIBDIR / "core" / "effects"
+CORE_CONDITION_PATH = LIBDIR / "core" / "conditions"
 
 # --- User Data Paths ---
 
 # main game and config dir
-USER_STORAGE_DIR = (
-    platform.get_user_storage_dir()
-)  # Ensure this doesn't depend on pygame
+# Ensure this doesn't depend on pygame
+USER_STORAGE_DIR = get_user_storage_dir()
 logger.debug(f"userdir: {USER_STORAGE_DIR}")
 
 # config file paths
 CONFIG_FILE = "tuxemon.yaml"
-USER_CONFIG_PATH = os.path.normpath(
-    os.path.join(USER_STORAGE_DIR, CONFIG_FILE)
-)
+USER_CONFIG_PATH = USER_STORAGE_DIR / CONFIG_FILE
 logger.debug(f"user config: {USER_CONFIG_PATH}")
 
 # game data dir
-USER_GAME_DATA_DIR = os.path.normpath(os.path.join(USER_STORAGE_DIR, "data"))
+USER_GAME_DATA_DIR = USER_STORAGE_DIR / "data"
 logger.debug(f"user game data: {USER_GAME_DATA_DIR}")
 
 # game savegame dir
-USER_GAME_SAVE_DIR = os.path.normpath(os.path.join(USER_STORAGE_DIR, "saves"))
+USER_GAME_SAVE_DIR = USER_STORAGE_DIR / "saves"
 logger.debug(f"save games: {USER_GAME_SAVE_DIR}")
 
 # game cache dir
-CACHE_DIR = os.path.normpath(os.path.join(USER_STORAGE_DIR, "cache"))
+CACHE_DIR = USER_STORAGE_DIR / "cache"
 logger.debug(f"cache: {CACHE_DIR}")
 
 # game lang dir
-L18N_MO_FILES = os.path.normpath(os.path.join(CACHE_DIR, "l18n"))
+L18N_MO_FILES = CACHE_DIR / "l18n"
 logger.debug(f"l18: {L18N_MO_FILES}")
 
 # --- System Paths ---
 
 # shared locations
 system_installed_folders = [
-    os.path.normpath(path) for path in platform.get_system_storage_dirs()
+    path.resolve() for path in get_system_storage_dirs()
 ]
 logger.debug(f"system folders: {system_installed_folders}")

--- a/tuxemon/core/effects/fishing.py
+++ b/tuxemon/core/effects/fishing.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import random
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Union
 
 import yaml
@@ -47,9 +48,9 @@ class FishingConfig:
             raise ValueError("Lower bound cannot be greater than upper bound.")
 
 
-def load_yaml(filepath: str) -> Any:
+def load_yaml(filepath: Path) -> Any:
     try:
-        with open(filepath) as file:
+        with filepath.open() as file:
             return yaml.safe_load(file)
     except FileNotFoundError:
         logger.error(f"Config file not found: {filepath}")
@@ -64,7 +65,7 @@ class Loader:
 
     @classmethod
     def get_config_fishing(cls, filename: str) -> dict[str, FishingConfig]:
-        yaml_path = f"{paths.mods_folder}/{filename}"
+        yaml_path = paths.mods_folder / filename
         if not cls._config_fishing:
             raw_map = load_yaml(yaml_path)
             cls._config_fishing = {

--- a/tuxemon/event/actions/celestial_cycles.py
+++ b/tuxemon/event/actions/celestial_cycles.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, final
 
 import yaml
@@ -24,9 +25,9 @@ class CelestialCycle:
     phase_data: list[tuple[int, str]]
 
 
-def load_yaml(filepath: str) -> Any:
+def load_yaml(filepath: Path) -> Any:
     try:
-        with open(filepath) as file:
+        with filepath.open() as file:
             return yaml.safe_load(file)
     except FileNotFoundError:
         logger.error(f"Config file not found: {filepath}")
@@ -41,7 +42,7 @@ class Loader:
 
     @classmethod
     def get_config_celestial_cycle(cls, filename: str) -> list[CelestialCycle]:
-        yaml_path = f"{paths.mods_folder}/{filename}"
+        yaml_path = paths.mods_folder / filename
         if not cls._config_celestial_cycle:
             raw_data = load_yaml(yaml_path)
             cls._config_celestial_cycle = [

--- a/tuxemon/event/actions/load_yaml.py
+++ b/tuxemon/event/actions/load_yaml.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import logging
-import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import final
 
 from tuxemon import prepare
@@ -37,14 +37,18 @@ class LoadYamlAction(EventAction):
 
     def start(self, session: Session) -> None:
         client = session.client
-        yaml_path = prepare.fetch("maps", f"{self.file}.yaml")
+        yaml_path = Path(prepare.fetch("maps", f"{self.file}.yaml"))
 
         _events = list(client.map_manager.events)
         _inits = list(client.map_manager.inits)
-        if os.path.exists(yaml_path):
-            yaml_events = YAMLEventLoader().load_events(yaml_path, "event")
+        if yaml_path.exists():
+            yaml_events = YAMLEventLoader().load_events(
+                yaml_path.as_posix(), "event"
+            )
             _events.extend(yaml_events["event"])
-            yaml_inits = YAMLEventLoader().load_events(yaml_path, "init")
+            yaml_inits = YAMLEventLoader().load_events(
+                yaml_path.as_posix(), "init"
+            )
             _inits.extend(yaml_inits["init"])
         else:
             raise ValueError(f"{yaml_path} doesn't exist")

--- a/tuxemon/event/eventaction.py
+++ b/tuxemon/event/eventaction.py
@@ -264,7 +264,7 @@ class EventAction(ABC):
 class ActionManager:
     def __init__(self) -> None:
         self.actions = load_plugins(
-            ACTIONS_PATH,
+            ACTIONS_PATH.as_posix(),
             "actions",
             interface=EventAction,  # type: ignore[type-abstract]
         )

--- a/tuxemon/event/eventcondition.py
+++ b/tuxemon/event/eventcondition.py
@@ -39,7 +39,7 @@ class EventCondition:
 class ConditionManager:
     def __init__(self) -> None:
         self.conditions = load_plugins(
-            CONDITIONS_PATH,
+            CONDITIONS_PATH.as_posix(),
             "conditions",
             interface=EventCondition,
         )

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -7,6 +7,7 @@ import math
 import random
 from collections.abc import Sequence
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 import yaml
@@ -114,9 +115,9 @@ class CombatConfig:
                 )
 
 
-def load_yaml(filepath: str) -> Any:
+def load_yaml(filepath: Path) -> Any:
     try:
-        with open(filepath) as file:
+        with filepath.open() as file:
             return yaml.safe_load(file)
     except FileNotFoundError:
         logger.error(f"Config file not found: {filepath}")
@@ -135,7 +136,7 @@ class Loader:
 
     @classmethod
     def get_capture_devices(cls, filename: str) -> CaptureDevicesConfig:
-        yaml_path = f"{paths.mods_folder}/{filename}"
+        yaml_path = paths.mods_folder / filename
         if cls._capture_devices is None:
             raw_map = load_yaml(yaml_path)
             items = {}
@@ -177,7 +178,7 @@ class Loader:
 
     @classmethod
     def get_config_combat(cls, filename: str) -> CombatConfig:
-        yaml_path = f"{paths.mods_folder}/{filename}"
+        yaml_path = paths.mods_folder / filename
         if cls._config_combat is None:
             raw_map = load_yaml(yaml_path)
             cls._config_combat = CombatConfig(**raw_map)
@@ -185,7 +186,7 @@ class Loader:
 
     @classmethod
     def get_config_monster(cls, filename: str) -> MonsterConfig:
-        yaml_path = f"{paths.mods_folder}/{filename}"
+        yaml_path = paths.mods_folder / filename
         if cls._config_monster is None:
             raw_map = load_yaml(yaml_path)
             cls._config_monster = MonsterConfig(**raw_map)
@@ -193,7 +194,7 @@ class Loader:
 
     @classmethod
     def get_config_capture(cls, filename: str) -> CaptureConfig:
-        yaml_path = f"{paths.mods_folder}/{filename}"
+        yaml_path = paths.mods_folder / filename
         if cls._config_capture is None:
             raw_map = load_yaml(yaml_path)
             cls._config_capture = CaptureConfig(**raw_map)
@@ -201,7 +202,7 @@ class Loader:
 
     @classmethod
     def get_range_map(cls, filename: str) -> dict[str, RangeMapEntry]:
-        yaml_path = f"{paths.mods_folder}/{filename}"
+        yaml_path = paths.mods_folder / filename
         if not cls._range_map:
             raw_map = load_yaml(yaml_path)
             cls._range_map = {

--- a/tuxemon/graphics.py
+++ b/tuxemon/graphics.py
@@ -9,9 +9,9 @@ have a home in any specific place.
 from __future__ import annotations
 
 import logging
-import os
 import re
 from collections.abc import Iterable, Sequence
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Protocol, Union
 
 from pygame.color import Color
@@ -201,11 +201,12 @@ def load_animated_sprite(
     """
     anim = []
     for filename in filenames:
-        if os.path.exists(filename):
-            image = load_and_scale(filename, scale)
+        path = Path(filename)
+        if path.exists():
+            image = load_and_scale(path.as_posix(), scale)
             anim.append((image, delay))
         else:
-            logger.error(f"File not found: {filename}")
+            logger.error(f"File not found: {path}")
 
     if not anim:
         raise ValueError("Cannot create animated sprite: no valid frames.")
@@ -259,11 +260,14 @@ def animation_frame_files(directory: str, name: str) -> Sequence[str]:
 
     """
     pattern = re.compile(rf"{name}\.?_?[0-9]+\.png")
-    frames = [
-        os.path.join(directory, filename)
-        for filename in sorted(os.listdir(directory))
-        if pattern.match(filename)
-    ]
+    dir_path = Path(directory)
+    frames = sorted(
+        [
+            file.as_posix()
+            for file in dir_path.iterdir()
+            if file.is_file() and pattern.match(file.name)
+        ]
+    )
     return frames
 
 

--- a/tuxemon/headless_client.py
+++ b/tuxemon/headless_client.py
@@ -6,7 +6,7 @@ import logging
 import time
 from collections.abc import Mapping, Sequence
 from enum import Enum
-from os.path import basename
+from pathlib import Path
 from typing import Any, Optional, TypeVar, Union, overload
 
 from tuxemon.audio import MusicPlayerState, SoundManager
@@ -195,9 +195,7 @@ class HeadlessClient:
         map_path = self.map_manager.get_map_filepath()
         if map_path is None:
             raise ValueError("Name of the map requested when no map is active")
-
-        # extract map name from path
-        return basename(map_path)
+        return Path(map_path).name
 
     """
     The following methods provide an interface to the state stack

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -66,11 +66,11 @@ class Item:
 
         if Item.effect_manager is None:
             Item.effect_manager = EffectManager(
-                ItemEffect, paths.CORE_EFFECT_PATH
+                ItemEffect, paths.CORE_EFFECT_PATH.as_posix()
             )
         if Item.condition_manager is None:
             Item.condition_manager = ConditionManager(
-                CoreCondition, paths.CORE_CONDITION_PATH
+                CoreCondition, paths.CORE_CONDITION_PATH.as_posix()
             )
 
         self.effects: Sequence[PluginObject] = []

--- a/tuxemon/log.py
+++ b/tuxemon/log.py
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import logging
-import os
 import subprocess
 import sys
 import time
 import warnings
 from operator import itemgetter
+from pathlib import Path
 
 from tuxemon import prepare
 from tuxemon.constants import paths
@@ -66,14 +66,13 @@ def configure() -> None:
             logger.addHandler(log_strm)
 
             if config.log_to_file:
-                log_dir = os.path.realpath(f"{paths.USER_STORAGE_DIR}/logs")
-                os.makedirs(
-                    log_dir, exist_ok=True
-                )  # creates the directory if it does not exists.
+                log_dir = paths.USER_STORAGE_DIR / "logs"
+                log_dir.mkdir(parents=True, exist_ok=True)
+
                 if config.log_keep_max > 0:
                     log_dir_files = {
                         entry.name: entry.stat().st_mtime
-                        for entry in os.scandir(log_dir)
+                        for entry in log_dir.iterdir()
                         if entry.is_file()
                     }
                     sorted_files = sorted(
@@ -82,19 +81,17 @@ def configure() -> None:
 
                     if len(sorted_files) > config.log_keep_max:
                         for x in range(config.log_keep_max, len(sorted_files)):
-                            filename = sorted_files[x][0]
-                            file_path = os.path.join(log_dir, filename)
-                            os.remove(file_path)
+                            Path(log_dir / sorted_files[x][0]).unlink()
 
-                    formatted_time = time.strftime(
-                        "%Y-%m-%d_%Hh%Mm%Ss", time.localtime()
-                    )
-                    log_file = logging.FileHandler(
-                        os.path.join(log_dir, f"{formatted_time}.log")
-                    )
-                    log_file.setFormatter(log_formatter)
-                    log_file.setLevel(log_level)
-                    logger.addHandler(log_file)
+                formatted_time = time.strftime(
+                    "%Y-%m-%d_%Hh%Mm%Ss", time.localtime()
+                )
+                log_file = logging.FileHandler(
+                    log_dir / f"{formatted_time}.log"
+                )
+                log_file.setFormatter(log_formatter)
+                log_file.setLevel(log_level)
+                logger.addHandler(log_file)
 
             loggers[logger_name] = logger
 

--- a/tuxemon/map_manager.py
+++ b/tuxemon/map_manager.py
@@ -23,9 +23,9 @@ class MapType:
 
 
 def load_map_types(filename: str) -> list[MapType]:
-    yaml_path = f"{paths.mods_folder}/{filename}"
     """Loads map types from a YAML file and returns a list of MapType instances."""
-    with open(yaml_path, encoding="utf-8") as file:
+    yaml_path = paths.mods_folder / filename
+    with yaml_path.open(encoding="utf-8") as file:
         data = yaml.safe_load(file)
         return [MapType(**entry) for entry in data.get("map_types", [])]
 

--- a/tuxemon/map_view.py
+++ b/tuxemon/map_view.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import logging
-import os
 from dataclasses import dataclass
 from enum import Enum
 from itertools import chain
+from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 import pygame
@@ -195,11 +195,13 @@ class SpriteRenderer:
                     if is_interactive_object
                     else f"{template.sprite_name}_{facing.value}.png"
                 )
-                path = os.path.join(
-                    "sprites_obj" if is_interactive_object else "sprites",
-                    filename,
+                path = (
+                    Path("sprites_obj" if is_interactive_object else "sprites")
+                    / filename
                 )
-                sprite_dict[facing] = load_and_scale_with_cache(path)
+                sprite_dict[facing] = load_and_scale_with_cache(
+                    path.as_posix()
+                )
             standing_sprite_cache[template.sprite_name] = sprite_dict
         else:
             logger.info(

--- a/tuxemon/menu/input.py
+++ b/tuxemon/menu/input.py
@@ -22,8 +22,8 @@ from tuxemon.ui.text import TextArea
 
 
 def load_names(file_path: str) -> Any:
-    yaml_path = f"{paths.mods_folder}/{file_path}"
-    with open(yaml_path) as file:
+    yaml_path = paths.mods_folder / file_path
+    with yaml_path.open() as file:
         return yaml.safe_load(file)
 
 

--- a/tuxemon/mod_manager/tuxemoncontentserver.py
+++ b/tuxemon/mod_manager/tuxemoncontentserver.py
@@ -6,7 +6,6 @@ https://github.com/vXtreniusX/TuxemonContentServer
 """
 
 import json
-import os
 import urllib.request
 from typing import Any
 
@@ -46,9 +45,8 @@ def download_package(
         release = str(release).replace(char, "_")
 
     url = str(repo) + f"/packages/{name}/releases/{str(release)}/download"
-    filename = os.path.join(
-        paths.CACHE_DIR,
-        f"downloaded_packages/{name}.{release}.zip",
+    filename = (
+        paths.CACHE_DIR / "downloaded_packages" / f"{name}.{release}.zip"
     )
 
     # Apparently this function is ported from urllib from python2.
@@ -56,13 +54,13 @@ def download_package(
     # https://docs.python.org/3/library/urllib.request.html#urllib.request.urlretrieve
     urllib.request.urlretrieve(url, filename=filename)
 
-    outfolder = os.path.join(paths.BASEDIR, "mods", f"{name}")
+    outfolder = paths.BASEDIR / "mods" / name
 
     self.write_package_to_list(outfolder, name)
 
     if not dont_extract:
         self.extract(filename, outfolder)
-        with open(f"{outfolder}/meta.json", "w") as metafile:
+        with (outfolder / "meta.json").open("w") as metafile:
             meta = self.get_package_info(name, repo)
             metafile.write(json.dumps(meta, indent=4, sort_keys=False))
 
@@ -118,8 +116,8 @@ def install_dependencies(
         )
 
         # Symlink deps
-        mainfolder = os.path.join(paths.BASEDIR, "mods", name)
-        depfolder = os.path.join(paths.BASEDIR, "mods", pack)
-        symlink_missing(mainfolder, depfolder)
+        mainfolder = paths.BASEDIR / "mods" / name
+        depfolder = paths.BASEDIR / "mods" / pack
+        symlink_missing(mainfolder.as_posix(), depfolder)
     else:
         pass

--- a/tuxemon/rumble/__init__.py
+++ b/tuxemon/rumble/__init__.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import logging
 import os
-from ctypes import CDLL, LibraryLoader
 from typing import Optional, Union
 
 from tuxemon.rumble.tools import Rumble, find_library

--- a/tuxemon/save.py
+++ b/tuxemon/save.py
@@ -94,7 +94,7 @@ def _get_save_extension() -> str:
 
 def get_save_path(slot: int) -> str:
     extension = _get_save_extension()
-    return f"{prepare.SAVE_PATH}{slot}.{extension}"
+    return f"{prepare.SAVE_PATH.as_posix()}{slot}.{extension}"
 
 
 def json_action(

--- a/tuxemon/state.py
+++ b/tuxemon/state.py
@@ -359,7 +359,7 @@ class StateManager:
 
         TODO: this functionality duplicates the plugin code.
         """
-        state_folder = Path(paths.LIBDIR) / Path(*self.package.split(".")[1:])
+        state_folder = paths.LIBDIR / Path(*self.package.split(".")[1:])
         exclude_endings = {".py", ".pyc", ".pyo"}
         exclude_names = {"__pycache__"}
 

--- a/tuxemon/states/persistance/save_menu.py
+++ b/tuxemon/states/persistance/save_menu.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import logging
-import os
 from base64 import b64decode
+from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 from pygame import SRCALPHA
@@ -44,8 +44,9 @@ class SaveMenuState(PopUpMenu[None]):
     def create_menu_item(
         self, slot_rect: Rect, slot_index: int, selectable: bool = True
     ) -> MenuItem[None]:
-        save_path = get_save_path(slot_index)
-        if os.path.exists(save_path):
+        save_path = Path(get_save_path(slot_index))
+
+        if save_path.exists():
             image = self.render_slot(slot_rect, slot_index)
             return MenuItem(image, T.translate("menu_save"), None, None, True)
         else:
@@ -197,10 +198,11 @@ def delete_save_slot(slot_num: int) -> bool:
     Returns:
         bool: True if the save file was deleted successfully, False otherwise.
     """
-    save_path = get_save_path(slot_num)
-    if os.path.exists(save_path):
+    save_path = Path(get_save_path(slot_num))
+
+    if save_path.exists():
         try:
-            os.remove(save_path)
+            save_path.unlink()
             logger.info(
                 f"Save slot {slot_num} deleted successfully at path {save_path}."
             )

--- a/tuxemon/states/phone/phone_map.py
+++ b/tuxemon/states/phone/phone_map.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
 import pygame_menu
@@ -30,9 +31,9 @@ class NuPhoneMapConfig:
     map_data: list[tuple[float, float, str]]
 
 
-def load_yaml(filepath: str) -> Any:
+def load_yaml(filepath: Path) -> Any:
     try:
-        with open(filepath) as file:
+        with filepath.open() as file:
             return yaml.safe_load(file)
     except FileNotFoundError:
         logger.error(f"Config file not found: {filepath}")
@@ -47,7 +48,7 @@ class Loader:
 
     @classmethod
     def get_config_nuphone_map(cls, filename: str) -> NuPhoneMapConfig:
-        yaml_path = f"{paths.mods_folder}/{filename}"
+        yaml_path = paths.mods_folder / filename
         if not cls._config_nuphone_map:
             raw_data = load_yaml(yaml_path)
             if not isinstance(raw_data, dict):

--- a/tuxemon/status/status.py
+++ b/tuxemon/status/status.py
@@ -76,11 +76,11 @@ class Status:
 
         if Status.effect_manager is None:
             Status.effect_manager = EffectManager(
-                StatusEffect, paths.CORE_EFFECT_PATH
+                StatusEffect, paths.CORE_EFFECT_PATH.as_posix()
             )
         if Status.condition_manager is None:
             Status.condition_manager = ConditionManager(
-                CoreCondition, paths.CORE_CONDITION_PATH
+                CoreCondition, paths.CORE_CONDITION_PATH.as_posix()
             )
 
         self.effects: Sequence[PluginObject] = []

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -72,11 +72,11 @@ class Technique:
 
         if Technique.effect_manager is None:
             Technique.effect_manager = EffectManager(
-                TechEffect, paths.CORE_EFFECT_PATH
+                TechEffect, paths.CORE_EFFECT_PATH.as_posix()
             )
         if Technique.condition_manager is None:
             Technique.condition_manager = ConditionManager(
-                CoreCondition, paths.CORE_CONDITION_PATH
+                CoreCondition, paths.CORE_CONDITION_PATH.as_posix()
             )
 
         self.effects: Sequence[PluginObject] = []


### PR DESCRIPTION
PR refactors multiple files by replacing `os.path` functions such as `os.path.join`, `os.path.basename`, and `os.path.exists`, etc. with `pathlib.Path`.

Key changes:
- replaced `os.path.join()` with `Path() / "filename"`
- used `.name` instead of `os.path.basename()` for cleaner path extraction
- switched from `os.path.exists()` to `Path.exists()` for improved clarity
- updated `os.remove()` calls to `Path.unlink()` for better deletion handling
- refactored loops using `Path.iterdir()` instead of `os.listdir()`

this is going to fix #1229 (probably), because:
- `LIBDIR.parent / "mods"` correctly moves up one level from `lib/tuxemon` to the parent directory (`exe.win-amd64-3.12`), then joins `"mods"` to it
- ensures that `mods` is a sibling of `lib`, not mistakenly placed inside it
- using `pathlib` ensures compatibility across different OS without requiring `os.path.join` or normalization