### PR TITLE
Improve YAML Extraction Scripts

### DIFF
--- a/scripts/yamlify_map_collision_script.py
+++ b/scripts/yamlify_map_collision_script.py
@@ -25,29 +25,34 @@ USAGE
 
 python yamlify_map_collision_script.py FILE0 FILE1 FILE2 ...
 """
+
 import logging
-import os
 import xml.etree.ElementTree as ET
+from pathlib import Path
+
 import yaml
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__file__)
 
-def process_collisions(tmx_filename: str):
+
+def process_collisions(tmx_filename: Path):
     """
     Extract collision objects from a TMX file and export them to a YAML file.
-    
+
     Parameters:
         tmx_filename: The path to the TMX file.
     """
     tree = ET.parse(tmx_filename)
     root = tree.getroot()
 
-    yaml_filename = os.path.splitext(tmx_filename)[0] + ".yaml"
+    yaml_filename = tmx_filename.with_suffix(".yaml")
 
-    if os.path.exists(yaml_filename):
+    if yaml_filename.exists():
         logger.error(f"YAML file already exists: {yaml_filename}")
-        yaml_filename = os.path.splitext(tmx_filename)[0] + "_copy.yaml"
+        yaml_filename = tmx_filename.with_name(
+            f"{tmx_filename.stem}_copy.yaml"
+        )
         logger.error(f"Creating a copy: {yaml_filename}")
 
     yaml_doc = {"collisions": []}
@@ -55,41 +60,48 @@ def process_collisions(tmx_filename: str):
     for object_group in root.findall(".//objectgroup[@name='Collisions']"):
         for obj in object_group.findall("object"):
             collision_data = {
-                "x": int(float(obj.get("x", 0))) // 16,  # Dividing by tile size
+                "x": int(float(obj.get("x", 0)))
+                // 16,  # Dividing by tile size
                 "y": int(float(obj.get("y", 0))) // 16,
                 "width": int(float(obj.get("width", 0))) // 16,
                 "height": int(float(obj.get("height", 0))) // 16,
-                "type": obj.get("type", "collision")
+                "type": obj.get("type", "collision"),
             }
             yaml_doc["collisions"].append(collision_data)
 
-    with open(yaml_filename, "w") as yaml_file:
+    with yaml_filename.open("w") as yaml_file:
         yaml.dump(
             yaml_doc,
             yaml_file,
             Dumper=yaml.SafeDumper,
             default_flow_style=False,
-            sort_keys=False
+            sort_keys=False,
         )
 
     logger.info(f"Collision data exported to {yaml_filename}")
 
-def process_tmx_files(file_list):
+
+def process_tmx_files(file_list: list[Path]) -> None:
     """
     Process multiple TMX files and extract collision data.
     """
     for tmx_file in file_list:
-        logger.info(f"Processing TMX file: {tmx_file}")
-        if not os.path.exists(tmx_file):
-            logger.error(f"File not found: {tmx_file}")
+        path_obj = Path(tmx_file)
+        logger.info(f"Processing TMX file: {path_obj}")
+
+        if not path_obj.exists():
+            logger.error(f"File not found: {path_obj}")
             continue
-        process_collisions(tmx_file)
+
+        process_collisions(path_obj)
+
 
 if __name__ == "__main__":
     import sys
+
     if len(sys.argv) < 2:
         print("USAGE: python yamlify_map_collision_script.py FILE0 FILE1 ...")
         sys.exit(1)
 
-    file_list = sys.argv[1:]
+    file_list = [Path(file) for file in sys.argv[1:]]
     process_tmx_files(file_list)


### PR DESCRIPTION
PR improves the two Python scripts that extract collision and event data from TMX files and convert them into YAML format. The key enhancements include replacing outdated file handling methods with `pathlib.Path`, removing unnecessary dependencies, and fixing potential future issues.

Key changes:
- replaced `os.path` methods with `Path` for cleaner and more efficient path management
- used `.with_suffix(".yaml")` instead of manual string manipulation for YAML file names
- eliminated `click` for argument parsing, simplifying the script by using `sys.argv` 
- changed `if properties:` to `if properties is not None:` to prevent future errors in Python versions
- the script no longer attempts to execute the `Tiled` export command, avoiding missing file errors