### PR TITLE
Improve `string_to_colorlike` method and refine unused image option in `ColorState`

### DIFF
--- a/tuxemon/event/actions/change_bg.py
+++ b/tuxemon/event/actions/change_bg.py
@@ -29,11 +29,8 @@ CATEGORY_PATHS: dict[str, str] = {
 @dataclass
 class ChangeBgAction(EventAction):
     """
-    Change the background.
-
-    Eg:
-    act1 change_bg background
-    act2 change_bg
+    Handles the background change within the session, allowing users
+    to apply a new background color or image dynamically.
 
     Script usage:
         .. code-block::
@@ -41,23 +38,20 @@ class ChangeBgAction(EventAction):
             change_bg <background>[,image][,category]
 
     Script parameters:
-        background:
-        - it can be the name of the file (see below note)
-        - it can be a RGB color separated by ":" (eg 255:0:0)
+        background: The background identifier, which can be:
+            - A file name located in `gfx/ui/background/`
+            - An RGB color formatted as `R:G:B` (e.g., `255:0:0`)
+        image: An optional image identifier, which can be:
+            - A monster slug (stored in `gfx/sprites/battle`)
+            - A template slug (stored in `gfx/sprites/player`)
+            - An item slug (stored in `gfx/items`)
+            - A direct file path
+        category: The category of the image (e.g., monster, template,
+            item, image). If omitted, defaults to "background".
 
-        image: monster_slug or template_slug or path
-            if path, then "gfx/ui/background/"
-            if template (eg. ceo) in "gfx/sprites/player"
-            "change_bg gradient_blue,ceo"
-
-        category: (optional) category of the image (e.g. monster, template, etc.)
-            if not provided, it will default to "background"
-
-        note: the background or image (if not monster or template)
-            must be inside the folder (gfx/ui/background/)
-
-        background size: 240x160
-
+    Notes:
+        - Background images must be in `gfx/ui/background/`.
+        - Background dimensions must be 240x160 pixels.
     """
 
     name = "change_bg"

--- a/tuxemon/graphics.py
+++ b/tuxemon/graphics.py
@@ -460,16 +460,15 @@ def string_to_colorlike(color: str) -> ColorLike:
 
     Returns:
         The ColorLike.
-
     """
-    rgb: ColorLike = prepare.BLACK_COLOR
-    part = color.split(":")
-    rgb = (
-        (int(part[0]), int(part[1]), int(part[2]), int(part[3]))
-        if len(part) == 4
-        else (int(part[0]), int(part[1]), int(part[2]))
-    )
-    return rgb
+    part = list(map(int, color.split(":")))
+
+    if len(part) == 3:
+        return (part[0], part[1], part[2])
+    elif len(part) == 4:
+        return (part[0], part[1], part[2], part[3])
+
+    raise ValueError("Invalid color format. Expected 'R:G:B' or 'R:G:B:A'")
 
 
 def apply_cinema_bars(

--- a/tuxemon/states/idle/color_state.py
+++ b/tuxemon/states/idle/color_state.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import Optional
 
-from pygame_menu.locals import ALIGN_CENTER
-
 from tuxemon import prepare
 from tuxemon.graphics import string_to_colorlike
 from tuxemon.menu.menu import PygameMenuState
@@ -15,31 +13,19 @@ from tuxemon.platform.events import PlayerInput
 
 class ColorState(PygameMenuState):
     """
-    It imposes a specific color over the world, where
-    it'll be possible to dispay dialogues, etc.
+    A state that overlays a solid color over the game world, allowing for
+    dialogues, menus, or other UI elements to be displayed.
     """
 
     def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
         return None
 
-    def __init__(self, color: str, image: Optional[str] = None) -> None:
+    def __init__(self, color: str) -> None:
         width, height = prepare.SCREEN_SIZE
         _color = string_to_colorlike(color)
         theme = get_theme()
-        theme.background_color = _color
+        if isinstance(_color, tuple) and len(_color) in (3, 4):
+            theme.background_color = _color
+        else:
+            raise ValueError("Invalid color format for background_color")
         super().__init__(height=height, width=width)
-        native = prepare.NATIVE_RESOLUTION
-
-        if image:
-            new_image = self._create_image(image)
-            image_size = new_image.get_size()
-            if image_size[0] > native[0] or image_size[1] > native[1]:
-                raise ValueError(
-                    f"{image} {image_size}: "
-                    f"It must be less than the native resolution {native}"
-                )
-            new_image.scale(prepare.SCALE, prepare.SCALE)
-            self.menu.add.image(
-                new_image,
-                align=ALIGN_CENTER,
-            )

--- a/tuxemon/states/idle/image_state.py
+++ b/tuxemon/states/idle/image_state.py
@@ -13,8 +13,8 @@ from tuxemon.platform.events import PlayerInput
 
 class ImageState(PygameMenuState):
     """
-    It imposes an image over the world, where it'll be possible to
-    dispay dialogues, etc.
+    A state that overlays an image over the game world, useful for displaying
+    dialogues, menus, or other UI elements.
     """
 
     def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:


### PR DESCRIPTION
split out from #2802 

PR enhances the `string_to_colorlike` method in `graphics.py` and refines the `ColorState` state. Previously, `ColorState` included an image option that was never utilized, as a different state was responsible for handling it.