### PR TITLE
Improve `VSync` Handling & FPS Display + `TuxemonConfig` Loading with Safer Merging

### DIFF
--- a/tuxemon/client.py
+++ b/tuxemon/client.py
@@ -71,9 +71,6 @@ class LocalPygameClient:
         self.state_manager.auto_state_discovery()
         self.screen = screen
         self.state = ClientState.RUNNING
-        self.caption = config.window_caption
-        self.fps = config.fps
-        self.show_fps = config.show_fps
         self.current_time = 0.0
 
         # setup controls
@@ -91,7 +88,7 @@ class LocalPygameClient:
         self.renderer = Renderer(
             self.screen,
             self.state_drawer,
-            config.window_caption,
+            self.config,
         )
 
         # Set up our networking for multiplayer.
@@ -163,7 +160,7 @@ class LocalPygameClient:
         screen = self.screen
         flip = pygame.display.update
         clock = time.time
-        frame_length = 1.0 / self.fps
+        frame_length = 1.0 / self.config.fps
         time_since_draw = 0.0
         last_update = clock()
 

--- a/tuxemon/config.py
+++ b/tuxemon/config.py
@@ -27,11 +27,17 @@ class TuxemonConfig:
         self.config = generate_default_config()
         self.config_path = config_path
 
-        # Load customized configuration if the yaml file exists
+        # Load customized configuration if the YAML file exists
         if config_path:
             try:
                 with open(config_path) as yaml_file:
-                    self.config.update(yaml.safe_load(yaml_file))
+                    loaded_config = yaml.safe_load(yaml_file)
+
+                    # Merge only existing sections while keeping defaults
+                    for category, defaults in self.config.items():
+                        if category in loaded_config:
+                            defaults.update(loaded_config[category])
+
             except FileNotFoundError:
                 # File does not exist; keep using defaults
                 pass
@@ -67,6 +73,7 @@ class TuxemonConfig:
         self.splash: bool = display["splash"]
         self.fullscreen: bool = display["fullscreen"]
         self.fps: float = display["fps"]
+        self.vsync: bool = display["vsync"]
         self.show_fps: bool = display["show_fps"]
         self.scaling: bool = display["scaling"]
         self.collision_map: bool = display["collision_map"]
@@ -280,6 +287,7 @@ def generate_default_config() -> dict[str, Any]:
             "splash": True,
             "fullscreen": False,
             "fps": 60.0,
+            "vsync": True,
             "show_fps": False,
             "scaling": True,
             "collision_map": False,

--- a/tuxemon/headless_client.py
+++ b/tuxemon/headless_client.py
@@ -56,7 +56,6 @@ class HeadlessClient:
         )
         self.state_manager.auto_state_discovery()
         self.state = ClientState.RUNNING
-        self.show_fps = config.show_fps
         self.current_time = 0.0
 
         # setup controls

--- a/tuxemon/menu/input.py
+++ b/tuxemon/menu/input.py
@@ -270,7 +270,7 @@ class InputMenu(Menu[InputMenuObj]):
                 self.leaving_char_variant_dialog = False
             else:
                 menu_item.game_object()
-        elif event.held and event.hold_time > self.client.fps:
+        elif event.held and event.hold_time > self.client.config.fps:
             base_char = menu_item.game_object.char
             if base_char:
                 variants = self.char_variants.get(base_char, "")

--- a/tuxemon/prepare.py
+++ b/tuxemon/prepare.py
@@ -368,7 +368,9 @@ def pygame_init() -> None:
         fullscreen = pg.FULLSCREEN
     flags = pg.HWSURFACE | pg.DOUBLEBUF | fullscreen
 
-    SCREEN = pg.display.set_mode(SCREEN_SIZE, flags)
+    if CONFIG.vsync:
+        pg.display.set_allow_screensaver()
+    SCREEN = pg.display.set_mode(SCREEN_SIZE, flags, vsync=CONFIG.vsync)
     SCREEN_RECT = SCREEN.get_rect()
 
     # Disable the mouse cursor visibility

--- a/tuxemon/state_draw.py
+++ b/tuxemon/state_draw.py
@@ -23,7 +23,7 @@ class Renderer:
         self,
         screen: Surface,
         state_drawer: StateDrawer,
-        caption: str,
+        config: TuxemonConfig,
     ) -> None:
         """
         Initializes the Renderer class.
@@ -35,11 +35,13 @@ class Renderer:
         Parameters:
             screen: The pygame screen surface where everything is drawn.
             state_drawer: Handles rendering the current game state.
-            caption: The window title used for displaying FPS updates.
+            config: Configuration settings that may affect rendering
+                behavior.
         """
         self.screen = screen
         self.state_drawer = state_drawer
-        self.caption = caption
+        self.caption = config.window_caption
+        self.vsync = config.vsync
         self.frames = 0
         self.fps_timer = 0.0
 
@@ -93,10 +95,10 @@ class Renderer:
         self.fps_timer += clock_tick
         self.frames += 1
         if self.fps_timer >= 1.0:
-            fps_display = (
-                f"{self.caption} - {self.frames / self.fps_timer:.2f} FPS"
-            )
-            pygame.display.set_caption(fps_display)
+            fps = self.frames / self.fps_timer
+            vsync_status = "VSync ON" if self.vsync else "VSync OFF"
+            with_fps = f"{self.caption} - {fps:.2f} FPS - {vsync_status}"
+            pygame.display.set_caption(with_fps)
             self.fps_timer = 0.0
             self.frames = 0
 


### PR DESCRIPTION
PR introduces enhancements to `VSync` management and FPS display in the game's rendering system.

Changes made:
- improved VSync configuration: added `pg.display.set_allow_screensaver()` when VSync is enabled and adjusted `SCREEN` initialization to ensure VSync is correctly applied using `pg.display.set_mode(SCREEN_SIZE, flags, vsync=CONFIG.vsync)`
- enhanced FPS Display in Window Title: modified caption formatting to display both FPS and VSync status and replaced the previous FPS-only format with a snipped that provides clearer visibility into the game's frame rate and whether VSync is active

ensuring proper VSync handling improves rendering stability and reduces screen tearing
displaying VSync status in the window caption makes debugging and performance tracking more transparent

regarding `TuxemonConfig`:
- replaced `.update()` with a section-wise merge to prevent overriding default values when the YAML file lacks certain keys
- ensured each category (`display`, `game`, etc.) retains existing defaults while incorporating custom settings
- prevented potential crashes due to missing values like `"vsync"`