### PR TITLE
Refactoring `Technique` to Use `is_recharging` Property + small fix

### DIFF
--- a/mods/tuxemon/maps/spyder.yaml
+++ b/mods/tuxemon/maps/spyder.yaml
@@ -23,9 +23,10 @@ events:
   Cathedral Share:
     actions:
     - variable_math battle_last_prize,*,cathedral_share
+    - format_variable battle_last_prize,int
+    - modify_bill player,bill_cathedral,,battle_last_prize
     - format_variable battle_last_prize,-int
     - modify_money player,,battle_last_prize
-    - modify_bill player,bill_cathedral,,battle_last_prize
     - set_variable battle_last_prize:0
     conditions:
     - is variable_set battle_last_result:won

--- a/tests/tuxemon/test_ai.py
+++ b/tests/tuxemon/test_ai.py
@@ -13,25 +13,6 @@ from tuxemon.ai import (
 )
 
 
-class TestRecharging(unittest.TestCase):
-    def test_recharging(self):
-        mock_technique = MagicMock(next_use=0)
-        global recharging
-        recharging = MagicMock(side_effect=lambda move: move.next_use == 0)
-        self.assertTrue(
-            recharging(mock_technique), "The technique should be recharging."
-        )
-
-    def test_not_recharging(self):
-        mock_technique = MagicMock(next_use=1)
-        global recharging
-        recharging = MagicMock(side_effect=lambda move: move.next_use == 0)
-        self.assertFalse(
-            recharging(mock_technique),
-            "The technique should not be recharging.",
-        )
-
-
 class TestOpponentEvaluator(unittest.TestCase):
     def setUp(self):
         self.mock_combat = MagicMock()

--- a/tuxemon/ai.py
+++ b/tuxemon/ai.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, Optional
 import yaml
 
 from tuxemon import prepare
-from tuxemon.combat import has_status, pre_checking, recharging
+from tuxemon.combat import has_status, pre_checking
 from tuxemon.constants import paths
 from tuxemon.formula import simple_damage_multiplier
 from tuxemon.technique.technique import Technique
@@ -215,7 +215,7 @@ class TechniqueTracker:
         return [
             (mov, opponent)
             for mov in self.moves
-            if not recharging(mov)
+            if not mov.is_recharging
             for opponent in opponents
             if mov.validate_monster(self.session, opponent)
         ]

--- a/tuxemon/combat.py
+++ b/tuxemon/combat.py
@@ -154,13 +154,6 @@ def fainted(monster: Monster) -> bool:
     return has_status(monster, "faint") or monster.is_fainted
 
 
-def recharging(technique: Technique) -> bool:
-    """
-    Checks to see if a technique is recharging.
-    """
-    return technique.next_use > 0
-
-
 def get_awake_monsters(
     character: NPC,
     monsters: list[Monster],

--- a/tuxemon/core/effects/confused.py
+++ b/tuxemon/core/effects/confused.py
@@ -6,7 +6,7 @@ import random
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from tuxemon.combat import has_effect_param, recharging
+from tuxemon.combat import has_effect_param
 from tuxemon.core.core_effect import StatusEffect, StatusEffectResult
 from tuxemon.locale import T
 from tuxemon.technique.technique import Technique
@@ -79,7 +79,7 @@ def _get_available_techniques(user: Monster) -> list[Technique]:
     return [
         move
         for move in user.moves
-        if not recharging(move)
+        if not move.is_recharging
         and not has_effect_param(move, "give", "condition", "confused")
     ]
 

--- a/tuxemon/states/combat/combat_menus.py
+++ b/tuxemon/states/combat/combat_menus.py
@@ -253,9 +253,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
 
         def choose_technique() -> None:
             available_techniques = [
-                tech
-                for tech in self.monster.moves
-                if not combat.recharging(tech)
+                tech for tech in self.monster.moves if not tech.is_recharging
             ]
 
             # open menu to choose technique
@@ -273,7 +271,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                 tech_color = None
                 tech_enabled = True
 
-                if combat.recharging(tech):
+                if tech.is_recharging:
                     tech_name = f"{tech.name} ({abs(tech.next_use)})"
                     tech_color = self.unavailable_color
                     tech_enabled = False

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -92,6 +92,11 @@ class Technique:
         method.load(slug)
         return method
 
+    @property
+    def is_recharging(self) -> bool:
+        """Returns whether the technique is currently recharging."""
+        return self.next_use > 0
+
     def load(self, slug: str) -> None:
         """
         Loads and sets this technique's attributes from the technique
@@ -157,7 +162,6 @@ class Technique:
     def advance_round(self) -> None:
         """
         Advance the counter for this technique if used.
-
         """
         self.counter += 1
 
@@ -197,7 +201,6 @@ class Technique:
     def set_stats(self) -> None:
         """
         Reset technique stats default value.
-
         """
         self.potency = self.default_potency
         self.power = self.default_power
@@ -205,7 +208,6 @@ class Technique:
     def get_state(self) -> Mapping[str, Any]:
         """
         Prepares a dictionary of the technique to be saved to a file.
-
         """
         save_data = {
             attr: getattr(self, attr)
@@ -220,7 +222,6 @@ class Technique:
     def set_state(self, save_data: Mapping[str, Any]) -> None:
         """
         Loads information from saved data.
-
         """
         if not save_data:
             return


### PR DESCRIPTION
PR removed the method `recharging()` in favor of a more intuitive property `is_recharging`. This property encapsulates the logic directly within the class, allowing checks to be performed without requiring a separate function.