### PR TITLE
Refactor `Taste` Initialization in `Monster` Class

### DIFF
--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -230,8 +230,9 @@ class Monster:
         self.shape = results.shape
         self.stage = results.stage or EvolutionStage.standalone
         self.tags = results.tags
-        self.taste_cold = self.set_taste_cold(self.taste_cold)
-        self.taste_warm = self.set_taste_warm(self.taste_warm)
+        self.taste_cold, self.taste_warm = Taste.generate(
+            self.taste_cold, self.taste_warm
+        )
         self.steps = self.steps
         self.bond = self.bond
 
@@ -458,50 +459,6 @@ class Monster:
         """
         self.calculate_base_stats()
         self.apply_stat_updates()
-
-    def set_taste_cold(self, taste_slug: str = "tasteless") -> str:
-        """Sets the cold taste of the monster."""
-
-        if taste_slug == "tasteless":
-            cold_tastes = [
-                taste.slug
-                for taste in Taste.get_all_tastes().values()
-                if taste.taste_type == "cold" and taste.slug != "tasteless"
-            ]
-            if cold_tastes:
-                self.taste_cold = random.choice(cold_tastes)
-            else:
-                self.taste_cold = taste_slug
-        else:
-            taste = Taste.get_taste(taste_slug)
-            if taste is None:
-                self.taste_cold = taste_slug
-            else:
-                self.taste_cold = taste.slug
-
-        return self.taste_cold
-
-    def set_taste_warm(self, taste_slug: str = "tasteless") -> str:
-        """Sets the warm taste of the monster."""
-
-        if taste_slug == "tasteless":
-            warm_tastes = [
-                taste.slug
-                for taste in Taste.get_all_tastes().values()
-                if taste.taste_type == "warm" and taste.slug != "tasteless"
-            ]
-            if warm_tastes:
-                self.taste_warm = random.choice(warm_tastes)
-            else:
-                self.taste_warm = taste_slug
-        else:
-            taste = Taste.get_taste(taste_slug)
-            if taste is None:
-                self.taste_warm = taste_slug
-            else:
-                self.taste_warm = taste.slug
-
-        return self.taste_warm
 
     def set_capture(self, amount: int) -> int:
         """

--- a/tuxemon/taste.py
+++ b/tuxemon/taste.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import random
 from collections.abc import Sequence
 from typing import Optional
 
@@ -88,6 +89,36 @@ class Taste:
     def clear_cache(cls) -> None:
         """Clears the taste cache."""
         cls._tastes.clear()
+
+    @classmethod
+    def generate(
+        cls, cold_slug: str = "tasteless", warm_slug: str = "tasteless"
+    ) -> tuple[str, str]:
+        """
+        Generates initial cold and warm tastes.
+        If 'tasteless', a random taste of that type is chosen.
+        """
+        cold_taste = cold_slug
+        if cold_taste == "tasteless":
+            cold_tastes = [
+                taste.slug
+                for taste in cls.get_all_tastes().values()
+                if taste.taste_type == "cold" and taste.slug != "tasteless"
+            ]
+            if cold_tastes:
+                cold_taste = random.choice(cold_tastes)
+
+        warm_taste = warm_slug
+        if warm_taste == "tasteless":
+            warm_tastes = [
+                taste.slug
+                for taste in cls.get_all_tastes().values()
+                if taste.taste_type == "warm" and taste.slug != "tasteless"
+            ]
+            if warm_tastes:
+                warm_taste = random.choice(warm_tastes)
+
+        return cold_taste, warm_taste
 
     def __repr__(self) -> str:
         return (


### PR DESCRIPTION
The pull request removes the `set_taste_cold` and `set_taste_warm` methods from the `Monster` class and introduces a new class method in `Taste`.

Changes:
- removed `set_taste_cold` and `set_taste_warm` from `Monster`
- introduced a class method `generate` in `Taste` to handle cold and warm taste initialization
- `generate` method selects a random taste if `'tasteless'` is provided