### PR TITLE
Fix Crash When Using Items Due to Missing `local_session`

### DIFF
--- a/tuxemon/states/items/item_menu.py
+++ b/tuxemon/states/items/item_menu.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator, Sequence
+from functools import partial
 from typing import TYPE_CHECKING, Optional
 
 import pygame
@@ -208,7 +209,7 @@ class ItemMenuState(Menu[Item]):
             self.client.remove_state_by_name("ChoiceState")
             if item.behaviors.requires_monster_menu:
                 menu = self.client.push_state(MonsterMenuState(self.char))
-                menu.is_valid_entry = item.validate_monster  # type: ignore[assignment]
+                menu.is_valid_entry = partial(item.validate_monster, local_session)  # type: ignore[method-assign]
                 menu.on_menu_selection = use_item_with_monster  # type: ignore[assignment]
             else:
                 use_item_without_monster()

--- a/tuxemon/states/techniques/__init__.py
+++ b/tuxemon/states/techniques/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
+from functools import partial
 from typing import TYPE_CHECKING
 
 import pygame
@@ -100,7 +101,7 @@ class TechniqueMenuState(Menu[Technique]):
             self.client.pop_state()  # close the confirm dialog
 
             menu = self.client.push_state(MonsterMenuState(self.char))
-            menu.is_valid_entry = technique.validate_monster  # type: ignore[assignment]
+            menu.is_valid_entry = partial(technique.validate_monster, local_session)  # type: ignore[method-assign]
             menu.on_menu_selection = use_technique  # type: ignore[assignment]
 
         def cancel() -> None:


### PR DESCRIPTION
PR addresses a crash that occurred when the player attempted to use an item from their bag. The issue was caused by a missing `local_session`, which resulted in an unexpected failure during item usage.