### PR TITLE
Refactor `Monster` to Extract `MonsterMovesHandler` for Moves Handling

### DIFF
--- a/tests/tuxemon/test_evolution.py
+++ b/tests/tuxemon/test_evolution.py
@@ -87,7 +87,7 @@ def mockPlayer(self) -> None:
     member2 = Monster()
     member2.slug = "rockitten"
     tech = Technique.create("ram")
-    member1.learn(tech)
+    member1.moves.learn(tech)
     self.monsters = [member1, member2]
 
 
@@ -363,7 +363,7 @@ class TestCanEvolve(unittest.TestCase):
     def test_moves_match(self):
         self.mon.owner = self.player
         tech = Technique.create("ram")
-        self.mon.learn(tech)
+        self.mon.moves.learn(tech)
         evo = MonsterEvolutionItemModel(monster_slug="rockat", moves=["ram"])
         context = {"map_inside": True}
         self.assertTrue(self.mon.evolution_handler.can_evolve(evo, context))
@@ -371,7 +371,7 @@ class TestCanEvolve(unittest.TestCase):
     def test_moves_mismatch(self):
         self.mon.owner = self.player
         tech = Technique.create("ram")
-        self.mon.learn(tech)
+        self.mon.moves.learn(tech)
         evo = MonsterEvolutionItemModel(
             monster_slug="rockat", moves=["strike"]
         )

--- a/tests/tuxemon/test_monster.py
+++ b/tests/tuxemon/test_monster.py
@@ -206,15 +206,14 @@ class Learn(MonsterTestBase):
     def setUp(self):
         self.mon = Monster()
         self.mon.name = "agnite"
-        self.mon.moves = []
         self._tech_model = {"ram": self._tech}
         db.database["technique"] = self._tech_model
 
     def test_learn(self):
         tech = Technique.create("ram")
-        self.mon.learn(tech)
-        self.assertEqual(len(self.mon.moves), 1)
-        move = self.mon.moves[0]
+        self.mon.moves.learn(tech)
+        self.assertEqual(len(self.mon.moves.current_moves), 1)
+        move = self.mon.moves.current_moves[0]
         self.assertEqual(move.slug, "ram")
         self.assertEqual(move.tech_id, 69)
         self.assertEqual(move.accuracy, 0.85)

--- a/tests/tuxemon/test_reward.py
+++ b/tests/tuxemon/test_reward.py
@@ -24,10 +24,13 @@ class TestRewardSystem(unittest.TestCase):
         self.loser.experience_modifier = 1.5
         self.loser.status = []
         self.loser.current_hp = 0
+        self.loser.moves = MagicMock()
 
         self.winner = MagicMock(spec=Monster)
         self.winner.name = "rockitten"
         self.winner.status = []
+        self.winner.level = 5
+        self.winner.moves = MagicMock()
         self.winner.current_hp = 50
         self.winner.owner = MagicMock(spec=NPC)
         self.winner.owner.isplayer = True
@@ -142,6 +145,8 @@ class TestRewardSystem(unittest.TestCase):
             MagicMock(
                 spec=Monster,
                 give_experience=MagicMock(),
+                moves=MagicMock(),
+                level=5,
                 status=[],
                 current_hp=50,
                 is_fainted=False,

--- a/tuxemon/ai.py
+++ b/tuxemon/ai.py
@@ -449,7 +449,9 @@ class AI:
         self.evaluator = OpponentEvaluator(
             self.combat, self.monster, self.opponents
         )
-        self.tracker = TechniqueTracker(self.session, self.monster.moves)
+        self.tracker = TechniqueTracker(
+            self.session, self.monster.moves.get_moves()
+        )
 
         self.decision_strategy = (
             TrainerAIDecisionStrategy(self.evaluator, self.tracker)

--- a/tuxemon/combat.py
+++ b/tuxemon/combat.py
@@ -119,7 +119,7 @@ def party_no_tech(party: list[Monster]) -> list[str]:
     """
     Return list of monsters without techniques.
     """
-    return [p.name for p in party if not p.moves]
+    return [p.name for p in party if not p.moves.has_moves()]
 
 
 def has_effect_param(

--- a/tuxemon/combat.py
+++ b/tuxemon/combat.py
@@ -37,33 +37,31 @@ logger = logging.getLogger()
 
 def check_battle_legal(character: NPC) -> bool:
     """
-    Checks to see if the character has any monsters fit for battle.
+    Checks if the character has monsters fit for battle.
 
     Parameters:
         character: Character object.
 
     Returns:
-        Whether the character has monsters that can fight.
-
+        True if the character's monsters can fight, False otherwise.
     """
     if not character.monsters:
         logger.error(f"Cannot start battle, {character.name} has no monsters!")
         return False
-    else:
-        if fainted_party(character.monsters):
-            logger.error(
-                f"Cannot start battle, {character.name}'s monsters are all DEAD."
-            )
-            return False
-        else:
-            if party_no_tech(character.monsters):
-                no_tech = party_no_tech(character.monsters)
-                logger.error(
-                    f"Cannot start battle, {no_tech} has/have no techniques."
-                )
-                return False
-            else:
-                return True
+
+    if fainted_party(character.monsters):
+        logger.error(
+            f"Cannot start battle, {character.name}'s monsters are all DEAD."
+        )
+        return False
+
+    if party_no_tech(character.monsters):
+        logger.error(
+            f"Cannot start battle, {party_no_tech(character.monsters)} has/have no techniques."
+        )
+        return False
+
+    return True
 
 
 def pre_checking(
@@ -160,7 +158,6 @@ def get_awake_monsters(
 
     Yields:
         Non-fainted monsters.
-
     """
     awake_monsters = [
         monster
@@ -233,7 +230,6 @@ def battlefield(session: Session, monster: Monster) -> None:
         session: Session
         monster: The monster on the ground.
         players: All the remaining players.
-
     """
     set_var(session, "battle_last_monster_name", monster.name)
     set_var(session, "battle_last_monster_level", str(monster.level))
@@ -404,7 +400,6 @@ def set_var(session: Session, key: str, value: str) -> None:
         session: Session
         key: The key game variable.
         value: The value game variable.
-
     """
     client = session.client.event_engine
     var = f"{key}:{value}"
@@ -422,7 +417,6 @@ def set_battle(
         output: Output of the battle: won, lost, draw
         player: The human player.
         enemy: The enemy player.
-
     """
     fighter = "player" if player.isplayer else player.slug
     opponent = "player" if enemy.isplayer else enemy.slug
@@ -449,7 +443,6 @@ def build_hud_text(
 
     Returns:
         A string representing the HUD text for the monster.
-
     """
     if menu == "MainParkMenuState" and monster.owner and is_right:
         # Special case for MainParkMenuState
@@ -487,7 +480,6 @@ def retrieve_from_party(party: list[Monster], method: str) -> Monster:
     Notes:
         If the method is not recognized, a random monster from
         the party will be returned.
-
     """
     methods = {
         "lv_highest": ("level", max),

--- a/tuxemon/core/conditions/has_tech.py
+++ b/tuxemon/core/conditions/has_tech.py
@@ -25,4 +25,4 @@ class HasTechCondition(CoreCondition):
     expected: str
 
     def test_with_monster(self, session: Session, target: Monster) -> bool:
-        return any(t.slug == self.expected for t in target.moves)
+        return target.moves.has_move(self.expected)

--- a/tuxemon/core/effects/confused.py
+++ b/tuxemon/core/effects/confused.py
@@ -78,7 +78,7 @@ class ConfusedEffect(CoreEffect):
 def _get_available_techniques(user: Monster) -> list[Technique]:
     return [
         move
-        for move in user.moves
+        for move in user.moves.get_moves()
         if not move.is_recharging
         and not has_effect_param(move, "give", "condition", "confused")
     ]

--- a/tuxemon/core/effects/cooldown.py
+++ b/tuxemon/core/effects/cooldown.py
@@ -54,7 +54,9 @@ class CoolDownEffect(CoreEffect):
 
         objectives = self.objectives.split(":")
         monsters = get_target_monsters(objectives, tech, user, target)
-        moves_to_update = [move for mon in monsters for move in mon.moves]
+        moves_to_update = [
+            move for mon in monsters for move in mon.moves.get_moves()
+        ]
 
         if self.parameter == "types":
             moves_to_update = [

--- a/tuxemon/core/effects/grabbed.py
+++ b/tuxemon/core/effects/grabbed.py
@@ -35,7 +35,9 @@ class GrabbedEffect(CoreEffect):
     ) -> StatusEffectResult:
         done: bool = False
         ranges = self.ranges.split(":")
-        moves = [tech for tech in target.moves if tech.range in ranges]
+        moves = [
+            tech for tech in target.moves.get_moves() if tech.range in ranges
+        ]
         if status.phase == "perform_action_status":
             done = True
         # applies effect on techniques

--- a/tuxemon/core/effects/learn_mm.py
+++ b/tuxemon/core/effects/learn_mm.py
@@ -37,7 +37,7 @@ class LearnMmEffect(CoreEffect):
         if not lookup_cache:
             _lookup_techniques(self.element)
 
-        moves = [tech.slug for tech in target.moves]
+        moves = [tech.slug for tech in target.moves.get_moves()]
 
         available = list(set(list(lookup_cache.keys())) - set(moves))
 

--- a/tuxemon/core/effects/learn_tm.py
+++ b/tuxemon/core/effects/learn_tm.py
@@ -29,9 +29,7 @@ class LearnTmEffect(CoreEffect):
     def apply_item_target(
         self, session: Session, item: Item, target: Monster
     ) -> ItemEffectResult:
-        target_moves = {tech.slug for tech in target.moves}
-
-        if self.technique not in target_moves:
+        if not target.moves.has_move(self.technique):
             client = session.client
             var = f"{self.name}:{str(target.instance_id.hex)}"
             client.event_engine.execute_action("set_variable", [var], True)

--- a/tuxemon/core/effects/stuck.py
+++ b/tuxemon/core/effects/stuck.py
@@ -35,7 +35,9 @@ class StuckEffect(CoreEffect):
     ) -> StatusEffectResult:
         done: bool = False
         ranges = self.ranges.split(":")
-        moves = [tech for tech in target.moves if tech.range in ranges]
+        moves = [
+            tech for tech in target.moves.get_moves() if tech.range in ranges
+        ]
         if status.phase == "perform_action_status":
             done = True
         # applies effect on techniques

--- a/tuxemon/event/actions/add_monster.py
+++ b/tuxemon/event/actions/add_monster.py
@@ -61,7 +61,7 @@ class AddMonsterAction(EventAction):
 
         monster = Monster.create(monster_slug)
         monster.set_level(self.monster_level)
-        monster.set_moves(self.monster_level)
+        monster.moves.set_moves(self.monster_level)
         monster.set_capture(today_ordinal())
         monster.current_hp = monster.hp
 

--- a/tuxemon/event/actions/add_tech.py
+++ b/tuxemon/event/actions/add_tech.py
@@ -81,4 +81,4 @@ class AddTechAction(EventAction):
                     f"{self.accuracy} must be between {lower} and {upper}",
                 )
         logger.info(f"{monster.name} learned {tech.name}!")
-        monster.learn(tech)
+        monster.moves.learn(tech)

--- a/tuxemon/event/actions/create_npc.py
+++ b/tuxemon/event/actions/create_npc.py
@@ -103,7 +103,7 @@ def party_monster(npc_monster: PartyMemberModel) -> Monster:
     monster.money_modifier = npc_monster.money_mod
     monster.experience_modifier = npc_monster.exp_req_mod
     monster.set_level(npc_monster.level)
-    monster.set_moves(npc_monster.level)
+    monster.moves.set_moves(npc_monster.level)
     monster.current_hp = monster.hp
     monster.gender = npc_monster.gender
     return monster

--- a/tuxemon/event/actions/dojo_method.py
+++ b/tuxemon/event/actions/dojo_method.py
@@ -64,9 +64,9 @@ class DojoMethodAction(EventAction):
             # Get the moves that the monster can learn but hasn't yet
             learnable_moves = [
                 tech.technique
-                for tech in monster.moveset
+                for tech in monster.moves.moveset
                 if tech.level_learned <= monster.level
-                and tech.technique not in [mov.slug for mov in monster.moves]
+                and not monster.moves.has_move(tech.technique)
             ]
 
             if not learnable_moves:
@@ -123,7 +123,7 @@ class DojoMethodAction(EventAction):
     def learn(self, monster: Monster, technique: str) -> None:
         """Deny the evolution"""
         tech = Technique.create(technique)
-        monster.learn(tech)
+        monster.moves.learn(tech)
         logger.info(f"{tech.name} learned!")
         self.client.sound_manager.play_sound("sound_confirm")
         self.client.pop_state()

--- a/tuxemon/event/actions/give_experience.py
+++ b/tuxemon/event/actions/give_experience.py
@@ -72,5 +72,5 @@ class GiveExperienceAction(EventAction):
                 level = mon.give_experience(exp)
                 logger.info(f"{mon.name} +{exp} exp")
                 if level > 0:
-                    mon.update_moves(level)
+                    mon.moves.update_moves(mon.level, level)
                     logger.info(f"{mon.name} +{level} levels")

--- a/tuxemon/event/actions/overwrite_tech.py
+++ b/tuxemon/event/actions/overwrite_tech.py
@@ -41,10 +41,9 @@ class OverwriteTechAction(EventAction):
     added: str
 
     def overwrite(self, monster: Monster, removed: Technique) -> None:
-        slot = monster.moves.index(removed)
+        slot = monster.moves.current_moves.index(removed)
         added = Technique.create(self.added)
-        monster.moves.remove(removed)
-        monster.moves.insert(slot, added)
+        monster.moves.replace_move(slot, added)
         logger.info(f"{removed.name} replaced by {added.name}")
 
     def start(self, session: Session) -> None:
@@ -54,7 +53,7 @@ class OverwriteTechAction(EventAction):
             return
         tech_id = uuid.UUID(player.game_variables[self.removed])
         for monster in player.monsters:
-            technique = monster.find_tech_by_id(tech_id)
+            technique = monster.moves.find_tech_by_id(tech_id)
             if technique is None:
                 logger.error(f"Technique not found in {monster.name}")
                 return

--- a/tuxemon/event/actions/random_battle.py
+++ b/tuxemon/event/actions/random_battle.py
@@ -81,7 +81,7 @@ class RandomBattleAction(EventAction):
             level = random.randint(self.min_level, self.max_level)
             current_monster = Monster.create(monster.slug)
             current_monster.set_level(level)
-            current_monster.set_moves(level)
+            current_monster.moves.set_moves(level)
             current_monster.set_capture(today_ordinal())
             current_monster.current_hp = current_monster.hp
             current_monster.money_modifier = level

--- a/tuxemon/event/actions/remove_tech.py
+++ b/tuxemon/event/actions/remove_tech.py
@@ -42,7 +42,7 @@ class RemoveTechAction(EventAction):
         tech_id = uuid.UUID(player.game_variables[self.tech_id])
 
         for monster in player.monsters:
-            technique = monster.find_tech_by_id(tech_id)
+            technique = monster.moves.find_tech_by_id(tech_id)
             if technique:
-                monster.moves.remove(technique)
+                monster.moves.forget(technique)
                 logger.info(f"{technique.name} removed from {monster.name}")

--- a/tuxemon/event/actions/set_monster_level.py
+++ b/tuxemon/event/actions/set_monster_level.py
@@ -55,9 +55,9 @@ class SetMonsterLevelAction(EventAction):
                 return
             new_level = monster.level + self.levels_added
             monster.set_level(new_level)
-            monster.update_moves(self.levels_added)
+            monster.moves.update_moves(monster.level, self.levels_added)
         else:
             for monster in player.monsters:
                 new_level = monster.level + self.levels_added
                 monster.set_level(new_level)
-                monster.update_moves(self.levels_added)
+                monster.moves.update_moves(monster.level, self.levels_added)

--- a/tuxemon/event/actions/spawn_monster.py
+++ b/tuxemon/event/actions/spawn_monster.py
@@ -93,17 +93,16 @@ class SpawnMonsterAction(EventAction):
         # Create a new child monster
         child = Monster.create(seed_slug)
         child.set_level(level)
-        child.set_moves(level)
+        child.moves.set_moves(level)
         child.set_capture(today_ordinal())
         child.name = name
         child.current_hp = child.hp
 
         # Give the child a random move from the father
-        father_moves = len(father.moves)
+        father_moves = len(father.moves.current_moves)
         replace_tech = random.randrange(0, 2)
-        child.moves[replace_tech] = father.moves[
-            random.randrange(0, father_moves - 1)
-        ]
+        random_move = father.moves.get_moves()[random.randrange(father_moves)]
+        child.moves.replace_move(replace_tech, random_move)
 
         # Add the child to the character's monsters
         character = get_npc(session, self.character)

--- a/tuxemon/event/actions/trading.py
+++ b/tuxemon/event/actions/trading.py
@@ -73,7 +73,7 @@ def _create_traded_monster(removed: Monster, added: str) -> Monster:
     """Create a new monster with the same level and moves as the removed monster."""
     new = Monster.create(added)
     new.set_level(removed.level)
-    new.set_moves(removed.level)
+    new.moves.set_moves(removed.level)
     new.set_capture(today_ordinal())
     new.current_hp = new.hp
     new.traded = True

--- a/tuxemon/event/actions/wild_encounter.py
+++ b/tuxemon/event/actions/wild_encounter.py
@@ -63,7 +63,7 @@ class WildEncounterAction(EventAction):
         current_monster = Monster.create(self.monster_slug)
         current_monster.level = self.monster_level
         current_monster.set_level(self.monster_level)
-        current_monster.set_moves(self.monster_level)
+        current_monster.moves.set_moves(self.monster_level)
         current_monster.current_hp = current_monster.hp
         if self.exp is not None:
             current_monster.experience_modifier = self.exp

--- a/tuxemon/event/conditions/check_max_tech.py
+++ b/tuxemon/event/conditions/check_max_tech.py
@@ -44,7 +44,7 @@ class CheckMaxTechCondition(EventCondition):
         monsters = [
             monster
             for monster in player.monsters
-            if len(monster.moves) > max_techs
+            if len(monster.moves.current_moves) > max_techs
         ]
         session.client.event_data[self.name] = monsters
         return bool(monsters)

--- a/tuxemon/evolution.py
+++ b/tuxemon/evolution.py
@@ -137,7 +137,7 @@ class Evolution:
         if evolution_item.traded is not None:
             conditions.append(evolution_item.traded == self.monster.traded)
         if evolution_item.moves:
-            moves_slugs = {mov.slug for mov in self.monster.moves}
+            moves_slugs = {mov.slug for mov in self.monster.moves.get_moves()}
             conditions.extend(
                 monster in moves_slugs for monster in evolution_item.moves
             )

--- a/tuxemon/locale.py
+++ b/tuxemon/locale.py
@@ -473,7 +473,9 @@ def replace_text(session: Session, text: str) -> str:
             + "_cold}}": T.translate(f"taste_{monster.taste_cold}"),
             "${{monster_"
             + str(i)
-            + "_moves}}": " - ".join(_move.name for _move in monster.moves),
+            + "_moves}}": " - ".join(
+                _move.name for _move in monster.moves.get_moves()
+            ),
         }
 
         # Add unit-specific monster replacements

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -116,8 +116,7 @@ class Monster:
 
         self.modifiers = ModifierStats()
 
-        self.moves: list[Technique] = []
-        self.moveset: list[MonsterMovesetItemModel] = []
+        self.moves = MonsterMovesHandler()
         self.evolutions: list[MonsterEvolutionItemModel] = []
         self.evolution_handler = Evolution(self)
         self.history: list[MonsterHistoryItemModel] = []
@@ -146,7 +145,6 @@ class Monster:
         self.taste_cold: str = "tasteless"
         self.taste_warm: str = "tasteless"
 
-        self.max_moves = prepare.MAX_MOVES
         self.txmn_id = 0
         self.capture = 0
         self.capture_device = "tuxeball"
@@ -259,7 +257,7 @@ class Monster:
             results.lower_catch_resistance or self.lower_catch_resistance
         )
 
-        self.moveset.extend(results.moveset or [])
+        self.moves.set_moveset(results.moveset or [])
         self.evolutions.extend(results.evolutions or [])
         self.history.extend(results.history or [])
 
@@ -329,16 +327,6 @@ class Monster:
         return self.sprite_handler.get_sprite(
             sprite_type, frame_duration, scale, **kwargs
         )
-
-    def learn(self, technique: Technique) -> None:
-        """
-        Adds a technique to this tuxemon's moveset.
-
-        Parameters:
-            technique: The technique for the monster to learn.
-        """
-
-        self.moves.append(technique)
 
     def reset_types(self) -> None:
         """
@@ -500,51 +488,6 @@ class Monster:
         self.total_experience = self.experience_required()
         self.set_stats()
 
-    def set_moves(self, level: int) -> None:
-        """
-        Set monster moves according to the level.
-
-        Parameters:
-            level: The level of the monster.
-
-        """
-        eligible_moves = [
-            move.technique
-            for move in self.moveset
-            if move.level_learned <= level
-        ]
-        moves_to_learn = eligible_moves[-prepare.MAX_MOVES :]
-        for move in moves_to_learn:
-            tech = Technique.create(move)
-            self.learn(tech)
-
-    def update_moves(self, levels_earned: int) -> list[Technique]:
-        """
-        Set monster moves according to the levels increased.
-        Excludes the moves already learned.
-
-        Parameters:
-            levels_earned: Number of levels earned.
-
-        Returns:
-            techniques: list containing the learned techniques
-
-        """
-        new_level = self.level - levels_earned
-        new_moves = self.moves.copy()
-        new_techniques = []
-        for move in self.moveset:
-            if (
-                move.technique not in (m.slug for m in self.moves)
-                and new_level < move.level_learned <= self.level
-            ):
-                technique = Technique.create(move.technique)
-                new_moves.append(technique)
-                new_techniques.append(technique)
-
-        self.moves = new_moves
-        return new_techniques
-
     def experience_required(self, level_ofs: int = 0) -> int:
         """
         Gets the experience requirement for the given level.
@@ -581,7 +524,7 @@ class Monster:
             save_data["body"] = body
 
         save_data["status"] = encode_status(self.status)
-        save_data["moves"] = encode_moves(self.moves)
+        save_data["moves"] = self.moves.encode_moves()
         save_data["held_item"] = self.held_item.encode_item()
         save_data["modifiers"] = self.modifiers.to_dict()
 
@@ -600,9 +543,8 @@ class Monster:
 
         self.load(save_data["slug"])
 
-        self.moves = []
-        for move in decode_moves(save_data.get("moves")):
-            self.moves.append(move)
+        self.moves.decode_moves(save_data)
+
         self.status = []
         for cond in decode_status(save_data.get("status")):
             self.status.append(cond)
@@ -639,22 +581,12 @@ class Monster:
         Ends combat, recharges all moves and heals statuses.
         """
         self.out_of_range = False
-        for move in self.moves:
-            move.full_recharge()
+        self.moves.full_recharge_moves()
 
         if "faint" in (s.slug for s in self.status):
             self.faint()
         else:
             self.status = []
-
-    def find_tech_by_id(self, instance_id: UUID) -> Optional[Technique]:
-        """
-        Finds a tech among the monster's moves which has the given id.
-
-        """
-        return next(
-            (m for m in self.moves if m.instance_id == instance_id), None
-        )
 
 
 class MonsterSpriteHandler:
@@ -850,6 +782,138 @@ class MonsterItemHandler:
         self, json_data: Optional[Mapping[str, Any]]
     ) -> Optional[Item]:
         return Item(save_data=json_data) if json_data is not None else None
+
+
+class MonsterMovesHandler:
+    def __init__(
+        self,
+        moves: Optional[list[Technique]] = None,
+        moveset: Optional[Sequence[MonsterMovesetItemModel]] = None,
+    ):
+        self.moves = moves if moves is not None else []
+        self.moveset = moveset if moveset is not None else []
+
+    @property
+    def current_moves(self) -> list[Technique]:
+        return self.moves
+
+    def set_moveset(self, moveset: Sequence[MonsterMovesetItemModel]) -> None:
+        """Sets the raw moveset data from the database."""
+        self.moveset = moveset
+
+    def learn(self, technique: Technique) -> None:
+        """
+        Adds a technique to this tuxemon's moveset.
+
+        Parameters:
+            technique: The technique for the monster to learn.
+        """
+
+        self.moves.append(technique)
+
+    def forget(self, technique: Technique) -> None:
+        """
+        Removes a technique from the monster's moveset.
+
+        Parameters:
+            technique: The technique to forget.
+        """
+        if technique in self.moves:
+            self.moves.remove(technique)
+
+    def replace_move(self, index: int, new_move: Technique) -> None:
+        """
+        Replaces a move at a given index with a new technique.
+
+        Parameters:
+            index: The position of the move to replace.
+            new_move: The new technique to insert.
+        """
+        if 0 <= index < len(self.moves):
+            self.moves[index] = new_move
+
+    def set_moves(
+        self, level: int, max_moves: int = prepare.MAX_MOVES
+    ) -> None:
+        """
+        Set monster moves according to the level.
+
+        Parameters:
+            level: The level of the monster.
+            max_moves: The maximum number of moves the monster can learn.
+        """
+        eligible_moves = [
+            move.technique
+            for move in self.moveset
+            if move.level_learned <= level
+        ]
+        moves_to_learn = eligible_moves[-max_moves:]
+        for move in moves_to_learn:
+            tech = Technique.create(move)
+            self.learn(tech)
+
+    def update_moves(
+        self, monster_level: int, levels_earned: int
+    ) -> list[Technique]:
+        """
+        Set monster moves according to the levels increased.
+        Excludes the moves already learned.
+
+        Parameters:
+            monster_level: The current level of the monster.
+            levels_earned: Number of levels earned.
+
+        Returns:
+            techniques: list containing the learned techniques
+        """
+        new_level = monster_level - levels_earned
+        new_moves = self.moves.copy()
+        new_techniques = []
+        for move in self.moveset:
+            if (
+                move.technique not in (m.slug for m in self.moves)
+                and new_level < move.level_learned <= monster_level
+            ):
+                technique = Technique.create(move.technique)
+                new_moves.append(technique)
+                new_techniques.append(technique)
+
+        self.moves = new_moves
+        return new_techniques
+
+    def recharge_moves(self) -> None:
+        for move in self.moves:
+            move.recharge()
+
+    def full_recharge_moves(self) -> None:
+        for move in self.moves:
+            move.full_recharge()
+
+    def set_stats(self) -> None:
+        for move in self.moves:
+            move.set_stats()
+
+    def find_tech_by_id(self, instance_id: UUID) -> Optional[Technique]:
+        """Finds a technique among the monster's moves which has the given id."""
+        return next(
+            (m for m in self.moves if m.instance_id == instance_id), None
+        )
+
+    def has_moves(self) -> bool:
+        return bool(self.moves)
+
+    def has_move(self, move_slug: str) -> bool:
+        return any(move.slug == move_slug for move in self.get_moves())
+
+    def get_moves(self) -> list[Technique]:
+        return self.moves
+
+    def encode_moves(self) -> Sequence[Mapping[str, Any]]:
+        return encode_moves(self.moves)
+
+    def decode_moves(self, json_data: Optional[Mapping[str, Any]]) -> None:
+        if json_data and "moves" in json_data:
+            self.moves = [mov for mov in decode_moves(json_data["moves"])]
 
 
 def decode_monsters(

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -607,10 +607,8 @@ class NPC(Entity[NPCState]):
         Parameters:
             tech: The slug name of the technique.
         """
-        for technique in self.monsters:
-            for move in technique.moves:
-                if move.slug == tech:
-                    return True
+        for monster in self.monsters:
+            return monster.moves.has_move(tech)
         return False
 
     def has_type(self, element: str) -> bool:

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -354,8 +354,7 @@ class CombatState(CombatAnimations):
                         if player in self.human_players:
                             self._decision_queue.append(monster)
                         else:
-                            for tech in monster.moves:
-                                tech.recharge()
+                            monster.moves.recharge_moves()
                             AI(self.session, self, monster, player)
 
         elif phase == CombatPhase.ACTION:
@@ -462,19 +461,16 @@ class CombatState(CombatAnimations):
     def handle_single_action(self, pending_monsters: list[Monster]) -> None:
         if pending_monsters:
             monster = pending_monsters.pop(0)
-            for tech in monster.moves:
-                tech.recharge()
+            monster.moves.recharge_moves()
             self.show_monster_action_menu(monster)
 
     def handle_double_action(self, pending_monsters: list[Monster]) -> None:
         if len(pending_monsters) >= 2:
             monster1 = pending_monsters.pop(0)
-            for tech in monster1.moves:
-                tech.recharge()
+            monster1.moves.recharge_moves()
             self.show_monster_action_menu(monster1)
             monster2 = pending_monsters.pop(0)
-            for tech in monster2.moves:
-                tech.recharge()
+            monster2.moves.recharge_moves()
             self.show_monster_action_menu(monster2)
         elif pending_monsters:
             self.handle_single_action(pending_monsters)
@@ -1310,8 +1306,7 @@ class CombatState(CombatAnimations):
                 # reset type
                 mon.reset_types()
                 # reset technique stats
-                for tech in mon.moves:
-                    tech.set_stats()
+                mon.moves.set_stats()
 
         # clear action queue
         self._action_queue.clear_queue()

--- a/tuxemon/states/combat/combat_menus.py
+++ b/tuxemon/states/combat/combat_menus.py
@@ -253,7 +253,9 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
 
         def choose_technique() -> None:
             available_techniques = [
-                tech for tech in self.monster.moves if not tech.is_recharging
+                tech
+                for tech in self.monster.moves.get_moves()
+                if not tech.is_recharging
             ]
 
             # open menu to choose technique
@@ -266,7 +268,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                 tech_skip = MenuItem(skip_image, None, None, skip)
                 menu.add(tech_skip)
 
-            for tech in self.monster.moves:
+            for tech in self.monster.moves.get_moves():
                 tech_name = tech.name
                 tech_color = None
                 tech_enabled = True

--- a/tuxemon/states/combat/reward_system.py
+++ b/tuxemon/states/combat/reward_system.py
@@ -93,7 +93,9 @@ class RewardSystem:
                 )
                 for non_participant in non_participants:
                     levels = non_participant.give_experience(awarded_exp)
-                    non_participant.update_moves(levels)
+                    non_participant.moves.update_moves(
+                        non_participant.level, levels
+                    )
 
             for winner in winners:
                 # Award money and experience
@@ -113,7 +115,9 @@ class RewardSystem:
                 # Grant experience and update moves
                 if winner.owner and winner.owner.isplayer:
                     levels = winner.give_experience(awarded_exp)
-                    rewards_data.moves = winner.update_moves(levels)
+                    rewards_data.moves = winner.moves.update_moves(
+                        winner.level, levels
+                    )
                     rewards_data.messages.append(
                         T.format(
                             "combat_gain_exp",

--- a/tuxemon/states/monster_moves/__init__.py
+++ b/tuxemon/states/monster_moves/__init__.py
@@ -63,7 +63,7 @@ class MonsterMovesState(PygameMenuState):
         lab1.translate(fix_measure(width, 0.50), fix_measure(height, 0.10))
         # moves
         moveset: list[Technique] = []
-        moveset = monster.moves
+        moveset = monster.moves.get_moves()
         output = sorted(moveset, key=lambda x: x.tech_id)
 
         _height = 0.10

--- a/tuxemon/states/techniques/__init__.py
+++ b/tuxemon/states/techniques/__init__.py
@@ -131,7 +131,7 @@ class TechniqueMenuState(Menu[Technique]):
         )
 
         moveset: list[Technique] = []
-        moveset = self.monster.moves
+        moveset = self.monster.moves.get_moves()
         output = sorted(moveset, key=lambda x: x.tech_id)
 
         for tech in output:


### PR DESCRIPTION
PR extracts monster moves / moveset handling into its own class, `MonsterMovesHandler`. This refactors how monster moves / moveset are managed, making the `Monster` class cleaner and the moves logic more encapsulated.

Changes:
- extracted `MonsterMovesHandler` to manage monster moves and movesets
- moved related methods from the `Monster` class to the new `MonsterMovesHandler` class, such as `learn`, `find_tech_by_id`, and `set_moves`
- added new methods to the `MonsterMovesHandler` class, including `recharge_moves`, `full_recharge_moves`, `set_stats`, `forget`, `has_moves`, `replace_move`, `has_move`, and `get_moves`