### PR TITLE
add `execute_tech_action`  in `Technique` 

### DIFF
--- a/tuxemon/combat.py
+++ b/tuxemon/combat.py
@@ -95,8 +95,10 @@ def pre_checking(
     ):
         slug = random.choice(infected_slugs)
         method = Technique.create(slug)
-        result_method = method.use(session, monster, target)
-        if result_method.success:
+        result_tech = method.execute_tech_action(
+            session, combat, monster, target
+        )
+        if result_tech.success:
             technique = method
     return technique
 

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -765,8 +765,9 @@ class CombatState(CombatAnimations):
         hit_delay = 0.0
         # monster uses move
         method.advance_round()
-        method.combat_state = self
-        result_tech = method.use(self.session, user, target)
+        result_tech = method.execute_tech_action(
+            self.session, self, user, target
+        )
         context = {
             "user": user.name,
             "name": method.name,

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -177,6 +177,17 @@ class Technique:
     def full_recharge(self) -> None:
         self.next_use = 0
 
+    def execute_tech_action(
+        self,
+        session: Session,
+        combat_instance: CombatState,
+        user: Monster,
+        target: Monster,
+    ) -> TechEffectResult:
+        """Executes the tech action and returns the result."""
+        self.combat_state = combat_instance
+        return self.use(session, user, target)
+
     def use(
         self, session: Session, user: Monster, target: Monster
     ) -> TechEffectResult:


### PR DESCRIPTION
PR adds `execute_tech_action` into `Technique`, the method `execute_tech_action`, which previously updated combat state and triggered tech effects, has been moved directly into the `Technique` class, this further improves encapsulation by keeping tech actions self-contained within their own class