### PR TITLE
Refactor `NPC` to Extract `NPCBagHandler` for Item Handling

### DIFF
--- a/tests/tuxemon/test_ai.py
+++ b/tests/tuxemon/test_ai.py
@@ -54,19 +54,25 @@ class TestOpponentEvaluator(unittest.TestCase):
 
 class TestTrainerAIDecisionStrategy(unittest.TestCase):
     def setUp(self):
+        self.mock_item = MagicMock(slug="potion")
         self.mock_ai = MagicMock()
-        self.mock_ai.character.items = []
         self.mock_evaluator = MagicMock()
         self.mock_tracker = MagicMock()
 
     def test_make_decision_use_potion(self):
-        mock_item = MagicMock(slug="potion")
-        self.mock_ai.character.items = [mock_item]
+        self.mock_ai.character.items.get_items = MagicMock(
+            return_value=[self.mock_item]
+        )
+        self.mock_ai.tracker.get_valid_moves = MagicMock(
+            return_value=[(MagicMock(), MagicMock())]
+        )
+
         AIConfigLoader.get_ai_items = MagicMock(
             return_value=AIItems(
                 items={"potion": ItemEntry(hp_range=(0.2, 0.8))}
             )
         )
+
         self.mock_ai.monster.hp_ratio = 40 / 100
 
         strategy = TrainerAIDecisionStrategy(
@@ -74,7 +80,7 @@ class TestTrainerAIDecisionStrategy(unittest.TestCase):
         )
         strategy.make_decision(self.mock_ai)
 
-        self.mock_ai.action_item.assert_called_once_with(mock_item)
+        self.mock_ai.action_item.assert_called_once_with(self.mock_item)
 
     def test_make_decision_select_move(self):
         self.mock_tracker.get_valid_moves.return_value = [

--- a/tests/tuxemon/test_npc_bag_handler.py
+++ b/tests/tuxemon/test_npc_bag_handler.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import unittest
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from tuxemon.npc import NPCBagHandler
+
+
+class TestNPCBagHandler(unittest.TestCase):
+
+    def setUp(self):
+        self.handler = NPCBagHandler(item_boxes=MagicMock())
+        self.item = MagicMock(slug="test_item", instance_id=uuid4())
+
+    def test_init(self):
+        self.assertEqual(self.handler._items, [])
+        self.assertEqual(self.handler._bag_limit, 99)
+
+    def test_add_item(self):
+        self.handler.add_item(self.item)
+        self.assertIn(self.item, self.handler._items)
+
+    def test_add_item_to_locker(self):
+        self.handler._bag_limit = 0
+
+        self.handler.add_item(self.item)
+        self.assertEqual(self.handler._items, [])
+
+    def test_remove_item(self):
+        self.handler.add_item(self.item)
+        self.handler.remove_item(self.item)
+        self.assertNotIn(self.item, self.handler._items)
+
+    def test_find_item(self):
+        self.handler.add_item(self.item)
+        found_item = self.handler.find_item("test_item")
+        self.assertEqual(found_item, self.item)
+
+    def test_find_item_not_found(self):
+        found_item = self.handler.find_item("test_item")
+        self.assertIsNone(found_item)
+
+    def test_get_items(self):
+        item1 = MagicMock(slug="test_item1", instance_id=uuid4())
+        item2 = MagicMock(slug="test_item2", instance_id=uuid4())
+        self.handler.add_item(item1)
+        self.handler.add_item(item2)
+        items = self.handler.get_items()
+        self.assertIn(item1, items)
+        self.assertIn(item2, items)
+
+    def test_has_item(self):
+        self.handler.add_item(self.item)
+        self.assertTrue(self.handler.has_item("test_item"))
+
+    def test_has_item_not_found(self):
+        self.assertFalse(self.handler.has_item("test_item"))
+
+    def test_find_item_by_id(self):
+        self.handler.add_item(self.item)
+        found_item = self.handler.find_item_by_id(self.item.instance_id)
+        self.assertEqual(found_item, self.item)
+
+    def test_find_item_by_id_not_found(self):
+        found_item = self.handler.find_item_by_id(uuid4())
+        self.assertIsNone(found_item)
+
+    def test_clear_items(self):
+        self.handler.add_item(self.item)
+        self.handler.clear_items()
+        self.assertEqual(self.handler._items, [])
+
+    def test_count_item(self):
+        self.handler.add_item(self.item)
+        self.handler.add_item(self.item)
+        self.assertEqual(self.handler.count_item("test_item"), 2)

--- a/tuxemon/ai.py
+++ b/tuxemon/ai.py
@@ -303,8 +303,9 @@ class TrainerAIDecisionStrategy(AIDecisionStrategy):
         character_slug = ai.character.slug
         config = self.ai_trainers.trainers.get(character_slug)
 
-        if len(ai.character.items) > 0:
-            for item in ai.character.items:
+        items = ai.character.items.get_items()
+        if len(items) > 0:
+            for item in items:
                 if self.need_healing(ai, item):
                     ai.action_item(item)
                     return

--- a/tuxemon/combat.py
+++ b/tuxemon/combat.py
@@ -454,7 +454,7 @@ def build_hud_text(
     if menu == "MainParkMenuState" and monster.owner and is_right:
         # Special case for MainParkMenuState
         ball = T.translate("tuxeball_park")
-        item = monster.owner.find_item("tuxeball_park")
+        item = monster.owner.items.find_item("tuxeball_park")
         if item is None:
             return f"{ball.upper()}: 0"
         return f"{ball.upper()}: {item.quantity}"

--- a/tuxemon/economy.py
+++ b/tuxemon/economy.py
@@ -310,6 +310,6 @@ class Economy:
         """
         for item in items:
             if isinstance(item, Item):
-                character.add_item(item)
+                character.items.add_item(item)
             else:
                 character.add_monster(item, len(character.monsters))

--- a/tuxemon/event/actions/add_item.py
+++ b/tuxemon/event/actions/add_item.py
@@ -55,14 +55,14 @@ class AddItemAction(EventAction):
             _item = self.item_slug
 
         itm = Item.create(_item)
-        existing = trainer.find_item(_item)
+        existing = trainer.items.find_item(_item)
         if existing:
             if self.quantity is None:
                 existing.quantity += 1
             elif self.quantity < 0:
                 diff = existing.quantity + self.quantity
                 if diff <= 0:
-                    trainer.remove_item(existing)
+                    trainer.items.remove_item(existing)
                 else:
                     existing.quantity = diff
             elif self.quantity > 0:
@@ -72,12 +72,12 @@ class AddItemAction(EventAction):
         else:
             if self.quantity is None:
                 itm.quantity = 1
-                trainer.add_item(itm)
+                trainer.items.add_item(itm)
             elif self.quantity > 0:
                 itm.quantity = self.quantity
-                trainer.add_item(itm)
+                trainer.items.add_item(itm)
             elif self.quantity < 0:
                 return
             else:
                 itm.quantity = 1
-                trainer.add_item(itm)
+                trainer.items.add_item(itm)

--- a/tuxemon/event/actions/create_npc.py
+++ b/tuxemon/event/actions/create_npc.py
@@ -113,14 +113,14 @@ def load_party_items(
     npc: NPC, bag: NpcModel, game_variables: dict[str, Any]
 ) -> None:
     """Loads the NPC's items from the database."""
-    npc.items = []
+    npc.items.clear_items()
     for npc_item in bag.items:
         if npc_item.variables and check_variables(
             npc_item.variables, game_variables
         ):
             item = Item.create(npc_item.slug, npc_item.model_dump())
             item.quantity = npc_item.quantity
-            npc.add_item(item)
+            npc.items.add_item(item)
 
 
 def check_variables(

--- a/tuxemon/event/conditions/has_bag.py
+++ b/tuxemon/event/conditions/has_bag.py
@@ -42,7 +42,9 @@ class HasBagCondition(EventCondition):
             return False
 
         visible_items = [
-            item for item in character.items if item.behaviors.visible
+            item
+            for item in character.items.get_items()
+            if item.behaviors.visible
         ]
         bag_size = sum(item.quantity for item in visible_items)
         return compare(check, bag_size, int(number))

--- a/tuxemon/event/conditions/has_item.py
+++ b/tuxemon/event/conditions/has_item.py
@@ -44,7 +44,7 @@ class HasItemCondition(EventCondition):
         if npc is None:
             logger.error(f"{npc_slug} doesn't exist.")
             return False
-        itm = npc.find_item(itm_slug)
+        itm = npc.items.find_item(itm_slug)
         if itm is None:
             return False
         else:

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -1015,7 +1015,7 @@ def on_capture_fail(item: Item, target: Monster, character: NPC) -> None:
         return
 
     if config.capdev_persistent_on_failure:
-        tuxeball = character.find_item(item.slug)
+        tuxeball = character.items.find_item(item.slug)
         if tuxeball:
             tuxeball.quantity += 1
 
@@ -1026,7 +1026,7 @@ def on_capture_success(item: Item, target: Monster, character: NPC) -> None:
         return
 
     if config.capdev_persistent_on_success:
-        tuxeball = character.find_item(item.slug)
+        tuxeball = character.items.find_item(item.slug)
         if tuxeball:
             tuxeball.quantity += 1
 

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -166,7 +166,7 @@ class Item:
             prepare.CONFIG.items_consumed_on_failure or result.success
         ) and self.behaviors.consumable:
             if self.quantity <= 1:
-                user.remove_item(self)
+                user.items.remove_item(self)
             else:
                 self.quantity -= 1
 

--- a/tuxemon/mission.py
+++ b/tuxemon/mission.py
@@ -214,7 +214,9 @@ class Mission:
                 setattr(self, key, value)
 
     def check_required_items(self, character: NPC) -> bool:
-        return all(character.find_item(item) for item in self.required_items)
+        return all(
+            character.items.find_item(item) for item in self.required_items
+        )
 
     def check_required_monsters(self, character: NPC) -> bool:
         return all(

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -121,8 +121,6 @@ class NPC(Entity[NPCState]):
         self.menu_missions: bool = True
         # This is a list of tuxemon the npc has. Do not modify directly
         self.monsters: list[Monster] = []
-        # The player's items.
-        self.items: list[Item] = []
         self.mission_controller = MissionController(self)
         self.economy: Optional[Economy] = None
         self.teleport_faint = TeleportFaint()
@@ -133,6 +131,7 @@ class NPC(Entity[NPCState]):
         # assume that all values are lists
         self.monster_boxes = MonsterBoxes()
         self.item_boxes = ItemBoxes()
+        self.items = NPCBagHandler(item_boxes=self.item_boxes)
         self.pending_evolutions: list[tuple[Monster, Monster]] = []
         self.moves: Sequence[Technique] = []  # list of techniques
         self.steps: float = 0.0
@@ -170,7 +169,7 @@ class NPC(Entity[NPCState]):
             "tuxepedia": encode_tuxepedia(self.tuxepedia),
             "relationships": encode_relationships(self.relationships),
             "money": dict(),
-            "items": encode_items(self.items),
+            "items": self.items.encode_items(),
             "template": self.template.model_dump(),
             "missions": self.mission_controller.encode_missions(),
             "monsters": encode_monsters(self.monsters),
@@ -205,9 +204,7 @@ class NPC(Entity[NPCState]):
         self.battles = []
         for battle in decode_battle(save_data.get("battles")):
             self.battles.append(battle)
-        self.items = []
-        for item in decode_items(save_data.get("items")):
-            self.add_item(item)
+        self.items.decode_items(save_data)
         self.monsters = []
         for monster in decode_monsters(save_data.get("monsters")):
             self.add_monster(monster, len(self.monsters))
@@ -619,47 +616,83 @@ class NPC(Entity[NPCState]):
         """
         return any(mon.has_type(element) for mon in self.monsters)
 
-    ####################################################
-    #                      Items                       #
-    ####################################################
-    def add_item(self, item: Item) -> None:
-        """
-        Adds an item to the npc's bag.
 
-        If the player's bag is full, it will send the item to
-        PCState archive.
-        """
-        locker = prepare.LOCKER
-        # it creates the locker
-        if not self.item_boxes.has_box(locker, "item"):
-            self.item_boxes.create_box(locker, "item")
+class NPCBagHandler:
 
-        if len(self.items) >= prepare.MAX_TYPES_BAG:
-            self.item_boxes.add_item(locker, item)
+    def __init__(
+        self,
+        item_boxes: ItemBoxes,
+        items: Optional[list[Item]] = None,
+        bag_limit: int = prepare.MAX_TYPES_BAG,
+    ) -> None:
+        self._items = items if items is not None else []
+        self._bag_limit = bag_limit
+        self._item_boxes = item_boxes
+
+    def add_item(self, item: Item, locker: str = prepare.LOCKER) -> None:
+        """
+        Adds an item to the NPC's bag.
+
+        If the bag is full (based on MAX_TYPES_BAG), it will send the item to
+        the PCState archive (item boxes).
+        """
+        if not self._item_boxes.has_box(locker, "item"):
+            self._item_boxes.create_box(locker, "item")
+
+        if len(self._items) >= self._bag_limit:
+            self._item_boxes.add_item(locker, item)
         else:
-            self.items.append(item)
+            self._items.append(item)
 
     def remove_item(self, item: Item) -> None:
         """
-        Removes an item from this npc's bag.
+        Removes a specific item instance from this NPC's bag.
         """
-        if item in self.items:
-            self.items.remove(item)
+        if item in self._items:
+            self._items.remove(item)
 
     def find_item(self, item_slug: str) -> Optional[Item]:
         """
-        Finds an item in the npc's bag.
+        Finds the first item in the NPC's bag with the given slug.
         """
-        for itm in self.items:
-            if itm.slug == item_slug:
+        for itm in self._items:
+            if self.has_item(item_slug):
                 return itm
-
         return None
+
+    def get_items(self) -> list[Item]:
+        return self._items
+
+    def has_item(self, item_slug: str) -> bool:
+        """
+        Checks if the NPC's bag contains an item with the given slug.
+        """
+        return any(itm.slug == item_slug for itm in self._items)
 
     def find_item_by_id(self, instance_id: uuid.UUID) -> Optional[Item]:
         """
-        Finds an item in the npc's bag which has the given id.
+        Finds an item in the NPC's bag which has the given instance ID.
         """
         return next(
-            (m for m in self.items if m.instance_id == instance_id), None
+            (itm for itm in self._items if itm.instance_id == instance_id),
+            None,
         )
+
+    def clear_items(self) -> None:
+        """
+        Removes all items from the NPC's bag.
+        """
+        self._items.clear()
+
+    def count_item(self, item_slug: str) -> int:
+        """
+        Counts the total number of items with the given slug in the NPC's bag.
+        """
+        return sum(1 for itm in self._items if itm.slug == item_slug)
+
+    def encode_items(self) -> Sequence[Mapping[str, Any]]:
+        return encode_items(self._items)
+
+    def decode_items(self, json_data: Optional[Mapping[str, Any]]) -> None:
+        if json_data and "items" in json_data:
+            self._items = [itm for itm in decode_items(json_data["items"])]

--- a/tuxemon/states/combat/combat_menus.py
+++ b/tuxemon/states/combat/combat_menus.py
@@ -186,7 +186,9 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
 
         def choose_item() -> None:
             # open menu to choose item
-            menu = self.client.push_state(ItemMenuState(self.character))
+            menu = self.client.push_state(
+                ItemMenuState(self.character, self.name)
+            )
 
             # set next menu after the selection is made
             menu.is_valid_entry = validate_item  # type: ignore[method-assign]

--- a/tuxemon/states/combat/combat_menus_park.py
+++ b/tuxemon/states/combat/combat_menus_park.py
@@ -93,14 +93,14 @@ class MainParkMenuState(PopUpMenu[MenuGameObj]):
         category = sum(
             [
                 itm.quantity
-                for itm in self.player.items
+                for itm in self.player.items.get_items()
                 if itm.category == cat_slug
             ]
         )
         return category
 
     def throw_tuxeball(self) -> None:
-        tuxeball = self.player.find_item("tuxeball_park")
+        tuxeball = self.player.items.find_item("tuxeball_park")
         if tuxeball:
             self.deliver_action(tuxeball)
 
@@ -111,7 +111,9 @@ class MainParkMenuState(PopUpMenu[MenuGameObj]):
             self.description = choice.description
 
         def choose_item() -> None:
-            menu = self.client.push_state(ItemMenuState(self.player))
+            menu = self.client.push_state(
+                ItemMenuState(self.player, self.name)
+            )
             menu.is_valid_entry = validate  # type: ignore[method-assign]
             menu.on_menu_selection = choose_target  # type: ignore[method-assign]
 

--- a/tuxemon/states/items/shop_menu.py
+++ b/tuxemon/states/items/shop_menu.py
@@ -221,7 +221,7 @@ class ShopBuyMenuState(ShopMenuState):
                 self.buyer, item, quantity, label
             )
             self.reload_items()
-            if item not in self.seller.items:
+            if not self.seller.items.has_item(item.slug):
                 self.on_menu_selection_change()
 
         money = self.buyer_manager.get_money()
@@ -254,7 +254,7 @@ class ShopSellMenuState(ShopMenuState):
         def sell_item(quantity: int) -> None:
             self.transaction_manager.sell_item(self.seller, item, quantity)
             self.reload_items()
-            if item not in self.seller.items:
+            if not self.seller.items.has_item(item.slug):
                 self.on_menu_selection_change()
 
         self.client.push_state(
@@ -289,13 +289,13 @@ class TransactionManager:
             item.quantity -= quantity
             buyer.game_variables[label] -= quantity
 
-        in_bag = buyer.find_item(item.slug)
+        in_bag = buyer.items.find_item(item.slug)
         if in_bag:
             in_bag.quantity += quantity
         else:
             new_item = Item.create(item.slug)
             new_item.quantity = quantity
-            buyer.add_item(new_item)
+            buyer.items.add_item(new_item)
 
         price = self.economy.lookup_item_price(item.slug)
         total_cost = quantity * price
@@ -305,7 +305,7 @@ class TransactionManager:
         """Process selling of items."""
         remaining_quantity = item.quantity - quantity
         if remaining_quantity <= 0:
-            seller.remove_item(item)
+            seller.items.remove_item(item)
         else:
             item.quantity = remaining_quantity
 
@@ -321,9 +321,13 @@ def filter_inventory(
     buyer: NPC, seller: NPC, economy: Economy, is_player_buyer: bool
 ) -> list[Item]:
     inventory = (
-        seller.items
+        seller.items.get_items()
         if is_player_buyer
-        else [item for item in seller.items if item.behaviors.resellable]
+        else [
+            item
+            for item in seller.items.get_items()
+            if item.behaviors.resellable
+        ]
     )
 
     if is_player_buyer:

--- a/tuxemon/states/monster_item/__init__.py
+++ b/tuxemon/states/monster_item/__init__.py
@@ -37,7 +37,9 @@ class MonsterItemState(PygameMenuState):
 
         def add_item() -> None:
             assert monster.owner
-            menu = self.client.push_state(ItemMenuState(monster.owner))
+            menu = self.client.push_state(
+                ItemMenuState(monster.owner, self.name)
+            )
             menu.is_valid_entry = validate  # type: ignore[method-assign]
             menu.on_menu_selection = choose_target  # type: ignore[method-assign]
 
@@ -48,7 +50,7 @@ class MonsterItemState(PygameMenuState):
             item = menu_item.game_object
             monster.held_item.set_item(item)
             assert monster.owner
-            monster.owner.remove_item(item)
+            monster.owner.items.remove_item(item)
             self.client.remove_state_by_name("ItemMenuState")
             self.client.remove_state_by_name("MonsterItemState")
             self.client.remove_state_by_name("MonsterMenuState")
@@ -57,7 +59,7 @@ class MonsterItemState(PygameMenuState):
             item = monster.held_item.get_item()
             if item is not None:
                 assert monster.owner
-                monster.owner.add_item(item)
+                monster.owner.items.add_item(item)
             monster.held_item.clear_item()
             self.client.remove_state_by_name("MonsterItemState")
             self.client.remove_state_by_name("MonsterMenuState")
@@ -95,7 +97,9 @@ class MonsterItemState(PygameMenuState):
         else:
             assert monster.owner
             holdable = [
-                item for item in monster.owner.items if item.behaviors.holdable
+                item
+                for item in monster.owner.items.get_items()
+                if item.behaviors.holdable
             ]
             if holdable:
                 menu.add.button(

--- a/tuxemon/states/party/__init__.py
+++ b/tuxemon/states/party/__init__.py
@@ -105,7 +105,7 @@ class PartyState(PygameMenuState):
 
         total = sum(monster.steps for monster in monsters)
         # bond
-        if self.char.find_item("friendship_scroll"):
+        if self.char.items.find_item("friendship_scroll"):
             lab5: Any = menu.add.label(
                 title=T.translate("menu_bond"),
                 font_size=self.font_size_big,

--- a/tuxemon/states/pc/__init__.py
+++ b/tuxemon/states/pc/__init__.py
@@ -61,7 +61,7 @@ class PCState(PygameMenuState):
         dropoff = change_state("MonsterDropOffState", character=char)
 
         # item boxes
-        if len(char.items) == prepare.MAX_LOCKER:
+        if len(char.items.get_items()) == prepare.MAX_LOCKER:
             storage = partial(
                 open_dialog,
                 self.client,
@@ -87,7 +87,7 @@ class PCState(PygameMenuState):
             menu.append(("menu_dropoff", dropoff))
         if nr_items > 0:
             menu.append(("menu_item_storage", item_storage))
-        if len(char.items) > 1:
+        if len(char.items.get_items()) > 1:
             menu.append(("menu_item_dropoff", item_dropoff))
         # replace multiplayer when fixed
         menu.append(("menu_multiplayer", not_implemented_dialog))

--- a/tuxemon/states/pc_locker/__init__.py
+++ b/tuxemon/states/pc_locker/__init__.py
@@ -139,13 +139,13 @@ class ItemTakeState(PygameMenuState):
             self.client.remove_state_by_name("ChoiceState")
             self.client.remove_state_by_name("ItemTakeState")
             diff = itm.quantity - quantity
-            retrieve = self.char.find_item(itm.slug)
+            retrieve = self.char.items.find_item(itm.slug)
             if diff <= 0:
                 self.item_boxes.remove_item(itm)
                 if retrieve is not None:
                     retrieve.quantity += quantity
                 else:
-                    self.char.add_item(itm)
+                    self.char.items.add_item(itm)
             else:
                 itm.quantity = diff
                 if retrieve is not None:
@@ -154,7 +154,7 @@ class ItemTakeState(PygameMenuState):
                     # item deposited
                     new_item = Item.create(itm.slug)
                     new_item.quantity = quantity
-                    self.char.add_item(new_item)
+                    self.char.items.add_item(new_item)
             open_dialog(
                 self.client,
                 [
@@ -374,7 +374,7 @@ class ItemDropOff(ItemMenuState):
     """Shows all items in player's bag, puts it into box if selected."""
 
     def __init__(self, box_name: str, character: NPC) -> None:
-        super().__init__(character=character)
+        super().__init__(character=character, source=self.name)
 
         self.box_name = box_name
         self.char = character
@@ -411,7 +411,7 @@ class ItemDropOff(ItemMenuState):
                     if stored is not None:
                         if diff <= 0:
                             stored.quantity += quantity
-                            self.char.remove_item(itm)
+                            self.char.items.remove_item(itm)
                         else:
                             stored.quantity += quantity
                             itm.quantity = diff
@@ -419,7 +419,7 @@ class ItemDropOff(ItemMenuState):
                     if diff <= 0:
                         new_item.quantity = quantity
                         item_boxes.add_item(self.box_name, new_item)
-                        self.char.remove_item(itm)
+                        self.char.items.remove_item(itm)
                     else:
                         itm.quantity = diff
                         new_item.quantity = quantity
@@ -428,7 +428,7 @@ class ItemDropOff(ItemMenuState):
                 if diff <= 0:
                     new_item.quantity = quantity
                     item_boxes.add_item(self.box_name, new_item)
-                    self.char.remove_item(itm)
+                    self.char.items.remove_item(itm)
                 else:
                     itm.quantity = diff
                     new_item.quantity = quantity

--- a/tuxemon/states/phone/phone.py
+++ b/tuxemon/states/phone/phone.py
@@ -51,9 +51,9 @@ class NuPhone(PygameMenuState):
             open_dialog(self.client, [no_signal])
 
         def _uninstall(itm: Item) -> None:
-            count = sum([1 for ele in self.char.items if ele.slug == itm.slug])
+            count = self.char.items.count_item(itm.slug)
             if count > 1:
-                self.char.remove_item(itm)
+                self.char.items.remove_item(itm)
                 self.client.replace_state("NuPhone", character=self.char)
             else:
                 open_dialog(
@@ -134,7 +134,7 @@ class NuPhone(PygameMenuState):
         self.char = character
 
         menu_items_map = []
-        for itm in self.char.items:
+        for itm in self.char.items.get_items():
             if (
                 itm.category == "phone"
                 and itm.slug != "nu_phone"

--- a/tuxemon/states/techniques/__init__.py
+++ b/tuxemon/states/techniques/__init__.py
@@ -6,7 +6,7 @@ from collections.abc import Generator
 from functools import partial
 from typing import TYPE_CHECKING
 
-import pygame
+from pygame.rect import Rect
 
 from tuxemon import prepare, tools
 from tuxemon.locale import T
@@ -50,7 +50,7 @@ class TechniqueMenuState(Menu[Technique]):
         self.text_area.rect = rect
         self.sprites.add(self.text_area, layer=100)
 
-    def calc_internal_rect(self) -> pygame.rect.Rect:
+    def calc_internal_rect(self) -> Rect:
         # area in the screen where the technique list is
         rect = self.rect.copy()
         rect.width = int(rect.width * 0.58)

--- a/tuxemon/states/world/world_menus.py
+++ b/tuxemon/states/world/world_menus.py
@@ -71,7 +71,12 @@ class WorldMenuState(PygameMenuState):
             menu.append(("menu_monster", self.open_monster_menu))
         if player.items and player.menu_bag:
             menu.append(
-                ("menu_bag", change("ItemMenuState", character=player))
+                (
+                    "menu_bag",
+                    change(
+                        "ItemMenuState", character=player, source=self.name
+                    ),
+                )
             )
         if player.menu_player:
             CharacterState = change("CharacterState", kwargs=param)
@@ -88,7 +93,7 @@ class WorldMenuState(PygameMenuState):
             menu.append(("menu_load", change("LoadMenuState")))
         menu.append(("menu_options", change("ControlState")))
         menu.append(("exit", exit_game))
-        for itm in player.items:
+        for itm in player.items.get_items():
             if itm.world_menu:
                 menu.insert(
                     itm.world_menu.position,


### PR DESCRIPTION
PR introduces a structured `NPCBagHandler` to manage NPC item interactions more efficiently. 

Changes:
- encapsulation of item handling, moves item management logic from the `NPC` class to `NPCBagHandler`
- improved item storage management, allows direct interaction with `item_boxes`
- added functions like `count_item`, `clear_items`
- simplified `NPC` by delegating item-specific tasks to `NPCBagHandler`
- introduced a test suite to verify item interactions
- modification to `ItemMenuState` initialization, adds a `source` parameter to `ItemMenuState.__init__`, allowing better tracking of the state origin without relying on the removed `determine_state_called_from` method