### PR TITLE
Simplify `lookup` Method by Removing Literal and Adding Type Checking

### DIFF
--- a/tuxemon/animation_entity.py
+++ b/tuxemon/animation_entity.py
@@ -8,7 +8,7 @@ from collections.abc import Iterable
 from pygame.surface import Surface
 
 from tuxemon import prepare
-from tuxemon.db import db
+from tuxemon.db import AnimationModel, db
 from tuxemon.graphics import create_animation, load_frames_files
 from tuxemon.map_view import AnimationInfo
 
@@ -34,11 +34,7 @@ class AnimationEntity:
 
     def load(self, slug: str) -> None:
         """Loads animation."""
-        try:
-            results = db.lookup(slug, table="animation")
-        except KeyError:
-            raise RuntimeError(f"Animation {slug} not found")
-
+        results = AnimationModel.lookup(slug, db)
         self.slug = results.slug
         self.file = results.file
 

--- a/tuxemon/core/effects/fishing.py
+++ b/tuxemon/core/effects/fishing.py
@@ -146,6 +146,6 @@ class FishingEffect(CoreEffect):
 def _lookup_monsters() -> None:
     monsters = list(db.database["monster"])
     for mon in monsters:
-        results = db.lookup(mon, table="monster")
+        results = MonsterModel.lookup(mon, db)
         if results.txmn_id > 0:
             lookup_cache[mon] = results

--- a/tuxemon/core/effects/learn_mm.py
+++ b/tuxemon/core/effects/learn_mm.py
@@ -59,6 +59,6 @@ class LearnMmEffect(CoreEffect):
 def _lookup_techniques(element: str) -> None:
     monsters = list(db.database["technique"])
     for mon in monsters:
-        results = db.lookup(mon, table="technique")
+        results = TechniqueModel.lookup(mon, db)
         if results.randomly and element in results.types:
             lookup_cache[mon] = results

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from enum import Enum
 from importlib import import_module
 from pathlib import Path
-from typing import Annotated, Any, Literal, Optional, Union, overload
+from typing import Annotated, Any, ClassVar, Literal, Optional, Union, cast
 
 import yaml
 from PIL import Image
@@ -215,6 +215,7 @@ class WorldMenuEntry(BaseModel):
 
 
 class ItemModel(BaseModel):
+    table_name: ClassVar[str] = "item"
     model_config = ConfigDict(title="Item")
     slug: str = Field(..., description="The slug of the item")
     use_item: str = Field(
@@ -258,6 +259,14 @@ class ItemModel(BaseModel):
     cost: int = Field(0, description="The standard cost of the item.", ge=0)
     modifiers: list[Modifier] = Field(..., description="Various modifiers")
 
+    @classmethod
+    def lookup(cls, slug: str, db: ModData) -> ItemModel:
+        """Retrieve an instance from the database using a slug."""
+        try:
+            return cast(ItemModel, db.lookup(slug, table=cls.table_name))
+        except EntryNotFoundError:
+            raise RuntimeError(f"Item {slug} not found")
+
     # Validate fields that refer to translated text
     @field_validator("use_item", "use_success", "use_failure")
     def translation_exists(cls: ItemModel, v: str) -> str:
@@ -300,12 +309,21 @@ class AttributesModel(BaseModel):
 
 
 class ShapeModel(BaseModel):
+    table_name: ClassVar[str] = "shape"
     slug: str = Field(
         ..., description="Slug of the shape, used as a unique identifier."
     )
     attributes: AttributesModel = Field(
         ..., description="Statistical attributes of the shape."
     )
+
+    @classmethod
+    def lookup(cls, slug: str, db: ModData) -> ShapeModel:
+        """Retrieve an instance from the database using a slug."""
+        try:
+            return cast(ShapeModel, db.lookup(slug, table=cls.table_name))
+        except EntryNotFoundError:
+            raise RuntimeError(f"Shape {slug} not found")
 
     @field_validator("slug")
     def translation_exists_shape(cls: ShapeModel, v: str) -> str:
@@ -573,6 +591,7 @@ class MonsterSoundsModel(BaseModel):
 
 # Validate assignment allows us to assign a default inside a validator
 class MonsterModel(BaseModel, validate_assignment=True):
+    table_name: ClassVar[str] = "monster"
     slug: str = Field(..., description="The slug of the monster")
     category: str = Field(..., description="The category of monster")
     txmn_id: int = Field(..., description="The id of the monster")
@@ -633,6 +652,14 @@ class MonsterModel(BaseModel, validate_assignment=True):
         None,
         description="The sounds this monster has",
     )
+
+    @classmethod
+    def lookup(cls, slug: str, db: ModData) -> MonsterModel:
+        """Retrieve an instance from the database using a slug."""
+        try:
+            return cast(MonsterModel, db.lookup(slug, table=cls.table_name))
+        except EntryNotFoundError:
+            raise RuntimeError(f"Monster {slug} not found")
 
     # Set the default sprites based on slug. Specifying 'always' is needed
     # because by default pydantic doesn't validate null fields.
@@ -788,6 +815,7 @@ class TargetModel(BaseModel):
 
 
 class TechniqueModel(BaseModel):
+    table_name: ClassVar[str] = "technique"
     slug: str = Field(..., description="The slug of the technique")
     sort: TechSort = Field(..., description="The sort of technique this is")
     category: TechCategory = Field(
@@ -874,6 +902,14 @@ class TechniqueModel(BaseModel):
         le=prepare.POTENCY_RANGE[1],
     )
 
+    @classmethod
+    def lookup(cls, slug: str, db: ModData) -> TechniqueModel:
+        """Retrieve an instance from the database using a slug."""
+        try:
+            return cast(TechniqueModel, db.lookup(slug, table=cls.table_name))
+        except EntryNotFoundError:
+            raise RuntimeError(f"Technique {slug} not found")
+
     @field_validator("use_tech", "use_success", "use_failure")
     def translation_exists(
         cls: TechniqueModel, v: Optional[str]
@@ -928,6 +964,7 @@ class TechniqueModel(BaseModel):
 
 
 class StatusModel(BaseModel):
+    table_name: ClassVar[str] = "status"
     slug: str = Field(..., description="The slug of the status")
     sort: TechSort = Field(..., description="The sort of status this is")
     icon: str = Field(..., description="The icon to use for the condition")
@@ -994,6 +1031,14 @@ class StatusModel(BaseModel):
     statdodge: Optional[StatModel] = Field(None)
     statmelee: Optional[StatModel] = Field(None)
     statranged: Optional[StatModel] = Field(None)
+
+    @classmethod
+    def lookup(cls, slug: str, db: ModData) -> StatusModel:
+        """Retrieve an instance from the database using a slug."""
+        try:
+            return cast(StatusModel, db.lookup(slug, table=cls.table_name))
+        except EntryNotFoundError:
+            raise RuntimeError(f"Status {slug} not found")
 
     # Validate resources that should exist
     @field_validator("icon")
@@ -1122,6 +1167,7 @@ class NpcTemplateModel(BaseModel):
 
 
 class NpcModel(BaseModel):
+    table_name: ClassVar[str] = "npc"
     slug: str = Field(..., description="Slug of the name of the NPC")
     forfeit: bool = Field(False, description="Whether you can forfeit or not")
     template: NpcTemplateModel
@@ -1131,6 +1177,14 @@ class NpcModel(BaseModel):
     items: Sequence[BagItemModel] = Field(
         [], description="List of items in the NPCs bag"
     )
+
+    @classmethod
+    def lookup(cls, slug: str, db: ModData) -> NpcModel:
+        """Retrieve an instance from the database using a slug."""
+        try:
+            return cast(NpcModel, db.lookup(slug, table=cls.table_name))
+        except EntryNotFoundError:
+            raise RuntimeError(f"NPC {slug} not found")
 
 
 class BattleHudModel(BaseModel):
@@ -1240,11 +1294,22 @@ class BattleGraphicsModel(BaseModel):
 
 
 class EnvironmentModel(BaseModel):
+    table_name: ClassVar[str] = "environment"
     slug: str = Field(..., description="Slug of the name of the environment")
     battle_music: str = Field(
         ..., description="Filename of the music to use for this environment"
     )
     battle_graphics: BattleGraphicsModel
+
+    @classmethod
+    def lookup(cls, slug: str, db: ModData) -> EnvironmentModel:
+        """Retrieve an instance from the database using a slug."""
+        try:
+            return cast(
+                EnvironmentModel, db.lookup(slug, table=cls.table_name)
+            )
+        except EntryNotFoundError:
+            raise RuntimeError(f"Encounter {slug} not found")
 
     @field_validator("battle_music")
     def battle_music_exists(cls: EnvironmentModel, v: str) -> str:
@@ -1296,6 +1361,7 @@ class EncounterItemModel(BaseModel):
 
 
 class EncounterModel(BaseModel):
+    table_name: ClassVar[str] = "encounter"
     slug: str = Field(
         ..., description="Slug to uniquely identify this encounter"
     )
@@ -1303,8 +1369,17 @@ class EncounterModel(BaseModel):
         [], description="Monsters encounterable"
     )
 
+    @classmethod
+    def lookup(cls, slug: str, db: ModData) -> EncounterModel:
+        """Retrieve an instance from the database using a slug."""
+        try:
+            return cast(EncounterModel, db.lookup(slug, table=cls.table_name))
+        except EntryNotFoundError:
+            raise RuntimeError(f"Encounter {slug} not found")
+
 
 class DialogueModel(BaseModel):
+    table_name: ClassVar[str] = "dialogue"
     slug: str = Field(
         ..., description="Slug to uniquely identify this dialogue"
     )
@@ -1314,7 +1389,14 @@ class DialogueModel(BaseModel):
     border_slug: str = Field(..., description="Name of the border")
     border_path: str = Field(..., description="Path to the border")
 
-    # Validate resources that should exist
+    @classmethod
+    def lookup(cls, slug: str, db: ModData) -> DialogueModel:
+        """Retrieve an instance from the database using a slug."""
+        try:
+            return cast(DialogueModel, db.lookup(slug, table=cls.table_name))
+        except EntryNotFoundError:
+            raise RuntimeError(f"Dialogue {slug} not found")
+
     @field_validator("border_slug")
     def file_exists(cls: DialogueModel, v: str) -> str:
         file: str = f"gfx/borders/{v}.png"
@@ -1335,9 +1417,18 @@ class ElementItemModel(BaseModel):
 
 
 class ElementModel(BaseModel):
+    table_name: ClassVar[str] = "element"
     slug: str = Field(..., description="Slug uniquely identifying the type")
     icon: str = Field(..., description="The icon to use for the type")
     types: Sequence[ElementItemModel]
+
+    @classmethod
+    def lookup(cls, slug: str, db: ModData) -> ElementModel:
+        """Retrieve an instance from the database using a slug."""
+        try:
+            return cast(ElementModel, db.lookup(slug, table=cls.table_name))
+        except EntryNotFoundError:
+            raise RuntimeError(f"Element {slug} not found")
 
     @field_validator("slug")
     def translation_exists_element(cls: ElementModel, v: str) -> str:
@@ -1353,6 +1444,7 @@ class ElementModel(BaseModel):
 
 
 class TasteModel(BaseModel):
+    table_name: ClassVar[str] = "taste"
     slug: str = Field(..., description="Slug of the taste")
     name: str = Field(..., description="Name of the taste")
     taste_type: Literal["warm", "cold"] = Field(
@@ -1361,6 +1453,14 @@ class TasteModel(BaseModel):
     modifiers: Sequence[Modifier] = Field(
         ..., description="Modifiers associated with the taste"
     )
+
+    @classmethod
+    def lookup(cls, slug: str, db: ModData) -> TasteModel:
+        """Retrieve an instance from the database using a slug."""
+        try:
+            return cast(TasteModel, db.lookup(slug, table=cls.table_name))
+        except EntryNotFoundError:
+            raise RuntimeError(f"Taste {slug} not found")
 
     @field_validator("name")
     def translation_exists_taste(cls: TasteModel, v: str) -> str:
@@ -1404,11 +1504,20 @@ class EconomyMonsterModel(EconomyEntityModel):
 
 
 class EconomyModel(BaseModel):
+    table_name: ClassVar[str] = "economy"
     slug: str = Field(..., description="Slug uniquely identifying the economy")
     resale_multiplier: float = Field(..., description="Resale multiplier")
     background: str = Field(..., description="Sprite used for background")
     items: Sequence[EconomyItemModel]
     monsters: Sequence[EconomyMonsterModel]
+
+    @classmethod
+    def lookup(cls, slug: str, db: ModData) -> EconomyModel:
+        """Retrieve an instance from the database using a slug."""
+        try:
+            return cast(EconomyModel, db.lookup(slug, table=cls.table_name))
+        except EntryNotFoundError:
+            raise RuntimeError(f"Economy {slug} not found")
 
     @field_validator("background")
     def background_exists(cls: EconomyModel, v: str) -> str:
@@ -1434,6 +1543,7 @@ class ProgressModel(BaseModel):
 
 
 class MissionModel(BaseModel):
+    table_name: ClassVar[str] = "mission"
     slug: str = Field(..., description="Slug uniquely identifying the mission")
     description: str = Field(
         ..., description="Detailed description of the mission objectives"
@@ -1459,6 +1569,14 @@ class MissionModel(BaseModel):
         ...,
         description="List of mission slugs that must be completed before this mission",
     )
+
+    @classmethod
+    def lookup(cls, slug: str, db: ModData) -> MissionModel:
+        """Retrieve an instance from the database using a slug."""
+        try:
+            return cast(MissionModel, db.lookup(slug, table=cls.table_name))
+        except EntryNotFoundError:
+            raise RuntimeError(f"Mission {slug} not found")
 
     @field_validator("slug")
     def translation_exists_mission(cls: MissionModel, v: str) -> str:
@@ -1516,8 +1634,17 @@ class SoundModel(BaseModel):
 
 
 class AnimationModel(BaseModel):
+    table_name: ClassVar[str] = "animation"
     slug: str = Field(..., description="Unique slug for the animation")
     file: str = Field(..., description="File of the animation")
+
+    @classmethod
+    def lookup(cls, slug: str, db: ModData) -> AnimationModel:
+        """Retrieve an instance from the database using a slug."""
+        try:
+            return cast(AnimationModel, db.lookup(slug, table=cls.table_name))
+        except EntryNotFoundError:
+            raise RuntimeError(f"Animation {slug} not found")
 
     @field_validator("file")
     def file_exists(cls: AnimationModel, v: str, info: ValidationInfo) -> str:
@@ -1529,11 +1656,20 @@ class AnimationModel(BaseModel):
 
 
 class TerrainModel(BaseModel):
+    table_name: ClassVar[str] = "terrain"
     slug: str = Field(..., description="Slug of the terrain")
     name: str = Field(..., description="Name of the terrain condition")
     element_modifier: dict[str, float] = Field(
         ..., description="Modifiers for elemental techniques in this terrain"
     )
+
+    @classmethod
+    def lookup(cls, slug: str, db: ModData) -> TerrainModel:
+        """Retrieve an instance from the database using a slug."""
+        try:
+            return cast(TerrainModel, db.lookup(slug, table=cls.table_name))
+        except EntryNotFoundError:
+            raise RuntimeError(f"Terrain {slug} not found")
 
     @field_validator("name")
     def translation_exists_item(cls: TerrainModel, v: str) -> str:
@@ -1543,6 +1679,7 @@ class TerrainModel(BaseModel):
 
 
 class WeatherModel(BaseModel):
+    table_name: ClassVar[str] = "weather"
     slug: str = Field(..., description="Slug of the weather")
     name: str = Field(..., description="Name of the weather condition")
     element_modifier: dict[str, float] = Field(
@@ -1550,34 +1687,20 @@ class WeatherModel(BaseModel):
         description="Modifiers for elemental techniques during this weather",
     )
 
+    @classmethod
+    def lookup(cls, slug: str, db: ModData) -> WeatherModel:
+        """Retrieve an instance from the database using a slug."""
+        try:
+            return cast(WeatherModel, db.lookup(slug, table=cls.table_name))
+        except EntryNotFoundError:
+            raise RuntimeError(f"Weather {slug} not found")
+
     @field_validator("name")
     def translation_exists_item(cls: WeatherModel, v: str) -> str:
         if has.translation(v):
             return v
         raise ValueError(f"no translation exists with msgid: {v}")
 
-
-TableName = Literal[
-    "economy",
-    "element",
-    "taste",
-    "shape",
-    "terrain",
-    "weather",
-    "template",
-    "mission",
-    "encounter",
-    "dialogue",
-    "environment",
-    "item",
-    "monster",
-    "music",
-    "animation",
-    "npc",
-    "sounds",
-    "status",
-    "technique",
-]
 
 DataModel = Union[
     EconomyModel,
@@ -1603,9 +1726,9 @@ DataModel = Union[
 
 
 def load_model_map(
-    model_map_config: dict[TableName, str],
-) -> dict[TableName, type[DataModel]]:
-    model_map: dict[TableName, type[DataModel]] = {}
+    model_map_config: dict[str, str],
+) -> dict[str, type[DataModel]]:
+    model_map: dict[str, type[DataModel]] = {}
     for table, model_path in model_map_config.items():
         module_name, class_name = model_path.rsplit(".", 1)
         module = import_module(module_name)
@@ -1615,16 +1738,16 @@ def load_model_map(
 
 @dataclass
 class DatabaseConfig:
-    model_map: dict[TableName, str]
+    model_map: dict[str, str]
     mod_base_path: str
     mod_db_subfolder: str
     file_extensions: list[str]
-    default_lookup_table: TableName
+    default_lookup_table: str
     active_mods: list[str]
     mod_versions: dict[str, str]
     mod_table_exclusions: dict[str, list[str]]
     mod_activation: dict[str, bool]
-    mod_tables: dict[str, list[TableName]]
+    mod_tables: dict[str, list[str]]
     mod_dependencies: dict[str, list[str]]
 
 
@@ -1677,10 +1800,10 @@ class ModMetadataLoader:
 
 
 class ModelLoader:
-    def __init__(self, model_map: dict[TableName, type[DataModel]]):
+    def __init__(self, model_map: dict[str, type[DataModel]]):
         self.model_map = model_map
 
-    def validate(self, item: Mapping[str, Any], table: TableName) -> DataModel:
+    def validate(self, item: Mapping[str, Any], table: str) -> DataModel:
         try:
             model_class = self.model_map.get(table)
             if model_class:
@@ -1694,7 +1817,7 @@ class ModelLoader:
             raise e
 
     def load(
-        self, item: Mapping[str, Any], table: TableName, validate: bool = False
+        self, item: Mapping[str, Any], table: str, validate: bool = False
     ) -> DataModel:
         try:
             if validate:
@@ -1726,8 +1849,8 @@ class ModData:
         self.config = config
         self.resolver = resolver
         self.loader = loader
-        self.preloaded: dict[TableName, dict[str, Any]] = {}
-        self.database: dict[TableName, dict[str, DataModel]] = {}
+        self.preloaded: dict[str, dict[str, Any]] = {}
+        self.database: dict[str, dict[str, DataModel]] = {}
         self.mod_metadata = mod_loader.load_metadata()
         if self.config.mod_tables:
             for mod, tables in self.config.mod_tables.items():
@@ -1737,9 +1860,7 @@ class ModData:
                             self.preloaded[table] = {}
                             self.database[table] = {}
 
-    def preload(
-        self, directory: Union[TableName, Literal["all"]] = "all"
-    ) -> None:
+    def preload(self, directory: str = "all") -> None:
         """
         Loads all data from JSON files located under our data path as an
         untyped preloaded dictionary.
@@ -1766,7 +1887,7 @@ class ModData:
             self._preload_table(directory, None)
 
     def _preload_table(
-        self, table: TableName, mod_directory: Optional[str] = None
+        self, table: str, mod_directory: Optional[str] = None
     ) -> None:
         """Preloads table data from mod directories."""
         active_mods = [
@@ -1813,7 +1934,7 @@ class ModData:
 
     def load(
         self,
-        directory: Union[TableName, Literal["all"]] = "all",
+        directory: str = "all",
         validate: bool = True,
     ) -> None:
         """
@@ -1835,9 +1956,7 @@ class ModData:
         else:
             self._load_models_from_preloaded(directory, validate)
 
-    def _load_models_from_preloaded(
-        self, table: TableName, validate: bool
-    ) -> None:
+    def _load_models_from_preloaded(self, table: str, validate: bool) -> None:
         """Loads models from preloaded data into the main database."""
         for item in self.preloaded[table].values():
             if "paths" in item:
@@ -1848,7 +1967,7 @@ class ModData:
                 self.database[table][model.slug] = model
 
     def _validate_and_load(
-        self, item: Mapping[str, Any], table: TableName, validate: bool
+        self, item: Mapping[str, Any], table: str, validate: bool
     ) -> Optional[DataModel]:
         """Validates and loads a model entry."""
         try:
@@ -1866,7 +1985,7 @@ class ModData:
             return None
 
     def load_model(
-        self, item: Mapping[str, Any], table: TableName, validate: bool = False
+        self, item: Mapping[str, Any], table: str, validate: bool = False
     ) -> None:
         """
         Loads a single json object, casts it to the appropriate data model,
@@ -1882,91 +2001,7 @@ class ModData:
         if model:
             self.database[table][model.slug] = model
 
-    @overload
-    def lookup(self, slug: str) -> MonsterModel:
-        pass
-
-    @overload
-    def lookup(self, slug: str, table: Literal["monster"]) -> MonsterModel:
-        pass
-
-    @overload
-    def lookup(self, slug: str, table: Literal["status"]) -> StatusModel:
-        pass
-
-    @overload
-    def lookup(self, slug: str, table: Literal["technique"]) -> TechniqueModel:
-        pass
-
-    @overload
-    def lookup(self, slug: str, table: Literal["item"]) -> ItemModel:
-        pass
-
-    @overload
-    def lookup(self, slug: str, table: Literal["npc"]) -> NpcModel:
-        pass
-
-    @overload
-    def lookup(self, slug: str, table: Literal["encounter"]) -> EncounterModel:
-        pass
-
-    @overload
-    def lookup(self, slug: str, table: Literal["dialogue"]) -> DialogueModel:
-        pass
-
-    @overload
-    def lookup(self, slug: str, table: Literal["economy"]) -> EconomyModel:
-        pass
-
-    @overload
-    def lookup(self, slug: str, table: Literal["element"]) -> ElementModel:
-        pass
-
-    @overload
-    def lookup(self, slug: str, table: Literal["taste"]) -> TasteModel:
-        pass
-
-    @overload
-    def lookup(self, slug: str, table: Literal["shape"]) -> ShapeModel:
-        pass
-
-    @overload
-    def lookup(self, slug: str, table: Literal["terrain"]) -> TerrainModel:
-        pass
-
-    @overload
-    def lookup(self, slug: str, table: Literal["weather"]) -> WeatherModel:
-        pass
-
-    @overload
-    def lookup(self, slug: str, table: Literal["template"]) -> TemplateModel:
-        pass
-
-    @overload
-    def lookup(self, slug: str, table: Literal["mission"]) -> MissionModel:
-        pass
-
-    @overload
-    def lookup(self, slug: str, table: Literal["music"]) -> MusicModel:
-        pass
-
-    @overload
-    def lookup(self, slug: str, table: Literal["animation"]) -> AnimationModel:
-        pass
-
-    @overload
-    def lookup(self, slug: str, table: Literal["sounds"]) -> SoundModel:
-        pass
-
-    @overload
-    def lookup(
-        self, slug: str, table: Literal["environment"]
-    ) -> EnvironmentModel:
-        pass
-
-    def lookup(
-        self, slug: str, table: Optional[TableName] = None
-    ) -> DataModel:
+    def lookup(self, slug: str, table: Optional[str] = None) -> DataModel:
         """
         Looks up a monster, technique, item, npc, etc based on slug.
 
@@ -1987,7 +2022,7 @@ class ModData:
             self.log_missing_entry_and_raise(table, slug)
         return table_entry[slug]
 
-    def log_missing_entry_and_raise(self, table: TableName, slug: str) -> None:
+    def log_missing_entry_and_raise(self, table: str, slug: str) -> None:
         """Logs a missing entry and raises EntryNotFoundError."""
         options = difflib.get_close_matches(slug, self.database[table].keys())
         options_str = ", ".join(repr(s) for s in options)
@@ -2000,7 +2035,7 @@ class ModData:
             f"Lookup failed for unknown {table} '{slug}'. {hint}"
         )
 
-    def get_entry(self, table: TableName, slug: str) -> str:
+    def get_entry(self, table: str, slug: str) -> str:
         """Checks existence of an entry and returns its file path if available."""
         table_data = self.database.get(table)
 
@@ -2018,7 +2053,7 @@ class ModData:
 
         return getattr(entry, "file", slug)
 
-    def reload(self, table: TableName, validate: bool = True) -> None:
+    def reload(self, table: str, validate: bool = True) -> None:
         """Reloads the data for a specific table."""
         if table not in self.database:
             logger.error(f"Table '{table}' not loaded.")
@@ -2054,7 +2089,7 @@ class ModData:
             logger.error(f"Error reloading table '{table}': {e}")
 
     def add_entry(
-        self, table: TableName, data: dict[str, Any], validate: bool = True
+        self, table: str, data: dict[str, Any], validate: bool = True
     ) -> None:
         try:
             model = self.loader.load(data, table, validate)
@@ -2086,7 +2121,7 @@ class ModData:
 
 
 def load_files(
-    directory: TableName, path: Path, config: DatabaseConfig
+    directory: str, path: Path, config: DatabaseConfig
 ) -> dict[str, Any]:
     preloaded_data: dict[str, Any] = {}
     extensions = config.file_extensions
@@ -2213,7 +2248,7 @@ class Validator:
                     )
         return True
 
-    def db_entry(self, table: TableName, slug: str) -> bool:
+    def db_entry(self, table: str, slug: str) -> bool:
         """
         Check to see if the given slug exists in the database for the given
         table.

--- a/tuxemon/economy.py
+++ b/tuxemon/economy.py
@@ -44,11 +44,7 @@ class Economy:
             RuntimeError: If the economy with the given slug is not found
             in the database.
         """
-        try:
-            results = db.lookup(slug, table="economy")
-        except KeyError:
-            raise RuntimeError(f"Failed to find economy with slug {slug}")
-
+        results = EconomyModel.lookup(slug, db)
         self.model.slug = results.slug
         self.model.resale_multiplier = results.resale_multiplier
         self.model.background = results.background

--- a/tuxemon/element.py
+++ b/tuxemon/element.py
@@ -6,7 +6,7 @@ import logging
 from collections.abc import Sequence
 from typing import Optional
 
-from tuxemon.db import ElementItemModel, db
+from tuxemon.db import ElementItemModel, ElementModel, db
 from tuxemon.locale import T
 
 logger = logging.getLogger(__name__)
@@ -36,11 +36,7 @@ class Element:
             self.icon = cached_element.icon
             return
 
-        try:
-            results = db.lookup(slug, table="element")
-        except KeyError:
-            raise RuntimeError(f"Element {slug} not found")
-
+        results = ElementModel.lookup(slug, db)
         self.slug = slug
         self.name = T.translate(self.slug)
         self.types = results.types

--- a/tuxemon/encounter.py
+++ b/tuxemon/encounter.py
@@ -8,7 +8,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Optional
 
 from tuxemon import prepare
-from tuxemon.db import EncounterItemModel, db
+from tuxemon.db import EncounterItemModel, EncounterModel, db
 
 if TYPE_CHECKING:
     from tuxemon.npc import NPC
@@ -23,11 +23,7 @@ class EncounterData:
 
     def load_encounters(self, slug: str) -> Sequence[EncounterItemModel]:
         """Loads encounter data from the db."""
-        try:
-            results = db.lookup(slug, table="encounter")
-        except KeyError:
-            raise RuntimeError(f"Encounter {slug} not found")
-
+        results = EncounterModel.lookup(slug, db)
         return results.monsters
 
     def get_encounters(self) -> Sequence[EncounterItemModel]:

--- a/tuxemon/event/actions/change_state.py
+++ b/tuxemon/event/actions/change_state.py
@@ -7,7 +7,7 @@ import uuid
 from dataclasses import dataclass
 from typing import Optional, final
 
-from tuxemon.db import db
+from tuxemon.db import MonsterModel, db
 from tuxemon.event import get_monster_by_iid, get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.monster import Monster
@@ -73,11 +73,7 @@ class ChangeStateAction(EventAction):
 
     def _handle_journal_info_state(self, optional: str) -> None:
         """Handle the JournalInfoState transition."""
-        journal = db.lookup(optional, table="monster")
-        if journal is None:
-            logger.error("Journal not found")
-            return
-
+        journal = MonsterModel.lookup(optional, db)
         _set_tuxepedia = ["player", journal.slug, "caught"]
         self.action.execute_action("set_tuxepedia", _set_tuxepedia, True)
         self.client.push_state(

--- a/tuxemon/event/actions/create_npc.py
+++ b/tuxemon/event/actions/create_npc.py
@@ -7,7 +7,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional, final
 
-from tuxemon.db import db
+from tuxemon.db import NpcModel, db
 from tuxemon.event.eventaction import EventAction
 from tuxemon.item.item import Item
 from tuxemon.monster import Monster
@@ -15,7 +15,7 @@ from tuxemon.npc import NPC
 from tuxemon.states.world.worldstate import WorldState
 
 if TYPE_CHECKING:
-    from tuxemon.db import NpcModel, PartyMemberModel
+    from tuxemon.db import PartyMemberModel
     from tuxemon.session import Session
 
 logger = logging.getLogger(__name__)
@@ -79,7 +79,7 @@ def load_party(slug: str) -> NpcModel:
     if slug in lookup_cache:
         return lookup_cache[slug]
     else:
-        npc_details = db.lookup(slug, "npc")
+        npc_details = NpcModel.lookup(slug, db)
         lookup_cache[slug] = npc_details
         return npc_details
 

--- a/tuxemon/event/actions/random_battle.py
+++ b/tuxemon/event/actions/random_battle.py
@@ -9,7 +9,7 @@ from typing import final
 
 from tuxemon import prepare
 from tuxemon.combat import check_battle_legal
-from tuxemon.db import MonsterModel, NpcModel, db
+from tuxemon.db import EnvironmentModel, MonsterModel, NpcModel, db
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.monster import Monster
@@ -90,8 +90,7 @@ class RandomBattleAction(EventAction):
 
         player = session.player
         env_slug = player.game_variables.get("environment", "grass")
-        env = db.lookup(env_slug, table="environment")
-
+        env = EnvironmentModel.lookup(env_slug, db)
         if not (check_battle_legal(player) and check_battle_legal(npc)):
             logger.warning("Battle is not legal, won't start")
             return
@@ -127,11 +126,11 @@ def _lookup() -> None:
     npcs = list(db.database["npc"])
 
     for mon in monsters:
-        _mon = db.lookup(mon, table="monster")
+        _mon = MonsterModel.lookup(mon, db)
         if _mon.txmn_id > 0 and _mon.randomly:
             lookup_cache_mon[mon] = _mon
 
     for npc in npcs:
-        _npc = db.lookup(npc, table="npc")
+        _npc = NpcModel.lookup(npc, db)
         if not _npc.monsters:
             lookup_cache_npc[npc] = _npc

--- a/tuxemon/event/actions/random_monster.py
+++ b/tuxemon/event/actions/random_monster.py
@@ -92,6 +92,6 @@ class RandomMonsterAction(EventAction):
 def _lookup_monsters() -> None:
     monsters = list(db.database["monster"])
     for mon in monsters:
-        results = db.lookup(mon, table="monster")
+        results = MonsterModel.lookup(mon, db)
         if results.txmn_id > 0:
             lookup_cache[mon] = results

--- a/tuxemon/event/actions/start_battle.py
+++ b/tuxemon/event/actions/start_battle.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Optional, final
 
 from tuxemon.combat import check_battle_legal
-from tuxemon.db import db
+from tuxemon.db import EnvironmentModel, db
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.session import Session
@@ -63,7 +63,7 @@ class StartBattleAction(EventAction):
                     "environment", "grass"
                 )
 
-        env = db.lookup(env_slug, table="environment")
+        env = EnvironmentModel.lookup(env_slug, db)
 
         fighters = sorted(
             [character1, character2], key=lambda x: not x.isplayer

--- a/tuxemon/event/actions/start_double_battle.py
+++ b/tuxemon/event/actions/start_double_battle.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Optional, final
 
 from tuxemon.combat import check_battle_legal
-from tuxemon.db import db
+from tuxemon.db import EnvironmentModel, db
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.prepare import MONSTERS_DOUBLE
@@ -64,7 +64,7 @@ class StartDoubleBattleAction(EventAction):
                     "environment", "grass"
                 )
 
-        env = db.lookup(env_slug, table="environment")
+        env = EnvironmentModel.lookup(env_slug, db)
 
         fighters = sorted(
             [character1, character2], key=lambda x: not x.isplayer

--- a/tuxemon/event/actions/translated_dialog.py
+++ b/tuxemon/event/actions/translated_dialog.py
@@ -95,7 +95,7 @@ def _get_style(cache_key: str) -> DialogueModel:
         return style_cache[cache_key]
     else:
         try:
-            style = db.lookup(cache_key, table="dialogue")
+            style = DialogueModel.lookup(cache_key, db)
             style_cache[cache_key] = style
             return style
         except KeyError:

--- a/tuxemon/event/actions/wild_encounter.py
+++ b/tuxemon/event/actions/wild_encounter.py
@@ -8,7 +8,7 @@ from typing import Optional, final
 
 from tuxemon import prepare
 from tuxemon.combat import check_battle_legal
-from tuxemon.db import db
+from tuxemon.db import EnvironmentModel, db
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.graphics import ColorLike, string_to_colorlike
@@ -91,7 +91,7 @@ class WildEncounterAction(EventAction):
 
         env_var = player.game_variables.get("environment", "grass")
         env = env_var if self.env is None else self.env
-        environment = db.lookup(env, table="environment")
+        environment = EnvironmentModel.lookup(env, db)
 
         player.tuxepedia.add_entry(current_monster.slug)
 

--- a/tuxemon/event/conditions/tuxepedia.py
+++ b/tuxemon/event/conditions/tuxepedia.py
@@ -56,6 +56,6 @@ class TuxepediaCondition(EventCondition):
 def _lookup_monsters() -> None:
     monsters = list(db.database["monster"])
     for mon in monsters:
-        results = db.lookup(mon, table="monster")
+        results = MonsterModel.lookup(mon, db)
         if results.txmn_id > 0:
             lookup_cache[mon] = results

--- a/tuxemon/graphics.py
+++ b/tuxemon/graphics.py
@@ -23,7 +23,7 @@ from pytmx.pytmx import TileFlags
 from pytmx.util_pygame import handle_transformation, smart_convert
 
 from tuxemon import prepare
-from tuxemon.db import db
+from tuxemon.db import MonsterModel, NpcModel, db
 from tuxemon.session import Session
 from tuxemon.sprite import Sprite
 from tuxemon.surfanim import SurfaceAnimation
@@ -422,7 +422,7 @@ def get_avatar(session: Session, avatar: str) -> Optional[Sprite]:
             return None
 
     if avatar in db.database.get("monster", {}):
-        monster_data = db.lookup(avatar, table="monster")
+        monster_data = MonsterModel.lookup(avatar, db)
         if not monster_data.sprites:
             logger.error(f"Monster '{avatar}' has no sprites")
             return None
@@ -439,7 +439,7 @@ def get_avatar(session: Session, avatar: str) -> Optional[Sprite]:
             return None
 
     if avatar in db.database.get("npc", {}):
-        npc_data = db.lookup(avatar, table="npc")
+        npc_data = NpcModel.lookup(avatar, db)
         path = f"gfx/sprites/player/{npc_data.template.combat_front}.png"
         sprite = load_sprite(path)
         scale_sprite(sprite, 0.5)

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -15,7 +15,7 @@ from tuxemon.core.core_condition import CoreCondition
 from tuxemon.core.core_effect import CoreEffect, ItemEffectResult
 from tuxemon.core.core_manager import ConditionManager, EffectManager
 from tuxemon.core.core_processor import ConditionProcessor, EffectProcessor
-from tuxemon.db import ItemCategory, State, db
+from tuxemon.db import ItemCategory, ItemModel, State, db
 from tuxemon.locale import T
 from tuxemon.surfanim import FlipAxes
 
@@ -95,11 +95,7 @@ class Item:
             slug: The item slug to look up in the monster.item database.
 
         """
-        try:
-            results = db.lookup(slug, table="item")
-        except KeyError:
-            raise RuntimeError(f"Item {slug} not found")
-
+        results = ItemModel.lookup(slug, db)
         self.slug = results.slug
         self.name = T.translate(self.slug)
         self.description = T.translate(f"{self.slug}_description")

--- a/tuxemon/mission.py
+++ b/tuxemon/mission.py
@@ -7,7 +7,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional
 
-from tuxemon.db import MissionStatus, db
+from tuxemon.db import MissionModel, MissionStatus, db
 from tuxemon.locale import T
 
 if TYPE_CHECKING:
@@ -155,11 +155,7 @@ class Mission:
         """
         Loads and sets mission from the db.
         """
-        try:
-            results = db.lookup(slug, table="mission")
-        except KeyError:
-            raise RuntimeError(f"Mission {slug} not found")
-
+        results = MissionModel.lookup(slug, db)
         self.slug = results.slug
         self.name = T.translate(results.slug)
         self.description = T.translate(results.description)

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -16,6 +16,7 @@ from tuxemon.db import (
     GenderType,
     MonsterEvolutionItemModel,
     MonsterHistoryItemModel,
+    MonsterModel,
     MonsterMovesetItemModel,
     MonsterSpritesModel,
     PlagueType,
@@ -214,11 +215,7 @@ class Monster:
         Parameters:
             slug: Slug to lookup.
         """
-        try:
-            results = db.lookup(slug, table="monster")
-        except KeyError:
-            raise RuntimeError(f"Monster {slug} not found")
-
+        results = MonsterModel.lookup(slug, db)
         self.level = random.randint(2, 5)
         self.slug = results.slug
         self.name = T.translate(results.slug)
@@ -709,7 +706,7 @@ class MonsterSpriteHandler:
         if not slug:
             return {}
 
-        results = db.lookup(slug, table="monster")
+        results = MonsterModel.lookup(slug, db)
         flairs: dict[str, Flair] = {}
 
         for flair in results.flairs:

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, Optional, TypedDict
 from tuxemon import prepare
 from tuxemon.battle import Battle, decode_battle, encode_battle
 from tuxemon.boxes import ItemBoxes, MonsterBoxes
-from tuxemon.db import Direction, db
+from tuxemon.db import Direction, NpcModel, db
 from tuxemon.entity import Entity
 from tuxemon.item.item import Item, decode_items, encode_items
 from tuxemon.locale import T
@@ -95,7 +95,7 @@ class NPC(Entity[NPCState]):
         super().__init__(slug=npc_slug, world=world)
 
         # load initial data from the npc database
-        npc_data = db.lookup(npc_slug, table="npc")
+        npc_data = NpcModel.lookup(npc_slug, db)
         self.template = npc_data.template
 
         # This is the NPC's name to be used in dialog

--- a/tuxemon/shape.py
+++ b/tuxemon/shape.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
-from tuxemon.db import AttributesModel, db
+from tuxemon.db import AttributesModel, ShapeModel, db
 
 logger = logging.getLogger(__name__)
 
@@ -33,11 +33,7 @@ class Shape:
             self.attributes = cached_shape.attributes
             return
 
-        try:
-            results = db.lookup(slug, table="shape")
-        except KeyError:
-            raise RuntimeError(f"Shape {slug} not found")
-
+        results = ShapeModel.lookup(slug, db)
         self.attributes = results.attributes
 
         Shape._shapes[slug] = self

--- a/tuxemon/states/character/__init__.py
+++ b/tuxemon/states/character/__init__.py
@@ -30,7 +30,7 @@ def fix_measure(measure: int, percentage: float) -> int:
 def _lookup_monsters() -> None:
     monsters = list(db.database["monster"])
     for mon in monsters:
-        results = db.lookup(mon, table="monster")
+        results = MonsterModel.lookup(mon, db)
         if results.txmn_id > 0:
             lookup_cache[mon] = results
 

--- a/tuxemon/states/choice/choice_item.py
+++ b/tuxemon/states/choice/choice_item.py
@@ -9,7 +9,7 @@ from pygame_menu.locals import POSITION_EAST
 from pygame_menu.widgets.selection.highlight import HighlightSelection
 
 from tuxemon import prepare
-from tuxemon.db import db
+from tuxemon.db import ItemModel, db
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.menu.theme import get_theme
 
@@ -84,10 +84,7 @@ class ChoiceItem(PygameMenuState):
         slug: str,
         callback: Callable[[], None],
     ) -> None:
-        try:
-            item = db.lookup(slug, table="item")
-        except KeyError:
-            raise RuntimeError(f"Item {slug} not found")
+        item = ItemModel.lookup(slug, db)
         new_image = self._create_image(item.sprite)
         new_image.scale(
             prepare.SCALE * SCALE_SPRITE, prepare.SCALE * SCALE_SPRITE

--- a/tuxemon/states/choice/choice_monster.py
+++ b/tuxemon/states/choice/choice_monster.py
@@ -11,7 +11,7 @@ from pygame_menu.widgets.selection.highlight import HighlightSelection
 
 from tuxemon import prepare
 from tuxemon.animation import Animation
-from tuxemon.db import db
+from tuxemon.db import MonsterModel, db
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.menu.theme import get_theme
 from tuxemon.session import local_session
@@ -58,11 +58,7 @@ class ChoiceMonster(PygameMenuState):
         slug: str,
         callback: Callable[[], None],
     ) -> None:
-        try:
-            monster = db.lookup(slug, table="monster")
-        except KeyError:
-            raise RuntimeError(f"Monster {slug} not found")
-
+        monster = MonsterModel.lookup(slug, db)
         path = f"gfx/sprites/battle/{monster.slug}-front.png"
         new_image = self._create_image(path)
         new_image.scale(

--- a/tuxemon/states/choice/choice_npc.py
+++ b/tuxemon/states/choice/choice_npc.py
@@ -11,7 +11,7 @@ from pygame_menu.widgets.selection.highlight import HighlightSelection
 
 from tuxemon import prepare
 from tuxemon.animation import Animation
-from tuxemon.db import db
+from tuxemon.db import NpcModel, db
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.menu.theme import get_theme
 
@@ -63,10 +63,7 @@ class ChoiceNpc(PygameMenuState):
         slug: str,
         callback: Callable[[], None],
     ) -> None:
-        try:
-            npc = db.lookup(slug, table="npc")
-        except KeyError:
-            raise RuntimeError(f"NPC {slug} not found")
+        npc = NpcModel.lookup(slug, db)
         path = f"gfx/sprites/player/{npc.template.combat_front}.png"
         new_image = self._create_image(path)
         new_image.scale(

--- a/tuxemon/states/evolution/__init__.py
+++ b/tuxemon/states/evolution/__init__.py
@@ -153,7 +153,8 @@ class EvolutionTransition(State):
         if slug not in db.database["monster"]:
             logger.error(f"{slug} doesn't exist.")
             return None
-        return db.lookup(slug, table="monster")
+        results = MonsterModel.lookup(slug, db)
+        return results
 
     def _load_sprite(self, slug: str) -> Sprite:
         path = tools.transform_resource_filename(

--- a/tuxemon/states/journal/journal.py
+++ b/tuxemon/states/journal/journal.py
@@ -33,7 +33,7 @@ def fix_measure(measure: int, percentage: float) -> int:
 def _lookup_monsters() -> None:
     monsters = list(db.database["monster"])
     for mon in monsters:
-        results = db.lookup(mon, table="monster")
+        results = MonsterModel.lookup(mon, db)
         if results.txmn_id > 0:
             lookup_cache[mon] = results
 

--- a/tuxemon/states/journal/journal_choice.py
+++ b/tuxemon/states/journal/journal_choice.py
@@ -33,7 +33,7 @@ def fix_measure(measure: int, percentage: float) -> int:
 def _lookup_monsters() -> None:
     monsters = list(db.database["monster"])
     for mon in monsters:
-        results = db.lookup(mon, table="monster")
+        results = MonsterModel.lookup(mon, db)
         if results.txmn_id > 0:
             lookup_cache[mon] = results
 

--- a/tuxemon/states/journal/journal_info.py
+++ b/tuxemon/states/journal/journal_info.py
@@ -28,7 +28,7 @@ def fix_measure(measure: int, percentage: float) -> int:
 def _lookup_monsters() -> None:
     monsters = list(db.database["monster"])
     for mon in monsters:
-        results = db.lookup(mon, table="monster")
+        results = MonsterModel.lookup(mon, db)
         if results.txmn_id > 0:
             lookup_cache[mon] = results
 

--- a/tuxemon/states/minigame/__init__.py
+++ b/tuxemon/states/minigame/__init__.py
@@ -28,7 +28,7 @@ def fix_measure(measure: int, percentage: float) -> int:
 def _lookup_monsters() -> None:
     monsters = list(db.database["monster"])
     for mon in monsters:
-        results = db.lookup(mon, table="monster")
+        results = MonsterModel.lookup(mon, db)
         if results.txmn_id > 0:
             lookup_cache[mon] = results
 

--- a/tuxemon/states/monster_info/__init__.py
+++ b/tuxemon/states/monster_info/__init__.py
@@ -22,7 +22,7 @@ lookup_cache: dict[str, MonsterModel] = {}
 def _lookup_monsters() -> None:
     monsters = list(db.database["monster"])
     for mon in monsters:
-        results = db.lookup(mon, table="monster")
+        results = MonsterModel.lookup(mon, db)
         if results.txmn_id > 0:
             lookup_cache[mon] = results
 

--- a/tuxemon/states/monster_moves/__init__.py
+++ b/tuxemon/states/monster_moves/__init__.py
@@ -26,7 +26,7 @@ lookup_cache: dict[str, MonsterModel] = {}
 def _lookup_monsters() -> None:
     monsters = list(db.database["monster"])
     for mon in monsters:
-        results = db.lookup(mon, table="monster")
+        results = MonsterModel.lookup(mon, db)
         if results.txmn_id > 0:
             lookup_cache[mon] = results
 

--- a/tuxemon/status/status.py
+++ b/tuxemon/status/status.py
@@ -16,6 +16,7 @@ from tuxemon.db import (
     CategoryStatus,
     Range,
     ResponseStatus,
+    StatusModel,
     db,
 )
 from tuxemon.locale import T
@@ -104,11 +105,7 @@ class Status:
         Parameters:
             The slug of the status to look up in the database.
         """
-        try:
-            results = db.lookup(slug, table="status")
-        except KeyError:
-            raise RuntimeError(f"Status {slug} not found")
-
+        results = StatusModel.lookup(slug, db)
         self.slug = results.slug  # a short English identifier
         self.name = T.translate(self.slug)
         self.description = T.translate(f"{self.slug}_description")

--- a/tuxemon/taste.py
+++ b/tuxemon/taste.py
@@ -7,7 +7,7 @@ import random
 from collections.abc import Sequence
 from typing import Optional
 
-from tuxemon.db import Modifier, db
+from tuxemon.db import Modifier, TasteModel, db
 from tuxemon.locale import T
 
 logger = logging.getLogger(__name__)
@@ -39,11 +39,7 @@ class Taste:
             self.taste_type = cached_taste.taste_type
             return
 
-        try:
-            results = db.lookup(slug, table="taste")
-        except KeyError:
-            raise RuntimeError(f"Taste {slug} not found")
-
+        results = TasteModel.lookup(slug, db)
         self.slug = slug
         self.name = T.translate(self.slug)
         self.description = T.translate(f"{results.slug}_description")

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -12,7 +12,7 @@ from tuxemon.core.core_condition import CoreCondition
 from tuxemon.core.core_effect import CoreEffect, TechEffectResult
 from tuxemon.core.core_manager import ConditionManager, EffectManager
 from tuxemon.core.core_processor import ConditionProcessor, EffectProcessor
-from tuxemon.db import Range, db
+from tuxemon.db import Range, TechniqueModel, db
 from tuxemon.element import Element
 from tuxemon.locale import T
 from tuxemon.surfanim import FlipAxes
@@ -105,11 +105,7 @@ class Technique:
         Parameters:
             The slug of the technique to look up in the database.
         """
-        try:
-            results = db.lookup(slug, table="technique")
-        except KeyError:
-            raise RuntimeError(f"Technique {slug} not found")
-
+        results = TechniqueModel.lookup(slug, db)
         self.slug = results.slug  # a short English identifier
         self.name = T.translate(self.slug)
         self.description = T.translate(f"{self.slug}_description")

--- a/tuxemon/terrain.py
+++ b/tuxemon/terrain.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
-from tuxemon.db import db
+from tuxemon.db import TerrainModel, db
 
 logger = logging.getLogger(__name__)
 
@@ -31,11 +31,7 @@ class Terrain:
             self.element_modifier = cached_terrain.element_modifier
             return
 
-        try:
-            results = db.lookup(slug, table="terrain")
-        except KeyError:
-            raise RuntimeError(f"Terrain {slug} not found")
-
+        results = TerrainModel.lookup(slug, db)
         self.element_modifier = results.element_modifier
 
         Terrain._terrains[slug] = self

--- a/tuxemon/weather.py
+++ b/tuxemon/weather.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
-from tuxemon.db import db
+from tuxemon.db import WeatherModel, db
 
 logger = logging.getLogger(__name__)
 
@@ -31,11 +31,7 @@ class Weather:
             self.element_modifier = cached_weather.element_modifier
             return
 
-        try:
-            results = db.lookup(slug, table="weather")
-        except KeyError:
-            raise RuntimeError(f"Weather {slug} not found")
-
+        results = WeatherModel.lookup(slug, db)
         self.element_modifier = results.element_modifier
 
         Weather._weathers[slug] = self


### PR DESCRIPTION
PR introduces the following changes:
- removed the `Literal` type with 20+ elements from the `lookup` method parameter, this was a bottleneck, requiring constant edits whenever a new table type was added
- replaced `TableName = Literal[...]` with a simple `Optional[str]` type, allowing for more flexibility without needing predefined overloads
- eliminated multiple `@overload` definitions for specific table names
- a `lookup` class method was introduced, allowing retrieval of instances using a `slug`, this ensures consistent database access across 16 classes, utilizing `table_name` to reference the correct table, and if an entry isn't found, a `RuntimeError` is raised for clear error handling
- a `ClassVar[str]` attribute was added for `table_name` in each class, maintaining a structured and uniform approach to table references at the class level