### PR TITLE
Refactor Collision Handling into a Dedicated `CollisionManager`   

### DIFF
--- a/tests/tuxemon/test_collision_manager.py
+++ b/tests/tuxemon/test_collision_manager.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import unittest
+from unittest.mock import MagicMock
+
+from tuxemon import prepare
+from tuxemon.collision_manager import CollisionManager
+from tuxemon.entity import Entity
+from tuxemon.map import RegionProperties
+from tuxemon.map_manager import MapManager
+from tuxemon.npc_manager import NPCManager
+
+
+class TestCollisionManager(unittest.TestCase):
+
+    def setUp(self):
+        self.map_manager = MagicMock(spec=MapManager)
+        self.npc_manager = MagicMock(spec=NPCManager)
+        self.collision_manager = CollisionManager(
+            self.map_manager, self.npc_manager
+        )
+
+    def test_get_all_tile_properties(self):
+        surface_map = {
+            (0, 0): {"label1": 1.0, "label2": 2.0},
+            (1, 1): {"label1": 3.0, "label3": 4.0},
+        }
+        self.map_manager.surface_map = surface_map
+        result = self.collision_manager.get_all_tile_properties(
+            surface_map, "label1"
+        )
+        self.assertEqual(result, [(0, 0), (1, 1)])
+
+    def test_update_tile_property(self):
+        surface_map = {
+            (0, 0): {"label1": 1.0, "label2": 2.0},
+            (1, 1): {"label1": 3.0, "label3": 4.0},
+        }
+        self.map_manager.surface_map = surface_map
+        prepare.SURFACE_KEYS = ["label1", "label2", "label3"]
+        self.collision_manager.update_tile_property("label1", 5.0)
+        self.assertEqual(self.map_manager.surface_map[(0, 0)]["label1"], 5.0)
+        self.assertEqual(self.map_manager.surface_map[(1, 1)]["label1"], 5.0)
+
+    def test_all_tiles_modified(self):
+        surface_map = {
+            (0, 0): {"label1": 5.0, "label2": 2.0},
+            (1, 1): {"label1": 5.0, "label3": 4.0},
+        }
+        self.map_manager.surface_map = surface_map
+        prepare.SURFACE_KEYS = ["label1", "label2", "label3"]
+        self.assertTrue(
+            self.collision_manager.all_tiles_modified("label1", 5.0)
+        )
+
+    def test_check_collision_zones(self):
+        collision_map = {
+            (0, 0): RegionProperties([], [], [], None, "label1"),
+            (1, 1): RegionProperties([], [], [], None, "label2"),
+        }
+        self.map_manager.collision_map = collision_map
+        result = self.collision_manager.check_collision_zones(
+            collision_map, "label1"
+        )
+        self.assertEqual(result, [(0, 0)])
+
+    def test_add_collision(self):
+        entity = MagicMock(spec=Entity)
+        entity.isplayer = True
+        entity.tile_pos = (0, 0)
+        region = RegionProperties([], [], [], None, "label1")
+        self.map_manager.collision_map = {(0, 0): region}
+        self.collision_manager.add_collision(entity, (0.0, 0.0))
+        self.assertIsNotNone(self.map_manager.collision_map[(0, 0)].entity)
+
+    def test_remove_collision(self):
+        region = RegionProperties([], [], [], None, "label1")
+        self.map_manager.collision_map = {(0, 0): region}
+        self.collision_manager.remove_collision((0, 0))
+        self.assertNotIn((0, 0), self.map_manager.collision_map)
+
+    def test_add_collision_label(self):
+        collision_map = {
+            (0, 0): RegionProperties([], [], [], None, "label1"),
+            (1, 1): RegionProperties([], [], [], None, "label2"),
+        }
+        self.map_manager.collision_map = collision_map
+        self.collision_manager.add_collision_label("label1")
+        self.assertEqual(self.map_manager.collision_map[(0, 0)].key, "label1")
+        self.assertEqual(self.map_manager.collision_map[(1, 1)].key, "label2")
+
+    def test_add_collision_position(self):
+        self.map_manager.collision_map = {}
+        self.collision_manager.add_collision_position("label1", (0, 0))
+        self.assertIn((0, 0), self.map_manager.collision_map)
+        self.assertEqual(self.map_manager.collision_map[(0, 0)].key, "label1")
+
+    def test_remove_collision_label(self):
+        collision_map = {
+            (0, 0): RegionProperties([], [], [], None, "label1"),
+            (1, 1): RegionProperties([], [], [], None, "label2"),
+        }
+        self.map_manager.collision_map = collision_map
+        self.collision_manager.remove_collision_label("label1")
+        self.assertEqual(self.map_manager.collision_map[(0, 0)].key, "label1")
+        self.assertEqual(self.map_manager.collision_map[(1, 1)].key, "label2")
+
+    def test_get_collision_map(self):
+        self.map_manager.collision_map = {
+            (0, 0): RegionProperties([], [], [], None, "label1")
+        }
+        self.map_manager.surface_map = {(0, 0): {"label1": 0.0}}
+        npc = MagicMock(spec=Entity)
+        npc.tile_pos = (0, 0)
+        self.npc_manager.get_all_entities.return_value = [npc]
+        collision_map = self.collision_manager.get_collision_map()
+        self.assertIn((0, 0), collision_map)
+
+    def test_get_region_properties(self):
+        region = RegionProperties([], [], [], None, "label1")
+        self.map_manager.collision_map = {(0, 0): region}
+        properties = self.collision_manager._get_region_properties(
+            (0, 0), "label1"
+        )
+        self.assertEqual(properties.key, "label1")

--- a/tuxemon/client.py
+++ b/tuxemon/client.py
@@ -17,6 +17,7 @@ from tuxemon.audio import MusicPlayerState, SoundManager
 from tuxemon.boundary import BoundaryChecker
 from tuxemon.camera import CameraManager
 from tuxemon.cli.processor import CommandProcessor
+from tuxemon.collision_manager import CollisionManager
 from tuxemon.config import TuxemonConfig
 from tuxemon.event.eventaction import ActionManager
 from tuxemon.event.eventcondition import ConditionManager
@@ -132,6 +133,9 @@ class LocalPygameClient:
         self.npc_manager = NPCManager()
         self.map_loader = MapLoader()
         self.map_manager = MapManager()
+        self.collision_manager = CollisionManager(
+            self.map_manager, self.npc_manager
+        )
         self.boundary = BoundaryChecker()
         self.camera_manager = CameraManager()
 

--- a/tuxemon/collision_manager.py
+++ b/tuxemon/collision_manager.py
@@ -1,0 +1,280 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import logging
+from collections import defaultdict
+from collections.abc import Mapping, MutableMapping, Sequence
+from typing import Any, DefaultDict, Optional, Union
+
+from tuxemon import prepare
+from tuxemon.db import Direction
+from tuxemon.entity import Entity
+from tuxemon.map import RegionProperties
+from tuxemon.map_manager import MapManager
+from tuxemon.npc import NPC
+from tuxemon.npc_manager import NPCManager
+
+logger = logging.getLogger(__name__)
+
+
+CollisionMap = Mapping[
+    tuple[int, int],
+    Optional[RegionProperties],
+]
+
+
+class CollisionManager:
+    """
+    Manages collision data and performs collision checks within the game world.
+    """
+
+    def __init__(
+        self, map_manager: MapManager, npc_manager: NPCManager
+    ) -> None:
+        self._map_manager = map_manager
+        self._npc_manager = npc_manager
+
+    def get_all_tile_properties(
+        self,
+        surface_map: MutableMapping[tuple[int, int], dict[str, float]],
+        label: str,
+    ) -> list[tuple[int, int]]:
+        """
+        Retrieves the coordinates of all tiles with a specific property.
+
+        Parameters:
+            map: The surface map.
+            label: The label (SurfaceKeys).
+
+        Returns:
+            A list of coordinates (tuples) of tiles with the specified label.
+        """
+        return [
+            coords for coords, props in surface_map.items() if label in props
+        ]
+
+    def update_tile_property(self, label: str, moverate: float) -> None:
+        """
+        Updates the movement rate property for existing tile entries in the
+        surface map.
+
+        This method modifies the moverate value for tiles that already contain
+        the specified label, ensuring that no new dictionary entries are created.
+        If the label is not present in a tile's properties, the tile remains
+        unchanged. The update process runs efficiently to prevent unnecessary
+        modifications.
+
+        Parameters:
+            label: The property key to update (e.g., terrain type).
+            moverate: The new movement rate value to assign.
+        """
+        if label not in prepare.SURFACE_KEYS:
+            return
+
+        for coord in self.get_all_tile_properties(
+            self._map_manager.surface_map, label
+        ):
+            props = self._map_manager.surface_map.get(coord)
+            if props and props.get(label) != moverate:
+                props[label] = moverate
+
+    def all_tiles_modified(self, label: str, moverate: float) -> bool:
+        """
+        Checks if all tiles with the specified label have been modified.
+
+        Parameters:
+            label: The property key to check.
+            moverate: The expected movement rate.
+
+        Returns:
+            True if all tiles have the expected moverate, False otherwise.
+        """
+        return all(
+            self._map_manager.surface_map[coord].get(label) == moverate
+            for coord in self.get_all_tile_properties(
+                self._map_manager.surface_map, label
+            )
+        )
+
+    def check_collision_zones(
+        self,
+        collision_map: MutableMapping[
+            tuple[int, int], Optional[RegionProperties]
+        ],
+        label: str,
+    ) -> list[tuple[int, int]]:
+        """
+        Returns coordinates of specific collision zones.
+
+        Parameters:
+            collision_map: The collision map.
+            label: The label to filter collision zones by.
+
+        Returns:
+            A list of coordinates of collision zones with the specific label.
+        """
+        return [
+            coords
+            for coords, props in collision_map.items()
+            if props and props.key == label
+        ]
+
+    def add_collision(
+        self,
+        entity: Entity[Any],
+        pos: Sequence[float],
+    ) -> None:
+        """
+        Registers the given entity's position within the collision zone.
+
+        Parameters:
+            entity: The entity object to be added to the collision zone.
+            pos: The X, Y coordinates (as floats) indicating the entity's position.
+        """
+        coords = (int(pos[0]), int(pos[1]))
+        region = self._map_manager.collision_map.get(coords)
+
+        enter_from = region.enter_from if entity.isplayer and region else []
+        exit_from = region.exit_from if entity.isplayer and region else []
+        endure = region.endure if entity.isplayer and region else []
+        key = region.key if entity.isplayer and region else None
+
+        prop = RegionProperties(
+            enter_from=enter_from,
+            exit_from=exit_from,
+            endure=endure,
+            entity=entity,
+            key=key,
+        )
+
+        self._map_manager.collision_map[coords] = prop
+
+    def remove_collision(self, tile_pos: tuple[int, int]) -> None:
+        """
+        Removes the specified tile position from the collision zone.
+
+        Parameters:
+            tile_pos: The X, Y tile coordinates to be removed from the collision map.
+        """
+        region = self._map_manager.collision_map.get(tile_pos)
+        if not region:
+            return  # Nothing to remove
+
+        if any([region.enter_from, region.exit_from, region.endure]):
+            prop = RegionProperties(
+                region.enter_from,
+                region.exit_from,
+                region.endure,
+                None,
+                region.key,
+            )
+            self._map_manager.collision_map[tile_pos] = prop
+        else:
+            # Remove region
+            del self._map_manager.collision_map[tile_pos]
+
+    def add_collision_label(self, label: str) -> None:
+        coords = self.check_collision_zones(
+            self._map_manager.collision_map, label
+        )
+        properties = RegionProperties(
+            enter_from=[],
+            exit_from=[],
+            endure=[],
+            key=label,
+            entity=None,
+        )
+        if coords:
+            for coord in coords:
+                self._map_manager.collision_map[coord] = properties
+
+    def add_collision_position(
+        self, label: str, position: tuple[int, int]
+    ) -> None:
+        properties = RegionProperties(
+            enter_from=[],
+            exit_from=[],
+            endure=[],
+            key=label,
+            entity=None,
+        )
+        self._map_manager.collision_map[position] = properties
+
+    def remove_collision_label(self, label: str) -> None:
+        properties = RegionProperties(
+            enter_from=list(Direction),
+            exit_from=list(Direction),
+            endure=[],
+            key=label,
+            entity=None,
+        )
+        coords = self.check_collision_zones(
+            self._map_manager.collision_map, label
+        )
+        if coords:
+            for coord in coords:
+                self._map_manager.collision_map[coord] = properties
+
+    def get_collision_map(self) -> CollisionMap:
+        """
+        Return dictionary for collision testing.
+
+        Returns a dictionary where keys are (x, y) tile tuples
+        and the values are tiles or NPCs.
+
+        # NOTE:
+        This will not respect map changes to collisions
+        after the map has been loaded!
+
+        Returns:
+            A dictionary of collision tiles.
+        """
+        collision_dict: DefaultDict[
+            tuple[int, int], Optional[RegionProperties]
+        ] = defaultdict(lambda: RegionProperties([], [], [], None, None))
+
+        # Get all the NPCs' tile positions
+        for npc in self._npc_manager.get_all_entities():
+            collision_dict[npc.tile_pos] = self._get_region_properties(
+                npc.tile_pos, npc
+            )
+
+        # Add surface map entries to the collision dictionary
+        for coords, surface in self._map_manager.surface_map.items():
+            for label, value in surface.items():
+                if float(value) == 0:
+                    collision_dict[coords] = self._get_region_properties(
+                        coords, label
+                    )
+
+        collision_dict.update(
+            {k: v for k, v in self._map_manager.collision_map.items()}
+        )
+
+        return dict(collision_dict)
+
+    def _get_region_properties(
+        self, coords: tuple[int, int], entity_or_label: Union[NPC, str]
+    ) -> RegionProperties:
+        region = self._map_manager.collision_map.get(coords)
+        if region:
+            if isinstance(entity_or_label, str):
+                return RegionProperties(
+                    region.enter_from,
+                    region.exit_from,
+                    region.endure,
+                    None,
+                    entity_or_label,
+                )
+            else:
+                return RegionProperties(
+                    region.enter_from,
+                    region.exit_from,
+                    region.endure,
+                    entity_or_label,
+                    region.key,
+                )
+        else:
+            if isinstance(entity_or_label, str):
+                return RegionProperties([], [], [], None, entity_or_label)
+            else:
+                return RegionProperties([], [], [], entity_or_label, None)

--- a/tuxemon/core/conditions/facing_tile.py
+++ b/tuxemon/core/conditions/facing_tile.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 from tuxemon.core.core_condition import CoreCondition
 from tuxemon.map import get_coords, get_direction
 from tuxemon.prepare import SURFACE_KEYS
-from tuxemon.states.world.worldstate import WorldState
 
 if TYPE_CHECKING:
     from tuxemon.monster import Monster
@@ -30,13 +29,12 @@ class FacingTileCondition(CoreCondition):
 
         tiles = get_coords(player.tile_pos, client.map_manager.map_size)
 
-        world = client.get_state_by_name(WorldState)
         label = (
-            world.get_all_tile_properties(
+            client.collision_manager.get_all_tile_properties(
                 client.map_manager.surface_map, self.facing_tile
             )
             if self.facing_tile in SURFACE_KEYS
-            else world.check_collision_zones(
+            else client.collision_manager.check_collision_zones(
                 client.map_manager.collision_map, self.facing_tile
             )
         )

--- a/tuxemon/event/actions/add_collision.py
+++ b/tuxemon/event/actions/add_collision.py
@@ -7,7 +7,6 @@ from typing import Optional, final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.session import Session
-from tuxemon.states.world.worldstate import WorldState
 
 
 @final
@@ -36,8 +35,8 @@ class AddCollisionAction(EventAction):
     y: Optional[int] = None
 
     def start(self, session: Session) -> None:
-        world = session.client.get_state_by_name(WorldState)
+        client = session.client.collision_manager
         if self.x and self.y:
-            world.add_collision_position(self.label, (self.x, self.y))
+            client.add_collision_position(self.label, (self.x, self.y))
         else:
-            world.add_collision_label(self.label)
+            client.add_collision_label(self.label)

--- a/tuxemon/event/actions/remove_collision.py
+++ b/tuxemon/event/actions/remove_collision.py
@@ -7,7 +7,6 @@ from typing import final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.session import Session
-from tuxemon.states.world.worldstate import WorldState
 
 
 @final
@@ -30,5 +29,4 @@ class RemoveCollisionAction(EventAction):
     label: str
 
     def start(self, session: Session) -> None:
-        world = session.client.get_state_by_name(WorldState)
-        world.remove_collision_label(self.label)
+        session.client.collision_manager.remove_collision_label(self.label)

--- a/tuxemon/event/actions/update_tile_properties.py
+++ b/tuxemon/event/actions/update_tile_properties.py
@@ -7,7 +7,6 @@ from typing import final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.session import Session
-from tuxemon.states.world.worldstate import WorldState
 
 
 @final
@@ -36,5 +35,6 @@ class UpdateTilePropertiesAction(EventAction):
     moverate: float
 
     def start(self, session: Session) -> None:
-        world = session.client.get_state_by_name(WorldState)
-        world.update_tile_property(self.label, self.moverate)
+        session.client.collision_manager.update_tile_property(
+            self.label, self.moverate
+        )

--- a/tuxemon/event/conditions/char_facing_tile.py
+++ b/tuxemon/event/conditions/char_facing_tile.py
@@ -10,7 +10,6 @@ from tuxemon.event.eventcondition import EventCondition
 from tuxemon.map import get_coords, get_direction
 from tuxemon.prepare import SURFACE_KEYS
 from tuxemon.session import Session
-from tuxemon.states.world.worldstate import WorldState
 
 logger = logging.getLogger(__name__)
 
@@ -50,15 +49,14 @@ class CharFacingTileCondition(EventCondition):
         npc_tiles = get_coords(character.tile_pos, client.map_manager.map_size)
 
         # check if the NPC is facing a specific set of tiles
-        world = session.client.get_state_by_name(WorldState)
         if len(condition.parameters) > 1:
             value = condition.parameters[1]
             if value in SURFACE_KEYS:
-                label = world.get_all_tile_properties(
+                label = client.collision_manager.get_all_tile_properties(
                     client.map_manager.surface_map, value
                 )
             else:
-                label = world.check_collision_zones(
+                label = client.collision_manager.check_collision_zones(
                     client.map_manager.collision_map, value
                 )
             tiles = list(set(npc_tiles).intersection(label))

--- a/tuxemon/event/conditions/char_in.py
+++ b/tuxemon/event/conditions/char_in.py
@@ -9,7 +9,6 @@ from tuxemon.event import MapCondition, get_npc
 from tuxemon.event.eventcondition import EventCondition
 from tuxemon.prepare import SURFACE_KEYS
 from tuxemon.session import Session
-from tuxemon.states.world.worldstate import WorldState
 
 logger = logging.getLogger(__name__)
 
@@ -38,15 +37,14 @@ class CharInCondition(EventCondition):
             logger.error(f"{condition.parameters[0]} not found")
             return False
         prop = condition.parameters[1]
-        world = client.get_state_by_name(WorldState)
 
         tiles = []
         if prop in SURFACE_KEYS:
-            tiles = world.get_all_tile_properties(
+            tiles = client.collision_manager.get_all_tile_properties(
                 client.map_manager.surface_map, prop
             )
         else:
-            tiles = world.check_collision_zones(
+            tiles = client.collision_manager.check_collision_zones(
                 client.map_manager.collision_map, prop
             )
         if tiles:

--- a/tuxemon/event/conditions/tile_property_updated.py
+++ b/tuxemon/event/conditions/tile_property_updated.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 from tuxemon.event import MapCondition
 from tuxemon.event.eventcondition import EventCondition
 from tuxemon.session import Session
-from tuxemon.states.world.worldstate import WorldState
 
 logger = logging.getLogger(__name__)
 
@@ -33,5 +32,6 @@ class TilePropertyUpdatedCondition(EventCondition):
 
     def test(self, session: Session, condition: MapCondition) -> bool:
         label, moverate = condition.parameters
-        world = session.client.get_state_by_name(WorldState)
-        return world.all_tiles_modified(label, float(moverate))
+        return session.client.collision_manager.all_tiles_modified(
+            label, float(moverate)
+        )

--- a/tuxemon/movement.py
+++ b/tuxemon/movement.py
@@ -17,9 +17,9 @@ from tuxemon.prepare import CONFIG
 
 if TYPE_CHECKING:
     from tuxemon.client import LocalPygameClient
+    from tuxemon.collision_manager import CollisionMap
     from tuxemon.db import Direction
     from tuxemon.npc import NPC
-    from tuxemon.states.world.worldstate import CollisionMap, WorldState
 
 logger = logging.getLogger(__name__)
 
@@ -122,16 +122,8 @@ class MovementManager:
 
 
 class Pathfinder:
-    def __init__(
-        self,
-        client: LocalPygameClient,
-        world_state: WorldState,
-    ) -> None:
-        """
-        Initializes the Pathfinder instance with the given world state.
-        """
+    def __init__(self, client: LocalPygameClient) -> None:
         self.client = client
-        self.world_state = world_state
 
     def pathfind(
         self, start: tuple[int, int], dest: tuple[int, int], facing: Direction
@@ -193,7 +185,7 @@ class Pathfinder:
         """
         if not queue:
             return None
-        collision_map = self.world_state.get_collision_map()
+        collision_map = self.client.collision_manager.get_collision_map()
         while queue:
             node = queue.pop(0)
             logger.debug(f"Checking node {node.get_value()}.")
@@ -259,7 +251,9 @@ class Pathfinder:
             A sequence of adjacent and traversable tile positions.
         """
         # get tile-level and npc/entity blockers
-        collision_map = collision_map or self.world_state.get_collision_map()
+        collision_map = (
+            collision_map or self.client.collision_manager.get_collision_map()
+        )
         skip_nodes = skip_nodes or set()
         logger.debug(f"Getting exits for position {position}.")
 

--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -3,14 +3,11 @@
 from __future__ import annotations
 
 import logging
-from collections import defaultdict
-from collections.abc import Mapping, MutableMapping, Sequence
+from collections.abc import Mapping, Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
-    DefaultDict,
     Optional,
-    Union,
     no_type_check,
 )
 
@@ -19,7 +16,6 @@ from pygame.surface import Surface
 from tuxemon import networking, prepare
 from tuxemon.camera import Camera
 from tuxemon.db import Direction
-from tuxemon.map import RegionProperties
 from tuxemon.map_view import MapRenderer
 from tuxemon.movement import MovementManager, Pathfinder
 from tuxemon.platform.const import intentions
@@ -34,7 +30,6 @@ from tuxemon.teleporter import Teleporter
 if TYPE_CHECKING:
     from tuxemon.entity import Entity
     from tuxemon.networking import EventData
-    from tuxemon.npc import NPC
 
 logger = logging.getLogger(__name__)
 
@@ -46,17 +41,6 @@ direction_map: Mapping[int, Direction] = {
 }
 
 
-CollisionDict = dict[
-    tuple[int, int],
-    Optional[RegionProperties],
-]
-
-CollisionMap = Mapping[
-    tuple[int, int],
-    Optional[RegionProperties],
-]
-
-
 class WorldState(State):
     """The state responsible for the world game play"""
 
@@ -64,17 +48,13 @@ class WorldState(State):
         super().__init__()
         self.session = session
         self.session.set_world(self)
-        self.movement = MovementManager(self.client)
-        self.teleporter = Teleporter(self.client, self)
-        self.pathfinder = Pathfinder(self.client, self)
-        # Provide access to the screen surface
         self.screen = self.client.screen
         self.tile_size = prepare.TILE_SIZE
-
+        self.movement = MovementManager(self.client)
+        self.teleporter = Teleporter(self.client, self)
+        self.pathfinder = Pathfinder(self.client)
         self.transition_manager = WorldTransition(self)
-
         self.player = Player.create(self.session, self)
-
         self.camera = Camera(self.player, self.client.boundary)
         self.client.camera_manager.add_camera(self.camera)
         self.map_renderer = MapRenderer(self.client)
@@ -123,7 +103,6 @@ class WorldState(State):
 
         Parameters:
             time_delta: Amount of time passed since last frame.
-
         """
         super().update(time_delta)
         self.client.npc_manager.update_npcs(time_delta, self.client)
@@ -138,7 +117,6 @@ class WorldState(State):
 
         Parameters:
             surface: Surface to draw into.
-
         """
         self.screen = surface
         if self.client.map_manager.current_map is None:
@@ -222,258 +200,17 @@ class WorldState(State):
         # Return event for others to process
         return event
 
-    ####################################################
-    #            Pathfinding and Collisions            #
-    ####################################################
-
-    def get_all_tile_properties(
-        self,
-        surface_map: MutableMapping[tuple[int, int], dict[str, float]],
-        label: str,
-    ) -> list[tuple[int, int]]:
-        """
-        Retrieves the coordinates of all tiles with a specific property.
-
-        Parameters:
-            map: The surface map.
-            label: The label (SurfaceKeys).
-
-        Returns:
-            A list of coordinates (tuples) of tiles with the specified label.
-
-        """
-        return [
-            coords for coords, props in surface_map.items() if label in props
-        ]
-
-    def update_tile_property(self, label: str, moverate: float) -> None:
-        """
-        Updates the movement rate property for existing tile entries in the
-        surface map.
-
-        This method modifies the moverate value for tiles that already contain
-        the specified label, ensuring that no new dictionary entries are created.
-        If the label is not present in a tile's properties, the tile remains
-        unchanged. The update process runs efficiently to prevent unnecessary
-        modifications.
-
-        Parameters:
-            label: The property key to update (e.g., terrain type).
-            moverate: The new movement rate value to assign.
-        """
-        if label not in prepare.SURFACE_KEYS:
-            return
-
-        for coord in self.get_all_tile_properties(
-            self.client.map_manager.surface_map, label
-        ):
-            props = self.client.map_manager.surface_map.get(coord)
-            if props and props.get(label) != moverate:
-                props[label] = moverate
-
-    def all_tiles_modified(self, label: str, moverate: float) -> bool:
-        """
-        Checks if all tiles with the specified label have been modified.
-
-        Parameters:
-            label: The property key to check.
-            moverate: The expected movement rate.
-
-        Returns:
-            True if all tiles have the expected moverate, False otherwise.
-        """
-        return all(
-            self.client.map_manager.surface_map[coord].get(label) == moverate
-            for coord in self.get_all_tile_properties(
-                self.client.map_manager.surface_map, label
-            )
-        )
-
-    def check_collision_zones(
-        self,
-        collision_map: MutableMapping[
-            tuple[int, int], Optional[RegionProperties]
-        ],
-        label: str,
-    ) -> list[tuple[int, int]]:
-        """
-        Returns coordinates of specific collision zones.
-
-        Parameters:
-            collision_map: The collision map.
-            label: The label to filter collision zones by.
-
-        Returns:
-            A list of coordinates of collision zones with the specific label.
-
-        """
-        return [
-            coords
-            for coords, props in collision_map.items()
-            if props and props.key == label
-        ]
-
-    def add_collision(
-        self,
-        entity: Entity[Any],
-        pos: Sequence[float],
-    ) -> None:
+    def add_collision(self, entity: Entity[Any], pos: Sequence[float]) -> None:
         """
         Registers the given entity's position within the collision zone.
-
-        Parameters:
-            entity: The entity object to be added to the collision zone.
-            pos: The X, Y coordinates (as floats) indicating the entity's position.
         """
-        coords = (int(pos[0]), int(pos[1]))
-        region = self.client.map_manager.collision_map.get(coords)
-
-        enter_from = region.enter_from if entity.isplayer and region else []
-        exit_from = region.exit_from if entity.isplayer and region else []
-        endure = region.endure if entity.isplayer and region else []
-        key = region.key if entity.isplayer and region else None
-
-        prop = RegionProperties(
-            enter_from=enter_from,
-            exit_from=exit_from,
-            endure=endure,
-            entity=entity,
-            key=key,
-        )
-
-        self.client.map_manager.collision_map[coords] = prop
+        self.client.collision_manager.add_collision(entity, pos)
 
     def remove_collision(self, tile_pos: tuple[int, int]) -> None:
         """
         Removes the specified tile position from the collision zone.
-
-        Parameters:
-            tile_pos: The X, Y tile coordinates to be removed from the collision map.
         """
-        region = self.client.map_manager.collision_map.get(tile_pos)
-        if not region:
-            return  # Nothing to remove
-
-        if any([region.enter_from, region.exit_from, region.endure]):
-            prop = RegionProperties(
-                region.enter_from,
-                region.exit_from,
-                region.endure,
-                None,
-                region.key,
-            )
-            self.client.map_manager.collision_map[tile_pos] = prop
-        else:
-            # Remove region
-            del self.client.map_manager.collision_map[tile_pos]
-
-    def add_collision_label(self, label: str) -> None:
-        coords = self.check_collision_zones(
-            self.client.map_manager.collision_map, label
-        )
-        properties = RegionProperties(
-            enter_from=[],
-            exit_from=[],
-            endure=[],
-            key=label,
-            entity=None,
-        )
-        if coords:
-            for coord in coords:
-                self.client.map_manager.collision_map[coord] = properties
-
-    def add_collision_position(
-        self, label: str, position: tuple[int, int]
-    ) -> None:
-        properties = RegionProperties(
-            enter_from=[],
-            exit_from=[],
-            endure=[],
-            key=label,
-            entity=None,
-        )
-        self.client.map_manager.collision_map[position] = properties
-
-    def remove_collision_label(self, label: str) -> None:
-        properties = RegionProperties(
-            enter_from=list(Direction),
-            exit_from=list(Direction),
-            endure=[],
-            key=label,
-            entity=None,
-        )
-        coords = self.check_collision_zones(
-            self.client.map_manager.collision_map, label
-        )
-        if coords:
-            for coord in coords:
-                self.client.map_manager.collision_map[coord] = properties
-
-    def get_collision_map(self) -> CollisionMap:
-        """
-        Return dictionary for collision testing.
-
-        Returns a dictionary where keys are (x, y) tile tuples
-        and the values are tiles or NPCs.
-
-        # NOTE:
-        This will not respect map changes to collisions
-        after the map has been loaded!
-
-        Returns:
-            A dictionary of collision tiles.
-
-        """
-        collision_dict: DefaultDict[
-            tuple[int, int], Optional[RegionProperties]
-        ] = defaultdict(lambda: RegionProperties([], [], [], None, None))
-
-        # Get all the NPCs' tile positions
-        for npc in self.client.npc_manager.get_all_entities():
-            collision_dict[npc.tile_pos] = self._get_region_properties(
-                npc.tile_pos, npc
-            )
-
-        # Add surface map entries to the collision dictionary
-        for coords, surface in self.client.map_manager.surface_map.items():
-            for label, value in surface.items():
-                if float(value) == 0:
-                    collision_dict[coords] = self._get_region_properties(
-                        coords, label
-                    )
-
-        collision_dict.update(
-            {k: v for k, v in self.client.map_manager.collision_map.items()}
-        )
-
-        return dict(collision_dict)
-
-    def _get_region_properties(
-        self, coords: tuple[int, int], entity_or_label: Union[NPC, str]
-    ) -> RegionProperties:
-        region = self.client.map_manager.collision_map.get(coords)
-        if region:
-            if isinstance(entity_or_label, str):
-                return RegionProperties(
-                    region.enter_from,
-                    region.exit_from,
-                    region.endure,
-                    None,
-                    entity_or_label,
-                )
-            else:
-                return RegionProperties(
-                    region.enter_from,
-                    region.exit_from,
-                    region.endure,
-                    entity_or_label,
-                    region.key,
-                )
-        else:
-            if isinstance(entity_or_label, str):
-                return RegionProperties([], [], [], None, entity_or_label)
-            else:
-                return RegionProperties([], [], [], entity_or_label, None)
+        self.client.collision_manager.remove_collision(tile_pos)
 
     def pathfind(
         self, start: tuple[int, int], dest: tuple[int, int], facing: Direction


### PR DESCRIPTION
PR introduces a refactoring of collision-related logic by extracting it into a separate `CollisionManager` class.

Changes:
- moved collision management functions from `WorldState` into the new `CollisionManager` class
- centralized collision logic, making it easier to modify and extend without altering the `WorldState`
- simplified `WorldState`, reducing its responsibilities and improving separation of concerns
- `CollisionManager` now handles tile properties, collision detection, and updates
- refactored `WorldState` to delegate collision operations to `CollisionManager`, minimizing redundant code
- removed WorldState injection in Pathfinding Class, with collision logic now handled by `CollisionManager`, the `Pathfinder` class no longer requires `WorldState`
- introduced a dedicated unit test to validate the functionality of the new `CollisionManager`

Note: the methods `add_collision` and `remove_collision` were kept inside `WorldState` because the `Entity` class directly accesses them.