### PR TITLE
Improve Flatpak Artifact Upload and Modularize Workflows

### DIFF
--- a/.github/workflows/appdata_validation.yml
+++ b/.github/workflows/appdata_validation.yml
@@ -1,0 +1,23 @@
+name: Appdata Validation
+
+on:
+  workflow_call:
+
+jobs:
+  appdata_validation:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Update package list
+      run: |
+        sudo apt update
+
+    # Command copied from flathub build process
+    - name: Validate appdata file
+      run: |
+        sudo apt install flatpak
+        sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+        sudo flatpak install -y org.freedesktop.appstream-glib
+        flatpak run --env=G_DEBUG=fatal-criticals org.freedesktop.appstream-glib validate ./buildconfig/flatpak/org.tuxemon.Tuxemon.appdata.xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,3 @@
-# https://docs.github.com/en/actions/learn-github-actions/contexts
-
----
 name: Tuxemon
 on:
   push:
@@ -16,129 +13,22 @@ env:
 
 jobs:
   appdata_validation:
-    name: "Appdata Validation"
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Update package list
-      run: |
-        sudo apt update
-
-    # Command copied from flathub build process
-    - name: Validate appdata file
-      run: |
-        sudo apt install flatpak
-        sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-        sudo flatpak install -y org.freedesktop.appstream-glib
-        flatpak run --env=G_DEBUG=fatal-criticals org.freedesktop.appstream-glib validate ./buildconfig/flatpak/org.tuxemon.Tuxemon.appdata.xml
+    uses: ./.github/workflows/appdata_validation.yml 
 
 
   flatpak:
-    name: "Flatpak"
-    runs-on: ubuntu-latest
-    container:
-      image: bilelmoussaoui/flatpak-github-actions:kde-6.3
-      options: --privileged
-    steps:
-    - name: Show environment variables
-      run: >
-        echo IS_RELEASE: ${{ env.IS_RELEASE }}
+    uses: ./.github/workflows/flatpak.yml 
+    with:
+      IS_RELEASE: ${{ github.event_name == 'push' && github.ref_type == 'tag' && startswith(github.ref_name, 'v') }}
 
-    - name: Checkout repository
-      uses: actions/checkout@v4
-    # https://stackoverflow.com/questions/60916931/github-action-does-the-if-have-an-else
-    - name: Determine flatpak release branch
-      uses: haya14busa/action-cond@v1
-      id: flatpak_release_branch
-      with:
-        cond: ${{ env.IS_RELEASE }}
-        if_true: 'stable'
-        if_false: 'development'
-
-    - name: Show Flatpak manifest
-      run:  |
-        ls -R buildconfig/flatpak/
-        cat buildconfig/flatpak/org.tuxemon.Tuxemon.yaml
-
-    - name: Build package
-      uses: flatpak/flatpak-github-actions/flatpak-builder@v6
-      with:
-        bundle: Tuxemon.flatpak
-        manifest-path: buildconfig/flatpak/org.tuxemon.Tuxemon.yaml
-        cache: false
-        branch: ${{ steps.flatpak_release_branch.outputs.value }}
 
   build_installer_windows:
-    runs-on: windows-latest
-    steps:
-      # Checkout the repo
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-            # Version range or exact version of a Python version to use, using SemVer's version range syntax.
-            python-version: 3.9 # optional, default is 3.x
-            # The target architecture (x86, x64) of the Python interpreter.
-            architecture: x64 # optional
+    uses: ./.github/workflows/installer_windows.yml 
 
-      - name: Install dependencies
-        run: python3 -m pip install -r requirements.txt
 
-      - name: Install cx-freeze
-        run: python3 -m pip install cx-freeze pyyaml
-
-      - name: Build
-        run: |
-          copy buildconfig/setup_cx_freeze.py setup_cx_freeze.py
-          copy buildconfig/build_config.yaml build_config.yaml
-          python setup_cx_freeze.py build
-
-      - name: Install nsis
-        run: |
-          Invoke-WebRequest -Uri "https://sourceforge.net/projects/nsis/files/NSIS%203/3.10/nsis-3.10-setup.exe" -OutFile "nsis.exe"
-
-      - name: Build Installer
-        run: |
-          cd buildconfig
-          cmd.exe /c "build_installer.bat"
-          mkdir ../dist/
-          mv tuxemon-installer.exe ../dist/.
-
-      - name: Upload installer
-        uses: actions/upload-artifact@v4
-        with:
-            name: tuxemon_windows_installer
-            path: dist
-              
   python-app:
+    uses: ./.github/workflows/python-app.yml 
 
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.9
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        # flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        # flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: install as lib
-      run: |
-        pip install -e .
-    - name: Test with pytest
-      run: |
-        pytest tests
-        
   publish:
     needs: [flatpak, build_installer_windows]
     runs-on: ubuntu-latest # does not matter which
@@ -190,4 +80,3 @@ jobs:
           # **/artifacts/tuxemon_windows_installer/*.exe
           files: |
             **/Tuxemon-x86_64/Tuxemon.flatpak
-...

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -1,0 +1,54 @@
+name: Build Flatpak
+
+on:
+  workflow_call:
+    inputs:
+      IS_RELEASE:
+        required: true
+        type: boolean
+
+jobs:
+  flatpak:
+    runs-on: ubuntu-latest
+    container:
+      image: bilelmoussaoui/flatpak-github-actions:kde-6.3
+      options: --privileged
+    steps:
+    - name: Show environment variables
+      run: >
+        echo IS_RELEASE: ${{ inputs.IS_RELEASE }}
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    # https://stackoverflow.com/questions/60916931/github-action-does-the-if-have-an-else
+    - name: Determine flatpak release branch
+      uses: haya14busa/action-cond@v1
+      id: flatpak_release_branch
+      with:
+        cond: ${{ inputs.IS_RELEASE }}
+        if_true: 'stable'
+        if_false: 'development'
+
+    - name: Show Flatpak manifest
+      run:  |
+        ls -R buildconfig/flatpak/
+        cat buildconfig/flatpak/org.tuxemon.Tuxemon.yaml
+
+    - name: Build package
+      uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+      with:
+        bundle: Tuxemon.flatpak
+        manifest-path: buildconfig/flatpak/org.tuxemon.Tuxemon.yaml
+        cache: false
+        branch: ${{ steps.flatpak_release_branch.outputs.value }}
+  
+    - name: Prepare Flatpak directory
+      run: |
+        mkdir -p Tuxemon-x86_64
+        mv Tuxemon.flatpak Tuxemon-x86_64/
+
+    - name: Upload Flatpak artifact as a folder
+      uses: actions/upload-artifact@v4
+      with:
+        name: Tuxemon-x86_64
+        path: Tuxemon-x86_64/

--- a/.github/workflows/installer_windows.yml
+++ b/.github/workflows/installer_windows.yml
@@ -1,0 +1,46 @@
+name: Build Installer Windows
+
+on:
+  workflow_call:
+
+jobs:
+  flatpak:
+    runs-on: windows-latest
+    steps:
+      # Checkout the repo
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+            # Version range or exact version of a Python version to use, using SemVer's version range syntax.
+            python-version: 3.9 # optional, default is 3.x
+            # The target architecture (x86, x64) of the Python interpreter.
+            architecture: x64 # optional
+
+      - name: Install dependencies
+        run: python3 -m pip install -r requirements.txt
+
+      - name: Install cx-freeze
+        run: python3 -m pip install cx-freeze pyyaml
+
+      - name: Build
+        run: |
+          copy buildconfig/setup_cx_freeze.py setup_cx_freeze.py
+          copy buildconfig/build_config.yaml build_config.yaml
+          python setup_cx_freeze.py build
+
+      - name: Install nsis
+        run: |
+          Invoke-WebRequest -Uri "https://sourceforge.net/projects/nsis/files/NSIS%203/3.10/nsis-3.10-setup.exe" -OutFile "nsis.exe"
+
+      - name: Build Installer
+        run: |
+          cd buildconfig
+          cmd.exe /c "build_installer.bat"
+          mkdir ../dist/
+          mv tuxemon-installer.exe ../dist/.
+
+      - name: Upload installer
+        uses: actions/upload-artifact@v4
+        with:
+            name: tuxemon_windows_installer
+            path: dist

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,16 @@ name: Lint
 
 on:
   workflow_dispatch: # Allows manual triggering of the workflow
+  workflow_call:
+    inputs:
+      RUN_LINT:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   lint:
+    if: ${{ github.event.action == 'workflow_dispatch' || inputs.RUN_LINT == true }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,30 @@
+name: Python Build & Test
+
+on:
+  workflow_call:
+
+jobs:
+  lint:
+    uses: ./.github/workflows/lint.yml
+    with:
+      RUN_LINT: false  # Linting is skipped
+
+  python-app:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.9
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: install as lib
+      run: |
+        pip install -e .
+    - name: Test with pytest
+      run: |
+        pytest tests


### PR DESCRIPTION
PR addresses an issue where the **Flatpak** artifact was incorrectly uploaded as a single file instead of inside a directory, causing the **publish** job to fail. Additionally, the workflow has been refactored into separate files to improve maintainability and modularity.

Changes:
- fixed Flatpak artifact upload: created a `Tuxemon-x86_64` folder before moving the `Tuxemon.flatpak` file into it, updated the **upload-artifact** step to upload the entire folder instead of just the file and this ensures the `publish` job correctly finds the expected `artifacts/Tuxemon-x86_64/` directory
- separated workflows into distinct files: `Flatpak build`, `Python app`, `Appdata validation`, and `Linting` now have their own dedicated workflow files, this improves modularity, allowing individual workflow components to be invoked separately
- explicit linting control: instead of relying on commented-out code, linting is now a separate workflow, workflows can now choose whether to run linting via a boolean flag (`RUN_LINT`), avoiding unnecessary executions and ensures the linting logic is cleanly separated while still enforcing code quality when enabled