### PR TITLE
Refactor `NPC` to Extract `BattlesHandler` for Battle Handling

### DIFF
--- a/tests/tuxemon/test_actions.py
+++ b/tests/tuxemon/test_actions.py
@@ -4,13 +4,13 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from tuxemon import prepare
+from tuxemon.battle import BattlesHandler
 from tuxemon.db import Direction
 from tuxemon.entity import Body, Mover
 from tuxemon.event.eventaction import ActionManager
 from tuxemon.event.eventcondition import ConditionManager
 from tuxemon.event.eventengine import EventEngine
 from tuxemon.math import Point3, Vector3
-from tuxemon.npc import NPCBattlesHandler
 from tuxemon.player import Player
 from tuxemon.session import local_session
 from tuxemon.tuxepedia import Tuxepedia
@@ -184,7 +184,7 @@ class TestBattleActions(unittest.TestCase):
             local_session.set_player(Player())
             self.player = local_session.player
             self.player.steps = 0.0
-            self.player.battle_handler = NPCBattlesHandler()
+            self.player.battle_handler = BattlesHandler()
 
     def test_set_battle_won(self):
         _params = ["figher", "won", "opponent"]

--- a/tests/tuxemon/test_actions.py
+++ b/tests/tuxemon/test_actions.py
@@ -10,6 +10,7 @@ from tuxemon.event.eventaction import ActionManager
 from tuxemon.event.eventcondition import ConditionManager
 from tuxemon.event.eventengine import EventEngine
 from tuxemon.math import Point3, Vector3
+from tuxemon.npc import NPCBattlesHandler
 from tuxemon.player import Player
 from tuxemon.session import local_session
 from tuxemon.tuxepedia import Tuxepedia
@@ -182,39 +183,41 @@ class TestBattleActions(unittest.TestCase):
             self.action = EventEngine(local_session, action, condition)
             local_session.set_player(Player())
             self.player = local_session.player
+            self.player.steps = 0.0
+            self.player.battle_handler = NPCBattlesHandler()
 
     def test_set_battle_won(self):
-        self.player.battles = []
-        self.player.steps = 0.0
         _params = ["figher", "won", "opponent"]
         self.action.execute_action("set_battle", _params)
-        self.assertEqual(len(self.player.battles), 1)
-        self.assertEqual(self.player.battles[0].fighter, "figher")
-        self.assertEqual(self.player.battles[0].outcome, "won")
-        self.assertEqual(self.player.battles[0].opponent, "opponent")
-        self.assertEqual(self.player.battles[0].steps, 0)
+        self.assertEqual(len(self.player.battle_handler.get_battles()), 1)
+        battle = self.player.battle_handler.get_last_battle()
+        self.assertIsNotNone(battle)
+        self.assertEqual(battle.fighter, "figher")
+        self.assertEqual(battle.outcome, "won")
+        self.assertEqual(battle.opponent, "opponent")
+        self.assertEqual(battle.steps, 0)
 
     def test_set_battle_lost(self):
-        self.player.battles = []
-        self.player.steps = 0.0
         _params = ["figher", "lost", "opponent"]
         self.action.execute_action("set_battle", _params)
-        self.assertEqual(len(self.player.battles), 1)
-        self.assertEqual(self.player.battles[0].fighter, "figher")
-        self.assertEqual(self.player.battles[0].outcome, "lost")
-        self.assertEqual(self.player.battles[0].opponent, "opponent")
-        self.assertEqual(self.player.battles[0].steps, 0)
+        self.assertEqual(len(self.player.battle_handler.get_battles()), 1)
+        battle = self.player.battle_handler.get_last_battle()
+        self.assertIsNotNone(battle)
+        self.assertEqual(battle.fighter, "figher")
+        self.assertEqual(battle.outcome, "lost")
+        self.assertEqual(battle.opponent, "opponent")
+        self.assertEqual(battle.steps, 0)
 
     def test_set_battle_draw(self):
-        self.player.battles = []
-        self.player.steps = 0.0
         _params = ["figher", "draw", "opponent"]
         self.action.execute_action("set_battle", _params)
-        self.assertEqual(len(self.player.battles), 1)
-        self.assertEqual(self.player.battles[0].fighter, "figher")
-        self.assertEqual(self.player.battles[0].outcome, "draw")
-        self.assertEqual(self.player.battles[0].opponent, "opponent")
-        self.assertEqual(self.player.battles[0].steps, 0)
+        self.assertEqual(len(self.player.battle_handler.get_battles()), 1)
+        battle = self.player.battle_handler.get_last_battle()
+        self.assertIsNotNone(battle)
+        self.assertEqual(battle.fighter, "figher")
+        self.assertEqual(battle.outcome, "draw")
+        self.assertEqual(battle.opponent, "opponent")
+        self.assertEqual(battle.steps, 0)
 
     def test_set_battle_wrong(self):
         _params = ["figher", "jimmy", "opponent"]

--- a/tests/tuxemon/test_battles_handler.py
+++ b/tests/tuxemon/test_battles_handler.py
@@ -2,18 +2,17 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import unittest
 
-from tuxemon.battle import Battle
+from tuxemon.battle import Battle, BattlesHandler
 from tuxemon.db import OutputBattle
-from tuxemon.npc import NPCBattlesHandler
 
 
-class TestNPCBattlesHandler(unittest.TestCase):
+class TestBattlesHandler(unittest.TestCase):
     def test_init(self):
-        handler = NPCBattlesHandler()
+        handler = BattlesHandler()
         self.assertEqual(handler.get_battles(), [])
 
     def test_add_battle(self):
-        handler = NPCBattlesHandler()
+        handler = BattlesHandler()
         battle = Battle(
             {
                 "fighter": "player",
@@ -26,7 +25,7 @@ class TestNPCBattlesHandler(unittest.TestCase):
         self.assertEqual(len(handler.get_battles()), 1)
 
     def test_get_battles(self):
-        handler = NPCBattlesHandler()
+        handler = BattlesHandler()
         battle1 = Battle(
             {
                 "fighter": "player",
@@ -48,7 +47,7 @@ class TestNPCBattlesHandler(unittest.TestCase):
         self.assertEqual(len(handler.get_battles()), 2)
 
     def test_clear_battles(self):
-        handler = NPCBattlesHandler()
+        handler = BattlesHandler()
         battle = Battle(
             {
                 "fighter": "player",
@@ -62,7 +61,7 @@ class TestNPCBattlesHandler(unittest.TestCase):
         self.assertEqual(len(handler.get_battles()), 0)
 
     def test_has_fought_and_outcome(self):
-        handler = NPCBattlesHandler()
+        handler = BattlesHandler()
         battle = Battle(
             {
                 "fighter": "player",
@@ -79,7 +78,7 @@ class TestNPCBattlesHandler(unittest.TestCase):
         )
 
     def test_get_last_battle_outcome(self):
-        handler = NPCBattlesHandler()
+        handler = BattlesHandler()
         battle1 = Battle(
             {
                 "fighter": "player",
@@ -103,7 +102,7 @@ class TestNPCBattlesHandler(unittest.TestCase):
         )
 
     def test_get_battle_outcome_stats(self):
-        handler = NPCBattlesHandler()
+        handler = BattlesHandler()
         battle1 = Battle(
             {
                 "fighter": "player",
@@ -128,7 +127,7 @@ class TestNPCBattlesHandler(unittest.TestCase):
         self.assertEqual(stats[OutputBattle.draw], 0)
 
     def test_get_battle_outcome_summary(self):
-        handler = NPCBattlesHandler()
+        handler = BattlesHandler()
         battle1 = Battle(
             {
                 "fighter": "player",

--- a/tests/tuxemon/test_npc_battles_handler.py
+++ b/tests/tuxemon/test_npc_battles_handler.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import unittest
+
+from tuxemon.battle import Battle
+from tuxemon.db import OutputBattle
+from tuxemon.npc import NPCBattlesHandler
+
+
+class TestNPCBattlesHandler(unittest.TestCase):
+    def test_init(self):
+        handler = NPCBattlesHandler()
+        self.assertEqual(handler.get_battles(), [])
+
+    def test_add_battle(self):
+        handler = NPCBattlesHandler()
+        battle = Battle(
+            {
+                "fighter": "player",
+                "opponent": "npc",
+                "outcome": OutputBattle.won,
+                "steps": 10,
+            }
+        )
+        handler.add_battle(battle)
+        self.assertEqual(len(handler.get_battles()), 1)
+
+    def test_get_battles(self):
+        handler = NPCBattlesHandler()
+        battle1 = Battle(
+            {
+                "fighter": "player",
+                "opponent": "npc",
+                "outcome": OutputBattle.won,
+                "steps": 10,
+            }
+        )
+        battle2 = Battle(
+            {
+                "fighter": "player",
+                "opponent": "npc",
+                "outcome": OutputBattle.lost,
+                "steps": 5,
+            }
+        )
+        handler.add_battle(battle1)
+        handler.add_battle(battle2)
+        self.assertEqual(len(handler.get_battles()), 2)
+
+    def test_clear_battles(self):
+        handler = NPCBattlesHandler()
+        battle = Battle(
+            {
+                "fighter": "player",
+                "opponent": "npc",
+                "outcome": OutputBattle.won,
+                "steps": 10,
+            }
+        )
+        handler.add_battle(battle)
+        handler.clear_battles()
+        self.assertEqual(len(handler.get_battles()), 0)
+
+    def test_has_fought_and_outcome(self):
+        handler = NPCBattlesHandler()
+        battle = Battle(
+            {
+                "fighter": "player",
+                "opponent": "npc",
+                "outcome": OutputBattle.won,
+                "steps": 10,
+            }
+        )
+        handler.add_battle(battle)
+        self.assertTrue(
+            handler.has_fought_and_outcome(
+                "player", OutputBattle.won.value, "npc"
+            )
+        )
+
+    def test_get_last_battle_outcome(self):
+        handler = NPCBattlesHandler()
+        battle1 = Battle(
+            {
+                "fighter": "player",
+                "opponent": "npc",
+                "outcome": OutputBattle.won,
+                "steps": 10,
+            }
+        )
+        battle2 = Battle(
+            {
+                "fighter": "player",
+                "opponent": "npc",
+                "outcome": OutputBattle.lost,
+                "steps": 5,
+            }
+        )
+        handler.add_battle(battle1)
+        handler.add_battle(battle2)
+        self.assertEqual(
+            handler.get_last_battle_outcome("player", "npc"), OutputBattle.lost
+        )
+
+    def test_get_battle_outcome_stats(self):
+        handler = NPCBattlesHandler()
+        battle1 = Battle(
+            {
+                "fighter": "player",
+                "opponent": "npc",
+                "outcome": OutputBattle.won,
+                "steps": 10,
+            }
+        )
+        battle2 = Battle(
+            {
+                "fighter": "player",
+                "opponent": "npc",
+                "outcome": OutputBattle.lost,
+                "steps": 5,
+            }
+        )
+        handler.add_battle(battle1)
+        handler.add_battle(battle2)
+        stats = handler.get_battle_outcome_stats("player")
+        self.assertEqual(stats[OutputBattle.won], 1)
+        self.assertEqual(stats[OutputBattle.lost], 1)
+        self.assertEqual(stats[OutputBattle.draw], 0)
+
+    def test_get_battle_outcome_summary(self):
+        handler = NPCBattlesHandler()
+        battle1 = Battle(
+            {
+                "fighter": "player",
+                "opponent": "npc",
+                "outcome": OutputBattle.won,
+                "steps": 10,
+            }
+        )
+        battle2 = Battle(
+            {
+                "fighter": "player",
+                "opponent": "npc",
+                "outcome": OutputBattle.lost,
+                "steps": 5,
+            }
+        )
+        handler.add_battle(battle1)
+        handler.add_battle(battle2)
+        summary = handler.get_battle_outcome_summary("player")
+        self.assertEqual(summary["total"], 2)
+        self.assertEqual(summary["won"], 1)
+        self.assertEqual(summary["lost"], 1)
+        self.assertEqual(summary["draw"], 0)

--- a/tuxemon/battle.py
+++ b/tuxemon/battle.py
@@ -2,11 +2,14 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping, Sequence
 from typing import Any, Optional
 from uuid import UUID, uuid4
 
 from tuxemon.db import OutputBattle
+
+logger = logging.getLogger(__name__)
 
 SIMPLE_PERSISTANCE_ATTRIBUTES = (
     "fighter",
@@ -64,6 +67,101 @@ class Battle:
                 self.instance_id = UUID(value)
             elif key in SIMPLE_PERSISTANCE_ATTRIBUTES:
                 setattr(self, key, value)
+
+
+class BattlesHandler:
+    """
+    Handles the battles associated with an Entity.
+    """
+
+    def __init__(self, initial_battles: Optional[list[Battle]] = None) -> None:
+        self._battles = initial_battles if initial_battles is not None else []
+
+    def add_battle(self, battle: Battle) -> None:
+        self._battles.append(battle)
+
+    def get_battles(self) -> list[Battle]:
+        return list(self._battles)
+
+    def clear_battles(self) -> None:
+        self._battles.clear()
+
+    def has_fought_and_outcome(
+        self, fighter: str, outcome: str, opponent: str
+    ) -> bool:
+        """
+        Checks if a specific battle outcome has occurred between the fighter and opponent.
+        This checks if there's at least one battle matching the criteria.
+        """
+        if outcome not in [o.value for o in OutputBattle]:
+            logger.error(f"'{outcome}' isn't a valid battle outcome.")
+            return False
+
+        for battle in reversed(self._battles):
+            if (
+                battle.fighter == fighter
+                and battle.opponent == opponent
+                and battle.outcome == outcome
+            ):
+                return True
+        return False
+
+    def get_last_battle(self) -> Optional[Battle]:
+        if self._battles:
+            return self._battles[-1]
+        return None
+
+    def get_last_battle_outcome(
+        self, fighter: str, opponent: str
+    ) -> Optional[str]:
+        """
+        Returns the outcome of the last battle between the specified fighter and opponent.
+        """
+        for battle in reversed(self._battles):
+            if battle.fighter == fighter and battle.opponent == opponent:
+                return battle.outcome
+        return None
+
+    def get_battle_outcome_stats(
+        self, fighter: str
+    ) -> dict[OutputBattle, int]:
+        """
+        Returns the battle outcome statistics for the specified fighter.
+
+        The statistics include the number of wins, losses, and draws.
+        """
+        battle_outcomes = {outcome: 0 for outcome in OutputBattle}
+
+        for battle in self._battles:
+            if battle.fighter == fighter:
+                battle_outcomes[battle.outcome] += 1
+
+        return battle_outcomes
+
+    def get_battle_outcome_summary(self, fighter: str) -> dict[str, int]:
+        """
+        Returns a summary of the battle outcome statistics for the specified fighter.
+
+        The summary includes the total number of battles, wins, losses, and draws.
+        """
+        battle_outcomes = self.get_battle_outcome_stats(fighter)
+        total_battles = sum(battle_outcomes.values())
+
+        return {
+            "total": total_battles,
+            "won": battle_outcomes[OutputBattle.won],
+            "lost": battle_outcomes[OutputBattle.lost],
+            "draw": battle_outcomes[OutputBattle.draw],
+        }
+
+    def encode_battle(self) -> Sequence[Mapping[str, Any]]:
+        return encode_battle(self._battles)
+
+    def decode_battle(self, json_data: Optional[Mapping[str, Any]]) -> None:
+        if json_data and "battles" in json_data:
+            self._battles = [
+                bat for bat in decode_battle(json_data["battles"])
+            ]
 
 
 def decode_battle(

--- a/tuxemon/battle.py
+++ b/tuxemon/battle.py
@@ -2,9 +2,9 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-import uuid
 from collections.abc import Mapping, Sequence
 from typing import Any, Optional
+from uuid import UUID, uuid4
 
 from tuxemon.db import OutputBattle
 
@@ -24,11 +24,11 @@ class Battle:
     def __init__(self, save_data: Optional[Mapping[str, Any]] = None) -> None:
         save_data = save_data or {}
 
-        self.instance_id = uuid.uuid4()
-        self.fighter = ""
-        self.opponent = ""
-        self.outcome = OutputBattle.draw
-        self.steps = 0
+        self.instance_id: UUID = uuid4()
+        self.fighter: str = ""
+        self.opponent: str = ""
+        self.outcome: OutputBattle = OutputBattle.draw
+        self.steps: int = 0
 
         self.set_state(save_data)
 
@@ -61,7 +61,7 @@ class Battle:
 
         for key, value in save_data.items():
             if key == "instance_id" and value:
-                self.instance_id = uuid.UUID(value)
+                self.instance_id = UUID(value)
             elif key in SIMPLE_PERSISTANCE_ATTRIBUTES:
                 setattr(self, key, value)
 

--- a/tuxemon/event/actions/set_battle.py
+++ b/tuxemon/event/actions/set_battle.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class SetBattleAction(EventAction):
     """
-    Append a new element in player.battles.
+    Appends a new battle to the player's battle history.
 
     Script usage:
         .. code-block::
@@ -26,31 +26,36 @@ class SetBattleAction(EventAction):
             set_battle <fighter>,<result>,<opponent>
 
     Script parameters:
-        fighter: Npc slug name (e.g. "npc_maple").
-        result: One among "won", "lost" and "draw".
-        opponent: Npc slug name (e.g. "npc_maple").
+        fighter_slug: The slug of the battle participant (e.g., "player").
+        outcome: The desired battle outcome ("won", "lost", or "draw").
+        opponent_slug: The slug of the opponent (e.g., "npc_maple").
 
-    eg. "set_battle player,won,npc_maple"
-        -> player won against npc_maple
-
+    Example:
+        `set_battle player,won,npc_maple`
+        Add the 'player' has won against 'npc_maple' to the history.
     """
 
     name = "set_battle"
-    fighter: str
+    fighter_slug: str
     outcome: str
-    opponent: str
+    opponent_slug: str
 
     def start(self, session: Session) -> None:
         player = session.player
 
-        _output = list(OutputBattle)
-        if self.outcome not in _output:
-            raise ValueError(f"{self.outcome} isn't among {_output}")
+        if self.outcome not in list(OutputBattle):
+            raise ValueError(
+                f"{self.outcome} isn't among {list(OutputBattle)}"
+            )
 
-        battle = Battle()
-        battle.fighter = self.fighter
-        battle.outcome = OutputBattle(self.outcome)
-        battle.opponent = self.opponent
-        battle.steps = int(player.steps)
-        logger.info(f"{self.fighter} {self.outcome} against {self.opponent}")
-        player.battles.append(battle)
+        data = {
+            "fighter": self.fighter_slug,
+            "opponent": self.opponent_slug,
+            "outcome": OutputBattle(self.outcome),
+            "steps": int(player.steps),
+        }
+        battle = Battle(data)
+        logger.info(
+            f"{self.fighter_slug} {self.outcome} against {self.opponent_slug}"
+        )
+        player.battle_handler.add_battle(battle)

--- a/tuxemon/event/conditions/battle_is.py
+++ b/tuxemon/event/conditions/battle_is.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
-from tuxemon.db import OutputBattle
 from tuxemon.event import MapCondition
 from tuxemon.event.eventcondition import EventCondition
 from tuxemon.session import Session
@@ -16,8 +15,8 @@ logger = logging.getLogger(__name__)
 @dataclass
 class BattleIsCondition(EventCondition):
     """
-    Check to see if a character has fought against another one
-    and won, lost or draw.
+    Checks if a character has achieved a specific battle outcome
+    against an opponent.
 
     Script usage:
         .. code-block::
@@ -25,38 +24,22 @@ class BattleIsCondition(EventCondition):
             is battle_is <fighter>,<outcome>,<opponent>
 
     Script parameters:
-        fighter: Npc slug name (e.g. "npc_maple").
-        outcome: One among "won", "lost" and "draw".
-        opponent: Npc slug name (e.g. "npc_maple").
+        fighter_slug: The slug of the battle participant (e.g., "player").
+        outcome: The desired battle outcome ("won", "lost", or "draw").
+        opponent_slug: The slug of the opponent (e.g., "npc_maple").
 
-    eg. "is battle_is player,won,npc_maple"
-        -> has player won against npc_maple in the last fight?
-
+    Example:
+        `is battle_is player,won,npc_maple`
+        Checks if the 'player' has won against 'npc_maple'.
     """
 
     name = "battle_is"
 
     def test(self, session: Session, condition: MapCondition) -> bool:
         player = session.player
-        # Read the parameters
         fighter, outcome, opponent = condition.parameters[:3]
-
-        # no battles
-        if not player.battles:
+        if not player.battle_handler:
             return False
-        if outcome not in list(OutputBattle):
-            logger.error(f"{outcome} isn't among {list(OutputBattle)}")
-            return False
-
-        battles = [
-            battle
-            for battle in player.battles
-            if battle.fighter == fighter
-            and battle.opponent == opponent
-            and battle.outcome == outcome
-        ]
-        # look for last battle
-        if len(battles) > 1:
-            last_one = sorted(battles, key=lambda x: x.steps, reverse=True)
-            return last_one[0].outcome == outcome
-        return bool(battles)
+        return player.battle_handler.has_fought_and_outcome(
+            fighter=fighter, outcome=outcome, opponent=opponent
+        )

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, Optional, TypedDict
 from tuxemon import prepare
 from tuxemon.battle import Battle, decode_battle, encode_battle
 from tuxemon.boxes import ItemBoxes, MonsterBoxes
-from tuxemon.db import Direction, db
+from tuxemon.db import Direction, OutputBattle, db
 from tuxemon.entity import Entity
 from tuxemon.item.item import Item, decode_items, encode_items
 from tuxemon.locale import T
@@ -104,7 +104,7 @@ class NPC(Entity[NPCState]):
         # general
         self.behavior: Optional[str] = "wander"  # not used for now
         self.game_variables: dict[str, Any] = {}  # Tracks the game state
-        self.battles: list[Battle] = []  # Tracks the battles
+        self.battle_handler = NPCBattlesHandler()
         self.forfeit: bool = False
         # Tracks Tuxepedia (monster seen or caught)
         self.tuxepedia = Tuxepedia()
@@ -166,7 +166,7 @@ class NPC(Entity[NPCState]):
             "current_map": session.client.get_map_name(),
             "facing": self.facing,
             "game_variables": self.game_variables,
-            "battles": encode_battle(self.battles),
+            "battles": self.battle_handler.encode_battle(),
             "tuxepedia": encode_tuxepedia(self.tuxepedia),
             "relationships": encode_relationships(self.relationships),
             "money": dict(),
@@ -202,9 +202,7 @@ class NPC(Entity[NPCState]):
         self.game_variables = save_data["game_variables"]
         self.tuxepedia = decode_tuxepedia(save_data["tuxepedia"])
         self.relationships = decode_relationships(save_data["relationships"])
-        self.battles = []
-        for battle in decode_battle(save_data.get("battles")):
-            self.battles.append(battle)
+        self.battle_handler.decode_battle(save_data)
         self.items = []
         for item in decode_items(save_data.get("items")):
             self.add_item(item)
@@ -661,3 +659,98 @@ class NPC(Entity[NPCState]):
         return next(
             (m for m in self.items if m.instance_id == instance_id), None
         )
+
+
+class NPCBattlesHandler:
+    """
+    Handles the battles associated with an NPC.
+    """
+
+    def __init__(self, initial_battles: Optional[list[Battle]] = None) -> None:
+        self._battles = initial_battles if initial_battles is not None else []
+
+    def add_battle(self, battle: Battle) -> None:
+        self._battles.append(battle)
+
+    def get_battles(self) -> list[Battle]:
+        return list(self._battles)
+
+    def clear_battles(self) -> None:
+        self._battles.clear()
+
+    def has_fought_and_outcome(
+        self, fighter: str, outcome: str, opponent: str
+    ) -> bool:
+        """
+        Checks if a specific battle outcome has occurred between the fighter and opponent.
+        This checks if there's at least one battle matching the criteria.
+        """
+        if outcome not in [o.value for o in OutputBattle]:
+            logger.error(f"'{outcome}' isn't a valid battle outcome.")
+            return False
+
+        for battle in reversed(self._battles):
+            if (
+                battle.fighter == fighter
+                and battle.opponent == opponent
+                and battle.outcome == outcome
+            ):
+                return True
+        return False
+
+    def get_last_battle(self) -> Optional[Battle]:
+        if self._battles:
+            return self._battles[-1]
+        return None
+
+    def get_last_battle_outcome(
+        self, fighter: str, opponent: str
+    ) -> Optional[str]:
+        """
+        Returns the outcome of the last battle between the specified fighter and opponent.
+        """
+        for battle in reversed(self._battles):
+            if battle.fighter == fighter and battle.opponent == opponent:
+                return battle.outcome
+        return None
+
+    def get_battle_outcome_stats(
+        self, fighter: str
+    ) -> dict[OutputBattle, int]:
+        """
+        Returns the battle outcome statistics for the specified fighter.
+
+        The statistics include the number of wins, losses, and draws.
+        """
+        battle_outcomes = {outcome: 0 for outcome in OutputBattle}
+
+        for battle in self._battles:
+            if battle.fighter == fighter:
+                battle_outcomes[battle.outcome] += 1
+
+        return battle_outcomes
+
+    def get_battle_outcome_summary(self, fighter: str) -> dict[str, int]:
+        """
+        Returns a summary of the battle outcome statistics for the specified fighter.
+
+        The summary includes the total number of battles, wins, losses, and draws.
+        """
+        battle_outcomes = self.get_battle_outcome_stats(fighter)
+        total_battles = sum(battle_outcomes.values())
+
+        return {
+            "total": total_battles,
+            "won": battle_outcomes[OutputBattle.won],
+            "lost": battle_outcomes[OutputBattle.lost],
+            "draw": battle_outcomes[OutputBattle.draw],
+        }
+
+    def encode_battle(self) -> Sequence[Mapping[str, Any]]:
+        return encode_battle(self._battles)
+
+    def decode_battle(self, json_data: Optional[Mapping[str, Any]]) -> None:
+        if json_data and "battles" in json_data:
+            self._battles = [
+                bat for bat in decode_battle(json_data["battles"])
+            ]

--- a/tuxemon/states/character/__init__.py
+++ b/tuxemon/states/character/__init__.py
@@ -90,20 +90,13 @@ class CharacterState(PygameMenuState):
             else T.translate("player_start_adventure_today")
         )
 
-        battle_outcomes = {
-            OutputBattle.won: 0,
-            OutputBattle.lost: 0,
-            OutputBattle.draw: 0,
-        }
-
-        for battle in self.char.battles:
-            if battle.fighter == player:
-                battle_outcomes[battle.outcome] += 1
-
-        tot = sum(battle_outcomes.values())
-        won = battle_outcomes[OutputBattle.won]
-        lost = battle_outcomes[OutputBattle.lost]
-        draw = battle_outcomes[OutputBattle.draw]
+        summary = self.char.battle_handler.get_battle_outcome_summary(player)
+        tot, won, lost, draw = (
+            summary["total"],
+            summary["won"],
+            summary["lost"],
+            summary["draw"],
+        )
 
         _msg_battles = {
             "tot": str(tot),


### PR DESCRIPTION
PR introduces a structured `BattlesHandler` to make managing NPC battles more efficient. This class not only streamlines the battle process but also centralizes operations that were previously scattered throughout the codebase, making it easier to maintain and update.

Changes:
- added methods to `BattlesHandler` to handle various battle-related tasks
- updated the `NPC` class to use `self.battle_handler` instead of `self.battles` for better organization
- created a unit test for the `BattlesHandler` class
- updated existing unit tests, such as the one for the `set_battle` event action, to reflect the changes made