### PR TITLE
Improve Initialization Flexibility + Path

### DIFF
--- a/tuxemon/config.py
+++ b/tuxemon/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from pathlib import Path
 from typing import Any, Optional
 
 import pygame
@@ -22,25 +23,20 @@ class TuxemonConfig:
     Do not forget to edit the default configuration specified below!
     """
 
-    def __init__(self, config_path: Optional[str] = None) -> None:
+    def __init__(self, config_path: Optional[Path] = None) -> None:
         # Default configuration dictionary
         self.config = generate_default_config()
         self.config_path = config_path
 
         # Load customized configuration if the YAML file exists
-        if config_path:
-            try:
-                with open(config_path) as yaml_file:
-                    loaded_config = yaml.safe_load(yaml_file)
+        if config_path and config_path.exists():
+            with config_path.open() as yaml_file:
+                loaded_config = yaml.safe_load(yaml_file)
 
-                    # Merge only existing sections while keeping defaults
-                    for category, defaults in self.config.items():
-                        if category in loaded_config:
-                            defaults.update(loaded_config[category])
-
-            except FileNotFoundError:
-                # File does not exist; keep using defaults
-                pass
+            # Merge only existing sections while keeping defaults
+            for category, defaults in self.config.items():
+                if category in loaded_config:
+                    defaults.update(loaded_config[category])
 
         self.load_config()
 
@@ -58,7 +54,7 @@ class TuxemonConfig:
         """Saves the configuration to a YAML file."""
         if not self.config_path:
             raise RuntimeError("No path specified for saving configuration.")
-        with open(self.config_path, "w") as yaml_file:
+        with self.config_path.open("w") as yaml_file:
             yaml.dump(
                 self.config, yaml_file, default_flow_style=False, indent=4
             )
@@ -127,12 +123,12 @@ class TuxemonConfig:
         self.player_runrate: float = player["player_runrate"]
 
     def reload_config(self) -> None:
-        if not self.config_path:
+        if not self.config_path or not self.config_path.exists():
             raise RuntimeError(
                 "No path specified for reloading configuration."
             )
 
-        with open(self.config_path) as yaml_file:
+        with self.config_path.open() as yaml_file:
             self.config.update(yaml.safe_load(yaml_file))
         self.load_config()
         self.input.config = self.config

--- a/tuxemon/main.py
+++ b/tuxemon/main.py
@@ -105,6 +105,8 @@ def headless(config: TuxemonConfig) -> None:
     Parameters:
         config: The Tuxemon configuration object containing game settings.
     """
+    log.configure()
+    prepare.init(platform="headless")
     control = HeadlessClient(config)
     control.push_state("HeadlessServerState")
     control.main()

--- a/tuxemon/prepare.py
+++ b/tuxemon/prepare.py
@@ -25,36 +25,53 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# TODO: refact this out when other platforms supported (such as headless)
-PLATFORM = "pygame"
 
-# list of regular expressions to blacklist devices
-joystick_blacklist = [
-    re.compile(r"Microsoft.*Transceiver.*"),
-    re.compile(r".*Synaptics.*", re.I),
-    re.compile(r"Wacom*.", re.I),
-]
+def _compile_joystick_blacklist() -> list[re.Pattern[str]]:
+    """Compiles a list of regex patterns for blacklisting joysticks."""
+    logger.debug("Compiling joystick blacklist patterns.")
+    return [
+        re.compile(r"Microsoft.*Transceiver.*"),
+        re.compile(r".*Synaptics.*", re.I),
+        re.compile(r"Wacom*.", re.I),
+    ]
 
-# Create game dir if missing
-paths.USER_STORAGE_DIR.mkdir(parents=True, exist_ok=True)
 
-# Create game data dir if missing
-paths.USER_GAME_DATA_DIR.mkdir(parents=True, exist_ok=True)
+joystick_blacklist = _compile_joystick_blacklist()
 
-# Create game savegame dir if missing
-paths.USER_GAME_SAVE_DIR.mkdir(parents=True, exist_ok=True)
 
-# Generate default config
-config.generate_default_config()
+def _setup_user_environment() -> config.TuxemonConfig:
+    """Sets up user storage directories and loads/saves the game configuration."""
+    logger.debug("Setting up user environment and config.")
+    try:
+        paths.USER_STORAGE_DIR.mkdir(parents=True, exist_ok=True)
+        paths.USER_GAME_DATA_DIR.mkdir(parents=True, exist_ok=True)
+        paths.USER_GAME_SAVE_DIR.mkdir(parents=True, exist_ok=True)
+        logger.info("User directories ensured.")
+    except OSError as e:
+        logger.critical(f"Failed to create user directories: {e}")
+        raise
 
-# Read "tuxemon.yaml" config from disk, update and write back
-CONFIG = config.TuxemonConfig(paths.USER_CONFIG_PATH.as_posix())
+    config.generate_default_config()
+    loaded_config = config.TuxemonConfig(paths.USER_CONFIG_PATH)
+
+    try:
+        with paths.USER_CONFIG_PATH.open("w") as fp:
+            yaml.dump(
+                loaded_config.config, fp, default_flow_style=False, indent=4
+            )
+        logger.info(
+            f"Configuration loaded and saved to {paths.USER_CONFIG_PATH}"
+        )
+    except Exception as e:
+        logger.error(f"Failed to save config: {e}")
+    return loaded_config
+
+
+# How it would be called in the main part of the file:
+CONFIG = _setup_user_environment()
 
 # Starting map
 STARTING_MAP = "start_"
-
-with paths.USER_CONFIG_PATH.open("w") as fp:
-    yaml.dump(CONFIG.config, fp, default_flow_style=False, indent=4)
 
 # Set up the screen size and caption
 SCREEN_SIZE = CONFIG.resolution
@@ -336,6 +353,10 @@ DEV_TOOLS = CONFIG.dev_tools
 
 def pygame_init() -> None:
     """Eventually refactor out of prepare."""
+    from tuxemon import platform
+
+    platform.init()
+
     global JOYSTICKS
     global FONTS
     global MUSIC
@@ -391,13 +412,24 @@ def pygame_init() -> None:
             logger.warning(f"Failed to initialize joystick {i}: {e}")
 
 
-# Initialize the game framework
-def init() -> None:
-    from tuxemon import platform
+def headless_init() -> None:
+    """Initializes game components for a headless environment."""
+    from tuxemon.locale import T
 
-    platform.init()
-    if PLATFORM == "pygame":
+    T.collect_languages(CONFIG.recompile_translations)
+    from tuxemon.db import db
+
+    db.load()
+    logger.debug("headless init")
+
+
+def init(platform: str = "pygame") -> None:
+    if platform == "pygame":
         pygame_init()
+    elif platform == "headless":
+        headless_init()
+    else:
+        raise ValueError(f"Unsupported platform: {platform}")
 
 
 # Fetches a resource file


### PR DESCRIPTION
PR enhances the initialization process by introducing a headless mode, making the game more adaptable to different environments.  

Changes:  
- introduced `headless_init()` to allow initialization without relying on `pygame`
- updated `init()` to accept a `platform` argument, enabling selection between `"pygame"` and `"headless"`
- refactored `pygame_init()` to ensure `platform.init()` is called before other initialization steps
- improved error handling by raising `ValueError` for unsupported platforms
- enhanced logging to provide better visibility during initialization
- encapsulated joystick blacklist logic in `_compile_joystick_blacklist()`
- refactored user storage setup into `_setup_user_environment()`, ensuring game directories are created with proper error handling
- added logging to track initialization steps and potential failures
- improved exception handling to log critical errors when directory creation fails, preventing silent failures
- the type hint for `config_path` was changed from `Optional[str]` to `Optional[Path]` (build up on #2812)
- the `try`-`except` block for checking if the file exists was replaced with a simple `if` statement using the `Path.exists()` and the `open()` function was replaced with the `open()` method of the `Path` object