### PR TITLE
Enhancing Path Consistency in PR #2812

### DIFF
--- a/tests/tuxemon/test_event_loader.py
+++ b/tests/tuxemon/test_event_loader.py
@@ -20,7 +20,7 @@ class TestEventLoader(unittest.TestCase):
         mock_load_collision.return_value = {(1, 2): None}
         result = self.event_loader.load_collision_events(yaml_file)
         self.assertEqual(result, {(1, 2): None})
-        mock_load_collision.assert_called_once_with(yaml_file.as_posix())
+        mock_load_collision.assert_called_once_with(yaml_file)
 
     @patch.object(YAMLEventLoader, "load_collision")
     def test_load_collision_events_failure(self, mock_load_collision):
@@ -28,7 +28,7 @@ class TestEventLoader(unittest.TestCase):
         mock_load_collision.side_effect = Exception("Test error")
         result = self.event_loader.load_collision_events(yaml_file)
         self.assertEqual(result, {})
-        mock_load_collision.assert_called_once_with(yaml_file.as_posix())
+        mock_load_collision.assert_called_once_with(yaml_file)
 
     @patch.object(YAMLEventLoader, "load_events")
     def test_load_specific_events_success(self, mock_load_events):
@@ -37,9 +37,7 @@ class TestEventLoader(unittest.TestCase):
         mock_load_events.return_value = {event_type: [Mock()]}
         result = self.event_loader.load_specific_events(yaml_file, event_type)
         self.assertEqual(len(result), 1)
-        mock_load_events.assert_called_once_with(
-            yaml_file.as_posix(), event_type
-        )
+        mock_load_events.assert_called_once_with(yaml_file, event_type)
 
     @patch.object(YAMLEventLoader, "load_events")
     def test_load_specific_events_failure(self, mock_load_events):
@@ -48,9 +46,7 @@ class TestEventLoader(unittest.TestCase):
         mock_load_events.side_effect = Exception("Test error")
         result = self.event_loader.load_specific_events(yaml_file, event_type)
         self.assertEqual(result, [])
-        mock_load_events.assert_called_once_with(
-            yaml_file.as_posix(), event_type
-        )
+        mock_load_events.assert_called_once_with(yaml_file, event_type)
 
     @patch.object(YAMLEventLoader, "load_events")
     def test_load_specific_events_empty(self, mock_load_events):
@@ -59,6 +55,4 @@ class TestEventLoader(unittest.TestCase):
         mock_load_events.return_value = {}
         result = self.event_loader.load_specific_events(yaml_file, event_type)
         self.assertEqual(result, [])
-        mock_load_events.assert_called_once_with(
-            yaml_file.as_posix(), event_type
-        )
+        mock_load_events.assert_called_once_with(yaml_file, event_type)

--- a/tests/tuxemon/test_plugin.py
+++ b/tests/tuxemon/test_plugin.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import unittest
 from collections.abc import Iterable
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from tuxemon.plugin import (
@@ -61,12 +62,12 @@ class TestPluginManager(unittest.TestCase):
         self.assertIsInstance(classes, Iterable)
 
     def test_load_directory(self):
-        plugin_folder = "folder1"
+        plugin_folder = Path("folder1")
         loaded_manager = load_directory(plugin_folder)
         self.assertIsInstance(loaded_manager, PluginManager)
 
     def test_get_available_classes(self):
-        plugin_folder = "folder1"
+        plugin_folder = Path("folder1")
         manager = load_directory(plugin_folder)
         classes = get_available_classes(manager, interface=self.interface)
         self.assertIsInstance(classes, list)

--- a/tuxemon/audio.py
+++ b/tuxemon/audio.py
@@ -157,7 +157,7 @@ class SoundManager:
     def __init__(self) -> None:
         self.sounds: dict[str, SoundProtocol] = {}
 
-    def get_sound_filename(self, slug: str) -> Optional[str]:
+    def get_sound_filename(self, slug: str) -> Optional[Path]:
         if slug is None or slug == "":
             return None
 
@@ -170,7 +170,7 @@ class SoundManager:
             logger.error(f"audio file does not exist: {filename}")
             return None
 
-        return path.as_posix()
+        return path
 
     def load_sound(
         self, slug: str, value: float = prepare.CONFIG.sound_volume

--- a/tuxemon/cli/processor.py
+++ b/tuxemon/cli/processor.py
@@ -76,7 +76,7 @@ class CommandProcessor:
         self.client = client
         folder = Path(__file__).parent / "commands"
         # TODO: add folder(s) from mods
-        commands = list(self.collect_commands(folder.as_posix()))
+        commands = list(self.collect_commands(folder))
         self.root_command = MetaCommand(commands)
 
     def run(self) -> None:
@@ -125,7 +125,7 @@ class CommandProcessor:
         """
         self.client.quit()
 
-    def collect_commands(self, folder: str) -> Iterable[CLICommand]:
+    def collect_commands(self, folder: Path) -> Iterable[CLICommand]:
         """
         Use plugins to load CLICommand classes for commands.
 

--- a/tuxemon/core/core_manager.py
+++ b/tuxemon/core/core_manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib
 import logging
 from collections.abc import Sequence
+from pathlib import Path
 
 from tuxemon import plugin
 from tuxemon.db import CommonCondition, CommonEffect
@@ -17,13 +18,13 @@ class CoreManager:
     """Core class for managing the loading and unloading of plugins."""
 
     def __init__(
-        self, interface: type[PluginObject], path: str, category: str
+        self, interface: type[PluginObject], path: Path, category: str
     ) -> None:
         self.classes: dict[str, type[PluginObject]] = {}
         self.load_plugins(interface, path, category)
 
     def load_plugins(
-        self, interface: type[PluginObject], path: str, category: str
+        self, interface: type[PluginObject], path: Path, category: str
     ) -> None:
         """Load all available plugins using the existing plugin system."""
         self.classes.update(
@@ -115,7 +116,7 @@ class EffectManager(CoreManager):
     def __init__(
         self,
         effect_class: type[PluginObject],
-        path: str,
+        path: Path,
         category: str = "effects",
     ) -> None:
         """
@@ -137,7 +138,7 @@ class ConditionManager(CoreManager):
     def __init__(
         self,
         condition_class: type[PluginObject],
-        path: str,
+        path: Path,
         category: str = "conditions",
     ) -> None:
         """

--- a/tuxemon/event/actions/load_yaml.py
+++ b/tuxemon/event/actions/load_yaml.py
@@ -42,13 +42,9 @@ class LoadYamlAction(EventAction):
         _events = list(client.map_manager.events)
         _inits = list(client.map_manager.inits)
         if yaml_path.exists():
-            yaml_events = YAMLEventLoader().load_events(
-                yaml_path.as_posix(), "event"
-            )
+            yaml_events = YAMLEventLoader().load_events(yaml_path, "event")
             _events.extend(yaml_events["event"])
-            yaml_inits = YAMLEventLoader().load_events(
-                yaml_path.as_posix(), "init"
-            )
+            yaml_inits = YAMLEventLoader().load_events(yaml_path, "init")
             _inits.extend(yaml_inits["init"])
         else:
             raise ValueError(f"{yaml_path} doesn't exist")

--- a/tuxemon/event/eventaction.py
+++ b/tuxemon/event/eventaction.py
@@ -264,7 +264,7 @@ class EventAction(ABC):
 class ActionManager:
     def __init__(self) -> None:
         self.actions = load_plugins(
-            ACTIONS_PATH.as_posix(),
+            ACTIONS_PATH,
             "actions",
             interface=EventAction,  # type: ignore[type-abstract]
         )

--- a/tuxemon/event/eventcondition.py
+++ b/tuxemon/event/eventcondition.py
@@ -39,7 +39,7 @@ class EventCondition:
 class ConditionManager:
     def __init__(self) -> None:
         self.conditions = load_plugins(
-            CONDITIONS_PATH.as_posix(),
+            CONDITIONS_PATH,
             "conditions",
             interface=EventCondition,
         )

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -66,11 +66,11 @@ class Item:
 
         if Item.effect_manager is None:
             Item.effect_manager = EffectManager(
-                CoreEffect, paths.CORE_EFFECT_PATH.as_posix()
+                CoreEffect, paths.CORE_EFFECT_PATH
             )
         if Item.condition_manager is None:
             Item.condition_manager = ConditionManager(
-                CoreCondition, paths.CORE_CONDITION_PATH.as_posix()
+                CoreCondition, paths.CORE_CONDITION_PATH
             )
 
         self.effects: Sequence[PluginObject] = []

--- a/tuxemon/map_loader.py
+++ b/tuxemon/map_loader.py
@@ -50,11 +50,11 @@ region_properties = [
 ]
 
 
-def parse_yaml(path: str) -> Any:
+def parse_yaml(path: Path) -> Any:
     """
     Parses a large YAML file efficiently using a streaming loader.
     """
-    with open(path) as fp:
+    with path.open() as fp:
         try:
             return yaml.load(fp.read(), Loader=yaml.SafeLoader)
         except yaml.YAMLError as e:
@@ -82,7 +82,7 @@ class EventLoader:
             A dictionary mapping coordinates to collision properties.
         """
         try:
-            return self.yaml_loader.load_collision(yaml_file.as_posix())
+            return self.yaml_loader.load_collision(yaml_file)
         except Exception as e:
             logger.error(
                 f"Failed to load collision events from {yaml_file}: {e}"
@@ -103,9 +103,9 @@ class EventLoader:
             A list of events of the specified type.
         """
         try:
-            return self.yaml_loader.load_events(
-                yaml_file.as_posix(), event_type
-            )[event_type]
+            return self.yaml_loader.load_events(yaml_file, event_type)[
+                event_type
+            ]
         except Exception as e:
             logger.error(
                 f"Failed to load '{event_type}' events from {yaml_file}: {e}"
@@ -233,7 +233,7 @@ class YAMLEventLoader:
     """Support for reading game events from a YAML file."""
 
     def load_collision(
-        self, path: str
+        self, path: Path
     ) -> MutableMapping[tuple[int, int], Optional[RegionProperties]]:
         """
         Load collision data from a YAML file.
@@ -267,7 +267,7 @@ class YAMLEventLoader:
         return collision_dict
 
     def load_events(
-        self, path: str, source: str
+        self, path: Path, source: str
     ) -> dict[str, list[EventObject]]:
         """
         Load EventObjects from a YAML file.

--- a/tuxemon/menu/theme.py
+++ b/tuxemon/menu/theme.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from pathlib import Path
 from typing import Optional
 
 import pygame_menu
@@ -102,7 +103,7 @@ _sound_engine: Optional[pygame_menu.Sound] = None
 
 
 def get_sound_engine(
-    volume: float, filename: Optional[str]
+    volume: float, filename: Optional[Path]
 ) -> pygame_menu.Sound:
     """Get Tuxemon default sound engine."""
     global _sound_engine

--- a/tuxemon/plugin.py
+++ b/tuxemon/plugin.py
@@ -59,7 +59,7 @@ class PluginDiscovery(ABC):
         """Discovers plugin modules."""
 
     @abstractmethod
-    def set_folders(self, folders: list[str]) -> None:
+    def set_folders(self, folders: list[Path]) -> None:
         """Sets the folders to search for plugins."""
 
 
@@ -67,7 +67,7 @@ class FileSystemPluginDiscovery(PluginDiscovery):
 
     def __init__(
         self,
-        folders: list[str],
+        folders: list[Path],
         folder_name: str = "tuxemon",
         file_extensions: tuple[str, str] = (".py", ".pyc"),
     ):
@@ -79,7 +79,7 @@ class FileSystemPluginDiscovery(PluginDiscovery):
         """Discovers plugin modules from the file system."""
         modules = []
         for folder in self.folders:
-            folder_path = Path(folder)
+            folder_path = folder
             if not folder_path.exists():
                 logger.warning(f"Folder {folder_path} does not exist")
                 continue
@@ -94,7 +94,7 @@ class FileSystemPluginDiscovery(PluginDiscovery):
             )
         return modules
 
-    def set_folders(self, folders: list[str]) -> None:
+    def set_folders(self, folders: list[Path]) -> None:
         """Sets the folders to search for plugins."""
         self.folders = folders
 
@@ -253,7 +253,7 @@ class PluginManager:
         return inspect.getmembers(module, predicate=predicate)
 
 
-def load_directory(plugin_folder: str) -> PluginManager:
+def load_directory(plugin_folder: Path) -> PluginManager:
     """
     Load plugins from a directory.
 
@@ -295,20 +295,20 @@ def get_available_classes(
 
 @overload
 def load_plugins(
-    path: str, category: str = "plugins"
+    path: Path, category: str = "plugins"
 ) -> Mapping[str, type[PluginObject]]:
     pass
 
 
 @overload
 def load_plugins(
-    path: str, category: str = "plugins", *, interface: type[InterfaceValue]
+    path: Path, category: str = "plugins", *, interface: type[InterfaceValue]
 ) -> Mapping[str, type[InterfaceValue]]:
     pass
 
 
 def load_plugins(
-    path: str,
+    path: Path,
     category: str = "plugins",
     *,
     interface: Union[type[InterfaceValue], type[PluginObject]] = PluginObject,

--- a/tuxemon/status/status.py
+++ b/tuxemon/status/status.py
@@ -77,11 +77,11 @@ class Status:
 
         if Status.effect_manager is None:
             Status.effect_manager = EffectManager(
-                CoreEffect, paths.CORE_EFFECT_PATH.as_posix()
+                CoreEffect, paths.CORE_EFFECT_PATH
             )
         if Status.condition_manager is None:
             Status.condition_manager = ConditionManager(
-                CoreCondition, paths.CORE_CONDITION_PATH.as_posix()
+                CoreCondition, paths.CORE_CONDITION_PATH
             )
 
         self.effects: Sequence[PluginObject] = []

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -72,11 +72,11 @@ class Technique:
 
         if Technique.effect_manager is None:
             Technique.effect_manager = EffectManager(
-                CoreEffect, paths.CORE_EFFECT_PATH.as_posix()
+                CoreEffect, paths.CORE_EFFECT_PATH
             )
         if Technique.condition_manager is None:
             Technique.condition_manager = ConditionManager(
-                CoreCondition, paths.CORE_CONDITION_PATH.as_posix()
+                CoreCondition, paths.CORE_CONDITION_PATH
             )
 
         self.effects: Sequence[PluginObject] = []


### PR DESCRIPTION
PR builds on the groundwork established in #2812, refining the transition to `Path` objects across the codebase. The previous implementation left some inconsistencies where `Path` objects were converted to `str` and later transformed back into `Path`, disrupting continuity. These unnecessary conversions have now been eliminated, ensuring that `Path` is consistently passed to various methods.

The remaining task is to address the `fetch` function (prepare.py), which must be updated to both accept and return `Path` objects. However, modifying `fetch` will require changes to files that are already affected by pending PRs, making it a separate step in this ongoing effort. This update furthers the overall goal of full `Path` integration.