### PR TITLE
Improved Mod Loading with Dependency Tracking

### DIFF
--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -1871,16 +1871,37 @@ class ModData:
         """
         if directory == "all":
             if self.config.mod_tables:
-                for mod, tables in self.config.mod_tables.items():
-                    if mod in self.config.active_mods:
+                ordered_mods_for_loading = []
+                resolved_set = set()
+
+                for mod in self.config.active_mods:
+                    if mod in self.config.mod_tables:
                         dependencies = self.resolver.resolve(mod)
-                        mods_to_load = dependencies + [mod]
-                        for mod_to_load in mods_to_load:
-                            if mod_to_load in self.config.mod_tables:
-                                for table in self.config.mod_tables[
-                                    mod_to_load
-                                ]:
-                                    self._preload_table(table, mod_to_load)
+
+                        for dep in dependencies:
+                            if dep not in resolved_set:
+                                logger.info(
+                                    f"Adding dependency to load queue: {dep}"
+                                )
+                                ordered_mods_for_loading.append(dep)
+                                resolved_set.add(dep)
+
+                        if mod not in resolved_set:
+                            logger.info(
+                                f"Adding main mod to load queue: {mod}"
+                            )
+                            ordered_mods_for_loading.append(mod)
+                            resolved_set.add(mod)
+
+                logger.info(
+                    f"Final ordered mods for loading: {ordered_mods_for_loading}"
+                )
+
+                for mod_to_load in ordered_mods_for_loading:
+                    if mod_to_load in self.config.mod_tables:
+                        logger.info(f"Loading mod: {mod_to_load}")
+                        for table in self.config.mod_tables[mod_to_load]:
+                            self._preload_table(table, mod_to_load)
             else:
                 logger.warning("No mod tables specified in config.")
         else:

--- a/tuxemon/states/start/__init__.py
+++ b/tuxemon/states/start/__init__.py
@@ -62,7 +62,7 @@ class StartState(PygameMenuState):
             )
             game_var = local_session.player.game_variables
             game_var["date_start_game"] = today_ordinal()
-            self.client.pop_state(self)
+            self.client.remove_state_by_name("StartState")
 
         def change_state(
             state: Union[State, str],
@@ -155,7 +155,8 @@ class ModsChoice(PygameMenuState):
             )
             game_var = local_session.player.game_variables
             game_var["date_start_game"] = today_ordinal()
-            self.client.pop_state(self)
+            self.client.remove_state_by_name("StartState")
+            self.client.remove_state_by_name("ModsChoice")
 
         for mod_name in self.mods:
             menu.add.button(


### PR DESCRIPTION
PR refactors the `preload` method to improve mod loading efficiency and maintain better dependency tracking.

Changes:
- mods are now processed in an ordered sequence using `ordered_mods_for_loading` instead of loading them immediately after resolving dependencies
- a new `resolved_set` ensures that each mod and its dependencies are only added once, avoiding unnecessary duplicate operations
- informational logs (`logger.info`) now provide visibility into which mods and dependencies are added to the loading queue, improving debugging
- the loop structure now cleanly separates dependency resolution from mod processing, making the logic easier to follow
- added `remove_state_by_name`, it improves stability by preventing crashes when attempting to load mods from `ModsChoice`
