### PR TITLE
Extract Bubble Management from `MapRenderer` into `BubbleManager`

### DIFF
--- a/tests/tuxemon/test_bubble_manager.py
+++ b/tests/tuxemon/test_bubble_manager.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import unittest
+from unittest.mock import MagicMock
+
+from pygame.surface import Surface
+
+from tuxemon.map_view import BubbleManager
+from tuxemon.npc import NPC
+
+
+class TestBubbleManager(unittest.TestCase):
+
+    def setUp(self):
+        self.manager = BubbleManager()
+        self.entity = MagicMock(spec=NPC)
+        self.surface = MagicMock(spec=Surface)
+
+    def test_init(self):
+        self.assertEqual(self.manager.layer, 100)
+        self.assertEqual(self.manager.offset_divisor, 10)
+        self.assertEqual(self.manager._bubbles, {})
+
+    def test_add_bubble(self):
+        self.manager.add_bubble(self.entity, self.surface)
+        self.assertIn(self.entity, self.manager._bubbles)
+        self.assertEqual(self.manager._bubbles[self.entity], self.surface)
+
+    def test_remove_bubble(self):
+        self.manager.add_bubble(self.entity, self.surface)
+        self.manager.remove_bubble(self.entity)
+        self.assertNotIn(self.entity, self.manager._bubbles)
+
+    def test_has_bubble(self):
+        self.assertFalse(self.manager.has_bubble(self.entity))
+        self.manager.add_bubble(self.entity, self.surface)
+        self.assertTrue(self.manager.has_bubble(self.entity))
+
+    def test_clear_all_bubbles(self):
+        entity1 = MagicMock(spec=NPC)
+        entity2 = MagicMock(spec=NPC)
+        surface1 = MagicMock(spec=Surface)
+        surface2 = MagicMock(spec=Surface)
+        self.manager.add_bubble(entity1, surface1)
+        self.manager.add_bubble(entity2, surface2)
+        self.manager.clear_all_bubbles()
+        self.assertEqual(self.manager._bubbles, {})

--- a/tuxemon/event/actions/set_bubble.py
+++ b/tuxemon/event/actions/set_bubble.py
@@ -28,11 +28,11 @@ class SetBubbleAction(EventAction):
         bubble: dots, drop, exclamation, heart, note, question, sleep,
             angry, confused, fireworks
 
-    eg. "set_bubble spyder_shopassistant" (remove bubble NPC)
-    eg. "set_bubble spyder_shopassistant,note" (set bubble NPC)
-    eg. "set_bubble player,note" (set bubble player)
-    eg. "set_bubble player" (remove bubble player)
-
+    Example usage:
+        "set_bubble spyder_shopassistant" (remove bubble from NPC)
+        "set_bubble spyder_shopassistant,note" (set bubble for NPC)
+        "set_bubble player,note" (set bubble for player)
+        "set_bubble player" (remove bubble from player)
     """
 
     name = "set_bubble"
@@ -42,18 +42,20 @@ class SetBubbleAction(EventAction):
     def start(self, session: Session) -> None:
         client = session.client
         npc = get_npc(session, self.npc_slug)
-        assert npc
+
+        if npc is None:
+            raise ValueError(f"NPC '{self.npc_slug}' not found.")
 
         world = client.get_state_by_name(WorldState)
         filename = f"gfx/bubbles/{self.bubble}.png"
 
         if self.bubble is None:
-            if npc in world.map_renderer.bubble:
-                del world.map_renderer.bubble[npc]
+            if world.map_renderer.bubble_manager.has_bubble(npc):
+                world.map_renderer.bubble_manager.remove_bubble(npc)
         else:
             try:
                 surface = load_and_scale(filename)
-            except:
-                raise ValueError(f"gfx/bubbles/{self.bubble}.png not found")
+            except FileNotFoundError:
+                raise ValueError(f"Bubble image '{filename}' not found.")
             else:
-                world.map_renderer.bubble[npc] = surface
+                world.map_renderer.bubble_manager.add_bubble(npc, surface)

--- a/tuxemon/event/conditions/check_world.py
+++ b/tuxemon/event/conditions/check_world.py
@@ -56,5 +56,5 @@ class CheckWorldCondition(EventCondition):
             if char is None:
                 logger.error(f"{params[1]} not found")
                 return False
-            return char in world.map_renderer.bubble
+            return world.map_renderer.bubble_manager.has_bubble(char)
         return False


### PR DESCRIPTION
PR introduces a new `BubbleManager` class to handle speech bubbles separately from `MapRenderer`

Changes:
- created `BubbleManager` class to manage the addition, removal, and rendering of speech bubbles
- removed speech bubble logic from `MapRenderer`
- refactored bubble positioning to be handled within `BubbleManager`
- updated integration where `MapRenderer` now uses `BubbleManager` to render speech bubbles