### PR TITLE
`MenuVisibility` Persistence in `MainCombatMenuState`

### DIFF
--- a/tuxemon/core/effects/button_lock.py
+++ b/tuxemon/core/effects/button_lock.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from tuxemon.core.core_effect import CoreEffect, TechEffectResult
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
+    from tuxemon.session import Session
+    from tuxemon.technique.technique import Technique
+
+
+@dataclass
+class ButtonLockEffect(CoreEffect):
+    """
+    Effect that modifies menu visibility in combat.
+    This effect dynamically enables or disables specific menu options.
+
+    Attributes:
+        menu: The menu option affected.
+        visible: Determines if the menu option is enabled ("true") or disabled ("false")
+    """
+
+    name = "button_lock"
+    menu: str
+    visible: str
+
+    def apply_tech_target(
+        self, session: Session, tech: Technique, user: Monster, target: Monster
+    ) -> TechEffectResult:
+        combat = tech.combat_state
+        assert combat
+        visible = self.visible.lower() == "true"
+        combat._menu_visibility.update_visibility(self.menu, visible)
+        return TechEffectResult(name=tech.name, success=True)

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -38,7 +38,6 @@ import random
 from collections.abc import Iterable, Sequence
 from enum import Enum
 from functools import partial
-from itertools import chain
 from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 
 from pygame.rect import Rect
@@ -81,6 +80,7 @@ from .combat_classes import (
     ActionQueue,
     DamageTracker,
     EnqueuedAction,
+    MenuVisibility,
     MethodAnimationCache,
     TextAnimationManager,
     compute_text_anim_time,
@@ -164,6 +164,7 @@ class CombatState(CombatAnimations):
         self._max_positions: dict[NPC, int] = {}
         self._random_tech_hit: dict[Monster, float] = {}
         self._combat_variables: dict[str, Any] = {}
+        self._menu_visibility = MenuVisibility()
 
         super().__init__(session, players, graphics, battle_mode)
         self.is_trainer_battle = combat_type == "trainer"
@@ -1305,7 +1306,7 @@ class CombatState(CombatAnimations):
                 # reset technique stats
                 mon.moves.set_stats()
 
-        # clear action queue
+        self._menu_visibility.reset_to_default()
         self._action_queue.clear_queue()
         self._action_queue.clear_history()
         self._action_queue.clear_pending()

--- a/tuxemon/states/combat/combat_classes.py
+++ b/tuxemon/states/combat/combat_classes.py
@@ -17,6 +17,24 @@ from tuxemon.technique.technique import Technique
 
 
 @dataclass
+class MenuVisibility:
+    menu_fight: bool = True
+    menu_monster: bool = True
+    menu_item: bool = True
+    menu_forfeit: bool = False
+    menu_run: bool = True
+
+    def update_visibility(self, key: str, visible: bool) -> None:
+        if hasattr(self, key):
+            setattr(self, key, visible)
+        else:
+            raise ValueError(f"Invalid menu item key: {key}")
+
+    def reset_to_default(self) -> None:
+        self.__dict__.update(MenuVisibility().__dict__)
+
+
+@dataclass
 class EnqueuedAction:
     user: Union[Monster, NPC, None]
     method: Union[Technique, Item, Status, None]

--- a/tuxemon/states/combat/combat_menus.py
+++ b/tuxemon/states/combat/combat_menus.py
@@ -64,13 +64,8 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
         if self.character == cmb.players[1]:
             self.enemy = cmb.players[0]
             self.opponents = cmb.field_monsters.get_monsters(self.enemy)
-        self.menu_visibility = {
-            "menu_fight": True,
-            "menu_monster": True,
-            "menu_item": True,
-            "menu_forfeit": self.enemy.forfeit,
-            "menu_run": True,
-        }
+        self.menu_visibility = cmb._menu_visibility
+        self.menu_visibility.menu_forfeit = self.enemy.forfeit
 
     def calculate_menu_rectangle(self) -> Rect:
         rect_screen = self.client.screen.get_rect()
@@ -97,7 +92,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
         for key, callback in menu_items_map:
             foreground = (
                 self.unavailable_color
-                if not self.menu_visibility[key]
+                if not getattr(self.menu_visibility, key)
                 else None
             )
             yield MenuItem(
@@ -105,14 +100,8 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                 T.translate(key).upper(),
                 None,
                 callback,
-                self.menu_visibility[key],
+                getattr(self.menu_visibility, key),
             )
-
-    def update_menu_visibility(self, key: str, visible: bool) -> None:
-        if key in self.menu_visibility:
-            self.menu_visibility[key] = visible
-        else:
-            raise ValueError(f"Invalid menu item key: {key}")
 
     def forfeit(self) -> None:
         """


### PR DESCRIPTION
PR introduces a refactor to improve how combat menu visibility is stored and updated. Instead of relying on a dictionary that gets reinitialized each time `MainCombatMenuState` is instantiated, the menu visibility settings are now managed by an external `dataclass`.

A new effect called `button_lock` has been introduced for Techniques, allowing certain buttons in the menu to be disabled. This opens up exciting strategic possibilities, where specific moves can prevent the player from switching monsters, using items, or even launching an attack.

![Screenshot_2025-06-16_18-02-17](https://github.com/user-attachments/assets/c8be3c4a-f99c-4188-b3f2-47d8ad446881)
